### PR TITLE
[Cloudflare One] Fix commands to test network connection

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/connectivity-prechecks.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/connectivity-prechecks.mdx
@@ -260,7 +260,7 @@ Choose one of the IPs from your `dig` output (for example, `198.41.192.167`) and
 ### 3.1. Test UDP connectivity
 
 ```sh
-nc -uz -w 3 198.41.192.167 7844
+nc -uvz -w 3 198.41.192.167 7844
 ```
 
 Example output:
@@ -272,7 +272,7 @@ Connection to 198.41.192.167 port 7844 [udp/*] succeeded!
 ### 3.2. Test TCP connectivity
 
 ```sh
-nc -z -w 3 198.41.192.167 7844
+nc -vz -w 3 198.41.192.167 7844
 ```
 
 Example output:


### PR DESCRIPTION
Updated netcat commands to include -v (verbose) flag for better output.

### Summary

The netcat command used for testing connectivity might not yield the result indicated in the example. I suggest adding -v flag (verbose) so the user can see the expected result.

### Screenshots (optional)

This is the result of the netcat command on my Ubuntu 20.04 server. The first command is used in the current docs, while the second is the change I propose.

<img width="507" height="49" alt="image" src="https://github.com/user-attachments/assets/244487bb-a49a-479d-a24c-d49f51d47411" />

Netcat version:
<img width="403" height="18" alt="image" src="https://github.com/user-attachments/assets/120f5f07-9b9d-48d7-ab82-e280f102644e" />

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
