### PR TITLE
Add Scalekit to MCP authorization documentation

### DIFF
--- a/src/content/docs/agents/model-context-protocol/authorization.mdx
+++ b/src/content/docs/agents/model-context-protocol/authorization.mdx
@@ -24,7 +24,7 @@ You can use the OAuth Provider Library in three ways:
 
 1. **Your Worker handles authorization itself.** Your MCP server, running on Cloudflare, handles the complete OAuth flow. ([Example](/agents/guides/remote-mcp-server/))
 2. **Integrate directly with a third-party OAuth provider**, such as GitHub or Google.
-3. **Integrate with your own OAuth provider**, including authorization-as-a-service providers you might already rely on, such as Stytch, Auth0, or WorkOS.
+3. **Integrate with your own OAuth provider**, including authorization-as-a-service providers you might already rely on, such as Stytch, Auth0, WorkOS, or Scalekit.
 
 The following sections describe each of these options and link to runnable code examples for each.
 
@@ -174,6 +174,12 @@ Get started with a remote MCP server that uses WorkOS's AuthKit to authenticate 
 Get started with a remote MCP server that uses [Descope](https://www.descope.com/) Inbound Apps to authenticate and authorize users (for example, email, social login, SSO) to interact with their data through AI agents. Leverage Descope custom scopes to define and manage permissions for more fine-grained control.
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-server-descope-auth)
+
+#### Scalekit
+
+Get started with a remote MCP server that uses [Scalekit's MCP Auth](https://docs.scalekit.com/authenticate/mcp/overview/) to authenticate and authorize users through OAuth 2.1 with support for dynamic client registration and CIMD (Client-Initiated Metadata Discovery). Deploy a full-stack TODO application that demonstrates how to extend a traditional application for use by AI agents, with a React frontend, REST API, and MCP server all running on Cloudflare Workers.
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/mcp-scalekit-todo-list)
 
 ## Using Authentication Context in Your MCP Server
 


### PR DESCRIPTION
### Summary

Adds Scalekit as an OAuth provider option in the MCP (Model Context Protocol) authorization documentation. This update adds Scalekit alongside existing providers (Stytch, Auth0, WorkOS, Descope) and includes a description of Scalekit's MCP Auth features with a deploy button linking to the demo application.

### Screenshots 
<img width="1118" height="213" alt="Screenshot 2025-12-17 at 5 09 19 PM" src="https://github.com/user-attachments/assets/2a31fb32-90a8-4229-ac6b-f1ed5e91bd79" />


### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).

## Details

This PR adds Scalekit to the MCP authorization documentation page, following the same pattern as other OAuth providers. The changes include:

1. **Updated provider list**: Added "Scalekit" to the list of authorization-as-a-service providers in the introduction section
2. **New Scalekit section**: Added a dedicated section describing Scalekit's MCP Auth with:
   - Link to Scalekit's MCP Auth documentation
   - Description of OAuth 2.1 features (dynamic client registration, CIMD)
   - Deploy button linking to the `mcp-scalekit-todo-list` demo

The Scalekit section follows the same format and structure as the existing Stytch, Auth0, WorkOS, and Descope sections.

## Related

- Demo application: [cloudflare/ai#332](https://github.com/cloudflare/ai/pull/332) - Add mcp-scalekit-todo-list demo