### PR TITLE
Remove note about TURN focusing on WebRTC

### DIFF
--- a/src/content/docs/realtime/turn/rfc-matrix.mdx
+++ b/src/content/docs/realtime/turn/rfc-matrix.mdx
@@ -30,7 +30,3 @@ sidebar:
 | oAuth third-party TURN/STUN authorization       | No                                                                                                                             | [RFC 7635](https://datatracker.ietf.org/doc/html/rfc7635)                                                            |
 | DTLS support (for TURN)                         | No                                                                                                                             | [draft-petithuguenin-tram-stun-dtls-00](https://datatracker.ietf.org/doc/html/draft-petithuguenin-tram-stun-dtls-00) |
 | Mobile ICE (MICE) support                       | No                                                                                                                             | [draft-wing-tram-turn-mobility-02](http://tools.ietf.org/html/draft-wing-tram-turn-mobility-02)                      |
-
-:::note
-
-The main focus of the TURN service right now is to be used in a WebRTC context.


### PR DESCRIPTION
### Summary

This PR removes a note from the TURN documentation.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
