### PR TITLE
[Images] Fix missing `image` argument in `segment` example

### DIFF
--- a/src/content/partials/images/segment.mdx
+++ b/src/content/partials/images/segment.mdx
@@ -15,7 +15,7 @@ Automatically isolates the subject of an image by replacing the background with 
   </TabItem>
   <TabItem label="Workers">
   ```js
-  cf: {segment: "foreground"}
+  cf: {image: {segment: "foreground"}}
   ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
### Summary

The `segment` parameter introduced in #24760 was missing the parent `image` argument in the [Transform via Workers](https://developers.cloudflare.com/images/transform-images/transform-via-workers/#segment) example.


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

