### PR TITLE
Change data type of cf.bot_management.static_resource and cf.edge.server_port

### DIFF
--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -552,7 +552,7 @@ entries:
       Requires a Cloudflare Enterprise plan with [Bot Management](/bots/plans/bm-subscription/) enabled.
 
   - name: cf.bot_management.static_resource
-    data_type: Number
+    data_type: Boolean
     categories: [Request, Bots]
     keywords: [request, bots, client, visitor]
     plan_info_label: Enterprise add-on

--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -625,7 +625,7 @@ entries:
       This field is only meaningful for [BYOIP customers](/byoip/).
 
   - name: cf.edge.server_port
-    data_type: IP address
+    data_type: Number
     categories: [Request]
     keywords: [request, cloudflare, client, visitor]
     summary: Represents the port number at which the Cloudflare global network received the request.


### PR DESCRIPTION
### Summary

Various examples show `cf.bot_management.static_resource` to be used as a boolean variable:

```
not cf.bot_management.verified_bot
and not cf.bot_management.static_resource
and not  cf.bot_management.corporate_proxy
and cf.bot_management.score lt 30
```

The type for `cf.edge.server_port` is updated to be a number. It was an IP address, but a port is not an IP address.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
