### PR TITLE
Adding instructions to create a password

### DIFF
--- a/src/content/docs/fundamentals/user-profiles/login.mdx
+++ b/src/content/docs/fundamentals/user-profiles/login.mdx
@@ -35,7 +35,8 @@ If you log in to your Cloudflare user account with Single Sign-On (SSO), you wil
 
 :::caution
 
-If you use social login to sign in, your user profile will not have a password associated with it at first. Some dashboard operations will require setting a password. To set a password, visit [Forgot Password](https://dash.cloudflare.com/forgot-password) in the Cloudflare dashboard.
+If you use social login to sign in, your user profile will not have a password associated with it at first. Some operations require setting a password, such as enabling 2-Factor Authentication or creating API tokens. To set a password, visit [Forgot Password](https://dash.cloudflare.com/forgot-password) in the Cloudflare dashboard, paste your email address and click "Send".
+You will receive an email with instructions to set your password. Once created, use your email and the new password to log in.
 :::
 
 

--- a/src/content/docs/fundamentals/user-profiles/login.mdx
+++ b/src/content/docs/fundamentals/user-profiles/login.mdx
@@ -35,7 +35,9 @@ If you log in to your Cloudflare user account with Single Sign-On (SSO), you wil
 
 :::caution
 
-If you use social login to sign in, your user profile will not have a password associated with it at first. Some operations require setting a password, such as enabling 2-Factor Authentication or creating API tokens. To set a password, visit [Forgot Password](https://dash.cloudflare.com/forgot-password) in the Cloudflare dashboard, paste your email address and click "Send".
+If you use social login to sign in, your user profile will not have a password associated with it at first. Some operations, such as enabling 2-Factor Authentication or creating API tokens, require setting a password.
+
+To set a password, go to [Forgot Password](https://dash.cloudflare.com/forgot-password) in the Cloudflare dashboard, paste your email address, and click **Send**.
 You will receive an email with instructions to set your password. Once created, use your email and the new password to log in.
 :::
 


### PR DESCRIPTION
When the customers create a Cloudflare account with the social login, they don't have access to some features such as 2FA, because they didn't create the account with a password. Added instructions to the warning banner

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
