### PR TITLE
Example custom semgrep rule for detecting fixed time references that is stored in repo for scanning against pull requests

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,7 @@ jobs:
         if: github.event_name == 'pull_request' && !contains(github.event.head_commit.message, '[skip semgrep]')
         run: |
 
+          git config --global --add safe.directory $PWD
           base_commit=$(git merge-base HEAD origin/$GITHUB_BASE_REF)
           git diff $base_commit... --diff-filter=ACMRT --name-only | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > tools/relevant_changed_files.txt || true
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,22 +37,23 @@ jobs:
       - name: Semgrep Repo Rules (Custom rules found in .semgrep/)
         if: github.event_name == 'pull_request' && !contains(github.event.head_commit.message, '[skip semgrep]')
         run: |
+          semgrep ci
           #git fetch origin ${{ github.base_ref }}
 
-          cd "$GITHUB_WORKSPACE"
-          echo "$PWD"
-          git show
+          #cd "$GITHUB_WORKSPACE"
+          #echo "$PWD"
+          #git show
 
-          git diff --name-only origin/production HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
-          list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
+          #git diff --name-only origin/production HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
+          #list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
 
           # Check if file list is empty to prevent errors
-          if [ -s changed_files.txt ]; then
-            semgrep scan \
-              --config .semgrep --metrics=off \
-              --include "*.mdx" --include "*.mdx" \
-              $list_of_files
+          #if [ -s changed_files.txt ]; then
+          #  semgrep scan \
+          #    --config .semgrep --metrics=off \
+          #    --include "*.mdx" --include "*.mdx" \
+          #    $list_of_files
             # add '--error' to return error code to workflow
-          else
-             echo "No relevant files changed."
-          fi
+          #else
+          #   echo "No relevant files changed."
+          #fi

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,14 +24,27 @@ jobs:
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch
       # scans using managed rules at cloudflare.semgrep.dev
-      - name: Semgrep CI (Managed at cloudflare.semgrep.dev)
+      - name: Semgrep CI Rules (Managed rules at cloudflare.semgrep.dev)
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: semgrep ci
 
       # Semgrep Scan to run on Pull Request events
       # scans using rules inside the .semgrep/ folder and fails on error
       # include [skip semgrep] in top-most commit message to skip scan
-      - name: Semgrep Local (Custom rules found in .semgrep)
+      - name: Semgrep Repo Rules (Custom rules found in .semgrep/)
         if: github.event_name == 'pull_request' && !contains(github.event.head_commit.message, '[skip semgrep]')
-        # add '--error' below to return error code to workflow
-        run: semgrep scan --config .semgrep --metrics=off --include "*.mdx" --include "*.mdx"
+        run: |
+          git fetch origin ${{ github.base_ref }}
+
+          git diff --name-only origin/${{ github.base_ref }} HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
+
+          # Check if file list is empty to prevent errors
+          if [ -s changed_files.txt ]; then
+            semgrep scan --config .semgrep --metrics=off \
+              --include "*.mdx" --include "*.mdx" \
+              --targets changed_files.txt
+            # add '--error' to return error code to workflow
+             semgrep scan --config .semgrep --error --targets changed_files.txt
+          else
+             echo "No relevant files changed."
+          fi

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,11 +39,11 @@ jobs:
         run: |
 
           base_commit=$(git merge-base HEAD origin/$GITHUB_BASE_REF)
-          git diff $base_commit... --diff-filter=ACMRT --name-only | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
+          git diff $base_commit... --diff-filter=ACMRT --name-only | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > tools/relevant_changed_files.txt || true
 
           # Check if file list is empty to prevent errors
-          if [ -s changed_files.txt ]; then
-            list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
+          if [ -s tools/relevant_changed_files.txt ]; then
+            list_of_files=$(cat tools/relevant_changed_files.txt | tr '\n' ' ')
             semgrep scan \
               --config .semgrep --metrics=off \
               --include "*.mdx" --include "*.mdx" \

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -40,6 +40,9 @@ jobs:
           #git fetch origin ${{ github.base_ref }}
 
           cd "$GITHUB_WORKSPACE"
+          echo "$PWD"
+          git show
+
           git diff --name-only origin/production HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
           list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           #git fetch origin ${{ github.base_ref }}
 
+          cd "$GITHUB_WORKSPACE"
           git diff --name-only origin/production HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
           list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,23 +37,18 @@ jobs:
       - name: Semgrep Repo Rules (Custom rules found in .semgrep/)
         if: github.event_name == 'pull_request' && !contains(github.event.head_commit.message, '[skip semgrep]')
         run: |
