### PR TITLE
feat: publish html files as artifact

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -29,6 +29,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENABLE_LAST_MOD_IN_SITEMAP: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: site-html
+          path: dist
       - run: npx wrangler deploy
         name: Deploy to Cloudflare Workers
         env:

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -30,6 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ENABLE_LAST_MOD_IN_SITEMAP: true
       - uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: site-html
           path: dist


### PR DESCRIPTION
This artifact will be used by later by external processes, i.e. a separate reverse build. This is the first step for removing the reverse build from the build time.