### PR TITLE
Remove documentation for non-public API

### DIFF
--- a/src/content/docs/workers/observability/traces/spans-and-attributes.mdx
+++ b/src/content/docs/workers/observability/traces/spans-and-attributes.mdx
@@ -460,12 +460,6 @@ The SQL API allow you to modify the SQLite database embedded within a Durable Ob
 - `db.operation.name`
 - `cloudflare.durable_object.response.db_size`
 
-#### `durable_object_storage_ingest`
-
-- `cloudflare.durable_object.response.rows_read`
-- `cloudflare.durable_object.response.rows_written`
-- `cloudflare.durable_object.response.statement_count`
-
 #### [`durable_object_storage_kv_get`](/durable-objects/api/sqlite-storage-api/#get)
 
 - `cloudflare.durable_object.kv.query.keys`


### PR DESCRIPTION
### Summary

Ingest is not a public API yet, so we shouldn't document it here.


