### PR TITLE
Add subrequests limit to wrangler config documentation

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -416,13 +416,16 @@ watch_dir = "build_watch_dir"
 ## Limits
 
 You can impose limits on your Worker's behavior at runtime. Limits are only supported for the [Standard Usage Model](/workers/platform/pricing/#example-pricing-standard-usage-model).
-Limits are only enforced when deployed to Cloudflare's network, not in local development. The CPU limit
-can be set to a maximum of 300,000 milliseconds (5 minutes).
+Limits are only enforced when deployed to Cloudflare's network, not in local development.
 
 <Render file="isolate-cpu-flexibility" product="workers" /> <br />
 
 - `cpu_ms` <Type text="number" /> <MetaInfo text="optional" />
   - The maximum CPU time allowed per invocation, in milliseconds.
+  - The limit can be set to a maximum of 300,000 milliseconds (5 minutes).
+
+- `subrequests` <Type text="number" /> <MetaInfo text="optional" />
+  - The maximum allowed number of fetch requests per invocation.
 
 Example:
 
@@ -431,6 +434,7 @@ Example:
 ```toml title="wrangler.toml"
 [limits]
 cpu_ms = 100
+subrequests = 100
 ```
 
 </WranglerConfig>


### PR DESCRIPTION
### Summary

Add subrequests limit to wrangler config documentation

### Screenshots (optional)

<img width="786" height="798" alt="Screenshot 2026-01-06 at 11 21 57" src="https://github.com/user-attachments/assets/4b46f033-868e-45d3-878d-9c4eeecd8ee2" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
