### PR TITLE
docs(browser-rendering): fix typos and clarify version numbers

### DIFF
--- a/src/content/docs/browser-rendering/index.mdx
+++ b/src/content/docs/browser-rendering/index.mdx
@@ -58,6 +58,19 @@ You can integrate Browser Rendering into your applications using the method that
   - **[Playwright](/browser-rendering/playwright/)**: Modern browser automation with a developer-friendly API. The [MCP integration](/browser-rendering/playwright/playwright-mcp/) enables AI agents to autonomously browse and extract data.
   - **[Stagehand](/browser-rendering/stagehand/)**: AI-native SDK using natural language selectors instead of brittle code selectors, ensuring workflows stay resilient when websites change.
 
+### Choosing an integration method
+
+| Use case | Recommended | Why |
+| --- | --- | --- |
+| Simple screenshot, PDF, or scrape | [REST API](/browser-rendering/rest-api/) | No code deployment needed; single HTTP request |
+| Multi-step browser automation | [Puppeteer](/browser-rendering/puppeteer/) or [Playwright](/browser-rendering/playwright/) | Full control over navigation, clicks, and form fills |
+| Porting existing automation scripts | [Puppeteer](/browser-rendering/puppeteer/) or [Playwright](/browser-rendering/playwright/) | Minimal code changes required from standard Puppeteer/Playwright |
+| Modern automation with tracing | [Playwright](/browser-rendering/playwright/) | Built-in tracing, assertions, and better async handling |
+| AI-powered data extraction | [REST API `/json` endpoint](/browser-rendering/rest-api/json-endpoint/) | Extract structured data using natural language prompts |
+| AI agent browsing autonomously | [Playwright MCP](/browser-rendering/playwright/playwright-mcp/) | Enables LLMs to control browsers via Model Context Protocol |
+| Resilient scraping (selectors break often) | [Stagehand](/browser-rendering/stagehand/) | Uses AI to find elements by intent, not brittle selectors |
+
+
 ## Related products
 
 <RelatedProduct header="Workers" href="/workers/" product="workers">

--- a/src/content/docs/browser-rendering/index.mdx
+++ b/src/content/docs/browser-rendering/index.mdx
@@ -50,25 +50,17 @@ Programmatically load and fully render dynamic webpages or raw HTML and capture 
 
 ## Integration methods
 
-You can integrate Browser Rendering into your applications using the method that best suits your needs:
-
-- **[REST API](/browser-rendering/rest-api/)**: Ideal for simple, stateless tasks like capturing screenshots, generating PDFs, extracting HTML content, and more.
-- **[Workers Bindings](/browser-rendering/workers-bindings/)**: Suitable for advanced browser automation within [Cloudflare Workers](/workers/). This method provides greater control, enabling more complex workflows and persistent sessions. Use one of the following libraries:
-  - **[Puppeteer](/browser-rendering/puppeteer/)**: Industry-standard Chrome automation API, ideal for porting existing scripts to the Cloudflare global network.
-  - **[Playwright](/browser-rendering/playwright/)**: Modern browser automation with a developer-friendly API. The [MCP integration](/browser-rendering/playwright/playwright-mcp/) enables AI agents to autonomously browse and extract data.
-  - **[Stagehand](/browser-rendering/stagehand/)**: AI-native SDK using natural language selectors instead of brittle code selectors, ensuring workflows stay resilient when websites change.
-
-### Choosing an integration method
+- **[REST API](/browser-rendering/rest-api/)**: Simple HTTP endpoints for stateless tasks like screenshots, PDFs, and scraping.
+- **[Workers Bindings](/browser-rendering/workers-bindings/)**: Full browser automation within Workers using [Puppeteer](/browser-rendering/puppeteer/), [Playwright](/browser-rendering/playwright/), or [Stagehand](/browser-rendering/stagehand/).
 
 | Use case | Recommended | Why |
 | --- | --- | --- |
