### PR TITLE
Add 'content-engineering' team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,17 +4,17 @@
 
 # More dev-specific files
 
-/.github/ @cloudflare/pcx-content-engineering @kodster28
-/.github/CODEOWNERS @cloudflare/pcx-technical-writing @kodster28
+/.github/ @cloudflare/pcx-content-engineering @cloudflare/content-engineering @kodster28
+/.github/CODEOWNERS @cloudflare/pcx-technical-writing @cloudflare/content-engineering @kodster28
 /.github/actions/assign-pr/index.js @cloudflare/pcx-technical-writing @kodster28
-/src/components/ @cloudflare/pcx-content-engineering @kodster28
-*.js @cloudflare/pcx-content-engineering @kodster28
-*.ts @cloudflare/pcx-content-engineering @kodster28
-*.astro @cloudflare/pcx-content-engineering @kodster28
-/src/schemas/tags.ts @cloudflare/pcx-content-engineering @kodster28
-/src/util/api.ts @cloudflare/pcx-content-engineering @pedrosousa @kodster28
-/src/content/workers-ai-models/ @craigsdennis @cloudflare/pcx-content-engineering @cloudflare/pcx-technical-writing @kodster28
-/public/__redirects @cloudflare/pcx-content-engineering @cloudflare/pcx-technical-writing
+/src/components/ @cloudflare/pcx-content-engineering @cloudflare/content-engineering @kodster28
+*.js @cloudflare/pcx-content-engineering @cloudflare/content-engineering @kodster28
+*.ts @cloudflare/pcx-content-engineering @cloudflare/content-engineering @kodster28
+*.astro @cloudflare/pcx-content-engineering @cloudflare/content-engineering @kodster28
+/src/schemas/tags.ts @cloudflare/pcx-content-engineering @cloudflare/content-engineering @kodster28
+/src/util/api.ts @cloudflare/pcx-content-engineering @cloudflare/content-engineering @pedrosousa @kodster28
+/src/content/workers-ai-models/ @craigsdennis @cloudflare/pcx-content-engineering @cloudflare/content-engineering @cloudflare/pcx-technical-writing @kodster28
+/public/__redirects @cloudflare/pcx-content-engineering @cloudflare/content-engineering @cloudflare/pcx-technical-writing
 
 
 # AI


### PR DESCRIPTION
We'll shortly remove the `pcx-content-engineering` team... just want to make sure we don't bork anything first.
