### PR TITLE
Logpush max upload paramaters clarification

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/api-configuration.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/api-configuration.mdx
@@ -243,13 +243,29 @@ Use filters to select the events to include and/or remove from your logs. For mo
 
 Value can range from `0.0` (exclusive) to `1.0` (inclusive). `sample=0.1` means `return 10% (1 in 10) of all records`. The default value is `1`, meaning logs will be unsampled.
 
-## Max Upload Parameters
+## Max upload parameters
 
-These parameters can be used to gain control of batch size in the case that a destination has specific requirements. Files will be sent based on whichever parameter is hit first. If these options are not set, the system uses our internal defaults of 30s, 100k records, or the destinations globally defined limits.
+These parameters control the size of each upload batch — not how quickly data is delivered. Use them to prevent overloading your destination with uploads that are too large or too small.
 
-1. **max_upload_bytes** (optional): The maximum uncompressed file size of a batch of logs. This setting value must be between 5 MB and 1 GB. Note that you cannot set a minimum file size; this means that log files may be much smaller than this batch size.
-2. **max_upload_records** (optional): The maximum number of log lines per batch. This setting must be between 1,000 and 1,000,000 lines. Note that you cannot specify a minimum number of log lines per batch; this means that log files may contain many fewer lines than this.
-3. **max_upload_interval_seconds** (optional): The maximum interval in seconds for log batches. This setting must be between 30 and 300 seconds. Note that you cannot specify a minimum interval for log batches; this means that log files may be sent in shorter intervals than this.
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `max_upload_bytes` | Maximum uncompressed file size of a batch of logs. | Varies by destination |
+| `max_upload_records` | Maximum number of log lines per batch. | 100,000 |
+| `max_upload_interval_seconds` | Maximum interval between log batches. | 30 |
+
+:::note
+These settings influence upload size, not delivery latency. Logpush processes data approximately once per minute, regardless of these parameter values. Adjusting these settings results in smaller or larger uploads per batch, which can help you avoid overloading destinations that have memory or request-size constraints.
+:::
+
+### When to adjust these parameters
+
+- Reduce `max_upload_records` if your destination struggles with large payloads or runs out of memory processing big batches.
+- Increase `max_upload_records` if you want fewer, larger files (for example, when pushing to object storage like R2 or S3).
+- For destinations like Datadog that have strict payload limits, Logpush automatically uses smaller batch sizes (for example, 1,000 rows).
+
+:::tip
+If you need to estimate the number of files generated for cost planning (for example, R2 write operations), run Logpush for a representative period and measure the actual output. The number of uploads depends on your data volume and cannot be precisely calculated in advance.
+:::
 
 ## Custom fields
 

--- a/src/content/docs/logs/logpush/logpush-job/api-configuration.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/api-configuration.mdx
@@ -251,7 +251,7 @@ These parameters control the size of each upload batch — not how quickly data 
 | --- | --- | --- |
 | `max_upload_bytes` | Maximum uncompressed file size of a batch of logs. | Varies by destination |
 | `max_upload_records` | Maximum number of log lines per batch. | 100,000 |
-| `max_upload_interval_seconds` | Maximum interval between log batches. | 30 |
+| `max_upload_interval_seconds` | Maximum time-span of log data per batch (used during catch-up scenarios). | Varies by destination |
 
 :::note
 These settings influence upload size, not delivery latency. Logpush processes data approximately once per minute, regardless of these parameter values. Adjusting these settings results in smaller or larger uploads per batch, which can help you avoid overloading destinations that have memory or request-size constraints.


### PR DESCRIPTION
Rewrote the max upload parameters section to better explain that these settings control upload batch size, not delivery latency. Converted parameter descriptions to a table format, added notes about Logpush's ~1 minute processing interval, and included guidance on when to adjust these parameters for different destination types.