### PR TITLE
[Workers] Clarify CPU time limit cutoff for scheduled Workers

### DIFF
--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -112,7 +112,7 @@ You can also customize this in the [Workers dashboard](https://dash.cloudflare.c
 
 :::note
 
-Scheduled Workers ([Cron Triggers](/workers/configuration/cron-triggers/)) have different limits on CPU time based on the schedule interval. When the schedule interval is less than 1 hour, a Scheduled Worker may run for up to 30 seconds. When the schedule interval is more than 1 hour, a scheduled Worker may run for up to 15 minutes.
+Scheduled Workers ([Cron Triggers](/workers/configuration/cron-triggers/)) have different limits on CPU time based on the schedule interval. When the schedule interval is less than 1 hour, a Scheduled Worker may run for up to 30 seconds. When the schedule interval is 1 hour or more, a scheduled Worker may run for up to 15 minutes.
 :::
 
 ---
@@ -159,6 +159,7 @@ Each [isolate](/workers/reference/how-workers-works/#isolates) of your Worker's 
 When an isolate running your Worker exceeds 128 MB of memory, the Workers runtime handles this gracefully instead of failing immediately. It allows in-flight requests to complete while simultaneously creating a new isolate for your Worker for new requests. While this approach typically allows in-flight requests to complete, during periods of extremely high load, some incoming requests may be cancelled to maintain system stability.
 
 To view out-of-memory errors (OOM), as well as CPU limit overages:
+
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />


### PR DESCRIPTION
### Summary

- Clarify that schedule intervals of exactly one hour get the higher limit

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

N/A

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
