### PR TITLE
Remove deprecated rate-limit provider configurations

### DIFF
--- a/src/content/docs/terraform/advanced-topics/provider-customization.mdx
+++ b/src/content/docs/terraform/advanced-topics/provider-customization.mdx
@@ -14,19 +14,4 @@ Typically, the only required parameters to the provider are those required to au
 The examples below build on the [Cloudflare Terraform tutorial](/terraform/tutorial/).
 :::
 
-You can customize the Cloudflare Terraform provider using configuration parameters, specified either in your `.tf` configuration files or via environment variables, such as `$CLOUDFLARE_RPS`. Using environment variables may make sense when running Terraform from a CI/CD system or when the change is temporary and does not need to be persisted in your configuration history.
-
-### Increase the frequency of API requests
-
-The `api.cloudflare.com` endpoint has a default rate limit of 1,200 calls per five minute period, or four requests per second (refer to [API Rate Limits](/fundamentals/api/reference/limits/)). Terraform will need to stay below the defined threshold or the Cloudflare API will respond with `HTTP 429 - Too Many Requests` responses. When this happens, the Cloudflare Terraform provider will back off before retrying.
-
-Enterprise customers may request a limit increase by contacting their account team. You can then configure the Cloudflare Terraform provider to make API calls at a faster rate. For example, you can increase the API request frequency by setting environment variables:
-
-```sh
-# Remove requests-per-second (RPS) limit for API calls performed by Terraform (default: 4).
-export CLOUDFLARE_RPS=
-# Print logs from the API client using the default log library logger (default: false).
-export CLOUDFLARE_API_CLIENT_LOGGING=true
-# Maximum backoff period in seconds after failed API calls (default: 30).
-export CLOUDFLARE_MAX_BACKOFF=20
-```
+You can customize the Cloudflare Terraform provider using configuration parameters, specified either in your `.tf` configuration files or via environment variables. Using environment variables may make sense when running Terraform from a CI/CD system or when the change is temporary and does not need to be persisted in your configuration history.


### PR DESCRIPTION
### Summary

Removed deprecated configurations about increasing API request frequency for the Cloudflare Terraform provider.

https://github.com/cloudflare/terraform-provider-cloudflare/issues/5496#issuecomment-2792173429

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
