### PR TITLE
fix: adjust scroll-to-top button icon size and center progress ring

### DIFF
--- a/src/styles/scroll-to-top-button.css
+++ b/src/styles/scroll-to-top-button.css
@@ -1,3 +1,15 @@
+button#scroll-to-top-button svg:not(.scroll-progress-ring) {
+	width: 20px !important;
+	height: 20px !important;
+}
+
+button#scroll-to-top-button .scroll-progress-ring {
+	transform: scale(0.85) !important;
+	left: 50% !important;
+	top: 50% !important;
+	transform: translate(-50%, -50%) scale(0.85) !important;
+}
+
 :root[data-theme="dark"] {
 	button#scroll-to-top-button {
 		background-color: var(--color-cl1-brand-orange);


### PR DESCRIPTION
### Summary

Fixed scroll-to-top button styling: reduced icon size, centered the progress ring and corrected positioning.

This addresses an issue in the upstream [ `starlight-scroll-to-top`](https://frostybee.github.io/starlight-scroll-to-top/svg-paths/) library where the button positioning was off by a few pixels and the progress ring wasn't properly centered. I had to go with CSS overrides to fix these issues

- Fixed button positioning (was a few pixels off)
- Reduced SVG icon size from 35px to 20px
- Scaled progress ring to 0.85 and centered it

### Screenshots (optional)

before:

<img width="1778" height="870" alt="image" src="https://github.com/user-attachments/assets/f2e3b85c-724a-441e-94d8-431cbef49a66" />

after:

<img width="176" height="199" alt="image" src="https://github.com/user-attachments/assets/6898d36c-e117-460d-83b6-568abef9ef9a" />

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.

- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).