### PR TITLE
Fix asgi reference

### DIFF
--- a/src/content/docs/workers/languages/python/packages/fastapi.mdx
+++ b/src/content/docs/workers/languages/python/packages/fastapi.mdx
@@ -12,7 +12,7 @@ The FastAPI package is supported in Python Workers.
 
 FastAPI applications use a protocol called the [Asynchronous Server Gateway Interface (ASGI)](https://asgi.readthedocs.io/en/latest/). This means that FastAPI never reads from or writes to a socket itself. An ASGI application expects to be hooked up to an ASGI server, typically [uvicorn](https://www.uvicorn.org/). The ASGI server handles all of the raw sockets on the application’s behalf.
 
-The Workers runtime provides [an ASGI server](https://github.com/cloudflare/workerd/blob/main/src/pyodide/internal/asgi.py) directly to your Python Worker, which lets you use FastAPI in Python Workers.
+The Workers runtime provides [an ASGI server](https://github.com/cloudflare/workerd/blob/main/src/pyodide/internal/workers-api/src/asgi.py) directly to your Python Worker, which lets you use FastAPI in Python Workers.
 
 ## Get Started
 


### PR DESCRIPTION
### Summary

- Change the url for `asgi.py` file to the correct location, the previous one throws a 404 page


