### PR TITLE
[Workers] Add latest changelog entries

### DIFF
--- a/src/content/release-notes/workers.yaml
+++ b/src/content/release-notes/workers.yaml
@@ -3,6 +3,12 @@ link: "/workers/platform/changelog/"
 productName: Workers
 productLink: "/workers/"
 entries:
+  - publish_date: "2026-01-13"
+    description: |-
+      - Updated v8 to version 14.4.
+  - publish_date: "2025-12-19"
+    description: |-
+      - Allow null name when creating dynamic workers.
   - publish_date: "2025-11-25"
     description: |-
       - Updated v8 to version 14.3.


### PR DESCRIPTION
### Summary

One Workers changelog entry for this week, and one that was forgotten previously.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).