### PR TITLE
Cancel in-progress production builds

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - production
 
+concurrency:
+  group: publish-production
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: Production


### PR DESCRIPTION
### Summary

We already put PRs in concurrency groups so that new pushes cancel in-progress builds, but we don't do that for production. This PR changes it so that new merges to production cancel any in-progress builds. We only care about the most recent commit, so it's wasteful to keep running builds that will be out of date very soon.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist
