### PR TITLE
[Publish GHA] Update copying logic to populate recent llms-full.txt files

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -51,12 +51,10 @@ jobs:
           cd ..
 
           cd distllms
-          for file in $(find . -type f); do
-            rclone copy \
-              --config ../bin/rclone.conf \
-              $file \
-              devdocs:vendored-markdown
-          done
+          rclone copy \
+            --config ../bin/rclone.conf \
+            . \
+            devdocs:vendored-markdown
           cd ..
       - name: Upload vendored Markdown files to ZT DevDocs bucket
         env:

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -51,7 +51,7 @@ jobs:
           cd ..
 
           cd distllms
-          rclone copy \
+          rclone copy --max-depth 2 \
             --config ../bin/rclone.conf \
             . \
             devdocs:vendored-markdown


### PR DESCRIPTION
**Context**
Ever since #23688, we actually haven't had updated `/$product/llms-full.txt` files getting uploaded into R2. But they're present locally... just not correctly getting uploaded via Rclone. 

This has meant that -- as we add new products (or change the name of existing ones) -- we see behavior like #25917.

This also means that the current `llms-full.txt` files aren't up to date (most have a last modified date of July 15th).

**Fix**

Based on some AI suggestions, tweaked the script.

I tested this behavior locally by creating a new R2 bucket in a testing account (`PCX Team > test-dev-docs-vendored-markdown`) and then manually tried uploading via rclone.

Seemed to have the correct result when I uploaded and then downloaded a sample.
[ai-search_llms-full.txt](https://github.com/user-attachments/files/23463300/ai-search_llms-full.txt)

<img width="1279" height="472" alt="image" src="https://github.com/user-attachments/assets/9f1a013b-f0ba-4d87-82a0-48e10de410d6" />

closes #25917 
