### PR TITLE
Update WAF zone lockdown steps in documentation

### DIFF
--- a/src/content/docs/waf/custom-rules/use-cases/allow-traffic-from-ips-in-allowlist.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/allow-traffic-from-ips-in-allowlist.mdx
@@ -8,25 +8,36 @@ head:
 
 import { Steps } from "~/components";
 
-This example skips WAF rules for requests from IP addresses in an allowlist (defined using an [IP list](/waf/tools/lists/custom-lists/#ip-lists)).
+This example blocks incoming requests from IP addresses that are not present in an allowlist (defined using an [IP list](/waf/tools/lists/custom-lists/#ip-lists)).
 
 <Steps>
 
 1.  [Create an IP list](/waf/tools/lists/create-dashboard/) with the IP addresses for which you want to allow access.<br/>
     For example, create an IP list named `allowed_ips` with one or more IP addresses. For more information on the accepted IP address formats, refer to [IP lists](/waf/tools/lists/custom-lists/#ip-lists).
 
-2.  [Create a custom rule](/waf/custom-rules/create-dashboard/) skipping all rules for any request from the IPs in the list you created (`allowed_ips` in the current example).
-    - **Expression**: `(ip.src in $allowed_ips)`
-    - **Action**: _Skip:_
-      - _All remaining custom rules_
-      - _Skip phases_:
-        - _All rate limiting rules_
-        - _All Super Bot Fight Mode rules_
-        - _All managed rules_
+2.  [Create a custom rule](/waf/custom-rules/create-dashboard/) blocking any requests from IPs not present in the list you created (`allowed_ips` in the current example).
+    - **When incoming requests match**:
+
+      | Field             | Operator       | Value         |
+      | ----------------- | -------------- | ------------- |
+      | IP Source Address | is not in list | `allowed_ips` |
+
+      If you are using the Expression Editor:<br/>
+      `(not ip.src in $allowed_ips)`
+
+    - **Action**: _Block_
+
+3.  (Optional) Update your expression with any extra filters, like blocking non-allowlisted IPs only for specific URI paths:
+
+    | Field             | Operator       | Value         |     |
+    | ----------------- | -------------- | ------------- | --- |
+    | IP Source Address | is not in list | `allowed_ips` | And |
+    | URI Path          | wildcard       | `/admin/*`    |     |
+
+    If you are using the Expression Editor:<br/>
+    `(not ip.src in $allowed_ips and http.request.uri.path wildcard "/admin/*")`
 
 </Steps>
-
-Make sure the new rule appears before any other custom rules in the rules list.
 
 ## Other resources
 

--- a/src/content/docs/waf/custom-rules/use-cases/site-admin-only-known-ips.mdx
+++ b/src/content/docs/waf/custom-rules/use-cases/site-admin-only-known-ips.mdx
@@ -3,14 +3,21 @@ pcx_content_type: configuration
 title: Require known IP addresses in site admin area
 ---
 
-If an attack compromises the administrative area of your website, the consequences can be severe. With custom rules, you can protect your site’s admin area by blocking requests for access to admin paths that do not come from a known IP address.
+If an attack compromises the administrative area of your website, the consequences can be severe. With custom rules, you can protect your site's admin area by blocking requests for access to admin paths that do not come from a known IP address.
 
-This example custom rule limits access to the WordPress admin area, `/wp-admin/`, by blocking requests that do not originate from a specified set of IP addresses:
+This example [custom rule](/waf/custom-rules/create-dashboard/) limits access to the WordPress admin area, `/wp-admin/`, by blocking requests that do not originate from a specified set of IP addresses:
 
-- **Expression**: `(not ip.src in {10.20.30.40 192.168.1.0/24} and starts_with(lower(http.request.uri.path), "/wp-admin"))`
+- **When incoming requests match**:
+
+  | Field             | Operator  | Value                          |     |
+  | ----------------- | --------- | ------------------------------ | --- |
+  | IP Source Address | is not in | `10.20.30.40` `192.168.1.0/24` | And |
+  | URI Path          | wildcard  | `/wp-admin/*`                  |     |
+
+  If you are using the Expression Editor:<br/>
+  `(not ip.src in {10.20.30.40 192.168.1.0/24} and http.request.uri.path wildcard "/wp-admin/*")`
+
 - **Action**: _Block_
-
-To prevent attackers from successfully using a permutation of `/wp-admin/` such as `/wP-AdMiN/`, the expression uses the [`lower()`](/ruleset-engine/rules-language/functions/#lower) transformation function to convert the URI path to lowercase.
 
 ## Other resources
 

--- a/src/content/docs/waf/tools/zone-lockdown.mdx
+++ b/src/content/docs/waf/tools/zone-lockdown.mdx
@@ -47,9 +47,9 @@ The number of available zone lockdown rules depends on your Cloudflare plan.
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account and domain.
 
-2. Go to **Security** > **WAF**, and select the **Tools** tab.
+2. Go to **Security** > **Settings**.
 
-3. Under **Zone Lockdown**, select **Create lockdown rule**.
+3. Under **Zone Lockdown**, select **Create Zone Lockdown custom rule**.
 
 4. Enter a descriptive name for the rule in **Name**.
 

--- a/src/content/docs/waf/tools/zone-lockdown.mdx
+++ b/src/content/docs/waf/tools/zone-lockdown.mdx
@@ -65,9 +65,7 @@ The number of available zone lockdown rules depends on your Cloudflare plan.
 </TabItem> <TabItem label="New dashboard" icon="rocket">
 
 :::note
-
-Zone Lockdown is only available in the new security dashboard if you have configured at least one zone lockdown rule.
-
+Zone Lockdown is only available in the [new security dashboard](/security/) if you have configured at least one zone lockdown rule.
 :::
 
 **If you have access to Zone Lockdown rules**
@@ -78,7 +76,8 @@ Zone Lockdown is only available in the new security dashboard if you have config
 
    <DashButton url="/?to=/:account/:zone/security/security-rules" />
 
-2. Select **Create rule** > **Zone lockdown rules**.
+2. Select **Create rule** > **Zone lockdown rules**.<br/>
+   If this option is not available, refer to the instructions below.
 
 3. Enter a descriptive name for the rule in **Name**.
 

--- a/src/content/docs/waf/tools/zone-lockdown.mdx
+++ b/src/content/docs/waf/tools/zone-lockdown.mdx
@@ -21,13 +21,12 @@ All IP addresses not specified in the zone lockdown rule will not have access to
 
 :::note
 
-Cloudflare recommends that you create [custom rules](/waf/custom-rules/) instead of zone lockdown rules to block requests from IP addresses not present in an allowlist of IPs and CIDR ranges.
+Cloudflare recommends that you use [custom rules](/waf/custom-rules/) instead of zone lockdown rules to block requests from IP addresses not present in an allowlist of IPs and CIDR ranges.
 
-For example, a custom rule equivalent to the zone lockdown [example rule](#example-rule) provided in this page could have the following configuration:
+For examples of using custom rules for this purpose, refer to the following use cases:
 
-- **Description**: `Block all traffic to staging and wiki unless it comes from HQ or branch offices`
-- **Expression**: `((http.host eq "staging.example.com") or (http.host eq "example.com" and starts_with(http.request.uri.path, "/wiki/")) and not ip.src in {192.0.2.0/24 2001:DB8::/64 203.0.133.1}`
-- **Action**: _Block_
+- [Allow traffic from IP addresses in allowlist only](/waf/custom-rules/use-cases/allow-traffic-from-ips-in-allowlist/)
+- [Require known IP addresses in site admin area](/waf/custom-rules/use-cases/site-admin-only-known-ips/)
 
 :::
 
@@ -47,9 +46,9 @@ The number of available zone lockdown rules depends on your Cloudflare plan.
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account and domain.
 
-2. Go to **Security** > **Settings**.
+2. Go to **Security** > **WAF**, and select the **Tools** tab.
 
-3. Under **Zone Lockdown**, select **Create Zone Lockdown custom rule**.
+3. Under **Zone Lockdown**, select **Create lockdown rule**.
 
 4. Enter a descriptive name for the rule in **Name**.
 
@@ -66,8 +65,12 @@ The number of available zone lockdown rules depends on your Cloudflare plan.
 </TabItem> <TabItem label="New dashboard" icon="rocket">
 
 :::note
-Zone Lockdown is only available in the new security dashboard if you have configured at least one zone lockdown rule. Cloudflare recommends that you use [custom rules](/waf/custom-rules/) instead of zone lockdown rules.
+
+Zone Lockdown is only available in the new security dashboard if you have configured at least one zone lockdown rule.
+
 :::
+
+**If you have access to Zone Lockdown rules**
 
 <Steps>
 
@@ -86,6 +89,22 @@ Zone Lockdown is only available in the new security dashboard if you have config
 6. (Optional) If you are creating a zone lockdown rule that overlaps with an existing rule, expand **Advanced Options** and enter a priority for the rule in **Priority**. The lower the number, the higher the priority. Higher priority rules take precedence.
 
 7. Select **Save and Deploy lockdown rule**.
+
+</Steps>
+
+**If you do not have access to Zone Lockdown rules**
+
+Create a [custom rule](/waf/custom-rules/create-dashboard/) to perform zone lockdown:
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Security rules** page.
+
+   <DashButton url="/?to=/:account/:zone/security/security-rules" />
+
+2. Select **Templates**, and then select the template **Allow only specified IP addresses**.
+
+3. Fill in the required fields and select **Deploy**.
 
 </Steps>
 
@@ -145,6 +164,23 @@ The following example rule will only allow visitors connecting from a company’
   ```
 
 This example would not protect an internal wiki located on a different directory path such as `example.com/internal/wiki`.
+
+:::note
+
+A [custom rule](/waf/custom-rules/create-dashboard/) with an equivalent behavior would have the following configuration:
+
+**Description**:<br/>
+`Block all traffic to staging and wiki unless it comes from HQ or branch offices`
+
+**Expression**:
+
+```txt
+((http.host eq "staging.example.com") or (http.host eq "example.com" and http.request.uri.path wildcard "/wiki/*")) and not ip.src in {192.0.2.0/24 2001:DB8::/64 203.0.133.1}
+```
+
+**Action**: _Block_
+
+:::
 
 ## Access denied example
 


### PR DESCRIPTION
Steps to create zone lockdown rules have changed in the dashboard. Updated this section - https://developers.cloudflare.com/waf/tools/zone-lockdown/#create-a-zone-lockdown-rule

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
