### PR TITLE
[ZT] Include IP calculator in Split Tunnels guide

### DIFF
--- a/src/content/partials/cloudflare-one/warp/add-split-tunnels-route.mdx
+++ b/src/content/partials/cloudflare-one/warp/add-split-tunnels-route.mdx
@@ -21,7 +21,17 @@ import { GlossaryTooltip, TabItem, Tabs, Render } from "~/components";
 		3. Select **Save destination**.
 
 		Traffic to this IP address is now excluded or included from the WARP tunnel.
+    
+    If you would like to exclude a certain specific IP range from a larger IP range, you can use this calculator:
 
+			<SubtractIPCalculator
+				client:load
+				defaults={{
+					base: "172.16.0.0/12",
+					exclude: ["172.31.0.0/16"]
+				}}
+			/>
+    
 		</TabItem> <TabItem label="Add a domain">
 
 		To add a domain to Split Tunnels:

--- a/src/content/partials/cloudflare-one/warp/add-split-tunnels-route.mdx
+++ b/src/content/partials/cloudflare-one/warp/add-split-tunnels-route.mdx
@@ -3,6 +3,7 @@
 ---
 
 import { GlossaryTooltip, TabItem, Tabs, Render } from "~/components";
+import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 

--- a/src/content/partials/cloudflare-one/warp/add-split-tunnels-route.mdx
+++ b/src/content/partials/cloudflare-one/warp/add-split-tunnels-route.mdx
@@ -22,8 +22,9 @@ import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
 		3. Select **Save destination**.
 
 		Traffic to this IP address is now excluded or included from the WARP tunnel.
-    
-    If you would like to exclude a certain specific IP range from a larger IP range, you can use this calculator:
+
+		:::note
+    If you would like to exclude a specific IP range from a larger IP range, you can use this calculator:
 
 			<SubtractIPCalculator
 				client:load
@@ -32,6 +33,7 @@ import SubtractIPCalculator from "~/components/SubtractIPCalculator.tsx";
 					exclude: ["172.31.0.0/16"]
 				}}
 			/>
+		:::
     
 		</TabItem> <TabItem label="Add a domain">
 


### PR DESCRIPTION
### Summary

Adds the CIDR IP calculator for excluding specific IP ranges from WARP tunnel. This is a common activity that would help users at this point in their configuration.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
