### PR TITLE
docs(browser-rendering): add waitUntil guidance for JS-heavy pages

### DIFF
--- a/src/content/docs/browser-rendering/reference/timeouts.mdx
+++ b/src/content/docs/browser-rendering/reference/timeouts.mdx
@@ -11,14 +11,27 @@ If any of these timers exceed their limit, the request returns a timeout error.
 
 Each timer controls a specific part of the rendering lifecycle — from page load, to selector load, to action.
 
-| Timer                                | Scope           |Default           |Max           |
-| -------------------------------------- | --------------- | --------------- | --------------- |
-|  `goToOptions.timeout`     | Time to wait for the page to load before timeout.  |   30 s       |   60 s        |
-|  `goToOptions.waitUntil`    |  Time until page load considered complete: <br />`load` = full page load, including resources, like images and stylesheets. <br />`Event.domcontentloaded` = waits until the DOM content has been fully loaded, fires before the page `load` event. <br />`Event.networkidle0` = there are no active network connections for at least 500 ms. <br />`Event.networkidle2` = there are no more than two active network connections for at least 500 ms.         |     —      |     —      |
-|  `waitForSelector`   | Time to wait for a specific element (any CSS selector) to appear on the page.  |    null      |     60 s      |
-|  `waitForTimeout`     | Additional amount of time to wait after the page has loaded to proceed with actions.  |     null     |      60 s     |
-|  `actionTimeout`     |  Time to wait for the action itself (for example: a screenshot, PDF, or scrape) to complete after the page has loaded.  |    null      |      5 min     |
-|  `PDFOptions.timeout`     |  Same as `actionTimeout`, but only applies to the [/pdf endpoint](/browser-rendering/rest-api/pdf-endpoint/). |     30 s     |     5 min      |
+| Timer                    | Scope                                                                                                              | Default | Max    |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------- | ------ |
+| `goToOptions.timeout`    | Time to wait for the page to load before timeout.                                                                  | 30 s    | 60 s   |
+| `goToOptions.waitUntil`  | Determines when page load is considered complete. Refer to [`waitUntil` options](#waituntil-options) for details.  | `domcontentloaded`  | —      |
+| `waitForSelector`        | Time to wait for a specific element (any CSS selector) to appear on the page.                                      | null    | 60 s   |
+| `waitForTimeout`         | Additional amount of time to wait after the page has loaded to proceed with actions.                               | null    | 60 s   |
+| `actionTimeout`          | Time to wait for the action itself (for example: a screenshot, PDF, or scrape) to complete after the page has loaded. | null | 5 min  |
+| `PDFOptions.timeout`     | Same as `actionTimeout`, but only applies to the [/pdf endpoint](/browser-rendering/rest-api/pdf-endpoint/).       | 30 s    | 5 min  |
+
+### `waitUntil` options
+
+The `goToOptions.waitUntil` parameter controls when the browser considers page navigation complete. This is important for JavaScript-heavy pages where content is rendered dynamically after the initial page load.
+
+| Value              | Behavior                                                                 |
+| ------------------ | ------------------------------------------------------------------------ |
+| `load`             | Waits for the `load` event, including all resources like images and stylesheets |
+| `domcontentloaded` | Waits until the DOM content has been fully loaded, which fires before the `load` event (default) |
+| `networkidle0`     | Waits until there are no network connections for at least 500 ms         |
+| `networkidle2`     | Waits until there are no more than two network connections for at least 500 ms |
+
+For pages that rely on JavaScript to render content, use `networkidle0` or `networkidle2` to ensure the page is fully rendered before extraction.
 
 ## Notes and recommendations
 You can set multiple timers — as long as one is complete, the request will fire.

--- a/src/content/docs/browser-rendering/rest-api/content-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/content-endpoint.mdx
@@ -84,6 +84,11 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 Many more options exist, like setting HTTP headers using `setExtraHTTPHeaders`, setting `cookies`, and using `gotoOptions` to control page load behaviour - check the endpoint [reference](/api/resources/browser_rendering/subresources/content/methods/create/) for all available parameters.
 
 <Render
+  file="javascript-heavy-pages"
+  product="browser-rendering"
+/>
+
+<Render
   file="setting-custom-user-agent"
   product="browser-rendering"
 />

--- a/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
@@ -375,6 +375,8 @@ In this example, Browser Rendering first calls Anthropic's Claude Sonnet 4 model
 ]
 ```
 
+<Render file="javascript-heavy-pages" product="browser-rendering" />
+
 <Render file="setting-custom-user-agent" product="browser-rendering" />
 
 <Render file="faq" product="browser-rendering" />

--- a/src/content/docs/browser-rendering/rest-api/links-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/links-endpoint.mdx
@@ -255,6 +255,8 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
   }'
 ```
 
