### PR TITLE
containers: add documentation for using external image registries

### DIFF
--- a/src/content/docs/containers/platform-details/image-management.mdx
+++ b/src/content/docs/containers/platform-details/image-management.mdx
@@ -41,7 +41,8 @@ This is not necessary if you are using a pre-built image, as described below.
 
 ## Using pre-built container images
 
-Currently, we support images stored in the Cloudflare managed registry at `registry.cloudflare.com` and in ECR.
+Currently, we support images stored in the Cloudflare managed registry at `registry.cloudflare.com` and in [Amazon ECR](https://aws.amazon.com/ecr/).
+Support for additional external registries is coming soon.
 
 If you wish to use a pre-built image from another registry provider, first, make sure it exists locally, then
 push it to the Cloudflare Registry:
@@ -82,13 +83,14 @@ This will output an image registry URI that you can then use in your Wrangler co
 
 </WranglerConfig>
 
-### Using ECR container images
+### Using Amazon ECR container images
 
-To use container images stored in ECR, you will need to configure the ECR registry domain with credentials.
-We will store these credentials in [Secrets Store](/secrets-store) under the `containers` scope.
-At runtime, these credentials will be used to generate a token to pull your image.
+To use container images stored in [Amazon ECR](https://aws.amazon.com/ecr/), you will need to configure the ECR registry domain with credentials.
+These credentials get stored in [Secrets Store](/secrets-store) under the `containers` scope.
+When we prepare your container, these credentials will be used to generate an ephemeral token that can pull your image.
 At this time, we don't support public ECR images.
-To generate the necessary credentials for ECR, you will need to create an IAM user with the following read-only policy.
+To generate the necessary credentials for ECR, you will need to create an IAM user with a read-only policy.
+The following example grants access to all image repositories under AWS account `123456789012` in `us-east-1`.
 
 ```json
 {
@@ -108,9 +110,8 @@ To generate the necessary credentials for ECR, you will need to create an IAM us
 			],
 			// arn:${Partition}:ecr:${Region}:${Account}:repository/${Repository-name}
 			"Resource": [
-				"arn:aws:ecr:us-east-1:123456789012:repository/my-repo",
-				"arn:aws:ecr:us-east-1:123456789012:repository/my-second-repo"
-				// "arn:aws:ecr:us-east-1:123456789012:repository/*"
+				"arn:aws:ecr:us-east-1:123456789012:repository/*"
+				// "arn:aws:ecr:us-east-1:123456789012:repository/example-repo",
 			]
 		}
 	]
@@ -133,7 +134,7 @@ Once this is setup, you will be able to use ECR images in your wrangler config.
 ```json
 {
 	"containers": {
-		"image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:tag"
+		"image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/example-repo:tag"
 		// ...rest of config...
 	}
 }

--- a/src/content/docs/containers/platform-details/image-management.mdx
+++ b/src/content/docs/containers/platform-details/image-management.mdx
@@ -41,16 +41,10 @@ This is not necessary if you are using a pre-built image, as described below.
 
 ## Using pre-built container images
 
-Currently, all images must use `registry.cloudflare.com`.
+Currently, we support images stored in the Cloudflare managed registry at `registry.cloudflare.com` and in ECR.
 
-:::note
-We plan to allow other image registries. Cloudflare will download your image, optionally using auth credentials,
-then cache it globally in the Cloudflare Registry.
-
-This is not yet available.
-:::
-
-If you wish to use a pre-built image, first, make sure it exists locally, then push it to the Cloudflare Registry:
+If you wish to use a pre-built image from another registry provider, first, make sure it exists locally, then
+push it to the Cloudflare Registry:
 
 ```
 docker pull <public-image>
@@ -81,6 +75,65 @@ This will output an image registry URI that you can then use in your Wrangler co
 {
 	"containers": {
 		"image": "registry.cloudflare.com/your-account-id/your-image:tag"
+		// ...rest of config...
+	}
+}
+```
+
+</WranglerConfig>
+
+### Using ECR container images
+
+To use container images stored in ECR, you will need to configure the ECR registry domain with credentials.
+We will store these credentials in [Secrets Store](/secrets-store) under the `containers` scope.
+At runtime, these credentials will be used to generate a token to pull your image.
+At this time, we don't support public ECR images.
+To generate the necessary credentials for ECR, you will need to create an IAM user with the following read-only policy.
+
+```json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Action": ["ecr:GetAuthorizationToken"],
+			"Effect": "Allow",
+			"Resource": "*"
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				"ecr:BatchCheckLayerAvailability",
+				"ecr:GetDownloadUrlForLayer",
+				"ecr:BatchGetImage"
+			],
+			// arn:${Partition}:ecr:${Region}:${Account}:repository/${Repository-name}
+			"Resource": [
+				"arn:aws:ecr:us-east-1:123456789012:repository/my-repo",
+				"arn:aws:ecr:us-east-1:123456789012:repository/my-second-repo"
+				// "arn:aws:ecr:us-east-1:123456789012:repository/*"
+			]
+		}
+	]
+}
+```
+
+You can then use the credentials for the IAM User to [configure a registry in wrangler](/workers/wrangler/commands/#containers-registries).
+Wrangler will prompt you to create a Secrets Store store if one does not already exist, and then create your secret.
+
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="containers registries configure 123456789012.dkr.ecr.us-east-1.amazonaws.com --aws-access-key-id=AKIAIOSFODNN7EXAMPLE"
+/>
+
+Once this is setup, you will be able to use ECR images in your wrangler config.
+
+<WranglerConfig>
+
+```json
+{
+	"containers": {
+		"image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:tag"
 		// ...rest of config...
 	}
 }

--- a/src/content/docs/containers/platform-details/image-management.mdx
+++ b/src/content/docs/containers/platform-details/image-management.mdx
@@ -88,7 +88,7 @@ This will output an image registry URI that you can then use in your Wrangler co
 To use container images stored in [Amazon ECR](https://aws.amazon.com/ecr/), you will need to configure the ECR registry domain with credentials.
 These credentials get stored in [Secrets Store](/secrets-store) under the `containers` scope.
 When we prepare your container, these credentials will be used to generate an ephemeral token that can pull your image.
-At this time, we don't support public ECR images.
+We do not currently support public ECR images.
 To generate the necessary credentials for ECR, you will need to create an IAM user with a read-only policy.
 The following example grants access to all image repositories under AWS account `123456789012` in `us-east-1`.
 

--- a/src/content/docs/containers/platform-details/image-management.mdx
+++ b/src/content/docs/containers/platform-details/image-management.mdx
@@ -111,14 +111,14 @@ The following example grants access to all image repositories under AWS account 
 			// arn:${Partition}:ecr:${Region}:${Account}:repository/${Repository-name}
 			"Resource": [
 				"arn:aws:ecr:us-east-1:123456789012:repository/*"
-				// "arn:aws:ecr:us-east-1:123456789012:repository/example-repo",
+				// "arn:aws:ecr:us-east-1:123456789012:repository/example-repo"
 			]
 		}
 	]
 }
 ```
 
-You can then use the credentials for the IAM User to [configure a registry in wrangler](/workers/wrangler/commands/#containers-registries).
+You can then use the credentials for the IAM User to [configure a registry in Wrangler](/workers/wrangler/commands/#containers-registries).
 Wrangler will prompt you to create a Secrets Store store if one does not already exist, and then create your secret.
 
 <PackageManagers

--- a/src/content/partials/workers/wrangler-commands/containers.mdx
+++ b/src/content/partials/workers/wrangler-commands/containers.mdx
@@ -67,6 +67,67 @@ wrangler containers images delete [IMAGE] [OPTIONS]
 - `IMAGE` <Type text="string" /> <MetaInfo text="required" />
   - Image to delete of the form `IMAGE:TAG`
 
+<AnchorHeading title="`registries`" slug="containers-registries" depth={3} />
+
+Configure and view registries available to your container.
+[Read more](/containers/platform-details/image-management/#using-ecr-container-images) about our currently supported external registries.
+
+<AnchorHeading
+	title="`registries list`"
+	slug="containers-registries-list"
+	depth={4}
+/>
+
+List registries your containers are able to use.
+
+```txt
+wrangler containers registries list [OPTIONS]
+```
+
+- `--json` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Return output as clean JSON.
+  - Default: false
+
+<AnchorHeading
+	title="`registries configure`"
+	slug="containers-registries-configure"
+	depth={4}
+/>
+
+Configure a new registry for your account.
+
+```txt
+wrangler containers registries configure [DOMAIN] [OPTIONS]
+```
+
+- `DOMAIN` <Type text="string" /> <MetaInfo text="required" />
+  - domain to configre for the registry
+- `--public-credential` <Type text="string" /> <MetaInfo text="required" />
+  - The public part of the registry credentials, e.g. `AWS_ACCESS_KEY_ID` for ECR
+- `--secret-store-id` <Type text="string" /> <MetaInfo text="optional" />
+  - The ID of the secret store to use to store the registry credentials
+- `--secret-name` <Type text="string" /> <MetaInfo text="optional" />
+  - The name Wrangler should store the registry credentials under
+
+When run interactively, wrangler will prompt you for your secret and store it in Secrets Store.
+To run non-interactively, you can send your secret value to wrangler through stdin to have
+the secret created for you.
+
+<AnchorHeading
+	title="`registries delete`"
+	slug="containers-registries-delete"
+	depth={4}
+/>
+
+Remove a registry configuration from your account.
+
+```txt
+wrangler containers registries delete [DOMAIN] [OPTIONS]
+```
+
+- `DOMAIN` <Type text="string" /> <MetaInfo text="required" />
+  - domain of the registry to delete
+
 <AnchorHeading title="`info`" slug="containers-info" depth={3} />
 
 Get information about a specific Container, including top-level details and a list of instances.

--- a/src/content/partials/workers/wrangler-commands/containers.mdx
+++ b/src/content/partials/workers/wrangler-commands/containers.mdx
@@ -70,7 +70,7 @@ wrangler containers images delete [IMAGE] [OPTIONS]
 <AnchorHeading title="`registries`" slug="containers-registries" depth={3} />
 
 Configure and view registries available to your container.
-[Read more](/containers/platform-details/image-management/#using-ecr-container-images) about our currently supported external registries.
+[Read more](/containers/platform-details/image-management/#using-amazon-ecr-container-images) about our currently supported external registries.
 
 <AnchorHeading
 	title="`registries list`"


### PR DESCRIPTION
### Summary

Adds documentation to configure ECR registries for use with containers.
After setting up the registry, users will be able to use ECR images int their `wrangler.jsonc` as follows:

```json
"containers": {
  "class_name": "MyECRContainer"
  "image": "123456789012.dkr.ecr.us-east-1.amazonaws.com/image:tag"
}
```

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
