### PR TITLE
docs: add pricing info to embeddinggemma-300m

### DIFF
--- a/src/content/workers-ai-models/embeddinggemma-300m.json
+++ b/src/content/workers-ai-models/embeddinggemma-300m.json
@@ -8,9 +8,20 @@
         "name": "Text Embeddings",
         "description": "Feature extraction models transform raw data into numerical features that can be processed while preserving the information in the original dataset. These models are ideal as part of building vector search applications or Retrieval Augmented Generation workflows with Large Language Models (LLM)."
     },
+
     "created_at": "2025-09-04 16:38:44.980",
     "tags": [],
-    "properties": [],
+    "properties": [
+        {
+            "property_id": "price",
+            "value": [
+                {
+                    "unit": "per M input tokens",
+                    "price": 0,
+                    "currency": "USD"
+                }
+            ]
+        }],
     "schema": {
         "input": {
             "type": "object",


### PR DESCRIPTION
### Summary

Fixes #27490

This PR updates the `embeddinggemma-300m.json` model definition to include missing pricing information.

**Changes:**
- Added the `properties` block containing pricing metadata.
- Set the price to `0` (Free) to align with current Workers AI pricing for this model.
- Matched the schema structure used in `qwen3-embedding-0.6b` for consistency.

### Screenshots (optional)

<img width="1020" height="677" alt="Screenshot 2026-01-09 121831" src="https://github.com/user-attachments/assets/350604ea-1876-42d8-9b36-a13930cd0cb8" />
<img width="1027" height="800" alt="Screenshot 2026-01-09 121844" src="https://github.com/user-attachments/assets/1b32aab0-6be7-44fe-a4f9-d867e4054900" />

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry?
* *(Note: I have left this unchecked as this is a metadata fix for an existing model page, not a new feature launch, but I am happy to add one if requested.)*
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.

## Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=180482232