### PR TITLE
Add Dash0 as observability export option

### DIFF
--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/dash0.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/dash0.mdx
@@ -7,8 +7,8 @@ sidebar:
 
 import {WranglerConfig} from "~/components";
 
-Dash0 is an OpenTelemetry-native observability platform built on open standards that simplifies system monitoring and troubleshooting. With observability in minutes, not months, Dash0 helps teams unify logs, metrics, and distributed traces in a single interface. By exporting your Cloudflare Workers application telemetry to Dash0, you can:
-- Correlate logs, metrics, and distributed traces across your entire system
+Dash0 is an OpenTelemetry-native observability platform built on open standards that simplifies observability and troubleshooting. By exporting your Cloudflare Workers application telemetry to Dash0, you can:
+- Correlate logs and distributed traces across your entire system
 - Instantly search and filter across high-cardinality attributes
 - Troubleshoot issues faster with unified observability
 

--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/dash0.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/dash0.mdx
@@ -1,0 +1,102 @@
+---
+pcx_content_type: how-to
+title: Export to Dash0
+sidebar:
+  order: 6
+---
+
+import {WranglerConfig} from "~/components";
+
+Dash0 is an OpenTelemetry-native observability platform built on open standards that simplifies system monitoring and troubleshooting. With observability in minutes, not months, Dash0 helps teams unify logs, metrics, and distributed traces in a single interface. By exporting your Cloudflare Workers application telemetry to Dash0, you can:
+- Correlate logs, metrics, and distributed traces across your entire system
+- Instantly search and filter across high-cardinality attributes
+- Troubleshoot issues faster with unified observability
+
+This guide will walk you through configuring your Cloudflare Worker application to export OpenTelemetry-compliant traces and logs to Dash0.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- An active [Dash0 account](https://dash0.com/) (free 14-day trial available)
+- A deployed Worker that you want to monitor
+
+## Step 1: Get your Dash0 authorization token and endpoint
+
+1. Log in to your [Dash0 account](https://app.dash0.com/)
+2. Navigate to **Organization Settings**
+3. In the **Endpoints** section, find your ingestion endpoints:
+   - **Traces endpoint**: (e.g., `https://ingress.eu-west-1.aws.dash0.com/v1/traces`)
+   - **Logs endpoint**: (e.g., `https://ingress.eu-west-1.aws.dash0.com/v1/logs`)
+4. Create or copy your **Authorization Token** from the same section
+5. **Important**: Copy the authorization token and store it securely
+
+The authorization token will look something like: `auth_hxZyXotVvAzhhweQJ6egeSEUsgUifw2B`
+
+## Step 2: Configure Cloudflare destinations
+
+Now you'll create destinations in the Cloudflare dashboard that point to Dash0.
+
+### Configure trace destination
+
+1. Navigate to your Cloudflare account's [Workers Observability](https://dash.cloudflare.com/?to=/:account/workers-and-pages/observability/pipelines) section
+2. Click **Add destination**
+3. Configure your trace destination:
+   - **Destination Name**: `dash0-traces` (or any descriptive name)
+   - **Destination Type**: Select **Traces**
+   - **OTLP Endpoint**: Your Dash0 traces endpoint (e.g., `https://ingress.eu-west-1.aws.dash0.com/v1/traces`)
+   - **Custom Headers**: Add the authentication header:
+     - Header name: `Authorization`
+     - Header value: `Bearer <your-auth-token>` (e.g., `Bearer auth_hxZyXotVvAzhhweQJ6egeSEUsgUifw2B`)
+   - **Optional - Dataset Header**: If you want to send data to a specific dataset:
+     - Header name: `Dash0-Dataset`
+     - Header value: Your dataset name (e.g., `default`)
+4. Click **Save**
+
+### Configure logs destination
+
+Repeat the process for logs:
+
+1. Click **Add destination** again
+2. Configure your logs destination:
+   - **Destination Name**: `dash0-logs` (or any descriptive name)
+   - **Destination Type**: Select **Logs**
+   - **OTLP Endpoint**: Your Dash0 logs endpoint (e.g., `https://ingress.eu-west-1.aws.dash0.com/v1/logs`)
+   - **Custom Headers**: Add the authentication header:
+     - Header name: `Authorization`
+     - Header value: `Bearer <your-auth-token>` (same as above)
+   - **Optional - Dataset Header**: If you want to send data to a specific dataset:
+     - Header name: `Dash0-Dataset`
+     - Header value: Your dataset name (e.g., `default`)
+3. Click **Save**
+
+## Step 3: Configure your Worker
+
+With your destinations created in the Cloudflare dashboard, update your Worker's configuration to enable telemetry export.
+
+<WranglerConfig>
+
+```json
+{
+  "observability": {
+    "traces": {
+      "enabled": true,
+      // Must match the destination name in the dashboard
+      "destinations": ["dash0-traces"]
+    },
+    "logs": {
+      "enabled": true,
+      // Must match the destination name in the dashboard
+      "destinations": ["dash0-logs"]
+    }
+  }
+}
+```
+
+</WranglerConfig>
+
+After updating your configuration, deploy your Worker for the changes to take effect.
+
+:::note
+It may take a few minutes after deployment for data to appear in Dash0.
+:::

--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
@@ -7,16 +7,16 @@ sidebar:
 
 import { Badge, DirectoryListing, WranglerConfig } from "~/components";
 
-Cloudflare Workers supports exporting OpenTelemetry (OTel)-compliant telemetry data to any destination with an available OTel endpoint, allowing you to integrate with your existing monitoring and observability stack. 
+Cloudflare Workers supports exporting OpenTelemetry (OTel)-compliant telemetry data to any destination with an available OTel endpoint, allowing you to integrate with your existing monitoring and observability stack.
 
 ### Supported telemetry types
 
 You can export the following types of telemetry data:
 
 - **Traces** - Traces showing request flows through your Worker and connected services
-- **Logs** - Application logs including `console.log()` output and system-generated logs  
+- **Logs** - Application logs including `console.log()` output and system-generated logs
 
-**Note**: exporting Worker metrics and custom metrics is not yet supported. 
+**Note**: exporting Worker metrics and custom metrics is not yet supported.
 
 ### Available OpenTelemetry destinations
 
@@ -29,6 +29,7 @@ Below are common OTLP endpoint formats for popular observability providers. Refe
 | [**Axiom**](/workers/observability/exporting-opentelemetry-data/axiom/) | `https://api.axiom.co/v1/traces` | `https://api.axiom.co/v1/logs` |
 | [**Sentry**](/workers/observability/exporting-opentelemetry-data/sentry/) | `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/traces` | `https://{HOST}/api/{PROJECT_ID}/integration/otlp/v1/logs` |
 | [**Datadog**](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/) | Not yet available. Pending release from Datadog | Not yet available. Pending release from Datadog |
+| [**Dash0**](/workers/observability/exporting-opentelemetry-data/dash0/) | `https://ingress.eu-west-1.aws.dash0.com/v1/traces` | `https://ingress.eu-west-1.aws.dash0.com/v1/logs` |
 
 :::note[Authentication]
 Most providers require authentication headers. Refer to your provider's documentation for specific authentication requirements.
@@ -41,20 +42,20 @@ To start sending data to your destination, you'll need to create a destination i
 
 ![Observability Destinations dashboard showing configured destinations for Grafana and Honeycomb with their respective endpoints and status](~/assets/images/workers-observability/destinations.png)
 
-1. Head to your account's [Workers Observability](https://dash.cloudflare.com/?to=/:account/workers-and-pages/observability/pipelines) section of the dashboard 
-2. Click add destination. 
+1. Head to your account's [Workers Observability](https://dash.cloudflare.com/?to=/:account/workers-and-pages/observability/pipelines) section of the dashboard
+2. Click add destination.
 3. Configure your destination:
    - **Destination Name** - A descriptive name (e.g., "Grafana-tracing", "Honeycomb-Logs")
    - **Destination Type** - Choose between "Traces" or "Logs"
-   - **OTLP Endpoint** - The URL where your observability platform accepts OTLP data. 
-   - **Custom Headers** (Optional) - Any authentication headers or other provider-required headers 
+   - **OTLP Endpoint** - The URL where your observability platform accepts OTLP data.
+   - **Custom Headers** (Optional) - Any authentication headers or other provider-required headers
 4. Save your destination
 
 ![Edit Destination dialog showing configuration for Honeycomb tracing with destination name, type selection, OTLP endpoint, and custom headers](~/assets/images/workers-observability/destination-setup.png)
 
 ## Enabling OpenTelemetry export for your Worker
 
-After setting up destinations in the dashboard, configure your Worker to export telemetry data by updating your Wrangler configuration. Your destination name configured in your configuration file should be the same as the destination configured in the dashboard. 
+After setting up destinations in the dashboard, configure your Worker to export telemetry data by updating your Wrangler configuration. Your destination name configured in your configuration file should be the same as the destination configured in the dashboard.
 
 <WranglerConfig>
 
@@ -64,7 +65,7 @@ After setting up destinations in the dashboard, configure your Worker to export 
     "traces": {
       "enabled": true,
       "destinations": ["tracing-destination-name"],
-      
+
       // traces sample rate of 5%
       "head_sampling_rate": 0.05,
 
@@ -76,7 +77,7 @@ After setting up destinations in the dashboard, configure your Worker to export 
       "destinations": ["logs-destination-name"],
       // logs sample rate of 60%
       "head_sampling_rate": 0.6,
-      
+
       // (optional disable logs in Cloudflare dashboard
       "persist": false
     }
@@ -86,7 +87,7 @@ After setting up destinations in the dashboard, configure your Worker to export 
 
 </WranglerConfig>
 
-Once you've configured your Wrangler configuration file, redeploy your Worker for new configurations to take effect. Note that it may take a few minutes for events to reach your destination. 
+Once you've configured your Wrangler configuration file, redeploy your Worker for new configurations to take effect. Note that it may take a few minutes for events to reach your destination.
 
 ## Destination status
 
@@ -101,7 +102,7 @@ After creating a destination, you can monitor its health and delivery status in 
 | **Error** | An error occurred while attempting to deliver data to this destination. |• Verify OTLP endpoint URL is correct<br />• Check authentication headers are valid<br />|
 
 ## Limits and pricing
-Exporting OTel data is currently **free** to those currently on a Workers Paid subscription or higher during the early beta period. However, starting on **`January 15, 2026`**, tracing will be billed as part of your usage on the Workers Paid plan or contract. 
+Exporting OTel data is currently **free** to those currently on a Workers Paid subscription or higher during the early beta period. However, starting on **`January 15, 2026`**, tracing will be billed as part of your usage on the Workers Paid plan or contract.
 
 This includes the following limits and pricing:
 
@@ -112,5 +113,5 @@ This includes the following limits and pricing:
 
 ## Known limitations
 OpenTelemetry data export is currently in beta. Please be aware of the following limitations:
-- **Metrics export not yet supported**: Exporting Worker infrastructure metrics and custom metrics via OpenTelemetry is not currently available. We are actively working to add metrics support in the future. 
+- **Metrics export not yet supported**: Exporting Worker infrastructure metrics and custom metrics via OpenTelemetry is not currently available. We are actively working to add metrics support in the future.
 - **Limited OTLP support from some providers**: Some observability providers are still rolling out OTLP endpoint support. Check the [Available OpenTelemetry destinations](#available-opentelemetry-destinations) table above for current availability.


### PR DESCRIPTION
### Summary
Added documentation for exporting Cloudflare Workers OpenTelemetry data to Dash0. This documentation follows the same structure and format as existing export options (Honeycomb, Grafana Cloud, Sentry, and Axiom).

The new guide includes:
- Introduction to Dash0's OpenTelemetry-native observability platform
- Prerequisites (Dash0 account with 14-day free trial)
- Step-by-step instructions for obtaining authorization tokens and endpoints
- Configuration for both trace and log destinations with Authorization Bearer tokens
- Optional Dash0-Dataset header configuration for dataset control
- Worker configuration examples

