### PR TITLE
clarifies currently ambigious attempts field of queue message

### DIFF
--- a/src/content/docs/queues/configuration/batching-retries.mdx
+++ b/src/content/docs/queues/configuration/batching-retries.mdx
@@ -308,7 +308,7 @@ Messages can be delayed by default at the queue level, or per-message (or batch)
 
 You can apply a backoff algorithm to increasingly delay messages based on the current number of attempts to deliver the message.
 
-Each message delivered to a consumer includes an `attempts` property that tracks the number of delivery attempts made.
+Each message delivered to a consumer includes an `attempts` property that tracks the number of delivery attempts made (including the current attempt).
 
 For example, to generate an [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) for a message, you can create a helper function that calculates this for you:
 


### PR DESCRIPTION
Currently, the attempts field is quickly misinterpreted to represent all previous attempts, making every message start at 0 and count up from there. 

The change is minimal and eliminates this ambiguity, making clear that messages start from one, meaning it includes the current attempt.

### Summary

Add "(including the current attempt)" behind the existing sentence.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
