### PR TITLE
[semgrep] Fix issue with commit messages that contain double quotes

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,13 +4,13 @@ on:
     - cron: "0 4 * * *"
   pull_request: {}
 
-name: Semgrep config
+name: Semgrep rules checking results
 permissions:
   contents: read
 
 jobs:
   semgrep:
-    name: semgrep
+    name: Semgrep
     runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
@@ -67,4 +67,3 @@ jobs:
           else
             echo "No relevant files changed"
           fi
-

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | | sed "s/\"/'/g")" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed 's/"/\'/g')\"" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | | sed "s/\"/'/g")" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})\"" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed 's/"/\\"/g')\"" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed 's/"/\\"/g')\"" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed 's/"/\'/g')\"" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")'" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch


### PR DESCRIPTION
At present the following command:
```
echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})\"" | tee /dev/stderr >> "$GITHUB_ENV"
```
produces an error if the commit message contains quotes. Add a sed substitution to replace double quotes with single quotes within the commit message just for use in this workflow.