-| Simple screenshot, PDF, or scrape | [REST API](/browser-rendering/rest-api/) | No code deployment needed; single HTTP request |
-| Multi-step browser automation | [Puppeteer](/browser-rendering/puppeteer/) or [Playwright](/browser-rendering/playwright/) | Full control over navigation, clicks, and form fills |
-| Porting existing automation scripts | [Puppeteer](/browser-rendering/puppeteer/) or [Playwright](/browser-rendering/playwright/) | Minimal code changes required from standard Puppeteer/Playwright |
-| Modern automation with tracing | [Playwright](/browser-rendering/playwright/) | Built-in tracing, assertions, and better async handling |
-| AI-powered data extraction | [REST API /json endpoint](/browser-rendering/rest-api/json-endpoint/) | Extract structured data using natural language prompts |
-| AI agent browsing autonomously | [Playwright MCP](/browser-rendering/playwright/playwright-mcp/) | Enables LLMs to control browsers via Model Context Protocol |
-| Resilient scraping (selectors break often) | [Stagehand](/browser-rendering/stagehand/) | Uses AI to find elements by intent, not brittle selectors |
+| Simple screenshot, PDF, or scrape | [REST API](/browser-rendering/rest-api/) | No code deployment; single HTTP request |
+| Browser automation | [Playwright](/browser-rendering/playwright/) | Full control with built-in tracing and assertions |
+| Porting existing scripts | [Puppeteer](/browser-rendering/puppeteer/) or [Playwright](/browser-rendering/playwright/) | Minimal code changes from standard libraries |
+| AI-powered data extraction | [JSON endpoint](/browser-rendering/rest-api/json-endpoint/) | Structured data via natural language prompts |
+| AI agent browsing | [Playwright MCP](/browser-rendering/playwright/playwright-mcp/) | LLMs control browsers via MCP |
+| Resilient scraping | [Stagehand](/browser-rendering/stagehand/) | AI finds elements by intent, not selectors |
 
 
 ## Related products

--- a/src/content/docs/browser-rendering/index.mdx
+++ b/src/content/docs/browser-rendering/index.mdx
@@ -66,7 +66,7 @@ You can integrate Browser Rendering into your applications using the method that
 | Multi-step browser automation | [Puppeteer](/browser-rendering/puppeteer/) or [Playwright](/browser-rendering/playwright/) | Full control over navigation, clicks, and form fills |
 | Porting existing automation scripts | [Puppeteer](/browser-rendering/puppeteer/) or [Playwright](/browser-rendering/playwright/) | Minimal code changes required from standard Puppeteer/Playwright |
 | Modern automation with tracing | [Playwright](/browser-rendering/playwright/) | Built-in tracing, assertions, and better async handling |
-| AI-powered data extraction | [REST API `/json` endpoint](/browser-rendering/rest-api/json-endpoint/) | Extract structured data using natural language prompts |
+| AI-powered data extraction | [REST API /json endpoint](/browser-rendering/rest-api/json-endpoint/) | Extract structured data using natural language prompts |
 | AI agent browsing autonomously | [Playwright MCP](/browser-rendering/playwright/playwright-mcp/) | Enables LLMs to control browsers via Model Context Protocol |
 | Resilient scraping (selectors break often) | [Stagehand](/browser-rendering/stagehand/) | Uses AI to find elements by intent, not brittle selectors |
 

