### PR TITLE
Bumps compat date to work with default entrypoint class

### DIFF
--- a/src/content/docs/workflows/python/bindings.mdx
+++ b/src/content/docs/workflows/python/bindings.mdx
@@ -26,7 +26,7 @@ From the configuration perspective, enabling Python Workflows requires adding th
 #:schema node_modules/wrangler/config-schema.json
 name = "workflows-starter"
 main = "src/index.ts"
-compatibility_date = "2024-10-22"
+compatibility_date = "2025-10-24"
 compatibility_flags = ["python_workflows", "python_workers"]
 
 [[workflows]]


### PR DESCRIPTION
### Summary

We have recently modified docs to use default entrypoint classes, as those have become the right way to declare fetch handlers on Python workers. We need a bump on the compat dates for the docs as well, since the older compat dates would rely on global handlers such as fetch and would, therefore, not work

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->


- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).