### PR TITLE
Update D1 import/export with note about sqlite 3.50.0 exporting

### DIFF
--- a/src/content/docs/d1/best-practices/import-export-data.mdx
+++ b/src/content/docs/d1/best-practices/import-export-data.mdx
@@ -92,6 +92,16 @@ For example, if you have a raw SQLite dump called `db_dump.sqlite3`, run the fol
 sqlite3 db_dump.sqlite3 .dump > db.sql
 ```
 
+:::note
+
+If you are using sqlite v3.50.0 or later you need to pass `--escape off` to the .dump command to avoid usage of `unistr`. See [sqlite v3.50.0 release notes](https://sqlite.org/releaselog/3_50_0.html) for more details
+
+```sh
+sqlite3 db_dump.sqlite3 .dump --escape off > db.sql
+```
+
+:::
+
 Once you have run the above command, you will need to edit the output SQL file to be compatible with D1:
 
 1. Remove `BEGIN TRANSACTION` and `COMMIT;` from the file


### PR DESCRIPTION
Added note about sqlite v3.50.0 requirement for .dump command.

### Summary

sqlite 3.50.0 uses a new [`unistr()`](https://sqlite.org/lang_corefunc.html#unistr) command in dumps which is not supported in D1. https://sqlite.org/releaselog/3_50_0.html

So dropping a note about how to get sqlite to not output the command in its dump. 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
