### PR TITLE
[Rules] Update page titles (SEO)

### DIFF
--- a/src/content/changelog/rules/2025-02-12-rules-upgraded-limits.mdx
+++ b/src/content/changelog/rules/2025-02-12-rules-upgraded-limits.mdx
@@ -8,7 +8,26 @@ date: 2025-02-12
 
 We have upgraded and streamlined [Cloudflare Rules](/rules/) limits across all plans, simplifying rule management and improving scalability for everyone.
 
-**New limits by product:** - [Bulk Redirects](/rules/url-forwarding/bulk-redirects/) - Free: **20** → **10,000** URL redirects across lists - Pro: **500** → **25,000** URL redirects across lists - Business: **500** → **50,000** URL redirects across lists - Enterprise: **10,000** → **1,000,000** URL redirects across lists - [Cloud Connector](/rules/cloud-connector/) - Free: **5** → **10** connectors - Enterprise: **125** → **300** connectors - [Custom Errors](/rules/custom-errors/) - Pro: **5** → **25** error assets and rules - Business: **20** → **50** error assets and rules - Enterprise: **50** → **300** error assets and rules - [Snippets](/rules/snippets/) - Pro: **10** → **25** code snippets and rules - Business: **25** → **50** code snippets and rules - Enterprise: **50** → **300** code snippets and rules - [Cache Rules](/cache/how-to/cache-rules/), [Configuration Rules](/rules/configuration-rules/), [Compression Rules](/rules/compression-rules/), [Origin Rules](/rules/origin-rules/), [Single Redirects](/rules/url-forwarding/single-redirects/), and [Transform Rules](/rules/transform/) - Enterprise: **125** → **300** rules
+**New limits by product:**
+
+- [Bulk Redirects](/rules/url-forwarding/bulk-redirects/)
+  - Free: **20** → **10,000** URL redirects across lists
+  - Pro: **500** → **25,000** URL redirects across lists
+  - Business: **500** → **50,000** URL redirects across lists
+  - Enterprise: **10,000** → **1,000,000** URL redirects across lists
+- [Cloud Connector](/rules/cloud-connector/)
+  - Free: **5** → **10** connectors
+  - Enterprise: **125** → **300** connectors
+- [Custom Errors](/rules/custom-errors/)
+  - Pro: **5** → **25** error assets and rules
+  - Business: **20** → **50** error assets and rules
+  - Enterprise: **50** → **300** error assets and rules
+- [Snippets](/rules/snippets/)
+  - Pro: **10** → **25** code snippets and rules
+  - Business: **25** → **50** code snippets and rules
+  - Enterprise: **50** → **300** code snippets and rules
+- [Cache Rules](/cache/how-to/cache-rules/), [Configuration Rules](/rules/configuration-rules/), [Compression Rules](/rules/compression-rules/), [Origin Rules](/rules/origin-rules/), [Single Redirects](/rules/url-forwarding/single-redirects/), and [Transform Rules](/rules/transform/)
+  - Enterprise: **125** → **300** rules
 
 :::note[Gradual rollout]
 Limits are updated gradually. Some customers may still see previous limits until the rollout is fully completed in the first half of 2025.

--- a/src/content/docs/rules/changelog.mdx
+++ b/src/content/docs/rules/changelog.mdx
@@ -1,15 +1,16 @@
 ---
 pcx_content_type: changelog
-title: Changelog
+title: Rules changelog
 sidebar:
   order: 25
+  label: Changelog
 ---
 
 import { ProductChangelog } from "~/components";
 
 {/* <!-- Actual content lives in /src/content/release-notes/rules.yaml. Update the file there for new entries to appear here. For more details, refer to https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/#yaml-file --> */}
 
-<ProductChangelog product="rules" hideEntry="2024-09-05-rules-templates"/>
+<ProductChangelog product="rules" hideEntry="2024-09-05-rules-templates" />
 
 ## 2024-09-20
 
