### PR TITLE
fix: replace duplicate learn-more components with deploy-to-pages

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-brunch-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-brunch-site.mdx
@@ -29,11 +29,7 @@ brunch new proj -s es6
 
 ## Deploy with Cloudflare Pages
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Brunch" }}
-/>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="brunch" />
 

--- a/src/content/docs/pages/framework-guides/deploy-a-hugo-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hugo-site.mdx
@@ -94,13 +94,11 @@ Inside of `hello-world.md`, add some initial content to create your post. Remove
 
 ## Deploy with Cloudflare Pages
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Hugo" }}
-/>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="hugo" />
+
+While `public` is the default build directory for Hugo sites, this setting can be configured with the [`publishDir` setting](https://gohugo.io/configuration/all/#publishdir).
 
 :::note[Base URL configuration]
 

--- a/src/content/docs/pages/framework-guides/deploy-a-jekyll-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-jekyll-site.mdx
@@ -65,11 +65,7 @@ If you are migrating an existing Jekyll project to Pages, confirm that your `Gem
 
 ## Deploy with Cloudflare Pages
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Jekyll" }}
-/>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="jekyll" />
 

--- a/src/content/docs/pages/framework-guides/deploy-a-nuxt-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-nuxt-site.mdx
@@ -74,17 +74,13 @@ git push -u origin main
 
 ### Create a Pages project
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Nuxt.js" }}
-/>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="nuxt-js" />
 
 Optionally, you can customize the **Project name** field. It defaults to the GitHub repository's name, but it does not need to match. The **Project name** value is assigned as your `*.pages.dev` subdomain.
 
-4. After completing configuration, select the **Save and Deploy**.
+7. After completing configuration, select the **Save and Deploy**.
 
 Review your first deploy pipeline in progress. Pages installs all dependencies and builds the project as specified. Cloudflare Pages will automatically rebuild your project and deploy it on every new pushed commit.
 

--- a/src/content/docs/pages/framework-guides/deploy-a-pelican-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-pelican-site.mdx
@@ -35,15 +35,11 @@ This is the directory name that you will set in the build command.
 
 ## Deploy with Cloudflare Pages
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Pelican" }}
-/>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="pelican" />
 
-4. Select **Environment variables (advanced)** and set the `PYTHON_VERSION` variable with the value of `3.7`.
+7. Select **Environment variables (advanced)** and set the `PYTHON_VERSION` variable with the value of `3.7`.
 
 For the complete guide to deploying your first site to Cloudflare Pages, refer to the [Get started guide](/pages/get-started/).
 

--- a/src/content/docs/pages/framework-guides/deploy-a-qwik-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-qwik-site.mdx
@@ -41,11 +41,7 @@ npm start
 
 ### Deploy via the Cloudflare dashboard
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Qwik" }}
-/>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="qwik" />
 

--- a/src/content/docs/pages/framework-guides/deploy-a-vue-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vue-site.mdx
@@ -34,17 +34,9 @@ To use `create-cloudflare` to create a new Vue project, run the following comman
 
 ### Deploy via the Cloudflare dashboard
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Vue" }}
-/>
-
-<div>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="vue" />
-
-</div>
 
 After configuring your site, you can begin your first deploy. You should see Cloudflare Pages installing `vue`, your project dependencies, and building your site, before deploying it.
 

--- a/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
@@ -49,11 +49,7 @@ git push -u origin main
 
 ### Create a Pages project
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Angular" }}
-/>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="angular" />
 
@@ -64,7 +60,7 @@ Change the `Build directory` to `dist/cloudflare/browser`
 
 Optionally, you can customize the **Project name** field. It defaults to the GitHub repository's name, but it does not need to match. The **Project name** value is assigned as your `*.pages.dev` subdomain.
 
-4. After completing configuration, select the **Save and Deploy**.
+7. After completing configuration, select the **Save and Deploy**.
 
 Review your first deploy pipeline in progress. Pages installs all dependencies and builds the project as specified. Cloudflare Pages will automatically rebuild your project and deploy it on every new pushed commit.
 

--- a/src/content/docs/pages/framework-guides/deploy-an-astro-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-astro-site.mdx
@@ -60,17 +60,9 @@ npm run astro add cloudflare
 
 ### Deploy via the Cloudflare dashboard
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "Astro" }}
-/>
-
-<div>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="astro" />
-
-</div>
 
 Optionally, you can customize the **Project name** field. It defaults to the GitHub repository's name, but it does not need to match. The **Project name** value is assigned as your `*.pages.dev` subdomain.
 

--- a/src/content/docs/pages/framework-guides/deploy-an-mkdocs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-mkdocs-site.mdx
@@ -37,15 +37,11 @@ You have successfully created a GitHub repository and pushed your MkDocs project
 
 ## Deploy with Cloudflare Pages
 
-<Render
-	file="framework-guides/learn-more"
-	product="pages"
-	params={{ name: "MkDocs" }}
-/>
+<Render file="deploy-to-pages-steps-no-preset" product="pages" />
 
 <PagesBuildPreset framework="mkdocs" />
 
-4. Go to **Environment variables (advanced)** > **Add variable** > and add the variable `PYTHON_VERSION` with a value of `3.7`.
+7. Go to **Environment variables (advanced)** > **Add variable** > and add the variable `PYTHON_VERSION` with a value of `3.7`.
 
 After deploying your site, you will receive a unique subdomain for your project on `*.pages.dev`.
 


### PR DESCRIPTION
### Summary

The Pages documentation for several frameworks renders the `framework-guides/learn-more` file instead of `deploy-to-pages-steps-no-preset`. This PR replaces the duplicate "Learn More" modals with the deployment modal.

It also adds another comment to the Hugo framework page that I would have found helpful when migrating to Pages.
