### PR TITLE
Fix typo in Workers/Runtime APIs/NodeJS docs

### DIFF
--- a/src/content/docs/workers/runtime-apis/nodejs/process.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/process.mdx
@@ -96,7 +96,7 @@ This ensures compatibility with inspector and structured logging outputs.
 
 ## Current Working Directory
 
-[`process.cwd()`](https://nodejs.org/docs/latest/api/process.html#processcwd) is the _current workding directory_, used as the default path for all filesystem operations, and is initialized to `/bundle`.
+[`process.cwd()`](https://nodejs.org/docs/latest/api/process.html#processcwd) is the _current working directory_, used as the default path for all filesystem operations, and is initialized to `/bundle`.
 
 [`process.chdir()`](https://nodejs.org/docs/latest/api/process.html#processchdirdirectory) allows modifying the `cwd` and is respected by FS operations when using `enable_nodejs_fs_module`.
 


### PR DESCRIPTION
### Summary

Fix a small typo ("workding directory" -> "working directory")