### PR TITLE
feat: add automatic resource provisioning documentation

### DIFF
--- a/src/components/WranglerConfig.astro
+++ b/src/components/WranglerConfig.astro
@@ -3,6 +3,13 @@ import { parse } from "node-html-parser";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import TOML from "@iarna/toml";
 import { parse as jsoncParse } from "jsonc-parser";
+import { z } from "astro:schema";
+
+const props = z.object({
+	removeSchema: z.boolean().optional().default(false),
+});
+
+const { removeSchema } = props.parse(Astro.props);
 
 const slot = await Astro.slots.render("default");
 
@@ -12,7 +19,7 @@ const copy = html.querySelector("div.copy > button");
 
 if (!copy) {
 	throw new Error(
-		`[WranglerConfig] Unable to find copy button in rendered code block HTML.`,
+		`[WranglerConfig] Unable to find copy button in rendered code block HTML.`
 	);
 }
 
@@ -20,7 +27,7 @@ let code = copy.attributes["data-code"];
 
 if (!code) {
 	throw new Error(
-		`[WranglerConfig] Unable to find data-code attribute on copy button.`,
+		`[WranglerConfig] Unable to find data-code attribute on copy button.`
 	);
 }
 
@@ -38,10 +45,11 @@ let toml, json;
 
 if (language === "toml") {
 	toml = code;
-	json = JSON.stringify({
-		"$schema": "./node_modules/wrangler/config-schema.json",
-		...TOML.parse(code),
-	}, null, 2);
+	const parsedToml = TOML.parse(code);
+	const jsonObj = removeSchema
+		? parsedToml
+		: { $schema: "./node_modules/wrangler/config-schema.json", ...parsedToml };
+	json = JSON.stringify(jsonObj, null, 2);
 } else {
 	json = code;
 	toml = TOML.stringify(jsoncParse(code));

--- a/src/content/docs/style-guide/components/wrangler-config.mdx
+++ b/src/content/docs/style-guide/components/wrangler-config.mdx
@@ -11,7 +11,6 @@ This component can be used to automatically generate a `jsonc` version of the `t
 ```mdx
 import { WranglerConfig } from "~/components";
 
-;
 ```
 
 ## Usage

--- a/src/content/docs/style-guide/components/wrangler-config.mdx
+++ b/src/content/docs/style-guide/components/wrangler-config.mdx
@@ -10,6 +10,8 @@ This component can be used to automatically generate a `jsonc` version of the `t
 
 ```mdx
 import { WranglerConfig } from "~/components";
+
+;
 ```
 
 ## Usage
@@ -25,11 +27,9 @@ database_name = "prod-d1-tutorial"
 database_id = "<unique-ID-for-your-database>"
 ```
 </WranglerConfig>
-
 ````
 
 A `$today` value can be used in this component to automatically insert the today's date. This is useful for suggesting that users set the latest compatibility date.
-
 
 ````mdx live
 import { WranglerConfig } from "~/components";
@@ -42,5 +42,21 @@ import { WranglerConfig } from "~/components";
 }
 ```
 </WranglerConfig>
+````
 
+The `removeSchema` prop can be used to remove the `$schema` reference from the generated JSON file. This can be useful if you want to add snippets of configuration files that are easier to copy paste, and are providing toml as the source config format.
+
+If you provide jsonc as the source config format, the `removeSchema` prop will be ignored.
+
+````mdx live
+import { WranglerConfig } from "~/components";
+
+<WranglerConfig removeSchema>
+```toml
+[[d1_databases]]
+binding = "DB" # available in your Worker on env.DB
+database_name = "prod-d1-tutorial"
+database_id = "<unique-ID-for-your-database>"
+```
+</WranglerConfig>
 ````

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -77,7 +77,8 @@ Further, there are a few keys that can _only_ appear at the top-level.
 
 <Render file="vite-environments" product="workers" />
 
-## Automatic provisioning <a href="https://developers.cloudflare.com/changelog/2025-10-24-automatic-resource-provisioning/" target="_blank"><InlineBadge preset="beta" /></a>
+## Automatic provisioning
+<a href="https://developers.cloudflare.com/changelog/2025-10-24-automatic-resource-provisioning/" target="_blank"><InlineBadge preset="beta" /></a>
 
 Wrangler can automatically provision resources for you when you deploy your Worker without you having to create them ahead of time.
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1422,57 +1422,63 @@ This is because such a file, when required, should be created as part of a build
 
 A common example of using a redirected configuration is where a custom build tool, or framework, wants to modify the user's configuration to be used when deploying, by generating a new configuration in a `dist` directory.
 
-1. First, the user writes code that uses Cloudflare Workers resources, configured via a user's Wrangler configuration file like the following:
+- First, the user writes code that uses Cloudflare Workers resources, configured via a user's Wrangler configuration file like the following:
 
   <WranglerConfig>
 
-```toml title="wrangler.toml"
-name = "my-worker"
-main = "src/index.ts"
+  ```toml title="wrangler.toml"
+  name = "my-worker"
+  main = "src/index.ts"
 
-[vars]
-MY_VARIABLE = "production variable"
+  [vars]
+  MY_VARIABLE = "production variable"
 
-[env.staging.vars]
-MY_VARIABLE = "staging variable"
-```
+  [env.staging.vars]
+  MY_VARIABLE = "staging variable"
+  ```
 
   </WranglerConfig>
 
-This configuration points `main` at the user's code entry-point and defines the `MY_VARIABLE` variable in two different environments.
+  This configuration points `main` at the user's code entry-point and defines the `MY_VARIABLE` variable in two different environments.
 
-2. Then, the user runs a custom build for a given environment (for example `staging`). This will read the user's Wrangler configuration file to find the source code entry-point and environment specific settings:
+- Then, the user runs a custom build for a given environment (for example `staging`). This will read the user's Wrangler configuration file to find the source code entry-point and environment specific settings:
 
-```bash
-> my-tool build --env=staging
-```
+  ```bash
+  > my-tool build --env=staging
+  ```
 
-3. `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file, containing only the settings for the given environment.
-   It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
+- `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file, containing only the settings for the given environment.
+  It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
 
-   <FileTree>
-   	- dist - index.js - wrangler.jsonc - .wrangler - deploy - config.json
-   </FileTree>
+  <FileTree>
+- dist
+  - index.js
+  - wrangler.jsonc
+- .wrangler
+  - deploy
+    - config.json
 
-The generated `dist/wrangler.jsonc` might contain:
+  </FileTree>
 
-```json
-{
-	"name": "my-worker",
-	"main": "./index.js",
-	"vars": {
-		"MY_VARIABLE": "staging variable"
-	}
-}
-```
+  The generated `dist/wrangler.jsonc` might contain:
 
-Now, the `main` property points to the generated code entry-point, no environment is defined,
-and the `MY_VARIABLE` variable is resolved to the staging environment value.
+  ```json
+  {
+  	"name": "my-worker",
+  	"main": "./index.js",
+  	"vars": {
+  		"MY_VARIABLE": "staging variable"
+  	}
+  }
+  ```
 
-And the `.wrangler/deploy/config.json` contains the path to the generated configuration file:
+  Now, the `main` property points to the generated code entry-point, no environment is defined,
+  and the `MY_VARIABLE` variable is resolved to the staging environment value.
 
-```json
-{
-	"configPath": "../../dist/wrangler.jsonc"
-}
-```
+  And the `.wrangler/deploy/config.json` contains the path to the generated configuration file:
+
+  ```json
+  {
+  	"configPath": "../../dist/wrangler.jsonc"
+  }
+  ```

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1450,35 +1450,34 @@ A common example of using a redirected configuration is where a custom build too
 - `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file, containing only the settings for the given environment.
   It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
 
-  <FileTree>
-- dist
-  - index.js
-  - wrangler.jsonc
-- .wrangler
-  - deploy
-    - config.json
+	<FileTree>
+		- dist
+  		- index.js
+  		- wrangler.jsonc
+		- .wrangler
+  		- deploy
+    		- config.json
+	</FileTree>
 
-  </FileTree>
+The generated `dist/wrangler.jsonc` might contain:
 
-  The generated `dist/wrangler.jsonc` might contain:
+```json
+{
+	"name": "my-worker",
+	"main": "./index.js",
+	"vars": {
+		"MY_VARIABLE": "staging variable"
+	}
+}
+```
 
-  ```json
-  {
-  	"name": "my-worker",
-  	"main": "./index.js",
-  	"vars": {
-  		"MY_VARIABLE": "staging variable"
-  	}
-  }
-  ```
+Now, the `main` property points to the generated code entry-point, no environment is defined,
+and the `MY_VARIABLE` variable is resolved to the staging environment value.
 
-  Now, the `main` property points to the generated code entry-point, no environment is defined,
-  and the `MY_VARIABLE` variable is resolved to the staging environment value.
+And the `.wrangler/deploy/config.json` contains the path to the generated configuration file:
 
-  And the `.wrangler/deploy/config.json` contains the path to the generated configuration file:
-
-  ```json
-  {
-  	"configPath": "../../dist/wrangler.jsonc"
-  }
-  ```
+```json
+{
+	"configPath": "../../dist/wrangler.jsonc"
+}
+```

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -9,7 +9,13 @@ description: Use a configuration file to customize the
   Platform products.
 ---
 
-import { Render, Type, MetaInfo, WranglerConfig } from "~/components";
+import {
+	Render,
+	Type,
+	MetaInfo,
+	WranglerConfig,
+	InlineBadge,
+} from "~/components";
 import { FileTree } from "@astrojs/starlight/components";
 
 Wrangler optionally uses a configuration file to customize the development and deployment setup for a Worker.
@@ -70,6 +76,28 @@ The majority of keys are inheritable, meaning that top-level configuration can b
 Further, there are a few keys that can _only_ appear at the top-level.
 
 <Render file="vite-environments" product="workers" />
+
+## Automatic provisioning <a href="https://developers.cloudflare.com/changelog/2025-10-24-automatic-resource-provisioning/" target="_blank"><InlineBadge preset="beta" /></a>
+
+Wrangler can automatically provision resources for you when you deploy your Worker without you having to create them ahead of time.
+
+This currently works for KV, R2 and D1 bindings.
+
+To use this feature, add bindings to your configuration file _without_ adding resource IDs, or in the case of R2, a bucket name. Resources will be created with the name of your worker as the prefix.
+
+<WranglerConfig removeSchema>
+
+```toml
+kv_namespaces = [
+  { binding = "<MY_KV_NAMESPACE>" }
+]
+```
+
+</WranglerConfig>
+
+When you run `wrangler dev` local resources will automatically be created which persist between runs. When you run `wrangler deploy` resources will be created for you, and their IDs will be written back to your configuration file.
+
+If you deploy a worker with resources and no resource IDs from the dashboard (eg. via GitHub), resources will be created, but their IDs will only be accessible via the dashboard. Currently these resource IDs will not be written back to your repository.
 
 ## Top-level only keys
 
@@ -1394,63 +1422,57 @@ This is because such a file, when required, should be created as part of a build
 
 A common example of using a redirected configuration is where a custom build tool, or framework, wants to modify the user's configuration to be used when deploying, by generating a new configuration in a `dist` directory.
 
-- First, the user writes code that uses Cloudflare Workers resources, configured via a user's Wrangler configuration file like the following:
+1. First, the user writes code that uses Cloudflare Workers resources, configured via a user's Wrangler configuration file like the following:
 
   <WranglerConfig>
 
-  ```toml title="wrangler.toml"
-  name = "my-worker"
-  main = "src/index.ts"
+```toml title="wrangler.toml"
+name = "my-worker"
+main = "src/index.ts"
 
-  [vars]
-  MY_VARIABLE = "production variable"
+[vars]
+MY_VARIABLE = "production variable"
 
-  [env.staging.vars]
-  MY_VARIABLE = "staging variable"
-  ```
+[env.staging.vars]
+MY_VARIABLE = "staging variable"
+```
 
   </WranglerConfig>
 
-  This configuration points `main` at the user's code entry-point and defines the `MY_VARIABLE` variable in two different environments.
+This configuration points `main` at the user's code entry-point and defines the `MY_VARIABLE` variable in two different environments.
 
-- Then, the user runs a custom build for a given environment (for example `staging`). This will read the user's Wrangler configuration file to find the source code entry-point and environment specific settings:
+2. Then, the user runs a custom build for a given environment (for example `staging`). This will read the user's Wrangler configuration file to find the source code entry-point and environment specific settings:
 
-  ```bash
-  > my-tool build --env=staging
-  ```
+```bash
+> my-tool build --env=staging
+```
 
-- `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file, containing only the settings for the given environment.
-  It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
+3. `my-tool` generates a `dist` directory that contains both compiled code and a new generated deployment configuration file, containing only the settings for the given environment.
+   It also creates a `.wrangler/deploy/config.json` file that redirects Wrangler to the new, generated deployment configuration file:
 
-  <FileTree>
-  - dist
-    - index.js
-    - wrangler.jsonc
-  - .wrangler
-    - deploy
-      - config.json
+   <FileTree>
+   	- dist - index.js - wrangler.jsonc - .wrangler - deploy - config.json
+   </FileTree>
 
-  </FileTree>
+The generated `dist/wrangler.jsonc` might contain:
 
-  The generated `dist/wrangler.jsonc` might contain:
+```json
+{
+	"name": "my-worker",
+	"main": "./index.js",
+	"vars": {
+		"MY_VARIABLE": "staging variable"
+	}
+}
+```
 
-  ```json
-  {
-  	"name": "my-worker",
-  	"main": "./index.js",
-  	"vars": {
-  		"MY_VARIABLE": "staging variable"
-  	}
-  }
-  ```
+Now, the `main` property points to the generated code entry-point, no environment is defined,
+and the `MY_VARIABLE` variable is resolved to the staging environment value.
 
-  Now, the `main` property points to the generated code entry-point, no environment is defined,
-  and the `MY_VARIABLE` variable is resolved to the staging environment value.
+And the `.wrangler/deploy/config.json` contains the path to the generated configuration file:
 
-  And the `.wrangler/deploy/config.json` contains the path to the generated configuration file:
-
-  ```json
-  {
-  	"configPath": "../../dist/wrangler.jsonc"
-  }
-  ```
+```json
+{
+	"configPath": "../../dist/wrangler.jsonc"
+}
+```

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -81,7 +81,7 @@ Further, there are a few keys that can _only_ appear at the top-level.
 
 Wrangler can automatically provision resources for you when you deploy your Worker without you having to create them ahead of time.
 
-This currently works for KV, R2 and D1 bindings.
+This currently works for KV, R2, and D1 bindings.
 
 To use this feature, add bindings to your configuration file _without_ adding resource IDs, or in the case of R2, a bucket name. Resources will be created with the name of your worker as the prefix.
 
@@ -95,9 +95,9 @@ kv_namespaces = [
 
 </WranglerConfig>
 
-When you run `wrangler dev` local resources will automatically be created which persist between runs. When you run `wrangler deploy` resources will be created for you, and their IDs will be written back to your configuration file.
+When you run `wrangler dev`, local resources will automatically be created which persist between runs. When you run `wrangler deploy`, resources will be created for you, and their IDs will be written back to your configuration file.
 
-If you deploy a worker with resources and no resource IDs from the dashboard (e.g. via GitHub), resources will be created, but their IDs will only be accessible via the dashboard. Currently these resource IDs will not be written back to your repository.
+If you deploy a worker with resources and no resource IDs from the dashboard (for example, via GitHub), resources will be created, but their IDs will only be accessible via the dashboard. Currently, these resource IDs will not be written back to your repository.
 
 ## Top-level only keys
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -97,7 +97,7 @@ kv_namespaces = [
 
 When you run `wrangler dev` local resources will automatically be created which persist between runs. When you run `wrangler deploy` resources will be created for you, and their IDs will be written back to your configuration file.
 
-If you deploy a worker with resources and no resource IDs from the dashboard (eg. via GitHub), resources will be created, but their IDs will only be accessible via the dashboard. Currently these resource IDs will not be written back to your repository.
+If you deploy a worker with resources and no resource IDs from the dashboard (e.g. via GitHub), resources will be created, but their IDs will only be accessible via the dashboard. Currently these resource IDs will not be written back to your repository.
 
 ## Top-level only keys
 


### PR DESCRIPTION

### Summary

- Added documentation for automatic provisioning of KV, R2, and D1 bindings without pre-creating resources
- Implemented removeSchema prop in WranglerConfig component to conditionally exclude JSON schema reference

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
…tion