@@ -31,7 +32,7 @@ The Cloudflare dashboard now automatically validates [DNS records](https://devel
 
 ## 2024-09-10
 
-**wildcard\_replace() function now supported in URL rewrites**
+**wildcard_replace() function now supported in URL rewrites**
 
 You can now use the [`wildcard_replace()`](https://developers.cloudflare.com/ruleset-engine/rules-language/functions/#wildcard_replace) function in rewrite expressions of [URL rewrites](https://developers.cloudflare.com/rules/transform/url-rewrite/).
 
@@ -71,8 +72,8 @@ Cloudflare Snippets (alpha) now allow multiple subrequests depending on your pla
 
 Wildcards are now supported across our Ruleset Engine-based products, including Single Redirects, Cache Rules, Transform Rules, WAF, Waiting Room, and more:
 
-* You can now use the `wildcard` and `strict wildcard` operators with any string field in the Ruleset Engine, such as full URI, host, headers, cookies, user-agent, and country. For more details, refer to [Operators](https://developers.cloudflare.com/ruleset-engine/rules-language/operators/) and [Wildcard matching](https://developers.cloudflare.com/ruleset-engine/rules-language/operators/#wildcard-matching).
-* In [Single Redirects](https://developers.cloudflare.com/rules/url-forwarding/single-redirects/), the `wildcard_replace()` function allows you to use segments matched by the `wildcard` and `strict wildcard` operators in redirect URL targets. For more information, refer to [Functions](https://developers.cloudflare.com/ruleset-engine/rules-language/functions/#wildcard_replace).
+- You can now use the `wildcard` and `strict wildcard` operators with any string field in the Ruleset Engine, such as full URI, host, headers, cookies, user-agent, and country. For more details, refer to [Operators](https://developers.cloudflare.com/ruleset-engine/rules-language/operators/) and [Wildcard matching](https://developers.cloudflare.com/ruleset-engine/rules-language/operators/#wildcard-matching).
+- In [Single Redirects](https://developers.cloudflare.com/rules/url-forwarding/single-redirects/), the `wildcard_replace()` function allows you to use segments matched by the `wildcard` and `strict wildcard` operators in redirect URL targets. For more information, refer to [Functions](https://developers.cloudflare.com/ruleset-engine/rules-language/functions/#wildcard_replace).
 
 ## 2024-07-01
 

--- a/src/content/docs/rules/cloud-connector/create-api.mdx
+++ b/src/content/docs/rules/cloud-connector/create-api.mdx
@@ -1,11 +1,9 @@
 ---
-title: Configure via API
+title: Configure a Cloud Connector rule via API
 pcx_content_type: how-to
 sidebar:
   order: 3
-head:
-  - tag: title
-    content: Configure a Cloud Connector rule via API
+  label: Configure a rule via API
 ---
 
 import { APIRequest } from "~/components";

--- a/src/content/docs/rules/cloud-connector/create-dashboard.mdx
+++ b/src/content/docs/rules/cloud-connector/create-dashboard.mdx
@@ -1,11 +1,9 @@
 ---
-title: Configure in the dashboard
+title: Configure a Cloud Connector rule in the dashboard
 pcx_content_type: how-to
 sidebar:
   order: 2
-head:
-  - tag: title
-    content: Configure a Cloud Connector rule in the dashboard
+  label: Configure a rule in the dashboard
 ---
 
 import { Render, Steps, DashButton } from "~/components";

--- a/src/content/docs/rules/cloud-connector/create-terraform.mdx
+++ b/src/content/docs/rules/cloud-connector/create-terraform.mdx
@@ -1,12 +1,9 @@
 ---
-title: Configure Cloud Connector using Terraform
+title: Configure Cloud Connector rules using Terraform
 pcx_content_type: how-to
 sidebar:
   order: 4
-  label: Configure using Terraform
-head:
-  - tag: title
-    content: Configure Cloud Connector using Terraform
+  label: Configure rules using Terraform
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/rules/cloud-connector/examples/index.mdx
+++ b/src/content/docs/rules/cloud-connector/examples/index.mdx
@@ -1,11 +1,15 @@
 ---
-
 pcx_content_type: navigation
-title: Examples
+title: Cloud Connector examples
 sidebar:
   order: 10
+  group:
+    label: Examples
 ---
 
 import { ResourcesBySelector } from "~/components";
 
-<ResourcesBySelector directory="rules/cloud-connector/examples/" types={["example"]} />
+<ResourcesBySelector
+	directory="rules/cloud-connector/examples/"
+	types={["example"]}
+/>

--- a/src/content/docs/rules/cloud-connector/providers.mdx
+++ b/src/content/docs/rules/cloud-connector/providers.mdx
@@ -1,8 +1,9 @@
 ---
-title: Supported cloud providers
+title: Supported cloud providers in Cloud Connector
 pcx_content_type: reference
 sidebar:
   order: 5
+  label: Supported cloud providers
 ---
 
 import { Render, Steps } from "~/components";

--- a/src/content/docs/rules/compression-rules/examples/index.mdx
+++ b/src/content/docs/rules/compression-rules/examples/index.mdx
@@ -1,11 +1,15 @@
 ---
-
 pcx_content_type: navigation
-title: Examples
+title: Compression Rules examples
 sidebar:
   order: 10
+  group:
+    label: Examples
 ---
 
 import { ResourcesBySelector } from "~/components";
 
-<ResourcesBySelector directory="rules/compression-rules/examples/" types={["example"]} />
+<ResourcesBySelector
+	directory="rules/compression-rules/examples/"
+	types={["example"]}
+/>

--- a/src/content/docs/rules/configuration-rules/examples/index.mdx
+++ b/src/content/docs/rules/configuration-rules/examples/index.mdx
@@ -1,11 +1,15 @@
 ---
-
 pcx_content_type: navigation
-title: Examples
+title: Configuration Rules examples
 sidebar:
   order: 10
+  group:
+    label: Examples
 ---
 
 import { ResourcesBySelector } from "~/components";
 
-<ResourcesBySelector directory="rules/configuration-rules/examples/" types={["example"]} />
+<ResourcesBySelector
+	directory="rules/configuration-rules/examples/"
+	types={["example"]}
+/>

--- a/src/content/docs/rules/custom-errors/api-calls.mdx
+++ b/src/content/docs/rules/custom-errors/api-calls.mdx
@@ -1,16 +1,14 @@
 ---
-title: Common API calls
+title: Common API calls for Custom Errors
 pcx_content_type: configuration
 sidebar:
   order: 5
-head:
-  - tag: title
-    content: Common API calls | Custom Error Assets
+  label: Common API calls
 ---
 
 import { APIRequest } from "~/components";
 
-The following sections provide examples of common API calls for managing custom error assets at the zone level.
+The following sections provide examples of common API calls for managing custom error assets and Error Pages at the zone level.
 
 To perform the same operations at the account level, use the corresponding account-level API endpoints.
 
@@ -241,3 +239,7 @@ This example defines a custom error page for `Rate limiting block` errors (with 
 To set the error page back to the default page, use `"state": "default"` in the request body.
 
 For a list of error page identifiers, refer to [Error page types](/rules/custom-errors/reference/error-page-types/).
+
+## More resources
+
+- [Custom Error Pages API reference](/api/resources/custom_pages/)

--- a/src/content/docs/rules/custom-errors/example-rules.mdx
+++ b/src/content/docs/rules/custom-errors/example-rules.mdx
@@ -1,8 +1,9 @@
 ---
-title: Example rules
+title: Example custom error rules
 pcx_content_type: configuration
 sidebar:
   order: 4
+  label: Example rules
 ---
 
 import { Tabs, TabItem, APIRequest, Render } from "~/components";

--- a/src/content/docs/rules/custom-errors/reference/parameters.mdx
+++ b/src/content/docs/rules/custom-errors/reference/parameters.mdx
@@ -1,11 +1,9 @@
 ---
-title: Parameters
+title: Custom Errors parameters
 pcx_content_type: reference
 sidebar:
   order: 2
-head:
-  - tag: title
-    content: Custom errors parameters
+  label: Parameters
 ---
 
 import { Type, MetaInfo } from "~/components";

--- a/src/content/docs/rules/examples.mdx
+++ b/src/content/docs/rules/examples.mdx
@@ -1,8 +1,9 @@
 ---
 pcx_content_type: navigation
-title: Examples
+title: Rules examples
 sidebar:
   order: 2
+  label: Examples
 ---
 
 import { ResourcesBySelector, GlossaryTooltip } from "~/components";

--- a/src/content/docs/rules/origin-rules/examples/index.mdx
+++ b/src/content/docs/rules/origin-rules/examples/index.mdx
@@ -1,11 +1,15 @@
 ---
-
 pcx_content_type: navigation
-title: Examples
+title: Origin Rules examples
 sidebar:
   order: 5
+  group:
+    label: Examples
 ---
 
 import { ResourcesBySelector } from "~/components";
 
-<ResourcesBySelector directory="rules/origin-rules/examples/" types={["example"]} />
+<ResourcesBySelector
+	directory="rules/origin-rules/examples/"
+	types={["example"]}
+/>

--- a/src/content/docs/rules/origin-rules/tutorials/index.mdx
+++ b/src/content/docs/rules/origin-rules/tutorials/index.mdx
@@ -1,9 +1,10 @@
 ---
-
 pcx_content_type: navigation
-title: Tutorials
+title: Origin Rules tutorials
 sidebar:
   order: 6
+  group:
+    label: Tutorials
 ---
 
 import { ListTutorials } from "~/components";

--- a/src/content/docs/rules/page-rules/reference/additional-reference.mdx
+++ b/src/content/docs/rules/page-rules/reference/additional-reference.mdx
@@ -1,12 +1,10 @@
 ---
 pcx_content_type: reference
 source: https://support.cloudflare.com/hc/en-us/articles/218411427-What-do-the-custom-caching-options-mean-in-Page-Rules-#summary-of-page-rules-settings
-title: Additional reference
+title: Additional reference for Page Rules
 sidebar:
   order: 4
-head:
-  - tag: title
-    content: Additional reference | Page Rules
+  label: Additional reference
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/rules/page-rules/reference/wildcard-matching.mdx
+++ b/src/content/docs/rules/page-rules/reference/wildcard-matching.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: reference
-title: Page Rules wildcard matching
+title: Wildcard matching in Page Rules
 sidebar:
   order: 5
   label: Wildcard matching

--- a/src/content/docs/rules/page-rules/troubleshooting/billing-and-subscription.mdx
+++ b/src/content/docs/rules/page-rules/troubleshooting/billing-and-subscription.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: faq
 source: https://support.cloudflare.com/hc/en-us/articles/225894428-Purchasing-Additional-Page-Rules
-title: Page Rules billing and subscription FAQ
+title: Troubleshoot Page Rules - Billing and subscription
 sidebar:
   label: Billing and subscription
 ---

--- a/src/content/docs/rules/page-rules/troubleshooting/general.mdx
+++ b/src/content/docs/rules/page-rules/troubleshooting/general.mdx
@@ -1,12 +1,10 @@
 ---
 pcx_content_type: troubleshooting
 source: https://support.cloudflare.com/hc/en-us/articles/218411427-What-do-the-custom-caching-options-mean-in-Page-Rules-#summary-of-page-rules-settings
-title: General
+title: Troubleshoot Page Rules - General
 sidebar:
   order: 6
-head:
-  - tag: title
-    content: General troubleshooting | Page Rules
+  label: General
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/rules/reference/troubleshooting.mdx
+++ b/src/content/docs/rules/reference/troubleshooting.mdx
@@ -1,8 +1,9 @@
 ---
-title: Troubleshooting
+title: Troubleshoot Rules
 pcx_content_type: troubleshooting
 sidebar:
   order: 1
+  label: Troubleshooting
 head:
   - tag: title
     content: Rules troubleshooting

--- a/src/content/docs/rules/snippets/errors.mdx
+++ b/src/content/docs/rules/snippets/errors.mdx
@@ -1,16 +1,12 @@
 ---
-title: Snippets troubleshooting
+title: Troubleshoot Snippets
 pcx_content_type: troubleshooting
 sidebar:
   order: 8
   label: Troubleshooting
-head:
-  - tag: title
-    content: Snippets troubleshooting
 ---
 
 import { GlossaryTooltip } from "~/components";
-
 
 ## Error 1201: Snippet tried to continue to origin multiple times
 

--- a/src/content/docs/rules/snippets/examples/index.mdx
+++ b/src/content/docs/rules/snippets/examples/index.mdx
@@ -1,9 +1,11 @@
 ---
 hideChildren: true
 pcx_content_type: navigation
-title: Examples
+title: Snippets examples
 sidebar:
   order: 7
+  group:
+    label: Examples
 ---
 
 import { ResourcesBySelector } from "~/components";

--- a/src/content/docs/rules/snippets/how-it-works.mdx
+++ b/src/content/docs/rules/snippets/how-it-works.mdx
@@ -1,11 +1,9 @@
 ---
-title: How it works
+title: How Snippets work
 pcx_content_type: concept
 sidebar:
   order: 1
-head:
-  - tag: title
-    content: How it works
+  label: How it works
 ---
 
 Cloudflare Snippets are executed based on rules defined within your zone. Here is how the process works:

--- a/src/content/docs/rules/trace-request/changelog.mdx
+++ b/src/content/docs/rules/trace-request/changelog.mdx
@@ -1,13 +1,11 @@
 ---
 pcx_content_type: changelog
-title: Changelog
+title: Cloudflare Trace changelog
 release_notes_file_name:
   - trace
 sidebar:
   order: 4
-head:
-  - tag: title
-    content: Changelog - Cloudflare Trace
+  label: Changelog
 ---
 
 import { ProductReleaseNotes } from "~/components";

--- a/src/content/docs/rules/trace-request/limitations.mdx
+++ b/src/content/docs/rules/trace-request/limitations.mdx
@@ -1,24 +1,21 @@
 ---
 pcx_content_type: reference
-title: Limitations
+title: Cloudflare Trace limitations
 sidebar:
   order: 3
-head:
-  - tag: title
-    content: Limitations - Cloudflare Trace
-
+  label: Limitations
 ---
 
 Trace currently does not support:
 
-* Hostnames using [Data Localization Suite](/data-localization/)
-* [Spectrum](/spectrum/) applications
+- Hostnames using [Data Localization Suite](/data-localization/)
+- [Spectrum](/spectrum/) applications
 
 Additionally, the following products will not appear in trace results:
 
-* [Firewall rules (deprecated)](/firewall/)
-* [Load Balancing](/load-balancing/) and [Load Balancer Custom Rules](/load-balancing/additional-options/load-balancing-rules/)
-* [IP Access rules](/waf/tools/ip-access-rules/)
-* [Rate limiting rules (previous version)](/waf/reference/legacy/old-rate-limiting/)
-* [WAF managed rules (previous version)](/waf/reference/legacy/old-waf-managed-rules/)
-* [Page Shield policies](/page-shield/policies/)
+- [Firewall rules (deprecated)](/firewall/)
+- [Load Balancing](/load-balancing/) and [Load Balancer Custom Rules](/load-balancing/additional-options/load-balancing-rules/)
+- [IP Access rules](/waf/tools/ip-access-rules/)
+- [Rate limiting rules (previous version)](/waf/reference/legacy/old-rate-limiting/)
+- [WAF managed rules (previous version)](/waf/reference/legacy/old-waf-managed-rules/)
+- [Page Shield policies](/page-shield/policies/)

--- a/src/content/docs/rules/transform/examples/index.mdx
+++ b/src/content/docs/rules/transform/examples/index.mdx
@@ -1,8 +1,10 @@
 ---
 pcx_content_type: navigation
-title: Examples
+title: Transform Rules examples
 sidebar:
   order: 10
+  group:
+    label: Examples
 ---
 
 import { ResourcesBySelector } from "~/components";

--- a/src/content/docs/rules/transform/troubleshooting.mdx
+++ b/src/content/docs/rules/transform/troubleshooting.mdx
@@ -1,11 +1,9 @@
 ---
-title: Troubleshooting
+title: Troubleshoot Transform Rules
 pcx_content_type: troubleshooting
 sidebar:
   order: 7
-head:
-  - tag: title
-    content: Troubleshoot Transform Rules
+  label: Troubleshooting
 ---
 
 When troubleshooting a rule configuration, review the [Transform Rules evaluation](/rules/transform/#transform-rules-evaluation) section to understand how and when your Transform Rule is evaluated for each request.

--- a/src/content/docs/rules/url-forwarding/bulk-redirects/concepts.mdx
+++ b/src/content/docs/rules/url-forwarding/bulk-redirects/concepts.mdx
@@ -1,11 +1,9 @@
 ---
-title: Concepts
+title: Bulk Redirects concepts
 pcx_content_type: concept
 sidebar:
   order: 3
-head:
-  - tag: title
-    content: Bulk Redirect concepts
+  label: Concepts
 description: Bulk Redirects work through a combination of URL redirects, a Bulk
   Redirect list, and a Bulk Redirect rule.
 ---

--- a/src/content/docs/rules/url-forwarding/bulk-redirects/reference/csv-file-format.mdx
+++ b/src/content/docs/rules/url-forwarding/bulk-redirects/reference/csv-file-format.mdx
@@ -1,12 +1,9 @@
 ---
-title: CSV file format
+title: CSV file format for Bulk Redirects
 pcx_content_type: reference
 sidebar:
   order: 6
-head:
-  - tag: title
-    content: CSV file format to import URL redirects
-
+  label: CSV file format
 ---
 
 You can use a CSV file to import URL redirects into a Bulk Redirect List [using the Cloudflare dashboard](/rules/url-forwarding/bulk-redirects/create-dashboard/#1-create-a-bulk-redirect-list). Each line in the CSV file must follow this format:
@@ -31,7 +28,7 @@ example.com/docs,https://example.com/draft-docs,302,,TRUE
 
 ## Important remarks
 
-* The CSV file must not include a header row with column names.
-* A source/target URL must be enclosed in quotes (`"`) when it includes a comma (`,`). You can always enclose URL values in quotes, but it is not required.
-* You can skip an optional value by immediately entering a comma (the delimiter) without entering any value.
-* You do not need to include trailing commas.
+- The CSV file must not include a header row with column names.
+- A source/target URL must be enclosed in quotes (`"`) when it includes a comma (`,`). You can always enclose URL values in quotes, but it is not required.
+- You can skip an optional value by immediately entering a comma (the delimiter) without entering any value.
+- You do not need to include trailing commas.

--- a/src/content/docs/rules/url-forwarding/bulk-redirects/reference/json-objects.mdx
+++ b/src/content/docs/rules/url-forwarding/bulk-redirects/reference/json-objects.mdx
@@ -1,12 +1,9 @@
 ---
-title: API JSON objects
+title: Bulk Redirects API JSON objects
 pcx_content_type: reference
 sidebar:
   order: 7
-head:
-  - tag: title
-    content: Bulk Redirects API JSON objects
-
+  label: API JSON objects
 ---
 
 ## Bulk Redirect Rule
@@ -15,29 +12,28 @@ A fully populated Bulk Redirect Rule object has the following JSON structure:
 
 ```json
 {
-  "action": "redirect",
-  "expression": "http.request.full_uri in $<LIST_NAME>",
-  "action_parameters": {
-    "from_list": {
-      "name": "<LIST_NAME>",
-      "key": "http.request.full_uri"
-    }
-  }
+	"action": "redirect",
+	"expression": "http.request.full_uri in $<LIST_NAME>",
+	"action_parameters": {
+		"from_list": {
+			"name": "<LIST_NAME>",
+			"key": "http.request.full_uri"
+		}
+	}
 }
 ```
 
 The JSON object properties must comply with the following:
 
-* `action` must be `redirect`
+- `action` must be `redirect`
 
-* `action_parameters` must contain a `from_list` object with additional settings.
+- `action_parameters` must contain a `from_list` object with additional settings.
 
-* `from_list` must contain the following properties:
+- `from_list` must contain the following properties:
+  - `name`: The name of an existing Bulk Redirect List to associate with the current Bulk Redirect Rule.
+  - `key`: An expression that defines the value that will be matched against the configured URL redirect’s source URL values, following the rules of the [URL matching algorithm](/rules/url-forwarding/bulk-redirects/how-it-works/#url-matching-algorithm). Refer to [Concepts](/rules/url-forwarding/bulk-redirects/concepts/#bulk-redirect-rules) for more information.
 
-  * `name`: The name of an existing Bulk Redirect List to associate with the current Bulk Redirect Rule.
-  * `key`: An expression that defines the value that will be matched against the configured URL redirect’s source URL values, following the rules of the [URL matching algorithm](/rules/url-forwarding/bulk-redirects/how-it-works/#url-matching-algorithm). Refer to [Concepts](/rules/url-forwarding/bulk-redirects/concepts/#bulk-redirect-rules) for more information.
-
-* `expression` must reference the request field used in the `key` property. Refer to [Concepts](/rules/url-forwarding/bulk-redirects/concepts/#bulk-redirect-rules) for more information.
+- `expression` must reference the request field used in the `key` property. Refer to [Concepts](/rules/url-forwarding/bulk-redirects/concepts/#bulk-redirect-rules) for more information.
 
 ## URL redirect list item
 
@@ -45,18 +41,18 @@ A fully populated URL redirect list item object has the following JSON structure
 
 ```json
 {
-  "id": "7c5dae5552338874e5053f2534d2767a",
-  "redirect": {
-    "source_url": "https://example.com/blog",
-    "target_url": "https://example.com/blog/latest",
-    "status_code": 301,
-    "include_subdomains": false,
-    "subpath_matching": false,
-    "preserve_query_string": false,
-    "preserve_path_suffix": true
-  },
-  "created_on": "2021-10-11T12:39:02Z",
-  "modified_on": "2021-10-11T12:39:02Z"
+	"id": "7c5dae5552338874e5053f2534d2767a",
+	"redirect": {
+		"source_url": "https://example.com/blog",
+		"target_url": "https://example.com/blog/latest",
+		"status_code": 301,
+		"include_subdomains": false,
+		"subpath_matching": false,
+		"preserve_query_string": false,
+		"preserve_path_suffix": true
+	},
+	"created_on": "2021-10-11T12:39:02Z",
+	"modified_on": "2021-10-11T12:39:02Z"
 }
 ```
 

--- a/src/content/docs/rules/url-forwarding/bulk-redirects/reference/url-components.mdx
+++ b/src/content/docs/rules/url-forwarding/bulk-redirects/reference/url-components.mdx
@@ -1,13 +1,10 @@
 ---
-title: Supported URL components
-
+title: Supported URL components in Bulk Redirects
 pcx_content_type: reference
 sidebar:
   order: 4
+  label: Supported URL components
 tableOfContents: false
-head:
-  - tag: title
-    content: Supported URL components in Bulk Redirects
 ---
 
 The source and target URLs of a URL redirect support different URL components.

--- a/src/content/docs/rules/url-forwarding/examples/index.mdx
+++ b/src/content/docs/rules/url-forwarding/examples/index.mdx
@@ -1,11 +1,15 @@
 ---
-
 pcx_content_type: navigation
-title: Examples
+title: Redirect examples
 sidebar:
   order: 10
+  group:
+    label: Examples
 ---
 
 import { ResourcesBySelector } from "~/components";
 
-<ResourcesBySelector directory="rules/url-forwarding/examples/" types={["example"]} />
+<ResourcesBySelector
+	directory="rules/url-forwarding/examples/"
+	types={["example"]}
+/>


### PR DESCRIPTION
### Summary

Updates page H1 text, keeping the sidebar text as a shorter version.
Helps differentiate between very similar Algolia search results (e.g., between the many different "Examples" pages under Rules). 

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
