### PR TITLE
workers: streaming JSON example

### DIFF
--- a/src/content/docs/workers/examples/streaming-json.mdx
+++ b/src/content/docs/workers/examples/streaming-json.mdx
@@ -1,8 +1,8 @@
 ---
 summary: Parse and transform large JSON request and response bodies using streaming.
 tags:
+  - Middleware
   - JSON
-  - Streams
   - JavaScript
   - TypeScript
 pcx_content_type: example

--- a/src/content/docs/workers/examples/streaming-json.mdx
+++ b/src/content/docs/workers/examples/streaming-json.mdx
@@ -1,0 +1,209 @@
+---
+summary: Parse and transform large JSON request and response bodies using streaming.
+tags:
+  - JSON
+  - Streams
+  - JavaScript
+  - TypeScript
+pcx_content_type: example
+title: Stream large JSON
+sidebar:
+  order: 1001
+description: Parse and transform large JSON request and response bodies using streaming.
+---
+
+import { TabItem, Tabs } from "~/components";
+
+Use the [Streams API](/workers/runtime-apis/streams/) to process JSON payloads that would exceed a Worker's 128 MB memory limit if fully buffered. Streaming allows you to parse and transform JSON data incrementally as it arrives. This is faster than buffering the entire payload into memory, as your Worker can start processing data incrementally, and allows your Worker to handle multi-gigabyte payloads or files within its memory limits.
+
+The [`@streamparser/json-whatwg`](https://www.npmjs.com/package/@streamparser/json-whatwg) library provides a streaming JSON parser compatible with the Web Streams API.
+
+Install the dependency:
+
+```sh
+npm install @streamparser/json-whatwg
+```
+
+## Stream a JSON request body
+
+This example parses a large JSON request body and extracts specific fields without loading the entire payload into memory.
+
+<Tabs syncKey="workersExamples"> <TabItem label="TypeScript" icon="seti:typescript">
+
+```ts
+import { JSONParser } from "@streamparser/json-whatwg";
+
+export default {
+	async fetch(request): Promise<Response> {
+		const parser = new JSONParser({ paths: ["$.users.*"] });
+
+		const users: string[] = [];
+
+		// Pipe the request body through the JSON parser
+		const reader = request.body
+			.pipeThrough(parser)
+			.getReader();
+
+		// Process matching JSON values as they stream in
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			// Extract only the name field from each user object
+			if (value.value?.name) {
+				users.push(value.value.name);
+			}
+		}
+
+		return Response.json({ userNames: users });
+	},
+} satisfies ExportedHandler;
+```
+
+</TabItem> <TabItem label="JavaScript" icon="seti:javascript">
+
+```js
+import { JSONParser } from "@streamparser/json-whatwg";
+
+export default {
+	async fetch(request) {
+		const parser = new JSONParser({ paths: ["$.users.*"] });
+
+		const users = [];
+
+		// Pipe the request body through the JSON parser
+		const reader = request.body
+			.pipeThrough(parser)
+			.getReader();
+
+		// Process matching JSON values as they stream in
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			// Extract only the name field from each user object
+			if (value.value?.name) {
+				users.push(value.value.name);
+			}
+		}
+
+		return Response.json({ userNames: users });
+	},
+};
+```
+
+</TabItem> </Tabs>
+
+## Stream and transform a JSON response
+
+This example fetches a large JSON response from an upstream API, transforms specific fields, and streams the modified response to the client.
+
+<Tabs syncKey="workersExamples"> <TabItem label="TypeScript" icon="seti:typescript">
+
+```ts
+import { JSONParser } from "@streamparser/json-whatwg";
+
+export default {
+	async fetch(request): Promise<Response> {
+		const response = await fetch("https://api.example.com/large-dataset.json");
+
+		const parser = new JSONParser({ paths: ["$.items.*"] });
+
+		const { readable, writable } = new TransformStream();
+		const writer = writable.getWriter();
+		const encoder = new TextEncoder();
+
+		// Process the upstream response in the background
+		(async () => {
+			const reader = response.body
+				.pipeThrough(parser)
+				.getReader();
+
+			await writer.write(encoder.encode('{"processedItems":['));
+			let first = true;
+
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				// Transform each item as it streams through
+				const item = value.value;
+				const transformed = {
+					id: item.id,
+					title: item.title.toUpperCase(),
+					processed: true,
+				};
+
+				if (!first) await writer.write(encoder.encode(","));
+				first = false;
+				await writer.write(encoder.encode(JSON.stringify(transformed)));
+			}
+
+			await writer.write(encoder.encode("]}"));
+			await writer.close();
+		})();
+
+		return new Response(readable, {
+			headers: { "Content-Type": "application/json" },
+		});
+	},
+} satisfies ExportedHandler;
+```
+
+</TabItem> <TabItem label="JavaScript" icon="seti:javascript">
+
+```js
+import { JSONParser } from "@streamparser/json-whatwg";
+
+export default {
+	async fetch(request) {
+		const response = await fetch("https://api.example.com/large-dataset.json");
+
+		const parser = new JSONParser({ paths: ["$.items.*"] });
+
+		const { readable, writable } = new TransformStream();
+		const writer = writable.getWriter();
+		const encoder = new TextEncoder();
+
+		// Process the upstream response in the background
+		(async () => {
+			const reader = response.body
+				.pipeThrough(parser)
+				.getReader();
+
+			await writer.write(encoder.encode('{"processedItems":['));
+			let first = true;
+
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				// Transform each item as it streams through
+				const item = value.value;
+				const transformed = {
+					id: item.id,
+					title: item.title.toUpperCase(),
+					processed: true,
+				};
+
+				if (!first) await writer.write(encoder.encode(","));
+				first = false;
+				await writer.write(encoder.encode(JSON.stringify(transformed)));
+			}
+
+			await writer.write(encoder.encode("]}"));
+			await writer.close();
+		})();
+
+		return new Response(readable, {
+			headers: { "Content-Type": "application/json" },
+		});
+	},
+};
+```
+
+</TabItem> </Tabs>
+
+## Related resources
+
+- [Streams API](/workers/runtime-apis/streams/) - Learn more about streaming in Workers
+- [TransformStream](/workers/runtime-apis/streams/transformstream/) - Create custom stream transformations
+- [@streamparser/json-whatwg](https://www.npmjs.com/package/@streamparser/json-whatwg) - Streaming JSON parser documentation

--- a/src/content/docs/workers/runtime-apis/streams/index.mdx
+++ b/src/content/docs/workers/runtime-apis/streams/index.mdx
@@ -14,16 +14,15 @@ The [Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) 
 
 <DirectoryListing />
 
-Workers do not need to prepare an entire response body before returning a `Response`. You can use a [`ReadableStream`](/workers/runtime-apis/streams/readablestream/) to stream a response body after sending the front matter (that is, HTTP status line and headers). This allows you to minimize:
+Use the Streams API to avoid buffering large requests or responses in memory. This enables you to parse extremely large request or response bodies within a Worker's 128 MB memory limit. This is faster than buffering the entire payload into memory, as your Worker can start processing data incrementally, and allows your Worker to handle multi-gigabyte payloads or files within its memory limits.
 
-- The visitor's time-to-first-byte.
-- The buffering done in the Worker.
-
-Minimizing buffering is especially important for processing or transforming response bodies larger than the Worker's memory limit. For these cases, streaming is the only implementation strategy.
+Workers do not need to prepare an entire response body before returning a `Response`. You can use a [`ReadableStream`](/workers/runtime-apis/streams/readablestream/) to stream a response body after sending the response status line and headers.
 
 :::note
 
-By default, Cloudflare Workers is capable of streaming responses using the [Streams APIs](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API). To maintain the streaming behavior, you should only modify the response body using the methods in the Streams APIs. If your Worker only forwards subrequest responses to the client verbatim without reading their body text, then its body handling is already optimal and you do not have to use these APIs.
+By default, Cloudflare Workers is capable of streaming responses using the [Streams APIs](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API). To maintain the streaming behavior, you should only modify the response body using the methods in the Streams APIs.
+
+If your Worker only forwards subrequest responses to the client verbatim without reading their body text, then its body handling is already optimal and you do not have to use these APIs.
 
 :::
 
@@ -144,6 +143,7 @@ The Streams API is only available inside of the [Request context](/workers/runti
 
 ## Related resources
 
+- [Stream large JSON](/workers/examples/streaming-json/) - Parse and transform large JSON request and response bodies
 - [MDN's Streams API documentation](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API)
 - [Streams API spec](https://streams.spec.whatwg.org/)
 - Write your Worker code in [ES modules syntax](/workers/reference/migrate-to-module-workers/) for an optimized experience.


### PR DESCRIPTION
This PR adds a streaming JSON example to the Workers docs and makes the Streams API docs a little clearer.