### PR TITLE
[Workers] Add prerendering guide to React Router docs

### DIFF
--- a/src/content/changelog/workers/2025-02-31-react-router-prerendering.mdx
+++ b/src/content/changelog/workers/2025-02-31-react-router-prerendering.mdx
@@ -1,0 +1,24 @@
+---
+title: Prerender React Router apps on Cloudflare Workers
+description: React Router apps can now prerender routes to static HTML at build time with full access to environment variables and bindings.
+products:
+  - workers
+date: 2025-02-31
+---
+
+You can now [prerender](https://reactrouter.com/how-to/pre-rendering#pre-rendering) [React Router](https://reactrouter.com) routes to static HTML at build time on Cloudflare Workers. Prerendered routes have full access to environment variables and bindings and are served as [static assets](/workers/static-assets/).
+
+Add `unstable_previewServerPrerendering` and `prerender` to your React Router config:
+
+```ts title="react-router.config.ts"
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  future: {
+    unstable_previewServerPrerendering: true,
+  },
+  prerender: true,
+} satisfies Config;
+```
+
+This feature requires `@react-router/dev` v7.x.y or later. See the [React Router prerendering guide](/workers/framework-guides/web-apps/react-router/#pre-rendering) for configuration options and CI setup.

--- a/src/content/changelog/workers/2025-02-31-react-router-prerendering.mdx
+++ b/src/content/changelog/workers/2025-02-31-react-router-prerendering.mdx
@@ -8,7 +8,7 @@ date: 2025-02-31
 
 You can now [prerender](https://reactrouter.com/how-to/pre-rendering#pre-rendering) [React Router](https://reactrouter.com) routes to static HTML at build time on Cloudflare Workers. Prerendered routes have full access to environment variables and bindings and are served as [static assets](/workers/static-assets/).
 
-Add `unstable_previewServerPrerendering` and `prerender` to your React Router config:
+Enable the experimental `unstable_previewServerPrerendering` future flag and set `prerender` in your React Router config:
 
 ```ts title="react-router.config.ts"
 import type { Config } from "@react-router/dev/config";

--- a/src/content/docs/workers/framework-guides/web-apps/react-router.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/react-router.mdx
@@ -29,7 +29,7 @@ import {
 [![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/react-router-starter-template)
 
 :::note
-SPA mode and prerendering are not currently supported when using the [Cloudflare Vite plugin](/workers/vite-plugin/).
+SPA mode is not currently supported when using the [Cloudflare Vite plugin](/workers/vite-plugin/).
 If you wish to use React Router in an SPA then we recommend starting with the [React template](/workers/framework-guides/web-apps/react/) and using React Router [as a library](https://reactrouter.com/start/data/installation).
 :::
 
@@ -204,3 +204,43 @@ As you have direct access to your Worker entry file (`workers/app.ts`), you can 
 </Details>
 
 <Render file="frameworks-bindings" product="workers" />
+
+## Pre-rendering
+
+:::note
+
+This feature is experimental and requires `@react-router/dev` v7.x.y or later.
+
+:::
+
+React Router can prerender routes to static HTML at build time. Prerendered routes are served as [static assets](/workers/static-assets/) with full access to environment variables and bindings.
+
+Add `unstable_previewServerPrerendering` and `prerender` to your React Router config to enable prerendering on Cloudflare Workers:
+
+```ts title="react-router.config.ts"
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  future: {
+    unstable_previewServerPrerendering: true,
+  },
+  prerender: true,
+} satisfies Config;
+```
+
+Setting `prerender` to `true` prerenders all static routes. You can also pass an array of paths to prerender specific routes. For more options, see the [React Router prerendering documentation](https://reactrouter.com/how-to/pre-rendering#pre-rendering).
+
+### Prerendering data sources
+
+:::caution
+
+Prerendering runs at build time. It uses your local environment variables, secrets, and bindings storage data.
+
+:::
+
+To prerender with production data, use [remote bindings](/workers/development-testing/#remote-bindings).
+
+In CI environments, environment variables or secrets may not be available during the build. To make them accessible:
+
+- Set `CLOUDFLARE_INCLUDE_PROCESS_ENV=true` in your CI environment and provide the required values as environment variables.
+- If using [Workers Builds](/workers/ci-cd/builds/), update your [build settings](/workers/ci-cd/builds/configuration/#build-settings).


### PR DESCRIPTION
### Summary

- Updates the React Router framework guide for **experimental** pre-rendering support
- Adds a changelog about **experimental** pre-rendering support with React Router

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
