### PR TITLE
[PCX-20023] [Cloudflare Tunnel] Prefer loglevel info as an example instead of debug

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/index.mdx
@@ -35,7 +35,7 @@ On Linux, Cloudflare Tunnel installs itself as a system service using `systemctl
    [Service]
    TimeoutStartSec=0
    Type=notify
-   ExecStart=/usr/local/bin/cloudflared tunnel --loglevel debug --logfile /var/log/cloudflared/cloudflared.log run --token <TOKEN VALUE>
+   ExecStart=/usr/local/bin/cloudflared tunnel --loglevel info --logfile /var/log/cloudflared/cloudflared.log run --token <TOKEN VALUE>
    Restart=on-failure
    RestartSec=5s
 
@@ -63,7 +63,7 @@ On Linux, Cloudflare Tunnel installs itself as a system service using `systemctl
      Memory: 16.3M
         CPU: 136ms
      CGroup: /system.slice/cloudflared.service
-             └─2157 /usr/bin/cloudflared tunnel --loglevel debug --logfile /var/log/cloudflared/cloudflared.log run --token eyJhIjoi...
+             └─2157 /usr/bin/cloudflared tunnel --loglevel info --logfile /var/log/cloudflared/cloudflared.log run --token eyJhIjoi...
 	```
 
 </TabItem> <TabItem label="macOS">
@@ -130,7 +130,7 @@ On Windows, Cloudflare Tunnel installs itself as a system service using the Regi
 4. Modify **Value data** with the desired configuration flag. For example,
 
    ```txt
-   C:\Program Files (x86)\cloudflared\.\cloudflared.exe tunnel --loglevel debug --logfile <PATH> run --token <TOKEN VALUE>
+   C:\Program Files (x86)\cloudflared\.\cloudflared.exe tunnel --loglevel info --logfile <PATH> run --token <TOKEN VALUE>
    ```
 
 ![Modify cloudflared service in the Registry Editor](~/assets/images/cloudflare-one/connections/connect-apps/remote-management-windows.png)

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/deployment-guides/kubernetes.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/deployment-guides/kubernetes.mdx
@@ -242,7 +242,7 @@ To run the Cloudflare Tunnel in Kubernetes:
               - tunnel
               - --no-autoupdate
               - --loglevel
-              - debug
+              - info
               - --metrics
               - 0.0.0.0:2000
               - run
@@ -263,7 +263,7 @@ To run the Cloudflare Tunnel in Kubernetes:
 	kubectl create -f tunnel.yaml
 	```
 
