### PR TITLE
CUSTESC-59217 - Add cache.match 504 to general 502/504 errors page

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-502-504.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-502-504.mdx
@@ -15,7 +15,7 @@ There are two possible causes:
 - [`502/504` errors from your origin web server](#502504-from-your-origin-web-server) (most common).
 - [`502/504` errors from Cloudflare](#502504-from-cloudflare).
 
-You may also see `504` status codes in logs or analytics caused by [cache MISS responses from Early Hints](/cache/advanced-configuration/early-hints/#emit-early-hints).
+You may also see `504` status codes in logs or analytics caused by [cache MISS responses from Early Hints](/cache/advanced-configuration/early-hints/#emit-early-hints), or by Cloudflare Workers Cache API [`cache.match` operations resulting in cache MISS](https://developers.cloudflare.com/workers/runtime-apis/cache/#errors-1).
 
 ### Resolution
 


### PR DESCRIPTION
### Summary

502/504 general errors page didn't mention 504s from Cache API cache.match operations.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
