### PR TITLE
docs: add `wrangler auth token` command documentation

### DIFF
--- a/src/content/changelog/workers/2025-12-18-wrangler-auth-token.mdx
+++ b/src/content/changelog/workers/2025-12-18-wrangler-auth-token.mdx
@@ -20,4 +20,17 @@ Use the `--json` flag to get structured output including the token type:
 wrangler auth token --json
 ```
 
-This also enables retrieving API key/email credentials from `CLOUDFLARE_API_KEY` and `CLOUDFLARE_EMAIL`, which requires the `--json` flag since this method uses two values instead of a single token.
+The JSON output includes the authentication type:
+
+```jsonc
+// API token
+{ "type": "api_token", "token": "..." }
+
+// OAuth token
+{ "type": "oauth", "token": "..." }
+
+// API key/email (only available with --json)
+{ "type": "api_key", "key": "...", "email": "..." }
+```
+
+API key/email credentials from `CLOUDFLARE_API_KEY` and `CLOUDFLARE_EMAIL` require the `--json` flag since this method uses two values instead of a single token.

--- a/src/content/changelog/workers/2025-12-18-wrangler-auth-token.mdx
+++ b/src/content/changelog/workers/2025-12-18-wrangler-auth-token.mdx
@@ -1,0 +1,23 @@
+---
+title: Retrieve your authentication token with `wrangler auth token`
+description: A new command to retrieve your current authentication credentials for use with other tools and scripts.
+products:
+  - workers
+date: 2025-12-18
+---
+
+Wrangler now includes a new [`wrangler auth token`](/workers/wrangler/commands/#auth-token) command that retrieves your current authentication token or credentials for use with other tools and scripts.
+
+```sh
+wrangler auth token
+```
+
+The command returns whichever authentication method is currently configured, in priority order: API token from `CLOUDFLARE_API_TOKEN`, or OAuth token from `wrangler login` (automatically refreshed if expired).
+
+Use the `--json` flag to get structured output including the token type:
+
+```sh
+wrangler auth token --json
+```
+
+This also enables retrieving API key/email credentials from `CLOUDFLARE_API_KEY` and `CLOUDFLARE_EMAIL`, which requires the `--json` flag since this method uses two values instead of a single token.

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -691,7 +691,9 @@ If you are using `CLOUDFLARE_API_TOKEN` instead of OAuth, and you can logout by 
 
 ---
 
-## `auth token`
+## `auth`
+
+### `auth token`
 
 Retrieve your current authentication token or credentials for use with other tools and scripts.
 
@@ -702,10 +704,10 @@ wrangler auth token [OPTIONS]
 - `--json` <Type text="boolean" /> <MetaInfo text="optional" />
   - Return output as JSON with token type information. This also enables retrieving API key/email credentials.
 
-The command returns whichever authentication method is currently configured:
+The command returns whichever authentication method is currently configured, in the following order of precedence:
 - API token from `CLOUDFLARE_API_TOKEN` environment variable
-- OAuth token from `wrangler login` (automatically refreshed if expired)
 - API key/email from `CLOUDFLARE_API_KEY` and `CLOUDFLARE_EMAIL` environment variables (requires `--json` flag, since this method uses two values instead of a single token)
+- OAuth token from `wrangler login` (automatically refreshed if expired)
 
 When using `--json`, the output includes the token type:
 
@@ -720,7 +722,7 @@ When using `--json`, the output includes the token type:
 { "type": "api_key", "key": "...", "email": "..." }
 ```
 
-This allows you to easily retrieve your authentication token without having to manually locate the config file or handle token refresh.
+An error is returned if no authentication method is available, or if API key/email is requested without `--json`.
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -705,6 +705,7 @@ wrangler auth token [OPTIONS]
 The command returns whichever authentication method is currently configured:
 - API token from `CLOUDFLARE_API_TOKEN` environment variable
 - OAuth token from `wrangler login` (automatically refreshed if expired)
