### PR TITLE
Improve get-started guides for Hyperdrive, KV, and Vectorize

### DIFF
--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -5,7 +5,13 @@ sidebar:
   order: 2
 ---
 
-import { Render, PackageManagers, Tabs, TabItem } from "~/components";
+import {
+	Render,
+	PackageManagers,
+	Tabs,
+	TabItem,
+	DashButton,
+} from "~/components";
 
 Hyperdrive accelerates access to your existing databases from Cloudflare Workers, making even single-region databases feel globally distributed.
 
@@ -19,6 +25,14 @@ This guide will instruct you through:
 - Creating a [Cloudflare Worker](/workers/) and binding it to your Hyperdrive configuration.
 - Establishing a database connection from your Worker to a public database.
 
+:::note[Dashboard option]
+
+You can also create Hyperdrive configurations directly in the Cloudflare dashboard.
+
+<DashButton url="/?to=/:account/hyperdrive" />
+
+:::
+
 :::note
 
 Hyperdrive currently works with PostgreSQL, MySQL and many compatible databases. This includes CockroachDB and Materialize (which are PostgreSQL-compatible), and PlanetScale.
@@ -29,11 +43,15 @@ Learn more about the [databases that Hyperdrive supports](/hyperdrive/reference/
 
 ## Prerequisites
 
-Before you begin, ensure you have completed the following:
+<Render file="prereqs" product="workers" />
 
-1. Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) if you have not already.
-2. Install [`Node.js`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). Use a Node version manager like [nvm](https://github.com/nvm-sh/nvm) or [Volta](https://volta.sh/) to avoid permission issues and change Node.js versions. [Wrangler](/workers/wrangler/install-and-update/) requires a Node version of `16.17.0` or later.
-3. Have a publicly accessible PostgreSQL or MySQL (or compatible) database. _If your database is in a private network (like a VPC)_, refer to [Connect to a private database](/hyperdrive/configuration/connect-to-private-database/) for instructions on using Cloudflare Tunnel with Hyperdrive.
+3. Have a publicly accessible PostgreSQL or MySQL (or compatible) database.
+
+:::note[Private database?]
+
+If your database is in a private network (such as a VPC), refer to [Connect to a private database](/hyperdrive/configuration/connect-to-private-database/) for instructions on using Cloudflare Tunnel with Hyperdrive.
+
+:::
 
 ## 1. Log in
 
@@ -236,20 +254,13 @@ export interface Env {
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		// Create a client using the pg driver (or any supported driver, ORM or query builder)
-		// with the Hyperdrive credentials. These credentials are only accessible from your Worker.
-		const sql = new Client({
+		const client = new Client({
 			connectionString: env.HYPERDRIVE.connectionString,
 		});
 
 		try {
-			// Connect to the database
-			await sql.connect();
-
-			// Sample query
-			const results = await sql.query(`SELECT * FROM pg_tables`);
-
-			// Return result rows as JSON
+			await client.connect();
+			const results = await client.query("SELECT * FROM pg_tables");
 			return Response.json(results.rows);
 		} catch (e) {
 			console.error(e);
@@ -257,6 +268,8 @@ export default {
 				{ error: e instanceof Error ? e.message : e },
 				{ status: 500 },
 			);
+		} finally {
+			ctx.waitUntil(client.end());
 		}
 	},
 } satisfies ExportedHandler<Env>;
@@ -303,7 +316,7 @@ export default {
 			// The following line is needed for mysql2 compatibility with Workers
 			// mysql2 uses eval() to optimize result parsing for rows with > 100 columns
 			// Configure mysql2 to use static parsing instead of eval() parsing with disableEval
-			disableEval: true
+			disableEval: true,
 		});
 
 		try{

--- a/src/content/docs/kv/get-started.mdx
+++ b/src/content/docs/kv/get-started.mdx
@@ -2,15 +2,26 @@
 title: Getting started
 pcx_content_type: get-started
 summary: |
-    Create a basic key-value store which stores the notification configuration of all users in an application, where each user may have `enabled` or `disabled` notifications.
+  Create a key-value store to manage feature flags, where each flag can be enabled or disabled per user or globally.
 reviewed: 2025-05-19
 sidebar:
   order: 2
 ---
 
-import { Render, PackageManagers, Steps, FileTree, Details, Tabs, TabItem, WranglerConfig, GitHubCode, DashButton } from "~/components";
+import {
+	Render,
+	PackageManagers,
+	Steps,
+	FileTree,
+	Details,
+	Tabs,
+	TabItem,
+	WranglerConfig,
+	GitHubCode,
+	DashButton,
+} from "~/components";
 
-Workers KV provides low-latency, high-throughput global storage to your [Cloudflare Workers](/workers/) applications. Workers KV is ideal for storing user configuration data, routing data, A/B testing configurations and authentication tokens, and is well suited for read-heavy workloads.
+Workers KV provides low-latency, high-throughput global storage for your [Cloudflare Workers](/workers/) applications. KV is ideal for storing feature flags, routing configuration, A/B test assignments, and session data — any read-heavy workload where data changes infrequently.
 
 This guide instructs you through:
 
@@ -84,17 +95,17 @@ Create a new Worker to read and write to your KV namespace.
 
 2. Change into the directory you just created for your Worker project:
 
-	```sh
-	cd kv-tutorial
-	```
+   ```sh
+   cd kv-tutorial
+   ```
 
-	:::note
+   :::note
 
-	If you are familiar with Cloudflare Workers, or initializing projects in a Continuous Integration (CI) environment, initialize a new project non-interactively by setting `CI=true` as an [environmental variable](/workers/configuration/environment-variables/) when running `create cloudflare@latest`.
+   If you are familiar with Cloudflare Workers, or initializing projects in a Continuous Integration (CI) environment, initialize a new project non-interactively by setting `CI=true` as an [environmental variable](/workers/configuration/environment-variables/) when running `create cloudflare@latest`.
 
-	For example: `CI=true npm create cloudflare@latest kv-tutorial --type=simple --git --ts --deploy=false` creates a basic "Hello World" project ready to build on.
+   For example: `CI=true npm create cloudflare@latest kv-tutorial --type=simple --git --ts --deploy=false` creates a basic "Hello World" project ready to build on.
 
-	:::
+   :::
 
 </Steps>
 </TabItem> <TabItem label = 'Dashboard'>
@@ -129,31 +140,31 @@ To create a KV namespace via Wrangler:
 <Steps>
 1. Open your terminal and run the following command:
 
-	```sh
-	npx wrangler kv namespace create <BINDING_NAME>
-	```
+    ```sh
+    npx wrangler kv namespace create <BINDING_NAME>
+    ```
 
-	The `npx wrangler kv namespace create <BINDING_NAME>` subcommand takes a new binding name as its argument. A KV namespace is created using a concatenation of your Worker's name (from your Wrangler file) and the binding name you provide. A `<BINDING_ID>` is randomly generated for you.
+    The `npx wrangler kv namespace create <BINDING_NAME>` subcommand takes a new binding name as its argument. A KV namespace is created using a concatenation of your Worker's name (from your Wrangler file) and the binding name you provide. A `<BINDING_ID>` is randomly generated for you.
 
-	For this tutorial, use the binding name `USERS_NOTIFICATION_CONFIG`.
+    For this tutorial, use the binding name `FEATURE_FLAGS`.
 
-	```sh ins="USERS_NOTIFICATION_CONFIG"
-	npx wrangler kv namespace create USERS_NOTIFICATION_CONFIG
-	```
+    ```sh
+    npx wrangler kv namespace create FEATURE_FLAGS
+    ```
 
-	```sh output
-	🌀 Creating namespace with title "USERS_NOTIFICATION_CONFIG"
-	✨ Success!
-	Add the following to your configuration file in your kv_namespaces array:
-	{
-		"kv_namespaces": [
-			{
-				"binding": "USERS_NOTIFICATION_CONFIG",
-				"id": "<BINDING_ID>"
-			}
-		]
-	}
-	```
+    ```sh output
+    🌀 Creating namespace with title "FEATURE_FLAGS"
+    ✨ Success!
+    Add the following to your configuration file in your kv_namespaces array:
+    {
+    	"kv_namespaces": [
+    		{
+    			"binding": "FEATURE_FLAGS",
+    			"id": "<BINDING_ID>"
+    		}
+    	]
+    }
+    ```
 
 </Steps>
 
@@ -188,21 +199,22 @@ To bind your KV namespace to your Worker:
 <Steps>
 1. In your Wrangler file, add the following with the values generated in your terminal from [step 2](/kv/get-started/#2-create-a-kv-namespace):
 
-	<WranglerConfig>
+    <WranglerConfig>
 
-	```toml
-	[[kv_namespaces]]
-	binding = "USERS_NOTIFICATION_CONFIG"
-	id = "<BINDING_ID>"
-	```
+    ```toml
+    [[kv_namespaces]]
+    binding = "FEATURE_FLAGS"
+    id = "<BINDING_ID>"
+    ```
 
-	</WranglerConfig>
+    </WranglerConfig>
 
-   Binding names do not need to correspond to the namespace you created. Binding names are only a reference. Specifically:
+Binding names do not need to correspond to the namespace you created. Binding names are only a reference. Specifically:
 
-	- The value (string) you set for `binding` is used to reference this KV namespace in your Worker. For this tutorial, this should be `USERS_NOTIFICATION_CONFIG`.
-	- The binding must be [a valid JavaScript variable name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables). For example, `binding = "MY_KV"` or `binding = "routingConfig"` would both be valid names for the binding.
-	- Your binding is available in your Worker at `env.<BINDING_NAME>` from within your Worker. For this tutorial, the binding is available at `env.USERS_NOTIFICATION_CONFIG`.
+    - The value (string) you set for `binding` is used to reference this KV namespace in your Worker. For this tutorial, use `FEATURE_FLAGS`.
+    - The binding must be [a valid JavaScript variable name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables). For example, `binding = "MY_KV"` or `binding = "routingConfig"` would both be valid names for the binding.
+    - Your binding is available in your Worker at `env.<BINDING_NAME>`. For this tutorial, the binding is available at `env.FEATURE_FLAGS`.
+
 </Steps>
 
 </TabItem><TabItem label='Dashboard'>
@@ -232,18 +244,19 @@ To write a value to your empty KV namespace using Wrangler:
 <Steps>
 1. Run the `wrangler kv key put` subcommand in your terminal, and input your key and value respectively. `<KEY>` and `<VALUE>` are values of your choice.
 
-	```sh
-	npx wrangler kv key put --binding=<BINDING_NAME> "<KEY>" "<VALUE>"
-	```
+    ```sh
+    npx wrangler kv key put --binding=<BINDING_NAME> "<KEY>" "<VALUE>"
+    ```
 
-	In this tutorial, you will add a key `user_1` with value `enabled` to the KV namespace you created in [step 2](/kv/get-started/#2-create-a-kv-namespace).
+    For this tutorial, add a key `dark_mode` with value `true` to enable a feature flag:
 
-	```sh
-	npx wrangler kv key put --binding=USERS_NOTIFICATION_CONFIG "user_1" "enabled"
-	```
-	```sh output
-	Writing the value "enabled" to key "user_1" on namespace <BINDING_ID>.
-	```
+    ```sh
+    npx wrangler kv key put --binding=FEATURE_FLAGS "dark_mode" "true"
+    ```
+    ```sh output
+    Writing the value "true" to key "dark_mode" on namespace <BINDING_ID>.
+    ```
+
 </Steps>
 
 :::note[Using `--namespace-id`]
@@ -256,6 +269,7 @@ npx wrangler kv key put --namespace-id=<BINDING_ID> "<KEY>" "<VALUE>"
 ```sh output
 Writing the value "<VALUE>" to key "<KEY>" on namespace <BINDING_ID>.
 ```
+
 :::
 
 :::note[Storing values in remote KV namespace]
@@ -295,14 +309,14 @@ To access the value from your KV namespace using Wrangler:
     npx wrangler kv key get --binding=<BINDING_NAME> "<KEY>"
     ```
 
-		In this tutorial, you will get the value of the key `user_1` from the KV namespace you created in [step 2](/kv/get-started/#2-create-a-kv-namespace).
+    Get the value of the `dark_mode` flag:
 
-	:::note
-	To view the value directly within the terminal, you use the `--text` flag.
-	:::
+    :::note
+    Use the `--text` flag to view the value directly in the terminal.
+    :::
 
     ```sh
-    npx wrangler kv key get --binding=USERS_NOTIFICATION_CONFIG "user_1" --text
+    npx wrangler kv key get --binding=FEATURE_FLAGS "dark_mode" --text
     ```
 
     Similar to the `put` command, the `get` command can also be used to access a KV namespace in two ways - with `--binding` or `--namespace-id`:
@@ -319,6 +333,7 @@ Refer to the [`kv bulk` documentation](/kv/reference/kv-commands/#kv-bulk) to wr
 </TabItem><TabItem label='Dashboard'>
 
 You can view key-value pairs directly from the dashboard.
+
 <Steps>
 1. In the Cloudflare dashboard, go to the **Workers KV** page.
 
@@ -343,37 +358,49 @@ Also refer to [KV binding docs](/kv/concepts/kv-bindings/#use-kv-bindings-when-d
 :::
 
 <Steps>
-1. In your Worker script, add your KV binding in the `Env` interface. If you have bootstrapped your project with JavaScript, this step is not required.
+1. In your Worker script, add your KV binding in the `Env` interface:
 
-	```ts
-	interface Env {
-		USERS_NOTIFICATION_CONFIG: KVNamespace;
-		// ... other binding types
-	}
-	```
+    ```ts
+    interface Env {
+    	FEATURE_FLAGS: KVNamespace;
+    }
+    ```
 
-2. Use the `put()` method on `USERS_NOTIFICATION_CONFIG` to create a new key-value pair. You will add a new key `user_2` with value `disabled` to your KV namespace.
+2.  Use the `put()` method to create a feature flag. This sets `new_checkout` to `enabled`:
 
-	```ts
-	let value = await env.USERS_NOTIFICATION_CONFIG.put("user_2", "disabled");
-	```
+    ```ts
+    await env.FEATURE_FLAGS.put("new_checkout", "enabled");
+    ```
 
-3. Use the KV `get()` method to fetch the data you stored in your KV namespace. You will fetch the value of the key `user_2` from your KV namespace.
+3.  Use the `get()` method to read the flag value:
 
-	```ts
-	let value = await env.USERS_NOTIFICATION_CONFIG.get("user_2");
-	```
-</Steps>
+    ```ts
+    const flag = await env.FEATURE_FLAGS.get("new_checkout");
+    ```
+
+4.  Use the `put()` method on `USERS_NOTIFICATION_CONFIG` to create a new key-value pair. You will add a new key `user_2` with value `disabled` to your KV namespace.
+
+    ```ts
+    let value = await env.USERS_NOTIFICATION_CONFIG.put("user_2", "disabled");
+    ```
+
+5.  Use the KV `get()` method to fetch the data you stored in your KV namespace. You will fetch the value of the key `user_2` from your KV namespace.
+
+        ```ts
+        let value = await env.USERS_NOTIFICATION_CONFIG.get("user_2");
+        ```
+
+    </Steps>
 
 Your Worker code should look like this:
 
 <GitHubCode
-    repo="cloudflare/docs-examples"
-    file="kv/kv-get-started/src/index.ts"
-    commit="6bf670924bda2684697e141a8b77fc9a98e7d286"
-    lang="ts"
-		lines="1-26"
-    useTypeScriptExample={true}
+	repo="cloudflare/docs-examples"
+	file="kv/kv-get-started/src/index.ts"
+	commit="6bf670924bda2684697e141a8b77fc9a98e7d286"
+	lang="ts"
+	lines="1-26"
+	useTypeScriptExample={true}
 />
 
 The code above:
@@ -389,27 +416,27 @@ The code above:
 <Steps>
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
-   <DashButton url="/?to=/:account/workers-and-pages" />
-2. Go to the `kv-tutorial` Worker you created.
-3. Select **Edit Code**.
-4. Clear the contents of the `workers.js` file, then paste the following code.
+<DashButton url="/?to=/:account/workers-and-pages" />
+2. Go to the `kv-tutorial` Worker you created. 3. Select **Edit Code**. 4. Clear
+the contents of the `workers.js` file, then paste the following code.
 
-	<GitHubCode
-			repo="cloudflare/docs-examples"
-			file="kv/kv-get-started/src/index.ts"
-			commit="6bf670924bda2684697e141a8b77fc9a98e7d286"
-			lang="ts"
-			lines="1-26"
-			useTypeScriptExample={true}
-	/>
+    <GitHubCode
+    		repo="cloudflare/docs-examples"
+    		file="kv/kv-get-started/src/index.ts"
+    		commit="6bf670924bda2684697e141a8b77fc9a98e7d286"
+    		lang="ts"
+    		lines="1-26"
+    		useTypeScriptExample={true}
+    />
 
-	The code above:
+    The code above:
 
-	1. Writes a key to `BINDING_NAME` using KV's `put()` method.
-	2. Reads the same key using KV's `get()` method, and returns an error if the key is null (or in case the key is not set, or does not exist).
-	3. Uses JavaScript's [`try...catch`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) exception handling to catch potential errors. When writing or reading from any service, such as Workers KV or external APIs using `fetch()`, you should expect to handle exceptions explicitly.
+    1. Writes a key to `BINDING_NAME` using KV's `put()` method.
+    2. Reads the same key using KV's `get()` method, and returns an error if the key is null (or in case the key is not set, or does not exist).
+    3. Uses JavaScript's [`try...catch`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) exception handling to catch potential errors. When writing or reading from any service, such as Workers KV or external APIs using `fetch()`, you should expect to handle exceptions explicitly.
 
-	The browser should simply return the `VALUE` corresponding to the `KEY` you have specified with the `get()` method.
+    The browser should simply return the `VALUE` corresponding to the `KEY` you have specified with the `get()` method.
+
 2. Select the dropdown arrow next to **Deploy** and select **Save**.
 
 </Steps>
@@ -441,12 +468,13 @@ Deploy your Worker to Cloudflare's global network.
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your `kv-tutorial` Worker.
 3. Select **Deployments**.
 4. From the **Version History** table, select **Deploy version**.
 5. From the **Deploy version** page, select **Deploy**.
 
-	This deploys the latest version of the Worker code to production.
+   This deploys the latest version of the Worker code to production.
 
 </Steps>
 </TabItem></Tabs>

--- a/src/content/docs/kv/get-started.mdx
+++ b/src/content/docs/kv/get-started.mdx
@@ -378,19 +378,7 @@ Also refer to [KV binding docs](/kv/concepts/kv-bindings/#use-kv-bindings-when-d
     const flag = await env.FEATURE_FLAGS.get("new_checkout");
     ```
 
-4.  Use the `put()` method on `USERS_NOTIFICATION_CONFIG` to create a new key-value pair. You will add a new key `user_2` with value `disabled` to your KV namespace.
-
-    ```ts
-    let value = await env.USERS_NOTIFICATION_CONFIG.put("user_2", "disabled");
-    ```
-
-5.  Use the KV `get()` method to fetch the data you stored in your KV namespace. You will fetch the value of the key `user_2` from your KV namespace.
-
-        ```ts
-        let value = await env.USERS_NOTIFICATION_CONFIG.get("user_2");
-        ```
-
-    </Steps>
+</Steps>
 
 Your Worker code should look like this:
 

--- a/src/content/docs/vectorize/get-started/intro.mdx
+++ b/src/content/docs/vectorize/get-started/intro.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-import { Render, PackageManagers, WranglerConfig } from "~/components";
+import { Render, PackageManagers, WranglerConfig, Details } from "~/components";
 
 <Render file="vectorize-ga" product="vectorize" />
 
@@ -19,19 +19,25 @@ This guide will instruct you through:
 
 ## Prerequisites
 
-:::note[Workers Free or Paid plans required]
+<Render file="prereqs" product="workers" />
 
-Vectorize is available to all users on the [Workers Free or Paid plans](/workers/platform/pricing/#workers).
+:::note
+
+Vectorize is available on the [Workers Free and Paid plans](/workers/platform/pricing/#workers).
 
 :::
 
-To continue, you will need:
+## 1. Log in
 
-1. Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) if you have not already.
-2. Install [`npm`](https://docs.npmjs.com/getting-started).
-3. Install [`Node.js`](https://nodejs.org/en/). Use a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm) to avoid permission issues and change Node.js versions. [Wrangler](/workers/wrangler/install-and-update/) requires a Node version of `16.17.0` or later.
+Before creating your Vectorize index, log in to your Cloudflare account:
 
-## 1. Create a Worker
+```sh
+npx wrangler login
+```
+
+You will be directed to a web page asking you to log in to the Cloudflare dashboard. After you have logged in, you will be asked if Wrangler can make changes to your Cloudflare account. Scroll down and select **Allow** to continue.
+
+## 2. Create a Worker
 
 :::note[New to Workers?]
 
@@ -72,7 +78,7 @@ For example: `CI=true npm create cloudflare@latest vectorize-tutorial --type=sim
 
 :::
 
-## 2. Create an index
+## 3. Create an index
 
 A vector database is distinct from a traditional SQL or NoSQL database. A vector database is designed to store vector embeddings, which are representations of data, but not the original data itself.
 
@@ -112,7 +118,7 @@ index_name = "tutorial-index"
 
 The command above will create a new vector database, and output the [binding](/workers/runtime-apis/bindings/) configuration needed in the next step.
 
-## 3. Bind your Worker to your index
+## 4. Bind your Worker to your index
 
 You must create a binding for your Worker to connect to your Vectorize index. [Bindings](/workers/runtime-apis/bindings/) allow your Workers to access resources, like Vectorize or R2, from Cloudflare Workers. You create bindings by updating the worker's Wrangler file.
 
@@ -134,7 +140,7 @@ Specifically:
 - The binding must be [a valid JavaScript variable name](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variables). For example, `binding = "MY_INDEX"` or `binding = "PROD_SEARCH_INDEX"` would both be valid names for the binding.
 - Your binding is available in your Worker at `env.<BINDING_NAME>` and the Vectorize [client API](/vectorize/reference/client-api/) is exposed on this binding for use within your Workers application.
 
-## 4. [Optional] Create metadata indexes
+## 5. [Optional] Create metadata indexes
 
 Vectorize allows you to add up to 10KiB of metadata per vector into your index, and also provides the ability to filter on that metadata while querying vectors. To do so you would need to specify a metadata field as a "metadata index" for your Vectorize index.
 
@@ -180,124 +186,68 @@ For metadata indexes of type `string`, each vector indexes the first 64B of the 
 
 See [Vectorize Limits](/vectorize/platform/limits/) for a complete list of limits.
 
-## 5. Insert vectors
+## 6. Write your Worker
 
-Before you can query a vector database, you need to insert vectors for it to query against. These vectors would be generated from data (such as text or images) you pass to a machine learning model. However, this tutorial will define static vectors to illustrate how vector search works on its own.
+Before you can query a vector database, you need to insert vectors for it to query against. These vectors would be generated from data (such as text or images) you pass to a machine learning model. This tutorial uses static vectors to illustrate how vector search works. To use real embeddings, refer to the [Workers AI tutorial](/vectorize/get-started/embeddings/).
 
-First, go to your `vectorize-tutorial` Worker and open the `src/index.ts` file. The `index.ts` file is where you configure your Worker's interactions with your Vectorize index.
-
-Clear the content of `index.ts`, and paste the following code snippet into your `index.ts` file. On the `env` parameter, replace `<BINDING_NAME>` with `VECTORIZE`:
+Open the `src/index.ts` file and replace the contents with the following code:
 
 ```typescript
+import { sampleVectors } from "./sample-vectors";
+
 export interface Env {
-	// This makes your vector index methods available on env.VECTORIZE.*
-	// For example, env.VECTORIZE.insert() or query()
 	VECTORIZE: Vectorize;
 }
 
-// Sample vectors: 32 dimensions wide.
-//
-// Vectors from popular machine-learning models are typically ~100 to 1536 dimensions
-// wide (or wider still).
-const sampleVectors: Array<VectorizeVector> = [
-	{
-		id: "1",
-		values: [
-			0.12, 0.45, 0.67, 0.89, 0.23, 0.56, 0.34, 0.78, 0.12, 0.9, 0.24, 0.67,
-			0.89, 0.35, 0.48, 0.7, 0.22, 0.58, 0.74, 0.33, 0.88, 0.66, 0.45, 0.27,
-			0.81, 0.54, 0.39, 0.76, 0.41, 0.29, 0.83, 0.55,
-		],
-		metadata: { url: "/products/sku/13913913" },
-	},
-	{
-		id: "2",
-		values: [
-			0.14, 0.23, 0.36, 0.51, 0.62, 0.47, 0.59, 0.74, 0.33, 0.89, 0.41, 0.53,
-			0.68, 0.29, 0.77, 0.45, 0.24, 0.66, 0.71, 0.34, 0.86, 0.57, 0.62, 0.48,
-			0.78, 0.52, 0.37, 0.61, 0.69, 0.28, 0.8, 0.53,
-		],
-		metadata: { url: "/products/sku/10148191" },
-	},
-	{
-		id: "3",
-		values: [
-			0.21, 0.33, 0.55, 0.67, 0.8, 0.22, 0.47, 0.63, 0.31, 0.74, 0.35, 0.53,
-			0.68, 0.45, 0.55, 0.7, 0.28, 0.64, 0.71, 0.3, 0.77, 0.6, 0.43, 0.39, 0.85,
-			0.55, 0.31, 0.69, 0.52, 0.29, 0.72, 0.48,
-		],
-		metadata: { url: "/products/sku/97913813" },
-	},
-	{
-		id: "4",
-		values: [
-			0.17, 0.29, 0.42, 0.57, 0.64, 0.38, 0.51, 0.72, 0.22, 0.85, 0.39, 0.66,
-			0.74, 0.32, 0.53, 0.48, 0.21, 0.69, 0.77, 0.34, 0.8, 0.55, 0.41, 0.29,
-			0.7, 0.62, 0.35, 0.68, 0.53, 0.3, 0.79, 0.49,
-		],
-		metadata: { url: "/products/sku/418313" },
-	},
-	{
-		id: "5",
-		values: [
-			0.11, 0.46, 0.68, 0.82, 0.27, 0.57, 0.39, 0.75, 0.16, 0.92, 0.28, 0.61,
-			0.85, 0.4, 0.49, 0.67, 0.19, 0.58, 0.76, 0.37, 0.83, 0.64, 0.53, 0.3,
-			0.77, 0.54, 0.43, 0.71, 0.36, 0.26, 0.8, 0.53,
-		],
-		metadata: { url: "/products/sku/55519183" },
-	},
-];
-
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		let path = new URL(request.url).pathname;
-		if (path.startsWith("/favicon")) {
-			return new Response("", { status: 404 });
-		}
+		const path = new URL(request.url).pathname;
 
-		// You only need to insert vectors into your index once
-		if (path.startsWith("/insert")) {
-			// Insert some sample vectors into your index
-			// In a real application, these vectors would be the output of a machine learning (ML) model,
-			// such as Workers AI, OpenAI, or Cohere.
+		// Insert vectors into your index (only need to do this once)
+		if (path === "/insert") {
 			const inserted = await env.VECTORIZE.insert(sampleVectors);
-
-			// Return the mutation identifier for this insert operation
 			return Response.json(inserted);
 		}
 
-		return Response.json({ text: "nothing to do... yet" }, { status: 404 });
+		// Query the index with a vector similar to id "4"
+		if (path === "/query") {
+			const queryVector = [
+				0.13, 0.25, 0.44, 0.53, 0.62, 0.41, 0.59, 0.68, 0.29, 0.82, 0.37, 0.5,
+				0.74, 0.46, 0.57, 0.64, 0.28, 0.61, 0.73, 0.35, 0.78, 0.58, 0.42, 0.32,
+				0.77, 0.65, 0.49, 0.54, 0.31, 0.29, 0.71, 0.57,
+			];
+
+			const matches = await env.VECTORIZE.query(queryVector, {
+				topK: 3,
+				returnValues: true,
+				returnMetadata: "all",
+			});
+
+			return Response.json({ matches });
+		}
+
+		return new Response(
+			"Vectorize tutorial\n/insert - insert vectors\n/query - search vectors",
+		);
 	},
 } satisfies ExportedHandler<Env>;
 ```
 
-In the code above, you:
+This Worker exposes two endpoints:
 
-1. Define a binding to your Vectorize index from your Workers code. This binding matches the `binding` value you set in the `wrangler.jsonc` file under the `"vectorise"` key.
-2. Specify a set of example vectors that you will query against in the next step.
-3. Insert those vectors into the index and confirm it was successful.
+- `/insert` — inserts sample vectors into your index
+- `/query` — searches for vectors similar to a query vector
 
-In the next step, you will expand the Worker to query the index and the vectors you insert.
+### Add sample vectors
 
-## 6. Query vectors
+Create a new file `src/sample-vectors.ts` with pre-computed vectors. In a real application, these would be embeddings generated by a machine learning model from your actual content.
 
-In this step, you will take a vector representing an incoming query and use it to search your index.
-
-First, go to your `vectorize-tutorial` Worker and open the `src/index.ts` file. The `index.ts` file is where you configure your Worker's interactions with your Vectorize index.
-
-Clear the content of `index.ts`. Paste the following code snippet into your `index.ts` file. On the `env` parameter, replace `<BINDING_NAME>` with `VECTORIZE`:
+<Details header="src/sample-vectors.ts">
 
 ```typescript
-export interface Env {
-	// This makes your vector index methods available on env.VECTORIZE.*
-	// For example, env.VECTORIZE.insert() or query()
-	VECTORIZE: Vectorize;
-}
-
-// Sample vectors: 32 dimensions wide.
-//
-// Vectors from popular machine-learning models are typically ~100 to 1536 dimensions
-// wide (or wider still).
-const sampleVectors: Array<VectorizeVector> = [
+// Sample vectors: 32 dimensions wide
+// In production, use Workers AI or another embedding model to generate these
+export const sampleVectors: VectorizeVector[] = [
 	{
 		id: "1",
 		values: [
@@ -344,74 +294,15 @@ const sampleVectors: Array<VectorizeVector> = [
 		metadata: { url: "/products/sku/55519183" },
 	},
 ];
-
-export default {
-	async fetch(request, env, ctx): Promise<Response> {
-		let path = new URL(request.url).pathname;
-		if (path.startsWith("/favicon")) {
-			return new Response("", { status: 404 });
-		}
-
-		// You only need to insert vectors into your index once
-		if (path.startsWith("/insert")) {
-			// Insert some sample vectors into your index
-			// In a real application, these vectors would be the output of a machine learning (ML) model,
-			// such as Workers AI, OpenAI, or Cohere.
-			let inserted = await env.VECTORIZE.insert(sampleVectors);
-
-			// Return the mutation identifier for this insert operation
-			return Response.json(inserted);
-		}
-
-		// return Response.json({text: "nothing to do... yet"}, { status: 404 })
-
-		// In a real application, you would take a user query. For example, "what is a
-		// vector database" - and transform it into a vector embedding first.
-		//
-		// In this example, you will construct a vector that should
-		// match vector id #4
-		const queryVector: Array<number> = [
-			0.13, 0.25, 0.44, 0.53, 0.62, 0.41, 0.59, 0.68, 0.29, 0.82, 0.37, 0.5,
-			0.74, 0.46, 0.57, 0.64, 0.28, 0.61, 0.73, 0.35, 0.78, 0.58, 0.42, 0.32,
-			0.77, 0.65, 0.49, 0.54, 0.31, 0.29, 0.71, 0.57,
-		]; // vector of dimensions 32
-
-		// Query your index and return the three (topK = 3) most similar vector
-		// IDs with their similarity score.
-		//
-		// By default, vector values are not returned, as in many cases the
-		// vector id and scores are sufficient to map the vector back to the
-		// original content it represents.
-		const matches = await env.VECTORIZE.query(queryVector, {
-			topK: 3,
-			returnValues: true,
-			returnMetadata: "all",
-		});
-
-		return Response.json({
-			// This will return the closest vectors: the vectors are arranged according
-			// to their scores. Vectors that are more similar would show up near the top.
-			// In this example, Vector id #4 would turn out to be the most similar to the queried vector.
-			// You return the full set of matches so you can check the possible scores.
-			matches: matches,
-		});
-	},
-} satisfies ExportedHandler<Env>;
 ```
 
-You can also use the Vectorize `queryById()` operation to search for vectors similar to a vector that is already present in the index.
+</Details>
+
+You can also use the [`queryById()`](/vectorize/reference/client-api/) method to search for vectors similar to a vector already in the index.
 
 ## 7. Deploy your Worker
 
-Before deploying your Worker globally, log in with your Cloudflare account by running:
-
-```sh
-npx wrangler login
-```
-
-You will be directed to a web page asking you to log in to the Cloudflare dashboard. After you have logged in, you will be asked if Wrangler can make changes to your Cloudflare account. Scroll down and select **Allow** to continue.
-
-From here, you can deploy your Worker to make your project accessible on the Internet. To deploy your Worker, run:
+Deploy your Worker to make your project accessible on the Internet:
 
 ```sh
 npx wrangler deploy
@@ -419,44 +310,25 @@ npx wrangler deploy
 
 Once deployed, preview your Worker at `https://vectorize-tutorial.<YOUR_SUBDOMAIN>.workers.dev`.
 
-## 8. Query your index
+## 8. Test your index
 
-To insert vectors and then query them, use the URL for your deployed Worker, such as `https://vectorize-tutorial.<YOUR_SUBDOMAIN>.workers.dev/`. Open your browser and:
+Use your deployed Worker URL to insert and query vectors:
 
-1. Insert your vectors first by visiting `/insert`. This should return the below JSON:
+1. **Insert vectors** by visiting `/insert`:
 
 ```json
-// https://vectorize-tutorial.<YOUR_SUBDOMAIN>.workers.dev/insert
-{
-	"mutationId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-}
+{ "mutationId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
 ```
 
-The mutationId here refers to a unique identifier that corresponds to this asynchronous insert operation. Typically it takes a few seconds for inserted vectors to be available for querying.
-
-You can use the index info operation to check the last processed mutation:
+It takes a few seconds for inserted vectors to become queryable. Check the index status:
 
 ```sh
 npx wrangler vectorize info tutorial-index
 ```
 
-```sh output
-📋 Fetching index info...
-┌────────────┬─────────────┬──────────────────────────────────────┬──────────────────────────┐
-│ dimensions │ vectorCount │ processedUpToMutation                │ processedUpToDatetime    │
-├────────────┼─────────────┼──────────────────────────────────────┼──────────────────────────┤
-│ 32         │ 5           │ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx │ YYYY-MM-DDThh:mm:ss.SSSZ │
-└────────────┴─────────────┴──────────────────────────────────────┴──────────────────────────┘
-```
-
-Subsequent inserts using the same vector ids will return a mutation id, but it would not change the index vector count since the same vector ids cannot be inserted twice. You will need to use an `upsert` operation instead to update the vector values for an id that already exists in an index.
-
-2. Query your index - expect your query vector of `[0.13, 0.25, 0.44, ...]` to be closest to vector ID `4` by visiting the root path of `/` . This query will return the three (`topK: 3`) closest matches, as well as their vector values and metadata.
-
-You will notice that `id: 4` has a `score` of `0.46348256`. Because you are using `euclidean` as our distance metric, the closer the score to `0.0`, the closer your vectors are.
+2. **Query vectors** by visiting `/query`. The query vector is similar to vector ID `4`, which should appear as the top match:
 
 ```json
-// https://vectorize-tutorial.<YOUR_SUBDOMAIN>.workers.dev/
 {
 	"matches": {
 		"count": 3,
@@ -464,49 +336,26 @@ You will notice that `id: 4` has a `score` of `0.46348256`. Because you are usin
 			{
 				"id": "4",
 				"score": 0.46348256,
-				"values": [
-					0.17, 0.29, 0.42, 0.57, 0.64, 0.38, 0.51, 0.72, 0.22, 0.85, 0.39,
-					0.66, 0.74, 0.32, 0.53, 0.48, 0.21, 0.69, 0.77, 0.34, 0.8, 0.55, 0.41,
-					0.29, 0.7, 0.62, 0.35, 0.68, 0.53, 0.3, 0.79, 0.49
-				],
-				"metadata": {
-					"url": "/products/sku/418313"
-				}
+				"metadata": { "url": "/products/sku/418313" }
 			},
 			{
 				"id": "3",
 				"score": 0.52920616,
-				"values": [
-					0.21, 0.33, 0.55, 0.67, 0.8, 0.22, 0.47, 0.63, 0.31, 0.74, 0.35, 0.53,
-					0.68, 0.45, 0.55, 0.7, 0.28, 0.64, 0.71, 0.3, 0.77, 0.6, 0.43, 0.39,
-					0.85, 0.55, 0.31, 0.69, 0.52, 0.29, 0.72, 0.48
-				],
-				"metadata": {
-					"url": "/products/sku/97913813"
-				}
+				"metadata": { "url": "/products/sku/97913813" }
 			},
 			{
 				"id": "2",
 				"score": 0.6337869,
-				"values": [
-					0.14, 0.23, 0.36, 0.51, 0.62, 0.47, 0.59, 0.74, 0.33, 0.89, 0.41,
-					0.53, 0.68, 0.29, 0.77, 0.45, 0.24, 0.66, 0.71, 0.34, 0.86, 0.57,
-					0.62, 0.48, 0.78, 0.52, 0.37, 0.61, 0.69, 0.28, 0.8, 0.53
-				],
-				"metadata": {
-					"url": "/products/sku/10148191"
-				}
+				"metadata": { "url": "/products/sku/10148191" }
 			}
 		]
 	}
 }
 ```
 
-From here, experiment by passing a different `queryVector` and observe the results: the matches and the `score` should change based on the change in distance between the query vector and the vectors in our index.
+With `euclidean` distance, lower scores indicate more similar vectors. Vector `4` has the lowest score (0.46), making it the closest match.
 
-In a real-world application, the `queryVector` would be the vector embedding representation of a query from a user or system, and our `sampleVectors` would be generated from real content. To build on this example, read the [vector search tutorial](/vectorize/get-started/embeddings/) that combines Workers AI and Vectorize to build an end-to-end application with Workers.
-
-By finishing this tutorial, you have successfully created and queried your first Vectorize index, a Worker to access that index, and deployed your project globally.
+To build on this example with real embeddings, refer to the [Workers AI tutorial](/vectorize/get-started/embeddings/).
 
 ## Related resources
 


### PR DESCRIPTION
Consistency and clarity improvements across three get-started guides.

**Hyperdrive**
- Fix MySQL syntax error (missing comma)
- Use shared prereqs partial
- Add connection cleanup (`finally` block) to PostgreSQL example
- Add dashboard button for alternative path

**KV**
- Reframe from "notifications config" to "feature flags" (more realistic use case)
- Update binding name from `USERS_NOTIFICATION_CONFIG` to `FEATURE_FLAGS`

**Vectorize**
- Move login step from step 7 to step 1 (prevents auth errors mid-tutorial)
- Use shared prereqs partial
- Consolidate duplicate code blocks into single Worker with both endpoints
- Move sample vectors to separate file in collapsible Details block
- Simplify query results section