### PR TITLE
Validate that no static redirect routes are declared after dynamic ones

### DIFF
--- a/bin/validate-redirects.ts
+++ b/bin/validate-redirects.ts
@@ -7,6 +7,8 @@ async function main() {
 	let numUrlsWithFragment = 0;
 	let numDuplicateRedirects = 0;
 	let numNonSlashedRedirects = 0;
+	let seenDynamicRedirects = false;
+	let numStaticRedirectsAfterDynamicRedirect = 0;
 
 	const validEndings = ["/", "*", ".xml", ".md", ".json", ".html", ".pdf"];
 
@@ -16,6 +18,17 @@ async function main() {
 		if (line.startsWith("#") || line.trim() === "") continue;
 
 		const [from, to] = line.split(" ");
+
+		if (from.includes("*")) {
+			seenDynamicRedirects = true;
+		}
+
+		if (seenDynamicRedirects && !from.includes("*")) {
+			console.log(
+				`✘ Found static redirect after dynamic redirect:\n    ${from}`,
+			);
+			numStaticRedirectsAfterDynamicRedirect++;
+		}
 
 		if (from === to) {
 			console.log(`✘ Found infinite redirect:\n    ${from} -> ${to}`);
@@ -49,7 +62,8 @@ async function main() {
 		numInfiniteRedirects ||
 		numUrlsWithFragment ||
 		numDuplicateRedirects ||
-		numNonSlashedRedirects
+		numNonSlashedRedirects ||
+		numStaticRedirectsAfterDynamicRedirect
 	) {
 		console.log("\nDetected errors:");
 
@@ -68,6 +82,12 @@ async function main() {
 		if (numNonSlashedRedirects > 0) {
 			console.log(
 				`- ${numNonSlashedRedirects} need slashes at the end of the source URL`,
+			);
+		}
+
+		if (numStaticRedirectsAfterDynamicRedirect > 0) {
+			console.log(
+				`- ${numStaticRedirectsAfterDynamicRedirect} static redirect(s) after dynamic redirect(s)`,
 			);
 		}
 


### PR DESCRIPTION
Validate that no static redirect routes are present in `public/__redirects` after any dynamic rule has been declared to avoid over shadowing

### Summary

The order of application of redirect rules matters. From the documentation:
https://developers.cloudflare.com/pages/configuration/redirects/#per-file: 

- The order of your redirects matter. If there are multiple redirects for the same source path, the top-most redirect is applied.
- Static redirects should appear before dynamic redirects.

This change helps to enforce these points.

### Output on issue

When a static route is found after any dynamic route has been declared the output is similar to the following:

```
✘ Found static redirect after dynamic redirect:
    /zoo/

Detected errors:
- 1 static redirect(s) after dynamic redirect(s)
```
and the `bin/validate-redirects.ts` will return a non-zero (error) code 

### Documentation checklist

This adds an additional validation to the rules listed in public/__redirects that should be triggered ahead of merging