### PR TITLE
Improve Workers AI model catalog search discoverability

### DIFF
--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -164,7 +164,16 @@ const ModelCatalog = ({ models }: { models: WorkersAIModelsSchema[] }) => {
 		}
 
 		if (filters.search) {
-			if (!model.name.toLowerCase().includes(filters.search.toLowerCase())) {
+			const searchTerm = filters.search.toLowerCase();
+			const matchesName = model.name.toLowerCase().includes(searchTerm);
+			const matchesDescription = model.description
+				.toLowerCase()
+				.includes(searchTerm);
+			const matchesTags = model.tags?.some((tag) =>
+				tag.toLowerCase().includes(searchTerm),
+			);
+
+			if (!matchesName && !matchesDescription && !matchesTags) {
 				return false;
 			}
 		}

--- a/src/content/workers-ai-models/llama-guard-3-8b.json
+++ b/src/content/workers-ai-models/llama-guard-3-8b.json
@@ -9,7 +9,12 @@
         "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
     },
     "created_at": "2025-01-22 23:26:23.495",
-    "tags": [],
+    "tags": [
+        "moderation",
+        "safety",
+        "content-filtering",
+        "guardrails"
+    ],
     "properties": [
         {
             "property_id": "context_window",

--- a/src/content/workers-ai-models/llamaguard-7b-awq.json
+++ b/src/content/workers-ai-models/llamaguard-7b-awq.json
@@ -9,7 +9,12 @@
         "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
     },
     "created_at": "2024-02-06 18:13:59.060",
-    "tags": [],
+    "tags": [
+        "moderation",
+        "safety",
+        "content-filtering",
+        "guardrails"
+    ],
     "properties": [
         {
             "property_id": "beta",


### PR DESCRIPTION
## Problem
[A user reported](https://x.com/roshfm/status/2001094698002227413) they couldn't find moderation/safety models when searching for "moderation" in the model catalog. The search only checked model names, missing relevant models like `llama-guard-3-8b` that are designed for content moderation and safety classification.

## Solution
This PR improves search discoverability by:
   1. **Expanding search scope** - Search now includes model name, description, AND tags (previously only searched model name)
   2. **Adding relevant tags** - Added tags to Llama Guard models: `["moderation", "safety", "content-filtering", "guardrails"]`

https://github.com/user-attachments/assets/80c53fe2-6bc9-4a82-8c40-1b29d77297aa

## Changes
   - **`src/components/ModelCatalog.tsx`** - Updated search filter logic to check name, description, and tags
   - **`src/content/workers-ai-models/llama-guard-3-8b.json`** - Added moderation/safety tags
   - **`src/content/workers-ai-models/llamaguard-7b-awq.json`** - Added moderation/safety tags

## Impact
 Users can now find safety/moderation models by searching:
 - "moderation"
 - "safety" 
 - "content-filtering"
 - "guardrails"
 - "classification"

> [!IMPORTANT]
> The model JSON files are generated by `bin/fetch-ai-models.js` which fetches from `https://ai-cloudflare-com.pages.dev/api/models`. The tags I added will be overwritten the next time this script runs.

**Should we:**
 1. Add tags upstream to the API source, OR
 2. Maintain a local post-processing step to add tags after fetching, OR  
 3. Some other approach?

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).