--- a/src/content/docs/browser-rendering/playwright/index.mdx
+++ b/src/content/docs/browser-rendering/playwright/index.mdx
@@ -23,7 +23,7 @@ Our version is open sourced and can be found in [Cloudflare's fork of Playwright
 <PackageManagers pkg="@cloudflare/playwright" dev />
 
 :::note
-The current version is [`@cloudflare/playwright` **v1.1.0**](https://github.com/cloudflare/playwright/releases/tag/v1.1.0), based on [Playwright **v1.57.0**](https://playwright.dev/docs/release-notes#version-157).
+The current version is [`@cloudflare/playwright` v1.1.0](https://github.com/cloudflare/playwright/releases/tag/v1.1.0), based on [Playwright v1.57.0](https://playwright.dev/docs/release-notes#version-157).
 :::
 
 ## Use Playwright in a Worker

--- a/src/content/docs/browser-rendering/playwright/index.mdx
+++ b/src/content/docs/browser-rendering/playwright/index.mdx
@@ -23,7 +23,7 @@ Our version is open sourced and can be found in [Cloudflare's fork of Playwright
 <PackageManagers pkg="@cloudflare/playwright" dev />
 
 :::note
-The current version of Playwright is [**v1.57.0**](https://github.com/cloudflare/playwright/releases/tag/v1.1.0).
+The current version is [`@cloudflare/playwright` **v1.1.0**](https://github.com/cloudflare/playwright/releases/tag/v1.1.0), based on [Playwright **v1.57.0**](https://playwright.dev/docs/release-notes#version-157).
 :::
 
 ## Use Playwright in a Worker

--- a/src/content/docs/browser-rendering/puppeteer.mdx
+++ b/src/content/docs/browser-rendering/puppeteer.mdx
@@ -19,7 +19,7 @@ Our version is open sourced and can be found in [Cloudflare's fork of Puppeteer]
 <PackageManagers pkg="@cloudflare/puppeteer" dev />
 
 :::note
-The current version is [`@cloudflare/puppeteer` **v1.0.4**](https://github.com/cloudflare/puppeteer/releases/tag/v1.0.4), based on [Puppeteer **v22.13.1**](https://pptr.dev/chromium-support).
+The current version is [`@cloudflare/puppeteer` v1.0.4](https://github.com/cloudflare/puppeteer/releases/tag/v1.0.4), based on [Puppeteer v22.13.1](https://pptr.dev/chromium-support).
 :::
 
 ## Use Puppeteer in a Worker

--- a/src/content/docs/browser-rendering/puppeteer.mdx
+++ b/src/content/docs/browser-rendering/puppeteer.mdx
@@ -19,7 +19,7 @@ Our version is open sourced and can be found in [Cloudflare's fork of Puppeteer]
 <PackageManagers pkg="@cloudflare/puppeteer" dev />
 
 :::note
-The current version of Puppeteer is [**v22.13.1**](https://github.com/cloudflare/puppeteer/releases/tag/v1.0.4).
+The current version is [`@cloudflare/puppeteer` **v1.0.4**](https://github.com/cloudflare/puppeteer/releases/tag/v1.0.4), based on [Puppeteer **v22.13.1**](https://pptr.dev/chromium-support).
 :::
 
 ## Use Puppeteer in a Worker

--- a/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
@@ -76,7 +76,7 @@ console.log(content);
 If you have raw HTML you want to generate a PDF from, use the `html` option. You can still apply custom styles using the `addStyleTag` parameter.
 
 ```bash
-curl -X POST https://api.cloudflare.com/client/v4/accounts/<acccountID>/browser-rendering/pdf \
+curl -X POST https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/pdf \
   -H 'Authorization: Bearer <apiToken>' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -131,7 +131,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 The options `rejectResourceTypes` and `rejectRequestPattern` can be used to block requests during rendering. The opposite can also be done, _only_ allow certain requests using `allowResourceTypes` and `allowRequestPattern`.
 
 ```bash
-curl -X POST https://api.cloudflare.com/client/v4/accounts/<acccountID>/browser-rendering/pdf \
+curl -X POST https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/pdf \
   -H 'Authorization: Bearer <apiToken>' \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
## Summary

- Fix typo: `<acccountID>` → `<accountId>` in pdf-endpoint.mdx
- Clarify Puppeteer version: show both `@cloudflare/puppeteer` (v1.0.4) and upstream Puppeteer (v22.13.1)
- Clarify Playwright version: show both `@cloudflare/playwright` (v1.1.0) and upstream Playwright (v1.57.0)
- Add "Choosing an integration method" decision guide table to help developers select REST API vs Puppeteer vs Playwright vs Stagehand

## Why

The version notes were confusing because they showed one version number but linked to a different release tag. New developers couldn't tell which version was the Cloudflare package vs the upstream library.

The decision guide table helps new developers quickly understand which integration method to use for their use case.