### PR TITLE
[Docs] Exclude RTK component gallery from image audit

### DIFF
--- a/.github/workflows/image-audit.yml
+++ b/.github/workflows/image-audit.yml
@@ -23,7 +23,7 @@ jobs:
         id: find-files
         run: |
           # Find all .png and .svg files, but only look in the ./src/assets/images directory
-          FILES=$(find . -type f \( -name "*.png" -o -name "*.svg" \) -path "./src/assets/images/*" -not -path "./src/assets/images/workers-ai/*.svg" -not -path "./src/assets/images/workers/ai/*.png" -not -path "./src/assets/images/changelog/*")
+          FILES=$(find . -type f \( -name "*.png" -o -name "*.svg" \) -path "./src/assets/images/*" -not -path "./src/assets/images/workers-ai/*.svg" -not -path "./src/assets/images/workers/ai/*.png" -not -path "./src/assets/images/changelog/*" -not -path "./src/assets/images/realtime/realtimekit/web/components-gallery/*.svg")
 
           # Check if files are referenced in any markdown file
           UNUSED_FILES=""


### PR DESCRIPTION
### Summary

Fixes issue detected in #27647.

