### PR TITLE
[Workflows] Add create/createBatch clarification regarding instances with repeated IDs

### DIFF
--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -266,6 +266,8 @@ return Response.json({
 
 Returns a `WorkflowInstance`.
 
+Throws an error if the provided ID is already used by an existing instance that has not yet passed its [retention limit](/workflows/reference/limits/). To re-run a workflow with the same ID, you can [`restart`](/workflows/build/trigger-workflows/#restart-a-workflow) the existing instance. 
+
 <Render file="workflows-type-parameters" product="workflows" />
 
 To provide an optional type parameter to the `Workflow`, pass a type argument with your type when defining your Workflow bindings:
@@ -325,6 +327,8 @@ let instances = await env.MY_WORKFLOW.createBatch(listOfInstances);
 ```
 
 Returns an array of `WorkflowInstance`.
+
+Unlike [`create`](/workflows/build/workers-api/#create), this operation is idempotent and will not fail if an ID is already in use. If an existing instance with the same ID is still within its [retention limit](/workflows/reference/limits/), it will be skipped and excluded from the returned array.
 
 ### get
 

--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -27,12 +27,12 @@ Many limits are inherited from those applied to Workers scripts and as documente
 | Concurrent Workflow instances (executions) per account [^7]   | 25 | 10,000 |
 | Maximum Workflow instance creation rate [^8] | 100 per second [^6] | 100 per second [^6] |
 | Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 10,000 | 100,000 |
-| Retention limit for completed Workflow state | 3 days | 30 days [^2] |
+| Retention limit for completed Workflow instance state | 3 days | 30 days [^2] |
 | Maximum length of a Workflow name [^4]         | 64 characters | 64 characters |
 | Maximum length of a Workflow instance ID [^4]         | 100 characters | 100 characters |
 | Maximum number of subrequests per Workflow instance | 50/request | 1000/request |
 
-[^2]: Workflow state and logs will be retained for 3 days on the Workers Free plan and for 7 days on the Workers Paid plan.
+[^2]: Workflow instance state and logs will be retained for 3 days on the Workers Free plan and for 30 days on the Workers Paid plan.
 
 [^3]: A Workflow instance can run forever, as long as each step does not take more than the CPU time limit and the maximum number of steps per Workflow is not reached.
 


### PR DESCRIPTION
### Summary

We lacked information regarding what happens if Workflow instances get created with repeated IDs. 

