### PR TITLE
Document deprecation of client edge transport classes

### DIFF
--- a/src/content/changelog/agents/2025-11-05-mcp-transport-deprecation.mdx
+++ b/src/content/changelog/agents/2025-11-05-mcp-transport-deprecation.mdx
@@ -1,0 +1,102 @@
+---
+title: MCP client transport deprecation - Use standard MCP SDK transports
+description: The custom SSEEdgeClientTransport and StreamableHTTPEdgeClientTransport classes are now deprecated. Migrate to the standard SSEClientTransport and StreamableHTTPClientTransport classes from the MCP SDK, which now support Cloudflare Workers natively.
+products:
+  - agents
+  - workers
+date: 2025-11-05
+---
+
+The Agents SDK previously provided custom `SSEEdgeClientTransport` and `StreamableHTTPEdgeClientTransport` classes to work around limitations in Cloudflare Workers. Since the MCP SDK now natively supports the `duplex` parameter in workerd, these custom transports are no longer necessary.
+
+## What's Changed
+
+The custom edge transport classes (`SSEEdgeClientTransport` and `StreamableHTTPEdgeClientTransport`) are now deprecated and will be removed in the next major version. They have been replaced with thin wrapper classes that emit deprecation warnings and delegate to the standard MCP SDK transports.
+
+**Internal changes:**
+- The Agents SDK now uses the standard `SSEClientTransport` and `StreamableHTTPClientTransport` from `@modelcontextprotocol/sdk` internally
+- Custom fetch overrides and auth header handling have been removed
+- Deprecated wrapper classes are provided for backward compatibility
+
+## Migration Guide
+
+If you're using the edge transport classes directly in your code, update your imports:
+
+### Before (Deprecated)
+
+```ts
+import { SSEEdgeClientTransport } from "agents/mcp";
+import { StreamableHTTPEdgeClientTransport } from "agents/mcp";
+
+const transport = new SSEEdgeClientTransport(
+  new URL("https://mcp-server.example.com/sse"),
+  options
+);
+
+// or
+
+const transport = new StreamableHTTPEdgeClientTransport(
+  new URL("https://mcp-server.example.com/mcp"),
+  options
+);
+```
+
+### After (Recommended)
+
+```ts
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const transport = new SSEClientTransport(
+  new URL("https://mcp-server.example.com/sse"),
+  options
+);
+
+// or
+
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://mcp-server.example.com/mcp"),
+  options
+);
+```
+
+## High-level MCP client API (No changes required)
+
+If you're using the high-level `Agent.addMcpServer()` API, no changes are required. The SDK automatically uses the correct transports internally:
+
+```ts
+// This continues to work without any changes
+await this.addMcpServer(
+  "Weather API",
+  "https://weather-mcp.example.com/mcp"
+);
+```
+
+The high-level API already uses the standard MCP SDK transports and will continue to work seamlessly.
+
+## Timeline
+
+- **Now**: Deprecated classes emit console warnings when instantiated
+- **Next major version**: Deprecated classes will be removed entirely
+
+## Why This Change?
+
+The custom edge transports were originally created to work around limitations in Cloudflare Workers' fetch implementation. Since workerd now supports the `duplex` parameter that the standard MCP SDK requires, these workarounds are no longer necessary. Using the standard MCP SDK transports:
+
+- Reduces maintenance burden
+- Ensures better compatibility with future MCP SDK updates
+- Simplifies the codebase
+- Follows standard MCP patterns
+
+## Resources
+
+- [MCP Transport Documentation](/agents/model-context-protocol/transport)
+- [MCP Client API Reference](/agents/model-context-protocol/mcp-client-api)
+- [Model Context Protocol Specification](https://spec.modelcontextprotocol.io/)
+
+## Need Help?
+
+If you have questions or encounter issues during migration:
+
+- [GitHub Issues](https://github.com/cloudflare/agents/issues) - Report bugs or ask questions
+- [GitHub Discussions](https://github.com/cloudflare/agents/discussions) - Community support

--- a/src/content/docs/agents/model-context-protocol/transport.mdx
+++ b/src/content/docs/agents/model-context-protocol/transport.mdx
@@ -109,3 +109,38 @@ With these few changes, your MCP server will support both transport methods, mak
 While most MCP clients have not yet adopted the new Streamable HTTP transport, you can start testing it today using [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), an adapter that lets MCP clients that otherwise only support local connections work with remote MCP servers.
 
 Follow [this guide](/agents/guides/test-remote-mcp-server/) for instructions on how to connect to your remote MCP server from Claude Desktop, Cursor, Windsurf, and other local MCP clients, using the [`mcp-remote` local proxy](https://www.npmjs.com/package/mcp-remote).
+
+## Advanced: Using transport classes directly
+
+:::note[Deprecated transport classes]
+The `SSEEdgeClientTransport` and `StreamableHTTPEdgeClientTransport` classes previously exported from the Agents SDK have been deprecated. If you were using these classes directly, update your imports to use the transport classes from the MCP TypeScript SDK instead.
+:::
+
+In most cases, you don't need to work with transport classes directly — the `McpAgent` class and the [`addMcpServer()` method](/agents/model-context-protocol/mcp-client-api#addmcpserver) handle transport configuration automatically.
+
+However, if you're building custom MCP client connections outside of the standard Agent patterns, you should use the transport classes from the official MCP TypeScript SDK:
+
+<Tabs syncKey="transportExamples">
+<TabItem label="Before (deprecated)" icon="seti:javascript">
+
+```ts
+// Deprecated - these classes will be removed in the next major version
+import {
+  SSEEdgeClientTransport,
+  StreamableHTTPEdgeClientTransport
+} from "agents/mcp";
+```
+
+</TabItem>
+<TabItem label="After (recommended)" icon="seti:typescript">
+
+```ts
+// Use the official MCP SDK transport classes instead
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+```
+
+</TabItem>
+</Tabs>
+
+The official SDK transport classes have been updated to work natively with Cloudflare Workers since summer 2024, eliminating the need for the custom edge transport wrappers. The behavior and API are identical — only the import path changes.


### PR DESCRIPTION
## Summary
Documents the deprecation of `SSEEdgeClientTransport` and `StreamableHTTPEdgeClientTransport` classes and provides migration guidance for users.

## Changes
- Added deprecation notice in the Transport documentation
- Provided before/after code examples showing how to migrate imports
- Explained that the official MCP SDK transport classes now work natively with Cloudflare Workers

## Context
Related to cloudflare/agents#637 - This PR removed the custom edge transport implementations since the official MCP TypeScript SDK now supports Cloudflare Workers natively (as of summer 2024). The SDK now exports deprecated wrapper classes that log console warnings to guide users to update their imports.

## Target Audience
Users who were directly importing and using these transport classes in custom MCP client implementations (advanced use case - most users rely on the automatic transport handling in `McpAgent` and `addMcpServer()`).

Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>