### PR TITLE
Update direct upload limitations for Workers Assets

### DIFF
--- a/src/content/docs/workers/static-assets/direct-upload.mdx
+++ b/src/content/docs/workers/static-assets/direct-upload.mdx
@@ -141,8 +141,7 @@ If all assets have been previously uploaded, `buckets` will be empty, and `jwt` 
 
 ### Limitations
 
-- Each file must be under 25 MiB
-- The overall manifest must not contain more than 20,000 file entries
+- Limits differ based on account plan. Refer to [Account Plan Limits](/workers/platform/limits/#account-plan-limits) for more information on limitations of static assets..
 
 ## Upload Static Assets
 

--- a/src/content/docs/workers/static-assets/direct-upload.mdx
+++ b/src/content/docs/workers/static-assets/direct-upload.mdx
@@ -141,7 +141,7 @@ If all assets have been previously uploaded, `buckets` will be empty, and `jwt` 
 
 ### Limitations
 
-- Limits differ based on account plan. Refer to [Account Plan Limits](/workers/platform/limits/#account-plan-limits) for more information on limitations of static assets..
+- Limits differ based on account plan. Refer to [Account Plan Limits](/workers/platform/limits/#account-plan-limits) for more information on limitations of static assets.
 
 ## Upload Static Assets
 


### PR DESCRIPTION
### Summary

This limit is no longer hardcoded for file count. Paid users may upload 100k files. We should instead point to one page rather than specifying limits in individual pages.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
