### PR TITLE
[Error] Enhance 400 Bad Request error explanation with examples

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-400.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-400.mdx
@@ -15,8 +15,8 @@ For more information, refer to [RFC 7231](https://tools.ietf.org/html/rfc7231).
 A `400 Bad Request` error occurs due to client-side issues, such as malformed request syntax, invalid request content, message framing problems, or deceptive request routing. 
 For example:
 
-- if the request contains a special character that is not properly [URL Encoded (or percent-encoded)](https://en.wikipedia.org/wiki/Percent-encoding), an `HTTP Error 400` will be returned.
-- if the request contains both `Content Length` and `Transfer Encoding` chunked, these two framing methods contradict each other. `Content Length` declares a fixed size body while chunked encoding declares a streamed body with no known size. [RFC 7230 section 3.3.3](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3) states that when `Transfer Encoding` is present the `Content Length` header must be ignored and a request that includes both is considered malformed. This creates ambiguity in body framing and can enable request smuggling if different systems parse the boundary differently. Cloudflare follows the RFC and an `HTTP Error 400` will be returned.
+- If the request contains a special character that is not properly [URL Encoded (or percent-encoded)](https://en.wikipedia.org/wiki/Percent-encoding), an `HTTP Error 400` will be returned.
+- If the request contains both `Content Length` and `Transfer Encoding` chunked, these two framing methods contradict each other. `Content Length` declares a fixed size body, while chunked encoding declares a streamed body with no known size. [RFC 7230 section 3.3.3](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3) states that when `Transfer Encoding` is present, the `Content Length` header must be ignored and a request that includes both is considered malformed. This creates ambiguity in body framing and can enable request smuggling if different systems parse the boundary differently. Cloudflare follows the RFC and an `HTTP Error 400` will be returned.
 
 ### Cloudflare-specific information
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-400.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-400.mdx
@@ -12,7 +12,11 @@ For more information, refer to [RFC 7231](https://tools.ietf.org/html/rfc7231).
 
 ### Common use cases
 
-A `400 Bad Request` error occurs due to client-side issues, such as malformed request syntax, invalid request content, message framing problems, or deceptive request routing. For example, if the request contains a special character that is not properly [URL Encoded (or percent-encoded)](https://en.wikipedia.org/wiki/Percent-encoding), an `HTTP Error 400` will be returned.
+A `400 Bad Request` error occurs due to client-side issues, such as malformed request syntax, invalid request content, message framing problems, or deceptive request routing. 
+For example:
+
+- if the request contains a special character that is not properly [URL Encoded (or percent-encoded)](https://en.wikipedia.org/wiki/Percent-encoding), an `HTTP Error 400` will be returned.
+- if the request contains both `Content Length` and `Transfer Encoding` chunked, these two framing methods contradict each other. `Content Length` declares a fixed size body while chunked encoding declares a streamed body with no known size. [RFC 7230 section 3.3.3](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3) states that when `Transfer Encoding` is present the `Content Length` header must be ignored and a request that includes both is considered malformed. This creates ambiguity in body framing and can enable request smuggling if different systems parse the boundary differently. Cloudflare follows the RFC and an `HTTP Error 400` will be returned.
 
 ### Cloudflare-specific information
 


### PR DESCRIPTION
Expanded the explanation of '400 Bad Request' errors with additional examples related to URL encoding and content framing issues. CUSTESC-58316
