### PR TITLE
docs(realtimekit): add quickstart docs for mobile

### DIFF
--- a/src/components/realtimekit/RTKSDKSelector/RTKSDKSelector.tsx
+++ b/src/components/realtimekit/RTKSDKSelector/RTKSDKSelector.tsx
@@ -35,9 +35,8 @@ export default function SDKSelector() {
 					{platforms.map((p) => (
 						<button
 							type="button"
-							className={`m-0 ${p.id === "mobile" ? "cursor-not-allowed opacity-45" : "cursor-pointer"} ${p.id === platform ? "rounded-t-md bg-neutral-50 text-blue-500 dark:bg-neutral-700" : "bg-blue-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"} px-2 py-1 font-medium`}
+							className={`m-0 ${p.id === platform ? "rounded-t-md bg-neutral-50 text-blue-500 dark:bg-neutral-700" : "bg-blue-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300"} px-2 py-1 font-medium`}
 							onClick={() => {
-								if (p.id === "mobile") return;
 								const nextPlatform = p.id;
 								const nextFramework =
 									nextPlatform === "web"

--- a/src/components/realtimekit/hooks/useFramework.ts
+++ b/src/components/realtimekit/hooks/useFramework.ts
@@ -28,10 +28,6 @@ export const webFrameworks: Framework[] = [
 ];
 export const mobileFrameworks: Framework[] = [
 	{
-		id: "react-native",
-		label: "React Native",
-	},
-	{
 		id: "android",
 		label: "Android",
 	},
@@ -42,6 +38,10 @@ export const mobileFrameworks: Framework[] = [
 	{
 		id: "flutter",
 		label: "Flutter",
+	},
+	{
+		id: "react-native",
+		label: "React Native",
 	},
 ];
 

--- a/src/content/docs/realtime/realtimekit/quickstart.mdx
+++ b/src/content/docs/realtime/realtimekit/quickstart.mdx
@@ -85,7 +85,7 @@ Select a framework based on the platform you are building for.
 <RTKCodeSnippet id="mobile-android">
 	Add the following dependencies to your `build.gradle` file:
 
-    ```bash
+    ```java
     dependencies {
       implementation 'com.cloudflare.realtimekit:core:1.5.5'
       // Optional: Add UI components for Android
@@ -97,9 +97,9 @@ Select a framework based on the platform you are building for.
 <RTKCodeSnippet id="mobile-ios">
 	Install the RealtimeKit SDK using Swift Package Manager:
 
-	1. In Xcode, go to **File > Add Package Dependencies**
-	2. Enter the package URL: `https://github.com/dyte-in/RealtimeKitCoreiOS.git`
-	3. Select the version and add the package to your project
+	1. In Xcode, go to **File > Add Package Dependencies**.
+	2. Enter the package URL: `https://github.com/dyte-in/RealtimeKitCoreiOS.git`.
+	3. Select the version and add the package to your project.
 
 	:::note[Optional]
 	You can also add the RealtimeKit UI components by adding the package URL: `https://github.com/dyte-in/RealtimeKitUI`
@@ -107,7 +107,7 @@ Select a framework based on the platform you are building for.
 
 	Add the following entries to the `Info.plist` file. This gives your app permissions to access the camera and microphone, access photos, and install the required fonts and icons.
 
-    ```bash
+    ```xml
     <key>NSBluetoothPeripheralUsageDescription</key>
     <string>Access Bluetooth to connect to headphones and audio devices during calls.</string>
     <key>NSBluetoothAlwaysUsageDescription</key>
@@ -146,7 +146,7 @@ Select a framework based on the platform you are building for.
 
 	Then import the package into your project:
 
-	```bash
+	```dart
 	import 'package:realtimekit_core/realtimekit_core.dart';
 	```
 
@@ -163,7 +163,7 @@ Select a framework based on the platform you are building for.
 
 	Set `compileSdkVersion 36` and `minSdkVersion 24` in your `build.gradle` file at `<project root>/android/app/build.gradle`:
 
-	```bash
+	```java
 	defaultConfig {
 	  ...
 	  compileSdkVersion 36
@@ -174,7 +174,7 @@ Select a framework based on the platform you are building for.
 
 	Change the Kotlin version to `1.9.0`:
 
-	```bash
+	```java
 	ext.kotlin_version = '1.9.0'
 	```
 
@@ -183,13 +183,13 @@ Select a framework based on the platform you are building for.
 
 	Set your platform to iOS 13.0 or above in your `Podfile`:
 
-	```bash
+	```txt
 	platform :ios, '13.0'
 	```
 
 	Add the following entries to the `Info.plist` file. This gives your app permissions to access the camera and microphone, access photos, and install the required fonts and icons.
 
-	```bash
+	```xml
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Access Bluetooth to connect to headphones and audio devices during calls.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
@@ -211,7 +211,7 @@ Select a framework based on the platform you are building for.
 
 	**Optional:** If you are allowing users to download attachments in chat, add the following permissions to your `Info.plist`:
 
-	```bash
+	```xml
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 	<key>UIFileSharingEnabled</key>
@@ -283,7 +283,7 @@ Select a framework based on the platform you are building for.
 	}
 	```
 
-	Run prebuild to setup native modules:
+	Run `prebuild` to set up native modules:
 
 	```bash
 	npx expo prebuild
@@ -299,14 +299,14 @@ Select a framework based on the platform you are building for.
 
 	Edit your `android/gradle.properties` and add the following lines:
 
-	```bash
+	```txt
 	newArchEnabled=false
 	android.useFullClasspathForDexingTransform=true
 	```
 
 	**Note:** Starting from version `>=0.2.0`, add a required `blob_provider_authority` string resource in the `strings.xml` file:
 
-	```bash
+	```xml
 	<resources>
 	  ...
 	  <string name="blob_provider_authority">YOUR_APP_RESOURCE_NAME</string>
@@ -316,14 +316,14 @@ Select a framework based on the platform you are building for.
 
 	Create or append to the file `android/app/proguard-rules.pro`:
 
-	```bash
+	```txt
 	-keep class realtimekit.org.webrtc.** { *; }
 	-dontwarn org.chromium.build.BuildHooksAndroid
 	```
 
 	In your `android/app/build.gradle`, edit the release configuration and add the following line importing the ProGuard configuration:
 
-	```bash
+	```java
 	buildTypes {
 	  release {
 	    ...
@@ -339,13 +339,13 @@ Select a framework based on the platform you are building for.
 
 	Open your `Podfile` and set the platform to iOS 14:
 
-	```bash
+	```txt
 	platform :ios, '14.0'
 	```
 
 	Add the following permission entries to your `Info.plist` file:
 
-	```bash
+	```xml
 	<key>NSCameraUsageDescription</key>
 	<string>Access camera to enable video during meetings.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/src/content/docs/realtime/realtimekit/quickstart.mdx
+++ b/src/content/docs/realtime/realtimekit/quickstart.mdx
@@ -36,7 +36,7 @@ Select a framework based on the platform you are building for.
 <RTKSDKSelector />
 
 <RTKCodeSnippet id="web-react">
-	Please install the following dependancies into your project repository:
+	Please install the following dependencies into your project repository:
   
 	```bash 
   npm i @cloudflare/realtimekit-react @cloudflare/realtimekit-react-ui
@@ -79,6 +79,285 @@ Select a framework based on the platform you are building for.
     git clone https://github.com/cloudflare/realtimekit-web-examples.git
     cd realtimekit-web-examples/angular-examples/examples/default-meeting-ui
     ```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+	Add the following dependencies to your `build.gradle` file:
+
+    ```bash
+    dependencies {
+      implementation 'com.cloudflare.realtimekit:core:1.5.5'
+      // Optional: Add UI components for Android
+      implementation 'com.cloudflare.realtimekit:ui-android:0.3.0'
+    }
+    ```
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+	Install the RealtimeKit SDK using Swift Package Manager:
+
+	1. In Xcode, go to **File > Add Package Dependencies**
+	2. Enter the package URL: `https://github.com/dyte-in/RealtimeKitCoreiOS.git`
+	3. Select the version and add the package to your project
+
+	:::note[Optional]
+	You can also add the RealtimeKit UI components by adding the package URL: `https://github.com/dyte-in/RealtimeKitUI`
+	:::
+
+	Add the following entries to the `Info.plist` file. This gives your app permissions to access the camera and microphone, access photos, and install the required fonts and icons.
+
+    ```bash
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>Access Bluetooth to connect to headphones and audio devices during calls.</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Access Bluetooth to connect to headphones and audio devices during calls.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Access camera to enable video during meetings.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Access microphone to enable audio during meetings.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Access photos to share images during meetings.</string>
+    <key>UIBackgroundModes</key>
+    <array>
+      <string>audio</string>
+      <string>voip</string>
+      <string>fetch</string>
+      <string>remote-notification</string>
+    </array>
+    ```
+
+	The `UIBackgroundModes` key is used in the `Info.plist` file of an iOS app to declare the app's supported background execution modes. This key is an array of strings that specifies the types of background tasks that the app supports. By declaring the background modes, the app can continue to run in the background and perform specific tasks even when it is not in the foreground.
+
+	:::note
+	The use of background modes should be justified and comply with Apple's App Store Review Guidelines. Apps that misuse background modes or unnecessarily run in the background may be rejected during the app review process.
+
+	Source: [Apple Developer Documentation: Declaring Your App's Supported Background Tasks](https://developer.apple.com/documentation/xcode/configuring-background-execution-modes)
+	:::
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+	Install the RealtimeKit Core Flutter SDK by adding the dependency to your `pubspec.yaml` file:
+
+	```bash
+	flutter pub add realtimekit_core
+	```
+
+	Then import the package into your project:
+
+	```bash
+	import 'package:realtimekit_core/realtimekit_core.dart';
+	```
+
+	:::note[Optional]
+	You can also add the RealtimeKit UI components:
+
+	```bash
+	flutter pub add realtimekit_ui
+	```
+	:::
+
+	<Tabs syncKey="flutter-platform">
+	<TabItem label="Android">
+
+	Set `compileSdkVersion 36` and `minSdkVersion 24` in your `build.gradle` file at `<project root>/android/app/build.gradle`:
+
+	```bash
+	defaultConfig {
+	  ...
+	  compileSdkVersion 36
+	  minSdkVersion 24
+	  ...
+	}
+	```
+
+	Change the Kotlin version to `1.9.0`:
+
+	```bash
+	ext.kotlin_version = '1.9.0'
+	```
+
+	</TabItem>
+	<TabItem label="iOS">
+
+	Set your platform to iOS 13.0 or above in your `Podfile`:
+
+	```bash
+	platform :ios, '13.0'
+	```
+
+	Add the following entries to the `Info.plist` file. This gives your app permissions to access the camera and microphone, access photos, and install the required fonts and icons.
+
+	```bash
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Access Bluetooth to connect to headphones and audio devices during calls.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Access Bluetooth to connect to headphones and audio devices during calls.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Access camera to enable video during meetings.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Access microphone to enable audio during meetings.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Access photos to share images during meetings.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+	  <string>audio</string>
+	  <string>voip</string>
+	  <string>fetch</string>
+	  <string>remote-notification</string>
+	</array>
+	```
+
+	**Optional:** If you are allowing users to download attachments in chat, add the following permissions to your `Info.plist`:
+
+	```bash
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	```
+
+	</TabItem>
+	</Tabs>
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+	<Tabs syncKey="rn-package-manager">
+	<TabItem label="React Native">
+
+	Install the core dependencies:
+
+	```bash
+	npm install @cloudflare/realtimekit-react-native @cloudflare/react-native-webrtc
+	```
+
+	**Optional:** For UI components, install additional dependencies:
+
+	```bash
+	npm install @cloudflare/realtimekit-react-native-ui @react-native-documents/picker react-native-file-viewer react-native-fs react-native-sound-player react-native-webview react-native-svg
+	```
+
+	Install `react-native-safe-area-context` based on your React Native version:
+	- React Native 0.64 - 0.74: `npm install react-native-safe-area-context@^4.0.0`
+	- React Native >= 0.74: `npm install react-native-safe-area-context@^5.0.0`
+
+	Refer to the [react-native-svg installation guide](https://github.com/software-mansion/react-native-svg) for setup.
+
+	**Optional:** For interactive livestream functionality:
+
+	```bash
+	npm install amazon-ivs-react-native-player
+	```
+
+	</TabItem>
+	<TabItem label="Expo">
+
+	Install the core and UI dependencies:
+
+	```bash
+	npx expo install @cloudflare/realtimekit-react-native-ui @cloudflare/realtimekit-react-native @cloudflare/react-native-webrtc @react-native-documents/picker react-native-file-viewer react-native-fs react-native-sound-player react-native-webview react-native-svg
+	```
+
+	Install `react-native-safe-area-context` based on your React Native version:
+	- React Native 0.64 - 0.74: `npm install react-native-safe-area-context@^4.0.0`
+	- React Native >= 0.74: `npm install react-native-safe-area-context@^5.0.0`
+
+	Install Expo config plugins:
+
+	```bash
+	npx expo install @expo/config-plugins
+	```
+
+	Add the plugins to your `app.json`:
+
+	```json
+	{
+	  "expo": {
+	    "plugins": [
+	      "@cloudflare/realtimekit-react-native",
+	      "@cloudflare/react-native-webrtc"
+	    ]
+	  }
+	}
+	```
+
+	Run prebuild to setup native modules:
+
+	```bash
+	npx expo prebuild
+	```
+
+	</TabItem>
+	</Tabs>
+
+	<Tabs syncKey="rn-platform">
+	<TabItem label="Android">
+
+	The following instructions are for release builds. Debug builds should work without additional steps.
+
+	Edit your `android/gradle.properties` and add the following lines:
+
+	```bash
+	newArchEnabled=false
+	android.useFullClasspathForDexingTransform=true
+	```
+
+	**Note:** Starting from version `>=0.2.0`, add a required `blob_provider_authority` string resource in the `strings.xml` file:
+
+	```bash
+	<resources>
+	  ...
+	  <string name="blob_provider_authority">YOUR_APP_RESOURCE_NAME</string>
+	  ...
+	</resources>
+	```
+
+	Create or append to the file `android/app/proguard-rules.pro`:
+
+	```bash
+	-keep class realtimekit.org.webrtc.** { *; }
+	-dontwarn org.chromium.build.BuildHooksAndroid
+	```
+
+	In your `android/app/build.gradle`, edit the release configuration and add the following line importing the ProGuard configuration:
+
+	```bash
+	buildTypes {
+	  release {
+	    ...
+	    proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+	  }
+	}
+	```
+
+	</TabItem>
+	<TabItem label="iOS">
+
+	**Note:** The minimum supported iOS version is **14.0**.
+
+	Open your `Podfile` and set the platform to iOS 14:
+
+	```bash
+	platform :ios, '14.0'
+	```
+
+	Add the following permission entries to your `Info.plist` file:
+
+	```bash
+	<key>NSCameraUsageDescription</key>
+	<string>Access camera to enable video during meetings.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Access microphone to enable audio during meetings.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Access photos to share images during meetings.</string>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+	```
+
+	</TabItem>
+	</Tabs>
 
 </RTKCodeSnippet>
 

--- a/src/content/docs/realtime/realtimekit/sdk-selection.mdx
+++ b/src/content/docs/realtime/realtimekit/sdk-selection.mdx
@@ -5,7 +5,6 @@ slug: realtime/realtimekit/sdk-selection
 sidebar:
   order: 4
 ---
-import RTKSDKSelector from '~/components/realtimekit/RTKSDKSelector/RTKSDKSelector.astro';
 import RTKPill from '~/components/realtimekit/RTKPill/RTKPill.astro';
 
 :::note
@@ -26,7 +25,6 @@ RealtimeKit provides two ways to build real-time media applications:
 ### Select you framework
 
 RealtimeKit support all the popular frameworks for web and mobile platforms. Please select the Platform and Framework that you are building on.
-<RTKSDKSelector />
 
 | Framework/Library                      | Core SDK                                                                                                   | UI Kit                                                                                                           | 
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | 


### PR DESCRIPTION
### Summary

Added quickstart docs for all mobile platforms.
Page Modified: https://developers.cloudflare.com/realtime/realtimekit/quickstart/

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
