### PR TITLE
warn users to avoid side effects top level

### DIFF
--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -207,9 +207,9 @@ export class MyWorkflow extends WorkflowEntrypoint {
 
 ### Avoid doing side effects outside of a `step.do`
 
-The Workflow engine may restart, it is not recommended to write code with any side effects outside of steps, unless you would like it to be repeated. If the engine restarts, the step logic will be preserved, but logic outside of the steps may be duplicated.
+It is not recommended to write code with any side effects outside of steps, unless you would like it to be repeated, because the Workflow engine may restart while an instance is running. If the engine restarts, the step logic will be preserved, but logic outside of the steps may be duplicated.
 
-For example, a console.log() outside of workflow steps may cause the logs to print twice when the engine restarts.
+For example, a `console.log()` outside of workflow steps may cause the logs to print twice when the engine restarts.
 
 However, logic involving non-serializable resources, like a database connection, should be executed outside of steps. Operations ouside of a `step.do` might be repeated more than once, due to the nature of the Workflows' instance lifecycle.
 

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -216,46 +216,46 @@ However, logic involving non-serializable resources, like a database connection,
 <TypeScriptExample filename="index.ts">
 ```ts
 export class MyWorkflow extends WorkflowEntrypoint {
-	async run(event: WorkflowEvent<MyEvent>, step: WorkflowStep) {
+	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
 		// 🔴 Bad: creating instances outside of steps
 		// This might get called more than once creating more instances than expected
-		const myNewInstance = this.env.ANOTHER_WORKFLOW.create({params})
+		const myNewInstance = this.env.ANOTHER_WORKFLOW.create();
 
 		// 🔴 Bad: using non-deterministic functions outside of steps
 		// this will produce different results if the instance has to restart, different runs of the same instance
 	  // might go through different paths
-		const myRandom = Math.random()
+		const myRandom = Math.random();
 
 		if(myRandom > 0) {
 			// do some stuff
 		}
 
 		// ⚠️ Warning: This log can happen many times if the engine restarts
-		console.log("This might be logged more than once")
+		console.log("This might be logged more than once");
 
 		await step.do("do some stuff and have a log for when it runs", async () => {
 			// do some stuff
 
 			// this log will only appear once
-			console.log('successfully did stuff')
+			console.log("successfully did stuff");
 		})
 
 
 		// ✅ Good: wrap non-deterministic function in a step
 		// after running successfully will not run again
 		const myRandom = await step.do("create a random number", async () => {
-	    return Math.random()
+	    return Math.random();
 		})
 
 		// ✅ Good: calls that have no side effects can be done outside of steps
-		const db = createDBConnection(this.env.DB_URL, this.env.DB_TOKEN)
+		const db = createDBConnection(this.env.DB_URL, this.env.DB_TOKEN);
 
 		// ✅ Good: run funtions with side effects inside of a step
 		// after running successfully will not run again
 		const myNewInstance = await step.do("good step that returns state", async () => {
-			const myNewInstance = this.env.ANOTHER_WORKFLOW.create({params})
+			const myNewInstance = this.env.ANOTHER_WORKFLOW.create();
 
-	    return myNewInstance
+	    return myNewInstance;
 		})
 	}
 }

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -205,6 +205,64 @@ export class MyWorkflow extends WorkflowEntrypoint {
 ```
 </TypeScriptExample>
 
+### Do not call functions with side effects outside of step.do
+
+The Workflow engine may restart, it is not recommended to write code with any side effects outside of steps, unless you would like it to be repeated. If the engine restarts, the step logic will be preserved, but logic outside of the steps may be duplicated.
+
+For example, a console.log() outside of workflow steps may cause the logs to print twice when the engine restarts.
+
+However, logic involving non-serializable resources, like a database connection, should be executed outside of steps. Then the operation will be repeated, and the resource will be restarted, when the Workflow engine restarts.
+
+<TypeScriptExample filename="index.ts">
+```ts
+export class MyWorkflow extends WorkflowEntrypoint {
+	async run(event: WorkflowEvent<MyEvent>, step: WorkflowStep) {
+		// 🔴 Bad: creating instances outside of steps
+		// This might get called more than once creating more instances than expected
+		const myNewInstance = this.env.ANOTHER_WORKFLOW.create({params})
+
+		// 🔴 Bad: using non-deterministic functions outside of steps
+		// this will produce different results if the instance has to restart, different runs of the same instance
+	  // might go through different paths
+		const myRandom = Math.random()
+
+		if(myRandom > 0) {
+			// do some stuff
+		}
+
+		// ⚠️ Warning: This log can happen many times if the engine restarts
+		console.log("This might be logged more than once")
+
+		await step.do("do some stuff and have a log for when it runs", async () => {
+			// do some stuff
+
+			// this log will only appear once
+			console.log('successfully did stuff')
+		})
+
+
+		// ✅ Good: wrap non-deterministic function in a step
+		// after running successfully will not run again
+		const myRandom = await step.do("create a random number", async () => {
+	    return Math.random()
+		})
+
+		// ✅ Good: calls that have no side effects can be done outside of steps
+		const db = createDBConnection(this.env.DB_URL, this.env.DB_TOKEN)
+
+		// ✅ Good: run funtions with side effects inside of a step
+		// after running successfully will not run again
+		const myNewInstance = await step.do("good step that returns state", async () => {
+			const myNewInstance = this.env.ANOTHER_WORKFLOW.create({params})
+
+	    return myNewInstance
+		})
+	}
+}
+```
+</TypeScriptExample>
+
+
 ### Do not mutate your incoming events
 
 The `event` passed to your Workflow's `run` method is immutable: changes you make to the event are not persisted across steps and/or Workflow restarts.

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -219,7 +219,7 @@ export class MyWorkflow extends WorkflowEntrypoint {
 	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
 		// 🔴 Bad: creating instances outside of steps
 		// This might get called more than once creating more instances than expected
-		const myNewInstance = this.env.ANOTHER_WORKFLOW.create();
+		const myNewInstance = await this.env.ANOTHER_WORKFLOW.create();
 
 		// 🔴 Bad: using non-deterministic functions outside of steps
 		// this will produce different results if the instance has to restart, different runs of the same instance
@@ -253,7 +253,7 @@ export class MyWorkflow extends WorkflowEntrypoint {
 		// ✅ Good: run funtions with side effects inside of a step
 		// after running successfully will not run again
 		const myNewInstance = await step.do("good step that returns state", async () => {
-			const myNewInstance = this.env.ANOTHER_WORKFLOW.create();
+			const myNewInstance = await this.env.ANOTHER_WORKFLOW.create();
 
 	    return myNewInstance;
 		})

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -205,13 +205,13 @@ export class MyWorkflow extends WorkflowEntrypoint {
 ```
 </TypeScriptExample>
 
-### Do not call functions with side effects outside of step.do
+### Avoid doing side effects outside of a `step.do`
 
 The Workflow engine may restart, it is not recommended to write code with any side effects outside of steps, unless you would like it to be repeated. If the engine restarts, the step logic will be preserved, but logic outside of the steps may be duplicated.
 
 For example, a console.log() outside of workflow steps may cause the logs to print twice when the engine restarts.
 
-However, logic involving non-serializable resources, like a database connection, should be executed outside of steps. Then the operation will be repeated, and the resource will be restarted, when the Workflow engine restarts.
+However, logic involving non-serializable resources, like a database connection, should be executed outside of steps. Operations ouside of a `step.do` might be repeated more than once, due to the nature of the Workflows' instance lifecycle.
 
 <TypeScriptExample filename="index.ts">
 ```ts
@@ -230,7 +230,7 @@ export class MyWorkflow extends WorkflowEntrypoint {
 			// do some stuff
 		}
 
-		// ⚠️ Warning: This log can happen many times if the engine restarts
+		// ⚠️ Warning: This log may happen many times
 		console.log("This might be logged more than once");
 
 		await step.do("do some stuff and have a log for when it runs", async () => {


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
The workflow engine might restart, as such functions with side effects should be avoided outside of steps. This new rule, gives some guidance on what to do, and what not to do. On the top level.

### Screenshots (optional)
<img width="674" height="367" alt="image" src="https://github.com/user-attachments/assets/73cf5fe1-4d70-47f2-8526-3bdff300de29" />
<img width="738" height="1211" alt="image" src="https://github.com/user-attachments/assets/55cfeab0-d815-47e4-a414-9513d88a25bc" />

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
