### PR TITLE
add docs on restart

### DIFF
--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -155,12 +155,6 @@ Once stopped/terminated, the Workflow instance *cannot* be resumed.
 
 ### Restart a Workflow
 
-:::caution
-
-**Known issue**: Restarting a Workflow via the `restart()` method is not currently supported and will throw an exception (error).
-
-:::
-
 ```ts
 let instance = await env.MY_WORKFLOW.get("abc-123")
 await instance.restart() // Returns Promise<void>

--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -25,7 +25,7 @@ Many limits are inherited from those applied to Workers scripts and as documente
 | Maximum steps per Workflow [^5]           | 1024 | 1024 |
 | Maximum Workflow executions               | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#worker-limits) | Unlimited |
 | Concurrent Workflow instances (executions) per account [^7]   | 25 | 10,000 |
-| Maximum Workflow instance creation rate | 100 per second [^6] | 100 per second [^6] |
+| Maximum Workflow instance creation rate [^8] | 100 per second [^6] | 100 per second [^6] |
 | Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 10,000 | 100,000 |
 | Retention limit for completed Workflow state | 3 days | 30 days [^2] |
 | Maximum length of a Workflow name [^4]         | 64 characters | 64 characters |
@@ -43,6 +43,8 @@ Many limits are inherited from those applied to Workers scripts and as documente
 [^6]: Workflows will return a HTTP 429 rate limited error if you exceed the rate of new Workflow instance creation.
 
 [^7]: Only instances with a `running` state count towards the concurrency limits. Instances in the `waiting` state are excluded from these limits.
+
+[^8]: Each instance created or restarted counts towards this limit
 
 <Render file="limits_increase" product="workers" />
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Workflows restart is implemented and working, this means updating limits (as restart counts towards creation rate limits) and we should no longer discourage restart usage.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
