### PR TITLE
Changelog for reusable Access policies for Workers

### DIFF
--- a/src/content/changelog/workers/2025-12-03-reusable-access-policies.mdx
+++ b/src/content/changelog/workers/2025-12-03-reusable-access-policies.mdx
@@ -1,0 +1,27 @@
+---
+title: One-click Access protection for Workers now creates reusable Cloudflare Access policies
+description: Workers now use reusable Access policies to reduce duplication and make it easier to manage access across multiple Workers.
+products:
+  - workers
+date: 2025-12-04
+---
+
+Workers applications now use reusable [Cloudflare Access policies](/cloudflare-one/access-controls/policies/) to reduce duplication and simplify access management across multiple Workers.
+
+Previously, enabling Cloudflare Access on a Worker created per-application policies, unique to each application. Now, we create reusable policies that can be shared across applications:
+
+- **Preview URLs**: All Workers preview URLs share a single "Cloudflare Workers Preview URLs" policy across your account. This policy is automatically created the first time you enable Access on any preview URL. By sharing a single policy across all preview URLs, you can configure access rules once and have them apply company-wide to all Workers which protect preview URLs. This makes it much easier to manage who can access preview environments without having to update individual policies for each Worker.
+
+- **Production workers.dev URLs**: When enabled, each Worker gets its own reusable policy (named `<worker-name> - Production`) by default. We recognize production services often have different access requirements and having individual policies here makes it easier to configure service-to-service authentication or protect internal dashboards or applications with specific user groups. Keeping these policies separate gives you the flexibility to configure exactly the right access rules for each production service. When you disable Access on a production Worker, the associated policy is automatically cleaned up if it's not being used by other applications.
+
+This change reduces policy duplication, simplifies cross-company access management for preview environments, and provides the flexibility needed for production services. You can still customize access rules by editing the reusable policies in the Zero Trust dashboard.
+
+To enable Cloudflare Access on your Worker:
+
+1. In the Cloudflare dashboard, go to **Workers & Pages**.
+2. Select your Worker.
+3. Go to **Settings** > **Domains & Routes**.
+4. For `workers.dev` or Preview URLs, click **Enable Cloudflare Access**.
+5. Optionally, click **Manage Cloudflare Access** to customize the policy.
+
+For more information on configuring Cloudflare Access for Workers, refer to the [Workers Access documentation](/workers/configuration/routing/workers-dev/#cloudflare-access).


### PR DESCRIPTION
### Summary

Documents the change to one-click Access protection for Workers. We now create reusable policies rather than the legacy per-application policies.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
