### PR TITLE
docs: add wrangler versions delete command

### DIFF
--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -74,6 +74,20 @@ New versions are not created when you make changes to [resources connected to yo
 
 See examples of creating a Worker, Versions, and Deployments directly with the API, library SDKs, and Terraform in [Infrastructure as Code](/workers/platform/infrastructure-as-code/).
 
+### Delete a version
+
+To delete a version that is not currently deployed, use the [`wrangler versions delete`](/workers/wrangler/commands/#versions-delete) command:
+
+```sh
+npx wrangler versions delete <VERSION_ID> --name <WORKER_NAME>
+```
+
+You will be prompted to confirm the deletion. Use `--yes` to skip the confirmation prompt in CI environments.
+
+:::note
+You cannot delete a version that is actively serving traffic. Remove the version from the active deployment first.
+:::
+
 ### View versions and deployments
 
 #### Via Wrangler

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -729,6 +729,12 @@ For example:
 
 <WranglerCommand command="versions view" headingLevel={3} />
 
+<WranglerCommand
+	command="versions delete"
+	description="Delete a specific [version](/workers/configuration/versions-and-deployments/#versions) of your Worker. A version can only be deleted if it is not actively deployed."
+	headingLevel={3}
+/>
+
 <WranglerCommand command="versions secret put" headingLevel={3} />
 
 <WranglerCommand command="versions secret delete" headingLevel={3} />


### PR DESCRIPTION
Documents the new `wrangler versions delete` command added in cloudflare/workers-sdk#11842.

- adds `versions delete` to the Wrangler commands reference
- adds "Delete a version" section to the Versions & Deployments concept page