### PR TITLE
Add Bonk workflow

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -24,9 +24,11 @@ jobs:
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_GATEWAY_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         with:
-          model: "anthropic/claude-opus-4-5"
+          model: "cloudflare-ai-gateway/anthropicclaude-opus-4-5"
           agent: docs # use our Docs agent by default in this repo
           mentions: "/bonk,@ask-bonk"
           permissions: CODEOWNERS

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -28,7 +28,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropicclaude-opus-4-5"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-5"
           agent: docs # use our Docs agent by default in this repo
           mentions: "/bonk,@ask-bonk"
           permissions: CODEOWNERS

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -28,7 +28,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-5"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
           agent: docs # use our Docs agent by default in this repo
           mentions: "/bonk,@ask-bonk"
           permissions: CODEOWNERS

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -27,5 +27,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           model: "anthropic/claude-opus-4-5"
+          agent: docs # use our Docs agent by default in this repo
           mentions: "/bonk,@ask-bonk"
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -26,6 +26,6 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: "opencode/claude-opus-4-5"
+          model: "anthropic/claude-opus-4-5"
           mentions: "/bonk,@ask-bonk"
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -1,0 +1,31 @@
+name: Bonk
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  bonk:
+    if: github.event.sender.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Bonk
+        uses: ask-bonk/ask-bonk/github@main
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: "opencode/claude-opus-4-5"
+          mentions: "/bonk,@ask-bonk"
+          permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           model: "opencode/claude-opus-4-5"
           mentions: "/bonk,@ask-bonk"

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -29,4 +29,4 @@ jobs:
           model: "anthropic/claude-opus-4-5"
           agent: docs # use our Docs agent by default in this repo
           mentions: "/bonk,@ask-bonk"
-          permissions: write
+          permissions: CODEOWNERS


### PR DESCRIPTION
Adds the Bonk workflow.

* CODEOWNERS (only) can invoke `/bonk` on any issue comment or PR to prompt fixes, create PRs or amend PRs for them. We don't restrict changes to specific paths - membership in CODEOWNERS alone is sufficient (GitHub does not expose a robust API here for checking against CODEOWNERS to bots/agents)
* Defaults to our Docs agent (which incorporates our styleguide, code conventions, etc)
* This workflow is for issue comments + PR review comments (only) - if we want to run Bonk against every new issue or PR we can introduce that in a different workflow with a more curated prompt at a later date.

e.g.

```
/bonk review this Durable Objects docs PR - ensure that it is not conflict with https://developers.cloudflare.com/durable-objects/best-practices/rules-of-durable-objects/. If it does, highlight the issues and propose fixes.
```