### PR TITLE
Add webhook payload schema reference for notifications

### DIFF
--- a/src/content/docs/logs/faq/index.mdx
+++ b/src/content/docs/logs/faq/index.mdx
@@ -1,48 +1,60 @@
 ---
-
 pcx_content_type: navigation
 hideChildren: true
 title: FAQ
 Weight: 130
-
 ---
 
-
-
-import { LinkButton } from "~/components"
+import { LinkButton } from "~/components";
 
 Below you will find answers to the most commonly asked questions regarding Cloudflare Logs. If you cannot find the answer you are looking for, go to the [community page](https://community.cloudflare.com/) and post your question there.
 
-
-
-***
+---
 
 ## General FAQ
 
 For general questions about Logs.
 
-<LinkButton variant="primary" href="/logs/faq/general-faq/">General FAQ  ❯</LinkButton>
+<LinkButton variant="primary" href="/logs/faq/general-faq/">
+	General FAQ ❯
+</LinkButton>
 
 ## Logpush
 
 For questions about Logpush.
 
-<LinkButton variant="primary" href="/logs/faq/logpush/">Logpush  ❯</LinkButton>
+<LinkButton variant="primary" href="/logs/faq/logpush/">
+	Logpush ❯
+</LinkButton>
 
 ## Instant Logs
 
 For questions about Instant Logs.
 
-<LinkButton variant="primary" href="/logs/faq/instant-logs/">Instant Logs ❯</LinkButton>
+<LinkButton variant="primary" href="/logs/faq/instant-logs/">
+	Instant Logs ❯
+</LinkButton>
 
 ## Logpull API
 
 For questions about the Logpull API.
 
-<LinkButton variant="primary" href="/logs/faq/logpull-api/">Logpull API ❯</LinkButton>
+<LinkButton variant="primary" href="/logs/faq/logpull-api/">
+	Logpull API ❯
+</LinkButton>
 
 ## Common calculations
 
 For questions about common calculations.
 
-<LinkButton variant="primary" href="/logs/faq/common-calculations/">Common calculations ❯</LinkButton>
+<LinkButton variant="primary" href="/logs/faq/common-calculations/">
+	Common calculations ❯
+</LinkButton>
+
+## Random hostnames
+
+For questions about unexpected hostnames in HTTP logs for partial zones.
+
+<LinkButton variant="primary" href="/logs/faq/random-hostnames-partial-zones/">
+	Random hostnames ❯
+</LinkButton>

--- a/src/content/docs/logs/faq/random-hostnames-partial-zones.mdx
+++ b/src/content/docs/logs/faq/random-hostnames-partial-zones.mdx
@@ -1,0 +1,103 @@
+---
+pcx_content_type: faq
+title: Random hostnames
+structured_data: true
+sidebar:
+  order: 6
+description: Why unexpected hostnames appear in HTTP logs for partial zones.
+---
+
+[❮ Back to FAQ](/logs/faq/)
+
+### Why do I see hostnames in my HTTP logs that I did not configure?
+
+If you use a [partial (CNAME) zone setup](/dns/zone-setups/partial-setup/), you may see hundreds of random hostnames in your HTTP request logs despite only proxying a few DNS records. This is caused by Host header manipulation attacks, not a bug in Cloudflare logging.
+
+### What causes this?
+
+Attackers use a technique called Host header injection:
+
+1. They discover the Cloudflare IP addresses serving your proxied hostname (for example, via DNS lookup of a known proxied subdomain).
+2. They send HTTP requests directly to those IPs with forged `Host` headers containing random subdomain guesses.
+3. Cloudflare logs the `Host` header value as-is in the `ClientRequestHost` field.
+4. The requests reach Cloudflare because they target valid Cloudflare IPs — but the attacker controls the `Host` header content.
+
+The [`http.host` field](/ruleset-engine/rules-language/fields/reference/http.host/) contains the `Host` header from the original request, which means attacker-controlled values appear in your logs.
+
+### Why are partial zones susceptible?
+
+With partial (CNAME) zones:
+
+- Only specific hostnames point to Cloudflare via CNAME at your authoritative DNS provider.
+- Cloudflare does not control the full zone, so it cannot validate that incoming `Host` headers match configured records.
+- Attackers can enumerate subdomains by sending requests to known-good IPs with guessed `Host` headers.
+
+### How do I identify this pattern?
+
+| Indicator                      | What to look for                                                                                                                                            |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Request count distribution** | Legitimate hostnames have thousands of requests. Suspicious hostnames have exactly two to five requests each.                                               |
+| **Hostname patterns**          | Sequential numbers (`0-0`, `0-56`, `007`), common words (`admin`, `api`, `test`, `staging`), or internal service names (`airflow`, `consul`, `prometheus`). |
+| **Source IPs**                 | Suspicious requests often come from a small set of IPs (scanner infrastructure).                                                                            |
+| **Response codes**             | Many 4xx responses (hostname not found, SSL mismatch).                                                                                                      |
+| **DNS correlation**            | Suspicious hostnames do not appear in DNS query logs.                                                                                                       |
+
+### Example data pattern
+
+```txt
+"ClientRequestHost","_count"
+"legitimate-proxied.example.com","12498"    # Real traffic
+"another-proxied.example.com","6082"        # Real traffic
+"0-0.example.com","2"                       # Scanner
+"admin.example.com","2"                     # Scanner
+"api-staging.example.com","2"               # Scanner
+"1234567890.example.com","2"                # Scanner
+```
+
+### How do I block these requests?
+
+Create a [WAF custom rule](/waf/custom-rules/) that only allows requests with valid `Host` headers:
+
+```txt
+Expression:
+(http.host ne "proxied-hostname-1.example.com" and
+ http.host ne "proxied-hostname-2.example.com" and
+ http.host ne "proxied-hostname-3.example.com")
+
+Action: Block
+```
+
+:::tip
+Use a hostname list if you have many proxied hostnames, or use a wildcard match if you use a consistent subdomain pattern.
+:::
+
+### Can I filter these from my logs instead?
+
+Yes. If you prefer cleaner logs without blocking traffic:
+
+- **At Logpush level** — Filter the job to include only known-good hostnames using [Logpush filters](/logs/logpush/logpush-job/filters/).
+- **At SIEM level** — Filter or exclude hostnames with request counts below a threshold during log analysis.
+
+### Are these requests reaching my origin?
+
+Possibly, if the `Host` header happens to match a configured hostname or if you have a default or catch-all origin. Check `EdgeResponseStatus` and `OriginResponseStatus` to see if origins were contacted.
+
+### Is this a security risk?
+
+The risk is low to moderate. The main concerns are:
+
+- Information disclosure if error pages reveal internal details.
+- Resource consumption if requests reach your origin.
+- Log noise that makes real attacks harder to identify.
+
+### Why do suspicious hostnames have exactly two requests?
+
+Automated scanners typically send one to two requests per subdomain guess — one initial probe and possibly one retry. This uniform distribution is a reliable indicator of scanning activity.
+
+### How do I verify my solution is working?
+
+After implementing a WAF rule:
+
+1. Check **Firewall Events** for blocked requests matching your rule.
+2. Compare log volume before and after — suspicious hostnames should disappear.
+3. Verify legitimate traffic is unaffected by checking request counts for real hostnames.

--- a/src/content/docs/logs/faq/random-hostnames-partial-zones.mdx
+++ b/src/content/docs/logs/faq/random-hostnames-partial-zones.mdx
@@ -1,0 +1,103 @@
+---
+pcx_content_type: faq
+title: Random hostnames
+structured_data: true
+sidebar:
+  order: 6
+description: Why unexpected hostnames appear in HTTP logs for partial zones.
+---
+
+[❮ Back to FAQ](/logs/faq/)
+
+### Why do I see hostnames in my HTTP logs that I did not configure?
+
+If you use a [partial (CNAME) zone setup](/dns/zone-setups/partial-setup/), you may see hundreds of random hostnames in your HTTP request logs despite only proxying a few DNS records. This is caused by Host header manipulation attacks, not a bug in Cloudflare logging.
+
+### What causes this?
+
+Attackers use a technique called Host header injection:
+
+1. They discover the Cloudflare IP addresses serving your proxied hostname (for example, via DNS lookup of a known proxied subdomain).
+2. They send HTTP requests directly to those IPs with forged `Host` headers containing random subdomain guesses.
+3. Cloudflare logs the `Host` header value as-is in the `ClientRequestHost` field.
+4. The requests reach Cloudflare because they target valid Cloudflare IPs — but the attacker controls the `Host` header content.
+
+The [`http.host` field](/ruleset-engine/rules-language/fields/reference/http.host/) contains the `Host` header from the original request, which means attacker-controlled values appear in your logs.
+
+### Why are partial zones susceptible?
+
+With partial (CNAME) zones:
+
+- Only specific hostnames point to Cloudflare via CNAME at your authoritative DNS provider.
+- Cloudflare does not control the full zone, so it cannot validate that incoming `Host` headers match configured records.
+- Attackers can enumerate subdomains by sending requests to known-good IPs with guessed `Host` headers.
+
+### How do I identify this pattern?
+
+| Indicator                      | What to look for                                                                                                                                            |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Request count distribution** | Legitimate hostnames have thousands of requests. Suspicious hostnames have exactly two to five requests each.                                               |
+| **Hostname patterns**          | Sequential numbers (`0-0`, `0-56`, `007`), common words (`admin`, `api`, `test`, `staging`), or internal service names (`airflow`, `consul`, `prometheus`). |
+| **Source IPs**                 | Suspicious requests often come from a small set of IPs (scanner infrastructure).                                                                            |
+| **Response codes**             | Many 4xx responses (hostname not found, SSL mismatch).                                                                                                      |
+| **DNS correlation**            | Suspicious hostnames do not appear in DNS query logs.                                                                                                       |
+
+### Example data pattern
+
+```txt
+"ClientRequestHost","_count"
+"legitimate-proxied.example.com","12498"    # Real traffic
+"another-proxied.example.com","6082"        # Real traffic
+"0-0.example.com","2"                       # Scanner
+"admin.example.com","2"                     # Scanner
+"api-staging.example.com","2"               # Scanner
+"1234567890.example.com","2"                # Scanner
+```
+
+### How do I block these requests?
+
+Create a [WAF custom rule](/waf/custom-rules/) that only allows requests with valid `Host` headers:
+
+```txt
+Expression:
+(http.host ne "proxied-hostname-1.example.com" and
+ http.host ne "proxied-hostname-2.example.com" and
+ http.host ne "proxied-hostname-3.example.com")
+
+Action: Block
+```
+
+:::tip
+Use a hostname list if you have many proxied hostnames, or use a wildcard match if you use a consistent subdomain pattern.
+:::
+
+### Can I filter these from my logs instead?
+
+Yes. If you prefer cleaner logs without blocking traffic:
+
+- **At Logpush level** — Filter the job to include only known-good hostnames using [Logpush filters](/logs/logpush/logpush-configuration-api/filters/).
+- **At SIEM level** — Filter or exclude hostnames with request counts below a threshold during log analysis.
+
+### Are these requests reaching my origin?
+
+Possibly, if the `Host` header happens to match a configured hostname or if you have a default or catch-all origin. Check `EdgeResponseStatus` and `OriginResponseStatus` to see if origins were contacted.
+
+### Is this a security risk?
+
+The risk is low to moderate. The main concerns are:
+
+- Information disclosure if error pages reveal internal details.
+- Resource consumption if requests reach your origin.
+- Log noise that makes real attacks harder to identify.
+
+### Why do suspicious hostnames have exactly two requests?
+
+Automated scanners typically send one to two requests per subdomain guess — one initial probe and possibly one retry. This uniform distribution is a reliable indicator of scanning activity.
+
+### How do I verify my solution is working?
+
+After implementing a WAF rule:
+
+1. Check **Firewall Events** for blocked requests matching your rule.
+2. Compare log volume before and after — suspicious hostnames should disappear.
+3. Verify legitimate traffic is unaffected by checking request counts for real hostnames.

--- a/src/content/docs/notifications/get-started/configure-webhooks.mdx
+++ b/src/content/docs/notifications/get-started/configure-webhooks.mdx
@@ -3,14 +3,13 @@ pcx_content_type: how-to
 title: Configure webhooks
 sidebar:
   order: 3
-
 ---
 
 import { DashButton } from "~/components";
 
 :::note
 
-This feature is only available if your account has at least one zone with a pro plan or above. For more information, refer to our [plans](https://www.cloudflare.com/plans/). 
+This feature is only available if your account has at least one zone with a pro plan or above. For more information, refer to our [plans](https://www.cloudflare.com/plans/).
 :::
 
 There are a variety of services you can connect to Cloudflare using webhooks to receive notifications from your Cloudflare account. Refer to the table below to learn how to connect your Cloudflare account to [popular webhook services](#popular-webhook-services).
@@ -18,8 +17,9 @@ There are a variety of services you can connect to Cloudflare using webhooks to 
 ## Configure webhooks
 
 1. In the Cloudflare dashboard, go to the **Notifications** page.
-  
-    <DashButton url="/?to=/:account/notifications" />
+
+   <DashButton url="/?to=/:account/notifications" />
+
 2. Go to **Destinations**.
 3. In the **Webhooks** card, select **Create**.
 4. Give your webhook a name to use for identification later.
@@ -34,8 +34,9 @@ The new webhook will appear in the **Webhooks** card.
 You can only edit the name of webhooks and/or delete them.
 
 1. In the Cloudflare dashboard, go to the **Notifications** page.
-  
-    <DashButton url="/?to=/:account/notifications" />
+
+   <DashButton url="/?to=/:account/notifications" />
+
 2. Go to **Destinations**.
 3. In the **Webhooks** card, select **Edit** on the webhook that you want to edit.
 4. Update the webhook's name and select **Save**.
@@ -54,14 +55,11 @@ When Cloudflare sends you a webhook, it will have the following schema:
 
 ```json title="Example schema"
 {
-    "text": "Hello World! This is a test message sent from https://cloudflare.com. If you can see this, your webhook is configured properly."
+	"text": "Hello World! This is a test message sent from https://cloudflare.com. If you can see this, your webhook is configured properly."
 }
 ```
 
-:::note
-
-`"text"` will vary depending on the alert that was fired. 
-:::
+For the full payload structure and examples for different alert types, refer to the [webhook payload schema reference](/notifications/reference/webhook-payload-schema/).
 
 ### Limitations of generic webhooks
 
@@ -117,11 +115,11 @@ For [OpsGenie](https://support.atlassian.com/opsgenie/docs/create-a-default-api-
 For [Splunk](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector):
 
 - **Secret**: The secret is required and has to be entered by the user. This is what Splunk refers to as `token`. Refer to [Splunk’s documentation](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector#How_the_Splunk_platform_uses_HTTP_Event_Collector_tokens_to_get_data_in) for details.
-- **URL**: 
-   1. We only support three Splunk endpoints: services/collector, services/collector/raw, and services/collector/event.
-   2. If SSL is enabled on the token, the port must be 443. If SSL is not enabled on the token, the port must be 8088.
-   3. SSL must be enabled on the server.
-   4. **Enable indexer acknowledgement** must be disabled on the Splunk HTTP Event Collector.
+- **URL**:
+  1.  We only support three Splunk endpoints: services/collector, services/collector/raw, and services/collector/event.
+  2.  If SSL is enabled on the token, the port must be 443. If SSL is not enabled on the token, the port must be 8088.
+  3.  SSL must be enabled on the server.
+  4.  **Enable indexer acknowledgement** must be disabled on the Splunk HTTP Event Collector.
 
 ### Feishu
 
@@ -150,7 +148,6 @@ For a Generic webhook:
 
 - **Secret**: User decides.
 - **URL**: User decides.
-
 
 ### Configuration of secrets
 

--- a/src/content/docs/notifications/reference/webhook-payload-schema.mdx
+++ b/src/content/docs/notifications/reference/webhook-payload-schema.mdx
@@ -1,0 +1,324 @@
+---
+pcx_content_type: reference
+title: Webhook payload schema
+sidebar:
+  order: 2
+---
+
+import { Details } from "~/components";
+
+When you [configure a generic webhook](/notifications/get-started/configure-webhooks/#generic-webhooks), Cloudflare sends a JSON payload to your specified URL for each notification. This page documents the structure of that payload.
+
+## Payload structure
+
+All generic webhook notifications follow this schema:
+
+```json
+{
+	"name": "string",
+	"text": "string",
+	"data": {},
+	"ts": 1136214245,
+	"account_id": "string",
+	"policy_id": "string",
+	"policy_name": "string",
+	"alert_type": "string",
+	"alert_correlation_id": "string",
+	"alert_event": "string"
+}
+```
+
+### Field descriptions
+
+| Field                  | Type    | Description                                                                    |
+| ---------------------- | ------- | ------------------------------------------------------------------------------ |
+| `name`                 | string  | The name of the notification policy.                                           |
+| `text`                 | string  | A human-readable description of the notification with interpolated values.     |
+| `data`                 | object  | Alert-specific data. The structure varies by `alert_type`.                     |
+| `ts`                   | integer | Unix timestamp (seconds since epoch, UTC) when the notification was generated. |
+| `account_id`           | string  | The account ID for which this webhook was fired.                               |
+| `policy_id`            | string  | UUID of the notification policy that triggered this webhook.                   |
+| `policy_name`          | string  | Name of the notification policy.                                               |
+| `alert_type`           | string  | Unique identifier for the alert type (for example, `http_alert_origin_error`). |
+| `alert_correlation_id` | string  | UUID that groups related alerts together.                                      |
+| `alert_event`          | string  | The event state, such as `ALERT_STATE_EVENT_START` or `ALERT_STATE_EVENT_END`. |
+
+:::note
+The `account_id`, `policy_id`, and `alert_type` fields may not be present in all notifications, depending on the alert type and context.
+:::
+
+## Example payloads
+
+The following examples show the payload structure for common alert types. The `data` object varies based on the specific alert.
+
+<Details header="DDoS attack (Layer 4)">
+
+```json
+{
+	"account_id": "9035f53656c247e895c5a6939ae8a0e0",
+	"alert_correlation_id": "000eaa907ed24e78946d3a93adb2ae57",
+	"alert_event": "ALERT_STATE_EVENT_START",
+	"alert_type": "advanced_ddos_attack_l4_alert",
+	"data": {
+		"account_name": "string",
+		"account_tag": "string",
+		"action": "string",
+		"attack_id": "string",
+		"attack_vector": "string",
+		"dashboard_link": "string",
+		"max_rate": "string",
+		"megabits_per_second": 0,
+		"mitigation": "string",
+		"packets_per_second": 0,
+		"protocol": "string",
+		"rule_description": "string",
+		"rule_id": "string",
+		"rule_name": "string",
+		"ruleset_id": "string",
+		"ruleset_override_id": "string",
+		"start_time": "2006-01-02T15:04:05Z",
+		"target_id": "string",
+		"target_ip": "string",
+		"target_port": 0
+	},
+	"name": "Example Cloudflare Notification",
+	"policy_id": "749b911ea5d04344a58e45edd099b328",
+	"policy_name": "Example Cloudflare Notification",
+	"text": "The description of my Cloudflare notification.",
+	"ts": 1136214245
+}
+```
+
+</Details>
+
+<Details header="DDoS attack (Layer 7)">
+
+```json
+{
+	"account_id": "9035f53656c247e895c5a6939ae8a0e0",
+	"alert_correlation_id": "000eaa907ed24e78946d3a93adb2ae57",
+	"alert_event": "ALERT_STATE_EVENT_START",
+	"alert_type": "advanced_ddos_attack_l7_alert",
+	"data": {
+		"account_name": "string",
+		"account_tag": "string",
+		"action": "string",
+		"attack_id": "string",
+		"attack_type": "string",
+		"dashboard_link": "string",
+		"max_rate": "string",
+		"mitigation": "string",
+		"requests_per_second": 0,
+		"rule_description": "string",
+		"rule_id": "string",
+		"rule_link": "string",
+		"ruleset_id": "string",
+		"ruleset_override_id": "string",
+		"start_time": "2006-01-02T15:04:05Z",
+		"target_hostname": "string",
+		"zone_name": "string",
+		"zone_tag": "string"
+	},
+	"name": "Example Cloudflare Notification",
+	"policy_id": "749b911ea5d04344a58e45edd099b328",
+	"policy_name": "Example Cloudflare Notification",
+	"text": "The description of my Cloudflare notification.",
+	"ts": 1136214245
+}
+```
+
+</Details>
+
+<Details header="SSL certificate expiration">
+
+```json
+{
+	"account_id": "9035f53656c247e895c5a6939ae8a0e0",
+	"alert_correlation_id": "000eaa907ed24e78946d3a93adb2ae57",
+	"alert_event": "ALERT_STATE_EVENT_START",
+	"alert_type": "dedicated_ssl_certificate_event_type",
+	"data": {
+		"account_name": "string",
+		"account_tag": "string",
+		"certificate_id": "string",
+		"certificate_pack_id": "string",
+		"certificate_status": "string",
+		"event_type": "string",
+		"hostnames": "string",
+		"pack_ca": "string",
+		"pack_id": "string",
+		"pack_status": "string",
+		"pack_validation": "string",
+		"zone_name": "string",
+		"zone_tag": "string"
+	},
+	"name": "Example Cloudflare Notification",
+	"policy_id": "749b911ea5d04344a58e45edd099b328",
+	"policy_name": "Example Cloudflare Notification",
+	"text": "The description of my Cloudflare notification.",
+	"ts": 1136214245
+}
+```
+
+</Details>
+
+<Details header="Origin health check">
+
+```json
+{
+	"account_id": "9035f53656c247e895c5a6939ae8a0e0",
+	"alert_correlation_id": "000eaa907ed24e78946d3a93adb2ae57",
+	"alert_event": "ALERT_STATE_EVENT_START",
+	"alert_type": "health_check_status_notification",
+	"data": {
+		"account_name": "string",
+		"account_tag": "string",
+		"failing_regions": "string",
+		"health_check_id": "string",
+		"health_check_name": "string",
+		"new_health_status": "string",
+		"new_status": "string",
+		"old_status": "string",
+		"origin_ip": "string",
+		"reason": "string",
+		"status_change_time": "2006-01-02T15:04:05Z",
+		"time_since_last_failure": "string",
+		"zone_name": "string",
+		"zone_tag": "string"
+	},
+	"name": "Example Cloudflare Notification",
+	"policy_id": "749b911ea5d04344a58e45edd099b328",
+	"policy_name": "Example Cloudflare Notification",
+	"text": "The description of my Cloudflare notification.",
+	"ts": 1136214245
+}
+```
+
+</Details>
+
+<Details header="Workers alert">
+
+```json
+{
+	"account_id": "9035f53656c247e895c5a6939ae8a0e0",
+	"alert_correlation_id": "000eaa907ed24e78946d3a93adb2ae57",
+	"alert_event": "ALERT_STATE_EVENT_START",
+	"alert_type": "workers_alert",
+	"data": {
+		"account_name": "string",
+		"account_script_count": 0,
+		"account_tag": "string",
+		"alert_type": "string",
+		"current_year": 0,
+		"end_date": "string",
+		"exceeding_script_count": 0,
+		"scripts": [
+			{
+				"constant_script_id": 0,
+				"cpu_time_previous_value": 0,
+				"cpu_time_unit": "string",
+				"cpu_time_value": 0,
+				"data_egress_unit": "string",
+				"data_egress_value": 0,
+				"duration_previous_value": 0,
+				"duration_unit": "string",
+				"duration_value": 0,
+				"last_modified": "string",
+				"request_count_previous_value": 0,
+				"request_count_unit": "string",
+				"request_count_value": 0,
+				"routes": ["string"],
+				"script_name": "string",
+				"usage_model": 0
+			}
+		],
+		"start_date": "string",
+		"total_data_egress_unit": "string",
+		"total_data_egress_value": 0,
+		"total_duration_unit": "string",
+		"total_duration_value": 0,
+		"total_request_count_unit": "string",
+		"total_request_count_value": 0
+	},
+	"name": "Example Cloudflare Notification",
+	"policy_id": "749b911ea5d04344a58e45edd099b328",
+	"policy_name": "Example Cloudflare Notification",
+	"text": "The description of my Cloudflare notification.",
+	"ts": 1136214245
+}
+```
+
+</Details>
+
+<Details header="Access certificate expiration">
+
+```json
+{
+	"account_id": "9035f53656c247e895c5a6939ae8a0e0",
+	"alert_correlation_id": "000eaa907ed24e78946d3a93adb2ae57",
+	"alert_event": "ALERT_STATE_EVENT_START",
+	"alert_type": "access_custom_certificate_expiration_type",
+	"data": {
+		"account_name": "string",
+		"account_tag": "string",
+		"certificate_id": "string",
+		"days_til_expiration": 0,
+		"hostnames": "string",
+		"zone_name": "string",
+		"zone_tag": "string"
+	},
+	"name": "Example Cloudflare Notification",
+	"policy_id": "749b911ea5d04344a58e45edd099b328",
+	"policy_name": "Example Cloudflare Notification",
+	"text": "The description of my Cloudflare notification.",
+	"ts": 1136214245
+}
+```
+
+</Details>
+
+<Details header="Workers observability alert">
+
+```json
+{
+	"account_id": "9035f53656c247e895c5a6939ae8a0e0",
+	"alert_correlation_id": "000eaa907ed24e78946d3a93adb2ae57",
+	"alert_event": "ALERT_STATE_EVENT_START",
+	"alert_type": "workers_observability_alert",
+	"data": {
+		"account": {
+			"id": "string",
+			"name": "string"
+		},
+		"config": {
+			"id": "string",
+			"name": "string"
+		},
+		"episode": {
+			"first_failed": "2006-01-02T15:04:05Z",
+			"first_fired": "2006-01-02T15:04:05Z",
+			"id": "string",
+			"last_failed": "2006-01-02T15:04:05Z",
+			"resolved_at": "2006-01-02T15:04:05Z",
+			"summary": "string"
+		},
+		"status": "PENDING"
+	},
+	"name": "Example Cloudflare Notification",
+	"policy_id": "749b911ea5d04344a58e45edd099b328",
+	"policy_name": "Example Cloudflare Notification",
+	"text": "The description of my Cloudflare notification.",
+	"ts": 1136214245
+}
+```
+
+</Details>
+
+## Validate webhook payloads
+
+You can use the `cf-webhook-auth` header to verify that incoming webhooks are from Cloudflare. When you configure a webhook with a secret, Cloudflare includes this header with your secret value in every request. Reject any requests where this header is missing or does not match your configured secret.
+
+## Related resources
+
+- [Configure webhooks](/notifications/get-started/configure-webhooks/)
+- [Available notification types](/notifications/notification-available/)


### PR DESCRIPTION
## Summary

Documents the generic webhook payload schema for Cloudflare notifications, a frequently asked question from customers.

## What this PR adds

**New page:** `/notifications/reference/webhook-payload-schema/`

Covers:

- **Payload structure** — All fields in the generic webhook JSON payload
- **Field descriptions** — Table explaining each field's type and purpose
- **Example payloads** — Seven collapsible examples for common alert types (DDoS L4/L7, SSL certificate, health check, Workers, Access certificate, Workers observability)
- **Webhook validation** — How to use `cf-webhook-auth` header

**Updated:** [/notifications/get-started/configure-webhooks.mdx](cci:7://file:///Users/rian/Documents/GitHub/cloudflare-docs/src/content/docs/notifications/get-started/configure-webhooks.mdx:0:0-0:0)

- Added link to new schema reference page from the generic webhooks section

## Why

Questions about the format of webhook alert payloads come up frequently. This information was previously only available on an internal wiki page.