### PR TITLE
Refactor Workers prompting page to highlight MCP servers

### DIFF
--- a/src/content/docs/workers/get-started/prompting.mdx
+++ b/src/content/docs/workers/get-started/prompting.mdx
@@ -1,6 +1,7 @@
 ---
 title: Prompting
 pcx_content_type: concept
+description: Build Workers apps with AI prompts and MCP servers.
 tags:
   - AI
   - LLM
@@ -15,9 +16,9 @@ You can create Workers applications from simple prompts in your favorite agent o
 
 ## Teach your agent about Workers
 
-The best way to teach your agent about Workers is to connect the [`cloudflare-docs`](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/docs-vectorize) MCP (Model Context Protocol) server: `https://docs.mcp.cloudflare.com/mcp` ([learn more](/agents/model-context-protocol/mcp-servers-for-cloudflare/)).
+Connect the [`cloudflare-docs`](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/docs-vectorize) MCP (Model Context Protocol) server to teach your agent about Workers. Add the server URL `https://docs.mcp.cloudflare.com/mcp` to your agent configuration ([learn more](/agents/model-context-protocol/mcp-servers-for-cloudflare/)).
 
-You can also connect the [`cloudflare-observability`](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/workers-observability) MCP server (`https://observability.mcp.cloudflare.com/mcp`) to help your agent check logs, look for exceptions, and automatically fix issues.
+You can also connect the [`cloudflare-observability`](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/workers-observability) MCP server (`https://observability.mcp.cloudflare.com/mcp`). This helps your agent check logs, look for exceptions, and automatically fix issues.
 
 ## Example prompts
 
@@ -56,7 +57,7 @@ Base prompt:
 The prompt above adopts several best practices, including:
 
 - Using `<xml>` tags to structure the prompt
-- API and usage examples for products and use-cases
+- API and usage examples for products and use cases
 - Guidance on how to generate configuration (for example, `wrangler.jsonc`) as part of the model's response
 - Recommendations on Cloudflare products to use for specific storage or state needs
 
@@ -66,7 +67,7 @@ You can use the prompt in several ways:
 
 - Within the user context window, with your own user prompt inserted between the `<user_prompt>` tags (**easiest**)
 - As the `system` prompt for models that support system prompts
