### PR TITLE
Automatically document all existing workers compat flags

### DIFF
--- a/src/content/compatibility-flags/cache-api-compat-flags.md
+++ b/src/content/compatibility-flags/cache-api-compat-flags.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Cache API compat flags"
+sort_date: "2025-04-19"
+enable_flag: "cache_api_compat_flags"
+disable_flag: "no_cache_api_compat_flags"
+---
+
+When enabled, exports compability flags for FL to Cache API requests.

--- a/src/content/compatibility-flags/cache-api-request-cf-overrides-cache-rules.md
+++ b/src/content/compatibility-flags/cache-api-request-cf-overrides-cache-rules.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Cache API request cf overrides cache rules"
+sort_date: "2025-05-19"
+enable_flag: "cache_api_request_cf_overrides_cache_rules"
+disable_flag: "no_cache_api_request_cf_overrides_cache_rules"
+---
+
+Enables cache settings specified request in cache api `cf` object to override cache rules. (only for user owned or grey-clouded sites)

--- a/src/content/compatibility-flags/enable-fast-jsg-struct.md
+++ b/src/content/compatibility-flags/enable-fast-jsg-struct.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Fast Jsg Struct"
+sort_date: "2025-12-03"
+enable_flag: "enable_fast_jsg_struct"
+disable_flag: "disable_fast_jsg_struct"
+---
+
+Enables the fast `jsg::Struct` optimization. With this enabled, `JSG_STRUCTS` will use a more efficient creation pattern that reduces construction time. However, optional fields will be explicitly set to `undefined` rather than being omitted, which is an observable behavior change.

--- a/src/content/compatibility-flags/enable-nodejs-cluster-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-cluster-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js cluster module"
+enable_flag: "enable_nodejs_cluster_module"
+disable_flag: "disable_nodejs_cluster_module"
+---
+
+Enables the Node.js non-functional stub `cluster` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-nodejs-console-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-console-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js console module"
+enable_flag: "enable_nodejs_console_module"
+disable_flag: "disable_nodejs_console_module"
+---
+
+Enables the Node.js `console` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-nodejs-domain-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-domain-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js domain module"
+enable_flag: "enable_nodejs_domain_module"
+disable_flag: "disable_nodejs_domain_module"
+---
+
+Enables the Node.js non-functional stub `domain` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-nodejs-fs-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-fs-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js fs Module"
+enable_flag: "enable_nodejs_fs_module"
+disable_flag: "disable_nodejs_fs_module"
+---
+
+Enables the Node.js `fs` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-nodejs-http2-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-http2-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js http2 Module"
+enable_flag: "enable_nodejs_http2_module"
+disable_flag: "disable_nodejs_http2_module"
+---
+
+Enables the Node.js `http2` module stubs.

--- a/src/content/compatibility-flags/enable-nodejs-os-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-os-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js os Module"
+enable_flag: "enable_nodejs_os_module"
+disable_flag: "disable_nodejs_os_module"
+---
+
+Enables the Node.js `os` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-nodejs-punycode-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-punycode-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js punycode module"
+enable_flag: "enable_nodejs_punycode_module"
+disable_flag: "disable_nodejs_punycode_module"
+---
+
+Enables the Node.js deprecated `punycode` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-nodejs-trace-events-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-trace-events-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js trace_events module"
+enable_flag: "enable_nodejs_trace_events_module"
+disable_flag: "disable_nodejs_trace_events_module"
+---
+
+Enables the Node.js non-functional stub `trace_events` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-nodejs-vm-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-vm-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js vm module"
+enable_flag: "enable_nodejs_vm_module"
+disable_flag: "disable_nodejs_vm_module"
+---
+
+Enables the Node.js non-functional stub `vm` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-nodejs-wasi-module.md
+++ b/src/content/compatibility-flags/enable-nodejs-wasi-module.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable Node.js wasi module"
+enable_flag: "enable_nodejs_wasi_module"
+disable_flag: "disable_nodejs_wasi_module"
+---
+
+Enables the Node.js non-functional stub `wasi` module. It is required to use this flag with `nodejs_compat` (or `nodejs_compat_v2`).

--- a/src/content/compatibility-flags/enable-validate-workflow-entrypoint.md
+++ b/src/content/compatibility-flags/enable-validate-workflow-entrypoint.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Enable validate workflow entrypoint"
+sort_date: "2025-09-20"
+enable_flag: "enable_validate_workflow_entrypoint"
+disable_flag: "disable_validate_workflow_entrypoint"
+---
+
+This flag enables additional checks in the control plane to validate that workflows are defined and used correctly

