### PR TITLE
[semgrep] prevent the command from reporting findings as errors

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -56,10 +56,11 @@ jobs:
           # Check if file list is empty to prevent errors
           if [ -s tools/relevant_changed_files.txt ]; then
             list_of_files=$(cat tools/relevant_changed_files.txt | tr '\n' ' ')
+
+            # when ready to show errors add back --error below
             semgrep scan \
               --config .semgrep --metrics=off \
               --include "*.mdx" --include "*.mdx" \
-              --error \
               --json \
               $list_of_files \
               | jq --raw-output ".results[] | \"::warning file=\(.path),line=\(.start.line),title=\(.check_id)::\(.extra.message)\""


### PR DESCRIPTION
When running semgrep scan remove the `--error` flag to prevent binary from returning error code on findings.