### PR TITLE
Cefan/semgrep multiline commit message

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,13 +4,13 @@ on:
     - cron: "0 4 * * *"
   pull_request: {}
 
-name: Semgrep config
+name: Semgrep rules checking results
 permissions:
   contents: read
 
 jobs:
   semgrep:
-    name: semgrep
+    name: Semgrep
     runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
@@ -67,4 +67,3 @@ jobs:
           else
             echo "No relevant files changed"
           fi
-

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | | sed "s/\"/'/g")" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")'" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")' | tr '\n' ' '" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed 's/"/\'/g')\"" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | | sed "s/\"/'/g")" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})\"" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed 's/"/\\"/g')\"" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")' | tr '\n' ' '" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")'" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed 's/"/\\"/g')\"" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE=\"$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed 's/"/\'/g')\"" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure
         run: |
           git config --global --add safe.directory $PWD
-          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")" | tee /dev/stderr >> "$GITHUB_ENV"
+          echo "COMMIT_MESSAGE='$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }} | sed "s/\"/'/g")'" | tee /dev/stderr >> "$GITHUB_ENV"
           echo "(if the last commit message contains '[skip style guide checks]' Semgrep style guide rule checks will be skipped)"
 
       # Semgrep CI to run on Schedule (Cron) or Manual Dispatch

--- a/.semgrep/style-guide-dates-in-docs.yaml
+++ b/.semgrep/style-guide-dates-in-docs.yaml
@@ -37,7 +37,7 @@ rules:
         - "/.semgrep/**"
         - "/.github/**"
     patterns:
-      - pattern-regex: "Jan|Feb|Mar[^k]|Apr|May[^b]|Jun[^k]|Jul|Aug|Sep|Nov|Dec[^i]"
+      - pattern-regex: "Jan|Feb|Mar[^ky]|Apr|May[^b]|Jun[^k]|Jul|Aug|Sep|Nov|Dec[^i]"
 
   - id: style-guide-potential-date-year
     languages: [generic]
@@ -58,4 +58,4 @@ rules:
         - "/.github/**"
     patterns:
       # ignore 2xxx- with a - at the end (double-escape because in string and not a range operator!)
-      - pattern-regex: "20[0-9][0-9][^\\-]"
+      - pattern-regex: "20[0-9][0-9][^\\-:]"


### PR DESCRIPTION
Fix some known false positives in the patterns that are matched for style guide rules:

 - 2001:: (as part of an IPv6 address should not match)
 - Mary (should not match a potential Mar month prefix)
 - Multiline comments should not break the setting of COMMIT_MESSAGE in workflow
