### PR TITLE
docs: add ctx.exports documentation for vitest-pool-workers

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
@@ -73,7 +73,16 @@ test('check if file exists', async () => {
 
 The `ctx.exports` property provides access to the exports of the main (`SELF`) Worker. The Workers Vitest integration attempts to automatically infer these exports by statically analyzing the Worker source code using esbuild. However, complex build setups, such as those using virtual modules or wildcard re-exports that esbuild cannot follow, may result in missing properties on the `ctx.exports` object.
 
-If you encounter missing exports, you can work around this by adding the `additionalExports` option to your Vitest configuration:
+For example, consider a Worker that re-exports an entrypoint from a virtual module using a wildcard export:
+
+```ts
+// index.ts
+export * from "@virtual-module";
+```
+
+In this case, any exports from `@virtual-module` (such as `MyEntrypoint`) cannot be automatically inferred and will be missing from `ctx.exports`.
+
+To work around this, add the `additionalExports` option to your Vitest configuration:
 
 ```ts
 import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
@@ -85,8 +94,6 @@ export default defineWorkersConfig({
 				wrangler: { configPath: "./wrangler.toml" },
 				additionalExports: {
 					MyEntrypoint: "WorkerEntrypoint",
-					MyDurableObject: "DurableObject",
-					MyWorkflow: "WorkflowEntrypoint",
 				},
 			},
 		},

--- a/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/known-issues.mdx
@@ -69,6 +69,33 @@ test('check if file exists', async () => {
 });
 ```
 
+### Missing properties on `ctx.exports`
+
+The `ctx.exports` property provides access to the exports of the main (`SELF`) Worker. The Workers Vitest integration attempts to automatically infer these exports by statically analyzing the Worker source code using esbuild. However, complex build setups, such as those using virtual modules or wildcard re-exports that esbuild cannot follow, may result in missing properties on the `ctx.exports` object.
+
+If you encounter missing exports, you can work around this by adding the `additionalExports` option to your Vitest configuration:
+
+```ts
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+	test: {
+		poolOptions: {
+			workers: {
+				wrangler: { configPath: "./wrangler.toml" },
+				additionalExports: {
+					MyEntrypoint: "WorkerEntrypoint",
+					MyDurableObject: "DurableObject",
+					MyWorkflow: "WorkflowEntrypoint",
+				},
+			},
+		},
+	},
+});
+```
+
+The `additionalExports` option is a map where keys are the export names and values are the type of export (`"WorkerEntrypoint"`, `"DurableObject"`, or `"WorkflowEntrypoint"`).
+
 ### Module resolution
 
 If you encounter module resolution issues such as: `Error: Cannot use require() to import an ES Module` or `Error: No such module`, you can bundle these dependencies using the [deps.optimizer](https://vitest.dev/config/#deps-optimizer) option:

--- a/src/content/docs/workers/testing/vitest-integration/recipes.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/recipes.mdx
@@ -24,6 +24,7 @@ Recipes are examples that help demonstrate how to write unit tests and integrati
 - [Tests using multiple auxiliary Workers and request mocks](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples/multiple-workers)
 - [Tests importing WebAssembly modules](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples/web-assembly)
 - [Tests using JSRPC with entrypoints and Durable Objects](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples/rpc)
+- [Tests using `ctx.exports` to access Worker exports](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples/context-exports)
 - [Integration test with static assets and Puppeteer](https://github.com/GregBrimble/puppeteer-vitest-workers-assets)
 - [Resolving modules with Vite Dependency Pre-Bundling](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples/module-resolution)
 - [Mocking Workers AI and Vectorize bindings in unit tests](https://github.com/cloudflare/workers-sdk/tree/main/fixtures/vitest-pool-workers-examples/ai-vectorize)


### PR DESCRIPTION
### Summary

Documents the new `ctx.exports` support for the Workers Vitest integration, corresponding to [cloudflare/workers-sdk#11533](https://github.com/cloudflare/workers-sdk/pull/11533).

Changes:
- Added link to the new `context-exports` fixture on the [Recipes and examples](/workers/testing/vitest-integration/recipes) page
- Added a known issue entry explaining that complex build setups (virtual modules, wildcard re-exports) may result in missing properties on `ctx.exports`, with documentation for the `additionalExports` workaround configuration

**Note**: This PR should be merged after or alongside workers-sdk#11533, as the fixture link and feature won't be available until that PR is merged.

### Updates since last revision

- Added a concrete code example showing the problematic scenario (wildcard re-export from a virtual module) to help readers map between the issue and the configuration workaround

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).

---

Link to Devin run: https://app.devin.ai/sessions/0c3f07329ad84e08ad29334e80c08faf
Requested by: pbacondarwin@cloudflare.com (@petebacondarwin)