### PR TITLE
[WAF] Remove small section in Managed Rules

### DIFF
--- a/src/content/docs/waf/managed-rules/deploy-zone-dashboard.mdx
+++ b/src/content/docs/waf/managed-rules/deploy-zone-dashboard.mdx
@@ -53,32 +53,7 @@ This operation deploys the managed ruleset for the current zone, creating a new 
 
 </TabItem> </Tabs>
 
-## Turn on or off a managed ruleset
-
-<Tabs syncKey="dashNewNav"> <TabItem label="Old dashboard">
-
-<Steps>
-
-1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/), and select your account and domain.
-2. Go to **Security** > **WAF** > **Managed rules** tab.
-3. Next to the managed ruleset you want to turn on or off, switch the **Enabled** toggle.
-
-</Steps>
-
-</TabItem> <TabItem label="New dashboard" icon="rocket">
-
-<Steps>
-
-1. In the Cloudflare dashboard, go to the Security **Settings** page.
-
-   <DashButton url="/?to=/:account/:zone/security/settings" />
-
-2. (Optional) Filter by **Web application exploits**.
-3. Next to the managed ruleset you want to turn on or off, set the toggle to **On** or **Off**, respectively.
-
-</Steps>
-
-</TabItem> </Tabs>
+To temporarily turn off a managed ruleset without deleting its deployment configuration, use the toggle next to the rule that deploys the managed ruleset.
 
 ## Configure a managed ruleset
 


### PR DESCRIPTION
### Summary

AI agents are using the "turn managed ruleset on or off" section in their responses. Instead they should be using the deployment instructions.
Rephrased the instructions so that the possibility of (temporarily) turning off a managed ruleset deployment is covered as a detail in the deployment instructions.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
