### PR TITLE
Add a new Vue Cloudflare Turnstile widget option to the docs.

### DIFF
--- a/src/content/docs/turnstile/community-resources.mdx
+++ b/src/content/docs/turnstile/community-resources.mdx
@@ -35,6 +35,7 @@ Cloudflare recommends [@marsidev/react-turnstile](https://www.npmjs.com/package/
 :::
 
 - Vue
+  - [vue-cloudflare-turnstile](https://www.npmjs.com/package/vue-cloudflare-turnstile)
   - [cfturnstile-vue3](https://www.npmjs.com/package/cfturnstile-vue3)
   - [vue-turnstile](https://www.npmjs.com/package/vue-turnstile)
 - [Angular](https://www.npmjs.com/package/ngx-turnstile)


### PR DESCRIPTION
### Summary

Added a link to a new Vue 3 Cloudflare Turnstile package. Package is worth mentioning in the docs.

### Documentation checklist
- [ X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
