### PR TITLE
add opencode.jsonc

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "default_agent": "docs"
+}


### PR DESCRIPTION
Adds a project level config + sets the default agent to our own “docs” agent for anyone opening opencode in this repo.

Ensures that people start off in the right mode.

Needs opencode version newer than v1.0.180 so will leave in draft for a bit until users catch up.