### PR TITLE
Add API deprecation note for mirage endpoints

### DIFF
--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -3,6 +3,39 @@ link: "/fundamentals/api/reference/deprecations/"
 productName: API deprecations
 productLink: "/fundamentals/"
 entries:
+  - publish_date: "2025-11-03"
+    title: "Cloudflare Mirage"
+    description: |-
+      Deprecation date: November, 2025
+
+      End of life date: January, 2026
+
+      Following on from the [deprecation of Cloudflare Mirage](/speed/optimization/images/mirage/), the following API endpoints that manage Mirage settings are now deprecated and will be sunsetted in January 2026.
+
+      Deprecated APIs:
+
+      - `GET /zones/{zone_id}/settings/mirage`
+      - `PATCH /zones/{zone_id}/settings/mirage`
+
+      Affected APIs:
+
+      - `GET /zones/{zone_id}/pagerules/settings` - mirage will be removed from available settings
+      - `POST /zones/{zone_id}/pagerules` - mirage parameter will be removed
+      - `PATCH /zones/{zone_id}/pagerules/{rule_id}` - mirage parameter will be removed
+      - `PUT /zones/{zone_id}/pagerules/{rule_id}` - mirage parameter will be removed
+      - `GET /zones/{zone_id}/rulesets/{ruleset_id}` - mirage parameter in `set_config` action will be removed
+      - `GET /zones/{zone_id}/rulesets/{ruleset_id}/versions/{version_id}` - mirage parameter in `set_config` action will be removed
+      - `POST /zones/{zone_id}/rulesets` - mirage parameter in `set_config` action will be removed
+      - `PUT /zones/{zone_id}/rulesets/{ruleset_id}` - mirage parameter in `set_config` action will be removed
+      - `POST /zones/{zone_id}/rulesets/{ruleset_id}/rules` - mirage parameter in `set_config` action will be removed
+      - `PATCH /zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id}` - mirage parameter in `set_config` action will be removed
+      - `GET /accounts/{account_id}/rulesets/{ruleset_id}` - mirage parameter in `set_config` action will be removed
+      - `GET /accounts/{account_id}/rulesets/{ruleset_id}/versions/{version_id}` - mirage parameter in `set_config` action will be removed
+      - `POST /accounts/{account_id}/rulesets` - mirage parameter in `set_config` action will be removed
+      - `PUT /accounts/{account_id}/rulesets/{ruleset_id}` - mirage parameter in `set_config` action will be removed
+      - `POST /accounts/{account_id}/rulesets/{ruleset_id}/rules` - mirage parameter in `set_config` action will be removed
+      - `PATCH /accounts/{account_id}/rulesets/{ruleset_id}/rules/{rule_id}` - mirage parameter in `set_config` action will be removed
+
   - publish_date: "2025-10-15"
     title: "Cloudflare Radar: Summary and Timeseries Groups Endpoints"
     description: |-

--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -6,9 +6,9 @@ entries:
   - publish_date: "2025-11-03"
     title: "Cloudflare Mirage"
     description: |-
-      Deprecation date: November, 2025
+      Deprecation date: November 2025
 
-      End of life date: January, 2026
+      End of life date: January 2026
 
       Following on from the [deprecation of Cloudflare Mirage](/speed/optimization/images/mirage/), the following API endpoints that manage Mirage settings are now deprecated and will be sunsetted in January 2026.
 
@@ -19,22 +19,22 @@ entries:
 
       Affected APIs:
 
