### PR TITLE
[Logs] Add link to Apitally under third-party Logpush integrations

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/third-party/apitally.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/third-party/apitally.mdx
@@ -1,0 +1,7 @@
+---
+pcx_content_type: how-to
+title: Apitally
+external_link: https://docs.apitally.io/setup-guides/cloudflare-workers
+sidebar:
+  order: 5
+---


### PR DESCRIPTION
### Summary

Add link to Apitally under *Logs > Logpush > Logpush job setup > Enable destinations > Third-party integrations*.

Page linked: https://docs.apitally.io/setup-guides/cloudflare-workers

[Apitally](https://apitally.io) is an API monitoring & analytics tool with a Logpush integration for REST APIs running on Cloudflare Workers.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).