### PR TITLE
docs: add wrangler analytics-engine command documentation

### DIFF
--- a/src/content/changelog/workers/2025-12-30-wrangler-analytics-engine-cli.mdx
+++ b/src/content/changelog/workers/2025-12-30-wrangler-analytics-engine-cli.mdx
@@ -7,12 +7,24 @@ products:
 date: 2025-12-30
 ---
 
-Wrangler now supports querying [Workers Analytics Engine](/analytics/analytics-engine/) directly from the command line, allowing you to quickly explore your datasets without writing code, plugins or ad-hoc `curl` commands.
+Wrangler now supports querying [Workers Analytics Engine](/analytics/analytics-engine/) directly from the command line, allowing you to quickly explore your datasets without writing code or ad-hoc `curl` commands.
 
 Workers Analytics Engine lets you ingest high-cardinality data at scale and query it using SQL. Use it to build custom analytics, usage-based billing, or observability tools. With the new `wrangler analytics-engine` command, you can run ad-hoc queries, debug data pipelines, and automate reports from your terminal.
 
+For example, if your Worker tracks product usage:
+
+```js
+env.USAGE.writeDataPoint({
+  indexes: ["customer_12345"],
+  blobs: ["acme-app", "user_789", "file.upload", "enterprise"],
+  doubles: [1, 2048000], // count, bytes
+});
+```
+
+You can query that data directly from your terminal:
+
 ```sh
-npx wrangler analytics-engine run "SELECT blob1 AS city, AVG(double1) AS avg_temp FROM weather GROUP BY city"
+npx wrangler analytics-engine run "SELECT blob1 AS app, blob3 AS action, SUM(double1) AS total FROM usage GROUP BY app, action ORDER BY total DESC"
 ```
 
 Output defaults to table format in interactive terminals and JSON when piped to other tools like `jq`. Use `--file` to run queries from a SQL file.

