### PR TITLE
Fix Response Status if File Not Modified

### DIFF
--- a/src/content/docs/r2/api/workers/workers-api-usage.mdx
+++ b/src/content/docs/r2/api/workers/workers-api-usage.mdx
@@ -125,7 +125,7 @@ export default class extends WorkerEntrypoint<Env> {
 
         // When no body is present, preconditions have failed
         return new Response("body" in object ? object.body : undefined, {
-          status: "body" in object ? 200 : 412,
+          status: "body" in object ? 200 : 304,
           headers,
         });
       }


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Shouldn't the response be a 304 Not Modified, not 412 Precondition Failed if the response returns a file without body?

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
