### PR TITLE
[SSL] Add SSL for SaaS section to certificate validity docs

### DIFF
--- a/src/content/docs/ssl/reference/certificate-validity-periods.mdx
+++ b/src/content/docs/ssl/reference/certificate-validity-periods.mdx
@@ -44,7 +44,7 @@ For information regarding custom certificates (managed by you), consider this ot
 
 ### SSL for SaaS
 
-For SSL for SaaS certificates, please refer to [this article](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/renew-certificates/).
+For SSL for SaaS certificates, refer to [Renew certificates](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/renew-certificates/).
 
 ## Domain control validation (DCV)
 

--- a/src/content/docs/ssl/reference/certificate-validity-periods.mdx
+++ b/src/content/docs/ssl/reference/certificate-validity-periods.mdx
@@ -42,6 +42,10 @@ For more details on the `validity_days` parameter used in API calls, refer to [O
 
 For information regarding custom certificates (managed by you), consider this other page on [renewal and expiration](/ssl/edge-certificates/custom-certificates/renewing/).
 
+### SSL for SaaS
+
+For SSL for SaaS certificates, please refer to [this article](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/renew-certificates/).
+
 ## Domain control validation (DCV)
 
 <Render file="dcv-definition" product="ssl" />


### PR DESCRIPTION
Added section for SSL for SaaS certificates with a reference link. The certificate validity for SSL for SaaS is not easy to find otherwise...
Reported by @simon-says 