-- Adding it to the prompt library and/or file context within your preferred IDE:
+- Adding it to the prompt library or file context in your preferred IDE:
   - Cursor: add the prompt to [your Project Rules](https://docs.cursor.com/context/rules-for-ai)
   - Zed: use [the `/file` command](https://zed.dev/docs/assistant/assistant-panel) to add the prompt to the Assistant context
   - Windsurf: use [the `@-mention` command](https://docs.codeium.com/chat/overview) to include a file containing the prompt to your Chat
@@ -75,9 +76,9 @@ You can use the prompt in several ways:
 
 :::note
 
-The prompt(s) here are examples and should be adapted to your specific use case.
+The prompts here are examples and should be adapted to your specific use case.
 
-Depending on the model and user prompt, it may generate invalid code, configuration or other errors. Review and test the generated code before deploying it.
+Depending on the model and user prompt, it may generate invalid code, configuration, or other errors. Review and test the generated code before deploying it.
 
 :::
 

--- a/src/content/docs/workers/get-started/prompting.mdx
+++ b/src/content/docs/workers/get-started/prompting.mdx
@@ -8,131 +8,93 @@ sidebar:
   order: 3
 ---
 
-import { Tabs, TabItem, GlossaryTooltip, Type, Badge, TypeScriptExample } from "~/components";
 import { Code } from "@astrojs/starlight/components";
-import BasePrompt from '~/content/partials/prompts/base-prompt.txt?raw';
+import BasePrompt from "~/content/partials/prompts/base-prompt.txt?raw";
 
-One of the fastest ways to build an application is by using AI to assist with writing the boiler plate code. When building, iterating on or debugging applications using AI tools and Large Language Models (LLMs), a well-structured and extensive prompt helps provide the model with clearer guidelines & examples that can dramatically improve output.
+You can create Workers applications from simple prompts in your favorite agent or editor, including Cursor, Windsurf, VS Code, Claude Code, Codex, and OpenCode.
 
-Below is an extensive example prompt that can help you build applications using Cloudflare Workers and your preferred AI model.
+## Teach your agent about Workers
 
-### Build Workers using a prompt
+The best way to teach your agent about Workers is to connect the [`cloudflare-docs`](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/docs-vectorize) MCP (Model Context Protocol) server: `https://docs.mcp.cloudflare.com/mcp` ([learn more](/agents/model-context-protocol/mcp-servers-for-cloudflare/)).
 
-To use the prompt:
+You can also connect the [`cloudflare-observability`](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/workers-observability) MCP server (`https://observability.mcp.cloudflare.com/mcp`) to help your agent check logs, look for exceptions, and automatically fix issues.
 
-1. Use the click-to-copy button at the top right of the code block below to copy the full prompt to your clipboard
-2. Paste into your AI tool of choice (for example OpenAI's ChatGPT or Anthropic's Claude)
-3. Make sure to enter your part of the prompt at the end between the `<user_prompt>` and `</user_prompt>` tags.
+## Example prompts
+
+```txt
+Create a Cloudflare Workers application that serves as a backend API server.
+```
+
+```txt
+Show me how to use Hyperdrive to connect my Worker to an existing Postgres database.
+```
+
+```txt
+Create an AI chat Agent using the Cloudflare Agents SDK that responds to user messages and maintains conversation history.
+```
+
+```txt
+Build a WebSocket-based pub/sub application using Durable Objects Hibernation APIs, where the server allows me to POST to /send-message with {topic: "foo", message: "bar"} and delivers that message to any connected client listening to that topic.
+```
+
+```txt
+Build an image upload application using R2 pre-signed URLs that allows users to securely upload images directly to object storage without exposing bucket credentials.
+```
+
+## Use a prompt
+
+You can use the base prompt below to provide your AI tool with context about Workers APIs and best practices.
+
+1. Use the click-to-copy button at the top right of the code block below to copy the full prompt to your clipboard.
+2. Paste into your AI tool of choice (for example OpenAI's ChatGPT or Anthropic's Claude).
+3. Enter your part of the prompt at the end between the `<user_prompt>` and `</user_prompt>` tags.
 
 Base prompt:
+
 <Code code={BasePrompt} collapse={"30-10000"} lang="md" />
 
 The prompt above adopts several best practices, including:
 
-* Using `<xml>` tags to structure the prompt
-* API and usage examples for products and use-cases
-* Guidance on how to generate configuration (e.g. `wrangler.jsonc`) as part of the models response.
-* Recommendations on Cloudflare products to use for specific storage or state needs
+- Using `<xml>` tags to structure the prompt
+- API and usage examples for products and use-cases
+- Guidance on how to generate configuration (for example, `wrangler.jsonc`) as part of the model's response
+- Recommendations on Cloudflare products to use for specific storage or state needs
 
 ### Additional uses
 
 You can use the prompt in several ways:
 
-* Within the user context window, with your own user prompt inserted between the `<user_prompt>` tags (**easiest**)
-* As the `system` prompt for models that support system prompts
-* Adding it to the prompt library and/or file context within your preferred IDE:
-	* Cursor: add the prompt to [your Project Rules](https://docs.cursor.com/context/rules-for-ai)
-	* Zed: use [the `/file` command](https://zed.dev/docs/assistant/assistant-panel) to add the prompt to the Assistant context.
-	* Windsurf: use [the `@-mention` command](https://docs.codeium.com/chat/overview) to include a file containing the prompt to your Chat.
-	* Claude Code: add the prompt to your CLAUDE.md configuration after running `/init` to include best practices to a Workers project.
-  * GitHub Copilot: create the [`.github/copilot-instructions.md`](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot) file at the root of your project and add the prompt.
+- Within the user context window, with your own user prompt inserted between the `<user_prompt>` tags (**easiest**)
+- As the `system` prompt for models that support system prompts
+- Adding it to the prompt library and/or file context within your preferred IDE:
+  - Cursor: add the prompt to [your Project Rules](https://docs.cursor.com/context/rules-for-ai)
+  - Zed: use [the `/file` command](https://zed.dev/docs/assistant/assistant-panel) to add the prompt to the Assistant context
+  - Windsurf: use [the `@-mention` command](https://docs.codeium.com/chat/overview) to include a file containing the prompt to your Chat
+  - Claude Code: add the prompt to your `CLAUDE.md` configuration after running `/init` to include best practices to a Workers project
+  - GitHub Copilot: create the [`.github/copilot-instructions.md`](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot) file at the root of your project and add the prompt
 
 :::note
 
-The prompt(s) here are examples and should be adapted to your specific use case. We'll continue to build out the prompts available here, including additional prompts for specific products.
+The prompt(s) here are examples and should be adapted to your specific use case.
 
-Depending on the model and user prompt, it may generate invalid code, configuration or other errors, and we recommend reviewing and testing the generated code before deploying it.
+Depending on the model and user prompt, it may generate invalid code, configuration or other errors. Review and test the generated code before deploying it.
 
 :::
-
-### Passing a system prompt
-
-If you are building an AI application that will itself generate code, you can additionally use the prompt above as a "system prompt", which will give the LLM additional information on how to structure the output code. For example:
-
-<TypeScriptExample filename="index.ts">
-
-```ts
-import workersPrompt from "./workersPrompt.md"
-
-// Llama 3.3 from Workers AI
-const PREFERRED_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
-
-export default {
-	async fetch(req: Request, env: Env, ctx: ExecutionContext) {
-		const openai = new OpenAI({
-			apiKey: env.WORKERS_AI_API_KEY
-		});
-
-		const stream = await openai.chat.completions.create({
-			messages: [
-				{
-					role: "system",
-					content: workersPrompt,
-				},
-				{
-					role: "user",
-					// Imagine something big!
-					content: "Build an AI Agent using Workflows. The Workflow should be triggered by a GitHub webhook on a pull request, and ..."
-				}
-			],
-			model: PREFERRED_MODEL,
-			stream: true,
-		});
-
-		// Stream the response so we're not buffering the entire response in memory,
-		// since it could be very large.
-		const transformStream = new TransformStream();
-		const writer = transformStream.writable.getWriter();
-		const encoder = new TextEncoder();
-
-		(async () => {
-			try {
-				for await (const chunk of stream) {
-					const content = chunk.choices[0]?.delta?.content || '';
-					await writer.write(encoder.encode(content));
-				}
-			} finally {
-				await writer.close();
-			}
-		})();
-
-		return new Response(transformStream.readable, {
-			headers: {
-				'Content-Type': 'text/plain; charset=utf-8',
-				'Transfer-Encoding': 'chunked'
-			}
-		});
-	}
-}
-
-```
-
-</TypeScriptExample>
 
 ## Use docs in your editor
 
 AI-enabled editors, including Cursor and Windsurf, can index documentation. Cursor includes the Cloudflare Developer Docs by default: you can use the [`@Docs`](https://cursor.com/docs/context/mentions#docs) command.
 
-In other editors, such as Zed or Windsurf, you can paste in URLs to add to your context. Use the _Copy Page_ button to paste in Cloudflare docs directly, or fetch docs for each product by appending `llms-full.txt` to the root URL - for example, `https://developers.cloudflare.com/agents/llms-full.txt` or `https://developers.cloudflare.com/workflows/llms-full.txt`.
+In other editors, such as Zed or Windsurf, you can paste in URLs to add to your context. Use the _Copy Page_ button to paste in Cloudflare docs directly, or fetch docs for each product by appending `llms-full.txt` to the root URL. For example, `https://developers.cloudflare.com/agents/llms-full.txt` or `https://developers.cloudflare.com/workflows/llms-full.txt`.
 
 You can combine these with the Workers system prompt on this page to improve your editor or agent's understanding of the Workers APIs.
 
 ## Additional resources
 
-To get the most out of AI models and tools, we recommend reading the following guides on prompt engineering and structure:
+To get the most out of AI models and tools, review the following guides on prompt engineering and structure:
 
-* OpenAI's [prompt engineering](https://platform.openai.com/docs/guides/prompt-engineering) guide and [best practices](https://platform.openai.com/docs/guides/reasoning-best-practices) for using reasoning models.
-* The [prompt engineering](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview) guide from Anthropic
-* Google's [quick start guide](https://services.google.com/fh/files/misc/gemini-for-google-workspace-prompting-guide-101.pdf) for writing effective prompts
-* Meta's [prompting documentation](https://www.llama.com/docs/how-to-guides/prompting/) for their Llama model family.
-* GitHub's guide for [prompt engineering](https://docs.github.com/en/copilot/using-github-copilot/copilot-chat/prompt-engineering-for-copilot-chat) when using Copilot Chat.
+- OpenAI's [prompt engineering](https://platform.openai.com/docs/guides/prompt-engineering) guide and [best practices](https://platform.openai.com/docs/guides/reasoning-best-practices) for using reasoning models.
+- The [prompt engineering](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview) guide from Anthropic.
+- Google's [quick start guide](https://services.google.com/fh/files/misc/gemini-for-google-workspace-prompting-guide-101.pdf) for writing effective prompts.
+- Meta's [prompting documentation](https://www.llama.com/docs/how-to-guides/prompting/) for their Llama model family.
+- GitHub's guide for [prompt engineering](https://docs.github.com/en/copilot/using-github-copilot/copilot-chat/prompt-engineering-for-copilot-chat) when using Copilot Chat.


### PR DESCRIPTION
Refactors the Workers prompting page to better reflect the current state of agents.

* focus on MCP servers
* shorter, click to copy prompts
* kept the big "mega prompt" but made it less prominent