### PR TITLE
[DNS] Fix dig command formatting in DNS troubleshooting docs

### DIFF
--- a/src/content/docs/dns/troubleshooting/dns-debug-endpoints.mdx
+++ b/src/content/docs/dns/troubleshooting/dns-debug-endpoints.mdx
@@ -13,7 +13,7 @@ For all commands, you can replace `alex.ns.cloudflare.com` with your Cloudflare 
 :::
 
 ```sh
-$ dig @alex.ns.cloudflare.com chaos txt myip.cloudflare +short
+dig @alex.ns.cloudflare.com chaos txt myip.cloudflare +short
 ```
 
 This command gives you your IP address, meaning the public IP address that Cloudflare receives this DNS query from. This is useful for debugging when you need to know your own IP.
@@ -21,7 +21,7 @@ This command gives you your IP address, meaning the public IP address that Cloud
 ---
 
 ```sh
-$ dig @alex.ns.cloudflare.com chaos txt id.server +short
+dig @alex.ns.cloudflare.com chaos txt id.server +short
 ```
 
 This command gives you the Cloudflare data center you are connecting to, for DNS queries sent from where you execute this command.
@@ -29,7 +29,7 @@ This command gives you the Cloudflare data center you are connecting to, for DNS
 ---
 
 ```sh
-$ dig @alex.ns.cloudflare.com chaos txt version.bind +short
+dig @alex.ns.cloudflare.com chaos txt version.bind +short
 ```
 
 This command gives you the version of Cloudflare's authoritative DNS software that is running on the data center you are connected to. Usually, the same version would always be present on all of our data centers. But, since we do staged releases, technically there can be different versions on different data centers.
@@ -37,7 +37,7 @@ This command gives you the version of Cloudflare's authoritative DNS software th
 ---
 
 ```sh
-$ dig @alex.ns.cloudflare.com txt whoami.cloudflare.net +short
+dig @alex.ns.cloudflare.com txt whoami.cloudflare.net +short
 ```
 
 This command gives you your public IP (same as the first command above), your ASN, and the associated country code, all indicating where you are sending this query from.


### PR DESCRIPTION
Updated dig command examples to remove unnecessary $ sign at the beginning, so that users can just copy/paste the command.