### PR TITLE
Extend the D1 how much worker can a database can do

### DIFF
--- a/src/content/partials/d1/faq-limits.mdx
+++ b/src/content/partials/d1/faq-limits.mdx
@@ -40,7 +40,7 @@ To ensure your queries are fast and efficient, [use appropriate indexes in your 
 
 #### CPU and memory
 
-A D1 database's operations, including query execution and result serialization, run within CPU and memory limits similar to [Workers platform limits](https://developers.cloudflare.com/workers/platform/limits/#memory).
+Operations on a D1 database, including query execution and result serialization, run within the [Workers platform CPU and memory limits](/workers/platform/limits/#memory).
 
 Exceeding these limits, or hitting other platform limits, will generate errors. Refer to the [D1 error list for more details](/d1/observability/debug-d1/#error-list).
 

--- a/src/content/partials/d1/faq-limits.mdx
+++ b/src/content/partials/d1/faq-limits.mdx
@@ -4,14 +4,45 @@
 
 ### How much work can a D1 database do?
 
-D1 is designed for horizontal scale out across multiple, smaller (10 GB) databases, such as per-user, per-tenant or per-entity databases. D1 allows you to build applications with thousands of databases at no extra cost for isolating with multiple databases, as the pricing is based only on query and storage costs.
+D1 is designed for horizontal scale out across multiple, smaller (10 GB) databases, such as per-user, per-tenant or per-entity databases.
+D1 allows you to build applications with thousands of databases at no extra cost, as the pricing is based only on query and storage costs.
 
-- Each D1 database can store up to 10 GB of data, and you can create up to thousands of separate D1 databases. This allows you to split a single monolithic database into multiple, smaller databases, thereby isolating application data by user, customer, or tenant.
-- SQL queries over a smaller working data set can be more efficient and performant while improving data isolation.
+#### Storage
+
+Each D1 database can store up to 10 GB of data.
 
 :::caution
 Note that the 10 GB limit of a D1 database cannot be further increased.
 :::
+
+#### Concurrency and throughput
+
+Each individual D1 database is inherently single-threaded, and processes queries one at a time.
+
+Your maximum throughput is directly related to the duration of your queries.
+
+- If your average query takes 1ms, you can run approximately 1,000 queries per second.
+- If your average query takes 100ms, you can run 10 queries per second.
+
+A database that receives too many concurrent requests will first attempt to queue them. If the queue becomes full, the database will return an ["overloaded" error](/d1/observability/debug-d1/#error-list).
+
+Each individual D1 database is backed by a single [Durable Object](/durable-objects/concepts/what-are-durable-objects/).
+
+#### Query performance
+
+Query performance is the most important factor for throughput. As a rough guideline:
+
+- Read queries like `SELECT name FROM users WHERE id = ?` with an appropriate index on `id` will take less than a millisecond.
+- Write queries like `INSERT` or `UPDATE` can take several milliseconds, and depend on the number of rows written. Writes need to be durably persisted across several locations, [read how D1 persists data under the hood](https://blog.cloudflare.com/d1-read-replication-beta/#under-the-hood-how-d1-read-replication-is-implemented).
+- Data migrations like a large `UPDATE` or `DELETE` affecting millions of rows must be run in batches. A single query that attempts to modify multiple gigabytes of data at once will exceed execution limits. Break the work into smaller chunks (e.g., processing 1,000 rows at a time) to stay within platform limits.
+
+To ensure your queries are fast and efficient, [use appropriate indexes in your SQL schema](https://developers.cloudflare.com/d1/best-practices/use-indexes/).
+
+#### CPU and memory
+
+A D1 database's operations, including query execution and result serialization, run within CPU and memory limits similar to [Workers platform limits](https://developers.cloudflare.com/workers/platform/limits/#memory).
+
+Exceeding these limits, or hitting other platform limits, will generate errors. Refer to the [D1 error list for more details](/d1/observability/debug-d1/#error-list).
 
 ### How many simultaneous connections can a Worker open to D1?
 

--- a/src/content/partials/d1/faq-limits.mdx
+++ b/src/content/partials/d1/faq-limits.mdx
@@ -26,7 +26,7 @@ Your maximum throughput is directly related to the duration of your queries.
 
 A database that receives too many concurrent requests will first attempt to queue them. If the queue becomes full, the database will return an ["overloaded" error](/d1/observability/debug-d1/#error-list).
 
-Each individual D1 database is backed by a single [Durable Object](/durable-objects/concepts/what-are-durable-objects/).
+Each individual D1 database is backed by a single [Durable Object](/durable-objects/concepts/what-are-durable-objects/). When using [D1 read replication](https://developers.cloudflare.com/d1/best-practices/read-replication/#primary-database-instance-vs-read-replicas) each replica instance is a different Durable Object and the guidelines apply to each replica instance independently.
 
 #### Query performance
 

--- a/src/content/partials/d1/faq-limits.mdx
+++ b/src/content/partials/d1/faq-limits.mdx
@@ -34,7 +34,7 @@ Query performance is the most important factor for throughput. As a rough guidel
 
 - Read queries like `SELECT name FROM users WHERE id = ?` with an appropriate index on `id` will take less than a millisecond.
 - Write queries like `INSERT` or `UPDATE` can take several milliseconds, and depend on the number of rows written. Writes need to be durably persisted across several locations - learn more on [how D1 persists data under the hood](https://blog.cloudflare.com/d1-read-replication-beta/#under-the-hood-how-d1-read-replication-is-implemented).
-- Data migrations like a large `UPDATE` or `DELETE` affecting millions of rows must be run in batches. A single query that attempts to modify multiple gigabytes of data at once will exceed execution limits. Break the work into smaller chunks (e.g., processing 1,000 rows at a time) to stay within platform limits.
+- Data migrations like a large `UPDATE` or `DELETE` affecting millions of rows must be run in batches. A single query that attempts to modify hundreds of thousands of rows or hundreds of MBs of data at once will exceed execution limits. Break the work into smaller chunks (e.g., processing 1,000 rows at a time) to stay within platform limits.
 
 To ensure your queries are fast and efficient, [use appropriate indexes in your SQL schema](/d1/best-practices/use-indexes/).
 

--- a/src/content/partials/d1/faq-limits.mdx
+++ b/src/content/partials/d1/faq-limits.mdx
@@ -21,8 +21,8 @@ Each individual D1 database is inherently single-threaded, and processes queries
 
 Your maximum throughput is directly related to the duration of your queries.
 
-- If your average query takes 1ms, you can run approximately 1,000 queries per second.
-- If your average query takes 100ms, you can run 10 queries per second.
+- If your average query takes 1 ms, you can run approximately 1,000 queries per second.
+- If your average query takes 100 ms, you can run 10 queries per second.
 
 A database that receives too many concurrent requests will first attempt to queue them. If the queue becomes full, the database will return an ["overloaded" error](/d1/observability/debug-d1/#error-list).
 
@@ -33,10 +33,10 @@ Each individual D1 database is backed by a single [Durable Object](/durable-obje
 Query performance is the most important factor for throughput. As a rough guideline:
 
 - Read queries like `SELECT name FROM users WHERE id = ?` with an appropriate index on `id` will take less than a millisecond.
-- Write queries like `INSERT` or `UPDATE` can take several milliseconds, and depend on the number of rows written. Writes need to be durably persisted across several locations, [read how D1 persists data under the hood](https://blog.cloudflare.com/d1-read-replication-beta/#under-the-hood-how-d1-read-replication-is-implemented).
+- Write queries like `INSERT` or `UPDATE` can take several milliseconds, and depend on the number of rows written. Writes need to be durably persisted across several locations - learn more on [how D1 persists data under the hood](https://blog.cloudflare.com/d1-read-replication-beta/#under-the-hood-how-d1-read-replication-is-implemented).
 - Data migrations like a large `UPDATE` or `DELETE` affecting millions of rows must be run in batches. A single query that attempts to modify multiple gigabytes of data at once will exceed execution limits. Break the work into smaller chunks (e.g., processing 1,000 rows at a time) to stay within platform limits.
 
-To ensure your queries are fast and efficient, [use appropriate indexes in your SQL schema](https://developers.cloudflare.com/d1/best-practices/use-indexes/).
+To ensure your queries are fast and efficient, [use appropriate indexes in your SQL schema](/d1/best-practices/use-indexes/).
 
 #### CPU and memory
 

--- a/src/content/partials/d1/faq-limits.mdx
+++ b/src/content/partials/d1/faq-limits.mdx
@@ -33,7 +33,7 @@ Each individual D1 database is backed by a single [Durable Object](/durable-obje
 Query performance is the most important factor for throughput. As a rough guideline:
 
 - Read queries like `SELECT name FROM users WHERE id = ?` with an appropriate index on `id` will take less than a millisecond.
-- Write queries like `INSERT` or `UPDATE` can take several milliseconds, and depend on the number of rows written. Writes need to be durably persisted across several locations - learn more on [how D1 persists data under the hood](https://blog.cloudflare.com/d1-read-replication-beta/#under-the-hood-how-d1-read-replication-is-implemented).
+- Write queries like `INSERT` or `UPDATE` can take several milliseconds for SQL duration, and depend on the number of rows written. Writes need to be durably persisted across several locations - learn more on [how D1 persists data under the hood](https://blog.cloudflare.com/d1-read-replication-beta/#under-the-hood-how-d1-read-replication-is-implemented).
 - Data migrations like a large `UPDATE` or `DELETE` affecting millions of rows must be run in batches. A single query that attempts to modify hundreds of thousands of rows or hundreds of MBs of data at once will exceed execution limits. Break the work into smaller chunks (e.g., processing 1,000 rows at a time) to stay within platform limits.
 
 To ensure your queries are fast and efficient, [use appropriate indexes in your SQL schema](/d1/best-practices/use-indexes/).

--- a/src/content/partials/d1/faq-limits.mdx
+++ b/src/content/partials/d1/faq-limits.mdx
@@ -32,7 +32,7 @@ Each individual D1 database is backed by a single [Durable Object](/durable-obje
 
 Query performance is the most important factor for throughput. As a rough guideline:
 
-- Read queries like `SELECT name FROM users WHERE id = ?` with an appropriate index on `id` will take less than a millisecond.
+- Read queries like `SELECT name FROM users WHERE id = ?` with an appropriate index on `id` will take less than a millisecond for SQL duration.
 - Write queries like `INSERT` or `UPDATE` can take several milliseconds for SQL duration, and depend on the number of rows written. Writes need to be durably persisted across several locations - learn more on [how D1 persists data under the hood](https://blog.cloudflare.com/d1-read-replication-beta/#under-the-hood-how-d1-read-replication-is-implemented).
 - Data migrations like a large `UPDATE` or `DELETE` affecting millions of rows must be run in batches. A single query that attempts to modify hundreds of thousands of rows or hundreds of MBs of data at once will exceed execution limits. Break the work into smaller chunks (e.g., processing 1,000 rows at a time) to stay within platform limits.
 


### PR DESCRIPTION
### Summary

Rewording the D1 documentation about how much work can be done since this is a very common question by D1 users.

### Screenshots (optional)

<img width="692" height="1158" alt="Screenshot 2025-11-07 at 11 41 46" src="https://github.com/user-attachments/assets/83846317-7e0c-4afc-a27f-6a0c32a03011" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
