### PR TITLE
fix: include width param in Next.js Cloudflare Image loader examples to resolve warnings

### DIFF
--- a/src/content/docs/images/transform-images/integrate-with-frameworks.mdx
+++ b/src/content/docs/images/transform-images/integrate-with-frameworks.mdx
@@ -34,6 +34,8 @@ module.exports = {
 Next, create the `imageLoader.ts` file in the specified path (relative to the root of your Next.js application).
 
 ```ts
+import type { ImageLoaderProps } from "next/image";
+
 const normalizeSrc = (src: string) => {
     return src.startsWith("/") ? src.slice(1) : src;
 };
@@ -42,7 +44,7 @@ export default function cloudflareLoader({
     src,
     width,
     quality,
-}: { src: string; width: number; quality?: number }) {
+}: ImageLoaderProps) {
     const params = [`width=${width}`];
     if (quality) {
       params.push(`quality=${quality}`);

--- a/src/content/docs/images/transform-images/integrate-with-frameworks.mdx
+++ b/src/content/docs/images/transform-images/integrate-with-frameworks.mdx
@@ -43,14 +43,14 @@ export default function cloudflareLoader({
     width,
     quality,
 }: { src: string; width: number; quality?: number }) {
-    if (process.env.NODE_ENV === "development") {
-        return src;
-    }
     const params = [`width=${width}`];
     if (quality) {
-        params.push(`quality=${quality}`);
+      params.push(`quality=${quality}`);
     }
     const paramsString = params.join(",");
+    if (process.env.NODE_ENV === "development") {
+      return `${src}?${paramsString}`;
+    }
     return `/cdn-cgi/image/${paramsString}/${normalizeSrc(src)}`;
 }
 ```
@@ -62,23 +62,23 @@ Alternatively, define a loader for each `<Image />` component.
 ```js
 import Image from 'next/image';
 
-const normalizeSrc = src => {
+const normalizeSrc = (src) => {
   return src.startsWith('/') ? src.slice(1) : src;
 };
 
 const cloudflareLoader = ({ src, width, quality }) => {
-  if (process.env.NODE_ENV === "development") {
-  	return src;
-  }
   const params = [`width=${width}`];
   if (quality) {
     params.push(`quality=${quality}`);
   }
   const paramsString = params.join(',');
+  if (process.env.NODE_ENV === "development") {
+    return `${src}?${paramsString}`;
+  }
   return `/cdn-cgi/image/${paramsString}/${normalizeSrc(src)}`;
 };
 
-const MyImage = props => {
+const MyImage = (props) => {
   return (
     <Image
       loader={cloudflareLoader}
@@ -86,6 +86,7 @@ const MyImage = props => {
       alt="Picture of the author"
       width={500}
       height={500}
+      {...props}
     />
   );
 };

--- a/src/content/docs/images/transform-images/integrate-with-frameworks.mdx
+++ b/src/content/docs/images/transform-images/integrate-with-frameworks.mdx
@@ -47,11 +47,10 @@ export default function cloudflareLoader({
     if (quality) {
       params.push(`quality=${quality}`);
     }
-    const paramsString = params.join(",");
     if (process.env.NODE_ENV === "development") {
-      return `${src}?${paramsString}`;
+      return `${src}?${params.join("&")}`;
     }
-    return `/cdn-cgi/image/${paramsString}/${normalizeSrc(src)}`;
+    return `/cdn-cgi/image/${params.join(",")}/${normalizeSrc(src)}`;
 }
 ```
 
@@ -71,11 +70,10 @@ const cloudflareLoader = ({ src, width, quality }) => {
   if (quality) {
     params.push(`quality=${quality}`);
   }
-  const paramsString = params.join(',');
   if (process.env.NODE_ENV === "development") {
-    return `${src}?${paramsString}`;
+    return `${src}?${params.join("&")}`;
   }
-  return `/cdn-cgi/image/${paramsString}/${normalizeSrc(src)}`;
+  return `/cdn-cgi/image/${params.join(",")}/${normalizeSrc(src)}`;
 };
 
 const MyImage = (props) => {


### PR DESCRIPTION
### Summary

This PR updates the [Integrate with frameworks · Cloudflare Images docs](https://developers.cloudflare.com/images/transform-images/integrate-with-frameworks/) documentation to fix an issue with the example `cloudflareLoader` implementation.  

The **Global Loader** and **Custom Loader** examples was causing Next.js warnings in development mode:

```
Image with src "..." has a "loader" property that does not implement width. Please implement it or use the "unoptimized" property instead.
```

This update modifies both the **Global Loader** and **Custom Loader** examples to always include the required `width` (and optional `quality`) parameters in development mode.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
