### PR TITLE
tooling: add new /changelog command

### DIFF
--- a/.opencode/command/changelog.md
+++ b/.opencode/command/changelog.md
@@ -1,0 +1,73 @@
+---
+description: Generate a product changelog entry
+---
+
+Generate a changelog entry for the Cloudflare documentation site based on the user's request.
+
+## User Request
+
+$ARGUMENTS
+
+## Instructions
+
+1. **Validate the request**: Ensure the user has provided:
+   - A clear product name (for example, Workers, KV, Hyperdrive, Containers, R2, etc.)
+   - A description of the change or feature being documented
+   - Enough context to explain the "why" and use-cases
+
+   If any of these are missing or unclear, ask the user for clarification before proceeding.
+
+2. **Determine the product folder**: Use the product name to identify the correct changelog folder under `src/content/changelog/{product}/`. Refer to existing folders for valid product names.
+
+3. **Create the changelog file**: Create a new file at:
+   ```
+   src/content/changelog/{product}/{YYYY-MM-DD}-{useful-short-name}.mdx
+   ```
+   Use today's date and a concise, hyphenated slug describing the change.
+
+4. **Frontmatter format**:
+   ```yaml
+   ---
+   title: {Concise title describing the change}
+   description: {One-sentence summary of what changed and why it matters}
+   products:
+     - {product}
+   date: {YYYY-MM-DD}
+   ---
+   ```
+
+5. **Writing style guidelines**:
+   - Use imperative mood and active voice
+   - The opening sentence must clearly explain what the new feature/change is and what problem it solves
+   - Expand on usage, use-cases, and the "why" in subsequent paragraphs
+   - Assume a technical developer/cloud audience
+   - Keep sentences concise (8-12 words where possible)
+   - Avoid contractions
+   - Avoid LLM-like phrases ("It's important to note", "leverage", "seamless", etc.)
+   - Replace `e.g.` with "for example" and `i.e.` with "that is"
+
+6. **Code examples for Developer Platform products**:
+   For products in the Developer Platform group (Workers, Durable Objects, Pipelines, KV, Hyperdrive, R2, D1, Queues, Containers, etc.):
+   - Include a code block demonstrating usage of the new feature
+   - Use plain JavaScript/TypeScript code blocks (```js or ```ts)
+   - If showing wrangler.json config, use ```jsonc
+   - Keep code snippets short and focused on the new feature
+   - Minimize boilerplate and unnecessary code
+   - Add imports at the top if using components: `import { Render, TypeScriptExample, WranglerConfig } from "~/components";`
+
+7. **Documentation links**: End the changelog with a link to relevant documentation:
+   - Use relative paths (for example, `/workers/configuration/placement/`)
+   - Link text should describe the destination, not "click here" or "read more"
+   - Check for any uncommitted/staged .md/.mdx files that might be the related documentation
+
+## Reference Examples
+
+Review these existing changelogs for style and format guidance:
+- `src/content/changelog/workers/` - Workers changelogs with code examples
+- `src/content/changelog/kv/` - KV changelogs
+- `src/content/changelog/hyperdrive/` - Hyperdrive changelogs
+- `src/content/changelog/containers/` - Container changelogs
+
+## Output
+
+Create the changelog file and show the user the complete file path and content.


### PR DESCRIPTION
This PR adds a new `/changelog` command to the opencode commands based on https://opencode.ai/docs/commands/#arguments 

Users using other tools can also just @ the filename to pull in the prompt/guidance.

<img width="755" height="179" alt="image" src="https://github.com/user-attachments/assets/a692a2bc-1783-44da-98cb-c2108665008e" />

Example usage:

```
/changelog Create a changelog for Workers that describes the new Placement Hint feature documented at /workers/configuration/placement/ - this feature allows users to provide an explicit placement hint that allows them to co-locate their Worker functions close to existing database and/or cloud infrastructure in order to significantly reduce latency between their Workers and upstream infra.
```

or:

```
/changelog Write a changelog Hyperdrive regarding updates to recommended drivers and usage.
```
```
I need to clarify a few things before creating the changelog entry.
You mentioned this is about "updates to recommended drivers and usage" for Hyperdrive. Could you provide more details:
1. What specifically changed? For example:
   - Are there new recommended database drivers?
   - Were existing driver recommendations updated?
   - Are certain drivers now deprecated or no longer recommended?
2. Which drivers are affected? For example:
   - PostgreSQL drivers (pg, postgres.js, etc.)
   - MySQL drivers
   - Other database drivers
3. What is the impact/why does this matter? For example:
   - Better performance with certain drivers
   - Compatibility improvements
   - New features enabled by updated drivers
4. Any specific usage changes? For example:
   - Configuration changes needed
   - New connection patterns
   - Updated code examples

This context will help me write a clear, accurate changelog entry that explains both what changed and why it matters to developers.
```

Builds on https://github.com/cloudflare/cloudflare-docs/pull/27000