### PR TITLE
Add 'bun' to package managers list

### DIFF
--- a/src/components/PackageManagers.astro
+++ b/src/components/PackageManagers.astro
@@ -8,6 +8,6 @@ type Props = PackageManagersProps;
 ---
 
 <PackageManagersComponent
-	pkgManagers={["npm", "yarn", "pnpm"]}
+	pkgManagers={["npm", "yarn", "pnpm", "bun"]}
 	{...Astro.props}
 />


### PR DESCRIPTION
### Summary

This commit adds the bun option to package managers.

### Screenshots (optional)

Ex: 
<img width="509" height="142" alt="image" src="https://github.com/user-attachments/assets/dfe7f858-789f-4757-9bb4-5a092ca91826" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
