### PR TITLE
update: add nix flakes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ pnpm-debug.log*
 .idea
 
 tools/relevant_changed_files.txt
+
+# nix
+/.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766714959,
+        "narHash": "sha256-+2xdB27fVMEVKWmh7UtpBGgK1FOVdk5ttV3ZPhpdqVY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8970f698c39f490df47e4cbb7beae7869ddf1978",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,6 @@
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [
             nodejs
-            corepack
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "This flakes provides devShell for cloudflare-docs";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            nodejs
+            corepack
+          ];
+        };
+      }
+    );
+}

--- a/src/content/docs/style-guide/contributions.mdx
+++ b/src/content/docs/style-guide/contributions.mdx
@@ -63,6 +63,13 @@ A link will appear in the terminal, `https://localhost:1111/`, where you can pre
 6. Push your commits to your branch and then back to your fork.
 7. Return to GitHub and create a pull request from your committed changes. In the description form, add the product you changed in brackets and a brief description of your changes. For example “[Images] Fixed broken link."
 
+If you are a Nix user, you can use `devShell` defined in `flake.nix` to set up the development environment:
+```bash
+nix develop
+```
+This command provides the environment with `nodejs` installed, so you can run `npm install` and `npm run dev`.
+You can also use `nix-direnv` to set up and enter the development environment.
+
 ## After you create an issue or PR
 After you create an issue or PR, a member of the Cloudflare organization will review your suggestion. Here is what to expect:
 * A member of the Cloudflare organization may tag others for technical or content reviews or feedback.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

I added `flake.nix` and `.envrc` for Nix users who have flakes enabled.
With these two files (three files including `flake.lock`), Nix users with flakes enabled can set up an environment where `npm` is available by using the `devShell`.
I also added an overview of how to use it in the “Full development” section on the /style-guide/contributions/ page.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

<img width="1731" height="935" alt="screenshot" src="https://github.com/user-attachments/assets/13cb46dc-e56e-4397-9dd3-4548fd0425d9" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
