### PR TITLE
feat: only add lastmod during prod build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_LINK_CHECK: true
+          ENABLE_LAST_MOD_IN_SITEMAP: true
 
       - run: npm run check:worker
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_LINK_CHECK: true
-          ENABLE_LAST_MOD_IN_SITEMAP: true
 
       - run: npm run check:worker
 

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -28,6 +28,7 @@ jobs:
         name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLE_LAST_MOD_IN_SITEMAP: true
       - run: npx wrangler deploy
         name: Deploy to Cloudflare Workers
         env:

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,7 +6,7 @@ import liveCode from "astro-live-code";
 import starlightLinksValidator from "starlight-links-validator";
 import starlightScrollToTop from "starlight-scroll-to-top";
 import icon from "astro-icon";
-import sitemap from "@astrojs/sitemap";
+import sitemap, { type SitemapItem } from "@astrojs/sitemap";
 import react from "@astrojs/react";
 
 import { readdir } from "fs/promises";
@@ -59,7 +59,10 @@ async function autogenStyles() {
 const sidebar = await autogenSections();
 const customCss = await autogenStyles();
 
-const runLinkCheck = process.env.RUN_LINK_CHECK || false;
+const runLinkCheck =
+	process.env.RUN_LINK_CHECK?.toLowerCase() === "true" || false;
+const ENABLE_LAST_MOD_IN_SITEMAP =
+	process.env.ENABLE_LAST_MOD_IN_SITEMAP?.toLowerCase() === "true";
 
 /**
  * Get the last Git modification date for a file
@@ -105,6 +108,22 @@ function urlToFilePath(url: string): string | null {
 	} catch (_error) {
 		return null;
 	}
+}
+
+function addLastModDate(item: SitemapItem) {
+	const filePath = urlToFilePath(item.url);
+	if (filePath) {
+		const gitDate = getGitLastModified(filePath);
+		if (gitDate) {
+			item.lastmod = gitDate;
+		}
+	} else {
+		console.warn(
+			`[sitemap] Could not find last modified for ${item.url} - setting to now`,
+		);
+		item.lastmod = new Date().toISOString();
+	}
+	return item;
 }
 
 // https://astro.build/config
@@ -242,19 +261,7 @@ export default defineConfig({
 				return true;
 			},
 			serialize(item) {
-				const filePath = urlToFilePath(item.url);
-				if (filePath) {
-					const gitDate = getGitLastModified(filePath);
-					if (gitDate) {
-						item.lastmod = gitDate;
-					}
-				} else {
-					console.warn(
-						`[sitemap] Could not find last modified for ${item.url} - setting to now`,
-					);
-					item.lastmod = new Date().toISOString();
-				}
-				return item;
+				return ENABLE_LAST_MOD_IN_SITEMAP ? addLastModDate(item) : item;
 			},
 		}),
 		react(),

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -59,7 +59,7 @@ async function autogenStyles() {
 const sidebar = await autogenSections();
 const customCss = await autogenStyles();
 
-const runLinkCheck =
+const RUN_LINK_CHECK =
 	process.env.RUN_LINK_CHECK?.toLowerCase() === "true" || false;
 const ENABLE_LAST_MOD_IN_SITEMAP =
 	process.env.ENABLE_LAST_MOD_IN_SITEMAP?.toLowerCase() === "true";
@@ -195,7 +195,7 @@ export default defineConfig({
 			customCss,
 			pagination: false,
 			plugins: [
-				...(runLinkCheck
+				...(RUN_LINK_CHECK
 					? [
 							starlightLinksValidator({
 								errorOnInvalidHashes: false,


### PR DESCRIPTION
# Summary

Updates build to only add git-based `lastmod` properties to the sitemap based on the `ENABLE_LAST_MOD_IN_SITEMAP` env var. This var is only set in `publish-production.yml`, which only runs on the `production` branch.

This will speed up non-production build times.

## Merge note

- [x] ~~I'm not going to merge this until I fix a local issue that's breaking local builds.~~ Nevermind; I was getting Warped.