### PR TITLE
Add docs for inheriting entry Worker config in auxiliary Workers

### DIFF
--- a/src/content/docs/workers/vite-plugin/reference/api.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/api.mdx
@@ -93,7 +93,7 @@ Auxiliary Workers require a `configPath`, a `config` option, or both.
 
   For more information about the Worker configuration, see [Configuration](/workers/wrangler/configuration/).
 
-- `config` <Type text='Partial<WorkerConfig> | ((config: WorkerConfig) => Partial<WorkerConfig> | void)' /> <MetaInfo text='optional' />
+- `config` <Type text='Partial<WorkerConfig> | ((config: WorkerConfig, entryWorkerConfig: ResolvedAssetsOnlyConfig) => Partial<WorkerConfig> | void)' /> <MetaInfo text='optional' />
 
   Customize or override Worker configuration programmatically.
   When used without `configPath`, this allows defining auxiliary Workers entirely in code.

--- a/src/content/docs/workers/vite-plugin/reference/api.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/api.mdx
@@ -32,7 +32,7 @@ It accepts an optional `PluginConfig` parameter.
 
   For more information about the Worker configuration, see [Configuration](/workers/wrangler/configuration/).
 
-- `config` <Type text='Partial<WorkerConfig> | ((config: WorkerConfig) => Partial<WorkerConfig> | void)' /> <MetaInfo text='optional' />
+- `config` <Type text='WorkerConfigCustomizer<true>' /> <MetaInfo text='optional' />
 
   Customize or override Worker configuration programmatically.
   Accepts a partial configuration object or a function that receives the current config.
@@ -93,7 +93,7 @@ Auxiliary Workers require a `configPath`, a `config` option, or both.
 
   For more information about the Worker configuration, see [Configuration](/workers/wrangler/configuration/).
 
-- `config` <Type text='Partial<WorkerConfig> | ((config: WorkerConfig, entryWorkerConfig: ResolvedAssetsOnlyConfig) => Partial<WorkerConfig> | void)' /> <MetaInfo text='optional' />
+- `config` <Type text='WorkerConfigCustomizer<false>' /> <MetaInfo text='optional' />
 
   Customize or override Worker configuration programmatically.
   When used without `configPath`, this allows defining auxiliary Workers entirely in code.

--- a/src/content/docs/workers/vite-plugin/reference/programmatic-configuration.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/programmatic-configuration.mdx
@@ -158,6 +158,33 @@ export default defineConfig({
 });
 ```
 
+### Configuration inheritance
+
+Auxiliary Workers receive the resolved entry Worker config as the second parameter to the `config` function. This makes it straightforward to inherit configuration from the entry Worker in auxiliary Workers.
+
+```ts title="vite.config.ts"
+import { defineConfig } from "vite";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({
+			auxiliaryWorkers: [
+				{
+					config: (_, entryWorkerConfig) => ({
+						name: "auxiliary-worker",
+						main: "./src/auxiliary-worker.ts",
+						// Inherit compatibility settings from entry Worker
+						compatibility_date: entryWorkerConfig.compatibility_date,
+						compatibility_flags: entryWorkerConfig.compatibility_flags,
+					}),
+				},
+			],
+		}),
+	],
+});
+```
+
 ## Configuration merging behavior
 
 The `config` option uses [defu](https://github.com/unjs/defu) for merging configuration objects.

--- a/src/content/docs/workers/vite-plugin/reference/programmatic-configuration.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/programmatic-configuration.mdx
@@ -160,7 +160,7 @@ export default defineConfig({
 
 ### Configuration inheritance
 
-Auxiliary Workers receive the resolved entry Worker config as the second parameter to the `config` function. This makes it straightforward to inherit configuration from the entry Worker in auxiliary Workers.
+Auxiliary Workers receive the resolved entry Worker config in the second parameter to the `config` function. This makes it straightforward to inherit configuration from the entry Worker in auxiliary Workers.
 
 ```ts title="vite.config.ts"
 import { defineConfig } from "vite";
@@ -171,7 +171,7 @@ export default defineConfig({
 		cloudflare({
 			auxiliaryWorkers: [
 				{
-					config: (_, entryWorkerConfig) => ({
+					config: (_, { entryWorkerConfig }) => ({
 						name: "auxiliary-worker",
 						main: "./src/auxiliary-worker.ts",
 						// Inherit compatibility settings from entry Worker


### PR DESCRIPTION
### Summary

Add docs for inheriting entry Worker config in auxiliary Workers

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
