### PR TITLE
Typo ports.mdx in Sandbox SDK

### DIFF
--- a/src/content/docs/sandbox/api/ports.mdx
+++ b/src/content/docs/sandbox/api/ports.mdx
@@ -30,7 +30,7 @@ const response = await sandbox.exposePort(port: number, options: ExposePortOptio
   - `hostname` - Your Worker's domain name (e.g., `'example.com'`). Required to construct preview URLs with wildcard subdomains like `https://8080-sandbox-abc123.example.com`. Cannot be a `.workers.dev` domain as it doesn't support wildcard DNS patterns.
   - `name` - Friendly name for the port (optional)
 
-**Returns**: `Promise<ExposePortResponse>` with `port`, `exposedAt` (preview URL), `name`
+**Returns**: `Promise<ExposePortResponse>` with `port`, `url` (preview URL), `name`
 
 <TypeScriptExample>
 ```


### PR DESCRIPTION
typo? I don't get exposedAt, url instead 
<img width="1195" height="267" alt="image" src="https://github.com/user-attachments/assets/f75b7c8b-a4d0-49ff-9b7a-6b5c9d7e1760" />

