### PR TITLE
[RealtimeKit] Add page about how to end a session using core SDK

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/end-a-session.mdx
+++ b/src/content/docs/realtime/realtimekit/core/end-a-session.mdx
@@ -1,0 +1,178 @@
+---
+pcx_content_type: how-to
+title: End a session
+slug: realtime/realtimekit/core/end-a-session
+sidebar:
+  order: 6
+---
+
+import { Render } from "~/components";
+import RTKSDKSelector from "~/components/realtimekit/RTKSDKSelector/RTKSDKSelector.astro";
+import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnippet.astro";
+
+To end the current [session](/realtime/realtimekit/concepts/meeting/#session/) for all participants, remove all participants using `kickAll()`. This stops any ongoing recording for that session and sets the session status to `ENDED`.
+
+Ending a session is different from leaving a meeting. Leaving disconnects only the current participant. The session remains active if other participants are still present.
+
+## Prerequisites
+
+- Ensure your participant's preset has the **Kick Participants** (`kick_participant`) host permission enabled.
+
+## Steps
+
+<RTKSDKSelector />
+
+1.  Check that the local participant has permission to remove participants.
+
+    <RTKCodeSnippet id="web-react">
+
+    ```ts
+    const canEndSession = meeting.self.permissions.kickParticipant === true;
+
+    if (!canEndSession) {
+    	// Disable the "End meeting/session" control in your UI.
+    	// You can also show a message to explain why the action is not available.
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="web-web-components">
+
+    ```ts
+    const canEndSession = meeting.self.permissions.kickParticipant === true;
+
+    if (!canEndSession) {
+    	// Disable the "End meeting/session" control in your UI.
+    	// You can also show a message to explain why the action is not available.
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="web-angular">
+
+    ```ts
+    const canEndSession = meeting.self.permissions.kickParticipant === true;
+
+    if (!canEndSession) {
+    	// Disable the "End meeting/session" control in your UI.
+    	// You can also show a message to explain why the action is not available.
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+2.  End the session by removing all participants.
+
+    <RTKCodeSnippet id="web-react">
+
+    If the participant does not have the required permission, `kickAll()` throws a ClientError with error code `1201`.
+
+    ```ts
+    try {
+    	await meeting.participants.kickAll();
+    } catch (err) {
+    	if (err?.code === 1201) {
+    		// The participant does not have permission to end the session.
+    		// Update your UI to indicate that the action is not allowed.
+    		return;
+    	}
+    	throw err;
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="web-web-components">
+
+    If the participant does not have the required permission, `kickAll()` throws a ClientError with error code `1201`.
+
+    ```ts
+    try {
+    	await meeting.participants.kickAll();
+    } catch (err) {
+    	if (err?.code === 1201) {
+    		// The participant does not have permission to end the session.
+    		// Update your UI to indicate that the action is not allowed.
+    		return;
+    	}
+    	throw err;
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="web-angular">
+
+    If the participant does not have the required permission, `kickAll()` throws a ClientError with error code `1201`.
+
+    ```ts
+    try {
+    	await meeting.participants.kickAll();
+    } catch (err) {
+    	if (err?.code === 1201) {
+    		// The participant does not have permission to end the session.
+    		// Update your UI to indicate that the action is not allowed.
+    		return;
+    	}
+    	throw err;
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+3.  Listen for the session end event.
+
+    <RTKCodeSnippet id="web-react">
+
+    When the session ends, all participants leave the session. The SDK emits a `roomLeft` event with `state` set to `ended`.
+
+    ```ts
+    meeting.self.on("roomLeft", ({ state }) => {
+    	if (state === "ended") {
+    		// Update your UI to show that the meeting session has ended.
+    	}
+    });
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="web-web-components">
+
+    When the session ends, all participants leave the session. The SDK emits a `roomLeft` event with `state` set to `ended`.
+
+    ```ts
+    meeting.self.on("roomLeft", ({ state }) => {
+    	if (state === "ended") {
+    		// Update your UI to show that the meeting session has ended.
+    	}
+    });
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="web-angular">
+
+    When the session ends, all participants leave the session. The SDK emits a `roomLeft` event with `state` set to `ended`.
+
+    ```ts
+    meeting.self.on("roomLeft", ({ state }) => {
+    	if (state === "ended") {
+    		// Update your UI to show that the meeting session has ended.
+    	}
+    });
+    ```
+
+    </RTKCodeSnippet>
+
+You can also end a session from your backend by removing all participants using the [Kick all participants](/api/resources/realtime_kit/subresources/active-session/methods/kick_all_participants/) API.
+
+<Render file="realtimekit/end-a-session-backend" product="realtime" />
+
+<Render file="realtimekit/disable-a-meeting" product="realtime" />
+
+## Next steps
+
+- Review how presets control permissions in [Preset](/realtime/realtimekit/concepts/preset/).
+- Review the possible values of the local participant room state in [Local Participant](/realtime/realtimekit/core/local-participant/#state-properties/).

--- a/src/content/docs/realtime/realtimekit/core/stage-management.mdx
+++ b/src/content/docs/realtime/realtimekit/core/stage-management.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Stage Management
 slug: realtime/realtimekit/core/stage-management
 sidebar:
-  order: 7
+  order: 8
 ---
 
 import { Tabs, TabItem } from "~/components";

--- a/src/content/docs/realtime/realtimekit/core/waiting-room.mdx
+++ b/src/content/docs/realtime/realtimekit/core/waiting-room.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Waiting Room
 slug: realtime/realtimekit/core/waiting-room
 sidebar:
-  order: 6
+  order: 7
 ---
 
 import { Tabs, TabItem } from "~/components";

--- a/src/content/partials/realtime/realtimekit/disable-a-meeting.mdx
+++ b/src/content/partials/realtime/realtimekit/disable-a-meeting.mdx
@@ -1,0 +1,18 @@
+---
+{}
+---
+
+import { APIRequest } from "~/components";
+
+## Disable a meeting
+
+Ending a session does not disable the meeting. Participants can join the meeting again and start a new session.
+To prevent participants from joining again and starting a new session, set the meeting status to `INACTIVE` using the [Update a meeting](/api/resources/realtime_kit/subresources/meetings/methods/update_meeting_by_id/) API.
+
+<APIRequest
+	path="/accounts/{account_id}/realtime/kit/{app_id}/meetings/{meeting_id}"
+	method="PATCH"
+	json={{
+		status: "INACTIVE",
+	}}
+/>

--- a/src/content/partials/realtime/realtimekit/end-a-session-backend.mdx
+++ b/src/content/partials/realtime/realtimekit/end-a-session-backend.mdx
@@ -1,0 +1,31 @@
+---
+{}
+---
+
+import { APIRequest } from "~/components";
+
+## End a session from your backend
+
+### Remove all participants with the API
+
+Use the [Kick all participants](/api/resources/realtime_kit/subresources/active-session/methods/kick_all_participants/) API method to remove all participants from an active session for a meeting.
+
+<APIRequest
+	path="/accounts/{account_id}/realtime/kit/{app_id}/meetings/{meeting_id}/active-session/kick-all"
+	method="POST"
+/>
+
+### Listen for session end events with webhooks
+
+Register a webhook that subscribes to `meeting.ended`. RealtimeKit sends this event when the session ends.
+You can use it to trigger backend workflows, such as sending a notification, generating a report, or updating session records in your database.
+
+<APIRequest
+	path="/accounts/{account_id}/realtime/kit/{app_id}/webhooks"
+	method="POST"
+	json={{
+		name: "Session ended webhook",
+		url: "<YOUR_WEBHOOK_URL>",
+		events: ["meeting.ended"],
+	}}
+/>


### PR DESCRIPTION
### Summary

This PR adds documentation on "End a session", explaining how to terminate a meeting session when using the RealtimeKit Core SDK.

NOTE: All the web code snippets for this page are the same. The code snippets for Mobile SDKs will be different and will be added to this page later by the mobile team.
