### PR TITLE
Adds missing space to "Connect to a PostgreSQL database with Cloudflare Workers" page

### DIFF
--- a/src/content/docs/workers/tutorials/postgres.mdx
+++ b/src/content/docs/workers/tutorials/postgres.mdx
@@ -113,7 +113,7 @@ DB_URL="<ENTER YOUR POSTGRESQL CONNECTION STRING>"
 
 ### Set explicit parameters
 
-Configure each database parameter as an [environment variable](/workers/configuration/environment-variables/) via the [Cloudflare dashboard](/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboard) or in your Wrangler file. Refer to an example of aWrangler file configuration:
+Configure each database parameter as an [environment variable](/workers/configuration/environment-variables/) via the [Cloudflare dashboard](/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboard) or in your Wrangler file. Refer to an example of a Wrangler file configuration:
 
 <WranglerConfig>
 


### PR DESCRIPTION
Adds missing space

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)
<img width="757" height="371" alt="Screenshot 2025-12-30 at 3 59 00 PM" src="https://github.com/user-attachments/assets/cb36b745-2cfd-4257-8258-f5b290d7ec7b" />


<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
