### PR TITLE
chore: ensure only npm is used

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-dev=true
 save-exact=true
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,8 @@
 				"wrangler": "4.58.0"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": "22.x",
+				"npm": "10.9.4"
 			}
 		},
 		"node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -143,5 +143,10 @@
 	},
 	"volta": {
 		"node": "22.9.0"
-	}
+	},
+	"engines": {
+		"npm": "10.9.4",
+		"node": "22.x"
+	},
+	"packageManager": "npm@10.9.4+sha512.3a7506f37e85c1ba1021baad79f0cd9724748131f321fc117c4dc3ba235ec01be7327584a41d15117c01945560aa9373220628fcc1e1dddd877a5fe9b336a900"
 }


### PR DESCRIPTION
### Summary

Ensures no accidental use of `yarn` or `pnpm`.