### PR TITLE
Add new component to augment generated WranglerCommand output

### DIFF
--- a/src/components/ExtraFlagDetails.astro
+++ b/src/components/ExtraFlagDetails.astro
@@ -1,0 +1,14 @@
+---
+import { z } from "astro:schema";
+
+const props = z.object({
+	key: z.string(),
+	mode: z.enum(["append", "replace"]).default("append"),
+});
+
+const { key, mode } = props.parse(Astro.props);
+---
+
+<div data-extra-flag-key={key} data-extra-flag-mode={mode}>
+	<slot />
+</div>

--- a/src/components/WranglerArg.astro
+++ b/src/components/WranglerArg.astro
@@ -8,9 +8,13 @@ import MetaInfo from "./MetaInfo.astro";
 const props = z.object({
 	key: z.string(),
 	definition: z.custom<any>(),
+	extraDetails: z.object({
+		content: z.string(),
+		mode: z.enum(["append", "replace"])
+	}).optional(),
 });
 
-const { key, definition } = props.parse(Astro.props);
+const { key, definition, extraDetails } = props.parse(Astro.props);
 
 const type = definition.type ?? definition.choices;
 const description = definition.description ?? definition.describe;
@@ -46,5 +50,12 @@ if (alias) {
 	{aliasText && <MetaInfo text={aliasText} />}
 	{required && <MetaInfo text="required" />}
 	{defaultValue !== undefined && <MetaInfo text={`default: ${defaultValue}`} />}
-	<Fragment set:html={marked.parse(sanitizedDescription)} />
+	{extraDetails?.mode === "replace" ? (
+		<Fragment set:html={marked.parse(extraDetails.content)} />
+	) : (
+		<>
+			<Fragment set:html={marked.parse(sanitizedDescription)} />
+			{extraDetails && <Fragment set:html={marked.parse(extraDetails.content)} />}
+		</>
+	)}
 </li>

--- a/src/components/WranglerCommand.astro
+++ b/src/components/WranglerCommand.astro
@@ -6,6 +6,7 @@ import WranglerArg from "./WranglerArg.astro";
 import Details from "./Details.astro";
 import { marked } from "marked";
 import { commands, getCommand } from "~/util/wrangler";
+import { parse } from "node-html-parser";
 
 const props = z.object({
 	command: z.string(),
@@ -30,6 +31,27 @@ const positionals = definition.positionalArgs
 	.join(" ");
 
 const positionalSet = new Set(definition.positionalArgs);
+
+// Extract ExtraFlagDetails from slot
+const slotContent = await Astro.slots.render("default");
+const extraFlagDetailsMap = new Map<string, { content: string; mode: "append" | "replace" }>();
+
+if (slotContent) {
+	const html = parse(slotContent);
+	const extraFlagElements = html.querySelectorAll("div[data-extra-flag-key]");
+
+	for (const element of extraFlagElements) {
+		const key = element.getAttribute("data-extra-flag-key");
+		const mode = element.getAttribute("data-extra-flag-mode") || "append";
+
+		if (key) {
+			extraFlagDetailsMap.set(key, {
+				content: element.innerHTML.trim(),
+				mode: mode as "append" | "replace"
+			});
+		}
+	}
+}
 ---
 
 <AnchorHeading depth={headingLevel} title={`\`${command}\``} />
@@ -53,6 +75,7 @@ const positionalSet = new Set(definition.positionalArgs);
 						<WranglerArg
 							key={key}
 							definition={{ ...value, positional: positionalSet.has(key) }}
+							extraDetails={extraFlagDetailsMap.get(key)}
 						/>
 					);
 				})}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ export { default as Details } from "./Details.astro";
 export { default as DirectoryListing } from "./DirectoryListing.astro";
 export { default as Example } from "./Example.astro";
 export { default as ExternalResources } from "./ExternalResources.astro";
+export { default as ExtraFlagDetails } from "./ExtraFlagDetails.astro";
 export { default as Feature } from "./Feature.astro";
 export { default as FeatureTable } from "./FeatureTable.astro";
 export { default as Flex } from "./Flex.astro";

--- a/src/content/docs/style-guide/components/wrangler-command.mdx
+++ b/src/content/docs/style-guide/components/wrangler-command.mdx
@@ -29,6 +29,26 @@ import { WranglerCommand } from "~/components";
 <WranglerCommand command="d1 execute" />
 ```
 
+## With ExtraFlagDetails
+
+You can add or replace help text for specific flags using the `ExtraFlagDetails` component:
+
+```mdx live
+import { WranglerCommand, ExtraFlagDetails } from "~/components";
+
+<WranglerCommand command="deploy">
+	<ExtraFlagDetails key="dry-run">
+		Additional details about the dry-run flag that will be appended to the
+		original help text. Here is a [link](https://cloudflare.com) for more
+		information.
+	</ExtraFlagDetails>
+	<ExtraFlagDetails key="compatibility-date" mode="replace">
+		Custom help text that completely replaces the original description for this
+		flag.
+	</ExtraFlagDetails>
+</WranglerCommand>
+```
+
 ## Arguments
 
 - `command` <Type text="string" /> <MetaInfo text="required" />


### PR DESCRIPTION
### Summary

Adds a new component that lets you append or replace the desciption for a flag generated by the WranglerCommand component.

### Screenshots (optional)

<img width="666" height="79" alt="Screenshot 2025-11-14 at 12 07 00" src="https://github.com/user-attachments/assets/d6c1175a-c07d-468a-9919-e76e835db215" />
<img width="660" height="141" alt="Screenshot 2025-11-14 at 12 07 48" src="https://github.com/user-attachments/assets/f01fcca9-b0d7-445c-bbf0-355ab04fdbc1" />
