### PR TITLE
Fix SFU dashboard link

### DIFF
--- a/src/content/docs/realtime/sfu/get-started.mdx
+++ b/src/content/docs/realtime/sfu/get-started.mdx
@@ -17,7 +17,7 @@ You must first [create a Cloudflare account](/fundamentals/account/create-accoun
 ## Create your first app
 
 Every Realtime App is a separate environment, so you can make one for development, staging and production versions for your product.
-Either using [Dashboard](https://dash.cloudflare.com/?to=/:account/calls), or the [API](/api/resources/calls/subresources/sfu/methods/create/) create a Realtime App. When you create a Realtime App, you will get:
+Either using [Dashboard](https://dash.cloudflare.com/?to=/:account/realtime/sfu), or the [API](/api/resources/calls/subresources/sfu/methods/create/) create a Realtime App. When you create a Realtime App, you will get:
 
 * App ID
 * App Secret


### PR DESCRIPTION
Corrects Dashboard link from `/calls` to `/realtime/sfu` in the quickstart guide.