### PR TITLE
Add basic MCP client documentation

### DIFF
--- a/src/content/docs/agents/api-reference/agents-api.mdx
+++ b/src/content/docs/agents/api-reference/agents-api.mdx
@@ -580,6 +580,40 @@ Visit the [state management API documentation](/agents/api-reference/store-and-s
 
 :::
 
+### MCP Client API
+
+The Agents SDK allows your Agent to act as an MCP (Model Context Protocol) client, connecting to remote MCP servers and using their tools, resources, and prompts.
+
+<TypeScriptExample>
+
+```ts
+class Agent<Env, State = unknown> {
+  // Connect to an MCP server
+  async addMcpServer(
+    serverName: string,
+    url: string,
+    callbackHost?: string,
+    agentsPrefix?: string,
+    options?: MCPClientOptions
+  ): Promise<{ id: string; authUrl: string | undefined }>;
+
+  // Disconnect from an MCP server
+  async removeMcpServer(id: string): Promise<void>;
+
+  // Get state of all connected MCP servers
+  getMcpServers(): MCPServersState;
+}
+```
+
+</TypeScriptExample>
+
+When your Agent connects to MCP servers, it can dynamically discover and use tools provided by those servers, enabling powerful integrations with external services.
+
+:::note
+
+For complete MCP client API documentation, including OAuth configuration and advanced usage, refer to the [Agent — MCP Client API](/agents/model-context-protocol/mcp-client-api/).
+
+:::
 
 ### Client API
 

--- a/src/content/docs/agents/guides/connect-mcp-client.mdx
+++ b/src/content/docs/agents/guides/connect-mcp-client.mdx
@@ -7,7 +7,7 @@ sidebar:
   order: 5
 ---
 
-import { Render, TypeScriptExample, PackageManagers } from "~/components";
+import { Render, TypeScriptExample, PackageManagers, Steps } from "~/components";
 
 Your Agent can connect to external [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers to access their tools and extend your Agent's capabilities. In this tutorial, you'll create an Agent that connects to an MCP server and uses one of its tools.
 
@@ -24,179 +24,190 @@ An MCP server to connect to (or use the public example in this tutorial).
 
 ## 1. Create a basic Agent
 
-Create a new Agent project using the hello-world template:
+<Steps>
 
-<PackageManagers
-	type="create"
-	pkg="cloudflare@latest"
-	args={"my-mcp-client --template=cloudflare/ai/demos/hello-world"}
-/>
+1. Create a new Agent project using the `hello-world` template:
 
-Move into the project directory:
+	<PackageManagers
+		type="create"
+		pkg="cloudflare@latest"
+		args={"my-mcp-client --template=cloudflare/ai/demos/hello-world"}
+	/>
 
-```sh
-cd my-mcp-client
-```
+2. Move into the project directory:
 
-Your Agent is ready! The template includes a minimal Agent in `src/index.ts`:
+	```sh
+	cd my-mcp-client
+	```
 
-<TypeScriptExample>
+	Your Agent is ready! The template includes a minimal Agent in `src/index.ts`:
 
-```ts title="src/index.ts"
-import { Agent, type AgentNamespace, routeAgentRequest } from "agents";
+	<TypeScriptExample>
 
-type Env = {
-	HelloAgent: AgentNamespace<HelloAgent>;
-};
+	```ts title="src/index.ts"
+	import { Agent, type AgentNamespace, routeAgentRequest } from "agents";
 
-export class HelloAgent extends Agent<Env, never> {
-	async onRequest(request: Request): Promise<Response> {
-		return new Response("Hello, Agent!", { status: 200 });
+	type Env = {
+		HelloAgent: AgentNamespace<HelloAgent>;
+	};
+
+	export class HelloAgent extends Agent<Env, never> {
+		async onRequest(request: Request): Promise<Response> {
+			return new Response("Hello, Agent!", { status: 200 });
+		}
 	}
-}
 
-export default {
-	async fetch(request: Request, env: Env) {
-		return (
-			(await routeAgentRequest(request, env, { cors: true })) ||
-			new Response("Not found", { status: 404 })
-		);
-	},
-} satisfies ExportedHandler<Env>;
-```
-
-</TypeScriptExample>
+	export default {
+		async fetch(request: Request, env: Env) {
+			return (
+				(await routeAgentRequest(request, env, { cors: true })) ||
+				new Response("Not found", { status: 404 })
+			);
+		},
+	} satisfies ExportedHandler<Env>;
+	```
+	</TypeScriptExample>
+</Steps>
 
 ## 2. Add MCP connection endpoint
 
-Add an endpoint to connect to MCP servers. Update your Agent class in `src/index.ts`:
+<Steps>
 
-<TypeScriptExample>
+1. Add an endpoint to connect to MCP servers. Update your Agent class in `src/index.ts`:
 
-```ts title="src/index.ts"
-export class HelloAgent extends Agent<Env, never> {
-	async onRequest(request: Request): Promise<Response> {
-		const url = new URL(request.url);
+	<TypeScriptExample>
 
-		// Connect to an MCP server
-		if (url.pathname.endsWith("add-mcp") && request.method === "POST") {
-			const { serverUrl, name } = (await request.json()) as {
-				serverUrl: string;
-				name: string;
-			};
+	```ts title="src/index.ts"
+	export class HelloAgent extends Agent<Env, never> {
+		async onRequest(request: Request): Promise<Response> {
+			const url = new URL(request.url);
 
-			const { id, authUrl } = await this.addMcpServer(name, serverUrl);
+			// Connect to an MCP server
+			if (url.pathname.endsWith("add-mcp") && request.method === "POST") {
+				const { serverUrl, name } = (await request.json()) as {
+					serverUrl: string;
+					name: string;
+				};
 
-			if (authUrl) {
-				// OAuth required - return auth URL
+				const { id, authUrl } = await this.addMcpServer(name, serverUrl);
+
+				if (authUrl) {
+					// OAuth required - return auth URL
+					return new Response(
+						JSON.stringify({ serverId: id, authUrl }),
+						{ headers: { "Content-Type": "application/json" } },
+					);
+				}
+
 				return new Response(
-					JSON.stringify({ serverId: id, authUrl }),
+					JSON.stringify({ serverId: id, status: "connected" }),
 					{ headers: { "Content-Type": "application/json" } },
 				);
 			}
 
-			return new Response(
-				JSON.stringify({ serverId: id, status: "connected" }),
-				{ headers: { "Content-Type": "application/json" } },
-			);
+			return new Response("Not found", { status: 404 });
 		}
-
-		return new Response("Not found", { status: 404 });
 	}
-}
-```
+	```
 
-</TypeScriptExample>
+	</TypeScriptExample>
+</Steps>
 
 The `addMcpServer()` method connects to an MCP server. If the server requires OAuth authentication, it returns an `authUrl` that users must visit to complete authorization.
 
 ## 3. Test the connection
 
-Start your development server:
+<Steps>
 
-```sh
-npm start
-```
+1. Start your development server:
 
-In a new terminal, connect to an MCP server (using a public example):
+	```sh
+	npm start
+	```
 
-```sh
-curl -X POST http://localhost:8788/agents/hello-agent/default/add-mcp \
-  -H "Content-Type: application/json" \
-  -d '{
-    "serverUrl": "https://docs.mcp.cloudflare.com/mcp",
-    "name": "Example Server"
-  }'
-```
+2. In a new terminal, connect to an MCP server (using a public example):
 
-You should see a response with the server ID:
+	```sh
+	curl -X POST http://localhost:8788/agents/hello-agent/default/add-mcp \
+		-H "Content-Type: application/json" \
+		-d '{
+			"serverUrl": "https://docs.mcp.cloudflare.com/mcp",
+			"name": "Example Server"
+		}'
+	```
 
-```json
-{
-	"serverId": "example-server-id",
-	"status": "connected"
-}
-```
+	You should see a response with the server ID:
+
+	```json
+	{
+		"serverId": "example-server-id",
+		"status": "connected"
+	}
+	```
+
+</Steps>
 
 ## 4. List available tools
 
-Add an endpoint to see which tools are available from connected servers:
+<Steps>
 
-<TypeScriptExample>
+1. Add an endpoint to see which tools are available from connected servers:
 
-```ts title="src/index.ts"
-export class HelloAgent extends Agent<Env, never> {
-	async onRequest(request: Request): Promise<Response> {
-		const url = new URL(request.url);
+	<TypeScriptExample>
 
-		// ... previous add-mcp endpoint ...
+	```ts title="src/index.ts"
+	export class HelloAgent extends Agent<Env, never> {
+		async onRequest(request: Request): Promise<Response> {
+			const url = new URL(request.url);
 
-		// List MCP state (servers, tools, etc)
-		if (url.pathname.endsWith("mcp-state") && request.method === "GET") {
-			const mcpState = this.getMcpServers();
+			// ... previous add-mcp endpoint ...
 
-			return new Response(JSON.stringify(mcpState, null, 2), {
-				headers: { "Content-Type": "application/json" },
-			});
+			// List MCP state (servers, tools, etc)
+			if (url.pathname.endsWith("mcp-state") && request.method === "GET") {
+				const mcpState = this.getMcpServers();
+
+				return new Response(JSON.stringify(mcpState, null, 2), {
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+
+			return new Response("Not found", { status: 404 });
 		}
-
-		return new Response("Not found", { status: 404 });
 	}
-}
-```
+	```
+	</TypeScriptExample>
 
-</TypeScriptExample>
+2. Test it:
 
-Test it:
+	```sh
+	curl http://localhost:8788/agents/hello-agent/default/mcp-state
+	```
 
-```sh
-curl http://localhost:8788/agents/hello-agent/default/mcp-state
-```
+	You'll see all connected servers, their connection states, and available tools:
 
-You'll see all connected servers, their connection states, and available tools:
+	```json
+	{
+		"servers": {
+			"example-server-id": {
+				"name": "Example Server",
+				"state": "ready",
+				"server_url": "https://docs.mcp.cloudflare.com/mcp",
+				...
+			}
+		},
+		"tools": [
+			{
+				"name": "add",
+				"description": "Add two numbers",
+				"serverId": "example-server-id",
+				...
+			}
+		]
+	}
+	```
+</Steps>
 
-```json
-{
-	"servers": {
-		"example-server-id": {
-			"name": "Example Server",
-			"state": "ready",
-			"server_url": "https://docs.mcp.cloudflare.com/mcp",
-			...
-		}
-	},
-	"tools": [
-		{
-			"name": "add",
-			"description": "Add two numbers",
-			"serverId": "example-server-id",
-			...
-		}
-	]
-}
-```
-
-## What you built
+## Summary
 
 You created an Agent that can:
 - Connect to external MCP servers dynamically

--- a/src/content/docs/agents/guides/connect-mcp-client.mdx
+++ b/src/content/docs/agents/guides/connect-mcp-client.mdx
@@ -1,0 +1,212 @@
+---
+title: Connect to an MCP server
+pcx_content_type: tutorial
+tags:
+  - MCP
+sidebar:
+  order: 5
+---
+
+import { Render, TypeScriptExample, PackageManagers } from "~/components";
+
+Your Agent can connect to external [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers to access their tools and extend your Agent's capabilities. In this tutorial, you'll create an Agent that connects to an MCP server and uses one of its tools.
+
+## What you will build
+
+An Agent with endpoints to:
+- Connect to an MCP server
+- List available tools from connected servers
+- Get the connection status
+
+## Prerequisites
+
+An MCP server to connect to (or use the public example in this tutorial).
+
+## 1. Create a basic Agent
+
+Create a new Agent project using the hello-world template:
+
+<PackageManagers
+	type="create"
+	pkg="cloudflare@latest"
+	args={"my-mcp-client --template=cloudflare/ai/demos/hello-world"}
+/>
+
+Move into the project directory:
+
+```sh
+cd my-mcp-client
+```
+
+Your Agent is ready! The template includes a minimal Agent in `src/index.ts`:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+import { Agent, type AgentNamespace, routeAgentRequest } from "agents";
+
+type Env = {
+	HelloAgent: AgentNamespace<HelloAgent>;
+};
+
+export class HelloAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		return new Response("Hello, Agent!", { status: 200 });
+	}
+}
+
+export default {
+	async fetch(request: Request, env: Env) {
+		return (
+			(await routeAgentRequest(request, env, { cors: true })) ||
+			new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+## 2. Add MCP connection endpoint
+
+Add an endpoint to connect to MCP servers. Update your Agent class in `src/index.ts`:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class HelloAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		// Connect to an MCP server
+		if (url.pathname.endsWith("add-mcp") && request.method === "POST") {
+			const { serverUrl, name } = (await request.json()) as {
+				serverUrl: string;
+				name: string;
+			};
+
+			const { id, authUrl } = await this.addMcpServer(name, serverUrl);
+
+			if (authUrl) {
+				// OAuth required - return auth URL
+				return new Response(
+					JSON.stringify({ serverId: id, authUrl }),
+					{ headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			return new Response(
+				JSON.stringify({ serverId: id, status: "connected" }),
+				{ headers: { "Content-Type": "application/json" } },
+			);
+		}
+
+		return new Response("Not found", { status: 404 });
+	}
+}
+```
+
+</TypeScriptExample>
+
+The `addMcpServer()` method connects to an MCP server. If the server requires OAuth authentication, it returns an `authUrl` that users must visit to complete authorization.
+
+## 3. Test the connection
+
+Start your development server:
+
+```sh
+npm start
+```
+
+In a new terminal, connect to an MCP server (using a public example):
+
+```sh
+curl -X POST http://localhost:8788/agents/hello-agent/default/add-mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "serverUrl": "https://docs.mcp.cloudflare.com/mcp",
+    "name": "Example Server"
+  }'
+```
+
+You should see a response with the server ID:
+
+```json
+{
+	"serverId": "example-server-id",
+	"status": "connected"
+}
+```
+
+## 4. List available tools
+
+Add an endpoint to see which tools are available from connected servers:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class HelloAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		// ... previous add-mcp endpoint ...
+
+		// List MCP state (servers, tools, etc)
+		if (url.pathname.endsWith("mcp-state") && request.method === "GET") {
+			const mcpState = this.getMcpServers();
+
+			return new Response(JSON.stringify(mcpState, null, 2), {
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+
+		return new Response("Not found", { status: 404 });
+	}
+}
+```
+
+</TypeScriptExample>
+
+Test it:
+
+```sh
+curl http://localhost:8788/agents/hello-agent/default/mcp-state
+```
+
+You'll see all connected servers, their connection states, and available tools:
+
+```json
+{
+	"servers": {
+		"example-server-id": {
+			"name": "Example Server",
+			"state": "ready",
+			"server_url": "https://docs.mcp.cloudflare.com/mcp",
+			...
+		}
+	},
+	"tools": [
+		{
+			"name": "add",
+			"description": "Add two numbers",
+			"serverId": "example-server-id",
+			...
+		}
+	]
+}
+```
+
+## What you built
+
+You created an Agent that can:
+- Connect to external MCP servers dynamically
+- Handle OAuth authentication flows when required
+- List all available tools from connected servers
+- Monitor connection status
+
+Connections persist in the Agent's [SQL storage](/agents/api-reference/store-and-sync-state/), so they remain active across requests.
+
+## Next steps
+
+- [Handle OAuth flows](/agents/guides/oauth-mcp-client) — Configure OAuth callbacks and error handling
+- [McpClient — API reference](/agents/model-context-protocol/mcp-client-api/) — Complete API documentation

--- a/src/content/docs/agents/guides/oauth-mcp-client.mdx
+++ b/src/content/docs/agents/guides/oauth-mcp-client.mdx
@@ -1,0 +1,412 @@
+---
+title: Handle OAuth with MCP servers
+pcx_content_type: how-to
+tags:
+  - MCP
+sidebar:
+  order: 8
+---
+
+import { Render, TypeScriptExample, PackageManagers } from "~/components";
+
+When you build an Agent that connects to OAuth-protected MCP servers (like GitHub, Slack, or Notion), your end users will need to authenticate before the Agent can access their data. This guide shows you how to implement OAuth flows so your users can authorize access seamlessly.
+
+## Understanding the OAuth flow
+
+When your Agent connects to an OAuth-protected MCP server, here's what happens:
+
+1. **Your code calls** `addMcpServer()` with the server URL
+2. **If OAuth is required**, it returns an `authUrl` instead of immediately connecting
+3. **Your application presents** the `authUrl` to your user
+4. **Your user authenticates** on the provider's site (GitHub, Slack, etc.)
+5. **The provider redirects** back to your Agent's callback URL with an authorization code
+6. **Your Agent completes** the connection automatically
+
+## Connect and initiate OAuth
+
+When you connect to an OAuth-protected server (like GitHub), check if `authUrl` is returned. If present, automatically redirect your user to complete authorization:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class GitHubAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname.endsWith("connect-github") && request.method === "POST") {
+			// Attempt to connect to GitHub's MCP server
+			const { id, authUrl } = await this.addMcpServer(
+				"GitHub",
+				"https://api.githubcopilot.com/mcp/",
+			);
+
+			if (authUrl) {
+				// OAuth required - redirect user to authorize
+				return Response.redirect(authUrl, 302);
+			}
+
+			// No OAuth needed - connection complete
+			return new Response(
+				JSON.stringify({ serverId: id, status: "connected" }),
+				{ headers: { "Content-Type": "application/json" } },
+			);
+		}
+
+		return new Response("Not found", { status: 404 });
+	}
+}
+```
+
+</TypeScriptExample>
+
+Your user is automatically redirected to GitHub (or whichever provider) to authorize access.
+
+**Alternative approaches**: Instead of automatic redirect, you can present the `authUrl` to your user as:
+- **Popup window**: `window.open(authUrl, '_blank', 'width=600,height=700')` (for dashboard-style apps)
+- **Clickable link**: Display as a button or link (for API documentation or multi-step flows)
+- **Deep link**: Use custom URL schemes for mobile apps
+
+## Configure callback behavior
+
+After your user completes OAuth, the provider redirects back to your Agent's callback URL. Configure what happens next.
+
+### Redirect to your application (recommended)
+
+For the automatic redirect approach, redirect users back to your application after OAuth completes:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class MyAgent extends Agent<Env, never> {
+	onStart() {
+		this.mcp.configureOAuthCallback({
+			successRedirect: "/dashboard",
+			errorRedirect: "/auth-error",
+		});
+	}
+}
+```
+
+</TypeScriptExample>
+
+Users return to `/dashboard` on success or `/auth-error?error=<message>` on failure, maintaining a smooth flow.
+
+### Close popup window
+
+If you used `window.open()` to open OAuth in a popup:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+import { Agent } from "agents";
+import type { MCPClientOAuthResult } from "agents/mcp";
+
+export class MyAgent extends Agent<Env, never> {
+	onStart() {
+		this.mcp.configureOAuthCallback({
+			customHandler: (result: MCPClientOAuthResult) => {
+				if (result.authSuccess) {
+					// Success - close the popup
+					return new Response("<script>window.close();</script>", {
+						headers: { "content-type": "text/html" },
+					});
+				} else {
+					// Error - show message, then close
+					return new Response(
+						`<script>alert('Authorization failed: ${result.authError}'); window.close();</script>`,
+						{ headers: { "content-type": "text/html" } },
+					);
+				}
+			},
+		});
+	}
+}
+```
+
+</TypeScriptExample>
+
+The popup closes automatically, and your main application can detect this and refresh the connection status.
+
+## Monitor connection status
+
+### For React applications (recommended)
+
+Use the `useAgent` hook for automatic state updates:
+
+<TypeScriptExample>
+
+```tsx title="src/App.tsx"
+import { useAgent } from "agents/react";
+import type { MCPServersState } from "agents";
+
+function App() {
+	const [mcpState, setMcpState] = useState<MCPServersState>({
+		prompts: [],
+		resources: [],
+		servers: {},
+		tools: [],
+	});
+
+	const agent = useAgent({
+		agent: "my-agent",
+		name: "session-id",
+		onMcpUpdate: (mcpServers: MCPServersState) => {
+			// Automatically called when MCP state changes!
+			setMcpState(mcpServers);
+		},
+	});
+
+	return (
+		<div>
+			{Object.entries(mcpState.servers).map(([id, server]) => (
+				<div key={id}>
+					<strong>{server.name}</strong>: {server.state}
+					{server.state === "authenticating" && server.auth_url && (
+						<button onClick={() => window.open(server.auth_url, "_blank")}>
+							Authorize
+						</button>
+					)}
+				</div>
+			))}
+		</div>
+	);
+}
+```
+
+</TypeScriptExample>
+
+The `onMcpUpdate` callback receives real-time updates via WebSocket. No polling needed!
+
+### For other applications
+
+If you're not using React, poll the connection status:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class MyAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (
+			url.pathname.endsWith("connection-status") &&
+			request.method === "GET"
+		) {
+			const mcpState = this.getMcpServers();
+
+			const connections = Object.entries(mcpState.servers).map(
+				([id, server]) => ({
+					serverId: id,
+					name: server.name,
+					state: server.state, // "authenticating" | "connecting" | "ready" | "failed"
+					isReady: server.state === "ready",
+					needsAuth: server.state === "authenticating",
+					authUrl: server.auth_url,
+				}),
+			);
+
+			return new Response(JSON.stringify(connections, null, 2), {
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+
+		return new Response("Not found", { status: 404 });
+	}
+}
+```
+
+</TypeScriptExample>
+
+Connection states: `authenticating` (needs OAuth) → `connecting` (completing setup) → `ready` (available for use)
+
+## Handle authentication failures
+
+When OAuth fails, the connection `state` becomes `"failed"`. Detect this in your UI and allow users to retry or clean up:
+
+<TypeScriptExample>
+
+```tsx title="src/App.tsx"
+import { useAgent } from "agents/react";
+import type { MCPServersState } from "agents";
+
+function App() {
+	const [mcpState, setMcpState] = useState<MCPServersState>({
+		prompts: [],
+		resources: [],
+		servers: {},
+		tools: [],
+	});
+
+	const agent = useAgent({
+		agent: "my-agent",
+		name: "session-id",
+		onMcpUpdate: (mcpServers: MCPServersState) => {
+			setMcpState(mcpServers);
+		},
+	});
+
+	const handleRetry = async (serverId: string, serverUrl: string, name: string) => {
+		// Remove failed connection
+		await fetch(`/agents/my-agent/session-id/disconnect`, {
+			method: "POST",
+			body: JSON.stringify({ serverId }),
+		});
+
+		// Retry connection
+		const response = await fetch(`/agents/my-agent/session-id/connect-github`, {
+			method: "POST",
+			body: JSON.stringify({ serverUrl, name }),
+		});
+		const { authUrl } = await response.json();
+		if (authUrl) window.open(authUrl, "_blank");
+	};
+
+	return (
+		<div>
+			{Object.entries(mcpState.servers).map(([id, server]) => (
+				<div key={id}>
+					<strong>{server.name}</strong>: {server.state}
+
+					{server.state === "failed" && (
+						<div>
+							<p>Connection failed. Please try again.</p>
+							<button onClick={() => handleRetry(id, server.server_url, server.name)}>
+								Retry Connection
+							</button>
+						</div>
+					)}
+				</div>
+			))}
+		</div>
+	);
+}
+```
+
+</TypeScriptExample>
+
+Common failure reasons:
+
+- **User canceled**: Closed OAuth window before completing authorization
+- **Invalid credentials**: GitHub/Slack credentials were incorrect
+- **Permission denied**: User lacks required permissions (e.g., not a workspace admin)
+- **Expired session**: OAuth session timed out
+
+Failed connections remain in state until you remove them with `removeMcpServer(serverId)`.
+
+## Complete example
+
+This example demonstrates a complete GitHub OAuth integration. Users click "Connect GitHub", authorize in a popup window, and the connection becomes available. The Agent provides endpoints to connect, check status, and disconnect.
+
+:::note
+
+For React applications: Replace the `/status` polling endpoint with the `useAgent` hook's `onMcpUpdate` callback for automatic state updates via WebSocket.
+
+:::
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+import { Agent, type AgentNamespace, routeAgentRequest } from "agents";
+import type { MCPClientOAuthResult } from "agents/mcp";
+
+type Env = {
+	GitHubAgent: AgentNamespace<GitHubAgent>;
+};
+
+export class GitHubAgent extends Agent<Env, never> {
+	onStart() {
+		// Configure OAuth callback to close popup window
+		this.mcp.configureOAuthCallback({
+			customHandler: (result: MCPClientOAuthResult) => {
+				if (result.authSuccess) {
+					return new Response("<script>window.close();</script>", {
+						headers: { "content-type": "text/html" },
+					});
+				} else {
+					return new Response(
+						`<script>alert('GitHub authorization failed: ${result.authError}'); window.close();</script>`,
+						{ headers: { "content-type": "text/html" } },
+					);
+				}
+			},
+		});
+	}
+
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		// Endpoint: Connect to GitHub MCP server
+		if (url.pathname.endsWith("connect-github") && request.method === "POST") {
+			const { id, authUrl } = await this.addMcpServer(
+				"GitHub",
+				"https://api.githubcopilot.com/mcp/",
+			);
+
+			if (authUrl) {
+				return new Response(
+					JSON.stringify({
+						serverId: id,
+						authUrl: authUrl,
+						message: "Please authorize GitHub access",
+					}),
+					{ headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			return new Response(
+				JSON.stringify({ serverId: id, status: "connected" }),
+				{ headers: { "Content-Type": "application/json" } },
+			);
+		}
+
+		// Endpoint: Check connection status
+		if (url.pathname.endsWith("status") && request.method === "GET") {
+			const mcpState = this.getMcpServers();
+
+			const connections = Object.entries(mcpState.servers).map(
+				([id, server]) => ({
+					serverId: id,
+					name: server.name,
+					state: server.state,
+					isReady: server.state === "ready",
+					needsAuth: server.state === "authenticating",
+					authUrl: server.auth_url,
+				}),
+			);
+
+			return new Response(JSON.stringify(connections, null, 2), {
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+
+		// Endpoint: Disconnect from GitHub
+		if (url.pathname.endsWith("disconnect") && request.method === "POST") {
+			const { serverId } = (await request.json()) as { serverId: string };
+			await this.removeMcpServer(serverId);
+
+			return new Response(
+				JSON.stringify({ message: "Disconnected from GitHub" }),
+				{ headers: { "Content-Type": "application/json" } },
+			);
+		}
+
+		return new Response("Not found", { status: 404 });
+	}
+}
+
+export default {
+	async fetch(request: Request, env: Env) {
+		return (
+			(await routeAgentRequest(request, env, { cors: true })) ||
+			new Response("Not found", { status: 404 })
+		);
+	},
+};
+```
+
+</TypeScriptExample>
+
+## Related
+
+- [Connect to an MCP server](/agents/guides/connect-mcp-client) — Get started tutorial (no OAuth)
+- [McpClient — API reference](/agents/model-context-protocol/mcp-client-api/) — Complete API documentation

--- a/src/content/docs/agents/guides/oauth-mcp-client.mdx
+++ b/src/content/docs/agents/guides/oauth-mcp-client.mdx
@@ -61,7 +61,10 @@ export class ObservabilityAgent extends Agent<Env, never> {
 
 Your user is automatically redirected to the provider's OAuth page to authorize access.
 
-**Alternative approaches**: Instead of automatic redirect, you can present the `authUrl` to your user as:
+### Alternative approaches
+
+Instead of an automatic redirect, you can also present the `authUrl` to your user as a:
+
 - **Popup window**: `window.open(authUrl, '_blank', 'width=600,height=700')` (for dashboard-style apps)
 - **Clickable link**: Display as a button or link (for API documentation or multi-step flows)
 - **Deep link**: Use custom URL schemes for mobile apps
@@ -217,7 +220,7 @@ export class MyAgent extends Agent<Env, never> {
 
 </TypeScriptExample>
 
-Connection states: `authenticating` (needs OAuth) → `connecting` (completing setup) → `ready` (available for use)
+Connection states: `authenticating` (needs OAuth) > `connecting` (completing setup) > `ready` (available for use)
 
 ## Handle authentication failures
 

--- a/src/content/docs/agents/guides/oauth-mcp-client.mdx
+++ b/src/content/docs/agents/guides/oauth-mcp-client.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 import { Render, TypeScriptExample, PackageManagers } from "~/components";
 
-When you build an Agent that connects to OAuth-protected MCP servers (like GitHub, Slack, or Notion), your end users will need to authenticate before the Agent can access their data. This guide shows you how to implement OAuth flows so your users can authorize access seamlessly.
+When you build an Agent that connects to OAuth-protected MCP servers (like Slack or Notion), your end users will need to authenticate before the Agent can access their data. This guide shows you how to implement OAuth flows so your users can authorize access seamlessly.
 
 ## Understanding the OAuth flow
 
@@ -18,26 +18,26 @@ When your Agent connects to an OAuth-protected MCP server, here's what happens:
 1. **Your code calls** `addMcpServer()` with the server URL
 2. **If OAuth is required**, it returns an `authUrl` instead of immediately connecting
 3. **Your application presents** the `authUrl` to your user
-4. **Your user authenticates** on the provider's site (GitHub, Slack, etc.)
+4. **Your user authenticates** on the provider's site (Slack, etc.)
 5. **The provider redirects** back to your Agent's callback URL with an authorization code
 6. **Your Agent completes** the connection automatically
 
 ## Connect and initiate OAuth
 
-When you connect to an OAuth-protected server (like GitHub), check if `authUrl` is returned. If present, automatically redirect your user to complete authorization:
+When you connect to an OAuth-protected server (like Cloudflare Observability), check if `authUrl` is returned. If present, automatically redirect your user to complete authorization:
 
 <TypeScriptExample>
 
 ```ts title="src/index.ts"
-export class GitHubAgent extends Agent<Env, never> {
+export class ObservabilityAgent extends Agent<Env, never> {
 	async onRequest(request: Request): Promise<Response> {
 		const url = new URL(request.url);
 
-		if (url.pathname.endsWith("connect-github") && request.method === "POST") {
-			// Attempt to connect to GitHub's MCP server
+		if (url.pathname.endsWith("connect-observability") && request.method === "POST") {
+			// Attempt to connect to Cloudflare Observability MCP server
 			const { id, authUrl } = await this.addMcpServer(
-				"GitHub",
-				"https://api.githubcopilot.com/mcp/",
+				"Cloudflare Observability",
+				"https://observability.mcp.cloudflare.com/mcp",
 			);
 
 			if (authUrl) {
@@ -59,7 +59,7 @@ export class GitHubAgent extends Agent<Env, never> {
 
 </TypeScriptExample>
 
-Your user is automatically redirected to GitHub (or whichever provider) to authorize access.
+Your user is automatically redirected to the provider's OAuth page to authorize access.
 
 **Alternative approaches**: Instead of automatic redirect, you can present the `authUrl` to your user as:
 - **Popup window**: `window.open(authUrl, '_blank', 'width=600,height=700')` (for dashboard-style apps)
@@ -253,7 +253,7 @@ function App() {
 		});
 
 		// Retry connection
-		const response = await fetch(`/agents/my-agent/session-id/connect-github`, {
+		const response = await fetch(`/agents/my-agent/session-id/connect-observability`, {
 			method: "POST",
 			body: JSON.stringify({ serverUrl, name }),
 		});
@@ -287,7 +287,7 @@ function App() {
 Common failure reasons:
 
 - **User canceled**: Closed OAuth window before completing authorization
-- **Invalid credentials**: GitHub/Slack credentials were incorrect
+- **Invalid credentials**: Slack credentials were incorrect
 - **Permission denied**: User lacks required permissions (e.g., not a workspace admin)
 - **Expired session**: OAuth session timed out
 
@@ -295,7 +295,7 @@ Failed connections remain in state until you remove them with `removeMcpServer(s
 
 ## Complete example
 
-This example demonstrates a complete GitHub OAuth integration. Users click "Connect GitHub", authorize in a popup window, and the connection becomes available. The Agent provides endpoints to connect, check status, and disconnect.
+This example demonstrates a complete Cloudflare Observability OAuth integration. Users connect to Cloudflare Observability, authorize in a popup window, and the connection becomes available. The Agent provides endpoints to connect, check status, and disconnect.
 
 :::note
 
@@ -310,10 +310,10 @@ import { Agent, type AgentNamespace, routeAgentRequest } from "agents";
 import type { MCPClientOAuthResult } from "agents/mcp";
 
 type Env = {
-	GitHubAgent: AgentNamespace<GitHubAgent>;
+	ObservabilityAgent: AgentNamespace<ObservabilityAgent>;
 };
 
-export class GitHubAgent extends Agent<Env, never> {
+export class ObservabilityAgent extends Agent<Env, never> {
 	onStart() {
 		// Configure OAuth callback to close popup window
 		this.mcp.configureOAuthCallback({
@@ -324,7 +324,7 @@ export class GitHubAgent extends Agent<Env, never> {
 					});
 				} else {
 					return new Response(
-						`<script>alert('GitHub authorization failed: ${result.authError}'); window.close();</script>`,
+						`<script>alert('Authorization failed: ${result.authError}'); window.close();</script>`,
 						{ headers: { "content-type": "text/html" } },
 					);
 				}
@@ -335,11 +335,11 @@ export class GitHubAgent extends Agent<Env, never> {
 	async onRequest(request: Request): Promise<Response> {
 		const url = new URL(request.url);
 
-		// Endpoint: Connect to GitHub MCP server
-		if (url.pathname.endsWith("connect-github") && request.method === "POST") {
+		// Endpoint: Connect to Cloudflare Observability MCP server
+		if (url.pathname.endsWith("connect-observability") && request.method === "POST") {
 			const { id, authUrl } = await this.addMcpServer(
-				"GitHub",
-				"https://api.githubcopilot.com/mcp/",
+				"Cloudflare Observability",
+				"https://observability.mcp.cloudflare.com/mcp",
 			);
 
 			if (authUrl) {
@@ -347,7 +347,7 @@ export class GitHubAgent extends Agent<Env, never> {
 					JSON.stringify({
 						serverId: id,
 						authUrl: authUrl,
-						message: "Please authorize GitHub access",
+						message: "Please authorize Cloudflare Observability access",
 					}),
 					{ headers: { "Content-Type": "application/json" } },
 				);
@@ -379,13 +379,13 @@ export class GitHubAgent extends Agent<Env, never> {
 			});
 		}
 
-		// Endpoint: Disconnect from GitHub
+		// Endpoint: Disconnect from Cloudflare Observability
 		if (url.pathname.endsWith("disconnect") && request.method === "POST") {
 			const { serverId } = (await request.json()) as { serverId: string };
 			await this.removeMcpServer(serverId);
 
 			return new Response(
-				JSON.stringify({ message: "Disconnected from GitHub" }),
+				JSON.stringify({ message: "Disconnected from Cloudflare Observability" }),
 				{ headers: { "Content-Type": "application/json" } },
 			);
 		}

--- a/src/content/docs/agents/model-context-protocol/mcp-client-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/mcp-client-api.mdx
@@ -48,7 +48,7 @@ Connections persist in the Agent's [SQL storage](/agents/api-reference/store-and
 
 ## Agent MCP Client Methods
 
-### addMcpServer()
+### `addMcpServer()`
 
 Add a connection to an MCP server and make its tools available to your Agent.
 
@@ -121,7 +121,7 @@ If the MCP server requires OAuth authentication, `authUrl` will be returned for 
 - [Transport options](/agents/model-context-protocol/transport)
 - [removeMcpServer()](#removemcpserver)
 
-### removeMcpServer()
+### `removeMcpServer()`
 
 Disconnect from an MCP server and clean up its resources.
 
@@ -160,7 +160,7 @@ export class MyAgent extends Agent<Env, never> {
 
 Disconnects from the MCP server, removes all related resources, and deletes the server record from storage.
 
-### getMcpServers()
+### `getMcpServers()`
 
 Get the current state of all MCP server connections.
 

--- a/src/content/docs/agents/model-context-protocol/mcp-client-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/mcp-client-api.mdx
@@ -1,0 +1,278 @@
+---
+title: McpClient — API reference
+pcx_content_type: concept
+tags:
+  - MCP
+sidebar:
+  order: 7
+---
+
+import { Render, TypeScriptExample } from "~/components";
+
+Your Agent can connect to external [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers to access tools, resources, and prompts. The `Agent` class provides three methods to manage MCP connections:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+import { Agent, type AgentNamespace } from "agents";
+
+type Env = {
+	MyAgent: AgentNamespace<MyAgent>;
+};
+
+export class MyAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/connect" && request.method === "POST") {
+			const { id, authUrl } = await this.addMcpServer(
+				"Weather API",
+				"https://weather-mcp.example.com/mcp",
+			);
+
+			if (authUrl) {
+				return new Response(JSON.stringify({ authUrl }), {
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+
+			return new Response(`Connected: ${id}`, { status: 200 });
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+Connections persist in the Agent's [SQL storage](/agents/api-reference/store-and-sync-state), and when an Agent connects to an MCP server, all tools from that server become available automatically.
+
+## Agent MCP Client Methods
+
+### addMcpServer()
+
+Add a connection to an MCP server and make its tools available to your Agent.
+
+```ts
+async addMcpServer(
+  serverName: string,
+  url: string,
+  callbackHost?: string,
+  agentsPrefix?: string,
+  options?: {
+    client?: ConstructorParameters<typeof Client>[1];
+    transport?: {
+      headers?: HeadersInit;
+      type?: "sse" | "streamable-http" | "auto";
+    };
+  }
+): Promise<{ id: string; authUrl: string | undefined }>
+```
+
+#### Parameters
+
+- **`serverName`** (string, required) — Display name for the MCP server
+- **`url`** (string, required) — URL of the MCP server endpoint
+- **`callbackHost`** (string, optional) — Host for OAuth callback URL. If omitted, automatically derived from the incoming request
+- **`agentsPrefix`** (string, optional) — URL prefix for OAuth callback path. Default: `"agents"`
+- **`options`** (object, optional) — Connection configuration:
+  - **`client`** — MCP client configuration options (passed to `@modelcontextprotocol/sdk` Client constructor)
+  - **`transport`** — Transport layer configuration:
+    - **`headers`** — Custom HTTP headers for authentication
+    - **`type`** — Transport type: `"sse"`, `"streamable-http"`, or `"auto"` (tries streamable-http first, falls back to sse)
+
+#### Returns
+
+A Promise that resolves to an object containing:
+
+- **`id`** (string) — Unique identifier for this server connection
+- **`authUrl`** (string | undefined) — OAuth authorization URL if authentication is required, otherwise `undefined`
+
+#### Example
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class MyAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		const { id, authUrl } = await this.addMcpServer(
+			"Weather API",
+			"https://weather-mcp.example.com/mcp",
+		);
+
+		if (authUrl) {
+			// User needs to complete OAuth flow
+			return new Response(JSON.stringify({ serverId: id, authUrl }), {
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+
+		return new Response("Connected", { status: 200 });
+	}
+}
+```
+
+</TypeScriptExample>
+
+If the MCP server requires OAuth authentication, `authUrl` will be returned for user authentication. Connections persist across requests and the Agent will automatically reconnect if the connection is lost.
+
+**Related:**
+
+- [OAuth handling guide](/agents/guides/oauth-mcp-client)
+- [Transport options](/agents/model-context-protocol/transport)
+- [removeMcpServer()](#removemcpserver)
+
+### removeMcpServer()
+
+Disconnect from an MCP server and clean up its resources.
+
+```ts
+async removeMcpServer(id: string): Promise<void>
+```
+
+#### Parameters
+
+- **`id`** (string, required) — Server connection ID returned from `addMcpServer()`
+
+#### Returns
+
+A Promise that resolves when disconnection is complete.
+
+#### Example
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class MyAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/disconnect" && request.method === "POST") {
+			const { serverId } = await request.json();
+			await this.removeMcpServer(serverId);
+
+			return new Response("Disconnected", { status: 200 });
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+Disconnects from the MCP server, removes all related resources, and deletes the server record from storage.
+
+### getMcpServers()
+
+Get the current state of all MCP server connections.
+
+```ts
+getMcpServers(): MCPServersState
+```
+
+#### Parameters
+
+None.
+
+#### Returns
+
+An `MCPServersState` object containing:
+
+```ts
+{
+	servers: Record<
+		string,
+		{
+			name: string;
+			server_url: string;
+			auth_url: string | null;
+			state:
+				| "authenticating"
+				| "connecting"
+				| "ready"
+				| "discovering"
+				| "failed";
+			capabilities: ServerCapabilities | null;
+			instructions: string | null;
+		}
+	>;
+	tools: Array<Tool & { serverId: string }>;
+	prompts: Array<Prompt & { serverId: string }>;
+	resources: Array<Resource & { serverId: string }>;
+}
+```
+
+#### Example
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class MyAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/mcp-state") {
+			const mcpState = this.getMcpServers();
+
+			return new Response(JSON.stringify(mcpState, null, 2), {
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+The `state` field can be: `authenticating`, `connecting`, `ready`, `discovering`, or `failed`. Use this method to monitor connection status, list available tools, or build UI for connected servers.
+
+## OAuth Configuration
+
+Customize OAuth callback behavior using `this.mcp.configureOAuthCallback()`:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+export class MyAgent extends Agent<Env, never> {
+	onStart() {
+		this.mcp.configureOAuthCallback({
+			successRedirect: "/connected",
+			errorRedirect: "/auth-failed",
+		});
+	}
+}
+```
+
+</TypeScriptExample>
+
+You can also provide a `customHandler` function for full control over the callback response. Refer to the [OAuth handling guide](/agents/guides/oauth-mcp-client) for details.
+
+## Error Handling
+
+Use error detection utilities to handle connection errors:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+import { isUnauthorized, isTransportNotImplemented } from "agents/mcp";
+
+export class MyAgent extends Agent<Env, never> {
+	async onRequest(request: Request): Promise<Response> {
+		try {
+			await this.addMcpServer("Server", "https://mcp.example.com/mcp");
+		} catch (error) {
+			if (isUnauthorized(error)) {
+				return new Response("Authentication required", { status: 401 });
+			} else if (isTransportNotImplemented(error)) {
+				return new Response("Transport not supported", { status: 400 });
+			}
+			throw error;
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Next Steps
+
+- [Connect your first MCP server](/agents/guides/connect-mcp-client) — Tutorial to get started
+- [Handle OAuth flows](/agents/guides/oauth-mcp-client) — Complete OAuth integration guide


### PR DESCRIPTION
### Summary

The Agent class provides public APIs for connecting to MCP servers but these were completely undocumented. This adds API reference documentation, a tutorial for first connection, and a guide for handling OAuth flows with MCP servers.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
