### PR TITLE
Move Agents quick start to a dedicated tab

### DIFF
--- a/src/content/docs/agents/getting-started/quickstart.mdx
+++ b/src/content/docs/agents/getting-started/quickstart.mdx
@@ -1,0 +1,62 @@
+---
+title: Quick Start
+pcx_content_type: get-started
+sidebar:
+  order: 2
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+To use the Agent starter template and create your first Agent with the Agents SDK:
+
+```sh
+# install it
+npm create cloudflare@latest agents-starter -- --template=cloudflare/agents-starter
+# and deploy it
+npx wrangler@latest deploy
+```
+
+Head to the guide on [building a chat agent](/agents/getting-started/build-a-chat-agent) to learn how the starter project is built and how to use it as a foundation for your own agents.
+
+If you're already building on [Workers](/workers/), you can install the `agents` package directly into an existing project:
+
+```sh
+npm i agents
+```
+
+And then define your first Agent by creating a class that extends the `Agent` class:
+
+<TypeScriptExample>
+
+```ts
+import { Agent, AgentNamespace } from "agents";
+
+export class MyAgent extends Agent {
+	// Define methods on the Agent:
+	// https://developers.cloudflare.com/agents/api-reference/agents-api/
+	//
+	// Every Agent has built in state via this.setState and this.sql
+	// Built-in scheduling via this.schedule
+	// Agents support WebSockets, HTTP requests, state synchronization and
+	// can run for seconds, minutes or hours: as long as the tasks need.
+}
+```
+
+</TypeScriptExample>
+
+Lastly, add the [Durable Objects](/durable-objects/) binding to your wrangler file:
+
+<WranglerConfig>
+```toml
+[[durable_objects.bindings]]
+name = "MyAgent"
+class_name = "MyAgent"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyAgent"]
+
+```
+</WranglerConfig>
+
+Dive into the [Agent SDK reference](/agents/api-reference/agents-api/) to learn more about how to use the Agents SDK package and defining an `Agent`.

--- a/src/content/docs/agents/index.mdx
+++ b/src/content/docs/agents/index.mdx
@@ -29,61 +29,9 @@ import {
 
 The Agents SDK enables you to build and deploy AI-powered agents that can autonomously perform tasks, communicate with clients in real time, call AI models, persist state, schedule tasks, run asynchronous workflows, browse the web, query data from your database, support human-in-the-loop interactions, and [a lot more](/agents/api-reference/).
 
-### Ship your first Agent
-
-To use the Agent starter template and create your first Agent with the Agents SDK:
-
-```sh
-# install it
-npm create cloudflare@latest agents-starter -- --template=cloudflare/agents-starter
-# and deploy it
-npx wrangler@latest deploy
-```
-
-Head to the guide on [building a chat agent](/agents/getting-started/build-a-chat-agent) to learn how the starter project is built and how to use it as a foundation for your own agents.
-
-If you're already building on [Workers](/workers/), you can install the `agents` package directly into an existing project:
-
-```sh
-npm i agents
-```
-
-And then define your first Agent by creating a class that extends the `Agent` class:
-
-<TypeScriptExample>
-
-```ts
-import { Agent, AgentNamespace } from "agents";
-
-export class MyAgent extends Agent {
-	// Define methods on the Agent:
-	// https://developers.cloudflare.com/agents/api-reference/agents-api/
-	//
-	// Every Agent has built in state via this.setState and this.sql
-	// Built-in scheduling via this.schedule
-	// Agents support WebSockets, HTTP requests, state synchronization and
-	// can run for seconds, minutes or hours: as long as the tasks need.
-}
-```
-
-</TypeScriptExample>
-
-Lastly, add the [Durable Objects](/durable-objects/) binding to your wrangler file:
-
-<WranglerConfig>
-```toml
-[[durable_objects.bindings]]
-name = "MyAgent"
-class_name = "MyAgent"
-
-[[migrations]]
-tag = "v1"
-new_sqlite_classes = ["MyAgent"]
-
-```
-</WranglerConfig>
-
-Dive into the [Agent SDK reference](/agents/api-reference/agents-api/) to learn more about how to use the Agents SDK package and defining an `Agent`.
+<LinkButton variant="primary" href="/agents/getting-started/quickstart/">
+	Quick Start
+</LinkButton>
 
 ### Why build agents on Cloudflare?
 


### PR DESCRIPTION
### Summary

Earlier we had a code snippet of how you can get started with agents (Installing dependencies, importing the right things and how to use it) in the Overview section of the page, I've created a new page for it and linked to the new page where the existing content resided

### Screenshots (optional)

<img width="264" height="230" alt="image" src="https://github.com/user-attachments/assets/72fc704a-c3f7-4770-873b-198a378a8f1a" />


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
