### PR TITLE
Removed beta flag for DNS Protection and added DDoS documentation links

### DIFF
--- a/src/content/docs/magic-transit/ddos.mdx
+++ b/src/content/docs/magic-transit/ddos.mdx
@@ -9,10 +9,10 @@ head:
 
 ---
 
-Cloudflare DDoS protection automatically detects and mitigates Distributed Denial of Service (DDoS) attacks using its Autonomous Edge. With Magic Transit, you have access to additional features, such as:
+Cloudflare DDoS protection automatically detects and mitigates Distributed Denial of Service (DDoS) attacks using its [Autonomous Edge](/ddos-protection/about/components/#autonomous-edge). With Magic Transit, you have access to additional [Advanced DDoS mitigation systems](/ddos-protection/advanced-ddos-systems/overview/), such as:
 
-- [Advanced TCP protection](/ddos-protection/advanced-ddos-systems/overview/advanced-tcp-protection/) (disabled by default)
-- [Advanced DNS protection (beta)](/ddos-protection/advanced-ddos-systems/overview/advanced-dns-protection/)
+- [Advanced TCP protection](/ddos-protection/advanced-ddos-systems/overview/advanced-tcp-protection/)
+- [Advanced DNS protection](/ddos-protection/advanced-ddos-systems/overview/advanced-dns-protection/)
 
 Refer to [Cloudflare DDoS documentation](/ddos-protection/) for more information.
 


### PR DESCRIPTION
Removed 'beta' from DNS Protection.
Updated DDoS protection section to include links for Autonomous Edge and Advanced DDoS mitigation systems.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
