### PR TITLE
fix: remove duplicate -- in Docusaurus CLI command

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/docusaurus.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/docusaurus.mdx
@@ -43,7 +43,7 @@ Docusaurus is designed to be easy to use and customizable, making it a popular c
 	 <PackageManagers
 	 	type="create"
 	 	pkg="cloudflare@latest"
-	 	args={"my-docusaurus-app -- --framework=docusaurus --platform=workers"}
+	 	args={"my-docusaurus-app --framework=docusaurus --platform=workers"}
 	 />
 
 	 <Details header="What's happening behind the scenes?">


### PR DESCRIPTION
## Summary
Remove the duplicate `--` separator in the Docusaurus create-cloudflare CLI command.

## Changes
The `PackageManagers` component args had an extra `--` that would cause the generated command to be invalid:

**Before:**
```
npm create cloudflare@latest my-docusaurus-app -- --framework=docusaurus --platform=workers
```

**After:**
```
npm create cloudflare@latest my-docusaurus-app --framework=docusaurus --platform=workers
```

## Related Issue
Fixes #27130

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297