### PR TITLE
docs(realtimekit): add waiting room reference for mobile platforms

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/waiting-room.mdx
+++ b/src/content/docs/realtime/realtimekit/core/waiting-room.mdx
@@ -6,7 +6,8 @@ sidebar:
   order: 7
 ---
 
-import { Tabs, TabItem } from "~/components";
+import RTKSDKSelector from "~/components/realtimekit/RTKSDKSelector/RTKSDKSelector.astro";
+import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnippet.astro";
 
 The waiting room feature allows hosts to control who can join a meeting. When enabled, participants must wait for approval before entering the meeting.
 
@@ -35,7 +36,7 @@ The diagram below represents only waiting room-related states. The `roomState` p
         join()
           ↓
     [waitlisted]  ←------ (host rejects)
-          ↓                      ↓
+          ↓                     ↓
    (host accepts)           [rejected]
           ↓
       [joined]
@@ -43,64 +44,13 @@ The diagram below represents only waiting room-related states. The `roomState` p
 
 ## Listening to State Changes
 
-<Tabs syncKey="realtimeKitFrameworkTabs">
-<TabItem label="Web Components">
+<RTKSDKSelector />
 
 ### Joined Event
 
-Triggered when the local user successfully joins the meeting:
+Triggered when the local user successfully joins the meeting.
 
-```js
-meeting.self.on("roomJoined", () => {
-	// Local user is in the meeting
-	console.log("Successfully joined the meeting");
-});
-```
-
-### Waitlisted Event
-
-Triggered when the local user is placed in the waiting room:
-
-```js
-meeting.self.on("waitlisted", () => {
-	// Local user is waitlisted
-	console.log("You are in the waiting room. Waiting for host approval...");
-});
-```
-
-### Rejected Event
-
-Triggered when the host rejects the entry request:
-
-```js
-meeting.self.on("roomLeft", ({ state }) => {
-	if (state === "rejected") {
-		// Host rejected the entry
-		console.log("Your entry request was rejected");
-	}
-});
-```
-
-### Monitor State with roomState
-
-You can also directly check the current room state:
-
-```js
-const currentState = meeting.self.roomState;
-
-if (currentState === "waitlisted") {
-	console.log("Waiting for approval");
-} else if (currentState === "joined") {
-	console.log("In the meeting");
-} else if (currentState === "rejected") {
-	console.log("Entry was rejected");
-}
-```
-
-</TabItem>
-<TabItem label="React">
-
-### Joined Event
+<RTKCodeSnippet id="web-react">
 
 Monitor when the local user joins the meeting:
 
