### PR TITLE
chore: Update Docusaurus setup command arguments

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/docusaurus.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/docusaurus.mdx
@@ -23,7 +23,7 @@ import {
 <PackageManagers
 	type="create"
 	pkg="cloudflare@latest"
-	args="my-docusaurus-app --framework=docusaurus"
+	args="my-docusaurus-app --framework=docusaurus --platform=workers"
 />
 
 **Or just deploy**: Create a documentation site with Docusaurus and deploy it on Cloudflare Workers, with CI/CD and previews all set up for you.
@@ -43,7 +43,7 @@ Docusaurus is designed to be easy to use and customizable, making it a popular c
 	 <PackageManagers
 	 	type="create"
 	 	pkg="cloudflare@latest"
-	 	args={"my-docusaurus-app -- --framework=docusaurus --platform=workers"}
+	 	args={"my-docusaurus-app --framework=docusaurus --platform=workers"}
 	 />
 
 	 <Details header="What's happening behind the scenes?">


### PR DESCRIPTION
### Summary

The redundant "--" causes an error: unknown option '--framework=docusaurus'

**create-cloudflare log:** Continue with Docusaurus via `npx create-docusaurus@3.9.1 app-name classic --framework=docusaurus --platform=workers`

After removing it, I can create the app successfully.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

