### PR TITLE
[HEADER] Fix focus outline on Chromium browsers and iOS Safari

### DIFF
--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -48,8 +48,26 @@ import HeaderDropdowns from "../HeaderDropdowns.tsx";
 	}
 
 	:global(starlight-theme-select > label > select) {
-		line-height: 1.25rem;
-	}
+        line-height: 1.25rem;
+        margin-inline: calc(var(--sl-inline-padding) * -1);
+        margin: 1px 1px;
+    }
+
+    :global(
+        starlight-theme-select > label > select:focus,
+        starlight-theme-select > label > select:focus-visible
+    ) {
+        margin: 1px 1px;
+        outline-offset: -4px;
+    }
+
+    :global(starlight-theme-select > label > .label-icon) {
+        left: 8%;
+    }
+
+    :global(starlight-theme-select > label > .caret) {
+        left: 75%;
+    }
 
 	@media screen and (min-width: 800px) {
 		#right-group {

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -49,7 +49,6 @@ import HeaderDropdowns from "../HeaderDropdowns.tsx";
 
 	:global(starlight-theme-select > label > select) {
         line-height: 1.25rem;
-        margin-inline: calc(var(--sl-inline-padding) * -1);
         margin: 1px 1px;
     }
 


### PR DESCRIPTION
### Summary

This fixes an issue with the focus outline for the Header component override's Starlight Theme Selector. This occurred on both Chromium browsers and Safari and should be now fixed on both. Please check the screenshots below for the before and after.

### Screenshots (optional)

**Brave (Chromium) before:** 
<img width="3830" height="986" alt="image" src="https://github.com/user-attachments/assets/631e5fc7-913a-4300-b75c-62b1299ac0bc" />

**Brave (Chromium) after:** 
<img width="1896" height="400" alt="image" src="https://github.com/user-attachments/assets/972c69c4-7a9d-4316-b4c9-5287d90049bc" />

**Safari (iOS) before:** 
<img width="2854" height="642" alt="image" src="https://github.com/user-attachments/assets/9125356e-038c-4ba9-8ac3-cbe9ae1e5ee9" />

**Safari (iOS) after:** 
<img width="2854" height="642" alt="image" src="https://github.com/user-attachments/assets/8c83d063-f191-4391-bd2d-bda620896d3b" />


