### PR TITLE
Add shell tab completion to `wrangler`

### DIFF
--- a/src/content/changelog/workers/2026-01-09-wrangler-tab-completion.mdx
+++ b/src/content/changelog/workers/2026-01-09-wrangler-tab-completion.mdx
@@ -1,0 +1,41 @@
+---
+title: Shell tab completions for Wrangler CLI
+description: Wrangler now supports shell tab completions for Bash, Zsh, Fish, and PowerShell, making it faster to navigate commands and flags.
+products:
+  - workers
+date: 2026-01-09
+---
+
+Wrangler now includes built-in shell tab completion support, making it faster and easier to navigate commands without memorizing every option. Press Tab as you type to autocomplete commands, subcommands, flags, and even option values like log levels.
+
+Tab completions are supported for Bash, Zsh, Fish, and PowerShell.
+
+### Setup
+
+Generate the completion script for your shell and add it to your configuration file:
+
+```sh
+# Bash
+wrangler complete bash >> ~/.bashrc
+
+# Zsh
+wrangler complete zsh >> ~/.zshrc
+
+# Fish
+wrangler complete fish >> ~/.config/fish/config.fish
+
+# PowerShell
+wrangler complete powershell >> $PROFILE
+```
+
+After adding the script, restart your terminal or source your configuration file for the changes to take effect. Then you can simply press Tab to see available completions:
+
+```sh
+wrangler d<TAB>          # completes to 'deploy', 'dev', 'd1', etc.
+wrangler deploy --<TAB>  # shows available flags like --name, --env
+wrangler kv <TAB>        # shows subcommands: namespace, key, bulk
+```
+
+Tab completions are dynamically generated from Wrangler's command registry, so they stay up-to-date as new commands and options are added. This feature is powered by [`@bomb.sh/tab`](https://github.com/bombshell-dev/tab/).
+
+See the [`wrangler complete` documentation](/workers/wrangler/commands/#complete) for more details.

--- a/src/content/changelog/workers/2026-01-09-wrangler-tab-completion.mdx
+++ b/src/content/changelog/workers/2026-01-09-wrangler-tab-completion.mdx
@@ -32,7 +32,6 @@ After adding the script, restart your terminal or source your configuration file
 
 ```sh
 wrangler d<TAB>          # completes to 'deploy', 'dev', 'd1', etc.
-wrangler deploy --<TAB>  # shows available flags like --name, --env
 wrangler kv <TAB>        # shows subcommands: namespace, key, bulk
 ```
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -588,7 +588,7 @@ Configure Cloudflare Pages.
 
 <WranglerNamespace namespace="pages" headingLevel={3} />
 
-{/* :::note[Deployment tail]
+{/\* :::note[Deployment tail]
 Filtering with `--ip self` will allow tailing your deployed Functions beyond the normal request per second limits.
 :::
 
@@ -1114,7 +1114,6 @@ After setup, press Tab to autocomplete commands, subcommands, and flags:
 
 ```sh
 wrangler d<TAB>          # completes to 'deploy', 'dev', 'd1', etc.
-wrangler deploy --<TAB>  # shows available flags like --name, --env, etc.
 wrangler kv <TAB>        # shows subcommands: namespace, key, bulk
 ```
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -588,7 +588,7 @@ Configure Cloudflare Pages.
 
 <WranglerNamespace namespace="pages" headingLevel={3} />
 
-{/\* :::note[Deployment tail]
+{/* :::note[Deployment tail]
 Filtering with `--ip self` will allow tailing your deployed Functions beyond the normal request per second limits.
 :::
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -24,6 +24,7 @@ Wrangler offers a number of commands to manage your Cloudflare Workers.
 
 - [`docs`](#docs) - Open this page in your default browser.
 - [`init`](#init) - Create a new project from a variety of web frameworks and templates.
+- [`complete`](#complete) - Generate shell completion scripts for Wrangler commands.
 - [`containers`](#containers) - Interact with Containers.
 - [`d1`](#d1) - Interact with D1.
 - [`vectorize`](#vectorize) - Interact with Vectorize indexes.
@@ -1052,5 +1053,69 @@ wrangler check startup
   - If you don't use Wrangler to deploy your Worker, you can use this argument to provide a Worker bundle to analyse. This should be a file path to a serialized multipart upload, with the exact same format as [the API expects](/api/resources/workers/subresources/scripts/methods/update/).
 - `--pages` <Type text="boolean" /> <MetaInfo text="optional" />
   - If you don't use a Wrangler config file with your Pages project (i.e. a Wrangler config file containing `pages_build_output_dir`), use this flag to force `wrangler check startup` to treat your project as a Pages project.
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+## `complete`
+
+Generate shell completion scripts for Wrangler commands. Shell completions allow you to autocomplete commands, subcommands, and flags by pressing Tab as you type.
+
+```txt
+wrangler complete <SHELL>
+```
+
+- `SHELL` <Type text="string" /> <MetaInfo text="required" />
+  - The shell to generate completions for. Supported values: `bash`, `zsh`, `fish`, `powershell`.
+
+### Setup
+
+Generate and add the completion script to your shell configuration file:
+
+<Tabs>
+<TabItem label="Bash">
+```sh
+wrangler complete bash >> ~/.bashrc
+```
+
+Then restart your terminal or run `source ~/.bashrc`.
+
+</TabItem>
+<TabItem label="Zsh">
+```sh
+wrangler complete zsh >> ~/.zshrc
+```
+
+Then restart your terminal or run `source ~/.zshrc`.
+
+</TabItem>
+<TabItem label="Fish">
+```sh
+wrangler complete fish >> ~/.config/fish/config.fish
+```
+
+Then restart your terminal or run `source ~/.config/fish/config.fish`.
+
+</TabItem>
+<TabItem label="PowerShell">
+```powershell
+wrangler complete powershell >> $PROFILE
+```
+
+Then restart PowerShell or run `. $PROFILE`.
+
+</TabItem>
+</Tabs>
+
+### Usage
+
+After setup, press Tab to autocomplete commands, subcommands, and flags:
+
+```sh
+wrangler d<TAB>          # completes to 'deploy', 'dev', 'd1', etc.
+wrangler deploy --<TAB>  # shows available flags like --name, --env, etc.
+wrangler kv <TAB>        # shows subcommands: namespace, key, bulk
+```
 
 <Render file="wrangler-commands/global-flags" product="workers" />


### PR DESCRIPTION
### Summary

Thanks to cloudflare/workers-sdk#11113 we are now adding support for shell tab completion, using `@bomb.sh/tab`. 

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
