### PR TITLE
Add Puppeteer version note to match Playwright page style

### DIFF
--- a/src/content/docs/browser-rendering/puppeteer.mdx
+++ b/src/content/docs/browser-rendering/puppeteer.mdx
@@ -19,7 +19,7 @@ Our version is open sourced and can be found in [Cloudflare's fork of Puppeteer]
 <PackageManagers pkg="@cloudflare/puppeteer" dev />
 
 :::note
-The current version of Puppeteer is [**v22.13.1**](https://github.com/puppeteer/puppeteer/releases/tag/v22.13.1).
+The current version of Puppeteer is [**v22.13.1**](https://github.com/cloudflare/puppeteer/releases/tag/v1.0.4).
 :::
 
 ## Use Puppeteer in a Worker

--- a/src/content/docs/browser-rendering/puppeteer.mdx
+++ b/src/content/docs/browser-rendering/puppeteer.mdx
@@ -18,6 +18,10 @@ Our version is open sourced and can be found in [Cloudflare's fork of Puppeteer]
 
 <PackageManagers pkg="@cloudflare/puppeteer" dev />
 
+:::note
+The current version of Puppeteer is [**v22.13.1**](https://github.com/puppeteer/puppeteer/releases/tag/v22.13.1).
+:::
+
 ## Use Puppeteer in a Worker
 
 Once the [browser binding](/browser-rendering/reference/wrangler/#bindings) is configured and the `@cloudflare/puppeteer` library is installed, Puppeteer can be used in a Worker:


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
