### PR TITLE
Clarify custom hostname routing for Worker as origin

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin.mdx
@@ -7,32 +7,51 @@ head:
   - tag: title
     content: Workers as your fallback origin
 description: Learn how to use a Worker as the fallback origin for your SaaS zone.
-
 ---
 
 import { Render } from "~/components";
 
 If you are building your application on [Cloudflare Workers](/workers/), you can use a Worker as the origin for your SaaS zone (also known as your fallback origin).
 
-1. In your SaaS zone, [create and set a fallback origin](/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/#1-create-fallback-origin). Ensure the fallback origin only has an [originless DNS record](/dns/troubleshooting/faq/#what-ip-should-i-use-for-parked-domain--redirect-only--originless-setup):
+## How custom hostname traffic reaches your Worker
 
-   * **Example**: `service.example.com AAAA 100::`
+When customers point their domains to your SaaS zone (for example, `mystore.customer.com` CNAMEs to `service.saasprovider.com`), their traffic enters your Cloudflare zone. Any Worker routes configured on your zone will match this incoming traffic.
+
+For example, if you have:
+
+- Your SaaS zone: `saasprovider.com`
+- Your fallback origin: `service.saasprovider.com`
+- Customer's custom hostname: `mystore.customer.com` (pointed to your zone via CNAME)
+- Worker route: `*/*`
+
+When a visitor requests `mystore.customer.com`, Cloudflare routes that request through your zone. The `*/*` route pattern matches all traffic entering your zone, including traffic from custom hostnames like `mystore.customer.com`.
+
+:::note
+You do not need to add individual Worker routes for each custom hostname. The wildcard route pattern (`*/*`) automatically captures all traffic entering your zone, including traffic from customer vanity domains.
+:::
+
+## Set up a Worker as your fallback origin
+
+1. In your SaaS zone, [create and set a fallback origin](/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started/#1-create-fallback-origin). Ensure the fallback origin only has an [originless DNS record](/dns/troubleshooting/faq/#what-ip-should-i-use-for-parked-domain--redirect-only--originless-setup):
+   - **Example**: `service.example.com AAAA 100::`
 
 2. In that same zone, navigate to **Workers Routes**.
 
 3. Click **Add route**.
 
-4. Decide whether you want traffic bound for your SaaS zone (`example.com`) to go to that Worker:
+4. Configure a route to send traffic to your Worker. Choose one of the following options based on your needs:
+   - **Route all traffic to the Worker** (recommended for most SaaS applications):
+     - **Route**: `*/*`
+     - **Worker**: Select the Worker used for your SaaS application.
 
-   * If *yes*, set the following values:
+     This pattern routes all traffic entering your zone to the Worker, including requests from custom hostnames (for example, `mystore.customer.com`) and requests to your own subdomains (for example, `app.saasprovider.com`).
 
-     * **Route**: `*/*` (routes everything — including custom hostnames — to the Worker).
-     * **Worker**: Select the Worker used for your SaaS application.
+   - **Route only custom hostname traffic to the Worker**:
+     - **Route**: `*/*`
+     - **Worker**: Select the Worker used for your SaaS application.
+     - Add a second route for your zone's own hostnames with **Worker** set to **None** to exclude them.
 
-   * If *no*, set the following values:
-
-     * **Route**: `*.<zonename>.com/*` (only routes custom hostname traffic to the Worker)
-     * **Worker**: **None**
+     For example, if your zone is `saasprovider.com` and you want `api.saasprovider.com` to bypass the Worker, create an additional route `api.saasprovider.com/*` with no Worker assigned. More specific routes take precedence over wildcard routes.
 
 5. Click **Save**.
 
@@ -43,3 +62,8 @@ If you are building your application on [Cloudflare Workers](/workers/), you can
 <Render file="same-name-as-zone" product="cloudflare-for-platforms" />
 
 :::
+
+## Related resources
+
+- [Hostname routing](/cloudflare-for-platforms/workers-for-platforms/configuration/hostname-routing/) - Learn about advanced routing patterns, including dispatch Workers and Orange-to-Orange (O2O) behavior.
+- [Workers routes](/workers/configuration/routing/routes/) - Learn more about route pattern matching and validity rules.

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin.mdx
@@ -46,12 +46,16 @@ You do not need to add individual Worker routes for each custom hostname. The wi
 
      This pattern routes all traffic entering your zone to the Worker, including requests from custom hostnames (for example, `mystore.customer.com`) and requests to your own subdomains (for example, `app.saasprovider.com`).
 
-   - **Route only custom hostname traffic to the Worker**:
+   - **Route all but specific routes to worker**:
      - **Route**: `*/*`
      - **Worker**: Select the Worker used for your SaaS application.
      - Add a second route for your zone's own hostnames with **Worker** set to **None** to exclude them.
 
      For example, if your zone is `saasprovider.com` and you want `api.saasprovider.com` to bypass the Worker, create an additional route `api.saasprovider.com/*` with no Worker assigned. More specific routes take precedence over wildcard routes.
+
+    - **Route only custom hostname traffic to the Worker**:
+     - **Route**: `vanity.customer.com`
+     - **Worker**: Select the Worker used for your SaaS application.
 
 5. Click **Save**.
 


### PR DESCRIPTION
## Summary

Addresses the lack of clarity about how custom hostname traffic reaches Workers when using Cloudflare for SaaS.

- Add new section explaining how custom hostname traffic flows through the SaaS zone
- Provide concrete example showing the relationship between SaaS zone, fallback origin, custom hostname, and Worker route
- Clarify that wildcard route pattern (`*/*`) automatically captures custom hostname traffic
- Rewrite step 4 with clearer routing options and examples
- Add related resources section linking to hostname routing and Workers routes docs

Fixes #27397