### PR TITLE
fix: remove duplicate word in Workers VPC get-started docs

### DIFF
--- a/src/content/docs/workers-vpc/get-started.mdx
+++ b/src/content/docs/workers-vpc/get-started.mdx
@@ -84,7 +84,7 @@ The dashboard will confirm when your tunnel is successfully connected.
 
 ### Configuring your private network for Cloudflare Tunnel
 
-Once your tunnel is connected, you will need to ensure it can access your the services that you want your Workers to have access to. The tunnel should be installed on a machine that can reach the internal resources you want to expose to Workers VPC. In external clouds, this may mean configuring Access-Control-Lists, Security Groups, or VPC Firewall Rules to ensure that the tunnel can access the desired services.
+Once your tunnel is connected, you will need to ensure it can access the services that you want your Workers to have access to. The tunnel should be installed on a machine that can reach the internal resources you want to expose to Workers VPC. In external clouds, this may mean configuring Access-Control-Lists, Security Groups, or VPC Firewall Rules to ensure that the tunnel can access the desired services.
 
 :::note
 This guide provides a quick setup for Workers VPC.


### PR DESCRIPTION
## Summary
- Fixes a typo in the Workers VPC get-started documentation
- Changes "you will need to ensure it can access your the services" to "you will need to ensure it can access the services"

## Location
`src/content/docs/workers-vpc/get-started.mdx` - "Configuring your private network for Cloudflare Tunnel" section