### PR TITLE
updating-limits

### DIFF
--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -3,40 +3,39 @@ pcx_content_type: concept
 title: Limits
 sidebar:
   order: 4
-
 ---
 
-import { Render, WranglerConfig } from "~/components"
+import { Render, WranglerConfig } from "~/components";
 
 Limits that apply to authoring, deploying, and running Workflows are detailed below.
 
 Many limits are inherited from those applied to Workers scripts and as documented in the [Workers limits](/workers/platform/limits/) documentation.
 
-| Feature                                   | Workers Free            | Workers Paid          |
-| ----------------------------------------- | ----------------------- | --------------------- |
-| Workflow class definitions per script     | 3MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits) | 10MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits)
-| Total scripts per account                 | 100 | 500 (shared with [Worker script limits](/workers/platform/limits/#account-plan-limits) |
-| Compute time per step [^3]                | 10 ms | 30 seconds (default) / configurable to 5 minutes of [active CPU time](/workers/platform/limits/#cpu-time) |
-| Duration (wall clock) per step [^3]       | Unlimited | Unlimited - for example, waiting on network I/O calls or querying a database |
-| Maximum persisted state per step          | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
-| Maximum event [payload size](/workflows/build/events-and-parameters/) | 1MiB (2^20 bytes) | 1MiB (2^20 bytes) |
-| Maximum state that can be persisted per Workflow instance | 100MB | 1GB |
-| Maximum `step.sleep` duration             | 365 days (1 year) | 365 days (1 year) |
-| Maximum steps per Workflow [^5]           | 1024 | 1024 |
-| Maximum Workflow executions               | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#worker-limits) | Unlimited |
-| Concurrent Workflow instances (executions) per account [^7]   | 25 | 10,000 |
-| Maximum Workflow instance creation rate [^8] | 100 per second [^6] | 100 per second [^6] |
-| Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 10,000 | 100,000 |
-| Retention limit for completed Workflow instance state | 3 days | 30 days [^2] |
-| Maximum length of a Workflow name [^4]         | 64 characters | 64 characters |
-| Maximum length of a Workflow instance ID [^4]         | 100 characters | 100 characters |
-| Maximum number of subrequests per Workflow instance | 50/request | 1000/request |
+| Feature                                                                                       | Workers Free                                                                                | Workers Paid                                                                                              |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Workflow class definitions per script                                                         | 3MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits) | 10MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits)              |
+| Total scripts per account                                                                     | 100                                                                                         | 500 (shared with [Worker script limits](/workers/platform/limits/#account-plan-limits)                    |
+| Compute time per step [^3]                                                                    | 10 ms                                                                                       | 30 seconds (default) / configurable to 5 minutes of [active CPU time](/workers/platform/limits/#cpu-time) |
+| Duration (wall clock) per step [^3]                                                           | Unlimited                                                                                   | Unlimited - for example, waiting on network I/O calls or querying a database                              |
+| Maximum persisted state per step                                                              | 1MiB (2^20 bytes)                                                                           | 1MiB (2^20 bytes)                                                                                         |
+| Maximum event [payload size](/workflows/build/events-and-parameters/)                         | 1MiB (2^20 bytes)                                                                           | 1MiB (2^20 bytes)                                                                                         |
+| Maximum state that can be persisted per Workflow instance                                     | 100MB                                                                                       | 1GB                                                                                                       |
+| Maximum `step.sleep` duration                                                                 | 365 days (1 year)                                                                           | 365 days (1 year)                                                                                         |
+| Maximum steps per Workflow [^5]                                                               | 1024                                                                                        | 1024                                                                                                      |
+| Maximum Workflow executions                                                                   | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#worker-limits)  | Unlimited                                                                                                 |
+| Concurrent Workflow instances (executions) per account [^7]                                   | 25                                                                                          | 10,000                                                                                                    |
+| Maximum Workflow instance creation rate [^8]                                                  | 100 per second [^6]                                                                         | 100 per second [^6]                                                                                       |
+| Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 100,000                                                                                     | 1,000,000                                                                                                 |
+| Retention limit for completed Workflow instance state                                         | 3 days                                                                                      | 30 days [^2]                                                                                              |
+| Maximum length of a Workflow name [^4]                                                        | 64 characters                                                                               | 64 characters                                                                                             |
+| Maximum length of a Workflow instance ID [^4]                                                 | 100 characters                                                                              | 100 characters                                                                                            |
+| Maximum number of subrequests per Workflow instance                                           | 50/request                                                                                  | 1000/request                                                                                              |
 
 [^2]: Workflow instance state and logs will be retained for 3 days on the Workers Free plan and for 30 days on the Workers Paid plan.
 
 [^3]: A Workflow instance can run forever, as long as each step does not take more than the CPU time limit and the maximum number of steps per Workflow is not reached.
 
-[^4]: Match pattern: _```^[a-zA-Z0-9_][a-zA-Z0-9-_]*$```_
+[^4]: Match pattern: _```^[a-zA-Z0-9_][a-zA-Z0-9-_]\*$```\_
 
 [^5]: `step.sleep` do not count towards the max. steps limit
 
@@ -55,7 +54,11 @@ Instances that are on a `waiting` state - either sleeping, waiting for a retry, 
 For example, consider a Workflow that does some work, waits for 30 days, and then continues with more work:
 
 ```ts title="src/index.ts"
-import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from 'cloudflare:workers';
+import {
+	WorkflowEntrypoint,
+	WorkflowStep,
+	WorkflowEvent,
+} from "cloudflare:workers";
 
 type Env = {
 	MY_WORKFLOW: Workflow;
@@ -63,27 +66,26 @@ type Env = {
 
 export class MyWorkflow extends WorkflowEntrypoint<Env> {
 	async run(event: WorkflowEvent<unknown>, step: WorkflowStep) {
-
-		const apiResponse = await step.do('initial work', async () => {
-			let resp = await fetch('https://api.cloudflare.com/client/v4/ips');
+		const apiResponse = await step.do("initial work", async () => {
+			let resp = await fetch("https://api.cloudflare.com/client/v4/ips");
 			return await resp.json<any>();
 		});
 
-		await step.sleep('wait 30 days', '30 days');
+		await step.sleep("wait 30 days", "30 days");
 
 		await step.do(
-			'make a call to write that could maybe, just might, fail',
+			"make a call to write that could maybe, just might, fail",
 			{
 				retries: {
 					limit: 5,
-					delay: '5 second',
-					backoff: 'exponential',
+					delay: "5 second",
+					backoff: "exponential",
 				},
-				timeout: '15 minutes',
+				timeout: "15 minutes",
 			},
 			async () => {
 				if (Math.random() > 0.5) {
-					throw new Error('API call to $STORAGE_SYSTEM failed');
+					throw new Error("API call to $STORAGE_SYSTEM failed");
 				}
 			},
 		);
@@ -103,11 +105,11 @@ By default, the maximum CPU time per Workflow invocation is set to 30 seconds, b
 
 ```jsonc
 {
-  // ...rest of your configuration...
-  "limits": {
-    "cpu_ms": 300000, // 300,000 milliseconds = 5 minutes
-  },
-  // ...rest of your configuration...
+	// ...rest of your configuration...
+	"limits": {
+		"cpu_ms": 300000, // 300,000 milliseconds = 5 minutes
+	},
+	// ...rest of your configuration...
 }
 ```
 


### PR DESCRIPTION
### Summary

Updating workflows queued instance limits to 100,00 for free plan & 1,000,000 for paid plan
