### PR TITLE
[workflows] Fix folder and template name in CLI quick start guide

### DIFF
--- a/src/content/docs/workflows/get-started/cli-quick-start.mdx
+++ b/src/content/docs/workflows/get-started/cli-quick-start.mdx
@@ -34,7 +34,7 @@ To create a Workflow, use the `create cloudflare` (C3) CLI tool, specifying the 
 npm create cloudflare@latest workflows-starter -- --template "cloudflare/workflows-starter"
 ```
 
-This will create a new folder called `workflows-tutorial`, which contains two files:
+This will create a new folder called `workflows-starter`, which contains two files:
 
 * `src/index.ts` - this is where your Worker script, including your Workflows definition, is defined.
 * wrangler.jsonc - the [Wrangler configuration file](/workers/wrangler/configuration/) for your Workers project and your Workflow.
@@ -158,7 +158,7 @@ You can run a Workflow via the `wrangler` CLI, via a Worker binding, or via the 
 
 ```sh
 # Trigger a Workflow from the CLI, and pass (optional) parameters as an event to the Workflow.
-npx wrangler@latest workflows trigger workflows-tutorial --params={"email": "user@example.com", "metadata": {"id": "1"}}
+npx wrangler@latest workflows trigger workflows-starter --params={"email": "user@example.com", "metadata": {"id": "1"}}
 ```
 
 Refer to the [events and parameters documentation](/workflows/build/events-and-parameters/) to understand how events are passed to Workflows.


### PR DESCRIPTION
### Summary

Fix typo in Workflow CLI quick start page commands

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
