### PR TITLE
Fix invalid TypeScript annotation

### DIFF
--- a/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -406,7 +406,7 @@ To begin, install the `@anthropic-ai/sdk` package:
 
 <PackageManagers pkg="@anthropic-ai/sdk" />
 
-In `src/index.js`, you can update the `GET /` route to check for the `ANTHROPIC_API_KEY` environment variable. If it's set, we can generate text using the Anthropic SDK. If it isn't set, we'll fall back to the existing Workers AI code:
+In `src/index.js`, you can update the `GET /` route to check for the `ANTHROPIC_API_KEY` environment variable. If it is set, we can generate text using the Anthropic SDK. If it is not set, we'll fall back to the existing Workers AI code:
 
 ```js
 import Anthropic from '@anthropic-ai/sdk';

--- a/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/build-a-retrieval-augmented-generation-ai.mdx
@@ -415,7 +415,7 @@ app.get('/', async (c) => {
   // ... Existing code
 	const systemPrompt = `When answering the question or responding, use the context provided, if it is provided and relevant.`
 
-	let modelUsed: string = ""
+	let modelUsed = ""
 	let response = null
 
 	if (c.env.ANTHROPIC_API_KEY) {


### PR DESCRIPTION
### Summary

This update fixes an incorrect TypeScript annotation used inside a JavaScript code example. The expression `let modelUsed: string = ""` has been corrected to `let modelUsed = ""` to match standard JavaScript syntax and improve accuracy for developers following the documentation.

### Screenshots (optional)

N/A

### Documentation checklist

* [ ] Is there a changelog entry?
* [x] The change adheres to the documentation style guide.
* [ ] If a larger change, an issue has been opened related to incorrect or outdated information.
* [ ] Files which have changed name or location have been allocated redirects.