### PR TITLE
docs(workflows): add rollback (saga pattern) documentation

### DIFF
--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -114,6 +114,7 @@ The possible values of status are as follows:
     | "complete"
     | "waiting" // instance is hibernating and waiting for sleep or event to finish
     | "waitingForPause" // instance is finishing the current work to pause
+    | "rollingBack" // rollback in progress (manual or via terminate with rollback)
     | "unknown";
   error?: {
     name: string,

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -514,9 +514,10 @@ Restart a Workflow instance.
 
 ### terminate
 
-Terminate a Workflow instance.
+Terminate a Workflow instance. Optionally run rollback handlers before terminating.
 
-- <code>terminate(): Promise&lt;void&gt;</code>
+- <code>terminate(options?: TerminateOptions): Promise&lt;void&gt;</code>
+  - `options.rollback` (optional) - if `true`, execute all registered undo handlers before terminating. Only works for `running`, `waiting`, or `paused` instances.
 
 ### sendEvent
 
@@ -571,6 +572,7 @@ type InstanceStatus = {
 		| "complete"
 		| "waiting" // instance is hibernating and waiting for sleep or event to finish
 		| "waitingForPause" // instance is finishing the current work to pause
+		| "rollingBack" // rollback in progress (manual or via terminate with rollback)
 		| "unknown";
 	error?: { 
 		name: string,

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -167,11 +167,21 @@ Workflows supports the [saga pattern](https://microservices.io/patterns/data/sag
 ### step.rollbackAll
 
 {/* prettier-ignore */}
-- <code>step.rollbackAll(error?: unknown): Promise&lt;void&gt;</code>
+- <code>step.rollbackAll(error?: unknown, options?: RollbackAllOptions): Promise&lt;void&gt;</code>
   - `error` (optional) - the error that triggered the rollback, passed to each undo function.
+  - `options` (optional) - configuration options for the rollback behavior.
   - Executes all registered undo functions in LIFO (last-in, first-out) order.
   - Each undo is wrapped in `step.do()` for durability and retry.
-  - Stops on first undo failure.
+  - By default, stops on first undo failure. Use `continueOnError: true` to execute all undos and collect failures into an `AggregateError`.
+
+### RollbackAllOptions
+
+```ts
+export type RollbackAllOptions = {
+  /** If true, continue executing remaining undos after a failure and throw AggregateError at end. Default: false */
+  continueOnError?: boolean;
+};
+```
 
 ### RollbackHandler
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -154,7 +154,9 @@ Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-
 
 ## Rollback (Saga Pattern)
 
-Workflows supports the [saga pattern](https://microservices.io/patterns/data/saga.html) for handling distributed transactions. When a step fails, you can roll back previously completed steps by executing compensating actions (undo functions) in reverse order (LIFO - last-in, first-out).
+Workflows supports the [saga pattern](https://microservices.io/patterns/data/saga.html) for handling distributed transactions. When a workflow throws an uncaught error, you can automatically roll back previously completed steps by executing compensating actions (undo functions) in reverse order (LIFO - last-in, first-out).
+
+To enable automatic rollback, pass a `rollback` configuration when creating the workflow instance. When an uncaught error occurs, all registered undo functions will execute automatically before the workflow enters the errored state.
 
 ### step.withRollback
 
@@ -163,25 +165,6 @@ Workflows supports the [saga pattern](https://microservices.io/patterns/data/sag
   - `name` - the name of the step.
   - `handler` - an object containing `do` and `undo` functions.
   - `config` (optional) - configuration for the step, optionally including separate `undoConfig` for the undo function.
-
-### step.rollbackAll
-
-{/* prettier-ignore */}
-- <code>step.rollbackAll(error?: unknown, options?: RollbackAllOptions): Promise&lt;void&gt;</code>
-  - `error` (optional) - the error that triggered the rollback, passed to each undo function.
-  - `options` (optional) - configuration options for the rollback behavior.
-  - Executes all registered undo functions in LIFO (last-in, first-out) order.
-  - Each undo is wrapped in `step.do()` for durability and retry.
-  - By default, stops on first undo failure. Use `continueOnError: true` to execute all undos and collect failures into an `AggregateError`.
-
-### RollbackAllOptions
-
-```ts
-export type RollbackAllOptions = {
-  /** If true, continue executing remaining undos after a failure and throw AggregateError at end. Default: false */
-  continueOnError?: boolean;
-};
-```
 
 ### RollbackHandler
 
@@ -200,6 +183,24 @@ export type RollbackStepConfig = WorkflowStepConfig & {
 };
 ```
 
+### RollbackConfig
+
+```ts
+export type RollbackConfig = {
+  /** If true, continue executing remaining undos after a failure and throw AggregateError at end. Default: false */
+  continueOnError?: boolean;
+};
+```
+
+Pass this configuration to `workflow.create()` to enable automatic rollback on uncaught errors:
+
+```ts
+let instance = await env.MY_WORKFLOW.create({
+  params: { userId: "123", items: ["item1", "item2"] },
+  rollback: { continueOnError: true }, // Enable auto-rollback
+});
+```
+
 ### Example
 
 <TypeScriptExample>
@@ -207,26 +208,29 @@ export type RollbackStepConfig = WorkflowStepConfig & {
 ```ts
 export class OrderWorkflow extends WorkflowEntrypoint<Env, Params> {
   async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
-    try {
-      const order = await step.withRollback("create order", {
-        do: async () => env.DB.orders.insert({ userId: event.payload.userId, items: event.payload.items }),
-        undo: async (err, order) => env.DB.orders.delete(order.id),
-      });
+    const order = await step.withRollback("create order", {
+      do: async () => env.DB.orders.insert({ userId: event.payload.userId, items: event.payload.items }),
+      undo: async (err, order) => env.DB.orders.delete(order.id),
+    });
 
-      await step.withRollback("charge payment", {
-        do: async () => env.STRIPE.charges.create({ amount: order.total, customer: event.payload.userId }),
-        undo: async (err, charge) => env.STRIPE.refunds.create({ charge: charge.id }),
-      });
+    await step.withRollback("charge payment", {
+      do: async () => env.STRIPE.charges.create({ amount: order.total, customer: event.payload.userId }),
+      undo: async (err, charge) => env.STRIPE.refunds.create({ charge: charge.id }),
+    });
 
-      await step.do("send confirmation", async () => {
-        await env.EMAIL.send({ to: event.payload.email, template: "order-confirmed", orderId: order.id });
-      });
-    } catch (e) {
-      await step.rollbackAll(e);
-      throw e;
-    }
+    // If this step throws, the undo functions above will run automatically
+    // (in reverse order) if the instance was created with rollback config enabled
+    await step.do("send confirmation", async () => {
+      await env.EMAIL.send({ to: event.payload.email, template: "order-confirmed", orderId: order.id });
+    });
   }
 }
+
+// Creating the workflow instance with rollback enabled:
+// const instance = await env.MY_WORKFLOW.create({
+//   params: orderParams,
+//   rollback: { continueOnError: false }, // Stop on first undo failure
+// });
 ```
 
 </TypeScriptExample>
@@ -449,8 +453,16 @@ interface WorkflowInstanceCreateOptions {
 	 * The event payload the Workflow instance is triggered with
 	 */
 	params?: unknown;
+	/**
+	 * Enable automatic rollback on uncaught errors.
+	 * When enabled, all registered undo functions will execute in LIFO order
+	 * if the workflow throws an uncaught error.
+	 */
+	rollback?: RollbackConfig;
 }
 ```
+
+Refer to the [Rollback (Saga Pattern)](#rollback-saga-pattern) section for details on `RollbackConfig`.
 
 ## WorkflowInstance
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -152,6 +152,75 @@ export type WorkflowStepConfig = {
 
 Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-and-retrying/) to learn more about how Workflows are retried.
 
+## Rollback (Saga Pattern)
+
+Workflows supports the [saga pattern](https://microservices.io/patterns/data/saga.html) for handling distributed transactions. When a step fails, you can roll back previously completed steps by executing compensating actions (undo functions) in reverse order (LIFO - last-in, first-out).
+
+### step.withRollback
+
+{/* prettier-ignore */}
+- <code>step.withRollback&lt;T&gt;(name: string, handler: RollbackHandler&lt;T&gt;, config?: RollbackStepConfig): Promise&lt;T&gt;</code>
+  - `name` - the name of the step.
+  - `handler` - an object containing `do` and `undo` functions.
+  - `config` (optional) - configuration for the step, optionally including separate `undoConfig` for the undo function.
+
+### step.rollbackAll
+
+{/* prettier-ignore */}
+- <code>step.rollbackAll(error?: unknown): Promise&lt;void&gt;</code>
+  - `error` (optional) - the error that triggered the rollback, passed to each undo function.
+  - Executes all registered undo functions in LIFO (last-in, first-out) order.
+  - Each undo is wrapped in `step.do()` for durability and retry.
+  - Stops on first undo failure.
+
+### RollbackHandler
+
+```ts
+export type RollbackHandler<T> = {
+  do: () => Promise<T>;
+  undo: (err: unknown, value: T) => Promise<void>;
+};
+```
+
+### RollbackStepConfig
+
+```ts
+export type RollbackStepConfig = WorkflowStepConfig & {
+  undoConfig?: WorkflowStepConfig;
+};
+```
+
+### Example
+
+<TypeScriptExample>
+
+```ts
+export class OrderWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
+    try {
+      const order = await step.withRollback("create order", {
+        do: async () => env.DB.orders.insert({ userId: event.payload.userId, items: event.payload.items }),
+        undo: async (err, order) => env.DB.orders.delete(order.id),
+      });
+
+      await step.withRollback("charge payment", {
+        do: async () => env.STRIPE.charges.create({ amount: order.total, customer: event.payload.userId }),
+        undo: async (err, charge) => env.STRIPE.refunds.create({ charge: charge.id }),
+      });
+
+      await step.do("send confirmation", async () => {
+        await env.EMAIL.send({ to: event.payload.email, template: "order-confirmed", orderId: order.id });
+      });
+    } catch (e) {
+      await step.rollbackAll(e);
+      throw e;
+    }
+  }
+}
+```
+
+</TypeScriptExample>
+
 ## NonRetryableError
 
 {/* prettier-ignore */}

--- a/src/content/docs/workflows/python/python-workers-api.mdx
+++ b/src/content/docs/workflows/python/python-workers-api.mdx
@@ -85,14 +85,22 @@ To enable automatic rollback, pass a `rollback` configuration when creating the 
 
 ### step.with_rollback
 
-* <code>step.with_rollback(name, config=None)</code> - decorator that allows you to define a step with a rollback handler.
-  * `name` - the name of the step.
-  * `config` - an optional `WorkflowStepConfig` dictionary.
+* <code>step.with_rollback(name, *, undo=None, depends=None, concurrent=False, config=None, undo_config=None)</code> - decorator that allows you to define a step with a rollback handler.
+  * `name` - the name of the step (up to 256 chars).
+  * `undo` - undo handler function, or use `@decorated_fn.undo` decorator.
+  * `depends` - optional list of steps this depends on (DAG pattern). See [DAG Workflows](/workflows/python/dag).
+  * `concurrent` - run dependencies in parallel (default: `False`).
+  * `config` - optional `WorkflowStepConfig` dictionary for the do function.
+  * `undo_config` - optional `WorkflowStepConfig` dictionary for the undo function.
+
+:::note
+An undo handler is **required** for `with_rollback` steps. If no undo handler is provided via the `undo=` parameter or `@fn.undo` decorator, a `ValueError` is raised at call time. Use `step.do()` for steps that don't need rollback.
+:::
 
 ### @do_fn.undo
 
 * <code>@do_fn.undo(config=None)</code> - decorator to register an undo function for a `with_rollback` step.
-  * `config` - optional separate config for the undo function. If not provided, inherits from the do step's config.
+  * `config` - optional separate config for the undo function.
 
 ### Enabling Rollback
 
@@ -101,51 +109,92 @@ Pass a `rollback` configuration when creating the workflow instance:
 ```python
 instance = await self.env.MY_WORKFLOW.create(
     params={"user_id": "123", "items": ["item1", "item2"]},
-    rollback={"continueOnError": True}  # Enable auto-rollback
+    rollback={"continue_on_error": True}  # Enable auto-rollback
 )
 ```
 
-* `continueOnError` - if `True`, continue executing remaining undos after a failure and raise `ExceptionGroup` at end. Default: `False`.
+* `continue_on_error` - if `True`, continue executing remaining undos after a failure and raise `ExceptionGroup` at end. Default: `False`.
 
 ### Example
 
+Two patterns are supported for attaching undo handlers:
+
 ```python
+from workers import WorkflowEntrypoint
+
 class OrderWorkflow(WorkflowEntrypoint):
     async def run(self, event, step):
+        payload = event["payload"]
+
+        # Pattern A: Chained decorator (preferred - keeps do/undo together)
         @step.with_rollback("create order")
         async def create_order():
-            return await env.DB.orders.insert({"user_id": event["payload"]["user_id"], "items": event["payload"]["items"]})
+            return await self.env.DB.prepare(
+                "INSERT INTO orders (user_id, items) VALUES (?, ?) RETURNING *"
+            ).bind(payload["user_id"], payload["items"]).first()
 
         @create_order.undo
-        async def undo_create_order(err, order):
-            await env.DB.orders.delete(order["id"])
+        async def _(err, order):
+            await self.env.DB.prepare("DELETE FROM orders WHERE id = ?").bind(order["id"]).run()
 
         order = await create_order()
 
-        @step.with_rollback("charge payment")
+        # Pattern B: undo= parameter (for reusable undo handlers)
+        async def refund_charge(err, charge):
+            await stripe_refund(charge["id"])
+
+        @step.with_rollback(
+            "charge payment",
+            undo=refund_charge,
+            config={"retries": {"limit": 3, "delay": "1 second", "backoff": "exponential"}},
+            undo_config={"retries": {"limit": 5, "delay": "2 seconds"}}
+        )
         async def charge_payment():
-            return await env.STRIPE.charges.create(amount=order["total"], customer=event["payload"]["user_id"])
+            return await stripe_charge(order["total"], payload["user_id"])
 
-        @charge_payment.undo
-        async def undo_charge_payment(err, charge):
-            await env.STRIPE.refunds.create(charge=charge["id"])
+        charge = await charge_payment()
 
-        await charge_payment()
+        # Steps can depend on other rollback steps (DAG pattern)
+        @step.with_rollback("reserve inventory", depends=[create_order])
+        async def reserve_inventory(order_result):
+            return await inventory_reserve(order_result["items"])
 
-        # If this step throws, the undo functions above will run automatically
-        # (in reverse order) if the instance was created with rollback config enabled
+        @reserve_inventory.undo
+        async def _(err, reservation):
+            await inventory_release(reservation["id"])
+
+        await reserve_inventory()
+
+        # Non-rollbackable step (email can't be unsent) - use step.do()
         @step.do("send confirmation")
         async def send_confirmation():
-            await env.EMAIL.send(to=event["payload"]["email"], template="order-confirmed", order_id=order["id"])
+            await send_email(payload["user_id"], "order-confirmed", order["id"])
 
         await send_confirmation()
 
+        return {"order_id": order["id"], "charge_id": charge["id"]}
+```
 
-# Creating the workflow instance with rollback enabled:
-# instance = await env.MY_WORKFLOW.create(
-#     params=order_params,
-#     rollback={"continueOnError": False}  # Stop on first undo failure
-# )
+Creating the workflow instance with rollback enabled:
+
+```python
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        # Auto-rollback enabled (stop on first undo failure)
+        instance = await self.env.MY_WORKFLOW.create(
+            id="order-456",
+            params={"user_id": "u2", "items": ["item1"]},
+            rollback={}
+        )
+
+        # Auto-rollback with continue-on-error
+        instance = await self.env.MY_WORKFLOW.create(
+            id="order-789",
+            params={"user_id": "u3", "items": ["item2"]},
+            rollback={"continue_on_error": True}
+        )
+
+        return Response.json({"id": instance.id})
 ```
 
 ### `event` parameter

--- a/src/content/docs/workflows/python/python-workers-api.mdx
+++ b/src/content/docs/workflows/python/python-workers-api.mdx
@@ -94,10 +94,11 @@ The Python SDK supports the [saga pattern](https://microservices.io/patterns/dat
 
 ### step.rollback_all
 
-* <code>await step.rollback_all(error=None)</code> - executes all registered undo functions in LIFO order.
+* <code>await step.rollback_all(error=None, *, continue_on_error=False)</code> - executes all registered undo functions in LIFO order.
   * `error` - optional error to pass to each undo function.
+  * `continue_on_error` - if `True`, continue executing remaining undos after a failure and raise `ExceptionGroup` at end. Default: `False`.
   * Each undo is wrapped in `step.do()` for durability and retry.
-  * Stops on first undo failure.
+  * By default, stops on first undo failure.
 
 ### Example
 

--- a/src/content/docs/workflows/python/python-workers-api.mdx
+++ b/src/content/docs/workflows/python/python-workers-api.mdx
@@ -79,7 +79,9 @@ async def run(self, event, step):
 
 ## Rollback (Saga Pattern)
 
-The Python SDK supports the [saga pattern](https://microservices.io/patterns/data/saga.html) for distributed transactions using the `with_rollback` decorator. When a step fails, you can roll back previously completed steps by executing compensating actions (undo functions) in reverse order (LIFO - last-in, first-out).
+The Python SDK supports the [saga pattern](https://microservices.io/patterns/data/saga.html) for distributed transactions using the `with_rollback` decorator. When a workflow throws an uncaught error, you can automatically roll back previously completed steps by executing compensating actions (undo functions) in reverse order (LIFO - last-in, first-out).
+
+To enable automatic rollback, pass a `rollback` configuration when creating the workflow instance. When an uncaught error occurs, all registered undo functions will execute automatically before the workflow enters the errored state.
 
 ### step.with_rollback
 
@@ -92,49 +94,58 @@ The Python SDK supports the [saga pattern](https://microservices.io/patterns/dat
 * <code>@do_fn.undo(config=None)</code> - decorator to register an undo function for a `with_rollback` step.
   * `config` - optional separate config for the undo function. If not provided, inherits from the do step's config.
 
-### step.rollback_all
+### Enabling Rollback
 
-* <code>await step.rollback_all(error=None, *, continue_on_error=False)</code> - executes all registered undo functions in LIFO order.
-  * `error` - optional error to pass to each undo function.
-  * `continue_on_error` - if `True`, continue executing remaining undos after a failure and raise `ExceptionGroup` at end. Default: `False`.
-  * Each undo is wrapped in `step.do()` for durability and retry.
-  * By default, stops on first undo failure.
+Pass a `rollback` configuration when creating the workflow instance:
+
+```python
+instance = await self.env.MY_WORKFLOW.create(
+    params={"user_id": "123", "items": ["item1", "item2"]},
+    rollback={"continueOnError": True}  # Enable auto-rollback
+)
+```
+
+* `continueOnError` - if `True`, continue executing remaining undos after a failure and raise `ExceptionGroup` at end. Default: `False`.
 
 ### Example
 
 ```python
 class OrderWorkflow(WorkflowEntrypoint):
     async def run(self, event, step):
-        try:
-            @step.with_rollback("create order")
-            async def create_order():
-                return await env.DB.orders.insert({"user_id": event["payload"]["user_id"], "items": event["payload"]["items"]})
+        @step.with_rollback("create order")
+        async def create_order():
+            return await env.DB.orders.insert({"user_id": event["payload"]["user_id"], "items": event["payload"]["items"]})
 
-            @create_order.undo
-            async def undo_create_order(err, order):
-                await env.DB.orders.delete(order["id"])
+        @create_order.undo
+        async def undo_create_order(err, order):
+            await env.DB.orders.delete(order["id"])
 
-            order = await create_order()
+        order = await create_order()
 
-            @step.with_rollback("charge payment")
-            async def charge_payment():
-                return await env.STRIPE.charges.create(amount=order["total"], customer=event["payload"]["user_id"])
+        @step.with_rollback("charge payment")
+        async def charge_payment():
+            return await env.STRIPE.charges.create(amount=order["total"], customer=event["payload"]["user_id"])
 
-            @charge_payment.undo
-            async def undo_charge_payment(err, charge):
-                await env.STRIPE.refunds.create(charge=charge["id"])
+        @charge_payment.undo
+        async def undo_charge_payment(err, charge):
+            await env.STRIPE.refunds.create(charge=charge["id"])
 
-            await charge_payment()
+        await charge_payment()
 
-            @step.do("send confirmation")
-            async def send_confirmation():
-                await env.EMAIL.send(to=event["payload"]["email"], template="order-confirmed", order_id=order["id"])
+        # If this step throws, the undo functions above will run automatically
+        # (in reverse order) if the instance was created with rollback config enabled
+        @step.do("send confirmation")
+        async def send_confirmation():
+            await env.EMAIL.send(to=event["payload"]["email"], template="order-confirmed", order_id=order["id"])
 
-            await send_confirmation()
+        await send_confirmation()
 
-        except Exception as e:
-            await step.rollback_all(e)
-            raise
+
+# Creating the workflow instance with rollback enabled:
+# instance = await env.MY_WORKFLOW.create(
+#     params=order_params,
+#     rollback={"continueOnError": False}  # Stop on first undo failure
+# )
 ```
 
 ### `event` parameter

--- a/src/content/docs/workflows/python/python-workers-api.mdx
+++ b/src/content/docs/workflows/python/python-workers-api.mdx
@@ -77,6 +77,64 @@ async def run(self, event, step):
     await step.wait_for_event("my-wait-for-event-step", "my-event-type")
 ```
 
+## Rollback (Saga Pattern)
+
+The Python SDK supports the [saga pattern](https://microservices.io/patterns/data/saga.html) for distributed transactions using the `with_rollback` decorator. When a step fails, you can roll back previously completed steps by executing compensating actions (undo functions) in reverse order (LIFO - last-in, first-out).
+
+### step.with_rollback
+
+* <code>step.with_rollback(name, config=None)</code> - decorator that allows you to define a step with a rollback handler.
+  * `name` - the name of the step.
+  * `config` - an optional `WorkflowStepConfig` dictionary.
+
+### @do_fn.undo
+
+* <code>@do_fn.undo(config=None)</code> - decorator to register an undo function for a `with_rollback` step.
+  * `config` - optional separate config for the undo function. If not provided, inherits from the do step's config.
+
+### step.rollback_all
+
+* <code>await step.rollback_all(error=None)</code> - executes all registered undo functions in LIFO order.
+  * `error` - optional error to pass to each undo function.
+  * Each undo is wrapped in `step.do()` for durability and retry.
+  * Stops on first undo failure.
+
+### Example
+
+```python
+class OrderWorkflow(WorkflowEntrypoint):
+    async def run(self, event, step):
+        try:
+            @step.with_rollback("create order")
+            async def create_order():
+                return await env.DB.orders.insert({"user_id": event["payload"]["user_id"], "items": event["payload"]["items"]})
+
+            @create_order.undo
+            async def undo_create_order(err, order):
+                await env.DB.orders.delete(order["id"])
+
+            order = await create_order()
+
+            @step.with_rollback("charge payment")
+            async def charge_payment():
+                return await env.STRIPE.charges.create(amount=order["total"], customer=event["payload"]["user_id"])
+
+            @charge_payment.undo
+            async def undo_charge_payment(err, charge):
+                await env.STRIPE.refunds.create(charge=charge["id"])
+
+            await charge_payment()
+
+            @step.do("send confirmation")
+            async def send_confirmation():
+                await env.EMAIL.send(to=event["payload"]["email"], template="order-confirmed", order_id=order["id"])
+
+            await send_confirmation()
+
+        except Exception as e:
+            await step.rollback_all(e)
+            raise
+```
 
 ### `event` parameter
 


### PR DESCRIPTION
## Summary

Adds documentation for the Workflows saga rollback API (`withRollback`, `rollbackAll`) to both TypeScript and Python documentation.

> **Note**: Depends on internal gitlab workflows!750 which adds the underlying engine support.

## Changed Files

- `src/content/docs/workflows/build/workers-api.mdx` - added "Rollback (Saga Pattern)" section
- `src/content/docs/workflows/python/python-workers-api.mdx` - added "Rollback (Saga Pattern)" section

## Content Added

### TypeScript
- `step.withRollback()` API reference
- `step.rollbackAll()` API reference
- `RollbackHandler<T>` and `RollbackStepConfig` type definitions
- Order/payment example with compensation logic

### Python
- `@step.with_rollback()` decorator reference
- `@do_fn.undo()` decorator reference  
- `step.rollback_all()` API reference
- Equivalent Python example with decorators

---

> [!NOTE]
> This PR was written with AI assistance.

<details><summary>AI Session Export</summary>
<p>

```json
{
  "info": {
    "title": "workflow rollback documentation",
    "agent": "opencode",
    "model": "claude opus 4.5"
  },
  "summary": [
    "user requested docs update for rollback API",
    "agent cloned cloudflare-docs repo",
    "agent explored existing workflows docs structure",
    "agent added rollback section to workers-api.mdx with TypeScript API and example",
    "agent added rollback section to python-workers-api.mdx with Python decorator API and example",
    "agent forked repo and pushed to fork",
    "agent created PR against production branch"
  ]
}
```

</p>
</details>