### PR TITLE
[ keep PR open ]  compat date fix to today's date

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/astro.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/astro.mdx
@@ -145,7 +145,7 @@ If your Astro project uses [on demand rendering (also known as SSR)](https://doc
         	"name": "my-astro-app",
         	"main": "./dist/_worker.js/index.js",
         	// Update to today's date
-        	"compatibility_date": "2025-03-25",
+        	"compatibility_date": "2025-12-11",
         	"compatibility_flags": ["nodejs_compat"],
         	"assets": {
         		"binding": "ASSETS",

--- a/src/content/docs/workers/framework-guides/web-apps/astro.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/astro.mdx
@@ -145,7 +145,7 @@ If your Astro project uses [on demand rendering (also known as SSR)](https://doc
         	"name": "my-astro-app",
         	"main": "./dist/_worker.js/index.js",
         	// Update to today's date
-        	"compatibility_date": "2025-12-11",
+        	"compatibility_date": "$today",
         	"compatibility_flags": ["nodejs_compat"],
         	"assets": {
         		"binding": "ASSETS",

--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/docusaurus.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/docusaurus.mdx
@@ -85,7 +85,7 @@ If your Docusaurus project is entirely pre-rendered (which it usually is), follo
 		{
 			"name": "my-docusaurus-app",
 			// Update to today's date
-			"compatibility_date": "2025-03-25",
+			"compatibility_date": "$today",
 			"assets": {
 				"directory": "./build"
 			}

--- a/src/content/docs/workers/framework-guides/web-apps/nextjs.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/nextjs.mdx
@@ -126,7 +126,7 @@ You can convert an existing Next.js application to run on Cloudflare
         		```toml
         			main = ".open-next/worker.js"
         			name = "my-app"
-        			compatibility_date = "2025-03-25"
+        			compatibility_date = "$today"
         			compatibility_flags = ["nodejs_compat"]
         			[assets]
         			directory = ".open-next/assets"

--- a/src/content/docs/workers/framework-guides/web-apps/tanstack-start.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/tanstack-start.mdx
@@ -51,7 +51,7 @@ If you have an existing TanStack Start application, you can configure it to run 
 		<WranglerConfig>
     ```toml
     	name = "<YOUR_PROJECT_NAME>"
-    	compatibility_date = "2025-09-02"
+    	compatibility_date = "$today"
     	compatibility_flags = ["nodejs_compat"]
     	main = "@tanstack/react-start/server-entry"
     	[observability]


### PR DESCRIPTION
[ keep PR open ] 

Ran into friction deploying his astro site on Workers due to a compatibility date issue. 

He used the Wrangler config shown in devdocs with the old compatibility date:https://developers.cloudflare.com/workers/framework-guides/web-apps/astro/#if-your-site-uses-on-demand-rendering

This was the GitHub issue that helped him with the fix: https://github.com/withastro/astro/issues/12824#issuecomment-3192602629
CF Docs with the old compatibility date:
https://developers.cloudflare.com/workers/framework-guides/web-apps/astro/#if-your-site-uses-on-demand-rendering

Editing the docs with today's date 