### PR TITLE
PCX-19909 [Cloudflare Tunnel] Update links to GPG key

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/create-local-tunnel.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/create-local-tunnel.mdx
@@ -55,7 +55,7 @@ Use the rpm package manager to install `cloudflared` on compatible machines.
 1. Add Cloudflare's repository:
 
 ```sh
-curl -fsSL https://pkg.cloudflare.com/cloudflared-ascii.repo | sudo tee /etc/yum.repos.d/cloudflared.repo
+curl -fsSl https://pkg.cloudflare.com/cloudflared.repo | sudo tee /etc/yum.repos.d/cloudflared.repo
 ```
 
 2. Update repositories and install cloudflared:

--- a/src/content/partials/cloudflare-one/tunnel/cloudflared-debian-install.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/cloudflared-debian-install.mdx
@@ -6,7 +6,7 @@
 
 ```sh
 sudo mkdir -p --mode=0755 /usr/share/keyrings
-curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+curl -fsSL https://pkg.cloudflare.com/cloudflare-public-v2.gpg | sudo tee /usr/share/keyrings/cloudflare-public-v2.gpg >/dev/null
 ```
 
 2. Add Cloudflare's apt repo to your apt repositories:

--- a/src/content/partials/ssl/keyless-key-server-setup.mdx
+++ b/src/content/partials/ssl/keyless-key-server-setup.mdx
@@ -20,10 +20,10 @@ These steps are also at the [Cloudflare package repository](https://pkg.cloudfla
 
 ```sh title="Debian or Ubuntu"
 sudo mkdir -p --mode=0755 /usr/share/keyrings
-curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+curl -fsSL https://pkg.cloudflare.com/cloudflare-public-v2.gpg | sudo tee /usr/share/keyrings/cloudflare-public-v2.gpg >/dev/null
 
 # Add this repo to your apt repositories
-echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/gokeyless buster main' | sudo tee /etc/apt/sources.list.d/cloudflare.list
+echo 'deb [signed-by=/usr/share/keyrings/cloudflare-public-v2.gpg] https://pkg.cloudflare.com/gokeyless buster main' | sudo tee /etc/apt/sources.list.d/cloudflare.list
 
 # install gokeyless
 sudo apt-get update && sudo apt-get install gokeyless


### PR DESCRIPTION
### Summary

We have rotated our public GPG key used for package signing. The "Install and run a connector" instructions are now outdated and will cause installation failures for users on Debian and RedHat. We must update the curl command and the signed-by path to use the new key URL and filename.