### PR TITLE
Update certificate authorities documentation

### DIFF
--- a/src/content/docs/ssl/reference/certificate-authorities.mdx
+++ b/src/content/docs/ssl/reference/certificate-authorities.mdx
@@ -67,8 +67,6 @@ You can find the full list of supported clients in the [Let's Encrypt documentat
 
 #### Limitations
 
-- Punycode domains are not yet supported.
-
 #### Browser compatibility (most compatible)
 
 :::caution[Warning]
@@ -81,7 +79,7 @@ By cross-signing with a [GlobalSign root CA](https://valid.r1.roots.globalsign.c
 
 Currently trusted by Microsoft, Mozilla, Safari, Cisco, Oracle Java, and Qihoo’s 360 browser, all browsers or operating systems that depend on these root programs are covered.
 
-You can use the [root CAs list](https://pki.goog/faq/#faq-27) for checking compatibility between chain and client but, as explained in [Certificate pinning](/ssl/reference/certificate-pinning/), you should **not** use this list for pinning against.
+You can use the [root CAs list](https://pki.goog/faq/#connecting-to-google) for checking compatibility between chain and client but, as explained in [Certificate pinning](/ssl/reference/certificate-pinning/), you should **not** use this list for pinning against.
 
 ---
 

--- a/src/content/docs/ssl/reference/certificate-authorities.mdx
+++ b/src/content/docs/ssl/reference/certificate-authorities.mdx
@@ -67,6 +67,8 @@ You can find the full list of supported clients in the [Let's Encrypt documentat
 
 #### Limitations
 
+- Punycode domains are not yet supported.
+
 #### Browser compatibility (most compatible)
 
 :::caution[Warning]


### PR DESCRIPTION
Removed mention of unsupported Punycode domains (GTS added support last year) and updated the link for checking trust anchors used to the best HTML anchor.

### Summary

Updating a few details about Google Trust Services to reflect the current state.

### Screenshots (optional)

N/A - minor text changes.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
