### PR TITLE
fix: render md in snippet descriptions

### DIFF
--- a/src/components/ResourcesBySelector.tsx
+++ b/src/components/ResourcesBySelector.tsx
@@ -5,6 +5,7 @@ import ReactSelect from "./ReactSelect";
 import { formatDistance } from "date-fns";
 import { setSearchParams } from "~/util/url";
 import { formatContentType } from "~/util/content-type";
+import Markdown from "react-markdown";
 
 type DocsData = keyof CollectionEntry<"docs">["data"];
 type VideosData = keyof CollectionEntry<"stream">["data"];
@@ -367,7 +368,12 @@ export default function ResourcesBySelector({
 								</p>
 								{showDescriptions && (
 									<span className="line-clamp-3" title={page.data.description}>
-										{page.data.description}
+										<Markdown
+											disallowedElements={["a"]}
+											unwrapDisallowed={true}
+										>
+											{page.data.description}
+										</Markdown>
 									</span>
 								)}
 								{showLastUpdated && "reviewed" in page.data && (


### PR DESCRIPTION
### Summary

This treats the description prop as markdown. Note that it disallows links to prevent nested links. Most of the description props have link markdown in them so this ends up having minimal impact expect to make the "links" look like normal text, which does improve the original bug( [CED-104](https://jira.cfdata.org/browse/CED-104)).