### PR TITLE
[DNS] Fix DNS delegation wording in nameservers documentation

### DIFF
--- a/src/content/docs/dns/foundation-dns/setup.mdx
+++ b/src/content/docs/dns/foundation-dns/setup.mdx
@@ -104,7 +104,7 @@ To enable advanced nameservers on an existing zone:
 
 2. Update the authoritative nameservers at your registrar. This step depends on whether you are using [Cloudflare Registrar](/registrar/):
    - If you are using Cloudflare Registrar, [contact Cloudflare Support](/support/contacting-cloudflare-support/) to have your nameservers updated.
-   - If you are using a different registrar or if your zone is delegated to a parent zone, [manually update your nameservers](/dns/nameservers/update-nameservers/#specific-processes).
+   - If you are using a different registrar or if your zone is delegated, [manually update your nameservers](/dns/nameservers/update-nameservers/#specific-processes).
 
      :::caution
 

--- a/src/content/docs/dns/nameservers/custom-nameservers/account-custom-nameservers.mdx
+++ b/src/content/docs/dns/nameservers/custom-nameservers/account-custom-nameservers.mdx
@@ -127,7 +127,7 @@ Use the endpoint [Update DNS Settings for a Zone](/api/resources/dns/subresource
 
 - If your domain uses [Cloudflare Registrar](/registrar/), [contact Cloudflare Support](/support/contacting-cloudflare-support/) to update your nameservers.
 - If your domain uses a different registrar, update the nameservers at your registrar to use the account custom nameservers.
-- If your zone is delegated to a parent zone, update the corresponding `NS` record at the parent zone.
+- If your zone is delegated, update the corresponding `NS` record at the parent zone.
 
 ### 3. (Optional) Make ACNS default for new zones
 

--- a/src/content/docs/dns/nameservers/update-nameservers.mdx
+++ b/src/content/docs/dns/nameservers/update-nameservers.mdx
@@ -19,7 +19,7 @@ If you are using Cloudflare Registrar with [custom nameservers](/dns/nameservers
 
 ### Your domain uses a different registrar
 
-If you have acquired your domain from a [registrar](https://www.cloudflare.com/learning/dns/glossary/what-is-a-domain-name-registrar/) other than Cloudflare Registrar - and it has not been [delegated to another zone](#your-domain-is-delegated-to-another-zone) - you need to update your nameservers at your registrar.
+If you have acquired your domain from a [registrar](https://www.cloudflare.com/learning/dns/glossary/what-is-a-domain-name-registrar/) other than Cloudflare Registrar - and it has not been [delegated](#your-domain-is-delegated) - you need to update your nameservers at your registrar.
 
 <Render file="ns-update-providers" product="dns" />
 
@@ -36,7 +36,7 @@ In that case, you may have to update your nameservers in the reseller platform, 
 Refer to [Squarespace documentation](https://support.squarespace.com/hc/articles/4404183898125-Nameservers-and-DNSSEC-for-Squarespace-managed-domains#toc-open-the-domain-s-advanced-settings) on how to update nameservers in their platform.
 :::
 
-### Your domain is delegated to another zone
+### Your domain is delegated
 
 If you are onboarding a subdomain `shop.example.com` as a [child domain](/dns/zone-setups/subdomain-setup/), the parent domain (`example.com`) must delegate authority to the child domain.
 

--- a/src/content/docs/dns/nameservers/update-nameservers.mdx
+++ b/src/content/docs/dns/nameservers/update-nameservers.mdx
@@ -38,7 +38,7 @@ Refer to [Squarespace documentation](https://support.squarespace.com/hc/articles
 
 ### Your domain is delegated to another zone
 
-If you are onboarding a subdomain `shop.example.com` as a [child domain](/dns/zone-setups/subdomain-setup/), it is expected that the child domain has been delegated to the parent domain.
+If you are onboarding a subdomain `shop.example.com` as a [child domain](/dns/zone-setups/subdomain-setup/), the parent domain (`example.com`) must delegate authority to the child domain.
 
 Delegation means that `shop.example.com` has specific `NS` records set up for it within the DNS records management of the parent zone (`example.com`).
 


### PR DESCRIPTION
### Summary

Fixes technical inaccuracy in the DNS delegation explanation for subdomain setup in the nameservers documentation.

The previous wording incorrectly stated "the child domain has been delegated to the parent domain," which is backwards. In DNS delegation, the parent zone delegates authority to a child zone by creating NS records for it.

**Change made:**
- Updated the sentence to correctly state: "the parent domain (`example.com`) must delegate authority to the child domain"

### Screenshots (optional)

N/A - Text correction only

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).