### PR TITLE
feat: rm zt, vendored uploads

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -60,15 +60,6 @@ jobs:
             . \
             devdocs:vendored-markdown
           cd ..
-      - name: Upload vendored Markdown files to ZT DevDocs bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.ZT_DEVDOCS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ZT_DEVDOCS_SECRET_ACCESS_KEY }}
-        run: |
-          rclone sync \
-            --config bin/rclone.conf \
-            distmd \
-            zt:zt-dashboard-dev-docs
       - name: Upload vendored Markdown files to AI Search DevDocs bucket
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AUTORAG_DEVDOCS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -41,25 +41,6 @@ jobs:
         run: sudo -v ; curl https://rclone.org/install.sh | sudo bash
       - name: Build vendored Markdown
         run: npx tsx bin/generate-index-md.ts
-      - name: Upload vendored Markdown archives to Vendored Markdown bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.VENDORED_DEVDOCS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.VENDORED_DEVDOCS_SECRET_ACCESS_KEY }}
-        run: |
-          cd distmd && zip -r markdown.zip .
-          rclone copy \
-            --config ../bin/rclone.conf \
-            ./markdown.zip \
-            devdocs:vendored-markdown
-          rm markdown.zip
-          cd ..
-
-          cd distllms
-          rclone copy --max-depth 2 \
-            --config ../bin/rclone.conf \
-            . \
-            devdocs:vendored-markdown
-          cd ..
       - name: Upload vendored Markdown files to AI Search DevDocs bucket
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AUTORAG_DEVDOCS_ACCESS_KEY_ID }}

--- a/bin/rclone.conf
+++ b/bin/rclone.conf
@@ -6,14 +6,6 @@ endpoint = https://b54f07a6c269ecca2fa60f1ae4920c99.r2.cloudflarestorage.com
 acl = private
 no_check_bucket = true
 
-[zt]
-type = s3
-provider = Cloudflare
-env_auth = true
-endpoint = https://e76c849bd111ee7d3006b6625713991e.r2.cloudflarestorage.com
-acl = private
-no_check_bucket = true
-
 [autorag]
 type = s3
 provider = Cloudflare

--- a/bin/rclone.conf
+++ b/bin/rclone.conf
@@ -1,11 +1,3 @@
-[devdocs]
-type = s3
-provider = Cloudflare
-env_auth = true
-endpoint = https://b54f07a6c269ecca2fa60f1ae4920c99.r2.cloudflarestorage.com
-acl = private
-no_check_bucket = true
-
 [autorag]
 type = s3
 provider = Cloudflare


### PR DESCRIPTION
### Summary

The zt upload isn't needed anymore and the vendored upload has been moved to a separate internal Cloudflare project. They are no longer needed and removing them can save some build time.

The autorag upload is kept as that will be moved to a separate internal Cloudflare project next week.