### PR TITLE
Remove outdated section regarding vite support for remote bindings

### DIFF
--- a/src/content/docs/workers/vite-plugin/reference/migrating-from-wrangler-dev.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/migrating-from-wrangler-dev.mdx
@@ -27,8 +27,3 @@ There are various options in the [Worker config file](/workers/wrangler/configur
 If these options are provided, then warnings will be printed to the console with suggestions for how to proceed.
 Examples where the Vite configuration should be used instead include `alias` and `define`.
 See [Vite Environments](/workers/vite-plugin/reference/vite-environments/) for more information about configuring your Worker environments in Vite.
-
-## No remote mode
-
-The Vite plugin does not support [remote mode](/workers/development-testing/#remote-bindings).
-We will be adding support for accessing remote resources in local development in a future update.


### PR DESCRIPTION
The Cloudflare Vite plugin supports remote bindings. This PR removes the outdated section from [this page](https://developers.cloudflare.com/workers/vite-plugin/reference/migrating-from-wrangler-dev/#no-remote-mode) that says that remote bindings are not yet supported.
