### PR TITLE
[semgrep] Avoid job returning an error code to avoid UI showing any semgrep failure for the moment

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -63,7 +63,9 @@ jobs:
               --json \
               $list_of_files \
               | jq --raw-output ".results[] | \"::warning file=\(.path),line=\(.start.line),title=\(.check_id)::\(.extra.message)\""
-            exit ${PIPESTATUS[0]}
+            #exit ${PIPESTATUS[0]}
+            # for the moment always return a successful run 
+            exit 0
           else
             echo "No relevant files changed"
           fi


### PR DESCRIPTION
Semgrep should currently not ever return an error code to the workflow to avoid showing the checks as potentially blocking the merge process.