### PR TITLE
[Cloudflare Tunnel] Document cfd-features.argotunnel.com used for UDP datagrams

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -2393,6 +2393,7 @@
 /cloudflare-one/connections/connect-apps/install-and-setup/deployment-guides/* /cloudflare-one/connections/connect-networks/deployment-guides/:splat 301
 /cloudflare-one/connections/connect-networks/deploy-tunnels/deployment-guides/* /cloudflare-one/connections/connect-networks/deployment-guides/:splat 301
 /cloudflare-one/connections/connect-networks/configure-tunnels/local-management/* /cloudflare-one/connections/connect-networks/do-more-with-tunnels/local-management/:splat 301
+/cloudflare-one/networks/connectors/cloudflare-tunnel/install-and-setup/* /cloudflare-one/networks/connectors/cloudflare-tunnel/ 301
 /cloudflare-one/analytics/logs/* /cloudflare-one/insights/logs/:splat 301
 /cloudflare-one/applications/scan-apps/* /cloudflare-one/applications/casb/:splat 301
 /cloudflare-one/connections/connect-apps/use_cases/* /cloudflare-one/connections/connect-networks/use-cases/:splat 301

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall.mdx
@@ -126,6 +126,14 @@ Allows `cloudflared` to report [post-quantum key exchange](https://blog.cloudfla
 | --------------------------- | ------------------------------------------- | ---- | ----------- |
 | `104.18.4.64` `104.18.5.64` | `2606:4700::6812:540` `2606:4700::6812:440` | 443  | TCP (HTTPS) |
 
+#### `cfd-features.argotunnel.com`
+
+| IPv4           | IPv6           | Port | Protocols    |
+| -------------- | -------------- | ---- | ------------ |
+| Not applicable | Not applicable | Not applicable | Not applicable |
+
+Performing a DNS query for a `TXT` record to this hostname allows `cloudflared` to determine which version of [UDP datagram](/changelog/2025-07-15-udp-improvements/) to use when connecting via the `quic` protocol. If your firewall filters egress DNS queries by FQDN, you may need to allow queries for this domain to ensure optimal `quic` performance.
+
 ## Firewall configuration
 
 ### Cloud VM firewall


### PR DESCRIPTION
### Summary

Performing a DNS query for a `TXT` record to this hostname allows `cloudflared` to determine which version of [UDP datagram](/changelog/2025-07-15-udp-improvements/) to use when connecting via the `quic` protocol.

Bonus: adding missing redirect pointed out via https://github.com/cloudflare/cloudflared/issues/1553.