--- a/src/content/compatibility-flags/fetch-iterable-type-support-override-adjustment.md
+++ b/src/content/compatibility-flags/fetch-iterable-type-support-override-adjustment.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Fetch Iterable type support override adjustment"
+enable_flag: "fetch_iterable_type_support_override_adjustment"
+disable_flag: "no_fetch_iterable_type_support_override_adjustment"
+---
+
+Further adapts the fetch iterable type support to adjust for `toString`/`toPrimitive` overrides on sync iterable objects. Specifically, if an object passed as the body of a fetch `Request` or `Response` is sync iterable but has a custom `toString` or `toPrimitive` method, we will skip treating it as a sync iterable and instead allow it to fall through to being handled as a stringified object.

--- a/src/content/compatibility-flags/handle-cross-request-promise-resolution.md
+++ b/src/content/compatibility-flags/handle-cross-request-promise-resolution.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Handle cross-request promise resolution"
+sort_date: "2024-10-14"
+enable_flag: "handle_cross_request_promise_resolution"
+disable_flag: "no_handle_cross_request_promise_resolution"
+---
+
+Historically, it has been possible to resolve a promise from an incorrect request `IoContext`. This leads to issues with promise continuations being scheduled to run in the wrong `IoContext` leading to errors and difficult to diagnose bugs. With this compatibility flag we arrange to have such promise continuations scheduled to run in the correct `IoContext` if it is still alive, or dropped on the floor with a warning if the correct `IoContext` is not still alive.

--- a/src/content/compatibility-flags/internal-writable-stream-abort-clears-queue.md
+++ b/src/content/compatibility-flags/internal-writable-stream-abort-clears-queue.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Internal writable stream abort clears queue"
+sort_date: "2024-09-02"
+enable_flag: "internal_writable_stream_abort_clears_queue"
+disable_flag: "internal_writable_stream_abort_does_not_clear_queue"
+---
+
+When using the original `WritableStream` implementation ("internal" streams), the `abort()` operation would be handled lazily, meaning that the queue of pending writes would not be cleared until the next time the queue was processed. This behavior leads to a situtation where the stream can hang if the consumer stops consuming. When set, this flag changes the behavior to clear the queue immediately upon abort.

--- a/src/content/compatibility-flags/nodejs-zlib.md
+++ b/src/content/compatibility-flags/nodejs-zlib.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Node.js Zlib module"
+enable_flag: "nodejs_zlib"
+disable_flag: "no_nodejs_zlib"
+---
+
+Enables `node:zlib` implementation. Automatically enabled when `nodejs_compat` is set.

--- a/src/content/compatibility-flags/python-dedicated-snapshot.md
+++ b/src/content/compatibility-flags/python-dedicated-snapshot.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Python Dedicated Snapshot"
+enable_flag: "python_dedicated_snapshot"
+disable_flag: "disable_python_dedicated_snapshot"
+---
+
+Enables the generation of dedicated snapshots on Python Worker upload. The snapshot will be stored inside the resulting WorkerBundle of the Worker. The snapshot will be taken after the top-level execution of the Worker.

--- a/src/content/compatibility-flags/python-workers-force-new-vendor-path.md
+++ b/src/content/compatibility-flags/python-workers-force-new-vendor-path.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Python Workers force new vendor path"
+sort_date: "2025-08-11"
+enable_flag: "python_workers_force_new_vendor_path"
+---
+
+Disables adding `/session/metadata/vendor` to the Python Worker's `sys.path`. So Workers using this flag will have to place their vendored modules in a `python_modules` directory.

--- a/src/content/compatibility-flags/python-workflows.md
+++ b/src/content/compatibility-flags/python-workflows.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Python Workflows"
+enable_flag: "python_workflows"
+disable_flag: "disable_python_workflows"
+---
+
+Enables support for Python workflows. This is still in development and may change in the future.

--- a/src/content/compatibility-flags/remove-nodejs-compat-eol-v22.md
+++ b/src/content/compatibility-flags/remove-nodejs-compat-eol-v22.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Remove Node.js Compat EOL features - v22"
+enable_flag: "remove_nodejs_compat_eol_v22"
+disable_flag: "add_nodejs_compat_eol_v22"
+---
+
+Removes APIs that reached end-of-life in Node.js 22.x. When using the `removeNodejsCompatEOL` flag, this will default enable on/after 2027-04-30.

