### PR TITLE
DS-15385: Add SQL `HAVING` documentation to Analytics Engine SQL reference

### DIFF
--- a/src/content/changelog/workers/2025-12-17-analytics-engine-having-clause.mdx
+++ b/src/content/changelog/workers/2025-12-17-analytics-engine-having-clause.mdx
@@ -1,0 +1,41 @@
+---
+title: HAVING clause support in Workers Analytics Engine
+description: Workers Analytics Engine now supports the HAVING clause for filtering aggregated results in SQL queries
+date: 2025-12-17
+products:
+  - workers-analytics-engine
+---
+
+You can now use the `HAVING` clause in [Workers Analytics Engine](https://developers.cloudflare.com/analytics/analytics-engine/) to filter results after grouping and aggregation.
+
+Workers Analytics Engine allows you to ingest and store high-cardinality data at scale and query your data through a simple SQL API.
+
+The `HAVING` clause complements the `WHERE` clause by enabling you to filter groups based on aggregate values. While `WHERE` filters rows before aggregation, `HAVING` filters groups after aggregation is complete.
+
+## Example queries
+
+Filter groups where the average exceeds a threshold:
+
+```sql
+SELECT
+    blob1 AS probe_name,
+    avg(double1) AS average_temp
+FROM temperature_readings
+GROUP BY probe_name
+HAVING average_temp > 10
+```
+
+Filter groups based on count:
+
+```sql
+SELECT
+    blob1 AS probe_name,
+    count() AS num_readings
+FROM temperature_readings
+GROUP BY probe_name
+HAVING num_readings > 100
+```
+
+## Ready to get started?
+
+Learn more about the `HAVING` clause and other SQL capabilities in the [Workers Analytics Engine SQL reference documentation](/analytics/analytics-engine/sql-reference/statements/#having-clause).

--- a/src/content/docs/analytics/analytics-engine/sql-reference/statements.mdx
+++ b/src/content/docs/analytics/analytics-engine/sql-reference/statements.mdx
@@ -6,8 +6,9 @@ sidebar:
 head:
   - tag: title
     content: Workers Analytics Engine SQL Reference
-
 ---
+
+import { Badge } from "~/components";
 
 ## SHOW TABLES statement
 
@@ -49,6 +50,7 @@ SELECT <expression_list>
 [FROM <table>|(<subquery>)]
 [WHERE <expression>]
 [GROUP BY <expression>, ...]
+[HAVING <expression>]
 [ORDER BY <expression_list>]
 [LIMIT <n>|ALL]
 [FORMAT <format>]
@@ -131,7 +133,7 @@ Note that queries can only operate on a single table. `UNION`, `JOIN` etc. are n
 
 ### WHERE clause
 
-`WHERE` is used to filter the rows returned by a query.
+`WHERE` is used to filter the rows returned by a query before grouping and aggregation.
 
 Usage:
 
@@ -144,6 +146,8 @@ WHERE <condition>
 [Comparison operators](/analytics/analytics-engine/sql-reference/operators/#comparison-operators) can be used to compare values and [boolean operators](/analytics/analytics-engine/sql-reference/operators/#boolean-operators) can be used to combine conditions.
 
 Expressions containing functions and [operators](/analytics/analytics-engine/sql-reference/operators/#supported-operators) are supported.
+
+To filter results after grouping and aggregation, use the [`HAVING` clause](#having-clause) instead.
 
 Examples:
 
@@ -185,6 +189,51 @@ GROUP BY probe_name
 ```
 
 In the usual case the `<expression>` can just be a column name but it is also possible to supply a complex expression here. Multiple expressions or column names can be supplied separated by commas.
+
+### HAVING clause <Badge text="New" variant="tip" size="small" />
+
+`HAVING` is used to filter the results after grouping and aggregation.
+
+Usage:
+
+```sql
+HAVING <condition>
+```
+
+`<condition>` can be any expression that evaluates to a boolean, and can reference aggregate functions or grouped columns.
+
+Unlike `WHERE`, which filters rows before grouping, `HAVING` filters groups after aggregation. This allows you to filter based on aggregate values.
+
+[Comparison operators](/analytics/analytics-engine/sql-reference/operators/#comparison-operators) can be used to compare values and [boolean operators](/analytics/analytics-engine/sql-reference/operators/#boolean-operators) can be used to combine conditions.
+
+Examples:
+
+```sql
+-- filter groups where the average is greater than 10
+SELECT
+    blob1 AS probe_name,
+    avg(double1) AS average_temp
+FROM temperature_readings
+GROUP BY probe_name
+HAVING average_temp > 10
+
+-- filter groups with more than 100 readings
+SELECT
+    blob1 AS probe_name,
+    count() AS num_readings
+FROM temperature_readings
+GROUP BY probe_name
+HAVING num_readings > 100
+
+-- combine multiple conditions
+SELECT
+    blob1 AS city,
+    avg(double1) AS avg_temp,
+    count() AS readings
+FROM weather_data
+GROUP BY city
+HAVING avg_temp > 20 AND readings >= 50
+```
 
 ### ORDER BY clause
 


### PR DESCRIPTION
### Summary

Workers Analytics Engine now supports `HAVING`. It's been soft-announced already but now needs some docs and a changelog. This PR does that.

### Screenshots (optional)

<img width="591" height="701" alt="Screenshot 2025-12-17 at 15 19 51" src="https://github.com/user-attachments/assets/2a0f400c-c39a-47f1-af7b-737f02ebd571" />

<img width="512" height="751" alt="Screenshot 2025-12-17 at 15 19 59" src="https://github.com/user-attachments/assets/e16a59d0-1e50-4d60-87f5-3f2880c1e7d5" />

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).