### PR TITLE
[Cloudflare Tunnel] cloudflared proxy-dns command will be removed

### DIFF
--- a/src/content/changelog/cloudflare-tunnel/2025-11-11-cloudflared-proxy-dns.mdx
+++ b/src/content/changelog/cloudflare-tunnel/2025-11-11-cloudflared-proxy-dns.mdx
@@ -6,23 +6,23 @@ products:
 date: 2025-11-11
 ---
 
-Starting **February 2, 2026**, the `cloudflared proxy-dns` command will be removed from all new `cloudflared` [releases](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/).
+Starting February 2, 2026, the `cloudflared proxy-dns` command will be removed from all new `cloudflared` [releases](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/).
 
-This change is being made to enhance security and address a potential vulnerability in an underlying DNS library. This vulnerability is specific to the `proxy-dns` command and **does not affect** any other `cloudflared` features, such as the core [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) service.
+This change is being made to enhance security and address a potential vulnerability in an underlying DNS library. This vulnerability is specific to the `proxy-dns` command and does not affect any other `cloudflared` features, such as the core [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) service.
 
 The `proxy-dns` command, which runs a client-side [DNS-over-HTTPS (DoH)](/1.1.1.1/encryption/dns-over-https/) proxy, has been an officially undocumented feature for several years. This functionality is fully and securely supported by our actively developed products.
 
-Versions of `cloudflared` released before this date will not be affected and will continue to operate. However, please note that our [official support policy](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/#deprecated-releases) for any `cloudflared` release is one year from its release date.
+Versions of `cloudflared` released before this date will not be affected and will continue to operate. However, note that our [official support policy](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/#deprecated-releases) for any `cloudflared` release is one year from its release date.
 
 ## Migration paths
 
-We strongly advise users of this undocumented feature to migrate to one of the following officially supported solutions before **February 2, 2026**, to continue benefiting from secure [DNS-over-HTTPS](/1.1.1.1/encryption/dns-over-https/).
+We strongly advise users of this undocumented feature to migrate to one of the following officially supported solutions before February 2, 2026, to continue benefiting from secure [DNS-over-HTTPS](/1.1.1.1/encryption/dns-over-https/).
 
-### 1. For end-user devices
+### End-user devices
 
 The preferred method for enabling DNS-over-HTTPS on user devices is the [Cloudflare WARP client](/cloudflare-one/team-and-resources/devices/warp/). The WARP client automatically secures and proxies all DNS traffic from your device, integrating it with your organization's [Zero Trust policies](/cloudflare-one/traffic-policies/) and [posture checks](/cloudflare-one/reusable-components/posture-checks/).
 
-### 2. For servers, routers, and IoT devices
+### Servers, routers, and IoT devices
 
 For scenarios where installing a client on every device is not possible (such as servers, routers, or IoT devices), we recommend using the [WARP Connector](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/).
 

--- a/src/content/changelog/cloudflare-tunnel/2025-11-11-cloudflared-proxy-dns.mdx
+++ b/src/content/changelog/cloudflare-tunnel/2025-11-11-cloudflared-proxy-dns.mdx
@@ -1,0 +1,29 @@
+---
+title: cloudflared proxy-dns command will be removed starting February 2, 2026
+description: To address a vulnerability in an underlying library, the `cloudflared proxy-dns` command will be removed from new `cloudflared` releases. Users are advised to migrate to the Cloudflare WARP client or WARP Connector.
+products:
+ - cloudflare-tunnel
+date: 2025-11-11
+---
+
+Starting **February 2, 2026**, the `cloudflared proxy-dns` command will be removed from all new `cloudflared` [releases](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/).
+
+This change is being made to enhance security and address a potential vulnerability in an underlying DNS library. This vulnerability is specific to the `proxy-dns` command and **does not affect** any other `cloudflared` features, such as the core [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) service.
+
+The `proxy-dns` command, which runs a client-side [DNS-over-HTTPS (DoH)](/1.1.1.1/encryption/dns-over-https/) proxy, has been an officially undocumented feature for several years. This functionality is fully and securely supported by our actively developed products.
+
+Versions of `cloudflared` released before this date will not be affected and will continue to operate. However, please note that our [official support policy](/cloudflare-one/networks/connectors/cloudflare-tunnel/downloads/#deprecated-releases) for any `cloudflared` release is one year from its release date.
+
+## Migration paths
+
+We strongly advise users of this undocumented feature to migrate to one of the following officially supported solutions before **February 2, 2026**, to continue benefiting from secure [DNS-over-HTTPS](/1.1.1.1/encryption/dns-over-https/).
+
+### 1. For end-user devices
+
+The preferred method for enabling DNS-over-HTTPS on user devices is the [Cloudflare WARP client](/cloudflare-one/team-and-resources/devices/warp/). The WARP client automatically secures and proxies all DNS traffic from your device, integrating it with your organization's [Zero Trust policies](/cloudflare-one/traffic-policies/) and [posture checks](/cloudflare-one/reusable-components/posture-checks/).
+
+### 2. For servers, routers, and IoT devices
+
+For scenarios where installing a client on every device is not possible (such as servers, routers, or IoT devices), we recommend using the [WARP Connector](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/).
+
+Instead of running `cloudflared proxy-dns` on a machine, you can install the WARP Connector on a single Linux host within your private network. This connector will act as a gateway, securely routing all DNS and network traffic from your [entire subnet](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/site-to-internet/) to Cloudflare for [filtering and logging](/cloudflare-one/traffic-policies/).


### PR DESCRIPTION
### Summary

To enhance security and address a potential vulnerability in an underlying DNS library specific to the `proxy-dns` command, the `cloudflared proxy-dns` feature will be removed from all new `cloudflared` releases.