### PR TITLE
Remove "Available on Paid plan" line from WFP overview page 

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/index.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/index.mdx
@@ -16,8 +16,6 @@ Deploy custom code on behalf of your users or let your users directly deploy the
 
 </Description>
 
-<Plan type="paid" />
-
 Workers for Platforms allows you to run your own code as a wrapper around your user's code. With Workers for Platforms, you can logically group your code separately from your users' code, create custom logic, and use additional APIs such as [script tags](/cloudflare-for-platforms/workers-for-platforms/configuration/tags/) for bulk operations.
 
 Workers for Platforms is built on top of [Cloudflare Workers](/workers/). Workers for Platforms lets you surpass Cloudflare Workers' 500 scripts per account [limit](/cloudflare-for-platforms/workers-for-platforms/platform/limits/).


### PR DESCRIPTION
<img width="710" height="286" alt="image" src="https://github.com/user-attachments/assets/23e19c55-715d-4ace-aaeb-ea25b4605b7c" />

Feels deceiving since it might imply that WFP is included as a part of the Workers Paid plan, even though its a part of its own subscription. 