### PR TITLE
[Chore] Remove /markdown.zip guidance

### DIFF
--- a/src/content/partials/style-guide/llms-txt.mdx
+++ b/src/content/partials/style-guide/llms-txt.mdx
@@ -11,8 +11,6 @@ We have implemented `llms.txt`, `llms-full.txt` and also created per-page Markdo
   - We also provide a `llms-full.txt` file on a per-product basis, i.e [`/workers/llms-full.txt`](/workers/llms-full.txt)
 - [`/$page/index.md`](index.md)
   - Add `/index.md` to the end of any page to get the Markdown version, i.e [`/style-guide/index.md`](/style-guide/index.md)
-- [`/markdown.zip`](/markdown.zip)
-  - An export of all of our documentation in the aforementioned `index.md` format.
 
 In the top right of this page, you will see a `Page options` button where you can copy the current page as Markdown that can be given to your LLM of choice.
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -31,9 +31,6 @@ export const GET: APIRoute = async () => {
 		Easily build and deploy full-stack applications everywhere,
 		thanks to integrated compute, storage, and networking.
 
-		> [!TIP]
-		> An archive of Markdown files is available at https://developers.cloudflare.com/markdown.zip
-
 		${grouped
 			.map(([product, entries]) => {
 				return dedent(`


### PR DESCRIPTION
### Summary

Given it's lack of consumers, we're removing the `/markdown.zip` functionality as an option to consume our docs.

First stage is removing the public guidance.
