### PR TITLE
Changelog: Inspect Cache Keys with Cloudflare Trace

### DIFF
--- a/src/content/changelog/cache/2025-11-07-cache-keys-for-cloudflare-trace.mdx
+++ b/src/content/changelog/cache/2025-11-07-cache-keys-for-cloudflare-trace.mdx
@@ -1,0 +1,41 @@
+---
+title: Inspect Cache Keys with Cloudflare Trace
+description: View the specific cache key generated for requests to troubleshoot caching behavior and rules configuration.
+products:
+  - cache
+date: 2025-11-07
+---
+
+You can now see the exact cache key generated for any request directly in Cloudflare Trace. This visibility helps you troubleshoot cache hits and misses, and verify that your Custom Cache Keys—configured via Cache Rules or Page Rules—are working as intended.
+
+Previously, diagnosing caching behavior required inferring the key from configuration settings. Now, you can confirm that your custom logic for headers, query strings, and device types is correctly applied.
+
+Access Trace via the [dashboard](/fundamentals/trace-request/#run-a-trace-in-the-dashboard) or [API](/api/resources/request_tracer/methods/trace/), either manually for ad-hoc debugging or automated as part of your quality-of-service monitoring.
+
+## Example scenario
+
+If you have a Cache Rule that segments content based on a specific cookie (for example, `user_region`), run a Trace with that cookie present to confirm the `user_region` value appears in the resulting cache key.
+
+The Trace response includes the cache key in the `cache` object:
+
+```json
+{
+  "step_name": "request",
+  "type": "cache",
+  "matched": true,
+  "public_name": "Cache Parameters",
+  "cache": {
+    "key": {
+      "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
+      "scheme": "https",
+      "host": "example.com",
+      "uri": "/images/hero.jpg"
+    },
+    "key_string": "023e105f4ecef8ad9ca31a8372d0c353::::https://example.com/images/hero.jpg:::::"
+  }
+}
+```
+
+## Get started
+
+To learn more, refer to the [Trace documentation](/fundamentals/trace-request/) and our guide on [Custom Cache Keys](/cache/how-to/cache-keys/).

--- a/src/content/changelog/cache/2025-11-07-cache-keys-for-cloudflare-trace.mdx
+++ b/src/content/changelog/cache/2025-11-07-cache-keys-for-cloudflare-trace.mdx
@@ -10,7 +10,7 @@ You can now see the exact cache key generated for any request directly in Cloudf
 
 Previously, diagnosing caching behavior required inferring the key from configuration settings. Now, you can confirm that your custom logic for headers, query strings, and device types is correctly applied.
 
-Access Trace via the [dashboard](/fundamentals/trace-request/#run-a-trace-in-the-dashboard) or [API](/api/resources/request_tracer/methods/trace/), either manually for ad-hoc debugging or automated as part of your quality-of-service monitoring.
+Access Trace via the [dashboard](/rules/trace-request/how-to/#use-trace-in-the-dashboard) or [API](/api/resources/request_tracer/methods/trace/), either manually for ad-hoc debugging or automated as part of your quality-of-service monitoring.
 
 ## Example scenario
 
@@ -38,4 +38,4 @@ The Trace response includes the cache key in the `cache` object:
 
 ## Get started
 
-To learn more, refer to the [Trace documentation](/fundamentals/trace-request/) and our guide on [Custom Cache Keys](/cache/how-to/cache-keys/).
+To learn more, refer to the [Trace documentation](/rules/trace-request/) and our guide on [Custom Cache Keys](/cache/how-to/cache-keys/).

--- a/src/content/changelog/cache/2025-11-07-cache-keys-for-cloudflare-trace.mdx
+++ b/src/content/changelog/cache/2025-11-07-cache-keys-for-cloudflare-trace.mdx
@@ -6,7 +6,7 @@ products:
 date: 2025-11-07
 ---
 
-You can now see the exact cache key generated for any request directly in Cloudflare Trace. This visibility helps you troubleshoot cache hits and misses, and verify that your Custom Cache Keys—configured via Cache Rules or Page Rules—are working as intended.
+You can now see the exact cache key generated for any request directly in Cloudflare Trace. This visibility helps you troubleshoot cache hits and misses, and verify that your Custom Cache Keys — configured via Cache Rules or Page Rules — are working as intended.
 
 Previously, diagnosing caching behavior required inferring the key from configuration settings. Now, you can confirm that your custom logic for headers, query strings, and device types is correctly applied.
 


### PR DESCRIPTION
### Summary

New changelog entry for Inspect Cache Keys with Cloudflare Trace.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).