### PR TITLE
[Stream] Clarify video id location when using signing keys

### DIFF
--- a/src/content/docs/stream/viewing-videos/securing-your-stream.mdx
+++ b/src/content/docs/stream/viewing-videos/securing-your-stream.mdx
@@ -74,7 +74,7 @@ You will see a response similar to this if the request succeeds:
 }
 ```
 
-To render the video, insert the `token` value in place of the `video id`:
+To render the video, insert the `token` value in place of the `video id`, replacing the entire string located between `cloudflarestream.com/` and `/iframe`:
 
 ```html
 <iframe
@@ -280,7 +280,7 @@ function objectToBase64url(payload) {
 
 ### Step 3: Rendering the video
 
-If you are using the Stream Player, insert the token returned by the Worker in Step 2 in place of the video id:
+If you are using the Stream Player, insert the `token` value returned by the Worker in Step 2 in place of the `video id`, replacing the entire string located between `cloudflarestream.com/` and `/iframe`:
 
 ```html
 <iframe

--- a/src/content/docs/stream/viewing-videos/securing-your-stream.mdx
+++ b/src/content/docs/stream/viewing-videos/securing-your-stream.mdx
@@ -47,9 +47,9 @@ Response:
 
 You can program your app to generate token in two ways:
 
-- **Low-volume or testing: Use the `/token` endpoint to generate a short-lived signed token.** This is recommended for testing purposes or if you are generating less than 1,000 tokens per day. It requires making an API call to Cloudflare for each token. The default result is valid for 1 hour.
+- **Low-volume or testing: Use the `/token` endpoint to generate a short-lived signed token.** This is recommended for testing purposes or if you are generating less than 1,000 tokens per day. It requires making an API call to Cloudflare for each token, _which is subject to [rate limiting](/fundamentals/api/reference/limits/)._ The default result is valid for 1 hour.
 
-- **Recommended: Use a signing key to create tokens.** If you have thousands of daily users or need to generate a high volume of tokens, you can create tokens yourself using a signing key. This way, you do not need to call a Stream API each time you need to generate a token.
+- **Recommended: Use a signing key to create tokens.** If you have thousands of daily users or need to generate a high volume of tokens, you can create tokens yourself using a signing key. This way, you do not need to call a Stream API each time you need to generate a token, and is therefore _not_ a rate-limited operation.
 
 ## Option 1: Using the /token endpoint
 
@@ -74,7 +74,7 @@ You will see a response similar to this if the request succeeds:
 }
 ```
 
-To render the video, insert the `token` value in place of the `video id`, replacing the entire string located between `cloudflarestream.com/` and `/iframe`:
+To render the video or use assets like manifests or thumbnails, use the `token` value in place of the video/input ID. For example, to use the Stream player, replace the ID between `cloudflarestream.com/` and `/iframe` with the token: `https://customer-<CODE>.cloudflarestream.com/<TOKEN>/iframe`.
 
 ```html
 <iframe
@@ -87,9 +87,10 @@ To render the video, insert the `token` value in place of the `video id`, replac
 ></iframe>
 ```
 
-If you are using your own player, replace the video id in the manifest URL with the `token` value:
+Similarly, if you are using your own player, retrieve the HLS or DASH manifest by replacing the video ID in the manifest URL with the `token` value:
 
-`https://customer-<CODE>.cloudflarestream.com/eyJhbGciOiJSUzI1NiIsImtpZCI6ImNkYzkzNTk4MmY4MDc1ZjJlZjk2MTA2ZDg1ZmNkODM4In0.eyJraWQiOiJjZGM5MzU5ODJmODA3NWYyZWY5NjEwNmQ4NWZjZDgzOCIsImV4cCI6IjE2MjE4ODk2NTciLCJuYmYiOiIxNjIxODgyNDU3In0.iHGMvwOh2-SuqUG7kp2GeLXyKvMavP-I2rYCni9odNwms7imW429bM2tKs3G9INms8gSc7fzm8hNEYWOhGHWRBaaCs3U9H4DRWaFOvn0sJWLBitGuF_YaZM5O6fqJPTAwhgFKdikyk9zVzHrIJ0PfBL0NsTgwDxLkJjEAEULQJpiQU1DNm0w5ctasdbw77YtDwdZ01g924Dm6jIsWolW0Ic0AevCLyVdg501Ki9hSF7kYST0egcll47jmoMMni7ujQCJI1XEAOas32DdjnMvU8vXrYbaHk1m1oXlm319rDYghOHed9kr293KM7ivtZNlhYceSzOpyAmqNFS7mearyQ/manifest/video.m3u8`
+- `https://customer-<CODE>.cloudflarestream.com/<TOKEN>/manifest/video.m3u8`
+- `https://customer-<CODE>.cloudflarestream.com/<TOKEN>/manifest/video.mpd`
 
 ### Customizing default restrictions
 


### PR DESCRIPTION
Addresses user feedback question about where video id is when replacing it with token during generation of signing keys.