### PR TITLE
Add more detail to the macOS Sequoia changes and their effect on WARP

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/warp/deployment/firewall.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/warp/deployment/firewall.mdx
@@ -195,7 +195,7 @@ If your organization does not currently allow inbound/outbound communication ove
 	
 	- Restrict the other allow exceptions to only the processes you want receiving traffic
 	
-	- Optionally, do not grant users administrative privileges (otherwise they will be able to add to this list, though that would also have allowed them to turn off the "Block all incoming connections" toggle anyway)
+	- Optionally, do not grant users administrative privileges (otherwise they will be able to add to this list, though this also applies to preventing modification to all firewall settings)
 
   :::
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/warp/deployment/firewall.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/warp/deployment/firewall.mdx
@@ -181,9 +181,21 @@ If your organization does not currently allow inbound/outbound communication ove
 
   :::caution
 
-  Due to changes in macOS Sequoia version 15.0 and 15.0.1., you must update your macOS firewall settings to allow the WARP client to manage your device's firewall.
+  Due to changes in macOS Sequoia versions 15.0 through 15.4, you must update your macOS firewall settings to allow the WARP client to manage your device's firewall.
 
-  To ensure proper functionality, disable the [Block all incoming connections](https://support.apple.com/guide/mac-help/change-firewall-settings-on-mac-mh11783/mac) option in your macOS firewall settings.
+  To ensure proper functionality when running the WARP client on macOS Sequoia versions 15.0 through 15.4, disable the [Block all incoming connections](https://support.apple.com/guide/mac-help/change-firewall-settings-on-mac-mh11783/mac) option in your macOS firewall settings. Later versions of macOS are not affected because of changes Apple introduced to fix the unexpected breaking changes in their firewall.
+	
+	To ensure you are still blocking unwanted incoming traffic but also allowing the WARP client to function on macOS Sequoia versions 15.0 through 15.4, please follow these steps:
+	
+	- Disable "Automatically allow built-in software to receive incoming connections"
+	
+	- Disable "Automatically allow downloaded signed software to receive incoming connections"
+	
+	- Add allow exceptions to the list above in the same window for the processes listed in Step 2 above
+	
+	- Restrict the other allow exceptions to only the processes you want receiving traffic
+	
+	- Optionally, do not grant users administrative privileges (otherwise they will be able to add to this list, though that would also have allowed them to turn off the "Block all incoming connections" toggle anyway)
 
   :::
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/warp/deployment/firewall.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/warp/deployment/firewall.mdx
@@ -179,24 +179,20 @@ If your organization does not currently allow inbound/outbound communication ove
 
       `com.cloudflare.1dot1dot1dot1dot1.macos` (Bundle ID)
 
-  :::caution
 
-  Due to changes in macOS Sequoia versions 15.0 through 15.4, you must update your macOS firewall settings to allow the WARP client to manage your device's firewall.
+  :::caution[macOS 15.0 through 15.4]
 
-  To ensure proper functionality when running the WARP client on macOS Sequoia versions 15.0 through 15.4, disable the [Block all incoming connections](https://support.apple.com/guide/mac-help/change-firewall-settings-on-mac-mh11783/mac) option in your macOS firewall settings. Later versions of macOS are not affected because of changes Apple introduced to fix the unexpected breaking changes in their firewall.
-	
-	To ensure you are still blocking unwanted incoming traffic but also allowing the WARP client to function on macOS Sequoia versions 15.0 through 15.4, please follow these steps:
-	
-	- Disable "Automatically allow built-in software to receive incoming connections"
-	
-	- Disable "Automatically allow downloaded signed software to receive incoming connections"
-	
-	- Add allow exceptions to the list above in the same window for the processes listed in Step 2 above
-	
-	- Restrict the other allow exceptions to only the processes you want receiving traffic
-	
-	- Optionally, do not grant users administrative privileges (otherwise they will be able to add to this list, though this also applies to preventing modification to all firewall settings)
+  Due to changes in macOS Sequoia versions 15.0 through 15.4, you must update your [macOS firewall settings](https://support.apple.com/guide/mac-help/change-firewall-settings-on-mac-mh11783/mac) to allow the WARP client to manage your device's firewall. Later versions of macOS are not affected because of changes Apple introduced to fix the unexpected breaking changes in their firewall.
 
+	To allow the WARP client to function on macOS Sequoia versions 15.0 through 15.4 while still blocking unwanted incoming traffic, follow these steps:
+
+		1. Turn off the following [macOS firewall settings](https://support.apple.com/guide/mac-help/change-firewall-settings-on-mac-mh11783/mac):
+			- **Block all incoming connections**
+			- **Automatically allow built-in software to receive incoming connections**
+			- **Automatically allow downloaded signed software to receive incoming connections**
+		2. Add the [WARP daemon and GUI processes](#required-scopes) to the firewall exceptions list and set them to _Allow incoming connections_.
+		3. Restrict the other allow exceptions to only the processes you want receiving traffic.
+		4. (Optional) Do not grant users administrative privileges, otherwise they will be able to modify firewall settings and exceptions.
   :::
 
 ### Optional scopes


### PR DESCRIPTION
### Summary

We have received questions about this section about (1) how to avoid regressing the security stance provided by the problematic toggle, and (2) how the changes are not needed for versions other than those specified (repeating the scope in every paragraph now).

### Screenshots (optional)

N/A

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
