### PR TITLE
fix: add RateLimit typescript binding to docs

### DIFF
--- a/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/rate-limit.mdx
@@ -67,7 +67,7 @@ export default {
 
 ```ts
 interface Env {
-  MY_RATE_LIMITER: any;
+  MY_RATE_LIMITER: RateLimit;
 }
 
 export default {


### PR DESCRIPTION
### Summary

Adds the `RateLimit` typescript binding to the rate limiting docs instead of using `any`. Available in all up to date `workers-types` versions since ~May 2024: https://github.com/cloudflare/workerd/pull/2170

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
