### PR TITLE
WC-4172 Document worker naming limitations, including subdomains

### DIFF
--- a/src/content/docs/workers/configuration/routing/workers-dev.mdx
+++ b/src/content/docs/workers/configuration/routing/workers-dev.mdx
@@ -73,6 +73,22 @@ If you do not specify `workers_dev = false` but add a [`routes` component](/work
 If you disable your `workers.dev` route in the Cloudflare dashboard but do not update your Worker's Wrangler file with `workers_dev = false`, the `workers.dev` route will be re-enabled the next time you deploy your Worker with Wrangler.
 :::
 
+## Limitations
+
+When deploying a Worker with a `workers.dev` subdomain enabled, your Worker name must meet the following requirements:
+
+- Must be 63 characters or less
+- Must contain only alphanumeric characters (`a-z`, `A-Z`, `0-9`) and dashes (`-`)
+- Cannot start or end with a dash (`-`)
+
+These restrictions apply because the Worker name is used as a DNS label in your `workers.dev` URL. DNS labels have a maximum length of 63 characters and cannot begin or end with a dash.
+
+:::note
+
+Worker names can be up to 255 characters when not using a `workers.dev` subdomain. If you need a longer name, you can disable `workers.dev` and use [routes](/workers/configuration/routing/routes/) or [custom domains](/workers/configuration/routing/custom-domains/) instead.
+
+:::
+
 ## Related resources
 
 - [Announcing `workers.dev`](https://blog.cloudflare.com/announcing-workers-dev)

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -100,7 +100,7 @@ The `main` key is optional for assets-only Workers.
 :::
 
 - `name` <Type text="string" /> <MetaInfo text="required" />
-  - The name of your Worker. Alphanumeric characters (`a`,`b`,`c`, etc.) and dashes (`-`) only. Do not use underscores (`_`).
+  - The name of your Worker. Alphanumeric characters (`a`,`b`,`c`, etc.) and dashes (`-`) only. Do not use underscores (`_`). Worker names can be up to 255 characters. If you plan to use a [`workers.dev` subdomain](/workers/configuration/routing/workers-dev/), the name must be 63 characters or less and cannot start or end with a dash.
 
 - `main` <Type text="string" /> <MetaInfo text="required" />
   - The path to the entrypoint of your Worker that will be executed. For example: `./src/index.ts`.


### PR DESCRIPTION
### Summary

Workers deployed to workers.dev subdomains have naming restrictions that weren't documented. This PR adds documentation for these limitations to help users understand why their deployments might fail due to worker name validation.

### Documentation checklist

- [na] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [na] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [na] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