--- a/src/content/compatibility-flags/remove-nodejs-compat-eol-v23.md
+++ b/src/content/compatibility-flags/remove-nodejs-compat-eol-v23.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Remove Node.js Compat EOL features - v23"
+enable_flag: "remove_nodejs_compat_eol_v23"
+disable_flag: "add_nodejs_compat_eol_v23"
+---
+
+Removes APIs that reached end-of-life in Node.js 23.x. This will default enable when the `removeNodejsCompatEOLv24` flag is enabled after 2025-09-01. Went EOL on 2025-06-01.

--- a/src/content/compatibility-flags/remove-nodejs-compat-eol-v24.md
+++ b/src/content/compatibility-flags/remove-nodejs-compat-eol-v24.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Remove Node.js Compat EOL features - v24"
+enable_flag: "remove_nodejs_compat_eol_v24"
+disable_flag: "add_nodejs_compat_eol_v24"
+---
+
+Removes APIs that reached end-of-life in Node.js 24.x. When using the `removeNodejsCompatEOL` flag, this will default enable on/after 2028-04-30.

--- a/src/content/compatibility-flags/remove-nodejs-compat-eol.md
+++ b/src/content/compatibility-flags/remove-nodejs-compat-eol.md
@@ -1,0 +1,12 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Remove Node.js Cpmpat EOL features"
+enable_flag: "remove_nodejs_compat_eol"
+disable_flag: "add_nodejs_compat_eol"
+---
+
+Removes the Node.js compatibility layer for EOL versions of Node.js. When the flag is enabled, APIs that have reached End-of-Life in Node.js will be removed for workers. When disabled, the APIs are present (but might still be non-functional stubs)

--- a/src/content/compatibility-flags/strip-authorization-on-cross-origin-redirect.md
+++ b/src/content/compatibility-flags/strip-authorization-on-cross-origin-redirect.md
@@ -1,0 +1,17 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Strip authorization on cross-origin redirect"
+sort_date: "2025-09-01"
+enable_flag: "strip_authorization_on_cross_origin_redirect"
+disable_flag: "retain_authorization_on_cross_origin_redirect"
+---
+
+This flag specifies that when automatic redirects are enabled, and a redirect points to a URL at a different origin, if the original request contained an `Authorization` header, that header is removed before following the redirect.  This behavior is required by the current version of the Fetch API specification.
+
+This requirement was added to the Fetch spec in 2022, well after Cloudflare Workers originally implemented it. Hence, Workers did not originally implement this requirement. This requirement is backwards-incompatible, and so the new behavior is guarded by a compatibility flag.
+
+Note that the old behavior was not inherently insecure, and indeed could be desirable in many circumstances. For example, if an API that requires authorization wishes to change its hostname, it might wish to redirect to the new hostname while having the client send along their credentials. Under the new fetch behavior, such a redirect will break clients, and this has legitimately broken real use cases. However, it's true that the old behavior could be a "gotcha" leading to security problems when combined with other mistakes. Hence, the spec was changed, and Workers must follow the spec.

--- a/src/content/compatibility-flags/strip-bom-in-read-all-text.md
+++ b/src/content/compatibility-flags/strip-bom-in-read-all-text.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Strip Bom In Read All Text"
+sort_date: "2026-01-13"
+enable_flag: "strip_bom_in_read_all_text"
+disable_flag: "do_not_strip_bom_in_read_all_text"
+---
+
+Instructs the `readAllText` method in streams to strip the leading UTF8 BOM if present.

--- a/src/content/compatibility-flags/urlpattern-standard.md
+++ b/src/content/compatibility-flags/urlpattern-standard.md
@@ -1,0 +1,13 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Standards-compliant URLPattern implementation"
+sort_date: "2025-05-01"
+enable_flag: "urlpattern_standard"
+disable_flag: "urlpattern_original"
+---
+
+The original `URLPattern` implementation is not compliant with the WHATWG `URLPattern` Standard, leading to a number of issues reported by users. Unfortunately, making it spec compliant is a breaking change. This flag controls the availability of the new spec-compliant `URLPattern` implementation.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

I wrote a script to automatically generate documentation stubs once a compatibility flag is added in workerd. I went over the output and edited it for clarity.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
