### PR TITLE
feat: elicit-me example

### DIFF
--- a/src/content/docs/agents/guides/mcp-elicitation.mdx
+++ b/src/content/docs/agents/guides/mcp-elicitation.mdx
@@ -1,0 +1,392 @@
+---
+pcx_content_type: concept
+title: User Input with MCP Elicitation
+tags:
+  - MCP
+sidebar:
+  order: 12
+---
+
+import { Render, TypeScriptExample, Aside } from "~/components";
+
+MCP Elicitation allows your MCP server to request input from users through interactive forms during tool execution. This is useful when you need user confirmation, additional parameters, or structured data that wasn't provided in the initial tool call.
+
+## What is Elicitation?
+
+Elicitation is part of the [MCP specification](https://spec.modelcontextprotocol.io/specification/draft/client/elicitation/) that enables servers to pause tool execution and request structured input from users. Common use cases include:
+
+- **User confirmation** — Ask for approval before performing sensitive operations
+- **Additional parameters** — Request information not provided in the initial tool call
+- **Dynamic forms** — Collect structured data based on the execution context
+- **Multi-step workflows** — Guide users through complex operations with interactive steps
+
+## Basic Example
+
+Here's a simple MCP server that uses elicitation to confirm user actions:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Agent } from "agents";
+import { createMcpHandler } from "agents/mcp";
+import { z } from "zod";
+
+type Env = {
+  MyAgent: DurableObjectNamespace<MyAgent>;
+};
+
+interface State {
+  counter: number;
+}
+
+export class MyAgent extends Agent<Env, State> {
+  server = new McpServer({
+    name: "Elicitation Demo",
+    version: "1.0.0"
+  });
+
+  initialState = {
+    counter: 0
+  };
+
+  onStart(): void {
+    this.server.registerTool(
+      "increase-counter",
+      {
+        description: "Increase the counter",
+        inputSchema: {
+          confirm: z.boolean().describe("Do you want to increase the counter?")
+        }
+      },
+      async ({ confirm }) => {
+        if (!confirm) {
+          return {
+            content: [{ type: "text", text: "Counter increase cancelled." }]
+          };
+        }
+
+        // Request amount via elicitation
+        const result = await this.server.server.elicitInput({
+          message: "By how much do you want to increase the counter?",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              amount: {
+                type: "number",
+                title: "Amount",
+                description: "The amount to increase the counter by",
+                minLength: 1
+              }
+            },
+            required: ["amount"]
+          }
+        });
+
+        if (result.action !== "accept" || !result.content) {
+          return {
+            content: [{ type: "text", text: "Counter increase cancelled." }]
+          };
+        }
+
+        const amount = Number(result.content.amount);
+        this.setState({
+          ...this.state,
+          counter: this.state.counter + amount
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Counter increased by ${amount}, current value is ${this.state.counter}`
+            }
+          ]
+        };
+      }
+    );
+  }
+
+  async onMcpRequest(request: Request) {
+    return createMcpHandler(this.server)(request, this.env, {} as ExecutionContext);
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const sessionId = request.headers.get("mcp-session-id") ?? crypto.randomUUID();
+    const agentId = env.MyAgent.idFromName(sessionId);
+    const agent = env.MyAgent.get(agentId);
+
+    return await agent.fetch(request);
+  }
+};
+```
+
+</TypeScriptExample>
+
+## Elicitation Schema
+
+The `requestedSchema` follows [JSON Schema](https://json-schema.org/) format and supports various input types:
+
+### Text Input
+
+```ts
+{
+  type: "object",
+  properties: {
+    username: {
+      type: "string",
+      title: "Username",
+      description: "Enter your username"
+    }
+  },
+  required: ["username"]
+}
+```
+
+### Email Input
+
+```ts
+{
+  type: "object",
+  properties: {
+    email: {
+      type: "string",
+      format: "email",
+      title: "Email Address",
+      description: "Your email address"
+    }
+  },
+  required: ["email"]
+}
+```
+
+### Boolean (Checkbox)
+
+```ts
+{
+  type: "object",
+  properties: {
+    confirmed: {
+      type: "boolean",
+      title: "Confirm Action",
+      description: "Check to confirm"
+    }
+  },
+  required: ["confirmed"]
+}
+```
+
+### Select Dropdown
+
+```ts
+{
+  type: "object",
+  properties: {
+    role: {
+      type: "string",
+      title: "User Role",
+      enum: ["viewer", "editor", "admin"],
+      enumNames: ["Viewer", "Editor", "Administrator"]
+    }
+  },
+  required: ["role"]
+}
+```
+
+### Number Input
+
+```ts
+{
+  type: "object",
+  properties: {
+    amount: {
+      type: "number",
+      title: "Amount",
+      description: "Enter a number"
+    }
+  }
+}
+```
+
+## Handling User Responses
+
+Elicitation returns an `ElicitResult` with three possible actions:
+
+- **`accept`** — User submitted the form with data in `content`
+- **`decline`** — User explicitly rejected the request
+- **`cancel`** — User dismissed the form without making a choice
+
+<TypeScriptExample>
+
+```ts
+const result = await this.server.server.elicitInput({
+  message: "Please provide information:",
+  requestedSchema: { /* schema */ }
+});
+
+if (result.action === "accept" && result.content) {
+  // User submitted data
+  const userData = result.content;
+  // Process the data...
+} else if (result.action === "decline") {
+  // User explicitly declined
+  return { content: [{ type: "text", text: "Action declined." }] };
+} else {
+  // User cancelled (closed without choice)
+  return { content: [{ type: "text", text: "Action cancelled." }] };
+}
+```
+
+</TypeScriptExample>
+
+## Multi-Field Forms
+
+You can request multiple fields at once:
+
+<TypeScriptExample>
+
+```ts
+const userInfo = await this.server.server.elicitInput({
+  message: "Create user account:",
+  requestedSchema: {
+    type: "object",
+    properties: {
+      username: {
+        type: "string",
+        title: "Username",
+        description: "Choose a username"
+      },
+      email: {
+        type: "string",
+        format: "email",
+        title: "Email Address"
+      },
+      role: {
+        type: "string",
+        title: "Role",
+        enum: ["viewer", "editor", "admin"],
+        enumNames: ["Viewer", "Editor", "Administrator"]
+      },
+      sendWelcome: {
+        type: "boolean",
+        title: "Send Welcome Email",
+        description: "Send welcome email to user"
+      }
+    },
+    required: ["username", "email", "role"]
+  }
+});
+
+if (userInfo.action === "accept" && userInfo.content) {
+  const { username, email, role, sendWelcome } = userInfo.content;
+  // Create user with provided information...
+}
+```
+
+</TypeScriptExample>
+
+## State Persistence
+
+When using elicitation with [Durable Objects hibernation](/durable-objects/best-practices/websockets/#websocket-hibernation-api), you may need to persist transport state to survive hibernation periods. Use the `storage` option with `createMcpHandler`:
+
+<TypeScriptExample>
+
+```ts
+import { createMcpHandler, type TransportState } from "agents/mcp";
+
+const STATE_KEY = "mcp_transport_state";
+
+async onMcpRequest(request: Request) {
+  return createMcpHandler(this.server, {
+    storage: {
+      get: () => {
+        return this.ctx.storage.kv.get<TransportState>(STATE_KEY);
+      },
+      set: (state: TransportState) => {
+        this.ctx.storage.kv.put<TransportState>(STATE_KEY, state);
+      }
+    }
+  })(request, this.env, {} as ExecutionContext);
+}
+```
+
+</TypeScriptExample>
+
+This ensures that session information persists across hibernation, allowing elicitation requests to resume correctly.
+
+## Best Practices
+
+### 1. Provide Clear Messages
+
+Make your elicitation messages descriptive and actionable:
+
+```ts
+// Good
+message: "By how much do you want to increase the counter?"
+
+// Less clear
+message: "Enter amount"
+```
+
+### 2. Use Descriptive Field Titles
+
+Help users understand what each field is for:
+
+```ts
+{
+  type: "string",
+  title: "Email Address",  // Clear title
+  description: "We'll send a confirmation to this address"  // Helpful context
+}
+```
+
+### 3. Mark Required Fields
+
+Use the `required` array to indicate mandatory fields:
+
+```ts
+{
+  type: "object",
+  properties: {
+    email: { type: "string", format: "email" },
+    phone: { type: "string" }
+  },
+  required: ["email"]  // Email is required, phone is optional
+}
+```
+
+### 4. Handle All Response Types
+
+Always handle all three response actions (`accept`, `decline`, `cancel`):
+
+```ts
+if (result.action === "accept" && result.content) {
+  // Process data
+} else if (result.action === "decline") {
+  // Handle explicit decline
+} else {
+  // Handle cancellation
+}
+```
+
+### 5. Validate User Input
+
+Even though the schema validates basic types, add business logic validation:
+
+```ts
+const amount = Number(result.content.amount);
+if (amount <= 0) {
+  return {
+    content: [{ type: "text", text: "Amount must be positive." }]
+  };
+}
+```
+
+## Related Resources
+
+- [MCP Specification — Elicitation](https://spec.modelcontextprotocol.io/specification/draft/client/elicitation/)
+- [MCP Tools](/agents/model-context-protocol/tools/)
+- [McpAgent API Reference](/agents/model-context-protocol/mcp-agent-api/)
+- [Build a Remote MCP Server](/agents/guides/remote-mcp-server/)

--- a/src/content/docs/agents/model-context-protocol/elicitation.mdx
+++ b/src/content/docs/agents/model-context-protocol/elicitation.mdx
@@ -1,0 +1,331 @@
+---
+pcx_content_type: concept
+title: Elicitation
+tags:
+  - MCP
+sidebar:
+  order: 7
+---
+
+import { Render, TypeScriptExample } from "~/components";
+
+[Elicitation](https://spec.modelcontextprotocol.io/specification/draft/client/elicitation/) is an MCP feature that allows servers to request user input during tool execution. This enables interactive workflows where tools can ask for confirmation, collect form data, or gather additional information before completing their operations.
+
+## How elicitation works
+
+When a tool needs user input, it calls `server.elicitInput()` with a message and a [JSON Schema](https://json-schema.org/) describing the expected input format. The MCP client presents this to the user (typically as a form or dialog), and returns the user's response to the server.
+
+The user can respond in three ways:
+- **Accept**: Provide the requested information and continue
+- **Decline**: Explicitly reject the request
+- **Cancel**: Dismiss without making a choice
+
+## Basic example
+
+Here's a simple tool that asks for user confirmation before incrementing a counter:
+
+<TypeScriptExample>
+
+```ts title="src/index.ts"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Agent } from "agents";
+import { createMcpHandler } from "agents/mcp";
+import { z } from "zod";
+
+type Env = {
+  MyAgent: DurableObjectNamespace<MyAgent>;
+};
+
+interface State {
+  counter: number;
+}
+
+export class MyAgent extends Agent<Env, State> {
+  server = new McpServer({
+    name: "Elicitation Demo",
+    version: "1.0.0"
+  });
+
+  initialState = {
+    counter: 0
+  };
+
+  onStart() {
+    this.server.registerTool(
+      "increase-counter",
+      {
+        description: "Increase the counter",
+        inputSchema: {
+          confirm: z.boolean().describe("Do you want to increase the counter?")
+        }
+      },
+      async ({ confirm }) => {
+        if (!confirm) {
+          return {
+            content: [{ type: "text", text: "Counter increase cancelled." }]
+          };
+        }
+
+        // Request additional input via elicitation
+        const result = await this.server.server.elicitInput({
+          message: "By how much do you want to increase the counter?",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              amount: {
+                type: "number",
+                title: "Amount",
+                description: "The amount to increase the counter by",
+                minimum: 1
+              }
+            },
+            required: ["amount"]
+          }
+        });
+
+        if (result.action !== "accept" || !result.content) {
+          return {
+            content: [{ type: "text", text: "Counter increase cancelled." }]
+          };
+        }
+
+        const amount = Number(result.content.amount);
+        this.setState({
+          counter: this.state.counter + amount
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Counter increased by ${amount}, current value is ${this.state.counter}`
+            }
+          ]
+        };
+      }
+    );
+  }
+
+  async onMcpRequest(request: Request) {
+    return createMcpHandler(this.server)(request, this.env, {} as ExecutionContext);
+  }
+}
+```
+
+</TypeScriptExample>
+
+## Elicitation response types
+
+The `elicitInput()` method returns an `ElicitResult` with one of three action types:
+
+```ts
+type ElicitResult = {
+  action: "accept" | "decline" | "cancel";
+  content?: Record<string, unknown>;
+};
+```
+
+- **accept**: User provided the requested information (available in `content`)
+- **decline**: User explicitly rejected the request
+- **cancel**: User dismissed without making a choice
+
+Always check the `action` before using `content`:
+
+```ts
+const result = await this.server.server.elicitInput({
+  message: "Enter your email",
+  requestedSchema: {
+    type: "object",
+    properties: {
+      email: { type: "string", format: "email" }
+    },
+    required: ["email"]
+  }
+});
+
+if (result.action === "accept" && result.content?.email) {
+  // Use result.content.email
+} else {
+  // Handle decline or cancel
+}
+```
+
+## Schema types
+
+Elicitation supports various input types through JSON Schema:
+
+### Boolean (confirmation)
+
+```ts
+requestedSchema: {
+  type: "object",
+  properties: {
+    confirmed: {
+      type: "boolean",
+      title: "Confirm action",
+      description: "Check to confirm"
+    }
+  }
+}
+```
+
+### Text input
+
+```ts
+requestedSchema: {
+  type: "object",
+  properties: {
+    name: {
+      type: "string",
+      title: "Name",
+      description: "Enter your name"
+    }
+  },
+  required: ["name"]
+}
+```
+
+### Email input
+
+```ts
+requestedSchema: {
+  type: "object",
+  properties: {
+    email: {
+      type: "string",
+      format: "email",
+      title: "Email Address"
+    }
+  }
+}
+```
+
+### Number input
+
+```ts
+requestedSchema: {
+  type: "object",
+  properties: {
+    amount: {
+      type: "number",
+      title: "Amount",
+      minimum: 1,
+      maximum: 100
+    }
+  }
+}
+```
+
+### Select/dropdown
+
+```ts
+requestedSchema: {
+  type: "object",
+  properties: {
+    role: {
+      type: "string",
+      title: "Role",
+      enum: ["viewer", "editor", "admin"],
+      enumNames: ["Viewer", "Editor", "Administrator"]
+    }
+  }
+}
+```
+
+### Multiple fields
+
+```ts
+requestedSchema: {
+  type: "object",
+  properties: {
+    username: { type: "string", title: "Username" },
+    email: { type: "string", format: "email", title: "Email" },
+    role: {
+      type: "string",
+      enum: ["viewer", "editor"],
+      title: "Role"
+    },
+    sendWelcome: {
+      type: "boolean",
+      title: "Send welcome email"
+    }
+  },
+  required: ["username", "email", "role"]
+}
+```
+
+## Best practices
+
+### Keep messages clear
+
+Use clear, action-oriented messages that explain what you're asking for:
+
+```ts
+// Good
+message: "Enter the email address for the new user account"
+
+// Less clear
+message: "Email"
+```
+
+### Provide helpful descriptions
+
+Use the `description` field to guide users:
+
+```ts
+properties: {
+  apiKey: {
+    type: "string",
+    title: "API Key",
+    description: "Your API key from the dashboard (Settings > API)"
+  }
+}
+```
+
+### Handle all response types
+
+Always handle `accept`, `decline`, and `cancel` appropriately:
+
+```ts
+const result = await this.server.server.elicitInput({...});
+
+switch (result.action) {
+  case "accept":
+    if (result.content) {
+      // Process the input
+      return { content: [{ type: "text", text: "Success!" }] };
+    }
+    break;
+  case "decline":
+    return { content: [{ type: "text", text: "Action declined." }] };
+  case "cancel":
+    return { content: [{ type: "text", text: "Action cancelled." }] };
+}
+```
+
+### Use required fields appropriately
+
+Mark fields as `required` when they're essential for the operation:
+
+```ts
+requestedSchema: {
+  type: "object",
+  properties: {
+    username: { type: "string", title: "Username" },
+    email: { type: "string", format: "email", title: "Email" }
+  },
+  required: ["username", "email"] // Both are mandatory
+}
+```
+
+## Limitations
+
+- Elicitation is currently only supported in direct MCP connections between clients and servers
+- Complex nested schemas may not be supported by all MCP clients
+- The visual presentation of elicitation forms depends on the MCP client implementation
+
+## Related resources
+
+- [MCP Elicitation Specification](https://spec.modelcontextprotocol.io/specification/draft/client/elicitation/)
+- [MCP Tools Documentation](/agents/model-context-protocol/tools/)
+- [JSON Schema Reference](https://json-schema.org/understanding-json-schema/)

--- a/src/content/docs/agents/model-context-protocol/transport.mdx
+++ b/src/content/docs/agents/model-context-protocol/transport.mdx
@@ -105,6 +105,177 @@ To use apiHandlers, update to @cloudflare/workers-oauth-provider v0.0.4 or later
 
 With these few changes, your MCP server will support both transport methods, making it compatible with both existing and new clients.
 
+## Advanced configuration with `createMcpHandler`
+
+For more control over your MCP server's transport layer, you can use the `createMcpHandler` function directly. This is useful when building MCP servers with Agents (not McpAgent) or when you need advanced features like state persistence.
+
+### Basic usage
+
+```ts
+import { createMcpHandler } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Agent } from "agents";
+
+export class MyAgent extends Agent<Env, State> {
+  server = new McpServer({ name: "My Server", version: "1.0.0" });
+
+  async onMcpRequest(request: Request) {
+    return createMcpHandler(this.server)(
+      request,
+      this.env,
+      {} as ExecutionContext
+    );
+  }
+}
+```
+
+### Configuration options
+
+`createMcpHandler` accepts an options object with the following properties:
+
+#### `route` (optional)
+
+Specify a path prefix for the MCP endpoint. Requests to other paths will return a 404.
+
+```ts
+createMcpHandler(this.server, {
+  route: "/mcp"
+})(request, env, ctx);
+```
+
+#### `sessionIdGenerator` (optional)
+
+Provide a custom function to generate session IDs:
+
+```ts
+createMcpHandler(this.server, {
+  sessionIdGenerator: () => crypto.randomUUID()
+})(request, env, ctx);
+```
+
+#### `storage` (optional)
+
+Persist transport state across requests. This is particularly useful for [Durable Objects with hibernation](/durable-objects/best-practices/websockets/#websocket-hibernation-api), allowing your MCP server to maintain session state even when the Durable Object hibernates:
+
+```ts
+createMcpHandler(this.server, {
+  storage: {
+    get: () => this.ctx.storage.kv.get("mcp_transport_state"),
+    set: (state) => this.ctx.storage.kv.put("mcp_transport_state", state)
+  }
+})(request, env, ctx);
+```
+
+The storage API must implement:
+- `get()`: Returns the stored state or `undefined`
+- `set(state)`: Stores the transport state
+
+Both methods can be synchronous or return Promises.
+
+#### `authContext` (optional)
+
+Provide authentication context from your OAuth flow:
+
+```ts
+createMcpHandler(this.server, {
+  authContext: {
+    props: {
+      userId: "user-123",
+      email: "user@example.com"
+    }
+  }
+})(request, env, ctx);
+```
+
+If not provided, the handler will automatically use `ctx.props` when available (e.g., from OAuth Provider).
+
+#### `transport` (optional)
+
+Provide a pre-configured `WorkerTransport` instance for advanced use cases:
+
+```ts
+import { WorkerTransport } from "agents/mcp";
+
+const transport = new WorkerTransport({
+  sessionIdGenerator: () => "custom-session",
+  storage: { /* ... */ }
+});
+
+// Pre-connect if needed
+await this.server.connect(transport);
+
+createMcpHandler(this.server, {
+  transport
+})(request, env, ctx);
+```
+
+#### `corsOptions` (optional)
+
+Configure CORS headers for cross-origin requests:
+
+```ts
+createMcpHandler(this.server, {
+  corsOptions: {
+    origin: "https://example.com",
+    methods: "GET, POST, OPTIONS",
+    headers: "Content-Type, Authorization"
+  }
+})(request, env, ctx);
+```
+
+Default CORS settings:
+- `origin`: `*`
+- `headers`: `Content-Type, Accept, Authorization, mcp-session-id, MCP-Protocol-Version`
+- `methods`: `GET, POST, DELETE, OPTIONS`
+- `exposeHeaders`: `mcp-session-id`
+- `maxAge`: `86400`
+
+### Complete example with state persistence
+
+```ts
+import { Agent } from "agents";
+import { createMcpHandler } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const STATE_KEY = "mcp_transport_state";
+
+export class MyAgent extends Agent<Env, State> {
+  server = new McpServer({
+    name: "Stateful MCP Server",
+    version: "1.0.0"
+  });
+
+  initialState = { counter: 0 };
+
+  onStart() {
+    this.server.registerTool(
+      "increment",
+      { description: "Increment counter" },
+      async () => {
+        this.setState({ counter: this.state.counter + 1 });
+        return {
+          content: [{
+            type: "text",
+            text: `Counter: ${this.state.counter}`
+          }]
+        };
+      }
+    );
+  }
+
+  async onMcpRequest(request: Request) {
+    return createMcpHandler(this.server, {
+      route: "/mcp",
+      sessionIdGenerator: () => this.name,
+      storage: {
+        get: () => this.ctx.storage.kv.get(STATE_KEY),
+        set: (state) => this.ctx.storage.kv.put(STATE_KEY, state)
+      }
+    })(request, this.env, {} as ExecutionContext);
+  }
+}
+```
+
 ### Testing with MCP clients
 While most MCP clients have not yet adopted the new Streamable HTTP transport, you can start testing it today using [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), an adapter that lets MCP clients that otherwise only support local connections work with remote MCP servers.
 

--- a/src/content/docs/agents/model-context-protocol/transport.mdx
+++ b/src/content/docs/agents/model-context-protocol/transport.mdx
@@ -109,3 +109,194 @@ With these few changes, your MCP server will support both transport methods, mak
 While most MCP clients have not yet adopted the new Streamable HTTP transport, you can start testing it today using [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), an adapter that lets MCP clients that otherwise only support local connections work with remote MCP servers.
 
 Follow [this guide](/agents/guides/test-remote-mcp-server/) for instructions on how to connect to your remote MCP server from Claude Desktop, Cursor, Windsurf, and other local MCP clients, using the [`mcp-remote` local proxy](https://www.npmjs.com/package/mcp-remote).
+
+## Advanced Transport Configuration
+
+For more control over MCP transport behavior, you can use the `createMcpHandler` function with custom options. This is useful when building MCP servers with regular `Agent` classes (not `McpAgent`) or when you need advanced features like state persistence.
+
+### Custom Transport Handler
+
+<Tabs syncKey="workersExamples"> <TabItem label="TypeScript" icon="seti:typescript">
+
+```ts
+import { Agent } from "agents";
+import { createMcpHandler } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+type Env = {
+  MyAgent: DurableObjectNamespace<MyAgent>;
+};
+
+export class MyAgent extends Agent<Env, State> {
+  server = new McpServer({
+    name: "My Server",
+    version: "1.0.0"
+  });
+
+  async onMcpRequest(request: Request) {
+    return createMcpHandler(this.server, {
+      route: "/mcp",
+      sessionIdGenerator: () => this.name
+    })(request, this.env, {} as ExecutionContext);
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const sessionId = request.headers.get("mcp-session-id") ?? crypto.randomUUID();
+    const agentId = env.MyAgent.idFromName(sessionId);
+    const agent = env.MyAgent.get(agentId);
+
+    return await agent.fetch(request);
+  }
+};
+```
+
+</TabItem> </Tabs>
+
+### Transport Options
+
+The `createMcpHandler` function accepts the following options:
+
+#### `route`
+
+Specify which URL path the handler should respond to:
+
+```ts
+createMcpHandler(server, {
+  route: "/mcp"  // Only handle requests to /mcp
+})
+```
+
+#### `sessionIdGenerator`
+
+Provide a custom function to generate session IDs:
+
+```ts
+createMcpHandler(server, {
+  sessionIdGenerator: () => `session-${Date.now()}`
+})
+```
+
+#### `storage`
+
+Persist transport state to survive [Durable Object hibernation](/durable-objects/best-practices/websockets/#websocket-hibernation-api). This is essential for features like [elicitation](/agents/guides/mcp-elicitation/) that require maintaining session state:
+
+```ts
+import { type TransportState } from "agents/mcp";
+
+const STATE_KEY = "mcp_transport_state";
+
+createMcpHandler(server, {
+  storage: {
+    get: () => {
+      return this.ctx.storage.kv.get<TransportState>(STATE_KEY);
+    },
+    set: (state: TransportState) => {
+      this.ctx.storage.kv.put<TransportState>(STATE_KEY, state);
+    }
+  }
+})
+```
+
+#### `authContext`
+
+Provide authentication context when not using the Workers OAuth Provider:
+
+```ts
+createMcpHandler(server, {
+  authContext: {
+    props: {
+      userId: "user-123",
+      role: "admin"
+    }
+  }
+})
+```
+
+#### `transport`
+
+Use a custom `WorkerTransport` instance for full control:
+
+```ts
+import { WorkerTransport } from "agents/mcp";
+
+const customTransport = new WorkerTransport({
+  sessionIdGenerator: () => crypto.randomUUID(),
+  storage: { /* storage config */ }
+});
+
+// Pre-configure transport
+await server.connect(customTransport);
+
+createMcpHandler(server, {
+  transport: customTransport
+})
+```
+
+#### `corsOptions`
+
+Customize CORS headers for cross-origin requests:
+
+```ts
+createMcpHandler(server, {
+  corsOptions: {
+    origin: "https://example.com",
+    methods: "GET, POST, OPTIONS",
+    headers: "Content-Type, Authorization",
+    maxAge: 3600
+  }
+})
+```
+
+### State Persistence Example
+
+Here's a complete example showing how to persist transport state for use with elicitation:
+
+```ts
+import { Agent } from "agents";
+import { createMcpHandler, type TransportState } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const STATE_KEY = "mcp_transport_state";
+
+export class MyAgent extends Agent<Env, State> {
+  server = new McpServer({
+    name: "Persistent Server",
+    version: "1.0.0"
+  });
+
+  onStart(): void {
+    this.server.registerTool(
+      "my-tool",
+      {
+        description: "Tool with elicitation",
+        inputSchema: { /* schema */ }
+      },
+      async (args) => {
+        // Elicitation works across hibernation
+        const result = await this.server.server.elicitInput({
+          message: "Please confirm:",
+          requestedSchema: { /* schema */ }
+        });
+
+        // Process result...
+      }
+    );
+  }
+
+  async onMcpRequest(request: Request) {
+    return createMcpHandler(this.server, {
+      sessionIdGenerator: () => this.name,
+      storage: {
+        get: () => this.ctx.storage.kv.get<TransportState>(STATE_KEY),
+        set: (state: TransportState) => {
+          this.ctx.storage.kv.put<TransportState>(STATE_KEY, state);
+        }
+      }
+    })(request, this.env, {} as ExecutionContext);
+  }
+}
+```
+
+This configuration ensures that MCP session state persists even when the Durable Object hibernates, allowing long-running elicitation requests to complete successfully.


### PR DESCRIPTION
Things to think about with this pattern:

AuthContext
This is really annoying because the types we get from props are not the same as the auth types in the extra param in tools etc. At the moment you can access them with asyncLocalStorage

Storage
The storage interface is pretty extensible. It would be cool to have patterns with kv or even cookies and no DO at all. This would tee us up very well for the stateless by default SEP coming soon to MCP.

---

Documentation sync from cloudflare/agents PR #620
https://github.com/cloudflare/agents/pull/620