### PR TITLE
[Chore] Markdown.zip cleanup

### DIFF
--- a/bin/validate-redirects.ts
+++ b/bin/validate-redirects.ts
@@ -10,7 +10,16 @@ async function main() {
 	let seenDynamicRedirects = false;
 	let numStaticRedirectsAfterDynamicRedirect = 0;
 
-	const validEndings = ["/", "*", ".xml", ".md", ".json", ".html", ".pdf"];
+	const validEndings = [
+		"/",
+		"*",
+		".xml",
+		".md",
+		".json",
+		".html",
+		".pdf",
+		".zip",
+	];
 
 	const redirectSourceUrls: string[] = [];
 

--- a/public/__redirects
+++ b/public/__redirects
@@ -14,6 +14,7 @@
 /sitemap.xml /sitemap-index.xml 301
 /deprecations/ /fundamentals/api/reference/deprecations/ 301
 /learning-paths/ /resources/ 301
+/markdown.zip /llms-full.txt 301
 
 # changelog
 /changelog/rss.xml /changelog/rss/index.xml 301

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -12,16 +12,6 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 
 export default class extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request) {
-		if (request.url.endsWith("/markdown.zip")) {
-			const res = await this.env.VENDORED_MARKDOWN.get("markdown.zip");
-
-			return new Response(res?.body, {
-				headers: {
-					"Content-Type": "application/zip",
-				},
-			});
-		}
-
 		if (request.url.endsWith("/llms-full.txt")) {
 			const { pathname } = new URL(request.url);
 			const res = await this.env.VENDORED_MARKDOWN.get(pathname.slice(1));


### PR DESCRIPTION
### Summary

Remove `markdown.zip` routing logic + add in redirect so those requests (if we receive them) go somewhere thematically similar
