### PR TITLE
Add documentation for the new `wrangler types --check` flag

### DIFF
--- a/src/content/changelog/workers/2026-01-11-wrangler-types-check.mdx
+++ b/src/content/changelog/workers/2026-01-11-wrangler-types-check.mdx
@@ -1,0 +1,19 @@
+---
+title: Validate your generated types with `wrangler types --check`
+description: A new flag for `wrangler types` lets you verify your generated types are up to date without modifying any files.
+products:
+  - workers
+date: 2026-01-12
+---
+
+Wrangler now supports a `--check` flag for the `wrangler types` command. This flag validates that your generated types are up to date without writing any changes to disk.
+
+This is useful in CI/CD pipelines where you want to ensure that developers have regenerated their types after making changes to their Wrangler configuration. If the types are out of date, the command will exit with a non-zero status code.
+
+```sh
+npx wrangler types --check
+```
+
+If your types are up to date, the command will succeed silently. If they are out of date, you'll see an error message indicating which files need to be regenerated.
+
+For more information, see the [Wrangler types documentation](/workers/wrangler/commands/#types).

--- a/src/content/docs/workers/languages/typescript/index.mdx
+++ b/src/content/docs/workers/languages/typescript/index.mdx
@@ -129,7 +129,7 @@ Most projects will have existing build and development scripts, as well as some 
 }
 ```
 
-We recommend you commit your generated types file for use in CI. Alternatively, you can run `wrangler types` before other CI commands, as it should not take more than a few seconds. For example:
+We recommend you commit your generated types file for use in CI. You can run `wrangler types` before other CI commands, as it should not take more than a few seconds. For example:
 
 <Tabs> <TabItem label="npm">
 
@@ -156,6 +156,36 @@ We recommend you commit your generated types file for use in CI. Alternatively, 
 ```
 
 </TabItem> </Tabs>
+
+Alternatively, if you commit your generated types file and want to verify it stays up-to-date in CI, you can use the `--check` flag:
+
+<Tabs> <TabItem label="npm">
+
+```yaml
+- run: npx wrangler types --check
+- run: npm run build
+- run: npm test
+```
+
+</TabItem> <TabItem label="yarn">
+
+```yaml
+- run: yarn wrangler types --check
+- run: yarn build
+- run: yarn test
+```
+
+</TabItem> <TabItem label="pnpm">
+
+```yaml
+- run: pnpm wrangler types --check
+- run: pnpm run build
+- run: pnpm test
+```
+
+</TabItem> </Tabs>
+
+This fails the CI job if the committed types file is out-of-date, prompting developers to regenerate and commit the updated types.
 
 ### Resources
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -980,6 +980,10 @@ wrangler types [<PATH>] [OPTIONS]
   - Control the types that Wrangler generates for `vars` bindings.
   - If `true`, (the default) Wrangler generates literal and union types for bindings (e.g. `myVar: 'my dev variable' | 'my prod variable'`).
   - If `false`, Wrangler generates generic types (e.g. `myVar: string`). This is useful when variables change frequently, especially when working across multiple environments.
+- `--check` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Check if the generated types at the specified path are up-to-date without regenerating them.
+  - Exits with code 0 if types are up-to-date, or code 1 if types are out-of-date.
+  - Useful for CI/CD pipelines and pre-commit hooks to ensure types have been regenerated after configuration changes.
 - `--config`, `-c` <Type text="string[]" /> <MetaInfo text="optional" />
   - Path(s) to [Wrangler configuration file](/workers/wrangler/configuration/). If the Worker you are generating types for has service bindings or bindings to Durable Objects, you can also provide the paths to those configuration files so that the generated `Env` type will include RPC types. For example, given a Worker with a service binding, `wrangler types -c wrangler.toml -c ../bound-worker/wrangler.toml` will generate an `Env` type like this:
   ```ts


### PR DESCRIPTION
### Summary

cloudflare/workers-sdk#11852 adds support for checking whether the current generated worker types are out of date or not by using the new `--check` flag.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))?
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
