### PR TITLE
[Workers] Add full-stack tag to Waku framework guide

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/waku.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/waku.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Waku
-head: []
+tags: ["full-stack"]
 description: Create a Waku application and deploy it to Cloudflare Workers with Workers Assets.
 ---
 


### PR DESCRIPTION
### Summary

Follow up to #25450. Waku is a full stack React server framework and can be listed here - https://developers.cloudflare.com/workers/static-assets/routing/full-stack-application/

### Documentation checklist

I'm not sure that a changelog entry is worthwhile for this tiny change. Thank you!

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
