### PR TITLE
Generation of linux WARP release files more explicit and standardize output

### DIFF
--- a/bin/fetch-warp-releases.js
+++ b/bin/fetch-warp-releases.js
@@ -14,6 +14,8 @@ fs.writeFileSync(
 	"utf-8",
 );
 
+const linuxDistributions = ["Ubuntu", "Debian", "CentOS", "Fedora"];
+
 const linesToRemove = [
 	"For related Cloudflare for Teams documentation please see: https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp",
 	"For Zero Trust documentation please see: <https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp>",
@@ -21,8 +23,10 @@ const linesToRemove = [
 	"For Consumer documentation please see: <https://developers.cloudflare.com/warp-client/>",
 ];
 
-for (const { platform } of platforms) {
-	const isLinux = platform !== "windows" && platform !== "macos";
+for (const { platform, display_name } of platforms) {
+	const isLinux = linuxDistributions.some((dist) =>
+		display_name.includes(dist),
+	);
 
 	for (const track of ["ga", "beta"]) {
 		fetch(`${BASE_URL}/update/json/${platform}/${track}`)
@@ -63,9 +67,17 @@ for (const { platform } of platforms) {
 								);
 
 								existingFile.linuxPlatforms[platform] = item.packageSize;
+							} else {
+								console.log(
+									`${platform} already exists in Linux ${track} ${item.version}.`,
+								);
 							}
 
-							fs.writeFileSync(path, YAML.stringify(existingFile), "utf-8");
+							fs.writeFileSync(
+								path,
+								YAML.stringify(existingFile, { blockQuote: "literal" }),
+								"utf-8",
+							);
 						} else {
 							console.log(
 								`${platform} ${track} ${item.version} already exists.`,
@@ -75,7 +87,7 @@ for (const { platform } of platforms) {
 						return;
 					}
 
-					console.log(`Saving ${track} ${item.version}.`);
+					console.log(`Saving ${platform} ${track} ${item.version}.`);
 
 					let markdown = item.releaseNotes;
 
@@ -103,14 +115,17 @@ for (const { platform } of platforms) {
 
 					fs.writeFileSync(
 						path,
-						YAML.stringify({
-							...item,
-							releaseNotes,
-							platformName,
-							linuxPlatforms: isLinux
-								? { [platform]: item.packageSize }
-								: undefined,
-						}),
+						YAML.stringify(
+							{
+								...item,
+								releaseNotes,
+								platformName,
+								linuxPlatforms: isLinux
+									? { [platform]: item.packageSize }
+									: undefined,
+							},
+							{ blockQuote: "literal" },
+						),
 						"utf-8",
 					);
 				});

--- a/src/content/warp-releases/linux/beta/2025.5.828.1.yaml
+++ b/src/content/warp-releases/linux/beta/2025.5.828.1.yaml
@@ -1,28 +1,12 @@
-releaseNotes: >-
+releaseNotes: |-
   **Changes and improvements**
+  This release contains improvements and new exciting features, including post-quantum cryptography. By tunnelling your corporate network traffic over Cloudflare, you can now gain the immediate protection of post-quantum cryptography without needing to upgrade any of your individual corporate applications or systems.
 
-  This release contains improvements and new exciting features, including
-  post-quantum cryptography. By tunnelling your corporate network traffic over
-  Cloudflare, you can now gain the immediate protection of post-quantum
-  cryptography without needing to upgrade any of your individual corporate
-  applications or systems.
-
-
-  - Fixed a device registration issue causing WARP connection failures when
-  changing networks.
-
-  - Captive portal improvements including showing connectivity status in the
-  client and sending system notifications for captive portal sign in
-
-  - The WARP client now applies post-quantum cryptography end-to-end on enabled
-  devices accessing resources behind a Cloudflare Tunnel. This feature can be
-  enabled by MDM.
-
-  - Improvement to gracefully handle changes made by MDM while WARP is not
-  running.
-
-  - Fixed an issue affecting split tunnel include mode, where traffic outside
-  the tunnel was blocked when switching between Wifi and ethernet networks.
+  - Fixed a device registration issue causing WARP connection failures when changing networks.
+  - Captive portal improvements including showing connectivity status in the client and sending system notifications for captive portal sign in
+  - The WARP client now applies post-quantum cryptography end-to-end on enabled devices accessing resources behind a Cloudflare Tunnel. This feature can be enabled by MDM.
+  - Improvement to gracefully handle changes made by MDM while WARP is not running.
+  - Fixed an issue affecting split tunnel include mode, where traffic outside the tunnel was blocked when switching between Wifi and ethernet networks.
 version: 2025.5.828.1
 releaseDate: 2025-06-12T22:36:30.420Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/fedora35-arm/version/2025.5.828.1

--- a/src/content/warp-releases/linux/ga/2025.5.893.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.5.893.0.yaml
@@ -14,7 +14,6 @@ releaseNotes: |-
 
   **Known issues**
   - Devices using WARP client 2025.4.929.0 and up may experience Local Domain Fallback failures if a fallback server has not been configured. To configure a fallback server, refer to [Route traffic to fallback server](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/local-domains/#route-traffic-to-fallback-server).
-
 version: 2025.5.893.0
 releaseDate: 2025-06-30T19:44:34.251Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/noble-intel/version/2025.5.893.0


### PR DESCRIPTION
Make generation of release files more explicit, especially for Linux:
 - list supported linux distributions explicitly for inclusion in Linux release notes
 - use literal block option in YAML Stringify for consistency
 - standardize console messages for easier debugging control flow paths when processing linux files

###  Output differences?

No change in visible appearance, but removal of the need to manually modify Linux release notes from `bin/fetch-warp-releases.js` script generated output