--- a/src/content/changelog/workers/2025-12-30-wrangler-analytics-engine-cli.mdx
+++ b/src/content/changelog/workers/2025-12-30-wrangler-analytics-engine-cli.mdx
@@ -1,0 +1,20 @@
+---
+title: Query Analytics Engine from the command line
+description: Wrangler now supports querying Workers Analytics Engine datasets directly from the CLI.
+products:
+  - workers-analytics-engine
+  - workers
+date: 2025-12-30
+---
+
+Wrangler now supports querying [Workers Analytics Engine](/analytics/analytics-engine/) directly from the command line, allowing you to quickly explore your datasets without writing code.
+
+Workers Analytics Engine lets you ingest high-cardinality data at scale and query it using SQL. Use it to build custom analytics, usage-based billing, or observability tools. With the new `wrangler analytics-engine` command, you can run ad-hoc queries, debug data pipelines, and automate reports from your terminal.
+
+```sh
+npx wrangler analytics-engine run "SELECT blob1 AS city, AVG(double1) AS avg_temp FROM weather GROUP BY city"
+```
+
+Output defaults to table format in interactive terminals and JSON when piped to other tools like `jq`. Use `--file` to run queries from a SQL file.
+
+To get started, see [Querying from CLI](/analytics/analytics-engine/cli-querying/) or the [wrangler analytics-engine command reference](/workers/wrangler/commands/#analytics-engine).

--- a/src/content/changelog/workers/2025-12-30-wrangler-analytics-engine-cli.mdx
+++ b/src/content/changelog/workers/2025-12-30-wrangler-analytics-engine-cli.mdx
@@ -7,19 +7,25 @@ products:
 date: 2025-12-30
 ---
 
+import { TypeScriptExample } from "~/components";
+
 Wrangler now supports querying [Workers Analytics Engine](/analytics/analytics-engine/) directly from the command line, allowing you to quickly explore your datasets without writing code or ad-hoc `curl` commands.
 
 Workers Analytics Engine lets you ingest high-cardinality data at scale and query it using SQL. Use it to build custom analytics, usage-based billing, or observability tools. With the new `wrangler analytics-engine` command, you can run ad-hoc queries, debug data pipelines, and automate reports from your terminal.
 
 For example, if your Worker tracks product usage:
 
-```js
+<TypeScriptExample>
+
+```ts
 env.USAGE.writeDataPoint({
   indexes: ["customer_12345"],
   blobs: ["acme-app", "user_789", "file.upload", "enterprise"],
   doubles: [1, 2048000], // count, bytes
 });
 ```
+
+</TypeScriptExample>
 
 You can query that data directly from your terminal:
 

--- a/src/content/changelog/workers/2025-12-30-wrangler-analytics-engine-cli.mdx
+++ b/src/content/changelog/workers/2025-12-30-wrangler-analytics-engine-cli.mdx
@@ -7,7 +7,7 @@ products:
 date: 2025-12-30
 ---
 
-Wrangler now supports querying [Workers Analytics Engine](/analytics/analytics-engine/) directly from the command line, allowing you to quickly explore your datasets without writing code.
+Wrangler now supports querying [Workers Analytics Engine](/analytics/analytics-engine/) directly from the command line, allowing you to quickly explore your datasets without writing code, plugins or ad-hoc `curl` commands.
 
 Workers Analytics Engine lets you ingest high-cardinality data at scale and query it using SQL. Use it to build custom analytics, usage-based billing, or observability tools. With the new `wrangler analytics-engine` command, you can run ad-hoc queries, debug data pipelines, and automate reports from your terminal.
 

--- a/src/content/docs/analytics/analytics-engine/cli-querying.mdx
+++ b/src/content/docs/analytics/analytics-engine/cli-querying.mdx
@@ -1,0 +1,113 @@
+---
+title: Querying from CLI
+pcx_content_type: reference
+sidebar:
+  order: 5
+head:
+  - tag: title
+    content: Querying Workers Analytics Engine from CLI
+---
+
+import { PackageManagers } from "~/components";
+
+You can query Workers Analytics Engine datasets directly from the command line using Wrangler. This is useful for ad-hoc queries, debugging, and scripting.
+
+## Prerequisites
+
+Before you can query Analytics Engine from the CLI, you need:
+
+1. [Wrangler installed](/workers/wrangler/install-and-update/) (version 4.0.0 or later)
+2. Authentication configured via `wrangler login` or a `CLOUDFLARE_API_TOKEN` environment variable with the `Account Analytics Read` permission
+
+## Basic usage
+
+Run a query directly:
+
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args='analytics-engine run "SELECT * FROM my_dataset LIMIT 10"'
+/>
+
+Run a query from a file:
+
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="analytics-engine run --file=query.sql"
+/>
+
+## Output formats
+
+By default, results are displayed as a table when running interactively, or as JSON when piped to another command.
+
+You can explicitly set the output format:
+
+```sh
+# Table format (default for interactive)
+npx wrangler analytics-engine run "SELECT * FROM my_dataset" --format=table
+
+# JSON format (default for non-interactive)
+npx wrangler analytics-engine run "SELECT * FROM my_dataset" --format=json
+```
+
+JSON output is useful for piping to other tools like `jq`:
+
+```sh
+npx wrangler analytics-engine run "SELECT * FROM my_dataset" --format=json | jq '.data[0]'
+```
+
+## Example queries
+
+### List all datasets
+
+```sh
+npx wrangler analytics-engine run "SHOW TABLES"
+```
+
+### Query with time filtering
+
+```sh
+npx wrangler analytics-engine run "SELECT blob1 AS city, AVG(double1) AS avg_temp FROM weather WHERE timestamp > NOW() - INTERVAL '1' DAY GROUP BY city"
+```
+
+### Query from a file
+
+Create a file `query.sql`:
+
+```sql
+SELECT
+    intDiv(toUInt32(timestamp), 300) * 300 AS t,
+    blob1 AS city,
+    SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_temp
+FROM weather
+WHERE timestamp >= NOW() - INTERVAL '1' DAY
+GROUP BY t, city
+ORDER BY t, city
+```
+
+Then run:
+
+```sh
+npx wrangler analytics-engine run --file=query.sql
+```
+
+## Using in scripts
+
+The CLI is useful for automation and scripting. For example, you can create a daily report:
+
+```bash
+#!/bin/bash
+
+# Query yesterday's data and save to a file
+npx wrangler analytics-engine run \
+  "SELECT blob1 AS endpoint, SUM(_sample_interval) AS request_count FROM api_requests WHERE timestamp >= NOW() - INTERVAL '1' DAY GROUP BY endpoint ORDER BY request_count DESC" \
+  --format=json > daily_report.json
+```
+
+## Related resources
+
+- [SQL API reference](/analytics/analytics-engine/sql-api/) - Direct HTTP API access
+- [SQL reference](/analytics/analytics-engine/sql-reference/) - Full SQL syntax documentation
+- [Querying from a Worker](/analytics/analytics-engine/worker-querying/) - Query from within a Worker
+- [Querying from Grafana](/analytics/analytics-engine/grafana/) - Visualize data in Grafana

--- a/src/content/docs/analytics/analytics-engine/cli-querying.mdx
+++ b/src/content/docs/analytics/analytics-engine/cli-querying.mdx
@@ -8,8 +8,6 @@ head:
     content: Querying Workers Analytics Engine from CLI
 ---
 
-import { PackageManagers } from "~/components";
-
 You can query Workers Analytics Engine datasets directly from the command line using Wrangler. This is useful for ad-hoc queries, debugging, and scripting.
 
 ## Prerequisites
@@ -23,19 +21,15 @@ Before you can query Analytics Engine from the CLI, you need:
 
 Run a query directly:
 
-<PackageManagers
-	type="exec"
-	pkg="wrangler"
-	args='analytics-engine run "SELECT * FROM my_dataset LIMIT 10"'
-/>
+```sh
+npx wrangler analytics-engine run "SELECT * FROM my_dataset LIMIT 10"
+```
 
 Run a query from a file:
 
-<PackageManagers
-	type="exec"
-	pkg="wrangler"
-	args="analytics-engine run --file=query.sql"
-/>
+```sh
+npx wrangler analytics-engine run --file=query.sql
+```
 
 ## Output formats
 
@@ -92,7 +86,7 @@ Then run:
 npx wrangler analytics-engine run --file=query.sql
 ```
 
-## Using in scripts
+## Use in scripts
 
 The CLI is useful for automation and scripting. For example, you can create a daily report:
 

--- a/src/content/docs/analytics/analytics-engine/get-started.mdx
+++ b/src/content/docs/analytics/analytics-engine/get-started.mdx
@@ -61,16 +61,17 @@ Currently, the `writeDataPoint()` API accepts ordered arrays of values. This mea
 
 ## 3. Query data using the SQL API
 
-You can query the data you have written in two ways:
+You can query the data you have written in several ways:
 
-* [**SQL API**](/analytics/analytics-engine/sql-api) — Best for writing your own queries and integrating with external tools like Grafana.
-* [**GraphQL API**](/analytics/graphql-api/) — This is the same API that powers the Cloudflare dashboard.
+* [**Wrangler CLI**](/analytics/analytics-engine/cli-querying/) — Query directly from the command line using `wrangler analytics-engine`.
+* [**SQL API**](/analytics/analytics-engine/sql-api/) — Best for writing your own queries and integrating with external tools like Grafana.
+* [**GraphQL API**](/analytics/graphql-api/) — This is the same API that powers the Cloudflare dashboard.
 
-For the purpose of this example, we will use the SQL API.
+For the purpose of this example, we will use Wrangler or the SQL API.
 
 ### Create an API token
 
-Create an [API Token](https://dash.cloudflare.com/profile/api-tokens) that has the `Account Analytics Read` permission.
+Create an [API Token](https://dash.cloudflare.com/profile/api-tokens) that has the `Account Analytics Read` permission. If you are using Wrangler and have already run `wrangler login`, you can skip this step.
 
 ### Write your first query
 
@@ -92,7 +93,13 @@ LIMIT 10
 We are using a custom averaging function to take [sampling](/analytics/analytics-engine/sql-api/#sampling) into account.
 :::
 
-You can run this query by making an HTTP request to the SQL API:
+You can run this query using Wrangler:
+
+```sh
+npx wrangler analytics-engine run "SELECT blob1 AS city, SUM(_sample_interval * double2) / SUM(_sample_interval) AS avg_humidity FROM WEATHER WHERE double1 > 0 GROUP BY city ORDER BY avg_humidity DESC LIMIT 10"
+```
+
+Or by making an HTTP request to the SQL API:
 
 ```bash
 curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/analytics_engine/sql" \

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -618,14 +618,18 @@ Manage your Workers [Queues](/queues/) configurations.
 
 Query [Workers Analytics Engine](/analytics/analytics-engine/) datasets using the SQL API.
 
+:::note
+`ae` is available as a shorthand alias for `analytics-engine`.
+:::
+
 ```txt
-wrangler analytics-engine run <QUERY> [OPTIONS]
+wrangler analytics-engine run [QUERY] [OPTIONS]
 ```
 
 - `QUERY` <Type text="string" /> <MetaInfo text="optional" />
-  - The SQL query to execute. Required if `--file` is not provided.
+  - The SQL query to execute. Either `QUERY` or `--file` must be provided.
 - `--file` <Type text="string" /> <MetaInfo text="optional" />
-  - Path to a file containing the SQL query to execute. Required if `QUERY` is not provided.
+  - Path to a file containing the SQL query to execute. Either `--file` or `QUERY` must be provided.
 - `--format` <Type text="'json' | 'table'" /> <MetaInfo text="optional" />
   - Output format for query results. Defaults to `table` when running in a TTY, `json` otherwise.
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -47,6 +47,7 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 - [`pages`](#pages) - Configure Cloudflare Pages.
 - [`pipelines`](#pipelines) - Configure Cloudflare Pipelines.
 - [`queues`](#queues) - Configure Workers Queues.
+- [`analytics-engine`](#analytics-engine) - Query Workers Analytics Engine datasets.
 - [`login`](#login) - Authorize Wrangler with your Cloudflare account using OAuth.
 - [`logout`](#logout) - Remove Wrangler's authorization for accessing your account.
 - [`whoami`](#whoami) - Retrieve your user information and test your authentication configuration.
@@ -610,6 +611,45 @@ Manage your [Pipelines](/pipelines/).
 Manage your Workers [Queues](/queues/) configurations.
 
 <WranglerNamespace namespace="queues" headingLevel={3} />
+
+---
+
+## `analytics-engine`
+
+Query [Workers Analytics Engine](/analytics/analytics-engine/) datasets using the SQL API.
+
+```txt
+wrangler analytics-engine run <QUERY> [OPTIONS]
+```
+
+- `QUERY` <Type text="string" /> <MetaInfo text="optional" />
+  - The SQL query to execute. Required if `--file` is not provided.
+- `--file` <Type text="string" /> <MetaInfo text="optional" />
+  - Path to a file containing the SQL query to execute. Required if `QUERY` is not provided.
+- `--format` <Type text="'json' | 'table'" /> <MetaInfo text="optional" />
+  - Output format for query results. Defaults to `table` when running in a TTY, `json` otherwise.
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+### Examples
+
+Query a dataset directly:
+
+```sh
+npx wrangler analytics-engine run "SELECT * FROM my_dataset LIMIT 10"
+```
+
+Query from a file:
+
+```sh
+npx wrangler analytics-engine run --file=query.sql
+```
+
+Output as JSON:
+
+```sh
+npx wrangler analytics-engine run "SELECT * FROM my_dataset" --format=json
+```
 
 ---
 


### PR DESCRIPTION
**DO NOT MERGE**: need https://github.com/cloudflare/workers-sdk/pull/11776 to merge first.

Adds documentation for the new `wrangler analytics-engine` command that allows querying Workers Analytics Engine datasets directly from the CLI.

### Changes

- **Wrangler Commands Reference** (`src/content/docs/workers/wrangler/commands.mdx`):
  - Added `analytics-engine` to the table of contents
  - Added full command documentation with usage, flags, and examples

- **New CLI Querying Page** (`src/content/docs/analytics/analytics-engine/cli-querying.mdx`):
  - Created new page following the pattern of existing "Querying from Grafana" and "Querying from a Worker" pages
  - Includes prerequisites, basic usage, output formats, example queries, and scripting examples

- **Get Started Guide** (`src/content/docs/analytics/analytics-engine/get-started.mdx`):
  - Added Wrangler CLI as a query option alongside SQL API and GraphQL API
  - Added Wrangler example in the "Write your first query" section

### Related

- workers-sdk PR: https://github.com/cloudflare/workers-sdk/pull/11776