+- API key/email from `CLOUDFLARE_API_KEY` and `CLOUDFLARE_EMAIL` environment variables (requires `--json` flag, since this method uses two values instead of a single token)
 
 When using `--json`, the output includes the token type:
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -722,7 +722,7 @@ When using `--json`, the output includes the token type:
 { "type": "api_key", "key": "...", "email": "..." }
 ```
 
-An error is returned if no authentication method is available, or if API key/email is requested without `--json`.
+An error is returned if no authentication method is available, or if API key/email is configured without `--json`.
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -49,6 +49,7 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 - [`queues`](#queues) - Configure Workers Queues.
 - [`login`](#login) - Authorize Wrangler with your Cloudflare account using OAuth.
 - [`logout`](#logout) - Remove Wrangler's authorization for accessing your account.
+- [`auth token`](#auth-token) - Retrieve your current authentication token or credentials.
 - [`whoami`](#whoami) - Retrieve your user information and test your authentication configuration.
 - [`versions`](#versions) - Retrieve details for recent versions.
 - [`deployments`](#deployments) - Retrieve details for recent deployments.
@@ -687,6 +688,40 @@ If you are using `CLOUDFLARE_API_TOKEN` instead of OAuth, and you can logout by 
 
 2. Select the three-dot menu on your Wrangler token.
 3. Select **Delete**.
+
+---
+
+## `auth token`
+
+Retrieve your current authentication token or credentials for use with other tools and scripts.
+
+```txt
+wrangler auth token [OPTIONS]
+```
+
+- `--json` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Return output as JSON with token type information. This also enables retrieving API key/email credentials.
+
+The command returns whichever authentication method is currently configured:
+- OAuth token from `wrangler login` (automatically refreshed if expired)
+- API token from `CLOUDFLARE_API_TOKEN` environment variable
+
+When using `--json`, the output includes the token type:
+
+```json
+// OAuth token
+{ "type": "oauth", "token": "..." }
+
+// API token
+{ "type": "api_token", "token": "..." }
+
+// API key/email (only available with --json)
+{ "type": "api_key", "key": "...", "email": "..." }
+```
+
+This is similar to `gh auth token` in the GitHub CLI and allows you to easily retrieve your authentication token without having to manually locate the config file or handle token refresh.
+
+<Render file="wrangler-commands/global-flags" product="workers" />
 
 ---
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -703,23 +703,23 @@ wrangler auth token [OPTIONS]
   - Return output as JSON with token type information. This also enables retrieving API key/email credentials.
 
 The command returns whichever authentication method is currently configured:
-- OAuth token from `wrangler login` (automatically refreshed if expired)
 - API token from `CLOUDFLARE_API_TOKEN` environment variable
+- OAuth token from `wrangler login` (automatically refreshed if expired)
 
 When using `--json`, the output includes the token type:
 
-```json
-// OAuth token
-{ "type": "oauth", "token": "..." }
-
+```jsonc
 // API token
 { "type": "api_token", "token": "..." }
+
+// OAuth token
+{ "type": "oauth", "token": "..." }
 
 // API key/email (only available with --json)
 { "type": "api_key", "key": "...", "email": "..." }
 ```
 
-This is similar to `gh auth token` in the GitHub CLI and allows you to easily retrieve your authentication token without having to manually locate the config file or handle token refresh.
+This allows you to easily retrieve your authentication token without having to manually locate the config file or handle token refresh.
 
 <Render file="wrangler-commands/global-flags" product="workers" />
 


### PR DESCRIPTION
### Summary

Adds documentation for the new `wrangler auth token` command being added in cloudflare/workers-sdk#11682. This command retrieves the current authentication token or credentials for use with other tools and scripts, similar to `gh auth token` in the GitHub CLI.

The documentation covers:
- Basic command usage
- The `--json` flag for structured output with token type information
- Support for all three Wrangler authentication methods (OAuth, API token, API key/email)

**Note:** This PR should be merged after cloudflare/workers-sdk#11682 is merged.

---

Devin PR requested by mkane@cloudflare.com

Link to Devin run: https://app.devin.ai/sessions/d407c26dd1da4edf905944a95e90226a

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).