### PR TITLE
[Pages] Add Cloudflare Images integration guide reference

### DIFF
--- a/src/content/docs/pages/framework-guides/nextjs/index.mdx
+++ b/src/content/docs/pages/framework-guides/nextjs/index.mdx
@@ -10,3 +10,5 @@ description: React framework for building full-stack web applications.
 If you want to deploy a full stack Server Side Rendered Next.js application please refer to the [Next.js Workers guide](/workers/framework-guides/web-apps/nextjs).
 
 To instead deploy a static Next.js site using Pages see the [static Next.js Pages guide](/pages/framework-guides/nextjs/deploy-a-static-nextjs-site).
+
+If you want to integrate with Cloudflare Images, see the [Images integration guide](/images/transform-images/integrate-with-frameworks/#nextjs).


### PR DESCRIPTION
Added a reference to the Images integration guide for Next.js.

### Summary

Adds a reference to the Cloudflare Images integration guide which was otherwise orphaned from the Next.js specific documentation.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
