### PR TITLE
Document new cache span attributes

### DIFF
--- a/src/content/docs/workers/observability/traces/spans-and-attributes.mdx
+++ b/src/content/docs/workers/observability/traces/spans-and-attributes.mdx
@@ -67,12 +67,37 @@ Cloudflare Workers provides automatic tracing instrumentation **out of the box**
 
 #### [`cache_put`](/workers/runtime-apis/cache/#put)
 
-- `cache_control.expiration`
-- `cache_control.revalidation`
+- `cache.request.url`
+- `cache.request.method`
+- `cache.request.payload.status_code`
+- `cache.request.payload.header.cache_control`
+- `cache.request.payload.header.cache_tag`
+- `cache.request.payload.header.etag`
+- `cache.request.payload.header.expires`
+- `cache.request.payload.header.last_modified`
+- `cache.request.payload.size`
+- `cache.response.success`
 
 #### [`cache_match`](/workers/runtime-apis/cache/#match)
 
+- `cache.request.ignore_method`
+- `cache.request.url`
+- `cache.request.method`
+- `cache.request.header.range`
+- `cache.request.header.if_modified_since`
+- `cache.request.header.if_none_match`
+- `cache.response.status_code`
+- `cache.response.body.size`
+- `cache.response.cache_status`
+- `cache.response.success`
+
 #### [`cache_delete`](/workers/runtime-apis/cache/#delete)
+
+- `cache.request.ignore_method`
+- `cache.request.url`
+- `cache.request.method`
+- `cache.response.status_code`
+- `cache.response.success`
 
 ---
 


### PR DESCRIPTION
### Summary

Updates cache span documentation to match recent changes: https://github.com/cloudflare/workerd/pull/5399

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
