### PR TITLE
Change product group from 'Consumer services' to 'Core platform'

### DIFF
--- a/src/content/products/registrar.yml
+++ b/src/content/products/registrar.yml
@@ -4,7 +4,7 @@ logo: <svg class="c_hf c_ck c_dw c_hg" role="presentation" xmlns="http://www.w3.
 product:
   title: Registrar
   url: /registrar/
-  group: Consumer services
+  group: Core platform
 
 meta:
   title: Cloudflare Registrar docs


### PR DESCRIPTION
### Summary

Recategorizing Registrar as Core platform rather than consumer products.

### Screenshots (optional)

N/A

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
