### PR TITLE
Add type generation support to `wrangler dev`

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -246,6 +246,8 @@ None of the options for this command are required. Many of these options can be 
   - Show the interactive dev session.
 - `--alias` `Array<string>`
   - Specify modules to alias using [module aliasing](/workers/wrangler/configuration/#module-aliasing).
+- `--types` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
+  - Generate types from your Worker configuration.
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1211,6 +1211,9 @@ You can configure various aspects of local development, such as the local protoc
   - Used for local development of [Containers](/containers/local-dev). Wrangler will attempt to automatically find the correct socket to use to communicate with your container engine. If that does not work (usually surfacing as an `internal error` when attempting to connect to your Container), you can try setting the socket path using this option. You can also set this via the environment variable `DOCKER_HOST`.
     Example:
 
+- `generate_types` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Generate types from your Worker configuration. Defaults to `false`.
+
 <WranglerConfig>
 
 ```toml title="wrangler.toml"


### PR DESCRIPTION
### Summary

cloudflare/workers-sdk#11616 adds support for generating worker configuration types either by using the new `wrangler dev --types` flag or by adding the `dev.generate_types` boolean configuration option.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
