### PR TITLE
[Turnstile] Adds Cloudflare.NET (C#/.NET) to the Turnstile community resources list under "Other" as a widget management option.

### DIFF
--- a/src/content/docs/turnstile/community-resources.mdx
+++ b/src/content/docs/turnstile/community-resources.mdx
@@ -78,7 +78,7 @@ Other resources related to integrating Turnstile:
 
 ### Widget management
 
-* [Cloudflare.NET](https://github.com/Alos-no/Cloudflare.NET) (C#/.NET)
+- [Cloudflare.NET](https://github.com/Alos-no/Cloudflare.NET) (C#/.NET)
 
 ### Additional support
 

--- a/src/content/docs/turnstile/community-resources.mdx
+++ b/src/content/docs/turnstile/community-resources.mdx
@@ -76,6 +76,10 @@ Other resources related to integrating Turnstile:
 - [turnstile-types](https://www.npmjs.com/package/turnstile-types)
 - [@types/cloudflare-turnstile](https://www.npmjs.com/package/@types/cloudflare-turnstile)
 
+### Widget management
+
+* [Cloudflare.NET](https://github.com/Alos-no/Cloudflare.NET) (C#/.NET)
+
 ### Additional support
 
 - [Cloudflare Community](https://community.cloudflare.com/c/website-application-performance/turnstile/83)


### PR DESCRIPTION
### Summary

The community resources page currently lists client-side rendering, server-side validation, full-stack libraries, and integrations, but it does not include options for programmatic Turnstile widget management (for example widget CRUD and secret rotation).

See Cloudflare.NET's [Turnstile documentation](https://alos.no/cfnet/articles/accounts/turnstile.html)


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] Changelog entry: N/A (docs-only update to community-resources list).