### PR TITLE
[SaaS] Update Shopify guide by removing domain activation note

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
@@ -45,8 +45,6 @@ Once you save the new DNS record, the Cloudflare dashboard will show a Shopify i
 
 For questions about Shopify setup, refer to their [support guide](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-manual).
 
-If you cannot activate your domain using [proxied DNS records](/dns/proxy-status/), reach out to your account team or the [Cloudflare Community](https://community.cloudflare.com).
-
 :::
 
 ## Product compatibility


### PR DESCRIPTION
Removed instructions for activating domain with proxied DNS records.
Follow up to PCX-14320