-          semgrep ci
-          #git fetch origin ${{ github.base_ref }}
 
-          #cd "$GITHUB_WORKSPACE"
-          #echo "$PWD"
-          #git show
-
-          #git diff --name-only origin/production HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
-          #list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
+          base_commit=$(git merge-base HEAD origin/$GITHUB_BASE_REF)
+          git diff $base_commit... --diff-filter=ACMRT --name-only | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
 
           # Check if file list is empty to prevent errors
-          #if [ -s changed_files.txt ]; then
-          #  semgrep scan \
-          #    --config .semgrep --metrics=off \
-          #    --include "*.mdx" --include "*.mdx" \
-          #    $list_of_files
+          if [ -s changed_files.txt ]; then
+            list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
+            semgrep scan \
+              --config .semgrep --metrics=off \
+              --include "*.mdx" --include "*.mdx" \
+              $list_of_files
             # add '--error' to return error code to workflow
-          #else
-          #   echo "No relevant files changed."
-          #fi
+          else
+            echo "No relevant files changed."
+          fi

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -39,15 +39,16 @@ jobs:
         run: |
           #git fetch origin ${{ github.base_ref }}
 
-          git diff --name-only origin/${{ github.base_ref }} HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
+          git diff --name-only origin/production HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
+          list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
 
           # Check if file list is empty to prevent errors
           if [ -s changed_files.txt ]; then
-            semgrep scan --config .semgrep --metrics=off \
+            semgrep scan \
+              --config .semgrep --metrics=off \
               --include "*.mdx" --include "*.mdx" \
-              --targets changed_files.txt
+              $list_of_files
             # add '--error' to return error code to workflow
-             semgrep scan --config .semgrep --error --targets changed_files.txt
           else
              echo "No relevant files changed."
           fi

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,12 +2,15 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: "0 4 * * *"
+  pull_request: {}
+
 name: Semgrep config
 permissions:
   contents: read
+
 jobs:
   semgrep:
-    name: semgrep/ci
+    name: semgrep
     runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
@@ -18,4 +21,16 @@ jobs:
       image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v4
-      - run: semgrep ci
+
+      # Semgrep CI to run on Schedule (Cron) or Manual Dispatch
+      # scans using managed rules at cloudflare.semgrep.dev
+      - name: Semgrep CI (Managed at cloudflare.semgrep.dev)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: semgrep ci
+
+      # Semgrep Scan to run on Pull Request events
+      # scans using rules inside the .semgrep/ folder and fails on error
+      - name: Semgrep Local (Custom rules found in .semgrep)
+        if: github.event_name == 'pull_request'
+        # add '--error' below to return error code to workflow
+        run: semgrep scan --config .semgrep --include "*.mdx" --include "*.mdx"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,6 +21,9 @@ jobs:
       image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v4
+        with:
+          # fetch full history so Semgrep can compare against the base branch
+          fetch-depth: 0
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch
       # scans using managed rules at cloudflare.semgrep.dev

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Semgrep Local (Custom rules found in .semgrep)
         if: github.event_name == 'pull_request'
         # add '--error' below to return error code to workflow
-        run: semgrep scan --config .semgrep --include "*.mdx" --include "*.mdx"
+        run: semgrep scan --config .semgrep --metrics=off --include "*.mdx" --include "*.mdx"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -30,7 +30,8 @@ jobs:
 
       # Semgrep Scan to run on Pull Request events
       # scans using rules inside the .semgrep/ folder and fails on error
+      # include [skip semgrep] in top-most commit message to skip scan
       - name: Semgrep Local (Custom rules found in .semgrep)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !contains(github.event.head_commit.message, '[skip semgrep]')
         # add '--error' below to return error code to workflow
         run: semgrep scan --config .semgrep --metrics=off --include "*.mdx" --include "*.mdx"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Semgrep Repo Rules (Custom rules found in .semgrep/)
         if: github.event_name == 'pull_request' && !contains(github.event.head_commit.message, '[skip semgrep]')
         run: |
-          git fetch origin ${{ github.base_ref }}
+          #git fetch origin ${{ github.base_ref }}
 
           git diff --name-only origin/${{ github.base_ref }} HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > changed_files.txt || true
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ pnpm-debug.log*
 /worker/functions/
 
 .idea
+
+tools/changed_files.txt

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ pnpm-debug.log*
 
 .idea
 