-      - `GET /zones/{zone_id}/pagerules/settings` - mirage will be removed from available settings
-      - `POST /zones/{zone_id}/pagerules` - mirage parameter will be removed
-      - `PATCH /zones/{zone_id}/pagerules/{rule_id}` - mirage parameter will be removed
-      - `PUT /zones/{zone_id}/pagerules/{rule_id}` - mirage parameter will be removed
-      - `GET /zones/{zone_id}/rulesets/{ruleset_id}` - mirage parameter in `set_config` action will be removed
-      - `GET /zones/{zone_id}/rulesets/{ruleset_id}/versions/{version_id}` - mirage parameter in `set_config` action will be removed
-      - `POST /zones/{zone_id}/rulesets` - mirage parameter in `set_config` action will be removed
-      - `PUT /zones/{zone_id}/rulesets/{ruleset_id}` - mirage parameter in `set_config` action will be removed
-      - `POST /zones/{zone_id}/rulesets/{ruleset_id}/rules` - mirage parameter in `set_config` action will be removed
-      - `PATCH /zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id}` - mirage parameter in `set_config` action will be removed
-      - `GET /accounts/{account_id}/rulesets/{ruleset_id}` - mirage parameter in `set_config` action will be removed
-      - `GET /accounts/{account_id}/rulesets/{ruleset_id}/versions/{version_id}` - mirage parameter in `set_config` action will be removed
-      - `POST /accounts/{account_id}/rulesets` - mirage parameter in `set_config` action will be removed
-      - `PUT /accounts/{account_id}/rulesets/{ruleset_id}` - mirage parameter in `set_config` action will be removed
-      - `POST /accounts/{account_id}/rulesets/{ruleset_id}/rules` - mirage parameter in `set_config` action will be removed
-      - `PATCH /accounts/{account_id}/rulesets/{ruleset_id}/rules/{rule_id}` - mirage parameter in `set_config` action will be removed
+      - `GET /zones/{zone_id}/pagerules/settings` - Mirage will be removed from available settings.
+      - `POST /zones/{zone_id}/pagerules` - Mirage parameter will be removed.
+      - `PATCH /zones/{zone_id}/pagerules/{rule_id}` - Mirage parameter will be removed.
+      - `PUT /zones/{zone_id}/pagerules/{rule_id}` - Mirage parameter will be removed.
+      - `GET /zones/{zone_id}/rulesets/{ruleset_id}` - Mirage parameter in `set_config` action will be removed.
+      - `GET /zones/{zone_id}/rulesets/{ruleset_id}/versions/{version_id}` - Mirage parameter in `set_config` action will be removed.
+      - `POST /zones/{zone_id}/rulesets` - Mirage parameter in `set_config` action will be removed.
+      - `PUT /zones/{zone_id}/rulesets/{ruleset_id}` - Mirage parameter in `set_config` action will be removed.
+      - `POST /zones/{zone_id}/rulesets/{ruleset_id}/rules` - Mirage parameter in `set_config` action will be removed.
+      - `PATCH /zones/{zone_id}/rulesets/{ruleset_id}/rules/{rule_id}` - Mirage parameter in `set_config` action will be removed.
+      - `GET /accounts/{account_id}/rulesets/{ruleset_id}` - Mirage parameter in `set_config` action will be removed.
+      - `GET /accounts/{account_id}/rulesets/{ruleset_id}/versions/{version_id}` - Mirage parameter in `set_config` action will be removed.
+      - `POST /accounts/{account_id}/rulesets` - Mirage parameter in `set_config` action will be removed.
+      - `PUT /accounts/{account_id}/rulesets/{ruleset_id}` - Mirage parameter in `set_config` action will be removed.
+      - `POST /accounts/{account_id}/rulesets/{ruleset_id}/rules` - Mirage parameter in `set_config` action will be removed.
+      - `PATCH /accounts/{account_id}/rulesets/{ruleset_id}/rules/{rule_id}` - Mirage parameter in `set_config` action will be removed.
 
   - publish_date: "2025-10-15"
     title: "Cloudflare Radar: Summary and Timeseries Groups Endpoints"


### PR DESCRIPTION
### Summary

Mirage is deprecated and as part of the decommissioning work we need to notify customers that some endpoints will be sunset in the coming months. This PR adds an api deprecation note for the impacted endpoints.

### Documentation checklist

- [`No changelog entry`] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
