### PR TITLE
Add WARP client release 2025.10.186.0

### DIFF
--- a/src/content/warp-releases/linux/ga/2025.10.186.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.10.186.0.yaml
@@ -8,7 +8,7 @@ releaseNotes: |-
   - Linux [disk encryption posture check](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/disk-encryption/) now supports non-filesystem encryption types like `dm-crypt`.
   - [Proxy mode](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/#proxy-mode) now supports transparent HTTP proxying in addition to CONNECT-based proxying.
   - Fixed an issue where the GUI becomes unresponsive when the **Re-Authenticate in browser** button is clicked.
-  -  Added a new feature to manage WARP client connectivity for all devices using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on prem HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
+  -  Added a new feature to manage WARP client connectivity for all devices using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on-premises HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
 version: 2025.10.186.0
 releaseDate: 2026-01-13T01:53:14.425Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/noble-arm/version/2025.10.186.0

--- a/src/content/warp-releases/linux/ga/2025.10.186.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.10.186.0.yaml
@@ -1,14 +1,14 @@
 releaseNotes: |-
-  This release contains minor fixes, improvements, and new features including a new feature to manage WARP client connectivity for all devices in your fleet using an external signal.
+  This release contains minor fixes, improvements, and new features, including the ability to manage WARP client connectivity for all devices in your fleet using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/).
 
   WARP client version 2025.8.779.0 introduced an updated public key for Linux packages. The public key must be updated if it was installed before September 12, 2025 to ensure the repository remains functional after December 4, 2025. Instructions to make this update are available at [pkg.cloudflareclient.com](https://pkg.cloudflareclient.com).
 
   **Changes and improvements**
-  - The Local Domain Fallback feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
-  - Improvement for WARP client posture check. Linux device posture for encrypted drives now also supports non-filesystem encryption types like dm-crypt.
-  - Improvement for WARP modes, proxy mode now supports transparent HTTP proxying in addition to CONNECT-based proxying.
-  - Fixed an issue where the GUI becomes unresponsive when the "Re-Authenticate in browser" button is clicked.
-  - Added a new feature to [Manage device connection using an external signal](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on prem HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
+  - The [Local Domain Fallback](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/local-domains/) feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
+  - Linux [disk encryption posture check](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/disk-encryption/) now supports non-filesystem encryption types like `dm-crypt`.
+  - [Proxy mode](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/#proxy-mode) now supports transparent HTTP proxying in addition to CONNECT-based proxying.
+  - Fixed an issue where the GUI becomes unresponsive when the **Re-Authenticate in browser** button is clicked.
+  -  Added a new feature to manage WARP client connectivity for all devices using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on prem HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
 version: 2025.10.186.0
 releaseDate: 2026-01-13T01:53:14.425Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/noble-arm/version/2025.10.186.0

--- a/src/content/warp-releases/linux/ga/2025.10.186.0.yaml
+++ b/src/content/warp-releases/linux/ga/2025.10.186.0.yaml
@@ -1,0 +1,35 @@
+releaseNotes: |-
+  This release contains minor fixes, improvements, and new features including a new feature to manage WARP client connectivity for all devices in your fleet using an external signal.
+
+  WARP client version 2025.8.779.0 introduced an updated public key for Linux packages. The public key must be updated if it was installed before September 12, 2025 to ensure the repository remains functional after December 4, 2025. Instructions to make this update are available at [pkg.cloudflareclient.com](https://pkg.cloudflareclient.com).
+
+  **Changes and improvements**
+  - The Local Domain Fallback feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
+  - Improvement for WARP client posture check. Linux device posture for encrypted drives now also supports non-filesystem encryption types like dm-crypt.
+  - Improvement for WARP modes, proxy mode now supports transparent HTTP proxying in addition to CONNECT-based proxying.
+  - Fixed an issue where the GUI becomes unresponsive when the "Re-Authenticate in browser" button is clicked.
+  - Added a new feature to [Manage device connection using an external signal](/cloudflare-one/connections/connect-devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on prem HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
+version: 2025.10.186.0
+releaseDate: 2026-01-13T01:53:14.425Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/noble-arm/version/2025.10.186.0
+packageSize: 51987674
+platformName: Linux
+linuxPlatforms:
+  noble-arm: 51987674
+  focal-arm: 51912080
+  bookworm-intel: 52296504
+  fedora34-arm: 54599628
+  jammy-intel: 52306444
+  fedora34-intel: 55209148
+  noble-intel: 52090374
+  bookworm-arm: 51571280
+  fedora35-intel: 54862462
+  jammy-arm: 51586370
+  bullseye-arm: 51839930
+  centos8-arm: 54385310
+  trixie-intel: 52091546
+  fedora35-arm: 54165334
+  trixie-arm: 51805154
+  focal-intel: 52614234
+  bullseye-intel: 52526626
+  centos8-intel: 54773719

--- a/src/content/warp-releases/macos/ga/2025.10.186.0.yaml
+++ b/src/content/warp-releases/macos/ga/2025.10.186.0.yaml
@@ -1,9 +1,9 @@
 releaseNotes: |-
-  This release contains minor fixes, improvements, and new features including a new feature to manage WARP client connectivity for all devices in your fleet using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/), and a new WARP client device posture check for [Antivirus](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/antivirus/).
+  This release contains minor fixes, improvements, and new features, including the ability to manage WARP client connectivity for all devices in your fleet using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/).
 
   **Changes and improvements**
-  - The Local Domain Fallback feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
-  - Improvement for WARP modes. Proxy mode now supports transparent HTTP proxying in addition to CONNECT-based proxying.
+  - The [Local Domain Fallback](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/local-domains/) feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
+  - [Proxy mode](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/#proxy-mode) now supports transparent HTTP proxying in addition to CONNECT-based proxying.
   - Added a new feature to manage WARP client connectivity for all devices using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on-premises HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
 version: 2025.10.186.0
 releaseDate: 2026-01-13T15:48:17.930Z

--- a/src/content/warp-releases/macos/ga/2025.10.186.0.yaml
+++ b/src/content/warp-releases/macos/ga/2025.10.186.0.yaml
@@ -1,0 +1,12 @@
+releaseNotes: |-
+  This release contains minor fixes, improvements, and new features including a new feature to manage WARP client connectivity for all devices in your fleet using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/), and a new WARP client device posture check for [Antivirus](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/antivirus/).
+
+  **Changes and improvements**
+  - The Local Domain Fallback feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
+  - Improvement for WARP modes. Proxy mode now supports transparent HTTP proxying in addition to CONNECT-based proxying.
+  - Added a new feature to manage WARP client connectivity for all devices using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on-premises HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
+version: 2025.10.186.0
+releaseDate: 2026-01-13T15:48:17.930Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/macos/version/2025.10.186.0
+packageSize: 111235956
+platformName: macOS

--- a/src/content/warp-releases/windows/ga/2025.10.186.0.yaml
+++ b/src/content/warp-releases/windows/ga/2025.10.186.0.yaml
@@ -1,0 +1,27 @@
+releaseNotes: |-
+  This release contains minor fixes, improvements, and new features including a new feature to manage WARP client connectivity for all devices in your fleet using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/), and a new WARP client device posture check for [Antivirus](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/antivirus/).
+
+  **Changes and improvements**
+  - Added a new feature to manage WARP client connectivity for all devices using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on-premises HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
+  - Fixed an issue that caused performance issues on Windows platform (i.e occasional audio degradation and increased CPU usage) by making improvements to route configuration for split tunneling to better handle large Domain-based split tunnel rules.
+  - The Local Domain Fallback feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
+  - Improvement for WARP modes, proxy mode now supports transparent HTTP proxying in addition to CONNECT-based proxying.
+  - Fixed an issue where sending large messages to the daemon by Inter-Process Communication (IPC) could cause the daemon to fail and result in service interruptions.
+  - Added support for a new WARP client device posture check for [Antivirus](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/antivirus/). The check confirms the presence of an antivirus program on a Windows device with the option to check if the antivirus is up to date.
+
+  **Known issues**
+  - For Windows 11 24H2 users, Microsoft has confirmed a regression that may lead to performance issues like mouse lag, audio cracking, or other slowdowns. Cloudflare recommends users experiencing these issues upgrade to a minimum [Windows 11 24H2 KB5062553](https://support.microsoft.com/en-us/topic/july-8-2025-kb5062553-os-build-26100-4652-523e69cb-051b-43c6-8376-6a76d6caeefd) or higher for resolution.
+
+  - Devices with KB5055523 installed may receive a warning about Win32/ClickFix.ABA being present in the installer. To resolve this false positive, update Microsoft Security Intelligence to [version 1.429.19.0](https://www.microsoft.com/en-us/wdsi/definitions/antimalware-definition-release-notes?requestVersion=1.429.19.0) or later.
+
+  - DNS resolution may be broken when the following conditions are all true:
+    - WARP is in Secure Web Gateway without DNS filtering (tunnel-only) mode.
+    - A custom DNS server address is configured on the primary network adapter.
+    - The custom DNS server address on the primary network adapter is changed while WARP is connected.
+
+    To work around this issue, please reconnect the WARP client by toggling off and back on.
+version: 2025.10.186.0
+releaseDate: 2026-01-13T15:48:19.406Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/windows/version/2025.10.186.0
+packageSize: 135471104
+platformName: Windows

--- a/src/content/warp-releases/windows/ga/2025.10.186.0.yaml
+++ b/src/content/warp-releases/windows/ga/2025.10.186.0.yaml
@@ -1,25 +1,25 @@
 releaseNotes: |-
-  This release contains minor fixes, improvements, and new features including a new feature to manage WARP client connectivity for all devices in your fleet using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/), and a new WARP client device posture check for [Antivirus](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/antivirus/).
+  This release contains minor fixes, improvements, and new features. New features include the ability to manage WARP client connectivity for all devices in your fleet using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/), and a new WARP client device posture check for [Antivirus](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/antivirus/).
 
   **Changes and improvements**
   - Added a new feature to manage WARP client connectivity for all devices using an [external signal](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-settings/external-disconnect/). This feature allows administrators to send a global signal from an on-premises HTTPS endpoint that force disconnects or reconnects all WARP clients in an account based on configuration set on the endpoint.
-  - Fixed an issue that caused performance issues on Windows platform (i.e occasional audio degradation and increased CPU usage) by making improvements to route configuration for split tunneling to better handle large Domain-based split tunnel rules.
-  - The Local Domain Fallback feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
-  - Improvement for WARP modes, proxy mode now supports transparent HTTP proxying in addition to CONNECT-based proxying.
+  - Fixed an issue that caused occasional audio degradation and increased CPU usage on Windows by optimizing route configurations for large [domain-based split tunnel rules](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/split-tunnels/#domain-based-split-tunnels).
+  - The [Local Domain Fallback](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/local-domains/) feature has been fixed for devices running WARP client version 2025.4.929.0 and newer. Previously, these devices could experience failures with Local Domain Fallback unless a fallback server was explicitly configured. This configuration is no longer a requirement for the feature to function correctly.
+  - [Proxy mode](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/#proxy-mode) now supports transparent HTTP proxying in addition to CONNECT-based proxying.
   - Fixed an issue where sending large messages to the daemon by Inter-Process Communication (IPC) could cause the daemon to fail and result in service interruptions.
   - Added support for a new WARP client device posture check for [Antivirus](/cloudflare-one/reusable-components/posture-checks/warp-client-checks/antivirus/). The check confirms the presence of an antivirus program on a Windows device with the option to check if the antivirus is up to date.
 
   **Known issues**
   - For Windows 11 24H2 users, Microsoft has confirmed a regression that may lead to performance issues like mouse lag, audio cracking, or other slowdowns. Cloudflare recommends users experiencing these issues upgrade to a minimum [Windows 11 24H2 KB5062553](https://support.microsoft.com/en-us/topic/july-8-2025-kb5062553-os-build-26100-4652-523e69cb-051b-43c6-8376-6a76d6caeefd) or higher for resolution.
 
-  - Devices with KB5055523 installed may receive a warning about Win32/ClickFix.ABA being present in the installer. To resolve this false positive, update Microsoft Security Intelligence to [version 1.429.19.0](https://www.microsoft.com/en-us/wdsi/definitions/antimalware-definition-release-notes?requestVersion=1.429.19.0) or later.
+  - Devices with KB5055523 installed may receive a warning about `Win32/ClickFix.ABA` being present in the installer. To resolve this false positive, update Microsoft Security Intelligence to [version 1.429.19.0](https://www.microsoft.com/en-us/wdsi/definitions/antimalware-definition-release-notes?requestVersion=1.429.19.0) or later.
 
   - DNS resolution may be broken when the following conditions are all true:
     - WARP is in Secure Web Gateway without DNS filtering (tunnel-only) mode.
     - A custom DNS server address is configured on the primary network adapter.
     - The custom DNS server address on the primary network adapter is changed while WARP is connected.
 
-    To work around this issue, please reconnect the WARP client by toggling off and back on.
+    To work around this issue, reconnect the WARP client by toggling off and back on.
 version: 2025.10.186.0
 releaseDate: 2026-01-13T15:48:19.406Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/windows/version/2025.10.186.0


### PR DESCRIPTION
## Summary
- Adds WARP client GA release 2025.10.186.0 for Windows, macOS, and Linux
- Release includes new features: external signal for device connectivity management, Antivirus posture check (Windows), and various fixes