### PR TITLE
[Docs] Update prettier extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,7 @@
 		"unifiedjs.vscode-mdx",
 		"bradlc.vscode-tailwindcss",
 		"redhat.vscode-yaml",
-		"esbenp.prettier-vscode",
+		"prettier.prettier-vscode",
 		"dbaeumer.vscode-eslint"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
 	"astro.content-intellisense": true,
 	"editor.formatOnSave": true,
-	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.defaultFormatter": "prettier.prettier-vscode",
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"cSpell.enableFiletypes": ["mdx"],
 	"files.associations": {
@@ -10,5 +10,4 @@
 	},
 	"[astro]": {
 		"editor.defaultFormatter": "astro-build.astro-vscode"
-	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,4 +10,5 @@
 	},
 	"[astro]": {
 		"editor.defaultFormatter": "astro-build.astro-vscode"
+	}
 }


### PR DESCRIPTION
### Summary

From the extension [README](https://github.com/prettier/prettier-vscode/blob/main/README.md):

> 🚨🚨🚨 **Extension Migration**: This extension is being moved from `esbenp.prettier-vscode` to [`prettier.prettier-vscode`](https://marketplace.visualstudio.com/items?itemName=prettier.prettier-vscode). Version 12+ is only published to the new for now as it is a major change. Once it is stable, we will publish v12 to both extensions and deprecate the `esbenp.prettier-vscode` extension. **Version 12.x is currently not stable, use with caution and report bugs.**

Waiting for 12.x to become stable before merging.
