### PR TITLE
durable objects: clarify behavior for WebSocket attachments

### DIFF
--- a/src/content/docs/durable-objects/best-practices/websockets.mdx
+++ b/src/content/docs/durable-objects/best-practices/websockets.mdx
@@ -170,11 +170,15 @@ The following are methods available on the **Native Durable Object WebSocket API
 
 #### `WebSocket.serializeAttachment()`
 
-- <code>{" "}serializeAttachment(value <Type text="any" />)</code>: <Type text="void" />
+- <code>serializeAttachment(value <Type text="any" />)</code>: <Type text="void" />
 
-  - Keeps a copy of `value` associated with the WebSocket to survive hibernation. The value can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types. If the value needs to be durable please use [Durable Object Storage](/durable-objects/api/sqlite-storage-api/).
+  - Keeps a copy of `value` associated with the WebSocket connection. Serialized attachments are available as long as their attached WebSocket connection is healthy, even after hibernation. If any side of the connection is closed, the attachments will be lost.
 
-  - If you modify `value` after calling this method, those changes will not be retained unless you call this method again. The serialized size of `value` is limited to 2,048 bytes, otherwise this method will throw an error. If you need larger values to survive hibernation, use the [Storage API](/durable-objects/api/sqlite-storage-api/) and pass the corresponding key to this method so it can be retrieved later.
+  - If you modify `value` after calling this method, those changes will not be retained unless you call this method again.
+
+	- The `value` can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types and the serialized size is limited to 2,048 bytes, otherwise this method will throw an error.
+
+	- If you need to store larger values, use the [Storage API](/durable-objects/api/sqlite-storage-api/) and store the corresponding key as an attachment so it can be retrieved later.
 
 #### `WebSocket.deserializeAttachment()`
 

--- a/src/content/docs/durable-objects/best-practices/websockets.mdx
+++ b/src/content/docs/durable-objects/best-practices/websockets.mdx
@@ -178,7 +178,7 @@ The following are methods available on the **Native Durable Object WebSocket API
 
 	- The `value` can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which is true of most types and the serialized size is limited to 2,048 bytes, otherwise this method will throw an error.
 
-	- If you need to store larger values, use the [Storage API](/durable-objects/api/sqlite-storage-api/) and store the corresponding key as an attachment so it can be retrieved later.
+	- If you need to store larger values, or want to persist values even if the Durable Object instance is evicted and the WebSocket connections are closed, use the [Storage API](/durable-objects/api/sqlite-storage-api/) and store the corresponding key as an attachment so it can be retrieved later.
 
 #### `WebSocket.deserializeAttachment()`
 

--- a/src/content/docs/durable-objects/best-practices/websockets.mdx
+++ b/src/content/docs/durable-objects/best-practices/websockets.mdx
@@ -172,7 +172,7 @@ The following are methods available on the **Native Durable Object WebSocket API
 
 - <code>serializeAttachment(value <Type text="any" />)</code>: <Type text="void" />
 
-  - Keeps a copy of `value` associated with the WebSocket connection. Serialized attachments are available as long as their attached WebSocket connection is healthy, even after hibernation. If any side of the connection is closed, the attachments will be lost.
+  - Keeps a copy of `value` associated with the WebSocket connection. Serialized attachments are available as long as their attached WebSocket connection is healthy, even after hibernation. If any side of the connection is closed, the attachments will be lost. If the value needs to be durable even if the [Durable Object is evicted](/durable-objects/concepts/durable-object-lifecycle/), please use [Durable Object Storage](/durable-objects/api/sqlite-storage-api/).
 
   - If you modify `value` after calling this method, those changes will not be retained unless you call this method again.
 


### PR DESCRIPTION
Clarifies the lifetime of attachments for the Durable Object Hibernation WebSocket API