### PR TITLE
Remove 4G/5G embedded modules known limitation

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/warp/troubleshooting/known-limitations.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/warp/troubleshooting/known-limitations.mdx
@@ -67,15 +67,6 @@ Alternatively, use PowerShell:
 Resolve-DnsName -Name google.com
 ```
 
-## 4G/5G embedded modules
-
-Because of how the WARP client instantiates the local DNS Proxy, it is incompatible with 4G/5G cellular adapters which have IPv6 enabled. To run WARP on these devices, you will need to disable IPv6 on the system.
-
-:::note
-
-This limitation does not apply to mobile phones, only desktop machines with cellular connectivity.
-:::
-
 ## Comcast DNS servers
 
 Comcast DNS traffic (to the IPs below) cannot be proxied through WARP. This is because Comcast rejects DNS traffic that is not sent directly from the user's device.


### PR DESCRIPTION
### Summary

Tested this out and it no longer applies.
