### PR TITLE
Update file name from worker.js to index.js

### DIFF
--- a/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -119,7 +119,7 @@ export default {
 
 By querying the LLM through the `AI` binding, we can interact directly with Cloudflare AI's large language models directly in our code. In this example, we are using the [`@cf/meta/llama-3-8b-instruct` model](/workers-ai/models/llama-3-8b-instruct/), which generates text.
 
-You can deploy your Worker using `wrangler`:
+Deploy your Worker using `wrangler`:
 
 ```sh
 npx wrangler deploy

--- a/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -54,7 +54,7 @@ In your project directory, C3 has generated several files.
 <Details header="What files did C3 create?">
 
 1. `wrangler.jsonc`: Your [Wrangler](/workers/wrangler/configuration/#sample-wrangler-configuration) configuration file.
-2. `worker.js` (in `/src`): A minimal `'Hello World!'` Worker written in [ES module](/workers/reference/migrate-to-module-workers/) syntax.
+2. `index.js` (in `/src`): A minimal `'Hello World!'` Worker written in [ES module](/workers/reference/migrate-to-module-workers/) syntax.
 3. `package.json`: A minimal Node dependencies configuration file.
 4. `package-lock.json`: Refer to [`npm` documentation on `package-lock.json`](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json).
 5. `node_modules`: Refer to [`npm` documentation `node_modules`](https://docs.npmjs.com/cli/v7/configuring-npm/folders#node-modules).


### PR DESCRIPTION
### Summary

This update corrects a documentation inconsistency where the example referenced a file named `worker.js`, while the accompanying code sample and typical Workers project structure use `index.js`.

### Screenshots (optional)

N/A

### Documentation checklist

* [ ] Is there a changelog entry?
* [x] The change adheres to the documentation style guide.
* [ ] If a larger change, an issue has been opened related to incorrect or outdated information.
* [ ] Files which have changed name or location have been allocated redirects.
