### PR TITLE
docs(realtimekit): add remote participant reference for mobile platforms

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/remote-participants/events.mdx
+++ b/src/content/docs/realtime/realtimekit/core/remote-participants/events.mdx
@@ -1,6 +1,6 @@
 ---
-pcx_content_type: navigation
-title: Remote Participants Events
+pcx_content_type: reference
+title: Events
 sidebar:
   label: Events
   order: 2
@@ -12,20 +12,20 @@ import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnipp
 This page provides an overview of the events emitted by `meeting.participants` and related participant maps, which you can use to keep your UI in sync with changes such as participants joining or leaving, pinning updates, active speaker changes, and grid view mode or page changes.
 
 :::note[Prerequisites]
-This page assumes you've already initialized the SDK and understand the meeting object structure. Refer to [Initialize SDK](/realtime/realtimekit/core/) and [Meeting Object Explained](/realtime/realtimekit/core/meeting-object-explained/) if needed.
+This page assumes you have already initialized the SDK and understand the meeting object structure. Refer to [Initialize SDK](/realtime/realtimekit/core/) and [Meeting Object Explained](/realtime/realtimekit/core/meeting-object-explained/) if needed.
 :::
 
 <RTKSDKSelector />
 
-## Grid
+## Grid events
 
-These events allow users to monitor changes to the grid.
+These events allow you to monitor changes to the grid.
 
-### View Mode Change
+### View mode change
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
-Triggered when the type of grid changes:
+Triggered when the view mode changes between `ACTIVE_GRID` and `PAGINATED`.
 
 ```js
 meeting.participants.on(
@@ -39,6 +39,8 @@ meeting.participants.on(
 </RTKCodeSnippet>
 
 <RTKCodeSnippet id="web-react">
+
+Triggered when the view mode changes between `ACTIVE_GRID` and `PAGINATED`.
 
 ```jsx
 const viewMode = useRealtimeKitSelector((m) => m.participants.viewMode);