@@ -142,7 +92,107 @@ useEffect(() => {
 }, [meeting]);
 ```
 
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="web-web-components">
+
+```js
+meeting.self.on("roomJoined", () => {
+	// Local user is in the meeting
+	console.log("Successfully joined the meeting");
+});
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+meeting.addMeetingRoomEventListener(object : RtkMeetingRoomEventListener {
+	override fun onMeetingRoomJoinCompleted(meeting: RealtimeKitClient) {
+		// Local user is in the meeting
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkMeetingRoomEventListener {
+	func onMeetingRoomJoinCompleted(meeting: RealtimeKitClient) {
+		// Local user is in the meeting
+	}
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class MeetingRoomNotifier extends RtkMeetingRoomEventListener {
+	@override
+	void onMeetingRoomJoinCompleted() {
+		// Local user is in the meeting
+	}
+}
+
+meeting.addMeetingRoomEventListener(MeetingRoomNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Monitor when the local user joins the meeting:
+
+```tsx
+import { useRealtimeKitSelector } from "@cloudflare/realtimekit-react-native";
+import { useEffect } from "react";
+
+function MeetingStatus() {
+	const roomState = useRealtimeKitSelector((m) => m.self.roomState);
+	const joined = roomState === "joined";
+
+	useEffect(() => {
+		if (joined) {
+			console.log("Successfully joined the meeting");
+		}
+	}, [joined]);
+
+	return joined ? <Text>You are in the meeting</Text> : null;
+}
+```
+
+Alternatively, use event listeners:
+
+```tsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react-native";
+
+useEffect(() => {
+	if (!meeting) return;
+
+	const handleRoomJoined = () => {
+		console.log("Successfully joined the meeting");
+	};
+
+	meeting.self.on("roomJoined", handleRoomJoined);
+
+	return () => {
+		meeting.self.off("roomJoined", handleRoomJoined);
+	};
+}, [meeting]);
+```
+
+</RTKCodeSnippet>
+
 ### Waitlisted Event
+
+Triggered when the local user is placed in the waiting room.
+
+<RTKCodeSnippet id="web-react">
 
 Monitor when the local user is in the waiting room:
 
@@ -179,7 +229,130 @@ useEffect(() => {
 }, [meeting]);
 ```
 
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="web-web-components">
+
+```js
+meeting.self.on("waitlisted", () => {
+	// Local user is waitlisted
+	console.log("You are in the waiting room. Waiting for host approval...");
+});
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+meeting.addSelfEventListener(object : RtkSelfEventListener {
+	override fun onWaitListStatusUpdate(waitListStatus: WaitListStatus) {
+		when (waitListStatus) {
+			WAITING -> {
+				// Local user is in the waiting room
+			}
+			REJECTED -> {
+				// Local user's join room request was rejected by the host
+			}
+			NONE, ACCEPTED -> {
+				// Local user is not in the wait list or was already accepted
+			}
+		}
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkSelfEventListener {
+	func onWaitListStatusUpdate(waitListStatus: WaitListStatus) {
+		switch waitListStatus {
+		case .accepted:
+			// Local user's join room request was accepted by the host
+		case .waiting:
+			// Local user is in the waiting room
+		case .rejected:
+			// Local user's join room request was rejected by the host
+		default:
+			return .none
+		}
+	}
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class WaitingRoomNotifier extends RtkSelfEventListener {
+	@override
+	void onWaitListStatusUpdate(WaitlistStatus waitListStatus) {
+		switch (waitListStatus) {
+			case WaitlistStatus.waiting:
+			// Local user is in the waiting room
+			case WaitlistStatus.rejected:
+			// Local user's join room request was rejected by the host
+			case WaitlistStatus.accepted:
+			// Local user's join room request was accepted by the host
+			default:
+				break;
+		}
+	}
+}
+
+meeting.addSelfEventListener(WaitingRoomNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Monitor when the local user is in the waiting room:
+
+```tsx
+function WaitingRoomStatus() {
+	const roomState = useRealtimeKitSelector((m) => m.self.roomState);
+	const isWaitlisted = roomState === "waitlisted";
+
+	useEffect(() => {
+		if (isWaitlisted) {
+			console.log("You are in the waiting room");
+		}
+	}, [isWaitlisted]);
+
+	return isWaitlisted ? <Text>Waiting for host approval...</Text> : null;
+}
+```
+
+Alternatively, use event listeners:
+
+```tsx
+useEffect(() => {
+	if (!meeting) return;
+
+	const handleWaitlisted = () => {
+		console.log("You are in the waiting room");
+	};
+
+	meeting.self.on("waitlisted", handleWaitlisted);
+
+	return () => {
+		meeting.self.off("waitlisted", handleWaitlisted);
+	};
+}, [meeting]);
+```
+
+</RTKCodeSnippet>
+
 ### Rejected Event
+
+Triggered when the host rejects the entry request.
+
+<RTKCodeSnippet id="web-react">
 
 Monitor when the host rejects the entry request:
 
@@ -218,7 +391,147 @@ useEffect(() => {
 }, [meeting]);
 ```
 
-### Comprehensive State Handler
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="web-web-components">
+
+```js
+meeting.self.on("roomLeft", ({ state }) => {
+	if (state === "rejected") {
+		// Host rejected the entry
+		console.log("Your entry request was rejected");
+	}
+});
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+When the host rejects the entry request, the `onWaitListStatusUpdate` callback is triggered with `WaitListStatus.REJECTED`:
+
+```kotlin
+meeting.addSelfEventListener(object : RtkSelfEventListener {
+	override fun onWaitListStatusUpdate(waitListStatus: WaitListStatus) {
+		when (waitListStatus) {
+			WaitListStatus.REJECTED -> {
+				// Local user's join room request was rejected by the host
+				Log.d("WaitingRoom", "Your entry request was rejected")
+			}
+			WaitListStatus.WAITING -> {
+				// Local user is in the waiting room
+			}
+			WaitListStatus.ACCEPTED, WaitListStatus.NONE -> {
+				// Local user was accepted or not in waitlist
+			}
+		}
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+When the host rejects the entry request, the `onWaitListStatusUpdate` callback is triggered with `WaitListStatus.rejected`:
+
+```swift
+extension MeetingViewModel: RtkSelfEventListener {
+	func onWaitListStatusUpdate(waitListStatus: WaitListStatus) {
+		switch waitListStatus {
+		case .rejected:
+			// Local user's join room request was rejected by the host
+			print("Your entry request was rejected")
+		case .waiting:
+			// Local user is in the waiting room
+			break
+		case .accepted:
+			// Local user's join room request was accepted by the host
+			break
+		default:
+			break
+		}
+	}
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+When the host rejects the entry request, the `onWaitListStatusUpdate` callback is triggered with `WaitlistStatus.rejected`:
+
+```dart
+class WaitingRoomNotifier extends RtkSelfEventListener {
+	@override
+	void onWaitListStatusUpdate(WaitlistStatus waitListStatus) {
+		switch (waitListStatus) {
+			case WaitlistStatus.rejected:
+				// Local user's join room request was rejected by the host
+				print("Your entry request was rejected");
+			case WaitlistStatus.waiting:
+				// Local user is in the waiting room
+				break;
+			case WaitlistStatus.accepted:
+				// Local user's join room request was accepted by the host
+				break;
+			default:
+				break;
+		}
+	}
+}
+
+meeting.addSelfEventListener(WaitingRoomNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Monitor when the host rejects the entry request:
+
+```tsx
+function RejectionStatus() {
+	const roomState = useRealtimeKitSelector((m) => m.self.roomState);
+	const rejected = roomState === "rejected";
+
+	useEffect(() => {
+		if (rejected) {
+			console.log("Your entry request was rejected");
+		}
+	}, [rejected]);
+
+	return rejected ? <Text>Your entry was rejected by the host</Text> : null;
+}
+```
+
+Alternatively, use event listeners:
+
+```tsx
+useEffect(() => {
+	if (!meeting) return;
+
+	const handleRoomLeft = ({ state }) => {
+		if (state === "rejected") {
+			console.log("Your entry request was rejected");
+		}
+	};
+
+	meeting.self.on("roomLeft", handleRoomLeft);
+
+	return () => {
+		meeting.self.off("roomLeft", handleRoomLeft);
+	};
+}, [meeting]);
+```
+
+</RTKCodeSnippet>
+
+### Monitor State with roomState
+
+You can also directly check the current room state.
+
+<RTKCodeSnippet id="web-react">
 
 Handle all waiting room states in one component:
 
@@ -249,8 +562,74 @@ function WaitingRoomManager() {
 }
 ```
 
-</TabItem>
-</Tabs>
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="web-web-components">
+
+```js
+const currentState = meeting.self.roomState;
+
+if (currentState === "waitlisted") {
+	console.log("Waiting for approval");
+} else if (currentState === "joined") {
+	console.log("In the meeting");
+} else if (currentState === "rejected") {
+	console.log("Entry was rejected");
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+Use the event listeners shown above to monitor state changes.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+Use the event listeners shown above to monitor state changes.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+Use the event listeners shown above to monitor state changes.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Handle all waiting room states in one component:
+
+```tsx
+function WaitingRoomManager() {
+	const roomState = useRealtimeKitSelector((m) => m.self.roomState);
+
+	switch (roomState) {
+		case "init":
+			return <Text>Connecting...</Text>;
+		case "waitlisted":
+			return <Text>Waiting for host approval...</Text>;
+		case "joined":
+			return <Text>You are in the meeting</Text>;
+		case "rejected":
+			return <Text>Your entry was rejected</Text>;
+		case "left":
+			return <Text>You left the meeting</Text>;
+		case "kicked":
+			return <Text>You were removed from the meeting</Text>;
+		case "ended":
+			return <Text>The meeting has ended</Text>;
+		case "disconnected":
+			return <Text>Connection lost</Text>;
+		default:
+			return null;
+	}
+}
+```
+
+</RTKCodeSnippet>
 
 ## Host Actions
 
@@ -261,22 +640,7 @@ Hosts can manage waiting room requests using participant management methods. See
 
 ### Example: Host Accepting Participants
 
-<Tabs syncKey="realtimeKitFrameworkTabs">
-<TabItem label="Web Components">
-
-```js
-// Get waitlisted participants
-const waitlistedParticipants = meeting.participants.waitlisted.toArray();
-
-// Accept the first waitlisted participant
-if (waitlistedParticipants.length > 0) {
-	const participantId = waitlistedParticipants[0].id;
-	await meeting.participants.acceptWaitingRoomRequest(participantId);
-}
-```
-
-</TabItem>
-<TabItem label="React">
+<RTKCodeSnippet id="web-react">
 
 ```jsx
 import {
@@ -317,8 +681,195 @@ function WaitingRoomHost() {
 }
 ```
 
-</TabItem>
-</Tabs>
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="web-web-components">
+
+```js
+// Get waitlisted participants
+const waitlistedParticipants = meeting.participants.waitlisted.toArray();
+
+// Accept the first waitlisted participant
+if (waitlistedParticipants.length > 0) {
+	const participantId = waitlistedParticipants[0].id;
+	await meeting.participants.acceptWaitingRoomRequest(participantId);
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+// Get waitlisted participants
+val waitlistedParticipants = meeting.participants.waitlisted
+
+// Accept a participant from the waiting room
+if (waitlistedParticipants.isNotEmpty()) {
+	val participant = waitlistedParticipants[0]
+	meeting.participants.acceptWaitingRoomRequest(participant.id)
+}
+
+// Reject a participant's entry request
+if (waitlistedParticipants.isNotEmpty()) {
+	val participant = waitlistedParticipants[0]
+	meeting.participants.rejectWaitingRoomRequest(participant.id)
+}
+
+// Listen for waiting room events
+meeting.addWaitlistEventListener(object : RtkWaitlistEventListener {
+	override fun onWaitListParticipantJoined(participant: RtkRemoteParticipant) {
+		// Called when a new participant joins the waiting room
+	}
+
+	override fun onWaitListParticipantAccepted(participant: RtkRemoteParticipant) {
+		// Called when a waitlisted participant is accepted into the meeting
+	}
+
+	override fun onWaitListParticipantRejected(participant: RtkRemoteParticipant) {
+		// Called when a waitlisted participant is denied entry
+	}
+
+	override fun onWaitListParticipantClosed(participant: RtkRemoteParticipant) {
+		// Called when a waitlisted participant leaves the waiting room
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+// Get waitlisted participants
+let waitlistedParticipants = meeting.participants.waitlisted
+
+// Accept a participant from the waiting room
+if let participant = waitlistedParticipants.first {
+	meeting.participants.acceptWaitingRoomRequest(id: participant.id)
+}
+
+// Reject a participant's entry request
+if let participant = waitlistedParticipants.first {
+	meeting.participants.rejectWaitingRoomRequest(participant.id)
+}
+
+// Listen for waiting room events
+extension MeetingViewModel: RtkWaitlistEventListener {
+	func onWaitListParticipantJoined(participant: RtkRemoteParticipant) {
+		// Called when a new participant joins the waiting room
+	}
+
+	func onWaitListParticipantAccepted(participant: RtkRemoteParticipant) {
+		// Called when a waitlisted participant is accepted into the meeting
+	}
+
+	func onWaitListParticipantRejected(participant: RtkRemoteParticipant) {
+		// Called when a waitlisted participant is denied entry
+	}
+
+	func onWaitListParticipantClosed(participant: RtkRemoteParticipant) {
+		// Called when a waitlisted participant leaves the waiting room
+	}
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+// Get waitlisted participants
+final waitlistedParticipants = meeting.participants.waitlisted;
+
+// Accept a participant from the waiting room
+if (waitlistedParticipants.isNotEmpty) {
+	final participant = waitlistedParticipants[0];
+	meeting.participants.acceptWaitlistedParticipant(participant);
+}
+
+// Reject a participant's entry request
+if (waitlistedParticipants.isNotEmpty) {
+	final participant = waitlistedParticipants[0];
+	meeting.participants.rejectWaitlistedParticipant(participant);
+}
+
+// Accept all waitlisted participants at once
+meeting.participants.acceptAllWaitingRoomRequests();
+
+// Listen for waiting room events
+class WaitlistStatusNotifier extends RtkWaitlistEventListener {
+	@override
+	void onWaitListParticipantJoined(RtkRemoteParticipant participant) {
+		// Called when a new participant joins the waiting room
+	}
+
+	@override
+	void onWaitListParticipantAccepted(RtkRemoteParticipant participant) {
+		// Called when a waitlisted participant is accepted into the meeting
+	}
+
+	@override
+	void onWaitListParticipantRejected(RtkRemoteParticipant participant) {
+		// Called when a waitlisted participant is denied entry
+	}
+
+	@override
+	void onWaitListParticipantClosed(RtkRemoteParticipant participant) {
+		// Called when a waitlisted participant leaves the waiting room
+	}
+}
+
+meeting.addWaitlistEventListener(WaitlistStatusNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+import {
+	useRealtimeKitClient,
+	useRealtimeKitSelector,
+} from "@cloudflare/realtimekit-react-native";
+import { View, Text, Button } from "react-native";
+
+function WaitingRoomHost() {
+	const [meeting] = useRealtimeKitClient();
+	const waitlistedParticipants = useRealtimeKitSelector((m) =>
+		m.participants.waitlisted.toArray(),
+	);
+
+	const acceptParticipant = async (participantId) => {
+		await meeting.participants.acceptWaitingRoomRequest(participantId);
+	};
+
+	const rejectParticipant = async (participantId) => {
+		await meeting.participants.rejectWaitingRoomRequest(participantId);
+	};
+
+	return (
+		<View>
+			<Text>Waiting Room ({waitlistedParticipants.length})</Text>
+			{waitlistedParticipants.map((participant) => (
+				<View key={participant.id}>
+					<Text>{participant.name}</Text>
+					<Button
+						title="Accept"
+						onPress={() => acceptParticipant(participant.id)}
+					/>
+					<Button
+						title="Reject"
+						onPress={() => rejectParticipant(participant.id)}
+					/>
+				</View>
+			))}
+		</View>
+	);
+}
+```
+
+</RTKCodeSnippet>
 
 ## Best Practices
 


### PR DESCRIPTION
### Summary

Added waiting room documentation for RealtimeKit Mobile SDKs.
Page Modified: http://developers.cloudflare.com/realtime/realtimekit/core/waiting-room/

### Documentation checklist
- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
