### PR TITLE
[Workflows] Add waitForEvent type limitations

### DIFF
--- a/src/content/docs/workflows/build/events-and-parameters.mdx
+++ b/src/content/docs/workflows/build/events-and-parameters.mdx
@@ -78,7 +78,7 @@ A running Workflow can wait for an event (or events) by calling `step.waitForEve
 
 Because `waitForEvent` is part of the `WorkflowStep` API, you can call it multiple times within a Workflow, and use control flow to conditionally wait for an event.
 
-Calling `waitForEvent` requires you to specify an `type`, which is used to match the corresponding `type` when sending an event to a Workflow instance.
+Calling `waitForEvent` requires you to specify an `type` (up to 100 characters [^1]), which is used to match the corresponding `type` when sending an event to a Workflow instance.
 
 For example, to wait for billing webhook:
 
@@ -150,7 +150,7 @@ export default {
 </TypeScriptExample>
 
 - Similar to the [`waitForEvent`](#wait-for-events) example in this guide, the `type` property in our `waitForEvent` and `sendEvent` fields must match.
-- To send multiple events to a Workflow that has multiple `waitForEvent` calls, call `sendEvent` with the corresponding `type` property set.
+- To send multiple events to a Workflow that has multiple `waitForEvent` calls, call `sendEvent` with the corresponding `type` property set (up to 100 characters [^1]).
 - Events can also be sent using the REST API (HTTP API)'s [Events endpoint](/api/resources/workflows/subresources/instances/subresources/events/methods/create/).
 
 ## TypeScript and type parameters
@@ -202,3 +202,5 @@ export class MyWorkflow extends WorkflowEntrypoint {
 ```
 
 <Render file="workflows-type-parameters" product="workflows" />
+
+[^1]: Match pattern: `^[a-zA-Z0-9_][a-zA-Z0-9-_]*$`

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -114,7 +114,7 @@ More information about the limits imposed on Workflow can be found in the [Workf
 
 - <code>step.waitForEvent(name: string, options: ): Promise&lt;void&gt;</code>
   - `name` - the name of the step.
-  - `options` - an object with properties for `type`, which determines which event type this `waitForEvent` call will match on when calling `instance.sendEvent`, and an optional `timeout` property, which defines how long the `waitForEvent` call will block for before throwing a timeout exception. The default timeout is 24 hours.
+  - `options` - an object with properties for `type` (up to 100 characters [^1]), which determines which event type this `waitForEvent` call will match on when calling `instance.sendEvent`, and an optional `timeout` property, which defines how long the `waitForEvent` call will block for before throwing a timeout exception. The default timeout is 24 hours.
 
 <TypeScriptExample>
 
@@ -444,7 +444,7 @@ Terminate a Workflow instance.
 [Send an event](/workflows/build/events-and-parameters/) to a running Workflow instance.
 
 - <code>sendEvent(): Promise&lt;void&gt;</code>
-  - `options` - the event `type` and `payload` to send to the Workflow instance. The `type` must match the `type` in the corresponding `waitForEvent` call in your Workflow.
+  - `options` - the event `type` (up to 100 characters [^1]) and `payload` to send to the Workflow instance. The `type` must match the `type` in the corresponding `waitForEvent` call in your Workflow.
 
 Return `void` on success; throws an exception if the Workflow is not running or is an errored state.
 


### PR DESCRIPTION
### Summary

`waitForEvent` `options.type` property was missing its limitations:
- 100 chars
- same regex as workflow name/instance id
