### PR TITLE
Changelog: New duplicate action for supported Cloudflare One resources

### DIFF
--- a/src/content/changelog/cloudflare-one/2025-12-16-new-duplicate-action-for-supported-cloudflare-one-resources.mdx
+++ b/src/content/changelog/cloudflare-one/2025-12-16-new-duplicate-action-for-supported-cloudflare-one-resources.mdx
@@ -14,4 +14,4 @@ Initially supported resources:
 * Access Policies
 * Gateway Policies
 
-To try this out, simply click on the overflow menu (⋮) from the resource table and click <i>Duplicate</i>. We will be continuing to add the Duplicate action for resources throughout 2026.
+To try this out, simply click on the overflow menu (⋮) from the resource table and click <i>Duplicate</i>. We will continue to add the Duplicate action for resources throughout 2026.

--- a/src/content/changelog/cloudflare-one/2025-12-16-new-duplicate-action-for-supported-cloudflare-one-resources.mdx
+++ b/src/content/changelog/cloudflare-one/2025-12-16-new-duplicate-action-for-supported-cloudflare-one-resources.mdx
@@ -1,0 +1,16 @@
+---
+title: New duplicate action for supported Cloudflare One resources
+description: New duplicate action for supported Cloudflare One resources
+date: 2025-12-16
+products:
+  - cloudflare-one
+---
+
+You can now duplicate specific Cloudflare One resources with a single click from the dashboard!
+
+Initially supported resources:
+* Access Applications
+* Access Policies
+* Gateway Policies
+
+To try this out, simply click on the overflow menu (⋮) from the resource table and click <i>Duplicate</i>. We will be continuing to add the Duplicate action for resources throughout 2026.

--- a/src/content/changelog/cloudflare-one/2025-12-16-new-duplicate-action-for-supported-cloudflare-one-resources.mdx
+++ b/src/content/changelog/cloudflare-one/2025-12-16-new-duplicate-action-for-supported-cloudflare-one-resources.mdx
@@ -6,7 +6,8 @@ products:
   - cloudflare-one
 ---
 
-You can now duplicate specific Cloudflare One resources with a single click from the dashboard!
+You can now duplicate specific Cloudflare One resources with a single click from the dashboard.
+
 
 Initially supported resources:
 * Access Applications


### PR DESCRIPTION
This PR was generated by the Changelog Assistant.

It adds a new changelog entry for **cloudflare-one**.

- Changelog: `src/content/changelog/cloudflare-one/2025-12-16-new-duplicate-action-for-supported-cloudflare-one-resources.mdx`
- Images: None