### PR TITLE
[Turnstile] add create account link to get started

### DIFF
--- a/src/content/docs/turnstile/get-started/index.mdx
+++ b/src/content/docs/turnstile/get-started/index.mdx
@@ -13,7 +13,7 @@ This guide will get you started on setting up the Turnstile widget to protect yo
 
 Before you begin, you must have:
 
-- A Cloudflare account
+- [A Cloudflare account](/fundamentals/account/create-account/)
 - A website or web application to protect
 - Basic knowledge of HTML and your preferred server-side language
 


### PR DESCRIPTION
### Summary

Adds a link to Fundamentals' Create Account page from Turnstile Get started prereqs

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