-tools/changed_files.txt
+tools/relevant_changed_files.txt

--- a/.semgrep/dates-in-docs.yaml
+++ b/.semgrep/dates-in-docs.yaml
@@ -12,7 +12,7 @@ rules:
         - "*.yaml"
         - "*.yml"
       exclude:
-        - "src/content/changelog/**"
-        - "src/content/release-notes/**"
+        - "/src/content/changelog/**"
+        - "/src/content/release-notes/**"
     patterns:
       - pattern-regex: "[Cc]oming [Ss]oon"

--- a/.semgrep/dates-in-docs.yaml
+++ b/.semgrep/dates-in-docs.yaml
@@ -15,6 +15,7 @@ rules:
         - "/src/content/changelog/**"
         - "/src/content/release-notes/**"
         - "/.semgrep/**"
+        - "/.github/**"
     patterns:
       - pattern-regex: "[Cc]oming [Ss]oon"
 
@@ -34,6 +35,7 @@ rules:
         - "/src/content/changelog/**"
         - "/src/content/release-notes/**"
         - "/.semgrep/**"
+        - "/.github/**"
     pattern-either:
       - pattern-regex: Jan\| Feb\| Mar\| Apr\| May\| Jun\| Jul\| Aug\| Sep\| Nov\| Dec
       - pattern-regex: \ 20[0-9][0-9]

--- a/.semgrep/dates-in-docs.yaml
+++ b/.semgrep/dates-in-docs.yaml
@@ -1,6 +1,6 @@
 rules:
   - id: coming-soon
-    languages: [html, yaml, generic]
+    languages: [generic]
     message: "Found the forbidden string 'coming soon'"
     severity: ERROR
     paths:

--- a/.semgrep/dates-in-docs.yaml
+++ b/.semgrep/dates-in-docs.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: coming-soon
+    languages: [html, yaml, generic]
+    message: "Found the forbidden string 'coming soon'"
+    severity: ERROR
+    paths:
+      include:
+        - "*.htm"
+        - "*.html"
+        - "*.md"
+        - "*.mdx"
+        - "*.yaml"
+        - "*.yml"
+      exclude:
+        - "src/content/changelog/**"
+        - "src/content/release-notes/**"
+    patterns:
+      - pattern-regex: "[Cc]oming [Ss]oon"

--- a/.semgrep/dates-in-docs.yaml
+++ b/.semgrep/dates-in-docs.yaml
@@ -14,6 +14,7 @@ rules:
       exclude:
         - "/src/content/changelog/**"
         - "/src/content/release-notes/**"
+        - "/.semgrep/**"
     patterns:
       - pattern-regex: "[Cc]oming [Ss]oon"
 
@@ -32,6 +33,7 @@ rules:
       exclude:
         - "/src/content/changelog/**"
         - "/src/content/release-notes/**"
+        - "/.semgrep/**"
     pattern-either:
       - pattern-regex: Jan\| Feb\| Mar\| Apr\| May\| Jun\| Jul\| Aug\| Sep\| Nov\| Dec
       - pattern-regex: \ 20[0-9][0-9]

--- a/.semgrep/dates-in-docs.yaml
+++ b/.semgrep/dates-in-docs.yaml
@@ -1,8 +1,8 @@
 rules:
   - id: coming-soon
     languages: [generic]
-    message: "Found the forbidden string 'coming soon'"
-    severity: ERROR
+    message: "Found forbidden string 'coming soon'. Too often we set expectations unfairly by attaching this phrase to a feature that is cancelled or a plan that changes."
+    severity: MEDIUM
     paths:
       include:
         - "*.htm"
@@ -16,3 +16,22 @@ rules:
         - "/src/content/release-notes/**"
     patterns:
       - pattern-regex: "[Cc]oming [Ss]oon"
+
+  - id: potential-date
+    languages: [generic]
+    message: "Potential date found. Documentation should strive to represent universal truth, not something time-bound."
+    severity: MEDIUM
+    paths:
+      include:
+        - "*.htm"
+        - "*.html"
+        - "*.md"
+        - "*.mdx"
+        - "*.yaml"
+        - "*.yml"
+      exclude:
+        - "/src/content/changelog/**"
+        - "/src/content/release-notes/**"
+    pattern-either:
+      - pattern-regex: Jan\| Feb\| Mar\| Apr\| May\| Jun\| Jul\| Aug\| Sep\| Nov\| Dec
+      - pattern-regex: \ 20[0-9][0-9]

