### PR TITLE
Add docs for SQL default module rule

### DIFF
--- a/src/content/changelog/workers/2026-01-20-sql-module-rule.mdx
+++ b/src/content/changelog/workers/2026-01-20-sql-module-rule.mdx
@@ -1,0 +1,17 @@
+---
+title: Import SQL files as additional modules by default
+description: The `.sql` file extension is now automatically configured to be importable in your Worker code
+products:
+  - workers
+date: 2026-01-20
+---
+
+The `.sql` file extension is now automatically configured to be importable in your Worker code when using [Wrangler](/workers/wrangler/bundling/#including-non-javascript-modules) or the [Cloudflare Vite plugin](/workers/vite-plugin/reference/non-javascript-modules/).
+This is particular useful for importing migrations in Durable Objects and means you no longer need to configure custom rules when using [Drizzle](https://orm.drizzle.team/docs/connect-cloudflare-do).
+
+SQL files are imported as JavaScript strings:
+
+```ts
+// `example` will be a JavaScript string
+import example from "./example.sql";
+```

--- a/src/content/docs/workers/vite-plugin/reference/non-javascript-modules.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/non-javascript-modules.mdx
@@ -1,0 +1,47 @@
+---
+pcx_content_type: reference
+title: Non-JavaScript modules
+sidebar:
+  order: 10
+description: Additional module types that can be imported in your Worker
+---
+
+{/* Changes to this section should also be applied to /workers/wrangler/bundling */}
+
+In addition to TypeScript and JavaScript, the following module types are automatically configured to be importable in your Worker code.
+
+| Module extension        | Imported type        |
+| ----------------------- | -------------------- |
+| `.txt`                  | `string`             |
+| `.html`                 | `string`             |
+| `.sql`                  | `string`             |
+| `.bin`                  | `ArrayBuffer`        |
+| `.wasm`, `.wasm?module` | `WebAssembly.Module` |
+
+For example, with the following import, `text` will be a string containing the contents of `example.txt`:
+
+```js
+import text from "./example.txt";
+```
+
+This is also the basis for importing Wasm, as in the following example:
+
+```ts
+import wasm from "./example.wasm";
+
+// Instantiate Wasm modules in the module scope
+const instance = await WebAssembly.instantiate(wasm);
+
+export default {
+	fetch() {
+		const result = instance.exports.exported_func();
+
+		return new Response(result);
+	},
+};
+```
+
+:::caution
+
+Cloudflare Workers does not support `WebAssembly.instantiateStreaming()`.
+:::

--- a/src/content/docs/workers/vite-plugin/reference/non-javascript-modules.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/non-javascript-modules.mdx
@@ -41,7 +41,7 @@ export default {
 };
 ```
 
-:::caution
+:::note
 
 Cloudflare Workers does not support `WebAssembly.instantiateStreaming()`.
 :::

--- a/src/content/docs/workers/vite-plugin/reference/programmatic-configuration.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/programmatic-configuration.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: reference
 title: Programmatic configuration
 sidebar:
-  order: 10
+  order: 11
 description: Configure Workers programmatically using the Vite plugin
 ---
 

--- a/src/content/docs/workers/wrangler/bundling.mdx
+++ b/src/content/docs/workers/wrangler/bundling.mdx
@@ -26,10 +26,11 @@ Furthermore, we have an escape hatch in the form of [Custom Builds](/workers/wra
 Bundling your Worker code takes multiple modules and bundles them into one file.
 Sometimes, you might have modules that cannot be inlined directly into the bundle.
 For example, instead of bundling a Wasm file into your JavaScript Worker, you would want to upload the Wasm file as a separate module that can be imported at runtime.
-Wrangler supports this for the following file types:
+Wrangler supports this by default for the following file types:
 
 - `.txt`
 - `.html`
+- `.sql`
 - `.bin`
 - `.wasm` and `.wasm?module`
 

--- a/src/content/docs/workers/wrangler/bundling.mdx
+++ b/src/content/docs/workers/wrangler/bundling.mdx
@@ -23,34 +23,42 @@ Furthermore, we have an escape hatch in the form of [Custom Builds](/workers/wra
 
 ## Including non-JavaScript modules
 
+{/* Changes to this section should also be applied to /workers/vite-plugin/reference/non-javascript-modules */}
+
 Bundling your Worker code takes multiple modules and bundles them into one file.
 Sometimes, you might have modules that cannot be inlined directly into the bundle.
 For example, instead of bundling a Wasm file into your JavaScript Worker, you would want to upload the Wasm file as a separate module that can be imported at runtime.
 Wrangler supports this by default for the following file types:
 
-- `.txt`
-- `.html`
-- `.sql`
-- `.bin`
-- `.wasm` and `.wasm?module`
+| Module extension        | Imported type        |
+| ----------------------- | -------------------- |
+| `.txt`                  | `string`             |
+| `.html`                 | `string`             |
+| `.sql`                  | `string`             |
+| `.bin`                  | `ArrayBuffer`        |
+| `.wasm`, `.wasm?module` | `WebAssembly.Module` |
 
 Refer to [Bundling configuration](/workers/wrangler/configuration/#bundling) to customize these file types.
 
-For example, with the following import, the variable `data` will be a string containing the contents of `example.html`:
+For example, with the following import, `text` will be a string containing the contents of `example.txt`:
 
 ```js
-import data from "./example.html"; // Where `example.html` is a file in your local directory
+import text from "./example.txt";
 ```
 
-This is also the basis of Wasm support with Wrangler. To use a Wasm module in a Worker developed with Wrangler, add the following to your Worker:
+This is also the basis for importing Wasm, as in the following example:
 
-```js
-import wasm from "./example.wasm"; // Where `example.wasm` is a file in your local directory
-const instance = await WebAssembly.instantiate(wasm); // Instantiate Wasm modules in global scope, not within the fetch() handler
+```ts
+import wasm from "./example.wasm";
+
+// Instantiate Wasm modules in the module scope
+const instance = await WebAssembly.instantiate(wasm);
 
 export default {
-	fetch(request) {
+	fetch() {
 		const result = instance.exports.exported_func();
+
+		return new Response(result);
 	},
 };
 ```

--- a/src/content/docs/workers/wrangler/bundling.mdx
+++ b/src/content/docs/workers/wrangler/bundling.mdx
@@ -63,7 +63,7 @@ export default {
 };
 ```
 
-:::caution
+:::note
 
 Cloudflare Workers does not support `WebAssembly.instantiateStreaming()`.
 :::


### PR DESCRIPTION
### Summary

Adds docs and changelog entry for SQL default module rule.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
