### PR TITLE
fix(realtimekit-redirects): fixed redirects & incorrect links

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -339,7 +339,6 @@
 /realtime/changelog/ /realtime/sfu/changelog/ 302
 /realtime/realtimekit/get-started/ /realtime/realtimekit/quickstart/ 302
 /realtime/realtimekit/ui-kit/meeting-lifecycle/ realtime/realtimekit/ui-kit/state-management/ 302
-/realtime/realtimekit/core/breakout-rooms/ /realtime/realtimekit/ui-kit/breakout-rooms/ 302
 /realtime/realtimekit/getting-started/ /realtime/realtimekit/quickstart/ 302
 /realtime/introduction/ /realtime/realtimekit/introduction/ 302
 /realtime/concepts/ /realtime/realtimekit/concepts/ 302

--- a/src/content/docs/realtime/realtimekit/core/breakout-rooms.mdx
+++ b/src/content/docs/realtime/realtimekit/core/breakout-rooms.mdx
@@ -140,5 +140,5 @@ You have successfully integrated breakout rooms into your RealtimeKit applicatio
 For more advanced customization, explore the following:
 
 - [UI Kit Components Library](/realtime/realtimekit/ui-kit/component-library/) - Browse available components
-- [UI Kit States](/realtime/realtimekit/ui-kit/meeting-lifecycle/) - Learn how components synchronize
+- [UI Kit States](/realtime/realtimekit/ui-kit/state-management/) - Learn how components synchronize
 - [Build Your Own UI](/realtime/realtimekit/ui-kit/build-your-own-ui/) - Create custom meeting interfaces


### PR DESCRIPTION
### Summary

1. Fixed the redirect now that page for breakout rooms exists for core.
2. Fixed the incorrect link in breakout rooms page

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
