### PR TITLE
Fix style guide violations in browser rendering docs

### DIFF
--- a/src/content/docs/browser-rendering/how-to/pdf-generation.mdx
+++ b/src/content/docs/browser-rendering/how-to/pdf-generation.mdx
@@ -11,7 +11,7 @@ As seen in [this Workers bindings guide](/browser-rendering/workers-bindings/scr
 
 You can generate PDFs with Browser Rendering in two ways:
 
-- **[REST API](/browser-rendering/rest-api/)**: Use the the [/pdf endpoint](/browser-rendering/rest-api/pdf-endpoint/). This is ideal if you don't need to customize rendering behavior.
+- **[REST API](/browser-rendering/rest-api/)**: Use the the [/pdf endpoint](/browser-rendering/rest-api/pdf-endpoint/). This is ideal if you do not need to customize rendering behavior.
 - **[Workers Bindings](/browser-rendering/workers-bindings/)**: Use [Puppeteer](/browser-rendering/puppeteer/) or [Playwright](/browser-rendering/playwright/) with Workers Bindings for additional control and customization.
 
 Choose the method that best fits your use case.

--- a/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
@@ -192,7 +192,9 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
         "left": "30px"
       },
       "timeout": 30000
-    }`
+    }
+  }' \
+  --output "dynamic-header-footer.pdf"
 ```
 
 <Render

--- a/src/content/docs/browser-rendering/workers-bindings/reuse-sessions.mdx
+++ b/src/content/docs/browser-rendering/workers-bindings/reuse-sessions.mdx
@@ -57,7 +57,7 @@ browser = { binding = "MYBROWSER" }
 
 ## 4. Code
 
-The script below starts by fetching the current running sessions. If there are any that don't already have a worker connection, it picks a random session ID and attempts to connect (`puppeteer.connect(..)`) to it. If that fails or there were no running sessions to start with, it launches a new browser session (`puppeteer.launch(..)`). Then, it goes to the website and fetches the dom. Once that's done, it disconnects (`browser.disconnect()`), making the connection available to other workers.
+The script below starts by fetching the current running sessions. If there are any that do not already have a worker connection, it picks a random session ID and attempts to connect (`puppeteer.connect(..)`) to it. If that fails or there were no running sessions to start with, it launches a new browser session (`puppeteer.launch(..)`). Then, it goes to the website and fetches the dom. Once that is done, it disconnects (`browser.disconnect()`), making the connection available to other workers.
 
 Take into account that if the browser is idle, i.e. does not get any command, for more than the current [limit](/browser-rendering/limits/), it will close automatically, so you must have enough requests per minute to keep it alive.
 


### PR DESCRIPTION
- Remove contractions per style guide grammar rules (don't → do not, that's → that is)
- Fix syntax error in pdf-endpoint.mdx (missing closing brace and command termination)
- Affected files: pdf-generation.mdx, reuse-sessions.mdx, pdf-endpoint.mdx

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
