### PR TITLE
Update `wrangler deploy` command docs to also mention that a directory can be passed as well

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -258,7 +258,7 @@ None of the options for this command are required. Many of these options can be 
 Deploy your Worker to Cloudflare.
 
 ```txt
-wrangler deploy [<SCRIPT>] [OPTIONS]
+wrangler deploy [<PATH>] [OPTIONS]
 ```
 
 :::note
@@ -267,8 +267,16 @@ None of the options for this command are required. Also, many can be set in your
 
 :::
 
-- `SCRIPT` <Type text="string" />
-  - The path to an entry point for your Worker. Only required if your [Wrangler configuration file](/workers/wrangler/configuration/) does not include a `main` key (for example, `main = "index.js"`).
+- `PATH` <Type text="string" />
+  - A path specific what needs to be deployed, this can either be:
+    - The path to an entry point for your Worker.
+      - Only required if your [Wrangler configuration file](/workers/wrangler/configuration/) does not include a `main` key (for example, `main = "index.js"`).
+
+    - Or the path to an assets directory for the deployment of a static site.
+      - Visit [assets](/workers/static-assets/) for more information.
+      - This overrides the eventual `assets` configuration in your [Wrangler configuration file](/workers/wrangler/configuration/).
+      - This is equivalent to the `--assets` option listed below.
+
 - `--name` <Type text="string" /> <MetaInfo text="optional" />
   - Name of the Worker.
 - `--no-bundle` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -276,6 +276,7 @@ None of the options for this command are required. Also, many can be set in your
       - Visit [assets](/workers/static-assets/) for more information.
       - This overrides the eventual `assets` configuration in your [Wrangler configuration file](/workers/wrangler/configuration/).
       - This is equivalent to the `--assets` option listed below.
+      - Note: this option currently only works only in interactive mode (so not in CI systems).
 
 - `--name` <Type text="string" /> <MetaInfo text="optional" />
   - Name of the Worker.


### PR DESCRIPTION
### Summary

In the `wrangler deploy` command, the positional argument can point to a script or to an assets directory, the latter is not documented so the changes here are adding such information to the docs.

See:
<img width="1211" height="754" alt="Screenshot 2025-11-09 at 14 42 02" src="https://github.com/user-attachments/assets/fb81f87c-9bfc-4118-8d15-9d374c0a9549" />

Note that however this does not work in non-interactive mode:
<img width="820" height="308" alt="Screenshot 2025-11-09 at 14 42 13" src="https://github.com/user-attachments/assets/b1c1e9e7-1216-436a-aabd-cebf802aa778" />

(but it will once we release the autoconfig flow)

