### PR TITLE
Update docs for auxiliary Workers in Vite plugin

### DIFF
--- a/src/content/changelog/workers/2026-01-20-auxiliary-workers.mdx
+++ b/src/content/changelog/workers/2026-01-20-auxiliary-workers.mdx
@@ -1,0 +1,32 @@
+---
+title: Use auxiliary Workers alongside full-stack frameworks
+description: Auxiliary Workers are now fully supported when using full-stack frameworks with the Cloudflare Vite plugin
+products:
+  - workers
+date: 2026-01-20
+---
+
+Auxiliary Workers are now fully supported when using full-stack frameworks, such as [React Router](/workers/framework-guides/web-apps/react-router/) and [TanStack Start](/workers/framework-guides/web-apps/tanstack-start/), that integrate with the [Cloudflare Vite plugin](/workers/vite-plugin/reference/api/).
+They are included alongside the framework's build output in the build output directory.
+Note that this feature requires Vite 7 or above.
+
+Auxiliary Workers are additional Workers that can be called via [service bindings](/workers/runtime-apis/bindings/service-bindings/) from your main (entry) Worker.
+They are defined in the plugin config, as in the example below:
+
+```ts title="vite.config.ts"
+import { defineConfig } from "vite";
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+	plugins: [
+		tanstackStart(),
+		cloudflare({
+			viteEnvironment: { name: "ssr" },
+			auxiliaryWorkers: [{ configPath: "./wrangler.aux.jsonc" }],
+		}),
+	],
+});
+```
+
+See the Vite plugin [API docs](/workers/vite-plugin/reference/api/) for more info.

--- a/src/content/docs/workers/vite-plugin/reference/api.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/api.mdx
@@ -73,10 +73,6 @@ It accepts an optional `PluginConfig` parameter.
   During the build, each Worker is output to a separate subdirectory of `dist`.
 
   :::note
-  Auxiliary Workers are not currently supported when using [React Router](https://reactrouter.com/) as a framework.
-  :::
-
-  :::note
   When running `wrangler deploy`, only your main (entry) Worker will be deployed.
   If using multiple Workers, each auxiliary Worker must be deployed individually.
   You can inspect the `dist` directory and then run `wrangler deploy -c dist/<auxiliary-worker>/wrangler.json` for each.


### PR DESCRIPTION
### Summary

Remove caveat about auxiliary Workers in Vite plugin API docs and add changelog entry.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
