### PR TITLE
Fix grammar in Ethereum node access explanation

### DIFF
--- a/src/content/docs/web3/ethereum-gateway/concepts/ethereum.mdx
+++ b/src/content/docs/web3/ethereum-gateway/concepts/ethereum.mdx
@@ -46,7 +46,7 @@ network accountable.
 To read content, a user needs to interact with a working Ethereum node. Such
 nodes can be run locally on a user's machine as daemons (such as:
 [https://github.com/ethereum/go-ethereum/](https://github.com/ethereum/go-ethereum/)). When the user accesses such a node,
-it can use the official JSONRPC API to send queries to the network, and learn
+they can use the official JSONRPC API to send queries to the network, and learn
 about specific aspects of the consensus.
 
 Writing content is just as simple, and can be done using a [single JSON

--- a/src/content/docs/web3/ethereum-gateway/concepts/ethereum.mdx
+++ b/src/content/docs/web3/ethereum-gateway/concepts/ethereum.mdx
@@ -45,7 +45,7 @@ network accountable.
 
 To read content, a user needs to interact with a working Ethereum node. Such
 nodes can be run locally on a user's machine as daemons (such as:
-[https://github.com/ethereum/go-ethereum/](https://github.com/ethereum/go-ethereum/)). When the user access to such a node
+[https://github.com/ethereum/go-ethereum/](https://github.com/ethereum/go-ethereum/)). When the user accesses such a node,
 it can use the official JSONRPC API to send queries to the network, and learn
 about specific aspects of the consensus.
 


### PR DESCRIPTION
Corrected grammatical error in the text regarding user access to Ethereum nodes
