### PR TITLE
[Rules] Update Origin Error Pages

### DIFF
--- a/src/content/docs/learning-paths/surge-readiness/concepts/custom-pages.mdx
+++ b/src/content/docs/learning-paths/surge-readiness/concepts/custom-pages.mdx
@@ -5,20 +5,14 @@ sidebar:
   order: 2
 ---
 
+import { Render } from "~/components";
+
 Design your custom HTML page and host it online anywhere. Once published, Cloudflare will use the customized page instead of serving our standard page to your visitors.
 
 :::note[Note]
-We encourage you to customize every page to provide a consistent branding experience for your users. Origin Error pages can also be activated for 502, 504, and 404 errors.
+We encourage you to customize every page to provide a consistent branding experience for your users. You can also [turn on Origin Error Pages](/rules/custom-errors/#error-pages) for 5XX errors (except errors `520`-`527`).
 :::
 
 Pages you can customize:
 
-- IP Block
-- WAF Block
-- 500 Class Errors
-- 1000 Class Errors
-- Always Online Error
-- Basic Security Challenge
-- WAF Challenge
-- Country Challenge
-- I'm Under Attack Mode Challenge
+<Render file="error-pages-list" product="rules" />

--- a/src/content/docs/rules/custom-errors/edit-error-pages.mdx
+++ b/src/content/docs/rules/custom-errors/edit-error-pages.mdx
@@ -5,28 +5,18 @@ sidebar:
   order: 2
 ---
 
-import { Details, DashButton, Steps, Tabs, TabItem } from "~/components";
+import {
+	Render,
+	Details,
+	DashButton,
+	Steps,
+	Tabs,
+	TabItem,
+} from "~/components";
 
 You can define custom [Error Pages](/rules/custom-errors/#error-pages) for the following errors and challenges:
 
-- WAF block
-- IP/Country block
-- IP/Country challenge
-- 500 class errors
-- 1000 class errors
-- Managed challenge / I'm Under Attack Mode
-- Rate limiting block
-
-<Details header="Older error page types">
-
-You can only customize the error pages for the following error page types if you have customized their error pages in the past:
-
-- Interactive Challenge
-- JavaScript Challenge
-
-These types of challenges are being discouraged in favor of managed challenges.
-
-</Details>
+<Render file="error-pages-list" product="rules" />
 
 For more information on the different types of Error Pages, refer to [Error page types](/rules/custom-errors/reference/error-page-types/).
 

--- a/src/content/docs/rules/custom-errors/index.mdx
+++ b/src/content/docs/rules/custom-errors/index.mdx
@@ -56,7 +56,7 @@ Error Pages do not apply to responses with an HTTP status code of `500`, `501`, 
 
 If you are on a Cloudflare paid plan, you can create custom error pages at the zone level or for your entire account. Zone-level error pages have priority over account-level error pages.
 
-Additionally, Enterprise customers can customize 5XX error pages (except errors `520`-`527`) at their origin via **Enable Origin Error Pages** in **Error Pages** in the dashboard.
+Additionally, Enterprise customers can customize 5XX error pages (except errors `520`-`527`) at their origin by turning on **Origin Error Pages** in **Error Pages** in the dashboard.
 
 You can design custom error pages to appear during a security challenge or when an error occurs. For more information on the different error page types, refer to [Error page types](/rules/custom-errors/reference/error-page-types/).
 

--- a/src/content/partials/rules/error-pages-list.mdx
+++ b/src/content/partials/rules/error-pages-list.mdx
@@ -1,0 +1,24 @@
+---
+{}
+---
+
+import { Details } from "~/components";
+
+- WAF block
+- IP/Country block
+- IP/Country challenge
+- 500 class errors
+- 1000 class errors
+- Managed challenge / I'm Under Attack Mode
+- Rate limiting block
+
+<Details header="Older error page types">
+
+You can only customize the error pages for the following error page types if you have customized their error pages in the past:
+
+- Interactive Challenge
+- JavaScript Challenge
+
+These types of challenges are being discouraged in favor of managed challenges.
+
+</Details>

--- a/src/content/plans/index.json
+++ b/src/content/plans/index.json
@@ -1282,7 +1282,7 @@
 					"ent": "Yes"
 				},
 				"z_origin_error_pages": {
-					"title": "Enable Origin Error Pages",
+					"title": "Origin Error Pages",
 					"free": "No",
 					"pro": "No",
 					"biz": "No",


### PR DESCRIPTION
### Summary

The UI label has changed from **Enable Origin Error Pages** to **Origin Error Pages**.
Also moves some content to a partial.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
