### PR TITLE
Update deploy-a-zola-site.mdx

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
@@ -79,12 +79,6 @@ Upon running `zola init`, you will prompted with three questions:
 
 ## Deploy with Cloudflare Pages
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Zola" }}
-/>
-
 <PagesBuildPreset framework="zola" />
 
 Below the configuration, make sure to set the **Environment Variables (advanced)** for specifying the `ZOLA_VERSION`.


### PR DESCRIPTION
"Learn more" section present mid-article

### Summary
Mid-article a end of article "learn more" section is present by mistake.

### Screenshots (optional)
<img width="707" height="688" alt="image" src="https://github.com/user-attachments/assets/4406c53f-8a8a-4167-881f-bb5f50bf81db" />


### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
