### PR TITLE
Add sentinelone as new logpush destination

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/api-configuration.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/api-configuration.mdx
@@ -3,7 +3,6 @@ pcx_content_type: concept
 title: API configuration
 sidebar:
   order: 2
-
 ---
 
 import { APIRequest } from "~/components";
@@ -16,10 +15,8 @@ You can locate `{zone_id}` and `{account_id}` arguments based on the [Find zone 
 The `{job_id}` argument is numeric, like 123456.
 The `{dataset_id}` argument indicates the log category (such as `http_requests` or `audit_logs`).
 
-
-
 | Operation | Description                                 | API                                                                                                                                                                                              |
-| --------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| --------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `POST`    | Create job                                  | [Documentation](/api/resources/logpush/subresources/jobs/methods/create/)                                             |
 | `GET`     | Retrieve job details                        | [Documentation](/api/resources/logpush/subresources/datasets/subresources/jobs/methods/get/)                                     |
 | `GET`     | Retrieve all jobs for all datasets          | [Documentation](/api/resources/logpush/subresources/jobs/methods/list/)                                                 |
@@ -32,17 +29,13 @@ The `{dataset_id}` argument indicates the log category (such as `http_requests` 
 | `POST`    | Validate ownership challenge                | [Documentation](/api/resources/logpush/subresources/ownership/methods/validate/)                      |
 | `POST`    | Validate log options                        | [Documentation](/api/resources/logpush/subresources/validate/methods/origin/)                           |
 
-
 For concrete examples, refer to the tutorials in [Logpush examples](/logs/logpush/examples/).
 
 ## Connecting
 
 The Logpush API requires credentials like any other Cloudflare API.
 
-<APIRequest
-  path="/zones/{zone_id}/logpush/jobs"
-  method="GET"
-/>
+<APIRequest path="/zones/{zone_id}/logpush/jobs" method="GET" />
 
 ## Ownership
 
@@ -77,15 +70,13 @@ You will need to provide the token contained in the file when creating a job.
 
 :::note[Note]
 
-
 When using Sumo Logic, you may find it helpful to have [Live Tail](https://help.sumologic.com/05Search/Live-Tail/About-Live-Tail) open to see the challenge file as soon as it is uploaded.
-
 
 :::
 
 ## Destination
 
-You can specify your cloud service provider destination via the required **destination\_conf** parameter.
+You can specify your cloud service provider destination via the required **destination_conf** parameter.
 
 :::note[Note]
 
@@ -101,44 +92,45 @@ The `destination_conf` parameter must follow this format:
 Supported schemes are listed below, each tailored to specific providers such as
 R2, S3, etc. Additionally, generic use cases like `https` are also covered:
 
-* `r2`,
-* `gs`,
-* `s3`,
-* `sumo`,
-* `https`,
-* `azure`,
-* `splunk`,
-* `datadog`.
+- `r2`,
+- `gs`,
+- `s3`,
+- `sumo`,
+- `https`,
+- `azure`,
+- `splunk`,
+- `sentinelone`,
+- `datadog`.
 
 The `destination-address` should generally be provided by the destination
 provider. However, for certain providers, we require the `destination-address`
 to follow a specific format:
 
-* **Cloudflare R2** (scheme `r2`): bucket path + account ID + R2 access key ID + R2 secret access key; for example: `r2://<BUCKET_PATH>?account-id=<ACCOUNT_ID>&access-key-id=<R2_ACCESS_KEY_ID>&secret-access-key=<R2_SECRET_ACCESS_KEY>`
-* **AWS S3** (scheme `s3`): bucket + optional directory + region + optional encryption parameter (if required by your policy); for example: `s3://bucket/[dir]?region=<REGION>[&sse=AES256]`
-* **Datadog** (scheme `datadog`): Datadog endpoint URL + Datadog API key + optional parameters; for example: `datadog://<DATADOG_ENDPOINT_URL>?header_DD-API-KEY=<DATADOG_API_KEY>&ddsource=cloudflare&service=<SERVICE>&host=<HOST>&ddtags=<TAGS>`
-* **Google Cloud Storage** (scheme `gs`): bucket + optional directory; for example: `gs://bucket/[dir]`
-* **Microsoft Azure** (scheme `azure`): service-level SAS URL with `https` replaced by `azure` + optional directory added before query string; for example: `azure://<BLOB_CONTAINER_PATH>/[dir]?<QUERY_STRING>`
-* **New Relic** (use scheme `https`): New Relic endpoint URL which is `https://log-api.newrelic.com/log/v1` for US or `https://log-api.eu.newrelic.com/log/v1` for EU + a license key + a format; for example: for US `"https://log-api.newrelic.com/log/v1?Api-Key=<NR_LICENSE_KEY>&format=cloudflare"` and for EU `"https://log-api.eu.newrelic.com/log/v1?Api-Key=<NR_LICENSE_KEY>&format=cloudflare"`
-* **Splunk** (scheme `splunk`): Splunk endpoint URL + Splunk channel ID + insecure-skip-verify flag + Splunk sourcetype + Splunk authorization token; for example: `splunk://<SPLUNK_ENDPOINT_URL>?channel=<SPLUNK_CHANNEL_ID>&insecure-skip-verify=<INSECURE_SKIP_VERIFY>&sourcetype=<SOURCE_TYPE>&header_Authorization=<SPLUNK_AUTH_TOKEN>`
-* **Sumo Logic** (scheme `sumo`): HTTP source address URL with `https` replaced by `sumo`; for example: `sumo://<SUMO_ENDPOINT_URL>/receiver/v1/http/<UNIQUE_HTTP_COLLECTOR_CODE>`
+- **Cloudflare R2** (scheme `r2`): bucket path + account ID + R2 access key ID + R2 secret access key; for example: `r2://<BUCKET_PATH>?account-id=<ACCOUNT_ID>&access-key-id=<R2_ACCESS_KEY_ID>&secret-access-key=<R2_SECRET_ACCESS_KEY>`
+- **AWS S3** (scheme `s3`): bucket + optional directory + region + optional encryption parameter (if required by your policy); for example: `s3://bucket/[dir]?region=<REGION>[&sse=AES256]`
+- **Datadog** (scheme `datadog`): Datadog endpoint URL + Datadog API key + optional parameters; for example: `datadog://<DATADOG_ENDPOINT_URL>?header_DD-API-KEY=<DATADOG_API_KEY>&ddsource=cloudflare&service=<SERVICE>&host=<HOST>&ddtags=<TAGS>`
+- **Google Cloud Storage** (scheme `gs`): bucket + optional directory; for example: `gs://bucket/[dir]`
+- **Microsoft Azure** (scheme `azure`): service-level SAS URL with `https` replaced by `azure` + optional directory added before query string; for example: `azure://<BLOB_CONTAINER_PATH>/[dir]?<QUERY_STRING>`
+- **New Relic** (use scheme `https`): New Relic endpoint URL which is `https://log-api.newrelic.com/log/v1` for US or `https://log-api.eu.newrelic.com/log/v1` for EU + a license key + a format; for example: for US `"https://log-api.newrelic.com/log/v1?Api-Key=<NR_LICENSE_KEY>&format=cloudflare"` and for EU `"https://log-api.eu.newrelic.com/log/v1?Api-Key=<NR_LICENSE_KEY>&format=cloudflare"`
+- **Splunk** (scheme `splunk`): Splunk endpoint URL + Splunk channel ID + insecure-skip-verify flag + Splunk sourcetype + Splunk authorization token; for example: `splunk://<SPLUNK_ENDPOINT_URL>?channel=<SPLUNK_CHANNEL_ID>&insecure-skip-verify=<INSECURE_SKIP_VERIFY>&sourcetype=<SOURCE_TYPE>&header_Authorization=<SPLUNK_AUTH_TOKEN>`
+- **Sumo Logic** (scheme `sumo`): HTTP source address URL with `https` replaced by `sumo`; for example: `sumo://<SUMO_ENDPOINT_URL>/receiver/v1/http/<UNIQUE_HTTP_COLLECTOR_CODE>`
+- **SentinelOne** (scheme `sentinelone`): SentinelOne endpoint URL + SentinelOne sourcetype + SentinelOne authorization token; for example: `sentinelone://<SENTINELONE_ENDPOINT_URL>?sourcetype=<SOURCE_TYPE>&header_Authorization=<SENTINELONE_AUTH_TOKEN>`
 
 For **R2**, **S3**, **Google Cloud Storage**, and **Azure**, you can organize logs into daily subdirectories by including the special placeholder `{DATE}` in the URL path. This placeholder will automatically be replaced with the date in the `YYYYMMDD` format (for example, `20180523`).
 
 For example:
 
-* `s3://mybucket/logs/{DATE}?region=us-east-1&sse=AES256`
-* `azure://myblobcontainer/logs/{DATE}?[QueryString]`
+- `s3://mybucket/logs/{DATE}?region=us-east-1&sse=AES256`
+- `azure://myblobcontainer/logs/{DATE}?[QueryString]`
 
 This approach is useful when you want your logs grouped by day.
 
-
 For more information on the value for your cloud storage provider, consult the following conventions:
 
-* [AWS S3 CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/index.html) (S3Uri path argument type)
-* [Google Cloud Storage CLI](https://cloud.google.com/storage/docs/gsutil) (Syntax for accessing resources)
-* [Microsoft Azure Shared Access Signature](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview)
-* [Sumo Logic HTTP Source](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source)
+- [AWS S3 CLI](https://docs.aws.amazon.com/cli/latest/reference/s3/index.html) (S3Uri path argument type)
+- [Google Cloud Storage CLI](https://cloud.google.com/storage/docs/gsutil) (Syntax for accessing resources)
+- [Microsoft Azure Shared Access Signature](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview)
+- [Sumo Logic HTTP Source](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source)
 
 To check if a destination is already in use:
 
@@ -173,9 +165,7 @@ The kind parameter (optional) is used to differentiate between Logpush and Edge 
 
 :::note[Note]
 
-
 The kind parameter cannot be used to update existing Logpush jobs. You can only specify the kind parameter when creating a new job.
-
 
 :::
 
@@ -196,19 +186,19 @@ The kind parameter cannot be used to update existing Logpush jobs. You can only 
         "EdgeResponseBytes",
         "EdgeResponseStatus",
         "EdgeStartTimestamp",
-        "RayID"
+				"RayID",
       ],
-      timestamp_format: "rfc3339"
+			timestamp_format: "rfc3339",
     },
-    kind: "edge"
+		kind: "edge",
   }}
 />
 
 ## Options
 
-Logpull\_options has been replaced with Custom Log Formatting output\_options. Please refer to the [Log Output Options](/logs/logpush/logpush-job/log-output-options/) documentation for instructions on configuring these options and updating your existing jobs to use these options.
+Logpull_options has been replaced with Custom Log Formatting output_options. Please refer to the [Log Output Options](/logs/logpush/logpush-job/log-output-options/) documentation for instructions on configuring these options and updating your existing jobs to use these options.
 
-If you are still using logpull\_options, here are the options that you can customize:
+If you are still using logpull_options, here are the options that you can customize:
 
 1. **Fields** (optional): Refer to [Datasets](/logs/logpush/logpush-job/datasets/) for the currently available fields. The list of fields is also accessible directly from the API: `https://api.cloudflare.com/client/v4/zones/{zone_id}/logpush/datasets/{dataset_id}/fields`. Default fields: `https://api.cloudflare.com/client/v4/zones/{zone_id}/logpush/datasets/{dataset_id}/fields/default`.
 2. **Timestamp format** (optional): The format in which timestamp fields will be returned. Value options: `unixnano` (nanoseconds unit - default), `unix` (seconds unit), `rfc3339` (seconds unit).
@@ -219,14 +209,15 @@ If you are still using logpull\_options, here are the options that you can custo
 The **CVE-2021-44228** parameter can only be set through the API at this time. Updating your Logpush job through the dashboard will set this option to false.
 :::
 
-To check if the selected **logpull\_options** are valid:
+To check if the selected **logpull_options** are valid:
 
 <APIRequest
   path="/zones/{zone_id}/logpush/validate/origin"
   method="POST"
   json={{
-    logpull_options: "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339&CVE-2021-44228=true",
-    dataset: "http_requests"
+		logpull_options:
+			"fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339&CVE-2021-44228=true",
+		dataset: "http_requests",
   }}
 />
 
@@ -256,9 +247,9 @@ Value can range from `0.0` (exclusive) to `1.0` (inclusive). `sample=0.1` means 
 
 These parameters can be used to gain control of batch size in the case that a destination has specific requirements. Files will be sent based on whichever parameter is hit first. If these options are not set, the system uses our internal defaults of 30s, 100k records, or the destinations globally defined limits.
 
-1. **max\_upload\_bytes** (optional): The maximum uncompressed file size of a batch of logs. This setting value must be between 5 MB and 1 GB. Note that you cannot set a minimum file size; this means that log files may be much smaller than this batch size.
-2. **max\_upload\_records** (optional): The maximum number of log lines per batch. This setting must be between 1,000 and 1,000,000 lines. Note that you cannot specify a minimum number of log lines per batch; this means that log files may contain many fewer lines than this.
-3. **max\_upload\_interval\_seconds** (optional): The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds. Note that you cannot specify a minimum interval for log batches; this means that log files may be sent in shorter intervals than this.
+1. **max_upload_bytes** (optional): The maximum uncompressed file size of a batch of logs. This setting value must be between 5 MB and 1 GB. Note that you cannot set a minimum file size; this means that log files may be much smaller than this batch size.
+2. **max_upload_records** (optional): The maximum number of log lines per batch. This setting must be between 1,000 and 1,000,000 lines. Note that you cannot specify a minimum number of log lines per batch; this means that log files may contain many fewer lines than this.
+3. **max_upload_interval_seconds** (optional): The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds. Note that you cannot specify a minimum interval for log batches; this means that log files may be sent in shorter intervals than this.
 
 ## Custom fields
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/sentinelone.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/sentinelone.mdx
@@ -1,0 +1,162 @@
+---
+title: Enable SentinelOne
+pcx_content_type: how-to
+sidebar:
+  order: 64
+head:
+  - tag: title
+    content: Enable Logpush to SentinelOne
+---
+
+import { Render, APIRequest } from "~/components";
+
+The HTTP Event Collector (HEC) is a reliable method to send log data to SentinelOne Singularity Data Lake. Cloudflare Logpush supports pushing logs directly to SentinelOne HEC via the Cloudflare dashboard or API.
+
+## Manage via the Cloudflare dashboard
+
+<Render file="enable-logpush-job" />
+
+4. In **Select a destination**, choose **SentinelOne**.
+
+5. Enter or select the following destination information:
+   - **SentinelOne HEC URL**
+   - **Auth Token** - Event Collector token.
+   - **Source Type** - For example, `marketplace-cloudflare-latest`.
+
+When you are done entering the destination details, select **Continue**.
+
+6. Select the dataset to push to the storage service.
+
+7. In the next step, you need to configure your logpush job:
+   - Enter the **Job name**.
+   - Under **If logs match**, you can select the events to include and/or remove from your logs. Refer to [Filters](/logs/logpush/logpush-job/filters/) for more information. Not all datasets have this option available.
+   - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
+
+8. In **Advanced Options**, you can:
+   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
+   - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
+
+9. Select **Submit** once you are done configuring your logpush job.
+
+## Manage via API
+
+To set up a SentinelOne Logpush job:
+
+1. Create a job with the appropriate endpoint URL and authentication parameters.
+2. Enable the job to begin pushing logs.
+
+:::note
+Unlike configuring Logpush jobs for AWS S3, GCS, or Azure, there is no ownership challenge when configuring Logpush to SentinelOne.
+:::
+
+<Render file="enable-read-permissions" />
+
+### 1. Create a job
+
+To create a job, make a `POST` request to the Logpush jobs endpoint with the following fields:
+
+- **name** (optional) - Use your domain name as the job name.
+- **destination_conf** - A log destination consisting of an endpoint URL, source type, authorization header in the string format below.
+  - **SENTINELONE_ENDPOINT_URL**: The SentinelOne raw HTTP Event Collector URL with port. For example: `sentinelone://ingest.us1.sentinelone.net/services/collector/raw`. Cloudflare expects the SentinelOne endpoint to be `/services/collector/raw` while configuring and setting up the Logpush job.
+  - **SENTINELONE_AUTH_TOKEN**: The SentinelOne authorization token that is URL-encoded. For example: `Bearer 0e6d94e8c-5792-4ad1-be3c-29bcaee0197d`.
+  - **SOURCE_TYPE**: The SentinelOne source type. For example: `marketplace-cloudflare-latest`.
+
+```bash
+"https://<SENTINELONE_ENDPOINT_URL>?sourcetype=<SOURCE_TYPE>&header_Authorization=<SENTINELONE_AUTH_TOKEN>"
+```
+
+- **dataset** - The category of logs you want to receive. Refer to [Datasets](/logs/logpush/logpush-job/datasets/) for the full list of supported datasets.
+
+- **output_options** (optional) - To configure fields, sample rate, and timestamp format, refer to [Log Output Options](/logs/logpush/logpush-job/log-output-options/). For timestamp, Cloudflare recommends using `timestamps=rfc3339`.
+
+Example request using cURL:
+
+<APIRequest
+	path="/zones/{zone_id}/logpush/jobs"
+	method="POST"
+	json={{
+		name: "<DOMAIN_NAME>",
+		destination_conf:
+			"sentinelone://<SENTINELONE_ENDPOINT_URL>?sourcetype=<SOURCE_TYPE>&header_Authorization=<SENTINELONE_AUTH_TOKEN>",
+		output_options: {
+			field_names: [
+				"ClientIP",
+				"ClientRequestHost",
+				"ClientRequestMethod",
+				"ClientRequestURI",
+				"EdgeEndTimestamp",
+				"EdgeResponseBytes",
+				"EdgeResponseStatus",
+				"EdgeStartTimestamp",
+				"RayID",
+			],
+			timestamp_format: "rfc3339",
+		},
+		dataset: "http_requests",
+	}}
+/>
+
+Response:
+
+```json
+{
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": <JOB_ID>,
+    "dataset": "http_requests",
+    "enabled": false,
+    "name": "<DOMAIN_NAME>",
+    "output_options": {
+      "field_names": ["ClientIP", "ClientRequestHost", "ClientRequestMethod", "ClientRequestURI", "EdgeEndTimestamp","EdgeResponseBytes", "EdgeResponseStatus", "EdgeStartTimestamp", "RayID"],
+      "timestamp_format": "rfc3339"
+    },
+    "destination_conf": "sentinelone://<SENTINELONE_ENDPOINT_URL>?sourcetype=<SOURCE_TYPE>&header_Authorization=<SENTINELONE_AUTH_TOKEN>",
+    "last_complete": null,
+    "last_error": null,
+    "error_message": null
+  },
+  "success": true
+}
+```
+
+### 2. Enable (update) a job
+
+To enable a job, make a `PUT` request to the Logpush jobs endpoint. Use the job ID returned from the previous step in the URL and send `{"enabled": true}` in the request body.
+
+Example request using cURL:
+
+<APIRequest
+	method="PUT"
+	path="/zones/{zone_id}/logpush/jobs/{job_id}"
+	json={{
+		enabled: true,
+	}}
+/>
+
+Response:
+
+```json
+{
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": <JOB_ID>,
+    "dataset": "http_requests",
+    "enabled": true,
+    "name": "<DOMAIN_NAME>",
+    "output_options": {
+      "field_names": ["ClientIP", "ClientRequestHost", "ClientRequestMethod", "ClientRequestURI", "EdgeEndTimestamp","EdgeResponseBytes", "EdgeResponseStatus", "EdgeStartTimestamp", "RayID"],
+      "timestamp_format": "rfc3339"
+    },
+    "destination_conf": "sentinelone://<SENTINELONE_ENDPOINT_URL>?sourcetype=<SOURCE_TYPE>&header_Authorization=<SENTINELONE_AUTH_TOKEN>",
+    "last_complete": null,
+    "last_error": null,
+    "error_message": null
+  },
+  "success": true
+}
+```
+
+Refer to the [Logpush FAQ](/logs/faq/logpush/) for troubleshooting information.

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/sentinelone.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/sentinelone.mdx
@@ -14,7 +14,7 @@ The HTTP Event Collector (HEC) is a reliable method to send log data to Sentinel
 
 ## Manage via the Cloudflare dashboard
 
-<Render file="enable-logpush-job" />
+<Render file="enable-logpush-job" product="logs" />
 
 4. In **Select a destination**, choose **SentinelOne**.
 
@@ -50,7 +50,7 @@ To set up a SentinelOne Logpush job:
 Unlike configuring Logpush jobs for AWS S3, GCS, or Azure, there is no ownership challenge when configuring Logpush to SentinelOne.
 :::
 
-<Render file="enable-read-permissions" />
+<Render file="enable-read-permissions" product="logs" />
 
 ### 1. Create a job
 


### PR DESCRIPTION
### Summary

This MR adds sentinelone as a new logpush destination

### Screenshots (optional)

<img width="1067" height="778" alt="sentinelone_1" src="https://github.com/user-attachments/assets/cd64c6c9-1963-4bf3-b249-2d9449d49aea" />
<img width="1079" height="595" alt="sentinelone_2" src="https://github.com/user-attachments/assets/32ded8ee-977d-4d50-88cc-9b223cc5f63d" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
