### PR TITLE
docs(realtimekit): add poll docs for Mobile SDKs

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/polls.mdx
+++ b/src/content/docs/realtime/realtimekit/core/polls.mdx
@@ -101,7 +101,7 @@ You can access the polls functionality in a meeting using the `meeting.polls` ob
 
 To retrieve all polls created during a meeting, use `meeting.polls.items`. This returns an array where each element is an object of type `com.cloudflare.realtimekit.polls.Poll`.
 
-### Poll Type
+### Poll type
 
 The `Poll` type represents a poll within a meeting:
 
@@ -165,7 +165,7 @@ The meetings polls object can be accessed using `meeting.polls`. It provides met
 
 `meeting.polls.items` returns an array of all polls created in a meeting, where each element is an object of type `Poll`.
 
-### Poll Type
+### Poll type
 
 The `Poll` type is defined as follows:
 
@@ -221,7 +221,7 @@ The meetings polls object can be accessed using `meeting.polls`. It provides met
 
 `meeting.polls.items` returns an array of all polls created in a meeting, where each element is an object of type `Poll`.
 
-### Poll Type
+### Poll type
 
 The `Poll` type is defined as follows:
 
@@ -295,7 +295,7 @@ The meetings polls object can be accessed using `meeting.polls`. It provides met
 
 `meeting.polls.items` returns an array of all polls created in a meeting, where each element is an object of type `Poll`.
 
-### Poll Type
+### Poll type
 
 The `Poll` type is defined as follows:
 
@@ -657,7 +657,7 @@ const polls = useRealtimeKitSelector((m) => m.polls.items);
 </TabItem>
 <TabItem label="Android">
 
-### View Poll Results
+### View poll results
 
 The total votes on a poll can be accessed in the following manner:
 
@@ -680,7 +680,7 @@ val options = poll.options
 </TabItem>
 <TabItem label="iOS">
 
-### View Poll Results
+### View poll results
 
 The total votes on a poll can be accessed in the following manner:
 
@@ -703,7 +703,7 @@ let options = poll.options
 </TabItem>
 <TabItem label="Flutter">
 
-### View Poll Results
+### View poll results
 
 The total votes on a poll can be accessed in the following manner:
 
@@ -726,7 +726,7 @@ final options = poll.options;
 </TabItem>
 <TabItem label="React Native">
 
-### View Poll Results
+### View poll results
 
 The total votes on a poll can be accessed in the following manner:
 
@@ -746,7 +746,7 @@ const options = poll.options;
 
 `options` returns an array of objects, where each object is of type `PollOption`.
 
-### Get Notified When a Poll is Created or Updated
+### Get notified when a poll is created or updated
 
 An event is fired each time `meeting.polls.items` is updated or created. You can listen for this to get the updated list of polls. The response object contains the following properties:
 