+<Render file="javascript-heavy-pages" product="browser-rendering" />
+
 <Render file="setting-custom-user-agent" product="browser-rendering" />
 
 <Render file="faq" product="browser-rendering" />

--- a/src/content/docs/browser-rendering/rest-api/markdown-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/markdown-endpoint.mdx
@@ -117,6 +117,11 @@ curl -X 'POST' 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browse
 ```
 
 <Render
+  file="javascript-heavy-pages"
+  product="browser-rendering"
+/>
+
+<Render
   file="setting-custom-user-agent"
   product="browser-rendering"
 />

--- a/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
@@ -198,6 +198,11 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 ```
 
 <Render
+  file="javascript-heavy-pages"
+  product="browser-rendering"
+/>
+
+<Render
   file="setting-custom-user-agent"
   product="browser-rendering"
 />

--- a/src/content/docs/browser-rendering/rest-api/scrape-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/scrape-endpoint.mdx
@@ -127,6 +127,11 @@ Visit the [Browser Rendering API reference](/api/resources/browser_rendering/sub
 :::
 
 <Render
+  file="javascript-heavy-pages"
+  product="browser-rendering"
+/>
+
+<Render
   file="setting-custom-user-agent"
   product="browser-rendering"
 />

--- a/src/content/docs/browser-rendering/rest-api/screenshot-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/screenshot-endpoint.mdx
@@ -187,6 +187,11 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 Many more options exist, like setting HTTP credentials using `authenticate`, setting `cookies`, and using `gotoOptions` to control page load behaviour - check the endpoint [reference](/api/resources/browser_rendering/subresources/screenshot/methods/create/) for all available parameters.
 
 <Render
+  file="javascript-heavy-pages"
+  product="browser-rendering"
+/>
+
+<Render
   file="setting-custom-user-agent"
   product="browser-rendering"
 />

--- a/src/content/docs/browser-rendering/rest-api/snapshot.mdx
+++ b/src/content/docs/browser-rendering/rest-api/snapshot.mdx
@@ -134,6 +134,11 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 />
 
 <Render
+  file="javascript-heavy-pages"
+  product="browser-rendering"
+/>
+
+<Render
   file="setting-custom-user-agent"
   product="browser-rendering"
 />

--- a/src/content/partials/browser-rendering/javascript-heavy-pages.mdx
+++ b/src/content/partials/browser-rendering/javascript-heavy-pages.mdx
@@ -2,7 +2,7 @@
 
 For JavaScript-heavy pages or Single Page Applications (SPAs), the default page load behavior may return empty or incomplete results. This happens because the browser considers the page loaded before JavaScript has finished rendering the content.
 
-To ensure the browser waits for dynamic content to render, use the `gotoOptions.waitUntil` parameter set to `networkidle0` or `networkidle2`:
+The simplest solution is to use the `gotoOptions.waitUntil` parameter set to `networkidle0` or `networkidle2`:
 
 ```json
 {
@@ -13,4 +13,4 @@ To ensure the browser waits for dynamic content to render, use the `gotoOptions.
 }
 ```
 
-For more details on `waitUntil` options and other timeout settings, refer to [REST API timeouts](/browser-rendering/reference/timeouts/).
+For faster responses, advanced users can use `waitForSelector` to wait for a specific element instead of waiting for all network activity to stop. This requires knowing which CSS selector indicates the content you need has loaded. For more details, refer to [REST API timeouts](/browser-rendering/reference/timeouts/).

--- a/src/content/partials/browser-rendering/javascript-heavy-pages.mdx
+++ b/src/content/partials/browser-rendering/javascript-heavy-pages.mdx
@@ -1,0 +1,16 @@
+### Handling JavaScript-heavy pages
+
+For JavaScript-heavy pages or Single Page Applications (SPAs), the default page load behavior may return empty or incomplete results. This happens because the browser considers the page loaded before JavaScript has finished rendering the content.
+
+To ensure the browser waits for dynamic content to render, use the `gotoOptions.waitUntil` parameter set to `networkidle0` or `networkidle2`:
+
+```json
+{
+  "url": "https://example.com",
+  "gotoOptions": {
+    "waitUntil": "networkidle0"
+  }
+}
+```
+
+For more details on `waitUntil` options and other timeout settings, refer to [REST API timeouts](/browser-rendering/reference/timeouts/).


### PR DESCRIPTION
- Add new partial explaining gotoOptions.waitUntil for JavaScript-heavy pages
- Add partial to all REST API endpoint docs
- Clean up timeouts reference page with dedicated waitUntil options table
- Fix default waitUntil value to domcontentloaded per API reference

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
