### PR TITLE
Revise GitHub identity provider registration steps

### DIFF
--- a/src/content/docs/cloudflare-one/integrations/identity-providers/github.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/github.mdx
@@ -13,7 +13,7 @@ To configure GitHub access in both GitHub and Cloudflare One:
 
 1. Log in to [GitHub](https://github.com/).
 
-2. Go to your account **Settings** > **Developer Settings**.
+2. Go to your account > **Settings** > **Developer Settings**.
 
 3. In **Developer Settings**, select **OAuth Apps** and select **New OAuth app**.
 
@@ -33,24 +33,29 @@ To configure GitHub access in both GitHub and Cloudflare One:
    https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/callback
    ```
 
-7. Go to **Account permissions** > **Email addresses** and add **Read-only** access.
+7. Select **Register application**.
 
-8. Select **Register application**.
+8. Make note of the **Client ID**.
 
-9. Find the **Client ID** and **Client Secret**.
+9. Select **Generate a new client secret** and copy the client secret to a safe place.
 
 10. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Integrations** > **Identity providers**.
 
 11. Select **Add new identity provider** and select **GitHub**.
 
-12. Choose **GitHub** on the next page.
+12. In **App ID**, enter the **Client ID** obtained from GitHub (refer to step 8).
 
-13. In the **App ID** field, copy and paste the **Client ID** you found in step 9. In the **Client secret** field, copy and paste the **Client secret** you found in step 9. You will need to select **Generate a new client secret** if one is not already displayed.
+13. In **Client secret**, enter the **Client secret** obtained from GitHub (refer to step 9).
 
 14. Select **Save**.
 
-To test that your connection is working, go to [Cloudflare One](https://one.dash.cloudflare.com) > **Integrations** > **Identity providers** and select **Test** next to your GitHub login method.
-If you have GitHub two-factor authentication enabled, you will need to first login to GitHub directly and return to Access.
+15. Select **Finish setup** to launch a GitHub authorization page. You will be asked to grant the following permissions to Cloudflare Access:
+	- Organizations and teams (read-only)
+	- Email addresses (read-only)
+
+16. Select **Authorize**.
+
+To test that your connection is working, go to [Cloudflare One](https://one.dash.cloudflare.com) > **Integrations** > **Identity providers** and select **Test** next to your GitHub login method. If you have GitHub two-factor authentication enabled, you will need to first login to GitHub directly and return to Access.
 
 :::note[Troubleshooting organization policies]
 

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/github.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/github.mdx
@@ -33,19 +33,21 @@ To configure GitHub access in both GitHub and Cloudflare One:
    https://<your-team-name>.cloudflareaccess.com/cdn-cgi/access/callback
    ```
 
-7. Select **Register application**.
+7. Go to **Account permissions** > **Email addresses** and add **Read-only** access.
 
-8. Find the **Client ID** and **Client Secret**.
+8. Select **Register application**.
 
-9. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Integrations** > **Identity providers**.
+9. Find the **Client ID** and **Client Secret**.
 
-10. Select **Add new identity provider** and select **GitHub**.
+10. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Integrations** > **Identity providers**.
 
-11. Choose **GitHub** on the next page.
+11. Select **Add new identity provider** and select **GitHub**.
 
-12. In the **App ID** field, copy and paste the **Client ID** you found in step 8. In the **Client secret** field, copy and paste the **Client secret** you found in step 8. You will need to select **Generate a new client secret** if one is not already displayed.
+12. Choose **GitHub** on the next page.
 
-13. Select **Save**.
+13. In the **App ID** field, copy and paste the **Client ID** you found in step 9. In the **Client secret** field, copy and paste the **Client secret** you found in step 9. You will need to select **Generate a new client secret** if one is not already displayed.
+
+14. Select **Save**.
 
 To test that your connection is working, go to [Cloudflare One](https://one.dash.cloudflare.com) > **Integrations** > **Identity providers** and select **Test** next to your GitHub login method.
 If you have GitHub two-factor authentication enabled, you will need to first login to GitHub directly and return to Access.


### PR DESCRIPTION
Updated steps for registering GitHub as an identity provider, including changes to permissions.

### Summary

Cloudflare Zero Trust integration with GitHub requires read access to user's e-mail.
