### PR TITLE
[cache] Creates partial for edge TTL information

### DIFF
--- a/src/content/docs/cache/concepts/default-cache-behavior.mdx
+++ b/src/content/docs/cache/concepts/default-cache-behavior.mdx
@@ -7,7 +7,7 @@ head:
 
 ---
 
-import { FeatureTable } from "~/components"
+import { FeatureTable, Render } from "~/components"
 
 Cloudflare respects the origin web server’s cache headers in the following order unless an [Edge Cache TTL cache rule](/cache/how-to/cache-rules/settings/#edge-ttl) overrides the headers. Refer to the [Edge TTL](/cache/how-to/configure-cache-status-code/#edge-ttl) section for details on default TTL behavior.
 
@@ -53,6 +53,14 @@ Cloudflare only caches based on file extension and not by MIME type. The Cloudfl
 | CSS   | FLAC | MID  | PLS  | TAR  | XLSX  |     |
 
 To cache additional content, refer to [Cache Rules](/cache/how-to/cache-rules/) to create a rule to cache everything.
+
+<Render
+  file="edge-ttl"
+	product="cache"
+	params={{
+		conditional: "dedicated-cache-tile"
+	}}
+/>
 
 ## Customization options and limits
 

--- a/src/content/docs/cache/how-to/configure-cache-status-code.mdx
+++ b/src/content/docs/cache/how-to/configure-cache-status-code.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 
 ---
 
+import { Render } from "~/components"
+
 Customers can set cache time-to-live (TTL) based on the response status from the origin web server. Cache TTL refers to the duration of a resource in the Cloudflare network before being marked as `STALE` or discarded from cache. Status codes are returned by a resource's origin.
 
 Setting cache TTL based on response status overrides the [default cache behavior (standard caching)](/cache/concepts/default-cache-behavior/) for static files and overrides cache instructions sent by the origin web server. To cache non-static assets, set a [Cache Level of Cache Everything using a Cache Rule](/cache/how-to/cache-rules/create-api/#example-requests). Setting `no-store` **Cache-Control** or a low TTL (using `max-age`/`s-maxage`) increases requests to origin web servers and decreases performance.
@@ -12,17 +14,13 @@ Setting cache TTL based on response status overrides the [default cache behavior
 
 The maximum caching limit for Free, Pro, and Business customers is 512 MB per file, and the maximum caching limit for Enterprise customers is 5 GB per file. If you need to raise the limits, contact your Customer Success Manager.
 
-## Edge TTL
-
-By default, Cloudflare caches certain HTTP response codes with the following Edge Cache TTL when a `cache-control` directive or `expires` response header are not present.
-
-| HTTP status code | Default TTL |
-| ---------------- | ----------- |
-| 200, 206, 301    | 120m        |
-| 302, 303         | 20m         |
-| 404, 410         | 3m          |
-
-All other status codes are not cached by default.
+<Render
+  file="edge-ttl"
+	product="cache"
+	params={{
+		conditional: "dedicated-cache-tile"
+	}}
+/>
 
 ## Set cache TTL by response status via the Cloudflare dashboard
 

--- a/src/content/partials/cache/edge-ttl.mdx
+++ b/src/content/partials/cache/edge-ttl.mdx
@@ -1,0 +1,15 @@
+---
+{}
+---
+
+## Edge TTL
+
+By default, Cloudflare caches certain HTTP response codes with the following Edge Cache TTL when a `cache-control` directive or `expires` response header are not present.
+
+| HTTP status code | Default TTL |
+| ---------------- | ----------- |
+| 200, 206, 301    | 120m        |
+| 302, 303         | 20m         |
+| 404, 410         | 3m          |
+
+All other status codes are not cached by default.


### PR DESCRIPTION
### Summary

Creates partial for edge TTL information. Closes https://github.com/cloudflare/cloudflare-docs/pull/26571

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

