### PR TITLE
[Cloudflare Tunnel] fix route limits description

### DIFF
--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -62,13 +62,13 @@ This page lists the default account limits for rules, applications, fields, and 
 
 ## Cloudflare Tunnel
 
-| Feature                                  | Limit |
-| ---------------------------------------- | ----- |
-| `cloudflared` tunnels per account        | 1,000 |
-| WARP Connectors per account              | 10    |
-| Routes per tunnel                        | 1,000 |
-| Active `cloudflared` replicas per tunnel | 25    |
-| Virtual networks per account             | 1,000 |
+| Feature                                            | Limit |
+| -------------------------------------------------- | ----- |
+| `cloudflared` tunnels per account                  | 1,000 |
+| WARP Connectors per account                        | 10    |
+| Routes (CIDR routes + Hostname routes) per account | 1,000 |
+| Active `cloudflared` replicas per tunnel           | 25    |
+| Virtual networks per account                       | 1,000 |
 
 ## Digital Experience Monitoring (DEX)
 


### PR DESCRIPTION
### Summary
The route limits description is incorrect. The limit is per account not per tunnel, and it applies to the sum of CIDR and Hostname routes.
