### PR TITLE
Include 'epilogue' text from wrangler help in command description

### DIFF
--- a/src/components/WranglerCommand.astro
+++ b/src/components/WranglerCommand.astro
@@ -20,21 +20,14 @@ let { command, headingLevel, description } = props.parse(Astro.props);
 const definition = getCommand(command);
 
 description ??= definition.metadata.description;
+// will be appended after the main description, if present
+const epilogue = definition.metadata.epilogue;
 
 // CED-192 - some commands are experimental and need to be marked as such
-let experimental = false;
-if (definition.metadata.status === "experimental") {
-	experimental = true;
-}
+const experimental = definition.metadata.status === "experimental";
 
 // CED-191 some commands are present but marked as "hidden" and shouldn't be shown
-let hidden = false;
-
 if (definition.metadata.hidden) {
-	hidden = true;
-}
-
-if (hidden) {
 	throw new Error(
 		`[WranglerCommand] "${command}" is marked as hidden. If you want to publish, fix upstream in workers-sdk repo.`
 	);
@@ -89,6 +82,8 @@ if (slotContent) {
 	)
 }
 <Fragment set:html={marked.parse(description)} />
+
+{epilogue && <Fragment set:html={marked.parse(epilogue)} />}
 
 <PackageManagers
 	pkg="wrangler"


### PR DESCRIPTION
### Summary

https://github.com/cloudflare/workers-sdk/pull/11393 moved some content from the docs into wrangler itself, but that was added under 'epilogue' so that the wrangler help isn't overly verbose in certain contexts. 

This PR just makes sure the epilogue content is actually included in the generated docs 😅

Looking at where `epilogue` is used in wrangler, this should only affect D1 currently.

### Screenshots (optional)

e.g. the d1 migrations command now has all this text instead of just 'create a new migration'
<img width="789" height="297" alt="Screenshot 2026-01-07 at 14 18 17" src="https://github.com/user-attachments/assets/fbbf3740-771b-42a4-aa1c-f6d7c941953b" />

