### PR TITLE
[API Shield] Raise GraphQL limit

### DIFF
--- a/src/content/docs/api-shield/security/graphql-protection/index.mdx
+++ b/src/content/docs/api-shield/security/graphql-protection/index.mdx
@@ -16,4 +16,4 @@ GraphQL malicious query protection is available for all API Shield customers. En
 
 ## Limitations
 
-Our initial release is limited to parsing GraphQL `POST` bodies smaller than 5 KB. This limit will be lifted in a future release. Additionally, we currently inspect only `POST` requests with `content-types` of `application/json` or `application/graphql` where the queries do not contain fragments or multiple operations. Parsing and rules are limited to paths ending in `/graphql`.
+Our initial release is limited to parsing GraphQL `POST` bodies smaller than 20 KB. This limit will be lifted in a future release. Additionally, we currently inspect only `POST` requests with `content-types` of `application/json` or `application/graphql` where the queries do not contain fragments or multiple operations. Parsing and rules are limited to paths ending in `/graphql`.


### PR DESCRIPTION
### Summary

Updates GraphQL limit from 5kb to 20kb

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
