### PR TITLE
docs: explictly say <index-name> in the wrangler vectorize command

### DIFF
--- a/src/content/docs/vectorize/reference/client-api.mdx
+++ b/src/content/docs/vectorize/reference/client-api.mdx
@@ -188,7 +188,7 @@ Get additional details about the index.
 Run the following `wrangler vectorize` command:
 
 ```sh
-wrangler vectorize info <name>
+wrangler vectorize info <index-name>
 ```
 
 ## Vectors


### PR DESCRIPTION
### Summary

The example `wrangler vectorize info` has `<name>` which could be ambiguous. To stay consistent with the rest of the docs, changing it to explicitly say `<index-name>`. 

### Screenshots (optional)

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).