### PR TITLE
chore: Updated documentation to reflect updated minimum Cache TTL for Workers KV

### DIFF
--- a/src/content/docs/kv/api/read-key-value-pairs.mdx
+++ b/src/content/docs/kv/api/read-key-value-pairs.mdx
@@ -92,7 +92,7 @@ env.NAMESPACE.get(key, options?);
     cacheTtl?: number,
     type?: "text" | "json" | "arrayBuffer" | "stream"
 }`
-  - Optional. Object containing the optional `cacheTtl` and `type` properties. The `cacheTtl` property defines the length of time in seconds that a KV result is cached in the global network location it is accessed from (minimum: 60). The `type` property defines the type of the value to be returned.
+  - Optional. Object containing the optional `cacheTtl` and `type` properties. The `cacheTtl` property defines the length of time in seconds that a KV result is cached in the global network location it is accessed from (minimum: 30). The `type` property defines the type of the value to be returned.
 
 ##### Response
 
@@ -169,7 +169,7 @@ Metadata is a serializable value you append to each KV entry.
     cacheTtl?: number,
     type?: "text" | "json" | "arrayBuffer" | "stream"
 }`
-  - Optional. Object containing the optional `cacheTtl` and `type` properties. The `cacheTtl` property defines the length of time in seconds that a KV result is cached in the global network location it is accessed from (minimum: 60). The `type` property defines the type of the value to be returned.
+  - Optional. Object containing the optional `cacheTtl` and `type` properties. The `cacheTtl` property defines the length of time in seconds that a KV result is cached in the global network location it is accessed from (minimum: 30). The `type` property defines the type of the value to be returned.
 
 ##### Response
 
@@ -242,6 +242,8 @@ For large values, the choice of `type` can have a noticeable effect on latency a
 
 Defining the length of time in seconds is useful for reducing cold read latency on keys that are read relatively infrequently. `cacheTtl` is useful if your data is write-once or write-rarely.
 
+If you need to have fresher data at the cost of more cold reads (and higher latencies), you can set `cacheTtl` to be as low as `30`.
+
 :::note[Hot and cold read]
 
 A hot read means that the data is cached on Cloudflare's edge network using the [CDN](https://developers.cloudflare.com/cache/), whether it is in a local cache or a regional cache. A cold read means that the data is not cached, so the data must be fetched from the central stores. Both existing key-value pairs and non-existent key-value pairs (also known as negative lookups) are cached at the edge.
@@ -249,7 +251,7 @@ A hot read means that the data is cached on Cloudflare's edge network using the 
 
 `cacheTtl` is not recommended if your data is updated often and you need to see updates shortly after they are written, because writes that happen from other global network locations will not be visible until the cached value expires.
 
-The `cacheTtl` parameter must be an integer greater than or equal to `60`, which is the default. The maximum value for `cacheTtl` is [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).
+The `cacheTtl` parameter must be an integer greater than or equal to `30`. The default value for `cacheTtl` is `60`. The maximum value for `cacheTtl` is [`Number.MAX_SAFE_INTEGER`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).
 
 Once a key has been read with a given `cacheTtl` in a region, it will remain cached in that region until the end of the `cacheTtl` or eviction. This affects regional and central tiers of KV's built-in caching layers. When writing to Workers KV, the regions in the regional and central caching layers internal to KV will get revalidated with the newly written result.
 


### PR DESCRIPTION

### Summary

Updates the documentation for Workers KV to reflect the ability of setting a lower than 60 `cacheTTL` (down to 30) for `get()` operations.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
