### PR TITLE
[Terraform] Fix link to Terraform backend documentation

### DIFF
--- a/src/content/docs/terraform/advanced-topics/remote-backend.mdx
+++ b/src/content/docs/terraform/advanced-topics/remote-backend.mdx
@@ -36,7 +36,7 @@ After your token has been successfully created, review your **Secret Access Key*
 
 ## Define R2 backend
 
-Update your [`cloudflare.tf`](/terraform/tutorial/initialize-terraform/) file to include a [backend](https://developer.hashicorp.com/terraform/language/settings/backends/configuration) for the `<YOUR_BUCKET_NAME>` bucket you created above.
+Update your [`cloudflare.tf`](/terraform/tutorial/initialize-terraform/) file to include a [backend](https://developer.hashicorp.com/terraform/language/backend) for the `<YOUR_BUCKET_NAME>` bucket you created above.
 
 <Render file="v4-code-snippets" product="terraform" />
 


### PR DESCRIPTION
Opening new PR based off the change in https://github.com/cloudflare/cloudflare-docs/pull/25993. (Compiles build kept failing even after multiple attempts to re-run).