### PR TITLE
Fix incorrect nginx docker configuration for managed networks

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/warp/configure-warp/managed-networks.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/warp/configure-warp/managed-networks.mdx
@@ -96,13 +96,13 @@ If you do not already have a TLS endpoint on your network, you can set one up as
 			```yml
 			version: "3.3"
 			services:
-			nginx:
-				image: nginx:latest
-				ports:
-					- 3333:443
-				volumes:
-					- ./nginx.conf:/etc/nginx/nginx.conf:ro
-					- ./certs:/certs:ro
+				nginx:
+					image: nginx:latest
+					ports:
+						- 3333:443
+					volumes:
+						- ./nginx.conf:/etc/nginx/nginx.conf:ro
+						- ./certs:/certs:ro
 			```
 
 			If needed, replace `./nginx.conf` and `./certs` with the locations of your nginx configuration file and certificate.


### PR DESCRIPTION
### Summary

Missing indents in the nginx docker YAML file for managed networks for WARP.

The current YAML file will cause docker-compose to fail with:
```
docker-compose up -d
ERROR: In file './compose.yaml', service must be a mapping, not a NoneType.
```

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
