### PR TITLE
update broken REST API link for VPC Services

### DIFF
--- a/src/content/docs/workers-vpc/configuration/vpc-services.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-services.mdx
@@ -58,7 +58,7 @@ The port provided in the `fetch()` operation is ignored — the port specified i
 
 ## Configuration example
 
-The following is an example of a VPC Service for a service using custom HTTP and HTTPS ports, and both IPv4 and IPv6 addresses. These configurations represent the expected contract of the [REST API for creating a VPC Service](https://developers.cloudflare.com/api/resources/zero_trust/subresources/connectivity/subresources/directory/subresources/services/), a type of service within the broader connectivity directory.
+The following is an example of a VPC Service for a service using custom HTTP and HTTPS ports, and both IPv4 and IPv6 addresses. These configurations represent the expected contract of the [REST API for creating a VPC Service](https://developers.cloudflare.com/api/resources/connectivity/subresources/directory/subresources/services/), a type of service within the broader connectivity directory.
 
 ```json
 {

--- a/src/content/docs/workers-vpc/configuration/vpc-services.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-services.mdx
@@ -58,7 +58,7 @@ The port provided in the `fetch()` operation is ignored — the port specified i
 
 ## Configuration example
 
-The following is an example of a VPC Service for a service using custom HTTP and HTTPS ports, and both IPv4 and IPv6 addresses. These configurations represent the expected contract of the [REST API for creating a VPC Service](https://developers.cloudflare.com/api/resources/connectivity/subresources/directory/subresources/services/), a type of service within the broader connectivity directory.
+The following is an example of a VPC Service for a service using custom HTTP and HTTPS ports, and both IPv4 and IPv6 addresses. These configurations represent the expected contract of the [REST API for creating a VPC Service](/api/resources/connectivity/subresources/directory/subresources/services/), a type of service within the broader connectivity directory.
 
 ```json
 {


### PR DESCRIPTION
### Summary
The Workers VPC API docs were originally created as a subresource of zero_trust, which is not what we wanted. Updating to the correct (non-broken) URL
<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
