### PR TITLE
Clarify loglevel instruction for Cloudflare tunnels

### DIFF
--- a/src/content/docs/cloudflare-one/faq/cloudflare-tunnels-faq.mdx
+++ b/src/content/docs/cloudflare-one/faq/cloudflare-tunnels-faq.mdx
@@ -81,6 +81,6 @@ Before contacting the Cloudflare support team:
 
 3. Gather any relevant error/access logs from your server.
 
-4. (Locally-managed tunnels only) Set [`--loglevel`](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters/#loglevel) to `debug`, so the Cloudflare support team can get more info from the `cloudflared.log` file.
+4. If needed set [`--loglevel`](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters/#loglevel) to `debug`, so the Cloudflare support team can get more info from the `cloudflared.log` file.
 
 5. Include your [Cloudflare Tunnel diagnostic logs](/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/diag-logs/) (`cloudflared-diag-YYYY-MM-DDThh-mm-ss.zip`).


### PR DESCRIPTION
### Summary

The log level flag can be used for dashboard and locally managed tunnels.
https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters/#loglevel

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