@@ -57,11 +59,38 @@ meeting.participants.on(
 
 </RTKCodeSnippet>
 
-### Page Change
+<RTKCodeSnippet id={["mobile-android", "mobile-ios", "mobile-flutter"]}>
 
-Triggered when the page changes in paginated mode:
+This event is not available on this platform.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Triggered when the view mode changes between `ACTIVE_GRID` and `PAGINATED`.
+
+```tsx
+const viewMode = useRealtimeKitSelector((m) => m.participants.viewMode);
+```
+
+Or use event listener:
+
+```tsx
+meeting.participants.on(
+	"viewModeChanged",
+	({ viewMode, currentPage, pageCount }) => {
+		console.log("view mode changed", viewMode);
+	},
+);
+```
+
+</RTKCodeSnippet>
+
+### Page change
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+
+Triggered when the page changes in paginated mode.
 
 ```js
 meeting.participants.on(
@@ -76,24 +105,35 @@ meeting.participants.on(
 
 <RTKCodeSnippet id="web-react">
 
+Triggered when the page changes in paginated mode.
+
 ```jsx
 const currentPage = useRealtimeKitSelector((m) => m.participants.currentPage);
 const pageCount = useRealtimeKitSelector((m) => m.participants.pageCount);
 ```
 
-Or use event listener:
+</RTKCodeSnippet>
 
-```js
-meeting.participants.on("activeSpeaker", (participant) => {
-	console.log(`${participant.id} is currently speaking`);
-});
+<RTKCodeSnippet id={["mobile-android", "mobile-ios", "mobile-flutter"]}>
+
+This event is not available on this platform.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Triggered when the page changes in paginated mode.
+
+```tsx
+const currentPage = useRealtimeKitSelector((m) => m.participants.currentPage);
+const pageCount = useRealtimeKitSelector((m) => m.participants.pageCount);
 ```
 
 </RTKCodeSnippet>
 
-### Active Speaker
+### Active speaker
 
-Triggered when a participant starts speaking:
+Triggered when a participant starts speaking.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -123,13 +163,78 @@ meeting.participants.on("activeSpeaker", (participant) => {
 
 </RTKCodeSnippet>
 
-## Participant Maps
+<RTKCodeSnippet id="mobile-android">
 
-These events allow users to monitor changes to remote participant maps. Ideal if you want to get notified when a participant joins or leaves the meeting, is pinned or moves out of the grid.
+```kotlin
+meeting.addParticipantsEventListener(object : RtkParticipantsEventListener {
+	override fun onActiveSpeakerChanged(participant: RtkRemoteParticipant?) {
+		participant?.let {
+			println("${it.id} is currently speaking")
+		}
+	}
+})
+```
 
-### Participant Joined
+</RTKCodeSnippet>
 
-Triggered when any participant joins the meeting:
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantsEventListener {
+	func onActiveSpeakerChanged(participant: RtkRemoteParticipant?) {
+		if let participant = participant {
+			print("\(participant.id) is currently speaking")
+		}
+	}
+}
+
+meeting.addParticipantsEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantsNotifier extends RtkParticipantsEventListener {
+	@override
+	void onActiveSpeakerChanged(RtkRemoteParticipant? participant) {
+		if (participant != null) {
+			print('${participant.id} is currently speaking');
+		}
+	}
+}
+
+meeting.addParticipantsEventListener(ParticipantsNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+const activeSpeaker = useRealtimeKitSelector(
+	(m) => m.participants.lastActiveSpeaker,
+);
+```
+
+Or use event listener:
+
+```tsx
+meeting.participants.on("activeSpeaker", (participant) => {
+	console.log(`${participant.id} is currently speaking`);
+});
+```
+
+</RTKCodeSnippet>
+
+## Participant map events
+
+These events allow you to monitor changes to remote participant maps. Use them to get notified when a participant joins or leaves the meeting, is pinned, or moves out of the grid.
+
+### Participant joined
+
+Triggered when any participant joins the meeting.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -157,9 +262,66 @@ meeting.participants.joined.on("participantJoined", (participant) => {
 
 </RTKCodeSnippet>
 
-### Participant Left
+<RTKCodeSnippet id="mobile-android">
 
-Triggered when any participant leaves the meeting:
+```kotlin
+meeting.addParticipantsEventListener(object : RtkParticipantsEventListener {
+	override fun onParticipantJoin(participant: RtkRemoteParticipant) {
+		println("A participant with id ${participant.id} has joined")
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantsEventListener {
+	func onParticipantJoin(participant: RtkRemoteParticipant) {
+		print("A participant with id \(participant.id) has joined")
+	}
+}
+
+meeting.addParticipantsEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantsNotifier extends RtkParticipantsEventListener {
+	@override
+	void onParticipantJoin(RtkRemoteParticipant participant) {
+		print('A participant with id ${participant.id} has joined');
+	}
+}
+
+meeting.addParticipantsEventListener(ParticipantsNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+const joinedParticipants = useRealtimeKitSelector((m) => m.participants.joined);
+```
+
+Or use event listener:
+
+```tsx
+meeting.participants.joined.on("participantJoined", (participant) => {
+	console.log(`A participant with id "${participant.id}" has joined`);
+});
+```
+
+</RTKCodeSnippet>
+
+### Participant left
+
+Triggered when any participant leaves the meeting.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -187,9 +349,127 @@ meeting.participants.joined.on("participantLeft", (participant) => {
 
 </RTKCodeSnippet>
 
-### Participant Pinned
+<RTKCodeSnippet id="mobile-android">
 
-Triggered when a participant is pinned:
+```kotlin
+meeting.addParticipantsEventListener(object : RtkParticipantsEventListener {
+	override fun onParticipantLeave(participant: RtkRemoteParticipant) {
+		println("A participant with id ${participant.id} has left the meeting")
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantsEventListener {
+	func onParticipantLeave(participant: RtkRemoteParticipant) {
+		print("A participant with id \(participant.id) has left the meeting")
+	}
+}
+
+meeting.addParticipantsEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantsNotifier extends RtkParticipantsEventListener {
+	@override
+	void onParticipantLeave(RtkRemoteParticipant participant) {
+		print('A participant with id ${participant.id} has left the meeting');
+	}
+}
+
+meeting.addParticipantsEventListener(ParticipantsNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+const joinedParticipants = useRealtimeKitSelector((m) => m.participants.joined);
+```
+
+Or use event listener:
+
+```tsx
+meeting.participants.joined.on("participantLeft", (participant) => {
+	console.log(`A participant with id "${participant.id}" has left the meeting`);
+});
+```
+
+</RTKCodeSnippet>
+
+### Active participants changed
+
+<RTKCodeSnippet id={["web-web-components", "web-angular", "web-react", "mobile-react-native"]}>
+
+Each participant map emits `participantJoined` and `participantLeft` events:
+
+```js
+// Listen for when a participant gets pinned
+meeting.participants.pinned.on("participantJoined", (participant) => {
+	console.log(`Participant ${participant.name} got pinned`);
+});
+
+// Listen for when a participant gets unpinned
+meeting.participants.pinned.on("participantLeft", (participant) => {
+	console.log(`Participant ${participant.name} got unpinned`);
+});
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+meeting.addParticipantsEventListener(object : RtkParticipantsEventListener {
+	override fun onActiveParticipantsChanged(active: List<RtkRemoteParticipant>) {
+		// Called when active participants change
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantsEventListener {
+	func onActiveParticipantsChanged(active: [RtkRemoteParticipant]) {
+		// Called when active participants change
+	}
+}
+
+meeting.addParticipantsEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantsNotifier extends RtkParticipantsEventListener {
+	@override
+	void onActiveParticipantsChanged(List<RtkRemoteParticipant> active) {
+		// Called when active participants change
+	}
+}
+
+meeting.addParticipantsEventListener(ParticipantsNotifier());
+```
+
+</RTKCodeSnippet>
+
+### Participant pinned
+
+Triggered when a participant is pinned.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -217,9 +497,66 @@ meeting.participants.joined.on("pinned", (participant) => {
 
 </RTKCodeSnippet>
 
-### Participant Unpinned
+<RTKCodeSnippet id="mobile-android">
 
-Triggered when a participant is unpinned:
+```kotlin
+meeting.addParticipantsEventListener(object : RtkParticipantsEventListener {
+	override fun onParticipantPinned(participant: RtkRemoteParticipant) {
+		println("Participant with id ${participant.id} was pinned")
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantsEventListener {
+	func onParticipantPinned(participant: RtkRemoteParticipant) {
+		print("Participant with id \(participant.id) was pinned")
+	}
+}
+
+meeting.addParticipantsEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantsNotifier extends RtkParticipantsEventListener {
+	@override
+	void onParticipantPinned(RtkRemoteParticipant participant) {
+		print('Participant with id ${participant.id} was pinned');
+	}
+}
+
+meeting.addParticipantsEventListener(ParticipantsNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+const pinnedParticipants = useRealtimeKitSelector((m) => m.participants.pinned);
+```
+
+Or use event listener:
+
+```tsx
+meeting.participants.joined.on("pinned", (participant) => {
+	console.log(`Participant with id "${participant.id}" was pinned`);
+});
+```
+
+</RTKCodeSnippet>
+
+### Participant unpinned
+
+Triggered when a participant is unpinned.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -241,21 +578,78 @@ Or use event listener:
 
 ```jsx
 meeting.participants.joined.on("unpinned", (participant) => {
-	console.log(`Participant with id "${participant.id}" was pinned`);
+	console.log(`Participant with id "${participant.id}" was unpinned`);
 });
 ```
 
 </RTKCodeSnippet>
 
-## Participant
+<RTKCodeSnippet id="mobile-android">
 
-You can monitor changes to a specific participant using the following events:
+```kotlin
+meeting.addParticipantsEventListener(object : RtkParticipantsEventListener {
+	override fun onParticipantUnpinned(participant: RtkRemoteParticipant) {
+		println("Participant with id ${participant.id} was unpinned")
+	}
+})
+```
 
-### Video Update
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantsEventListener {
+	func onParticipantUnpinned(participant: RtkRemoteParticipant) {
+		print("Participant with id \(participant.id) was unpinned")
+	}
+}
+
+meeting.addParticipantsEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantsNotifier extends RtkParticipantsEventListener {
+	@override
+	void onParticipantUnpinned(RtkRemoteParticipant participant) {
+		print('Participant with id ${participant.id} was unpinned');
+	}
+}
+
+meeting.addParticipantsEventListener(ParticipantsNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+const pinnedParticipants = useRealtimeKitSelector((m) => m.participants.pinned);
+```
+
+Or use event listener:
+
+```tsx
+meeting.participants.joined.on("unpinned", (participant) => {
+	console.log(`Participant with id "${participant.id}" was unpinned`);
+});
+```
+
+</RTKCodeSnippet>
+
+## Participant events
+
+You can monitor changes to a specific participant using the following events.
+
+### Video update
+
+Triggered when any participant starts or stops video.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
-
-Triggered when any participant starts/stops video:
 
 ```js
 meeting.participants.joined.on("videoUpdate", (participant) => {
@@ -285,27 +679,72 @@ const videoEnabled = useRealtimeKitSelector(
 const videoEnabledParticipants = useRealtimeKitSelector((m) =>
 	m.participants.joined.toArray().filter((p) => p.videoEnabled),
 );
-
-meeting.participants.joined.on("videoUpdate", (participant) => {
-	console.log(
-		`A participant with id "${participant.id}" updated their video track`,
-	);
-
-	if (participant.videoEnabled) {
-		// Use participant.videoTrack
-	} else {
-		// Handle stop video
-	}
-});
 ```
 
 </RTKCodeSnippet>
 
-### Audio Update
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+meeting.addParticipantEventListener(object : RtkParticipantEventListener {
+	override fun onVideoUpdate(participant: RtkRemoteParticipant, isEnabled: Boolean) {
+		println("Participant ${participant.id} video is now ${if (isEnabled) "enabled" else "disabled"}")
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantEventListener {
+	func onVideoUpdate(participant: RtkRemoteParticipant, isEnabled: Bool) {
+		print("Participant \(participant.id) video is now \(isEnabled ? "enabled" : "disabled")")
+	}
+}
+
+meeting.addParticipantEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantUpdateHandler extends RtkParticipantUpdateListener {
+	@override
+	void onVideoUpdate(RtkRemoteParticipant participant, bool isEnabled) {
+		print('Participant ${participant.id} video is now ${isEnabled ? "enabled" : "disabled"}');
+	}
+}
+
+participant.addParticipantUpdateListener(ParticipantUpdateHandler());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+// Check for one participant
+const videoEnabled = useRealtimeKitSelector(
+	(m) => m.participants.joined.get(participantId)?.videoEnabled,
+);
+
+// All video enabled participants
+const videoEnabledParticipants = useRealtimeKitSelector((m) =>
+	m.participants.joined.toArray().filter((p) => p.videoEnabled),
+);
+```
+
+</RTKCodeSnippet>
+
+### Audio update
+
+Triggered when any participant starts or stops audio.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
-
-Triggered when any participant starts/stops audio:
 
 ```js
 meeting.participants.joined.on("audioUpdate", (participant) => {
@@ -335,25 +774,70 @@ const audioEnabled = useRealtimeKitSelector(
 const audioEnabledParticipants = useRealtimeKitSelector((m) =>
 	m.participants.joined.toArray().filter((p) => p.audioEnabled),
 );
-
-meeting.participants.joined.on("audioUpdate", (participant) => {
-	console.log(
-		`A participant with id "${participant.id}" updated their audio track`,
-	);
-
-	if (participant.audioEnabled) {
-		// Use participant.audioTrack
-	} else {
-		// Handle stop audio
-	}
-});
 ```
 
 </RTKCodeSnippet>
 
-### Screen Share Update
+<RTKCodeSnippet id="mobile-android">
 
-Triggered when any participant starts/stops screen share:
+```kotlin
+meeting.addParticipantEventListener(object : RtkParticipantEventListener {
+	override fun onAudioUpdate(participant: RtkRemoteParticipant, isEnabled: Boolean) {
+		println("Participant ${participant.id} audio is now ${if (isEnabled) "enabled" else "disabled"}")
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantEventListener {
+	func onAudioUpdate(participant: RtkRemoteParticipant, isEnabled: Bool) {
+		print("Participant \(participant.id) audio is now \(isEnabled ? "enabled" : "disabled")")
+	}
+}
+
+meeting.addParticipantEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantUpdateHandler extends RtkParticipantUpdateListener {
+	@override
+	void onAudioUpdate(RtkRemoteParticipant participant, bool isEnabled) {
+		print('Participant ${participant.id} audio is now ${isEnabled ? "enabled" : "disabled"}');
+	}
+}
+
+participant.addParticipantUpdateListener(ParticipantUpdateHandler());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+// Check for one participant
+const audioEnabled = useRealtimeKitSelector(
+	(m) => m.participants.joined.get(participantId)?.audioEnabled,
+);
+
+// All audio enabled participants
+const audioEnabledParticipants = useRealtimeKitSelector((m) =>
+	m.participants.joined.toArray().filter((p) => p.audioEnabled),
+);
+```
+
+</RTKCodeSnippet>
+
+### Screen share update
+
+Triggered when any participant starts or stops screen share.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -387,27 +871,70 @@ const screenSharingParticipants = useRealtimeKitSelector((m) =>
 );
 ```
 
-```js
-meeting.participants.joined.on("screenShareUpdate", (participant) => {
-	console.log(
-		`A participant with id "${participant.id}" updated their screen share`,
-	);
+</RTKCodeSnippet>
 
-	if (participant.screenShareEnabled) {
-		// Use participant.screenShareTracks
-	} else {
-		// Handle stop screen share
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+meeting.addParticipantEventListener(object : RtkParticipantEventListener {
+	override fun onScreenShareUpdate(participant: RtkRemoteParticipant, isEnabled: Boolean) {
+		println("Participant ${participant.id} screen share is now ${if (isEnabled) "enabled" else "disabled"}")
 	}
-});
+})
 ```
 
 </RTKCodeSnippet>
 
-### Network Quality Score
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+extension MeetingViewModel: RtkParticipantEventListener {
+	func onScreenShareUpdate(participant: RtkRemoteParticipant, isEnabled: Bool) {
+		print("Participant \(participant.id) screen share is now \(isEnabled ? "enabled" : "disabled")")
+	}
+}
+
+meeting.addParticipantEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+class ParticipantUpdateHandler extends RtkParticipantUpdateListener {
+	@override
+	void onScreenShareUpdate(RtkRemoteParticipant participant, bool isEnabled) {
+		print('Participant ${participant.id} screen share is now ${isEnabled ? "enabled" : "disabled"}');
+	}
+}
+
+participant.addParticipantUpdateListener(ParticipantUpdateHandler());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+// Check for one participant
+const screensharingParticipant = useRealtimeKitSelector((m) =>
+	m.participants.joined.toArray().find((p) => p.screenShareEnabled),
+);
+
+// All screen sharing participants
+const screenSharingParticipants = useRealtimeKitSelector((m) =>
+	m.participants.joined.toArray().filter((p) => p.screenShareEnabled),
+);
+```
+
+</RTKCodeSnippet>
+
+### Network quality score
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
-Monitor participant network quality:
+Monitor participant network quality using the `mediaScoreUpdate` event.
 
 ```js
 meeting.participants.joined.on(
@@ -438,7 +965,11 @@ meeting.participants.joined.on(
 
 <RTKCodeSnippet id="web-react">
 
+Monitor participant network quality using the `mediaScoreUpdate` event.
+
 ```jsx
+import { useEffect } from "react";
+
 // Use event listener for media score updates
 useEffect(() => {
 	if (!meeting) return;
@@ -468,6 +999,264 @@ useEffect(() => {
 		meeting.participants.joined.off("mediaScoreUpdate", handleMediaScoreUpdate);
 	};
 }, [meeting]);
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id={["mobile-android", "mobile-ios", "mobile-flutter"]}>
+
+This event is not available on this platform.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Monitor participant network quality using the `mediaScoreUpdate` event.
+
+```tsx
+import { useEffect } from "react";
+
+// Use event listener for media score updates
+useEffect(() => {
+	if (!meeting) return;
+
+	const handleMediaScoreUpdate = ({
+		participantId,
+		kind,
+		isScreenshare,
+		score,
+		scoreStats,
+	}) => {
+		if (kind === "video") {
+			console.log(
+				`Participant ${participantId}'s ${isScreenshare ? "screenshare" : "video"} quality score is`,
+				score,
+			);
+		}
+
+		if (score < 5) {
+			console.log(`Participant ${participantId}'s media quality is poor`);
+		}
+	};
+
+	meeting.participants.joined.on("mediaScoreUpdate", handleMediaScoreUpdate);
+
+	return () => {
+		meeting.participants.joined.off("mediaScoreUpdate", handleMediaScoreUpdate);
+	};
+}, [meeting]);
+```
+
+</RTKCodeSnippet>
+
+## Listen to participant events
+
+<RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+
+Each participant object is an event emitter:
+
+```js
+meeting.participants.joined
+	.get(participantId)
+	.on("audioUpdate", ({ audioEnabled, audioTrack }) => {
+		console.log(
+			"The participant with id",
+			participantId,
+			"has toggled their mic to",
+			audioEnabled,
+		);
+	});
+```
+
+Alternatively, listen on the participant map for all participants:
+
+```js
+meeting.participants.joined.on(
+	"audioUpdate",
+	(participant, { audioEnabled, audioTrack }) => {
+		console.log(
+			"The participant with id",
+			participant.id,
+			"has toggled their mic to",
+			audioEnabled,
+		);
+	},
+);
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="web-react">
+
+```jsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react";
+import { useEffect } from "react";
+
+function ParticipantAudioListener({ participantId }) {
+	const [meeting] = useRealtimeKitClient();
+
+	useEffect(() => {
+		if (!meeting) return;
+
+		const handleAudioUpdate = ({ audioEnabled, audioTrack }) => {
+			console.log(
+				"The participant with id",
+				participantId,
+				"has toggled their mic to",
+				audioEnabled,
+			);
+		};
+
+		const participant = meeting.participants.joined.get(participantId);
+		participant.on("audioUpdate", handleAudioUpdate);
+
+		return () => {
+			participant.off("audioUpdate", handleAudioUpdate);
+		};
+	}, [meeting, participantId]);
+}
+```
+
+Or use the selector for specific properties:
+
+```jsx
+const audioEnabled = useRealtimeKitSelector(
+	(m) => m.participants.joined.get(participantId)?.audioEnabled,
+);
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+Implement the `RtkParticipantEventListener` interface to receive participant event updates:
+
+```kotlin
+meeting.addParticipantEventListener(object : RtkParticipantEventListener {
+	override fun onVideoUpdate(participant: RtkRemoteParticipant, isEnabled: Boolean) {
+		// Called when participant's video state changes
+	}
+
+	override fun onAudioUpdate(participant: RtkRemoteParticipant, isEnabled: Boolean) {
+		// Called when participant's audio state changes
+	}
+
+	override fun onScreenShareUpdate(participant: RtkRemoteParticipant, isEnabled: Boolean) {
+		// Called when participant's screen share state changes
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+Implement the `RtkParticipantEventListener` protocol to receive participant event updates:
+
+```swift
+extension MeetingViewModel: RtkParticipantEventListener {
+	func onVideoUpdate(participant: RtkRemoteParticipant, isEnabled: Bool) {
+		// Called when participant's video state changes
+	}
+
+	func onAudioUpdate(participant: RtkRemoteParticipant, isEnabled: Bool) {
+		// Called when participant's audio state changes
+	}
+
+	func onScreenShareUpdate(participant: RtkRemoteParticipant, isEnabled: Bool) {
+		// Called when participant's screen share state changes
+	}
+}
+
+meeting.addParticipantEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+Implement the `RtkParticipantUpdateListener` interface and add the listener on a participant:
+
+```dart
+class ParticipantUpdateHandler extends RtkParticipantUpdateListener {
+	@override
+	void onVideoUpdate(RtkRemoteParticipant participant, bool isEnabled) {
+		print("${participant.name}'s video is now ${isEnabled ? 'on' : 'off'}");
+	}
+
+	@override
+	void onAudioUpdate(RtkRemoteParticipant participant, bool isEnabled) {
+		print("${participant.name}'s audio is now ${isEnabled ? 'on' : 'off'}");
+	}
+
+	@override
+	void onPinned(RtkRemoteParticipant participant) {
+		print("${participant.name} was pinned");
+	}
+
+	@override
+	void onUnpinned(RtkRemoteParticipant participant) {
+		print("${participant.name} was unpinned");
+	}
+
+	@override
+	void onScreenShareUpdate(RtkRemoteParticipant participant, bool isEnabled) {
+		print("${participant.name}'s screen-share is now ${isEnabled ? 'on' : 'off'}");
+	}
+
+	@override
+	void onUpdate(RtkRemoteParticipant participant) {
+		print("${participant.name} was updated");
+	}
+}
+
+// Register the listener with a specific participant
+final listener = ParticipantUpdateHandler();
+participant.addParticipantUpdateListener(listener);
+
+// When done listening, remove the listener
+participant.removeParticipantUpdateListener(listener);
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react-native";
+import { useEffect } from "react";
+
+function ParticipantAudioListener({ participantId }) {
+	const [meeting] = useRealtimeKitClient();
+
+	useEffect(() => {
+		if (!meeting) return;
+
+		const handleAudioUpdate = ({ audioEnabled, audioTrack }) => {
+			console.log(
+				"The participant with id",
+				participantId,
+				"has toggled their mic to",
+				audioEnabled,
+			);
+		};
+
+		const participant = meeting.participants.joined.get(participantId);
+		participant.on("audioUpdate", handleAudioUpdate);
+
+		return () => {
+			participant.off("audioUpdate", handleAudioUpdate);
+		};
+	}, [meeting, participantId]);
+}
+```
+
+Or use the selector for specific properties:
+
+```tsx
+const audioEnabled = useRealtimeKitSelector(
+	(m) => m.participants.joined.get(participantId)?.audioEnabled,
+);
 ```
 
 </RTKCodeSnippet>

--- a/src/content/docs/realtime/realtimekit/core/remote-participants/index.mdx
+++ b/src/content/docs/realtime/realtimekit/core/remote-participants/index.mdx
@@ -21,7 +21,9 @@ The participant object contains all information related to a particular particip
 
 ### Properties
 
-#### Metadata Properties:
+<RTKCodeSnippet id={["web-web-components", "web-angular", "web-react", "mobile-react-native"]}>
+
+#### Metadata properties
 
 - `id` - The `participantId` of the participant (aka `peerId`)
 - `userId` - The `userId` of the participant
@@ -30,6 +32,81 @@ The participant object contains all information related to a particular particip
 - `customParticipantId` - An arbitrary ID that can be set to identify the participant
 - `isPinned` - Set to `true` if the participant is pinned
 - `presetName` - Name of the preset associated with the participant
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+#### Metadata properties
+
+- `id` - Session-specific identifier generated when the participant joins meeting session (also known as `peerId`)
+- `userId` - Permanent identifier of the participant generated when adding the participant to a meeting
+- `name` - Display name of the participant
+- `picture` - String URL to the participant's display picture (if any)
+- `customParticipantId` - Custom identifier that can be set while adding participant to a meeting by customer
+- `isHost` - Boolean value whether this participant has host privileges
+- `isPinned` - Whether this participant is currently pinned in the meeting
+- `presetName` - Name of the preset applied to this participant while adding to meeting
+- `stageStatus` - Indicates the participant's current stage status (applicable only in stage-enabled meetings)
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+#### Metadata properties
+
+- `id` - Session-specific identifier generated when the participant joins meeting session (also known as `peerId`)
+- `userId` - Permanent identifier of the participant generated when adding the participant to a meeting
+- `name` - Display name of the participant
+- `picture` - String URL to the participant's display picture (if any)
+- `customParticipantId` - Custom identifier that can be set while adding participant to a meeting by customer
+- `isHost` - Boolean value whether this participant has host privileges
+- `isPinned` - Whether this participant is currently pinned in the meeting
+- `presetName` - Name of the preset applied to this participant while adding to meeting
+- `stageStatus` - Indicates the participant's current stage status (applicable only in stage-enabled meetings)
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+#### Metadata properties
+
+- `id` - Session-specific identifier generated when the participant joins meeting session (also known as `peerId`)
+- `userId` - Permanent identifier of the participant generated when adding the participant to a meeting
+- `name` - Display name of the participant
+- `picture` - String URL to the participant's display picture (if any)
+- `isHost` - Boolean value whether this participant has host privileges
+- `customParticipantId` - Custom identifier that can be set while adding participant to a meeting by customer
+- `stageStatus` - Indicates the participant's current stage status (applicable only in stage-enabled meetings)
+- `isPinned` - Whether this participant is currently pinned in the meeting
+- `presetName` - Name of the preset applied to this participant while adding to meeting
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id={["web-web-components", "web-angular", "web-react", "mobile-react-native"]}>
+
+#### Media properties
+
+- `videoEnabled` - Set to `true` if the participant's camera is on
+- `audioEnabled` - Set to `true` if the participant is unmuted
+- `screenShareEnabled` - Set to `true` if the participant is sharing their screen
+- `videoTrack` - The video track of the participant
+- `audioTrack` - The audio track of the participant
+- `screenShareTracks` - The video and audio tracks of the participant's screen share
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id={["mobile-android", "mobile-ios", "mobile-flutter"]}>
+
+#### Media properties
+
+- `videoEnabled` - Whether the participant's camera is currently enabled
+- `audioEnabled` - Whether the participant's microphone is currently unmuted
+- `screenshareEnabled` - Whether the participant is currently sharing their screen
+
+</RTKCodeSnippet>
+
+### Access participant properties
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -72,18 +149,81 @@ const lastActiveSpeaker = useRealtimeKitSelector(
 ```
 
 </RTKCodeSnippet>
-#### Media Properties:
 
-These properties are available on each participant in `meeting.participants`.
+<RTKCodeSnippet id="mobile-android">
 
-- `videoEnabled` - Set to `true` if the participant's camera is on
-- `audioEnabled` - Set to `true` if the participant is unmuted
-- `screenShareEnabled` - Set to `true` if the participant is sharing their screen
-- `videoTrack` - The video track of the participant
-- `audioTrack` - The audio track of the participant
-- `screenShareTracks` - The video and audio tracks of the participant's screen share
+```kotlin
+// Number of participants joined in the meeting
+val participantCount = meeting.participants.joined.size
 
-You can fetch a participant from the [Participant Maps](/realtime/realtimekit/core/remote-participants/#participant-maps/).
+// Access pagination properties
+val maxNumberOnScreen = meeting.participants.maxNumberOnScreen
+val currentPageNumber = meeting.participants.currentPageNumber
+val pageCount = meeting.participants.pageCount
+val canGoNextPage = meeting.participants.canGoNextPage
+val canGoPreviousPage = meeting.participants.canGoPreviousPage
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+// Number of participants joined in the meeting
+let participantCount = meeting.participants.joined.count
+
+// Access pagination properties
+let maxNumberOnScreen = meeting.participants.maxNumberOnScreen
+let currentPageNumber = meeting.participants.currentPageNumber
+let pageCount = meeting.participants.pageCount
+let canGoNextPage = meeting.participants.canGoNextPage
+let canGoPreviousPage = meeting.participants.canGoPreviousPage
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+// Number of participants joined in the meeting
+final participantCount = meeting.participants.joined.length;
+
+// Access pagination properties
+final currentPageNumber = meeting.participants.currentPageNumber;
+final pageCount = meeting.participants.pageCount;
+final canGoNextPage = meeting.participants.isNextPagePossible;
+final canGoPreviousPage = meeting.participants.isPreviousPagePossible;
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Use the `useRealtimeKitSelector` hook to access properties:
+
+```tsx
+// Number of participants joined in the meeting
+const participantCount = useRealtimeKitSelector((m) => m.participants.count);
+
+// Number of pages available in paginated mode
+const pageCount = useRealtimeKitSelector((m) => m.participants.pageCount);
+
+// Maximum number of participants in active state
+const maxActiveCount = useRealtimeKitSelector(
+	(m) => m.participants.maxActiveParticipantsCount,
+);
+
+// ParticipantId of the last participant who spoke
+const lastActiveSpeaker = useRealtimeKitSelector(
+	(m) => m.participants.lastActiveSpeaker,
+);
+```
+
+</RTKCodeSnippet>
+
+### Access participant object
+
+You can fetch a participant from the [participant maps](#participant-maps).
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -107,35 +247,82 @@ const participant = useRealtimeKitSelector((m) =>
 );
 
 // Access participant properties
-console.log(participant.name);
-console.log(participant.videoEnabled);
-console.log(participant.audioEnabled);
+const participantName = participant?.name;
+const isVideoEnabled = participant?.videoEnabled;
+const isAudioEnabled = participant?.audioEnabled;
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+// Find a participant by peer ID
+val participant = meeting.participants.joined.firstOrNull { it.id == participantId }
+
+// Access participant properties
+participant?.let {
+	println("Participant: ${it.name}")
+	println("Video: ${it.videoEnabled}")
+	println("Audio: ${it.audioEnabled}")
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+// Find a participant by peer ID
+if let participant = meeting.participants.joined.first(where: { $0.id == participantId }) {
+	// Access participant properties
+	print("Participant: \(participant.name)")
+	print("Video: \(participant.videoEnabled)")
+	print("Audio: \(participant.audioEnabled)")
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+// Find a participant by peer ID
+final participant = meeting.participants.joined
+	.where((p) => p.id == "<peerId>")
+	.firstOrNull;
+
+// Access participant properties
+if (participant != null) {
+	print('Participant: ${participant.name} (ID: ${participant.id})');
+	print('Audio: ${participant.audioEnabled ? "On" : "Off"}');
+	print('Video: ${participant.videoEnabled ? "On" : "Off"}');
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+// Get a specific participant
+const participant = useRealtimeKitSelector((m) =>
+	m.participants.joined.get(participantId),
+);
+
+// Access participant properties
+const participantName = participant?.name;
+const isVideoEnabled = participant?.videoEnabled;
+const isAudioEnabled = participant?.audioEnabled;
 ```
 
 </RTKCodeSnippet>
 
 ## Participant Maps
 
-<RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+<RTKCodeSnippet id={["web-web-components", "web-angular", "web-react", "mobile-react-native"]}>
 
 All participants are stored under `meeting.participants`. These do not include the local user.
-
-The `meeting.participants` is an object that contains the following maps:
-
-- **`joined`** - All participants currently in the meeting (excluding the local user)
-- **`waitlisted`** - All participants waiting to join the meeting
-- **`active`** - All participants whose media is subscribed to (participants that should be displayed on screen)
-- **`pinned`** - All pinned participants in the meeting
-
-If you're building a video/audio grid, you'd use the `active` map. To display a list of all participants, use the `joined` map.
-
-Each participant in these maps is of type `RTKParticipant`.
-
-</RTKCodeSnippet>
-
-<RTKCodeSnippet id="web-react">
-
-The data regarding all meeting participants is stored under `meeting.participants`. These do not include the local user.
 
 The `meeting.participants` object contains the following maps:
 
@@ -144,9 +331,42 @@ The `meeting.participants` object contains the following maps:
 - **`active`** - All participants whose media is subscribed to (participants that should be displayed on screen)
 - **`pinned`** - All pinned participants in the meeting
 
-If you're building a video/audio grid, you'd use the `active` map. To display a list of all participants, use the `joined` map.
+If you are building a video/audio grid, use the `active` map. To display a list of all participants, use the `joined` map.
 
 Each participant in these maps is of type `RTKParticipant`.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id={["mobile-android", "mobile-ios"]}>
+
+All participants are stored under `meeting.participants`. These do not include the local user.
+
+The `meeting.participants` object contains the following lists:
+
+- **`joined`** - All participants currently in the meeting (excluding the local user)
+- **`waitlisted`** - All participants waiting to join the meeting
+- **`active`** - All participants whose media is subscribed to (participants that should be displayed on screen)
+- **`pinned`** - All pinned participants in the meeting
+- **`screenShares`** - All participants who are sharing their screen
+
+If you are building a video/audio grid, use the `active` list. To display a list of all participants, use the `joined` list.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+All participants are stored under `meeting.participants`. These do not include the local user.
+
+The `meeting.participants` object contains the following lists:
+
+- **`joined`** - All participants currently in the meeting (excluding the local user)
+- **`waitlisted`** - All participants waiting to join the meeting
+- **`active`** - All participants whose media is subscribed to (participants that should be displayed on screen)
+- **`pinned`** - All pinned participants in the meeting
+
+If you are building a video/audio grid, use the `active` list. To display a list of all participants, use the `joined` list.
+
+Each participant in these lists is of type `RtkRemoteParticipant`.
 
 </RTKCodeSnippet>
 
@@ -192,19 +412,98 @@ const waitlistedParticipants = useRealtimeKitSelector(
 
 </RTKCodeSnippet>
 
-## Types of Grids
+<RTKCodeSnippet id="mobile-android">
 
-The SDK offers two kinds of grids out of the box
+```kotlin
+// Get all joined participants
+val joinedParticipants: List<RtkRemoteParticipant> = meeting.participants.joined
 
-- **Active Grid** - Participants are automatically replaced in the grid based on who is speaking or has their video turned on.
-- **Paginated Grid** - Allows users to view all participants by changing pages. Use `setPage()` to change the current page.
+// Get active participants (those on screen)
+val activeParticipants: List<RtkRemoteParticipant> = meeting.participants.active
 
-The `viewMode` property indicates which grid type is currently active, It can assume two values: `ACTIVE_GRID` mode or `PAGINATED`.
+// Get pinned participants
+val pinnedParticipants: List<RtkRemoteParticipant> = meeting.participants.pinned
 
-- **`ACTIVE_GRID` mode** - Participants are automatically replaced in the `meeting.participants.active`map based on their media state.
-- **`PAGINATED` mode** - Participants in `meeting.participants.active` are fixed based on the page number. Use `setPage()` to change the active participants.
+// Get waitlisted participants
+val waitlistedParticipants: List<RtkRemoteParticipant> = meeting.participants.waitlisted
 
-### Set View Mode
+// Get screen sharing participants
+val screenShareParticipants: List<RtkRemoteParticipant> = meeting.participants.screenShares
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+// Get all joined participants
+let joinedParticipants: [RtkRemoteParticipant] = meeting.participants.joined
+
+// Get active participants (those on screen)
+let activeParticipants: [RtkRemoteParticipant] = meeting.participants.active
+
+// Get pinned participants
+let pinnedParticipants: [RtkRemoteParticipant] = meeting.participants.pinned
+
+// Get waitlisted participants
+let waitlistedParticipants: [RtkRemoteParticipant] = meeting.participants.waitlisted
+
+// Get screen sharing participants
+let screenShareParticipants: [RtkRemoteParticipant] = meeting.participants.screenShares
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+// Get all joined participants
+final joinedParticipants = meeting.participants.joined;
+
+// Get active participants (those on screen)
+final activeParticipants = meeting.participants.active;
+
+// Get pinned participants
+final pinnedParticipants = meeting.participants.pinned;
+
+// Get waitlisted participants
+final waitlistedParticipants = meeting.participants.waitlisted;
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Use the `useRealtimeKitSelector` hook to access participant maps:
+
+```tsx
+import { useRealtimeKitSelector } from "@cloudflare/realtimekit-react-native";
+
+// Get all joined participants
+const joinedParticipants = useRealtimeKitSelector((m) => m.participants.joined);
+
+// Get active participants (those on screen)
+const activeParticipants = useRealtimeKitSelector((m) => m.participants.active);
+
+// Get pinned participants
+const pinnedParticipants = useRealtimeKitSelector((m) => m.participants.pinned);
+
+// Get waitlisted participants
+const waitlistedParticipants = useRealtimeKitSelector(
+	(m) => m.participants.waitlisted,
+);
+```
+
+</RTKCodeSnippet>
+
+## View Modes
+
+The view mode indicates whether participants are populated in `ACTIVE_GRID` mode or `PAGINATED` mode.
+
+- **`ACTIVE_GRID` mode** - Participants are automatically replaced in `meeting.participants.active` based on who is speaking or who has their video turned on
+- **`PAGINATED` mode** - Participants in `meeting.participants.active` are fixed. Use `setPage()` to change the active participants
+
+### Set view mode
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -220,7 +519,13 @@ await meeting.participants.setViewMode("ACTIVE_GRID");
 
 <RTKCodeSnippet id="web-react">
 
+Use the `useRealtimeKitClient` hook to access the meeting object:
+
 ```jsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react";
+
+const [meeting] = useRealtimeKitClient();
+
 // Set the view mode to paginated
 await meeting.participants.setViewMode("PAGINATED");
 
@@ -230,7 +535,37 @@ await meeting.participants.setViewMode("ACTIVE_GRID");
 
 </RTKCodeSnippet>
 
-### Set Page in Paginated Mode
+<RTKCodeSnippet id="mobile-android">
+
+Android SDK uses active grid mode by default on page 0. If you switch to the next page, it automatically switches to paginated mode.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+iOS SDK uses active grid mode by default on page 0. If you switch to the next page, it automatically switches to paginated mode.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+Flutter SDK uses active grid mode by default on page 0. If you switch to the next page, it automatically switches to paginated mode.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+// Set the view mode to paginated
+await meeting.participants.setViewMode("PAGINATED");
+
+// Set the view mode to active grid
+await meeting.participants.setViewMode("ACTIVE_GRID");
+```
+
+</RTKCodeSnippet>
+
+### Set page in paginated mode
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -244,17 +579,54 @@ await meeting.participants.setPage(2);
 <RTKCodeSnippet id="web-react">
 
 ```jsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react";
+
+const [meeting] = useRealtimeKitClient();
+
 // Switch to second page
 await meeting.participants.setPage(2);
 ```
 
 </RTKCodeSnippet>
 
-### Fetch View Mode
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+// Switch to first page
+meeting.participants.setPage(1)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+// Switch to first page
+meeting.participants.setPage(1)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+Flutter SDK automatically manages participant pagination.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+// Switch to second page
+await meeting.participants.setPage(2);
+```
+
+</RTKCodeSnippet>
+
+### Monitor view mode
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
-```jsx
+```js
 const viewMode = meeting.participants.viewMode;
 const currentPage = meeting.participants.currentPage;
 ```
@@ -270,13 +642,28 @@ const currentPage = useRealtimeKitSelector((m) => m.participants.currentPage);
 
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id={["mobile-android", "mobile-ios", "mobile-flutter"]}>
+
+Monitoring view mode is not available on this platform.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+const viewMode = useRealtimeKitSelector((m) => m.participants.viewMode);
+const currentPage = useRealtimeKitSelector((m) => m.participants.currentPage);
+```
+
+</RTKCodeSnippet>
+
 ## Host Controls
 
-The participant object allows the host, several controls. These can be selected while creating the host [preset](/api/resources/realtime_kit/subresources/presets/methods/create/).
+The participant object allows the host several controls. These can be selected while creating the host [preset](/api/resources/realtime_kit/subresources/presets/methods/create/).
 
 ### Media controls
 
-With the correct permissions, the host can disable media for remote participants like so:
+With the correct permissions, the host can disable media for remote participants.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -298,6 +685,9 @@ participant.kick();
 <RTKCodeSnippet id="web-react">
 
 ```jsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react";
+
+const [meeting] = useRealtimeKitClient();
 const participant = meeting.participants.joined.get(participantId);
 
 // Disable a participant's video stream
@@ -311,13 +701,88 @@ participant.kick();
 ```
 
 </RTKCodeSnippet>
-### Waiting Room Controls
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+val participant = meeting.participants.joined.firstOrNull { it.id == participantId }
+
+participant?.let { pcpt ->
+	// Disable a participant's video stream
+	val videoError = pcpt.disableVideo()
+
+	// Disable a participant's audio stream
+	val audioError = pcpt.disableAudio()
+
+	// Kick a participant from the meeting
+	val kickError = pcpt.kick()
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+if let participant = meeting.participants.joined.first(where: { $0.id == participantId }) {
+	// Disable a participant's video stream
+	let videoError: HostError? = participant.disableVideo()
+
+	// Disable a participant's audio stream
+	let audioError: HostError? = participant.disableAudio()
+
+	// Kick a participant from the meeting
+	let kickError: HostError? = participant.kick()
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+// Disable a remote participant's video
+participant.disableVideo(onResult: (e) {
+	// handle error if any
+});
+
+// Disable a remote participant's audio
+participant.disableAudio(onResult: (e) {
+	// handle error if any
+});
+
+// Remove the participant from the meeting
+participant.kick();
+```
+
+**Required Permission**: `permissions.host.canDisableVideo`, `permissions.host.canDisableAudio` must be `true`
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+const participant = meeting.participants.joined.get(participantId);
+
+// Disable a participant's video stream
+participant.disableVideo();
+
+// Disable a participant's audio stream
+participant.disableAudio();
+
+// Kick a participant from the meeting
+participant.kick();
+```
+
+</RTKCodeSnippet>
+
+### Waiting room controls
 
 The waiting room allows the host to control which users can join your meeting and when. They can either choose to accept or reject the request.
 
 You can also automate this flow so that users join the meeting automatically when the host joins the meeting, using [presets](/api/resources/realtime_kit/subresources/presets/methods/create/).
 
-#### Accept Waiting Room Request
+#### Accept waiting room request
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -330,12 +795,49 @@ await meeting.participants.acceptWaitingRoomRequest(participantId);
 <RTKCodeSnippet id="web-react">
 
 ```jsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react";
+
+const [meeting] = useRealtimeKitClient();
+
 await meeting.participants.acceptWaitingRoomRequest(participantId);
 ```
 
 </RTKCodeSnippet>
 
-#### Reject Waiting Room Request
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+meeting.participants.acceptWaitingRoomRequest(participantId)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+meeting.participants.acceptWaitingRoomRequest(id: participantId)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+final participant = meeting.participants.waitlisted[0];
+meeting.participants.acceptWaitlistedParticipant(participant);
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+await meeting.participants.acceptWaitingRoomRequest(participantId);
+```
+
+</RTKCodeSnippet>
+
+#### Reject waiting room request
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -348,14 +850,51 @@ await meeting.participants.rejectWaitingRoomRequest(participantId);
 <RTKCodeSnippet id="web-react">
 
 ```jsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react";
+
+const [meeting] = useRealtimeKitClient();
+
 await meeting.participants.rejectWaitingRoomRequest(participantId);
 ```
 
 </RTKCodeSnippet>
 
-#### Pin Participants
+<RTKCodeSnippet id="mobile-android">
 
-The host can choose to pin/unpin participants to the grid. The current limit on pinning is 1 participant.
+```kotlin
+meeting.participants.rejectWaitingRoomRequest(participantId)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+meeting.participants.rejectWaitingRoomRequest(participantId)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+final participant = meeting.participants.waitlisted[0];
+meeting.participants.rejectWaitlistedParticipant(participant);
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+await meeting.participants.rejectWaitingRoomRequest(participantId);
+```
+
+</RTKCodeSnippet>
+
+### Pin participants
+
+The host can choose to pin or unpin participants to the grid.
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -374,6 +913,9 @@ await participant.unpin();
 <RTKCodeSnippet id="web-react">
 
 ```jsx
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react";
+
+const [meeting] = useRealtimeKitClient();
 const participant = meeting.participants.joined.get(participantId);
 
 // Pin a participant
@@ -385,19 +927,85 @@ await participant.unpin();
 
 </RTKCodeSnippet>
 
-### Update Participant Permissions
+<RTKCodeSnippet id="mobile-android">
 
-The host can additionally modify the permissions for a participant. Permissions for a participant are defined by their preset.
+```kotlin
+val participant = meeting.participants.joined.firstOrNull { it.id == participantId }
+
+participant?.let { pcpt ->
+	// Pin a participant
+	val pinError = pcpt.pin()
+
+	// Unpin a participant
+	val unpinError = pcpt.unpin()
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+if let participant = meeting.participants.joined.first(where: { $0.id == participantId }) {
+	// Pin a participant
+	let pinError: HostError? = participant.pin()
+
+	// Unpin a participant
+	let unpinError: HostError? = participant.unpin()
+}
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+```dart
+// Pin a remote participant
+participant.pin();
+
+// Unpin a previously pinned participant
+participant.unpin();
+```
+
+**Required Permission**: `permissions.host.canPinParticipant` must be `true`
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+```tsx
+const participant = meeting.participants.joined.get(participantId);
+
+// Pin a participant
+await participant.pin();
+
+// Unpin a participant
+await participant.unpin();
+```
+
+</RTKCodeSnippet>
+
+### Update participant permissions
+
+<RTKCodeSnippet id={["web-web-components", "web-angular", "web-react", "mobile-react-native"]}>
+
+The host can modify the permissions for a participant. Permissions for a participant are defined by their preset.
 
 :::note
-
 When the host updates the permissions for a participant, the preset is not modified and the permission changes are limited to the duration of the meeting.
-
 :::
 
-First, you need to find the participant(s) you want to update.
+</RTKCodeSnippet>
 
-<RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+<RTKCodeSnippet id={["mobile-android", "mobile-ios", "mobile-flutter"]}>
+
+Updating participant permissions is not available on this platform.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id={["web-web-components", "web-angular", "web-react", "mobile-react-native"]}>
+
+First, find the participant(s) you want to update.
 
 ```js
 const participantIds = meeting.participants.joined
@@ -406,22 +1014,7 @@ const participantIds = meeting.participants.joined
 	.map((p) => p.id);
 ```
 
-</RTKCodeSnippet>
-
-<RTKCodeSnippet id="web-react">
-
-```jsx
-const participantIds = meeting.participants.joined
-	.toArray()
-	.filter((e) => e.name.startsWith("John"))
-	.map((p) => p.id);
-```
-
-</RTKCodeSnippet>
-
-You can use the `updatePermission` method like so to modify the permissions for the participant.
-
-<RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+Use the `updatePermissions` method to modify the permissions for the participant.
 
 ```js
 // Allow file upload permissions in public chat
@@ -436,28 +1029,7 @@ const newPermissions = {
 meeting.participants.updatePermissions(participantIds, newPermissions);
 ```
 
-</RTKCodeSnippet>
-
-<RTKCodeSnippet id="web-react">
-
-```jsx
-// Allow file upload permissions in public chat
-const newPermissions = {
-	chat: {
-		public: {
-			files: true,
-		},
-	},
-};
-
-meeting.participants.updatePermissions(participantIds, newPermissions);
-```
-
-</RTKCodeSnippet>
-
-The following permissions can be modified
-
-<RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+The following permissions can be modified:
 
 ```typescript
 interface UpdatedPermissions {
@@ -486,42 +1058,7 @@ interface UpdatedPermissions {
 
 </RTKCodeSnippet>
 
-<RTKCodeSnippet id="web-react">
-
-```typescript
-interface UpdatedPermissions {
-	polls?: {
-		canCreate?: boolean;
-		canVote?: boolean;
-	};
-	plugins?: {
-		canClose?: boolean;
-		canStart?: boolean;
-	};
-	chat?: {
-		public?: {
-			canSend?: boolean;
-			text?: boolean;
-			files?: boolean;
-		};
-		private?: {
-			canSend?: boolean;
-			text?: boolean;
-			files?: boolean;
-		};
-	};
-}
-```
-
-</RTKCodeSnippet>
-
-## Display Videos in your UI
-
-This guide will show you how to display videos in your custom grid.
-
-Optionally, you can use the `RtkGrid` component from the UI Kit to display participants. This component handles all grid-related events and data automatically.
-
-### Register Video Element
+## Display participant videos
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
 
@@ -548,12 +1085,6 @@ For local user preview (video not sent to other users):
 meeting.self.registerVideoElement(videoElement, true);
 ```
 
-</RTKCodeSnippet>
-
-### Deregister Video Element
-
-<RTKCodeSnippet id={["web-web-components", "web-angular"]}>
-
 Clean up when the video element is no longer needed:
 
 ```js
@@ -562,202 +1093,104 @@ participant.deregisterVideoElement(videoElement);
 
 </RTKCodeSnippet>
 
-### Using UI Kit Grid
-
 <RTKCodeSnippet id="web-react">
 
-RealtimeKit provides ready-to-use grid components for displaying participant videos:
+To play a participant's video track on a `<video>` element:
 
 ```jsx
-import { RtkGrid } from "@cloudflare/realtimekit-react-ui";
+import { useRealtimeKitClient } from "@cloudflare/realtimekit-react";
 
-function MeetingGrid() {
-	return <RtkGrid />;
-}
+const [meeting] = useRealtimeKitClient();
+
+// Get the video element
+const videoElement = document.getElementById("participant-video");
+
+// Get the participant
+const participant = meeting.participants.joined.get(participantId);
+
+// Register the video element
+participant.registerVideoElement(videoElement);
+
+// Clean up when the video element is no longer needed
+participant.deregisterVideoElement(videoElement);
 ```
 
-The `RtkGrid` component handles all grid-related events and data automatically. It supports:
+For local user preview (video not sent to other users):
 
-- **`RtkSimpleGrid`** - Renders participant tiles in a simple grid
-- **`RtkSpotlightGrid`** - Renders pinned participants in a spotlight area with others in a smaller grid
-- **`RtkMixedGrid`** - Renders screenshares and plugins in the main view with a configurable smaller grid
-
-</RTKCodeSnippet>
-
-<RTKCodeSnippet id="web-angular">
-
-RealtimeKit provides ready-to-use grid components for displaying participant videos:
-
-```typescript title="meeting-grid.component.ts"
-import { Component, Input } from "@angular/core";
-
-@Component({
-	selector: "app-meeting-grid",
-	templateUrl: "./meeting-grid.component.html",
-})
-export class MeetingGridComponent {
-	@Input() meeting: any;
-}
-```
-
-```html title="meeting-grid.component.html"
-<rtk-grid meeting="meeting"></rtk-grid>
+```jsx
+meeting.self.registerVideoElement(videoElement, true);
 ```
 
 </RTKCodeSnippet>
 
-<RTKCodeSnippet id="web-web-components">
+<RTKCodeSnippet id="mobile-android">
 
-RealtimeKit provides ready-to-use grid components for displaying participant videos:
+Call `participant.getVideoView()` which returns a `View` that renders the participant's video stream:
 
-```jsx
+```kotlin
+// Get video view of a given participant
+val videoView = participant.getVideoView()
 
-	<head>
-		<!-- Import RealtimeKit Core via CDN -->
-		<script src="https://cdn.jsdelivr.net/npm/@cloudflare/realtimekit@latest/dist/browser.js"></script>
-		<!-- Import RealtimeKit UI via CDN -->
-		<script src="https://cdn.jsdelivr.net/npm/@cloudflare/realtimekit-ui@latest/dist/browser.js"></script>
-	</head>
-	<body>
-	<rtk-ui-provider
-			id="rtk-ui-provider"
-			style="display: flex; flex-direction: column; height: 100vh; margin: 0;"
-		>
-		<rtk-grid id="my-grid" />
-	</rtk-ui-provider>
-	</body>
-	<script>
-      const searchParams = new URL(window.location.href).searchParams;
-      const authToken = searchParams.get('authToken');
-
-      if (!authToken) {
-        alert(
-          "An authToken wasn't passed, please pass an authToken in the URL query to join a meeting."
-        );
-      }
-
-      // Initialize a meeting
-      RealtimeKitClient.init({
-        authToken,
-      }).then((meeting) => {
-		document.querySelector("rtk-ui-provider").meeting = meeting;
-      });
-	</script>
+// Get screen share video view
+val screenShareView = participant.getScreenShareVideoView()
 ```
-
-The `rtk-grid` component handles all grid-related events and data automatically. It supports:
-
-- **`rtk-simple-grid`** - Renders participant tiles in a simple grid
-- **`rtk-spotlight-grid`** - Renders pinned participants in a spotlight area with others in a smaller grid
-- **`rtk-mixed-grid`** - Renders screenshares and plugins in the main view with a configurable smaller grid
 
 </RTKCodeSnippet>
 
-### Custom Grid using UI Kit
+<RTKCodeSnippet id="mobile-ios">
 
-<RTKCodeSnippet id="web-react">
+Call `participant.getVideoView()` which returns a `UIView` that renders the participant's video stream:
 
-For custom video rendering, use the `RtkParticipantTile` component:
+```swift
+// Get video view of a given participant
+let videoView = participant.getVideoView()
 
-```jsx
-import { RtkParticipantTile } from "@cloudflare/realtimekit-react-ui";
-import { useRealtimeKitSelector } from "@cloudflare/realtimekit-react";
+// Get screen share video view
+let screenShareView = participant.getScreenShareVideoView()
+```
 
-function CustomVideoGrid() {
-	const participants = useRealtimeKitSelector((m) =>
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+Use the video view methods which return a `Widget` that you can place directly in your UI hierarchy:
+
+```dart
+// Create a widget to display the participant's camera video
+final cameraView = VideoView(meetingParticipant: participant);
+
+// Create a widget to display the participant's screen share
+final screenShareView = ScreenshareView(meetingParticipant: participant);
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Use `useRealtimeKitSelector` to get the video track and render it with `RTCView`:
+
+```tsx
+import { useRealtimeKitSelector } from "@cloudflare/realtimekit-react-native";
+import { MediaStream, RTCView } from "@cloudflare/react-native-webrtc";
+
+function VideoView() {
+	const { videoTrack } = useRealtimeKitSelector((m) =>
 		m.participants.active.toArray(),
-	);
+	)[0];
+
+	const stream = new MediaStream(undefined);
+	stream.addTrack(videoTrack);
 
 	return (
-		<div
-			style={{
-				display: "grid",
-				gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
-			}}
-		>
-			{participants.map((participant) => (
-				<RtkParticipantTile key={participant.id} participant={participant} />
-			))}
-		</div>
+		<RTCView
+			objectFit="cover"
+			style={{ flex: 1 }}
+			streamURL={stream.toURL()}
+			mirror={true}
+			zOrder={1}
+		/>
 	);
 }
-```
-
-</RTKCodeSnippet>
-
-<RTKCodeSnippet id="web-angular">
-
-For custom video rendering, use the `rtk-participant-tile` component.
-
-```typescript title="custom-video-grid.component.ts"
-import { Component, Input, OnInit } from "@angular/core";
-
-@Component({
-	selector: "app-custom-video-grid",
-	templateUrl: "./custom-video-grid.component.html",
-})
-export class CustomVideoGridComponent implements OnInit {
-	@Input() meeting: any;
-
-	participants: any[] = [];
-
-	ngOnInit() {
-		this.participants = this.meeting?.participants?.active?.toArray?.() ?? [];
-	}
-}
-```
-
-```html title="custom-video-grid.component.html"
-<div
-	style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));"
->
-	<rtk-participant-tile
-		*ngFor="let participant of participants"
-		[participant]="participant"
-	></rtk-participant-tile>
-</div>
-```
-
-</RTKCodeSnippet>
-
-<RTKCodeSnippet id="web-web-components">
-
-For custom video rendering, use the `rtk-participant-tile` component:
-
-```jsx
-
-	<head>
-		<!-- Import RealtimeKit Core via CDN -->
-		<script src="https://cdn.jsdelivr.net/npm/@cloudflare/realtimekit@latest/dist/browser.js"></script>
-		<!-- Import RealtimeKit UI via CDN -->
-		<script src="https://cdn.jsdelivr.net/npm/@cloudflare/realtimekit-ui@latest/dist/browser.js"></script>
-	</head>
-	<body>
-		<rtk-ui-provider
-			id="rtk-ui-provider"
-			style="display: flex; flex-direction: column; height: 100vh; margin: 0;"
-		>
-			<rtk-participant-tile id="my-tile" />
-		</rtk-ui-provider>
-	</body>
-	<script>
-      const searchParams = new URL(window.location.href).searchParams;
-      const authToken = searchParams.get('authToken');
-
-      if (!authToken) {
-        alert(
-          "An authToken wasn't passed, please pass an authToken in the URL query to join a meeting."
-        );
-      }
-
-      // Initialize a meeting
-      const meeting = await RealtimeKitClient.init({
-        authToken,
-      }).then((meeting) => {
-		document.querySelector("rtk-ui-provider").meeting = meeting;
-        document.getElementById('my-tile').participant = meeting.self;
-      });
-	</script>
 ```
 
 </RTKCodeSnippet>

--- a/src/content/docs/realtime/realtimekit/core/remote-participants/pip.mdx
+++ b/src/content/docs/realtime/realtimekit/core/remote-participants/pip.mdx
@@ -1,9 +1,9 @@
 ---
-pcx_content_type: navigation
+pcx_content_type: how-to
 title: Picture in Picture
 sidebar:
   label: Picture in Picture
-  order: 2
+  order: 3
 ---
 
 import RTKSDKSelector from "~/components/realtimekit/RTKSDKSelector/RTKSDKSelector.astro";
@@ -12,50 +12,34 @@ import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnipp
 Picture-in-Picture API allows you to render `meeting.participants.active` participant's video as a floating tile outside of the current webpage's context.
 
 :::note
-Supported in Chrome/Edge/Chromium-based browsers only.
+Supported in Chrome, Edge, and Chromium-based browsers only.
 :::
 
-### Check Support
+<RTKSDKSelector />
 
-Picture-in-Picture API might not be supported for your browser. It is important to always check for support.
+<RTKCodeSnippet id={["mobile-android", "mobile-ios", "mobile-flutter", "mobile-react-native"]}>
+
+Picture-in-Picture is not available on this platform.
+
+</RTKCodeSnippet>
 
 <RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+
+## Check support
+
+Picture-in-Picture API might not be supported in your browser. Always check for support before using the API.
 
 ```js
 const isSupported = meeting.participants.pip.isSupported();
 ```
 
-</RTKCodeSnippet>
-
-<RTKCodeSnippet id="web-react">
-
-```jsx
-const isSupported = meeting.participants.pip.isSupported();
-```
-
-</RTKCodeSnippet>
-
-### Enable Picture-in-Picture
-
-<RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+## Enable Picture-in-Picture
 
 ```js
 await meeting.participants.pip.enable();
 ```
 
-</RTKCodeSnippet>
-
-<RTKCodeSnippet id="web-react">
-
-```jsx
-await meeting.participants.pip.enable();
-```
-
-</RTKCodeSnippet>
-
-### Disable Picture-in-Picture
-
-<RTKCodeSnippet id={["web-web-components", "web-angular"]}>
+## Disable Picture-in-Picture
 
 ```js
 await meeting.participants.pip.disable();
@@ -64,6 +48,22 @@ await meeting.participants.pip.disable();
 </RTKCodeSnippet>
 
 <RTKCodeSnippet id="web-react">
+
+## Check support
+
+Picture-in-Picture API might not be supported in your browser. Always check for support before using the API.
+
+```jsx
+const isSupported = meeting.participants.pip.isSupported();
+```
+
+## Enable Picture-in-Picture
+
+```jsx
+await meeting.participants.pip.enable();
+```
+
+## Disable Picture-in-Picture
 
 ```jsx
 await meeting.participants.pip.disable();


### PR DESCRIPTION
### Summary

Added remote participant docs for RealtimeKit mobile SDKs.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
