### PR TITLE
Clarify blockConcurrencyWhile usage

### DIFF
--- a/src/content/docs/durable-objects/api/state.mdx
+++ b/src/content/docs/durable-objects/api/state.mdx
@@ -95,18 +95,20 @@ Durable Objects automatically remain active as long as there is ongoing work or 
 
 `blockConcurrencyWhile` executes an async callback while blocking any other events from being delivered to the Durable Object until the callback completes. This method guarantees ordering and prevents concurrent requests. All events that were not explicitly initiated as part of the callback itself will be blocked. Once the callback completes, all other events will be delivered.
 
-* `blockConcurrencyWhile` is commonly used within the constructor of the Durable Object class to enforce initialization to occur before any requests are delivered.
-* Another use case is executing `async` operations based on the current state of the Durable Object and using `blockConcurrencyWhile` to prevent that state from changing while yielding the event loop.
-* If the callback throws an exception, the object will be terminated and reset. This ensures that the object cannot be left stuck in an uninitialized state if something fails unexpectedly.
-* To avoid this behavior, enclose the body of your callback in a `try...catch` block to ensure it cannot throw an exception.
+- `blockConcurrencyWhile` is commonly used within the constructor of the Durable Object class to enforce initialization to occur before any requests are delivered.
+- Another use case is executing `async` operations based on the current state of the Durable Object and using `blockConcurrencyWhile` to prevent that state from changing while yielding the event loop.
+- If the callback throws an exception, the object will be terminated and reset. This ensures that the object cannot be left stuck in an uninitialized state if something fails unexpectedly.
+- To avoid this behavior, enclose the body of your callback in a `try...catch` block to ensure it cannot throw an exception.
 
 To help mitigate deadlocks there is a 30 second timeout applied when executing the callback. If this timeout is exceeded, the Durable Object will be reset. It is best practice to have the callback do as little work as possible to improve overall request throughput to the Durable Object.
 
-:::note
+:::note[When to use `blockConcurrencyWhile`]
 
-You should only need `blockConcurrencyWhile` if you are making additional, asynchronous calls (such as to another API or service), and cannot tolerate other requests processed by the Durable Object changing its internal while the event loop is yielded from the original request.
+Use `blockConcurrencyWhile` in the constructor to run schema migrations or initialize state before any requests are processed. This ensures your Durable Object is fully ready before handling traffic.
 
-In practice, this is quite rare, and most use cases do not need `blockConcurrencyWhile`.
+For regular request handling, you rarely need `blockConcurrencyWhile`. SQLite storage operations are synchronous and do not yield the event loop, so they execute atomically without it. For asynchronous KV storage operations, input gates already prevent other requests from interleaving during storage calls.
+
+Reserve `blockConcurrencyWhile` outside the constructor for cases where you make external async calls (such as `fetch()`) and cannot tolerate state changes while the event loop yields.
 
 :::
 


### PR DESCRIPTION
Resolves confusion between the state API docs (which say blockConcurrencyWhile is rarely needed) and the rules page (which recommends it for constructor initialization).

Both are correct in context - clarifies that constructor use for migrations is valid, while regular request handling rarely needs it due to SQLite's synchronous nature and input gate protection.

Fixes #27441.