### PR TITLE
Note the requirement for prepare: true in postgres.js hyperdrive documentation to allow caching

### DIFF
--- a/src/content/partials/hyperdrive/use-postgres-js-to-make-query.mdx
+++ b/src/content/partials/hyperdrive/use-postgres-js-to-make-query.mdx
@@ -35,6 +35,9 @@ export default {
 			max: 5,
 			// If you are not using array types in your Postgres schema, disable `fetch_types` to avoid an additional round-trip (unnecessary latency)
 			fetch_types: false,
+
+			// This is set to true by default, but certain query generators such as Kysely or queries using sql.unsafe() will set this to false. Hyperdrive will not cache prepared statements when this option is set to false and will require additional round-trips.  
+			prepare: true,
 		});
 
 		try {


### PR DESCRIPTION
### Summary

Note the requirement for prepare: true in postgres.js hyperdrive documentation to allow caching
