### PR TITLE
[Workflows] Fix InstanceStatus types

### DIFF
--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -5,7 +5,6 @@ tags:
   - Bindings
 sidebar:
   order: 3
-
 ---
 
 import { WranglerConfig } from "~/components";
@@ -14,7 +13,7 @@ You can trigger Workflows both programmatically and via the Workflows APIs, incl
 
 1. With [Workers](/workers) via HTTP requests in a `fetch` handler, or bindings from a `queue` or `scheduled` handler
 2. Using the [Workflows REST API](/api/resources/workflows/methods/list/)
-2. Via the [wrangler CLI](/workers/wrangler/commands/#workflows) in your terminal
+3. Via the [wrangler CLI](/workers/wrangler/commands/#workflows) in your terminal
 
 ## Workers API (Bindings)
 
@@ -22,10 +21,10 @@ You can interact with Workflows programmatically from any Worker script by creat
 
 You can interact with a Workflow:
 
-* Directly over HTTP via the [`fetch`](/workers/runtime-apis/handlers/fetch/) handler
-* From a [Queue consumer](/queues/configuration/javascript-apis/#consumer) inside a `queue` handler
-* From a [Cron Trigger](/workers/configuration/cron-triggers/) inside a `scheduled` handler
-* Within a [Durable Object](/durable-objects/)
+- Directly over HTTP via the [`fetch`](/workers/runtime-apis/handlers/fetch/) handler
+- From a [Queue consumer](/queues/configuration/javascript-apis/#consumer) inside a `queue` handler
+- From a [Cron Trigger](/workers/configuration/cron-triggers/) inside a `scheduled` handler
+- Within a [Durable Object](/durable-objects/)
 
 :::note
 
@@ -59,9 +58,9 @@ The `binding = "MY_WORKFLOW"` line defines the JavaScript variable that our Work
 
 The following example shows how you can manage Workflows from within a Worker, including:
 
-* Retrieving the status of an existing Workflow instance by its ID
-* Creating (triggering) a new Workflow instance
-* Returning the status of a given instance ID
+- Retrieving the status of an existing Workflow instance by its ID
+- Creating (triggering) a new Workflow instance
+- Returning the status of a given instance ID
 
 ```ts title="src/index.ts"
 interface Env {
@@ -70,20 +69,20 @@ interface Env {
 
 export default {
 	async fetch(req: Request, env: Env) {
-    // Get instanceId from query parameters
-    const instanceId = new URL(req.url).searchParams.get("instanceId")
+		// Get instanceId from query parameters
+		const instanceId = new URL(req.url).searchParams.get("instanceId");
 
-    // If an ?instanceId=<id> query parameter is provided, fetch the status
-    // of an existing Workflow by its ID.
-    if (instanceId) {
-      let instance = await env.MY_WORKFLOW.get(instanceId);
+		// If an ?instanceId=<id> query parameter is provided, fetch the status
+		// of an existing Workflow by its ID.
+		if (instanceId) {
+			let instance = await env.MY_WORKFLOW.get(instanceId);
 			return Response.json({
 				status: await instance.status(),
 			});
-    }
+		}
 
-    // Else, create a new instance of our Workflow, passing in any (optional)
-    // params and return the ID.
+		// Else, create a new instance of our Workflow, passing in any (optional)
+		// params and return the ID.
 		const newId = await crypto.randomUUID();
 		let instance = await env.MY_WORKFLOW.create({ id: newId });
 		return Response.json({
@@ -99,8 +98,8 @@ export default {
 You can inspect the status of any running Workflow instance by calling `status` against a specific instance ID. This allows you to programmatically inspect whether an instance is queued (waiting to be scheduled), actively running, paused, or errored.
 
 ```ts
-let instance = await env.MY_WORKFLOW.get("abc-123")
-let status = await instance.status() // Returns an InstanceStatus
+let instance = await env.MY_WORKFLOW.get("abc-123");
+let status = await instance.status(); // Returns an InstanceStatus
 ```
 
 The possible values of status are as follows:
@@ -116,18 +115,22 @@ The possible values of status are as follows:
     | "waiting" // instance is hibernating and waiting for sleep or event to finish
     | "waitingForPause" // instance is finishing the current work to pause
     | "unknown";
-  error?: string;
-  output?: object;
-};
+  error?: { 
+    name: string,
+    message: string
+  };
+	output?: unknown;
 ```
-{/*
+
+
+
 ### Explicitly pause a Workflow
 
 You can explicitly pause a Workflow instance (and later resume it) by calling `pause` against a specific instance ID.
 
 ```ts
-let instance = await env.MY_WORKFLOW.get("abc-123")
-await instance.pause() // Returns Promise<void>
+let instance = await env.MY_WORKFLOW.get("abc-123");
+await instance.pause(); // Returns Promise<void>
 ```
 
 ### Resume a Workflow
@@ -135,29 +138,29 @@ await instance.pause() // Returns Promise<void>
 You can resume a paused Workflow instance by calling `resume` against a specific instance ID.
 
 ```ts
-let instance = await env.MY_WORKFLOW.get("abc-123")
-await instance.resume() // Returns Promise<void>
+let instance = await env.MY_WORKFLOW.get("abc-123");
+await instance.resume(); // Returns Promise<void>
 ```
 
 Calling `resume` on an instance that is not currently paused will have no effect.
-*/}
+
 
 ### Stop a Workflow
 
 You can stop/terminate a Workflow instance by calling `terminate` against a specific instance ID.
 
 ```ts
-let instance = await env.MY_WORKFLOW.get("abc-123")
-await instance.terminate() // Returns Promise<void>
+let instance = await env.MY_WORKFLOW.get("abc-123");
+await instance.terminate(); // Returns Promise<void>
 ```
 
-Once stopped/terminated, the Workflow instance *cannot* be resumed.
+Once stopped/terminated, the Workflow instance _cannot_ be resumed.
 
 ### Restart a Workflow
 
 ```ts
-let instance = await env.MY_WORKFLOW.get("abc-123")
-await instance.restart() // Returns Promise<void>
+let instance = await env.MY_WORKFLOW.get("abc-123");
+await instance.restart(); // Returns Promise<void>
 ```
 
 Restarting an instance will immediately cancel any in-progress steps, erase any intermediate state, and treat the Workflow as if it was run for the first time.

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -266,7 +266,7 @@ return Response.json({
 
 Returns a `WorkflowInstance`.
 
-Throws an error if the provided ID is already used by an existing instance that has not yet passed its [retention limit](/workflows/reference/limits/). To re-run a workflow with the same ID, you can [`restart`](/workflows/build/trigger-workflows/#restart-a-workflow) the existing instance. 
+Throws an error if the provided ID is already used by an existing instance that has not yet passed its [retention limit](/workflows/reference/limits/). To re-run a workflow with the same ID, you can [`restart`](/workflows/build/trigger-workflows/#restart-a-workflow) the existing instance.
 
 <Render file="workflows-type-parameters" product="workflows" />
 
@@ -334,8 +334,8 @@ Unlike [`create`](/workflows/build/workers-api/#create), this operation is idemp
 
 Get a specific Workflow instance by ID.
 
-- <code>get(id: string): Promise&lt;WorkflowInstance&gt;</code>
-  - `id` - the ID of the Workflow instance.
+- <code>get(id: string): Promise&lt;WorkflowInstance&gt;</code>- `id` - the ID
+  of the Workflow instance.
 
 Returns a `WorkflowInstance`. Throws an exception if the instance ID does not exist.
 
@@ -493,8 +493,11 @@ type InstanceStatus = {
 		| "waiting" // instance is hibernating and waiting for sleep or event to finish
 		| "waitingForPause" // instance is finishing the current work to pause
 		| "unknown";
-	error?: string;
-	output?: object;
+	error?: { 
+		name: string,
+		message: string 
+	};
+	output?: unknown;
 };
 ```
 


### PR DESCRIPTION
### Summary

Update `InstanceStatus` return types due to recent added changes to workerd types (https://github.com/cloudflare/workerd/pull/5575).

Also uncomment `pause`/`resume`.