-	 Kubernetes will install the `cloudflared` image on two pods and run the tunnel using the command `cloudflared tunnel --no-autoupdate --loglevel debug --metrics 0.0.0.0:2000 run`. `cloudflared` will consume the tunnel token from the `TUNNEL_TOKEN` environment variable.
+	 Kubernetes will install the `cloudflared` image on two pods and run the tunnel using the command `cloudflared tunnel --no-autoupdate --loglevel info --metrics 0.0.0.0:2000 run`. `cloudflared` will consume the tunnel token from the `TUNNEL_TOKEN` environment variable.
 
 3. Check the status of your cluster:
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/logs.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/logs.mdx
@@ -17,10 +17,10 @@ If you have access to the origin server, you can use the [`--loglevel` flag](/cl
 To enable logs for a locally-managed tunnel:
 
 ```sh
-cloudflared tunnel --loglevel debug --logfile cloudflared.log run <UUID>
+cloudflared tunnel --loglevel info --logfile cloudflared.log run <UUID>
 ```
 
-To enable logs for a remotely-managed tunnel, add `--loglevel debug` and `--logfile <PATH>` to your system service as shown in [Add tunnel run parameters](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/#update-tunnel-run-parameters).
+To enable logs for a remotely-managed tunnel, add `--loglevel info` and `--logfile <PATH>` to your system service as shown in [Add tunnel run parameters](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/#update-tunnel-run-parameters).
 
 ## View logs on your local machine
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/tips.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/tips.mdx
@@ -38,27 +38,5 @@ To allow `cloudflared` to connect, use [Split Tunnels](/cloudflare-one/team-and-
 Split Tunnels is the only supported method of running both connectors on one machine. Due to its low-level integration with the kernel networking stack, WARP Connector will override any routing configurations made by commands such as `ip route add` and `iptables`.
 :::
 
-## MTU, MSS, and packet fragmentation
 
-To ensure reliable network performance, it is important to understand the requirements for [Maximum Transmission Unit (MTU)](https://www.cloudflare.com/learning/network-layer/what-is-mtu/) and [Maximum Segment Size (MSS)](https://www.cloudflare.com/learning/network-layer/what-is-mss/) when using WARP Connector. An incorrect configuration can lead to performance degradation or packet loss.
 
-WARP Connector uses [encapsulation](/magic-wan/reference/mtu-mss/#encapsulation) to route traffic, which adds extra headers and bytes to each [packet](https://www.cloudflare.com/learning/network-layer/what-is-a-packet/). This is especially critical for traffic from your private network (on-ramped via WARP Connector) to a remote WARP client. This traffic flow is encapsulated twice:
-1. By the WARP Connector on your Linux host.
-2. Again by the Cloudflare edge before being delivered to the off-ramp.
-
-This final encapsulation adds overhead. If a device on your private network sends a packet that is already near the maximum size (1,460 bytes or more), this final encapsulation will create a packet larger than 1,500 bytes, which will be dropped.
-
-Generally, this doesn't cause issues for TCP traffic and modern applications that use [Path MTU Discovery (PMTUD)](/cloudflare-one/team-and-resources/devices/warp/deployment/mdm-deployment/path-mtu-discovery/). When they send a large packet with the `do not fragment` (DF) bit set, the WARP Connector's Linux host will correctly send an ICMP `Fragmentation Needed` message back to the source device. The source device then learns to send smaller packets.
-
-However, this may cause issues for legacy applications (like some video streaming or monitoring tools) that may not perform [Path MTU Discovery (PMTUD)](/cloudflare-one/team-and-resources/devices/warp/deployment/mdm-deployment/path-mtu-discovery/). Instead, they send large packets (e.g., more than 1,280 bytes) with the `do not fragment` (DF) bit unset (`DF=0`).
-
-In this situation, WARP Connector host receives this large packet (e.g., 1,460 bytes), then fragments the packet to fit its [tunnel MTU](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/warp-architecture/#virtual-interface). These fragments are then reassembled at the Cloudflare edge back into the original 1,460-byte packet.
-The edge then tries to encapsulate this 1,460-byte packet to send to the WARP client, pushing it over 1,500 bytes and causing it to be dropped. Our edge does not currently support fragmenting these outgoing encapsulated packets.
-
-### Recommendations
-
-To ensure reliable connectivity for all traffic types, especially legacy UDP applications, the most effective solution is to configure the MTU on your source devices (e.g., servers, cameras, or other devices on your private network) to 1,280 bytes. 
-
-This ensures the original packet is small enough to be encapsulated and delivered without being fragmented or dropped.
-
-For TCP-only applications, you can alternatively apply an [MSS clamping](/magic-wan/reference/mtu-mss/#mss-clamping) on your router (an intermediary network device). A value of 1,240 bytes (1,280 bytes MTU - 20-byte IP header - 20-byte TCP header) is recommended to align with the WARP Connector's [tunnel MTU](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/warp-architecture/#virtual-interface).

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/tips.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/tips.mdx
@@ -38,5 +38,27 @@ To allow `cloudflared` to connect, use [Split Tunnels](/cloudflare-one/team-and-
 Split Tunnels is the only supported method of running both connectors on one machine. Due to its low-level integration with the kernel networking stack, WARP Connector will override any routing configurations made by commands such as `ip route add` and `iptables`.
 :::
 
+## MTU, MSS, and packet fragmentation
 
+To ensure reliable network performance, it is important to understand the requirements for [Maximum Transmission Unit (MTU)](https://www.cloudflare.com/learning/network-layer/what-is-mtu/) and [Maximum Segment Size (MSS)](https://www.cloudflare.com/learning/network-layer/what-is-mss/) when using WARP Connector. An incorrect configuration can lead to performance degradation or packet loss.
 
+WARP Connector uses [encapsulation](/magic-wan/reference/mtu-mss/#encapsulation) to route traffic, which adds extra headers and bytes to each [packet](https://www.cloudflare.com/learning/network-layer/what-is-a-packet/). This is especially critical for traffic from your private network (on-ramped via WARP Connector) to a remote WARP client. This traffic flow is encapsulated twice:
+1. By the WARP Connector on your Linux host.
+2. Again by the Cloudflare edge before being delivered to the off-ramp.
+
+This final encapsulation adds overhead. If a device on your private network sends a packet that is already near the maximum size (1,460 bytes or more), this final encapsulation will create a packet larger than 1,500 bytes, which will be dropped.
+
+Generally, this doesn't cause issues for TCP traffic and modern applications that use [Path MTU Discovery (PMTUD)](/cloudflare-one/team-and-resources/devices/warp/deployment/mdm-deployment/path-mtu-discovery/). When they send a large packet with the `do not fragment` (DF) bit set, the WARP Connector's Linux host will correctly send an ICMP `Fragmentation Needed` message back to the source device. The source device then learns to send smaller packets.
+
+However, this may cause issues for legacy applications (like some video streaming or monitoring tools) that may not perform [Path MTU Discovery (PMTUD)](/cloudflare-one/team-and-resources/devices/warp/deployment/mdm-deployment/path-mtu-discovery/). Instead, they send large packets (e.g., more than 1,280 bytes) with the `do not fragment` (DF) bit unset (`DF=0`).
+
+In this situation, WARP Connector host receives this large packet (e.g., 1,460 bytes), then fragments the packet to fit its [tunnel MTU](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/warp-architecture/#virtual-interface). These fragments are then reassembled at the Cloudflare edge back into the original 1,460-byte packet.
+The edge then tries to encapsulate this 1,460-byte packet to send to the WARP client, pushing it over 1,500 bytes and causing it to be dropped. Our edge does not currently support fragmenting these outgoing encapsulated packets.
+
+### Recommendations
+
+To ensure reliable connectivity for all traffic types, especially legacy UDP applications, the most effective solution is to configure the MTU on your source devices (e.g., servers, cameras, or other devices on your private network) to 1,280 bytes. 
+
+This ensures the original packet is small enough to be encapsulated and delivered without being fragmented or dropped.
+
+For TCP-only applications, you can alternatively apply an [MSS clamping](/magic-wan/reference/mtu-mss/#mss-clamping) on your router (an intermediary network device). A value of 1,240 bytes (1,280 bytes MTU - 20-byte IP header - 20-byte TCP header) is recommended to align with the WARP Connector's [tunnel MTU](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/warp-architecture/#virtual-interface).


### PR DESCRIPTION
### Summary

Prefer `loglevel info` over `loglevel debug` in all examples since `info` might expose sensitive information in the logs.