### PR TITLE
fix: sanitize `<` chars in markdown

### DIFF
--- a/src/components/WranglerArg.astro
+++ b/src/components/WranglerArg.astro
@@ -14,6 +14,9 @@ const { key, definition } = props.parse(Astro.props);
 
 const type = definition.type ?? definition.choices;
 const description = definition.description ?? definition.describe;
+const sanitizedDescription = description
+	.replace(/</g, "&lt;")
+	.replace(/>/g, "&gt;");
 const required = definition.demandOption;
 const defaultValue = definition.default;
 const alias = definition.alias;
@@ -44,5 +47,5 @@ if (alias) {
 	{aliasText && <MetaInfo text={aliasText} />}
 	{required && <MetaInfo text="required" />}
 	{defaultValue !== undefined && <MetaInfo text={`default: ${defaultValue}`} />}
-	<Fragment set:html={marked.parse(description)} />
+	<Fragment set:html={marked.parse(sanitizedDescription)} />
 </li>

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -1290,16 +1290,14 @@ The minimum required wrangler version to use these commands is 3.40.0. For versi
 
 <WranglerCommand
 	command="versions upload"
-	description="
-Upload a new [version](/workers/configuration/versions-and-deployments/#versions) of your Worker that is not deployed immediately."
+	description="Upload a new [version](/workers/configuration/versions-and-deployments/#versions) of your Worker that is not deployed immediately."
 	headingLevel={3}
 />
 
 <WranglerCommand
 	command="versions deploy"
-description="Deploy a previously created [version](/workers/configuration/versions-and-deployments/#versions) of your Worker all at once or create a [gradual deployment](/workers/configuration/versions-and-deployments/gradual-deployments/) to incrementally shift traffic to a new version by following an interactive prompt."
-    headingLevel={3}
-
+	description="Deploy a previously created [version](/workers/configuration/versions-and-deployments/#versions) of your Worker all at once or create a [gradual deployment](/workers/configuration/versions-and-deployments/gradual-deployments/) to incrementally shift traffic to a new version by following an interactive prompt."
+	headingLevel={3}
 />
 
 :::note
@@ -1313,16 +1311,13 @@ For example:
 
 <WranglerCommand
 	command="versions list"
-description="Retrieve details for the 10 most recent versions. Details include `Version ID`, `Created on`, `Author`, `Source`, and optionally, `Tag` or `Message`."
-    headingLevel={3}
-
+	description="Retrieve details for the 10 most recent versions. Details include `Version ID`, `Created on`, `Author`, `Source`, and optionally, `Tag` or `Message`."
+	headingLevel={3}
 />
 
 <WranglerCommand
 	command="versions view"
-
-    headingLevel={3}
-
+	headingLevel={3}
 />
 
 ### `secret put`

--- a/src/content/warp-releases/windows/beta/2024.11.688.1.yaml
+++ b/src/content/warp-releases/windows/beta/2024.11.688.1.yaml
@@ -2,7 +2,7 @@ releaseNotes: |
   This release contains minor fixes and improvements.
 
   **Changes and improvements:**
-  - Consumers can now set the tunnel protocol using "warp-cli tunnel protocol set <proto>".
+  - Consumers can now set the tunnel protocol using "warp-cli tunnel protocol set &lt;proto&gt;".
   - Extended diagnostics collection time in warp-diag to ensure logs are captured reliably.
   - Improved captive portal support by disabling the firewall during captive portal login flows.
   - Improved captive portal detection on certain public networks.


### PR DESCRIPTION
# Context

We have two builds in the project.
- `astro build`: turns `.md`/`.mdx` into `.html`
    - I colloquially refer to this as the _build_. 
- `generate-index-md.ts`: turns the resulting `.html` back into `.md` (but not `.mdx`)
    - I colloquially refer to this as the _reverse build_. 

# Problem

The following pages have a broken _Copy page_ button. The string "Not Found" is copied, not the page's markdown.

- [cloudflare-one/changelog](https://developers.cloudflare.com/cloudflare-one/changelog)
- [cloudflare-one/changelog/warp](https://developers.cloudflare.com/cloudflare-one/changelog/warp)
- [workers/wrangler/commands](https://developers.cloudflare.com/workers/wrangler/commands)
- [cloudflare-one/team-and-resources/devices/warp/download-warp/beta-releases](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/download-warp/beta-releases)
- [changelog/2024-12-06-warp-windows-beta](https://developers.cloudflare.com/changelog/2024-12-06-warp-windows-beta)
    - If this page had a _Copy page_ button, it would not work.

Because we use `<` to denote arguments (i.e. `cmd <argOne> <argTwo>`), markdown can misinterpret the arguments as an HTML tag in certain cases. If you do this in a `.mdx` file, Astro will catch it and give you a very visible error long before you ever commit it. But we have several places where markdown strings are stored in data files (`.yml`/`.json`) and converted from markdown to HTML outside of the standard Astro mechanisms. The above pages were importing data that contained an `<arg>` string and our custom conversion wasn't catching it, resulting in unclosed tags in the build's resulting HTML.

These unclosed tags aren't particularly noticeable in the app since the browser just drops them, leaving a subtle error in the content. (See screenshots.) Browsers are notoriously forgiving when it comes to odd HTML, but the reverse build uses `node-html-parser` to parse the HTML and it is not forgiving. It would struggle on these pages and silently fail, resulting in a missing `index.md` for the page. Without an `index.md`, the page's _Copy page_ button's HTTP call would fail and just give a "Not found" string.

The fix is to properly escape/sanitize these `<`. 

## Specific loose `<` chars

The `src/content/warp-releases/windows/beta/2024.11.688.1.yaml` changelog was being referenced in a handful of places. Properly escaping the `<` fixed most of the pages.

Before: 

<img width="623" height="157" alt="Screenshot 2025-11-12 at 16 48 56" src="https://github.com/user-attachments/assets/766c9cc7-a9a0-4076-8b12-752208179698" />

After:

<img width="631" height="171" alt="Screenshot 2025-11-12 at 16 49 25" src="https://github.com/user-attachments/assets/3363294d-9887-4272-a11f-890c897f1d07" />

The tougher one to find comes from `wrangler` itself. We are leveraging a [constant](https://github.com/cloudflare/workers-sdk/blob/wrangler%404.40.2/packages/wrangler/src/experimental-commands-api.ts) from the `wrangler` project that contains metadata about the commands. One of those pieces of metadata (the [version-specs argument](https://github.com/cloudflare/workers-sdk/blob/wrangler%404.40.2/packages/wrangler/src/versions/deploy.ts#L75) of the `versions deploy` command) contains `<` chars to specify arguments. Sanitizing every description prop from `wrangler` before converting the markdown fixes the page.

Before:

<img width="635" height="404" alt="Screenshot 2025-11-12 at 17 00 13" src="https://github.com/user-attachments/assets/bcea6955-ad17-40ab-9685-44b69f86ecfd" />

After:

<img width="625" height="427" alt="Screenshot 2025-11-12 at 17 00 29" src="https://github.com/user-attachments/assets/869db435-d0e9-4315-a46e-517b12691d14" />

fixes #26084
