### PR TITLE
[CED] Remove Type column from ListTutorials

### DIFF
--- a/src/components/ListTutorials.astro
+++ b/src/components/ListTutorials.astro
@@ -14,7 +14,7 @@ const currentProduct = await getEntry("products", currentSection!);
 
 if (!currentProduct) {
 	throw new Error(
-		`[ListTutorials] Unable to find product YAML for ${currentSection}.`,
+		`[ListTutorials] Unable to find product YAML for ${currentSection}.`
 	);
 }
 
@@ -67,7 +67,6 @@ const timeAgo = (date?: Date) => {
 							<Fragment set:html={anchor} />
 						</td>
 						<td>{timeAgo(tutorial.data.reviewed)}</td>
-						<td>📝 Tutorial</td>
 						<td>{tutorial.data.difficulty}</td>
 					</tr>
 				);

--- a/src/components/ListTutorials.astro
+++ b/src/components/ListTutorials.astro
@@ -46,7 +46,6 @@ const timeAgo = (date?: Date) => {
 		<tr>
 			<td>Name</td>
 			<td>Last Updated</td>
-			<td>Type</td>
 			<td>Difficulty</td>
 		</tr>
 	</thead>


### PR DESCRIPTION
Since this components only lists tutorials, the Type column is redundant. I checked each instance of <ListTutorials> and there are no exceptions to this rule.