### PR TITLE
chore: add changelog for v5.15.0 Terraform provider release

### DIFF
--- a/src/content/changelog/terraform/2025-12-19-terraform-v5.15.0-provider.mdx
+++ b/src/content/changelog/terraform/2025-12-19-terraform-v5.15.0-provider.mdx
@@ -24,9 +24,9 @@ This release includes bug fixes, the stabilization of even more popular resource
 * **zero_trust_gateway_policy:** Support `forensic_copy` ([5741fd0](https://github.com/cloudflare/terraform-provider-cloudflare/commit/5741fd0ed9f7270d20731cc47ec45eb0403a628b))
 * **zero_trust_list:** Support additional types (category, location, device) ([5741fd0](https://github.com/cloudflare/terraform-provider-cloudflare/commit/5741fd0ed9f7270d20731cc47ec45eb0403a628b))
 
-### Bug Fixes
+### Bug fixes
 
-* **access_rules:** Add validation to prevent state drift. Ideally we'd use Semantic Equality but since that isn't an option, this will remove a foot-gun. ([4457791](https://github.com/cloudflare/terraform-provider-cloudflare/commit/44577911b3cbe45de6279aefa657bdee73c0794d))
+* **access_rules:** Add validation to prevent state drift. Ideally, we'd use Semantic Equality but since that isn't an option, this will remove a foot-gun. ([4457791](https://github.com/cloudflare/terraform-provider-cloudflare/commit/44577911b3cbe45de6279aefa657bdee73c0794d))
 * **cloudflare_pages_project:** Addressing drift issues ([6edffcf](https://github.com/cloudflare/terraform-provider-cloudflare/commit/6edffcfcf187fdc9b10b624b9a9b90aed2fb2b2e)) ([3db318e](https://github.com/cloudflare/terraform-provider-cloudflare/commit/3db318e747423bf10ce587d9149e90edcd8a77b0))
 * **cloudflare_worker:** Can be cleanly imported ([4859b52](https://github.com/cloudflare/terraform-provider-cloudflare/commit/4859b52968bb25570b680df9813f8e07fd50728f))
 * **cloudflare_worker:** Ensure clean imports ([5b525bc](https://github.com/cloudflare/terraform-provider-cloudflare/commit/5b525bc478a4e2c9c0d4fd659b92cc7f7c18016a))
@@ -39,4 +39,4 @@ We suggest waiting to migrate to v5 while we work on stabilization. This helps w
 
 ### For more information
 - [Terraform Provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs)
-- [Documentation on using Terraform with Cloudflare](https://developers.cloudflare.com/terraform/)
+- [Documentation on using Terraform with Cloudflare](/terraform/)

--- a/src/content/changelog/terraform/2025-12-19-terraform-v5.15.0-provider.mdx
+++ b/src/content/changelog/terraform/2025-12-19-terraform-v5.15.0-provider.mdx
@@ -1,0 +1,42 @@
+---
+title: Terraform v5.15.0 now available
+description: Terraform v5.15.0 stabilizes a number of resources and known issues
+products:
+  - fundamentals
+date: 2025-12-19
+---
+
+Earlier this year, we announced the launch of the new Terraform v5 Provider. We are aware of the high number of issues reported by the Cloudflare community related to the v5 release. We have committed to releasing improvements on a [2-3 week cadence](https://github.com/cloudflare/terraform-provider-cloudflare/issues/5774) to ensure its stability and reliability, including the v5.15 release. We have also pivoted from an [issue-to-issue approach to a resource-per-resource approach](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237) - we will be focusing on specific resources to not only stabilize the resource but also ensure it is migration-friendly for those migrating from v4 to v5.
+
+Thank you for continuing to raise issues. They make our provider stronger and help us build products that reflect your needs.
+
+This release includes bug fixes, the stabilization of even more popular resources, and more.
+
+### Features
+
+* **ai_search:** Add AI Search endpoints ([6f02adb](https://github.com/cloudflare/terraform-provider-cloudflare/commit/6f02adb420e872457f71f95b49cb527663388915))
+* **certificate_pack:** Ensure proper Terraform resource ID handling for path parameters in API calls ([081f32a](https://github.com/cloudflare/terraform-provider-cloudflare/commit/081f32acab4ce9a194a7ff51c8e9fcabd349895a))
+* **worker_version:** Support `startup_time_ms` ([286ab55](https://github.com/cloudflare/terraform-provider-cloudflare/commit/286ab55bea8d5be0faa5a2b5b8b157e4a2214eba))
+* **zero_trust_dlp_custom_entry:** Support `upload_status` ([7dc0fe3](https://github.com/cloudflare/terraform-provider-cloudflare/commit/7dc0fe3b23726ead8dc075f86728a0540846d90c))
+* **zero_trust_dlp_entry:** Support `upload_status` ([7dc0fe3](https://github.com/cloudflare/terraform-provider-cloudflare/commit/7dc0fe3b23726ead8dc075f86728a0540846d90c))
+* **zero_trust_dlp_integration_entry:** Support `upload_status` ([7dc0fe3](https://github.com/cloudflare/terraform-provider-cloudflare/commit/7dc0fe3b23726ead8dc075f86728a0540846d90c))
+* **zero_trust_dlp_predefined_entry:** Support `upload_status` ([7dc0fe3](https://github.com/cloudflare/terraform-provider-cloudflare/commit/7dc0fe3b23726ead8dc075f86728a0540846d90c))
+* **zero_trust_gateway_policy:** Support `forensic_copy` ([5741fd0](https://github.com/cloudflare/terraform-provider-cloudflare/commit/5741fd0ed9f7270d20731cc47ec45eb0403a628b))
+* **zero_trust_list:** Support additional types (category, location, device) ([5741fd0](https://github.com/cloudflare/terraform-provider-cloudflare/commit/5741fd0ed9f7270d20731cc47ec45eb0403a628b))
+
+### Bug Fixes
+
+* **access_rules:** Add validation to prevent state drift. Ideally we'd use Semantic Equality but since that isn't an option, this will remove a foot-gun. ([4457791](https://github.com/cloudflare/terraform-provider-cloudflare/commit/44577911b3cbe45de6279aefa657bdee73c0794d))
+* **cloudflare_pages_project:** Addressing drift issues ([6edffcf](https://github.com/cloudflare/terraform-provider-cloudflare/commit/6edffcfcf187fdc9b10b624b9a9b90aed2fb2b2e)) ([3db318e](https://github.com/cloudflare/terraform-provider-cloudflare/commit/3db318e747423bf10ce587d9149e90edcd8a77b0))
+* **cloudflare_worker:** Can be cleanly imported ([4859b52](https://github.com/cloudflare/terraform-provider-cloudflare/commit/4859b52968bb25570b680df9813f8e07fd50728f))
+* **cloudflare_worker:** Ensure clean imports ([5b525bc](https://github.com/cloudflare/terraform-provider-cloudflare/commit/5b525bc478a4e2c9c0d4fd659b92cc7f7c18016a))
+* **list_items:** Add validation for IP List items to avoid inconsistent state ([b6733dc](https://github.com/cloudflare/terraform-provider-cloudflare/commit/b6733dc4be909a5ab35895a88e519fc2582ccada))
+* **zero_trust_access_application:** Remove all conditions from sweeper ([3197f1a](https://github.com/cloudflare/terraform-provider-cloudflare/commit/3197f1aed61be326d507d9e9e3b795b9f1d18fd7))
+* **spectrum_application:** Map missing fields during spectrum resource import ([#6495](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6495)) ([ddb4e72](https://github.com/cloudflare/terraform-provider-cloudflare/commit/ddb4e722b82c735825a549d651a9da219c142efa))
+
+### Upgrade to newer version
+We suggest waiting to migrate to v5 while we work on stabilization. This helps with avoiding any blocking issues while the Terraform resources are actively being [stabilized](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237). We will be releasing a new migration tool in March 2026 to help support v4 to v5 transitions for our most popular resources.
+
+### For more information
+- [Terraform Provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs)
+- [Documentation on using Terraform with Cloudflare](https://developers.cloudflare.com/terraform/)


### PR DESCRIPTION
### Summary

This is the changelog for the most recent release for the Terraform provider.

### Screenshots (optional)

<img width="1052" height="1194" alt="Screenshot 2025-12-26 at 8 55 48 AM" src="https://github.com/user-attachments/assets/2eff618f-e696-4546-89fd-4c37f7cde28d" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
