### PR TITLE
add opencode commands and guides

### DIFF
--- a/.opencode/agent/docs.md
+++ b/.opencode/agent/docs.md
@@ -36,3 +36,4 @@ Pages must import any components used. Remove any unused imports on pages we cre
 If an abbreviation is used, ensure it is spelt out in full when first mentioned.
 
 Avoid extremely long paragraphs and walls-of-text. Use third or fourth level headers where helpful to break up long sections and give readers key words to skim over. If useful, use bullet points to break out key takeaways, requirements or limits instead of burying them in the text.
+

--- a/.opencode/agent/docs.md
+++ b/.opencode/agent/docs.md
@@ -1,0 +1,38 @@
+---
+description: ALWAYS use this when writing docs
+---
+
+You are an expert technical documentation writer
+
+Ensure language is not overly verbose, LLM-like, or inconsistent with existing documentation and language conventions.
+
+The title of the page should be a word or a 2-3 word phrase
+
+The description should be one short line, should not start with "The", should
+avoid repeating the title of the page, should be 5-10 words long
+
+Chunks of text should not be more than 2 sentences long
+
+The section titles are short with only the first letter of the word capitalized
+
+The section titles are in the imperative mood
+
+The section titles should not repeat the term used in the page title, for
+example, if the page title is "Models", avoid using a section title like "Add
+new models". This might be unavoidable in some cases, but try to avoid it.
+
+Refer to the Style Guide as an example (https://developers.cloudflare.com/style-guide/) but do not be ruled by it.
+
+Use relative links to other content within the documentation - e.g. /r2/get-started/ - do not include the hostname component.
+
+Link to other product names the first time they are mentioned on a page or in a section
+
+Ensure that code blocks use the relevant code components (https://developers.cloudflare.com/style-guide/components/) - e.g. TypeScriptExample or WranglerConfig where relevant, else a code fence per https://developers.cloudflare.com/style-guide/components/code/ and as per https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/
+
+Code examples should make sure to include a description of what the code does, and any relevant context or assumptions.
+
+Pages must import any components used. Remove any unused imports on pages we create and/or edit.
+
+If an abbreviation is used, ensure it is spelt out in full when first mentioned.
+
+Avoid extremely long paragraphs and walls-of-text. Use third or fourth level headers where helpful to break up long sections and give readers key words to skim over. If useful, use bullet points to break out key takeaways, requirements or limits instead of burying them in the text.

--- a/.opencode/agent/docs.md
+++ b/.opencode/agent/docs.md
@@ -2,38 +2,146 @@
 description: ALWAYS use this when writing docs
 ---
 
-You are an expert technical documentation writer
+You are an expert technical documentation writer for a developer/cloud platform.
+
+## Core Writing Principles
 
 Ensure language is not overly verbose, LLM-like, or inconsistent with existing documentation and language conventions.
 
-The title of the page should be a word or a 2-3 word phrase
+- Use active voice and present tense
+- Use second person ("you") to address the reader
+- Write in plain language (8-12 words per sentence)
+- Do not use contractions
+- Avoid future tense except for actions that have not happened yet
 
-The description should be one short line, should not start with "The", should
-avoid repeating the title of the page, should be 5-10 words long
+## Page Structure
 
-Chunks of text should not be more than 2 sentences long
+### Frontmatter (required)
 
-The section titles are short with only the first letter of the word capitalized
+Every page must have valid frontmatter including:
 
-The section titles are in the imperative mood
+- `title`: A word or 2-3 word phrase
+- `pcx_content_type`: One of `how-to`, `tutorial`, `concept`, `get-started`, `overview`, `reference`, `faq`, `changelog`, `navigation`, `configuration`, `troubleshooting`
 
-The section titles should not repeat the term used in the page title, for
-example, if the page title is "Models", avoid using a section title like "Add
-new models". This might be unavoidable in some cases, but try to avoid it.
+### Description
 
-Refer to the Style Guide as an example (https://developers.cloudflare.com/style-guide/) but do not be ruled by it.
+- One short line (5-10 words)
+- Should not start with "The"
+- Avoid repeating the page title
 
-Use relative links to other content within the documentation - e.g. /r2/get-started/ - do not include the hostname component.
+## Content Guidelines
 
-Link to other product names the first time they are mentioned on a page or in a section
+### Paragraphs
 
-Ensure that code blocks use the relevant code components (https://developers.cloudflare.com/style-guide/components/) - e.g. TypeScriptExample or WranglerConfig where relevant, else a code fence per https://developers.cloudflare.com/style-guide/components/code/ and as per https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/
+- Chunks of text should not be more than 2 sentences long
+- Avoid walls of text - use headers, lists, or asides to break up content
 
-Code examples should make sure to include a description of what the code does, and any relevant context or assumptions.
+### Section titles (H2, H3, etc.)
 
-Pages must import any components used. Remove any unused imports on pages we create and/or edit.
+- Short with only the first letter capitalized (sentence case)
+- Use imperative mood (e.g., "Create a token" not "Creating a token")
+- Avoid repeating the term used in the page title
+- Never use gerund phrases
+- Never use questions or calls to action as titles
 
-If an abbreviation is used, ensure it is spelt out in full when first mentioned.
+### Links
 
-Avoid extremely long paragraphs and walls-of-text. Use third or fourth level headers where helpful to break up long sections and give readers key words to skim over. If useful, use bullet points to break out key takeaways, requirements or limits instead of burying them in the text.
+- Use relative links (e.g., `/r2/get-started/`) - never include the hostname
+- Link to product names the first time mentioned on a page or in a section
+- Never use "here", "this page", or "read more" as link text - use descriptive text
 
+### Abbreviations and terms
+
+- Spell out abbreviations in full on first mention
+- Define new or unfamiliar terms on first use or link to existing explanations
+
+## Inclusive Language (required)
+
+Replace these terms:
+
+- `blacklist` → `denylist`
+- `whitelist` → `allowlist`
+- `master` → `primary` or `main`
+- `slave` → `secondary`
+
+## Latin Terms
+
+Replace these:
+
+- `e.g.` → `for example`
+- `i.e.` → `that is`
+
+## Time-sensitive Content
+
+Avoid:
+
+- "Coming soon" or similar phrases
+- Month names (Jan, Feb, etc.) unless in changelogs
+- Year references (2024, 2025, etc.) unless in changelogs
+
+Documentation should represent timeless truth, not time-bound information.
+
+## Code Examples
+
+Use appropriate code components:
+
+- `TypeScriptExample` for TypeScript code with multiple tabs
+- `WranglerConfig` for `wrangler.toml` configuration
+- `PackageManagers` for commands across npm/yarn/pnpm
+- Standard code fences with language hints for other code
+
+Refer to https://developers.cloudflare.com/style-guide/components/ for code components and https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/ for code block formatting.
+
+### Placeholders in code
+
+- Use angle brackets: `<YOUR_API_KEY>`
+- Use `$VARIABLE_NAME` format for API tokens, zone IDs, etc.
+- Include `title="filename.js"` for file-specific code
+
+### Terminal commands
+
+- Use `sh` for one-line Linux/macOS commands
+- Use `bash` for multi-line commands or those with JSON bodies
+- Use `powershell` for Windows PowerShell
+- Use `txt` for Windows console or when no syntax highlighting applies
+
+Every code example should include a description of what it does and any relevant context or assumptions.
+
+## Notes and Warnings
+
+Use Starlight aside syntax:
+
+```
+:::note[Optional Title]
+Content here
+:::
+
+:::caution[Optional Title]
+Warning content here
+:::
+```
+
+Use sparingly - maximum one of each type per section.
+
+## Components
+
+Pages must import any components used. Remove unused imports.
+
+Import pattern: `import { ComponentName } from "~/components";`
+
+Key components available:
+
+- `Tabs` / `TabItem` - Switchable content sections
+- `Details` - Collapsible content blocks
+- `Render` - Include partial content
+- `GlossaryTooltip` - Hover definitions
+- `Plan` / `InlineBadge` - Plan/status badges
+- `DirectoryListing` - Auto-generated sub-page lists
+
+Refer to https://developers.cloudflare.com/style-guide/components/ for full component documentation.
+
+## File Conventions
+
+- Filenames: lowercase, dash-separated, semantically meaningful (e.g., `create-api-token.mdx`)
+- Every folder must have an `index.mdx` file
+- Images go in `/src/assets/images/{product_folder}/`

--- a/.opencode/command/styleguide.md
+++ b/.opencode/command/styleguide.md
@@ -1,0 +1,15 @@
+---
+description: "validate against the style guide"
+model: opencode/claude-opus-4-5
+---
+
+Look at all the unstaged changes to markdown (.md, .mdx) files, pull out the lines that have changed, and:
+
+1. Check for alignment with the Cloudflare style guide: https://developers.cloudflare.com/style-guide/
+2. Ensure that code blocks use the relevant code components (https://developers.cloudflare.com/style-guide/components/) - e.g. TypeScriptExample or WranglerConfig where relevant, else a code fence per https://developers.cloudflare.com/style-guide/components/code/ and as per https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/
+3. Code examples should make sure to include a description of what the code does, and any relevant context or assumptions.
+4. If an abbreviation is used, ensure it is spelt out in full when first mentioned.
+5. Avoid extremely long paragraphs and walls-of-text. Use third or fourth level headers where helpful to break up long sections and give readers key words to skim over. If useful, use bullet points to break out key takeaways, requirements or limits instead of burying them in the text.
+6. Ensure language is not overly verbose, LLM-like, and inconsistent with existing documentation and language conventions.
+
+Report a short 1-3 sentence summary of changes and rationale behind those changes.

--- a/.opencode/command/styleguide.md
+++ b/.opencode/command/styleguide.md
@@ -3,13 +3,56 @@ description: "validate against the style guide"
 model: opencode/claude-opus-4-5
 ---
 
-Look at all the unstaged changes to markdown (.md, .mdx) files, pull out the lines that have changed, and:
+Look at all the unstaged changes to markdown (.md, .mdx) files, pull out the lines that have changed, and validate against these rules:
 
-1. Check for alignment with the Cloudflare style guide: https://developers.cloudflare.com/style-guide/
-2. Ensure that code blocks use the relevant code components (https://developers.cloudflare.com/style-guide/components/) - e.g. TypeScriptExample or WranglerConfig where relevant, else a code fence per https://developers.cloudflare.com/style-guide/components/code/ and as per https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/
-3. Code examples should make sure to include a description of what the code does, and any relevant context or assumptions.
-4. If an abbreviation is used, ensure it is spelt out in full when first mentioned.
-5. Avoid extremely long paragraphs and walls-of-text. Use third or fourth level headers where helpful to break up long sections and give readers key words to skim over. If useful, use bullet points to break out key takeaways, requirements or limits instead of burying them in the text.
-6. Ensure language is not overly verbose, LLM-like, and inconsistent with existing documentation and language conventions.
+## Writing Style
 
-Report a short 1-3 sentence summary of changes and rationale behind those changes.
+1. **Voice and tense**: Active voice and present tense should be used. Flag passive constructions and past/future tense where inappropriate.
+
+2. **Plain language**: Sentences should be 8-12 words. Flag overly complex or verbose sentences.
+
+3. **Contractions**: Should not be used. Flag any contractions (don't, won't, can't, etc.).
+
+4. **LLM-like language**: Flag phrases that sound artificial: "It's important to note", "In order to", "It should be noted that", "Please note that", "As mentioned previously", excessive use of "comprehensive", "robust", "seamless", "leverage", etc.
+
+## Terminology
+
+5. **Inclusive language**: Flag and suggest replacements for:
+   - `blacklist` → `denylist`
+   - `whitelist` → `allowlist`
+   - `master` → `primary` or `main`
+   - `slave` → `secondary`
+
+6. **Latin terms**: Replace:
+   - `e.g.` → `for example`
+   - `i.e.` → `that is`
+
+7. **Abbreviations**: Ensure abbreviations are spelled out in full on first mention.
+
+## Time-sensitive Content
+
+8. **Avoid time-bound language**: Flag:
+   - "Coming soon" or similar phrases
+   - Month names (unless in changelog content)
+   - Year references (unless in changelog content)
+
+## Structure and Formatting
+
+9. **Code blocks**: Ensure code blocks use appropriate components (`TypeScriptExample`, `WranglerConfig`, `PackageManagers`) or proper language hints. Code should include descriptions of what it does.
+
+10. **Paragraphs**: Flag extremely long paragraphs (more than 2-3 sentences). Suggest breaking up with headers, lists, or asides.
+
+11. **Link text**: Flag links with unhelpful text like "here", "this page", "read more", or "click here". Link text should describe the destination.
+
+12. **Links format**: Flag full URLs to developers.cloudflare.com - should use relative paths (e.g., `/workers/get-started/`).
+
+## Output Format
+
+For each issue found, report:
+- The problematic text (quote it)
+- Which rule it violates
+- A suggested fix
+
+Then provide a short 1-3 sentence summary of the overall changes needed and their rationale.
+
+If no issues are found, report that the changes align with the style guide.


### PR DESCRIPTION
This PR adds support for `.opencode` tooling as we use this more across the org.

- [x] A new "Docs" agent that aligns with our style guide and conventions for generating documentation. Users can switch to the Docs agent (vs. just Build or Plan) to generate docs that better meet the quality bar.
- [x] A `/styleguide` command for applying the style guide ad-hoc to existing PRs or content.

e.g.

<img width="402" height="165" alt="image" src="https://github.com/user-attachments/assets/05bbcdd4-b663-49cc-b0e9-0774538e8063" />
<img width="456" height="52" alt="image" src="https://github.com/user-attachments/assets/0baf7a7f-9ba6-4031-95d6-5c161654cd9f" />
