### PR TITLE
Cefan/linux warp release format difference

### DIFF
--- a/src/components/changelog/Header.astro
+++ b/src/components/changelog/Header.astro
@@ -32,10 +32,8 @@ const products = await uniqueProducts(notes);
 ---
 
 <div
-	id="changelogHeader"
-	class="mt-0! mb-16 ml-[calc(50%-50vw)] flex w-screen items-center justify-evenly border-b-2 border-b-(--sl-color-hairline) bg-linear-to-r from-[#FFE9CB99] to-[#FFFFFF99] p-4 max-sm:flex-col-reverse sm:h-[18.75rem] dark:from-[#FBAD411F] dark:to-[#2C2C2C00]"
->
-	<div class="text-center sm:text-left">
+	id="changelogHeader" class="mt-0! mb-16 flex items-center justify-between gap-6 border-b-2 border-b-(--sl-color-hairline) bg-linear-to-r from-[#FFE9CB99] to-[#FFFFFF99] p-4 max-sm:flex-col-reverse sm:h-[18.75rem] dark:from-[#FBAD411F] dark:to-[#2C2C2C00]">
+	<div class="text-left sm:text-left">
 		<h1>Changelog</h1>
 		<p>New updates and improvements at Cloudflare.</p>
 		<p>

--- a/src/content/warp-releases/linux/ga/2025.8.779.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.8.779.0.yaml
@@ -1,16 +1,11 @@
-releaseNotes: >-
+releaseNotes: |-
   This release contains minor fixes and improvements including an updated public key for Linux packages. The public key must be updated if it was installed before September 12, 2025 to ensure the repository remains functional after December 4, 2025. Instructions to make this update are available at [pkg.cloudflareclient.com](https://pkg.cloudflareclient.com/).
 
-
   **Changes and improvements**
-
   - The MASQUE protocol is now the only protocol that can use [Proxy mode](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/#proxy-mode). If you previously configured a device profile to use Proxy mode with Wireguard, you will need to select a new WARP mode or switch to the MASQUE protocol. Otherwise, all devices matching the profile will lose connectivity.
 
-
   **Known issues**
-
   - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
-
 version: 2025.8.779.0
 releaseDate: 2025-10-07T19:20:00.003Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/bullseye-intel/version/2025.8.779.0


### PR DESCRIPTION
### Summary

The release notes for Linux clients were rendering differently to the release notes of the Mac and Windows clients.

### Resolution

YAML multiline strings can be represented as [block scalars](https://yaml-multiline.info/) with different "block chomping" behaviour. The Mac and Windows release files were using: `|-` whereas the latest Linux release file was using `>-` which is so-called "folded style". This replaces newlines with spaces in the source Markdown which resulted in Markdown -> HTML not seeing the newlines needed to signal headers. 