--- a/.semgrep/dates-in-docs.yaml
+++ b/.semgrep/dates-in-docs.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: coming-soon
     languages: [generic]
-    message: "Found forbidden string 'coming soon'. Too often we set expectations unfairly by attaching this phrase to a feature that is cancelled or a plan that changes."
+    message: "Found forbidden string 'coming soon'. Too often we set expectations unfairly by attaching this phrase to a feature that may not actually arrive soon."
     severity: MEDIUM
     paths:
       include:

--- a/tools/semgrep-repo-rules
+++ b/tools/semgrep-repo-rules
@@ -4,14 +4,22 @@ repo_root_dir="$(git rev-parse --show-toplevel)"
 
 pushd "${repo_root_dir}" > /dev/null || return
 
-git diff --name-only origin/production HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > tools/changed_files.txt || true
+# this file wants to match all changes in working dir, not just commited changes (in CI this is not the case)
+#base_commit=$(git merge-base HEAD origin/production)
 
-list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
+git diff --diff-filter=ACMRT --name-only | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > tools/changed_files.txt || true
 
-docker run --rm -v "${PWD}:/src" semgrep/semgrep \
-  semgrep scan \
-    --config .semgrep --metrics=off \
-    --include "*.mdx" --include "*.mdx" \
-    $list_of_files
+if [ -s tools/changed_files.txt ]; then
+  list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
+
+  docker run --rm -v "${PWD}:/src" semgrep/semgrep \
+    semgrep scan \
+      --config .semgrep --metrics=off \
+      --include "*.mdx" --include "*.mdx" \
+      --force-color \
+      $list_of_files
+else
+  echo "No relevant files changed."
+fi
 
 popd > /dev/null || return

--- a/tools/semgrep-repo-rules
+++ b/tools/semgrep-repo-rules
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+repo_root_dir="$(git rev-parse --show-toplevel)"
+
+pushd "${repo_root_dir}" > /dev/null || return
+
+git diff --name-only origin/production HEAD --diff-filter=ACMRT | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > tools/changed_files.txt || true
+
+list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
+
+docker run --rm -v "${PWD}:/src" semgrep/semgrep \
+  semgrep scan \
+    --config .semgrep --metrics=off \
+    --include "*.mdx" --include "*.mdx" \
+    $list_of_files
+
+popd > /dev/null || return

--- a/tools/semgrep-repo-rules
+++ b/tools/semgrep-repo-rules
@@ -4,13 +4,14 @@ repo_root_dir="$(git rev-parse --show-toplevel)"
 
 pushd "${repo_root_dir}" > /dev/null || return
 
-# this file wants to match all changes in working dir, not just commited changes (in CI this is not the case)
-#base_commit=$(git merge-base HEAD origin/production)
+base_commit=$(git merge-base HEAD origin/production)
+git diff $base_commit... --diff-filter=ACMRT --name-only | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > tools/relevant_changed_files.txt || true
 
-git diff --diff-filter=ACMRT --name-only | grep -E '\.(htm|html|yaml|yml|md|mdx)$' > tools/changed_files.txt || true
+# this file wants to also match uncommitted changes, not just commited changes (in CI this is not the case)
+git diff --diff-filter=ACMRT --name-only | grep -E '\.(htm|html|yaml|yml|md|mdx)$' >> tools/relevant_changed_files.txt || true
 
-if [ -s tools/changed_files.txt ]; then
-  list_of_files=$(cat tools/changed_files.txt | tr '\n' ' ')
+if [ -s tools/relevant_changed_files.txt ]; then
+  list_of_files=$(cat tools/relevant_changed_files.txt | tr '\n' ' ')
 
   docker run --rm -v "${PWD}:/src" semgrep/semgrep \
     semgrep scan \


### PR DESCRIPTION
This is a github workflow change that impacts the semgrep workflow. 
Until now the semgrep scan has been using semgrep ci which uses managed rules and is done when manually triggered and on a cron schedule. This PR intends to allow the execution of custom rules located in the `.semgrep` directory when pull requests are made through the use of [semgrep scan](https://github.com/cloudflare/cloudflare-docs/pull/26647/files#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbbR48)  
includes:
- an example rule `.semgrep/dates-in-docs.yaml` that marks matches of the pattern `[Cc]oming [Ss]oon` and for digit numbers as a stand-in for year in dates as an error but does not return an error code to the workflow which should avoid impacting any users even if there are issues.
- a locally runnable script `tools/semgrep-repo-rules`that executes the same rule matching by semgrep locally 