### PR TITLE
Document WRANGLER_OUTPUT_FILE_PATH and WRANGLER_OUTPUT_FILE_DIRECTORY environment variables

### DIFF
--- a/src/content/changelog/workers/2025-11-03-wrangler-output-file.mdx
+++ b/src/content/changelog/workers/2025-11-03-wrangler-output-file.mdx
@@ -1,0 +1,9 @@
+---
+title: Capture Wrangler command output in structured format
+description: New environment variables allow CI/CD pipelines to programmatically access deployment information
+products:
+  - workers
+date: 2025-11-03
+---
+
+You can now capture Wrangler command output in a structured [ND-JSON](https://github.com/ndjson/ndjson-spec) format by setting the [`WRANGLER_OUTPUT_FILE_PATH`](/workers/wrangler/system-environment-variables/#supported-environment-variables) or [`WRANGLER_OUTPUT_FILE_DIRECTORY`](/workers/wrangler/system-environment-variables/#supported-environment-variables) environment variables. This feature is particularly useful for CI/CD pipelines and automation tools that need programmatic access to deployment information such as worker names, version IDs, deployment URLs, and error details. Commands that support this feature include [`wrangler deploy`](/workers/wrangler/commands/#deploy), [`wrangler versions upload`](/workers/wrangler/commands/#versions), [`wrangler versions deploy`](/workers/wrangler/commands/#versions), and [`wrangler pages deploy`](/workers/wrangler/commands/#deploy-1).

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -107,6 +107,23 @@ Wrangler supports the following environment variables:
 
   - Specifies a directory where Wrangler will create a randomly-named file (format: `wrangler-output-<timestamp>-<random>.json`) to write output data in [ND-JSON](https://github.com/ndjson/ndjson-spec) format. This is useful when you want to keep output files organized in a specific directory but don't need to control the exact filename. If both `WRANGLER_OUTPUT_FILE_PATH` and `WRANGLER_OUTPUT_FILE_DIRECTORY` are set, `WRANGLER_OUTPUT_FILE_PATH` takes precedence.
 
+### Example output file
+
+When these environment variables are set, Wrangler writes one JSON object per line to the output file. Each entry includes a `timestamp` field and a `type` field indicating the kind of operation. Here's an example of what the file might contain after running `wrangler deploy`:
+
+```json
+{"type":"wrangler-session","version":1,"wrangler_version":"3.78.0","command_line_args":["deploy"],"log_file_path":"/path/to/logs/wrangler-2024-11-03_12-00-00_abc.log","timestamp":"2024-11-03T12:00:00.000Z"}
+{"type":"deploy","version":1,"worker_name":"my-worker","worker_tag":"abc123def456","version_id":"v1-abc123","targets":["https://my-worker.example.workers.dev"],"worker_name_overridden":false,"wrangler_environment":"production","timestamp":"2024-11-03T12:00:05.000Z"}
+```
+
+The `wrangler-session` entry is written when Wrangler starts and contains information about the command being run. The `deploy` entry is written when a deployment completes successfully and includes the worker name, version ID, and deployment URLs.
+
+Other entry types include:
+- `version-upload` - Written by `wrangler versions upload` with version ID and preview URLs
+- `version-deploy` - Written by `wrangler versions deploy` with deployment information
+- `pages-deploy` - Written by `wrangler pages deploy` with Pages deployment details
+- `command-failed` - Written when a command fails, including error code and message
+
 ## Example `.env` file
 
 The following is an example `.env` file:

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -98,6 +98,15 @@ Wrangler supports the following environment variables:
 
 * `WRANGLER_R2_SQL_AUTH_TOKEN` <Type text="string" /> <MetaInfo text="optional" />
   - API token used for executing queries with [R2 SQL](/r2-sql).
+
+- `WRANGLER_OUTPUT_FILE_PATH` <Type text="string" /> <MetaInfo text="optional" />
+
+  - Specifies a file path where Wrangler will write output data in [ND-JSON](https://github.com/ndjson/ndjson-spec) (newline-delimited JSON) format. Each line in the file is a separate JSON object containing information about Wrangler operations such as deployments, version uploads, and errors. This is useful for CI/CD pipelines and automation tools that need to programmatically access deployment information. If both `WRANGLER_OUTPUT_FILE_PATH` and `WRANGLER_OUTPUT_FILE_DIRECTORY` are set, `WRANGLER_OUTPUT_FILE_PATH` takes precedence.
+
+- `WRANGLER_OUTPUT_FILE_DIRECTORY` <Type text="string" /> <MetaInfo text="optional" />
+
+  - Specifies a directory where Wrangler will create a randomly-named file (format: `wrangler-output-<timestamp>-<random>.json`) to write output data in [ND-JSON](https://github.com/ndjson/ndjson-spec) format. This is useful when you want to keep output files organized in a specific directory but don't need to control the exact filename. If both `WRANGLER_OUTPUT_FILE_PATH` and `WRANGLER_OUTPUT_FILE_DIRECTORY` are set, `WRANGLER_OUTPUT_FILE_PATH` takes precedence.
+
 ## Example `.env` file
 
 The following is an example `.env` file:

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -105,11 +105,11 @@ Wrangler supports the following environment variables:
 
 - `WRANGLER_OUTPUT_FILE_DIRECTORY` <Type text="string" /> <MetaInfo text="optional" />
 
-  - Specifies a directory where Wrangler will create a randomly-named file (format: `wrangler-output-<timestamp>-<random>.json`) to write output data in [ND-JSON](https://github.com/ndjson/ndjson-spec) format. This is useful when you want to keep output files organized in a specific directory but don't need to control the exact filename. If both `WRANGLER_OUTPUT_FILE_PATH` and `WRANGLER_OUTPUT_FILE_DIRECTORY` are set, `WRANGLER_OUTPUT_FILE_PATH` takes precedence.
+  - Specifies a directory where Wrangler will create a randomly-named file (format: `wrangler-output-<timestamp>-<random>.json`) to write output data in [ND-JSON](https://github.com/ndjson/ndjson-spec) format. This is useful when you want to keep output files organized in a specific directory but do not need to control the exact filename. If both `WRANGLER_OUTPUT_FILE_PATH` and `WRANGLER_OUTPUT_FILE_DIRECTORY` are set, `WRANGLER_OUTPUT_FILE_PATH` takes precedence.
 
 ### Example output file
 
-When these environment variables are set, Wrangler writes one JSON object per line to the output file. Each entry includes a `timestamp` field and a `type` field indicating the kind of operation. Here's an example of what the file might contain after running `wrangler deploy`:
+When these environment variables are set, Wrangler writes one JSON object per line to the output file. Each entry includes a `timestamp` field and a `type` field indicating the kind of operation. Here is an example of what the file might contain after running `wrangler deploy`:
 
 ```json
 {"type":"wrangler-session","version":1,"wrangler_version":"3.78.0","command_line_args":["deploy"],"log_file_path":"/path/to/logs/wrangler-2024-11-03_12-00-00_abc.log","timestamp":"2024-11-03T12:00:00.000Z"}


### PR DESCRIPTION
### Summary

This PR documents the `WRANGLER_OUTPUT_FILE_PATH` and `WRANGLER_OUTPUT_FILE_DIRECTORY` environment variables that enable capturing Wrangler command output in structured ND-JSON format for CI/CD pipelines and automation tools.

**Changes:**
- Added reference documentation for both environment variables in the system environment variables page
- Added an example output file section showing ND-JSON format and entry types
- Added a changelog entry for the new feature

**Key details:**
- `WRANGLER_OUTPUT_FILE_PATH` specifies an exact file path for output
- `WRANGLER_OUTPUT_FILE_DIRECTORY` specifies a directory where a randomly-named file will be created
- Output format is [ND-JSON](https://github.com/ndjson/ndjson-spec) (newline-delimited JSON)
- `WRANGLER_OUTPUT_FILE_PATH` takes precedence over `WRANGLER_OUTPUT_FILE_DIRECTORY` when both are set

### Updates since last revision

- **Rebased onto latest `production`**: The `commands.mdx` file was deleted upstream (commands are now auto-generated from Wrangler source), so the per-command usage notes from the original PR were dropped. Per-command documentation should be added via the Wrangler source in a separate `workers-sdk` PR (see [comment thread](https://github.com/cloudflare/cloudflare-docs/pull/26259#issuecomment-3559281801)).
- **Style guide fixes**: Replaced contractions ("don't" → "do not", "Here's" → "Here is") per Devin Review feedback.

### Human review checklist

- [ ] Verify the changelog links to `/workers/wrangler/commands/#deploy`, `#versions`, and `#deploy-1` still resolve correctly on the auto-generated commands page
- [ ] Confirm the changelog date (2025-11-03) is acceptable or should be updated to reflect the actual merge date

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))?
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes. **Not applicable** - minor documentation additions
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file). **Not applicable** - no files renamed or moved

Link to Devin session: https://app.devin.ai/sessions/99e43353306345328c43989cc2cc6c33
Requested by: @petebacondarwin
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/26259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