--- a/src/content/docs/realtime/realtimekit/core/polls.mdx
+++ b/src/content/docs/realtime/realtimekit/core/polls.mdx
@@ -95,6 +95,233 @@ interface PollOption {
 ```
 
 </TabItem>
+<TabItem label="Android">
+
+You can access the polls functionality in a meeting using the `meeting.polls` object. This object provides methods to create polls, vote, and perform other poll-related actions.
+
+To retrieve all polls created during a meeting, use `meeting.polls.items`. This returns an array where each element is an object of type `com.cloudflare.realtimekit.polls.Poll`.
+
+### Poll Type
+
+The `Poll` type represents a poll within a meeting:
+
+```kotlin
+class Poll(
+  val id: String,
+  val question: String,
+  val anonymous: Boolean,
+  val hideVotes: Boolean,
+  val createdBy: String,
+  val options: List<PollOption>,
+  val voted: List<String>,
+)
+```
+
+Each poll contains a list of `PollOption` objects, representing the available options for that poll.
+
+Every `PollOption` includes a list of `PollVote` objects, where each vote contains the voter's `id` and `name`.
+
+```kotlin
+class PollOption(
+  val text: String,
+  val votes: List<PollVote>,
+  val count: Int
+)
+```
+
+```kotlin
+class PollVote(
+  val id: String,
+  val name: String
+)
+```
+
+### Listening to new polls in a meeting
+
+To receive updates about new polls or poll changes during a meeting, implement the `RtkPollsEventListener` interface. Register your listener using `meeting.addPollsEventListener(rtkPollsEventListener)`.
+
+The `onNewPoll()` method is called whenever a new poll is created in the meeting.
+
+The `onPollUpdate()` method is invoked when a specific poll is updated, such as when participants vote or poll details change. The `onPollUpdates()` method is called when there are updates to the list of polls, including new polls being created or multiple polls being updated at once. Use these callbacks to keep your poll UI in sync with the latest poll data.
+
+```kotlin
+meeting.addPollsEventListener(object : RtkPollsEventListener {
+    override fun onNewPoll(poll: Poll) {
+    }
+
+    override fun onPollUpdate(poll: Poll) {
+    }
+
+    override fun onPollUpdates(pollItems: List<Poll>) {
+    }
+  }
+)
+```
+
+</TabItem>
+<TabItem label="iOS">
+
+The meetings polls object can be accessed using `meeting.polls`. It provides methods to create polls, vote, and more.
+
+`meeting.polls.items` returns an array of all polls created in a meeting, where each element is an object of type `Poll`.
+
+### Poll Type
+
+The `Poll` type is defined as follows:
+
+```swift
+class Poll {
+  let id: String
+  let question: String
+  let anonymous: Bool
+  let hideVotes: Bool
+  let createdBy: String
+  let options: [PollOption]
+  let voted: [String]
+}
+```
+
+The type `Poll` is the main class for any poll in RealtimeKit. It also contains list of `PollOption` which are options for a given poll. And every `PollOption` has list of votes inside of it. Votes are objects of class `PollVote` which internally has id and name of the vote.
+
+```swift
+class PollOption {
+  let text: String
+  let votes: [PollVote]
+  let count: Int
+}
+
+class PollVote {
+  let id: String
+  let name: String
+}
+```
+
+### Listening to new polls in a meeting
+
+To be able to receive new poll messages you need to implement a method `onPollUpdates()` method from callback `RtkPollsEventListener`. You can subscribe to this events by calling `meeting.addPollsEventListener(meetingViewModel)`
+
+```swift
+extension MeetingViewModel: RtkPollsEventListener {
+  func onNewPoll(poll: Poll) {
+    // code to handle new poll
+  }
+
+  func onPollUpdates(pollItems: [Poll]) {
+    // code to handle polls and their vote updates.
+  }
+
+  func onPollUpdate(poll: Poll) {}
+}
+```
+
+</TabItem>
+<TabItem label="Flutter">
+
+The meetings polls object can be accessed using `meeting.polls`. It provides methods to create polls, vote, and more.
+
+`meeting.polls.items` returns an array of all polls created in a meeting, where each element is an object of type `Poll`.
+
+### Poll Type
+
+The `Poll` type is defined as follows:
+
+```dart
+class Poll {
+  final String id;
+  final String question;
+  final bool anonymous;
+  final bool hideVotes;
+  final String createdBy;
+  final List<PollOption> options;
+  final List<String> voted;
+}
+```
+
+The `Poll` class has the following properties:
+
+- `id`: Unique ID assigned to each poll.
+- `question`: Question of the poll.
+- `anonymous`: To hide the votes of each user even after completion. (false by default)
+- `hideVotes`: Hide votes until the voting is complete. (enabled if anonymous is enabled)
+- `createdBy`: Name of creator the poll.
+- `options`: Array of `PollOption` object, contains all the options to the poll question.
+- `voted`: Array of String which contains User IDs that have voted.
+
+The type `Poll` represents a poll in a RealtimeKit meeting. It also contains list of `PollOption` which are options for a given poll. And every `PollOption` has list of votes inside of it. Votes are objects of class `PollVote` which internally has id and name of the vote.
+
+```dart
+class PollOption(
+  final String text;   // Option text.
+  final List<PollVote> votes;   // List of votes.
+  final int count;    // Number of votes.
+);
+
+class PollVote {
+  final String id;    // ID of the voter.
+  final String name;  // Name of the voter.
+}
+```
+
+### Listening to new polls in a meeting
+
+To be able to receive new poll messages you need to implement a method `onPollUpdates()` method from callback `RtkPollsEventListener`:
+
+To get poll updates, listen to `onPollUpdates()` callback:
+
+```dart
+class PollEventsListener extends RtkPollsEventListener {
+  @override
+  void onPollUpdates(List<Poll> pollItems) {
+    /// code to handle polls
+  }
+
+  @override
+  void onNewPoll(Poll poll) {
+    /// code to handle new poll
+  }
+}
+```
+
+You can subscribe to these events as follows:
+
+```dart
+meeting.addPollsEventListener(PollEventsListener());
+```
+
+</TabItem>
+<TabItem label="React Native">
+
+The meetings polls object can be accessed using `meeting.polls`. It provides methods to create polls, vote, and more.
+
+`meeting.polls.items` returns an array of all polls created in a meeting, where each element is an object of type `Poll`.
+
+### Poll Type
+
+The `Poll` type is defined as follows:
+
+```ts
+interface Poll {
+	id: string;
+	question: string;
+	options: PollOption[];
+	anonymous: boolean;
+	hideVotes: boolean;
+	createdBy: string;
+	createdByUserId: string;
+	voted: string[]; // stores participant ID
+}
+
+interface PollOption {
+	text: string;
+	votes: {
+		id: string; // stores participant ID
+		name: string;
+	}[];
+	count: number;
+}
+```
+
+</TabItem>
 </Tabs>
 
 ## Creating a Poll
@@ -140,6 +367,97 @@ await meeting.polls.create(
 ```
 
 </TabItem>
+<TabItem label="Android">
+
+To create a new poll, use the `create` method available on the `meeting.polls` object. The `meeting.polls.create()` function requires the following parameters:
+
+| Param     | Type           | Required | Description                                |
+| --------- | -------------- | -------- | ------------------------------------------ |
+| question  | `String`       | yes      | The question that is to be voted for.      |
+| options   | `List<String>` | yes      | The options of the poll.                   |
+| anonymous | `Boolean`      | yes      | If true, the poll votes are anonymous.     |
+| hideVotes | `Boolean`      | yes      | If true, the votes on the poll are hidden. |
+
+The following snippet creates a poll where votes are anonymous.
+
+```kotlin
+val pollsCreateError: PollsError? = meeting.polls.create(
+  question = "Are you an early bird or a night owl?",
+  options = listOf("Early bird", "Night owl"),
+  anonymous = true,
+  hideVotes = false
+)
+```
+
+</TabItem>
+<TabItem label="iOS">
+
+A new poll can be created using the `create` method from the `meeting.polls` object. The `meeting.polls.createPoll()` method accepts the following parameters:
+
+| Param     | Type       | Default Value | Required | Description                                |
+| --------- | ---------- | ------------- | -------- | ------------------------------------------ |
+| question  | `string`   | -             | yes      | The question that is to be voted for.      |
+| options   | `string[]` | -             | yes      | The options of the poll.                   |
+| anonymous | `boolean`  | -             | no       | If true, the poll votes are anonymous.     |
+| hideVotes | `boolean`  | -             | no       | If true, the votes on the poll are hidden. |
+
+The following snippet creates a poll where votes are anonymous.
+
+```swift
+let pollsCreateError: PollsError? = meeting.polls.createPoll(
+    question: "Are you an early bird or a night owl?",
+    options: ["Early bird", "Night owl"],
+    anonymous: true,
+    hideVotes: false
+)
+```
+
+</TabItem>
+<TabItem label="Flutter">
+
+A new poll can be created using the `create` method from the `meeting.polls` object. The `meeting.polls.create(...)` method accepts the following parameters:
+
+| Param     | Type           | Default Value | Required | Description                                |
+| --------- | -------------- | ------------- | -------- | ------------------------------------------ |
+| question  | `String`       | -             | yes      | The question that is to be voted for.      |
+| options   | `List<String>` | -             | yes      | The options of the poll.                   |
+| anonymous | `bool`         | -             | yes      | If true, the poll votes are anonymous.     |
+| hideVotes | `bool`         | -             | yes      | If true, the votes on the poll are hidden. |
+
+The following snippet creates a poll where votes are anonymous.
+
+```dart
+meeting.polls.create(
+    question: "Are you an early bird or a night owl?",
+    options: ["Early bird", "Night owl"],
+    anonymous: true,
+    hideVotes: false,
+);
+```
+
+</TabItem>
+<TabItem label="React Native">
+
+A new poll can be created using the `create` method from the `meeting.polls` object. The `meeting.polls.create()` method accepts the following parameters:
+
+| Param     | Type       | Default Value | Required | Description                                |
+| --------- | ---------- | ------------- | -------- | ------------------------------------------ |
+| question  | `string`   | -             | yes      | The question that is to be voted for.      |
+| options   | `string[]` | -             | yes      | The options of the poll.                   |
+| anonymous | `boolean`  | false         | no       | If true, the poll votes are anonymous.     |
+| hideVotes | `boolean`  | false         | no       | If true, the votes on the poll are hidden. |
+
+The following snippet creates a poll where votes are anonymous.
+
+```ts
+await meeting.poll.create(
+	"Are you an early bird or a night owl?",
+	["Early bird", "Night owl"],
+	true,
+);
+```
+
+</TabItem>
 </Tabs>
 
 ## Voting on a Poll
@@ -172,6 +490,80 @@ The following snippet votes for the first option on the first poll created in th
 ```jsx
 const poll = meeting.polls.items[0];
 await meeting.polls.vote(poll.id, 0);
+```
+
+</TabItem>
+<TabItem label="Android">
+
+To register a vote on a poll, use the `meeting.polls.vote()` method. This method requires the following parameters:
+
+| Param       | Type         | Default Value | Required | Description                  |
+| ----------- | ------------ | ------------- | -------- | ---------------------------- |
+| pollMessage | `Poll`       | -             | yes      | The poll message to vote on. |
+| pollOption  | `PollOption` | -             | yes      | The option to vote for.      |
+
+The following snippet votes for the first option on the first poll created in the meeting.
+
+```kotlin
+val poll: Poll = meeting.polls.items.first()
+val selectedPollOption: PollOption = poll.options.first()
+
+val pollsError: PollsError? = meeting.polls.vote(poll.id, selectedPollOption)
+```
+
+</TabItem>
+<TabItem label="iOS">
+
+The `meeting.polls.vote()` method can be used to register a vote on a poll. It accepts the following parameters:
+
+| Param       | Type         | Default Value | Required | Description                  |
+| ----------- | ------------ | ------------- | -------- | ---------------------------- |
+| pollMessage | `Poll`       | -             | yes      | The poll message to vote on. |
+| pollOption  | `PollOption` | -             | yes      | The option to vote for.      |
+
+The following snippet votes for the first option on the first poll created in the meeting.
+
+```swift
+let poll: Poll = meeting.polls.items[0]
+let selectedPollOption: PollOption = poll.options[0]
+
+meeting.poll.vote(poll, selectedPollOption)
+```
+
+</TabItem>
+<TabItem label="Flutter">
+
+The `meeting.polls.vote()` method can be used to register a vote on a poll. It accepts the following parameters:
+
+| Param       | Type         | Default Value | Required | Description                                                |
+| ----------- | ------------ | ------------- | -------- | ---------------------------------------------------------- |
+| pollMessage | `Poll`       | -             | yes      | Contains all the poll properties (question, options, etc.) |
+| pollOption  | `PollOption` | yes           | yes      | Option on which the user voted                             |
+
+The following snippet votes for the first option on the first poll created in the meeting.
+
+```dart
+final poll = meeting.polls.items[0];
+final selectedPollOption = poll.options[0];
+
+meeting.polls.vote(poll: poll, pollOption: selectedPollOption);
+```
+
+</TabItem>
+<TabItem label="React Native">
+
+The `meeting.polls.vote()` method can be used to register a vote on a poll. It accepts the following parameters:
+
+| Param | Type     | Default Value | Required | Description                                |
+| ----- | -------- | ------------- | -------- | ------------------------------------------ |
+| id    | `string` | -             | yes      | The ID of the poll that is to be voted on. |
+| index | `number` | -             | yes      | The index of the option.                   |
+
+The following snippet votes for the first option on the first poll created in the meeting.
+
+```ts
+const poll = meeting.polls.items[0];
+await meeting.poll.vote(poll.id, 0);
 ```
 
 </TabItem>
@@ -260,6 +652,111 @@ import { useRealtimeKitSelector } from "@cloudflare/realtimekit-react";
 
 // useRealtimeKitSelector hook only works when `RealtimeKitProvider` is used.
 const polls = useRealtimeKitSelector((m) => m.polls.items);
+```
+
+</TabItem>
+<TabItem label="Android">
+
+### View Poll Results
+
+The total votes on a poll can be accessed in the following manner:
+
+```kotlin
+val poll = meeting.polls.items[0]
+val votes = poll.voted
+```
+
+`votes` is an array of participant IDs (`meeting.participant.id`).
+
+The total votes on a poll option can be accessed in the following manner:
+
+```kotlin
+val poll = meeting.polls.items[0]
+val options = poll.options
+```
+
+`options` returns an array of objects, where each object is of type `PollOption`.
+
+</TabItem>
+<TabItem label="iOS">
+
+### View Poll Results
+
+The total votes on a poll can be accessed in the following manner:
+
+```swift
+let poll = meeting.polls.items[0]
+let votes = poll.voted
+```
+
+`votes` is an array of participant IDs (`meeting.participant.id`).
+
+The total votes on a poll option can be accessed in the following manner:
+
+```swift
+let poll = meeting.polls.items[0]
+let options = poll.options
+```
+
+`options` returns an array of objects, where each object is of type `PollOption`.
+
+</TabItem>
+<TabItem label="Flutter">
+
+### View Poll Results
+
+The total votes on a poll can be accessed in the following manner:
+
+```dart
+final poll = meeting.polls.items.first;
+final votes = poll.voted;
+```
+
+`votes` is an array of participant IDs (`meeting.participant.id`).
+
+The total votes on a poll option can be accessed in the following manner:
+
+```dart
+final poll = meeting.polls.items.first;
+final options = poll.options;
+```
+
+`options` returns an array of objects, where each object is of type `PollOption`.
+
+</TabItem>
+<TabItem label="React Native">
+
+### View Poll Results
+
+The total votes on a poll can be accessed in the following manner:
+
+```ts
+const poll = meeting.polls.items[0];
+const votes = poll.voted;
+```
+
+`votes` is an array of participant IDs (`meeting.participant.id`).
+
+The total votes on a poll option can be accessed in the following manner:
+
+```ts
+const poll = meeting.polls.items[0];
+const options = poll.options;
+```
+
+`options` returns an array of objects, where each object is of type `PollOption`.
+
+### Get Notified When a Poll is Created or Updated
+
+An event is fired each time `meeting.polls.items` is updated or created. You can listen for this to get the updated list of polls. The response object contains the following properties:
+
+- `polls` - List of all polls
+- `newPoll` - A boolean variable which is `true` when a new poll has been created
+
+```ts
+meeting.polls.on("pollsUpdate", ({ polls, newPoll }) => {
+	console.log(polls, newPoll);
+});
 ```
 
 </TabItem>


### PR DESCRIPTION
### Summary

Added poll docs for RealtimeKit Mobile SDKs

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
