### PR TITLE
docs(log-explorer): clarify stopping ingestion vs canceling subscription

### DIFF
--- a/src/content/docs/log-explorer/faq.mdx
+++ b/src/content/docs/log-explorer/faq.mdx
@@ -11,7 +11,7 @@ import { DashButton } from "~/components";
 
 ## Which fields (or columns) are available for querying?
 
-All fields listed in [Datasets](/logs/logpush/logpush-job/datasets/) for the [supported datasets](/log-explorer/manage-datasets/#supported-datasets) are viewable in Log Explorer. 
+All fields listed in [Datasets](/logs/logpush/logpush-job/datasets/) for the [supported datasets](/log-explorer/manage-datasets/#supported-datasets) are viewable in Log Explorer.
 
 ## Why does my query not complete or time out?
 
@@ -63,7 +63,7 @@ Log Explorer uses Cloudflare Logpush and R2 behind the scenes to stream and stor
 
 Custom Dashboards currently run on [GraphQL](/analytics/graphql-api/sampling/). Over time, this will evolve to include deeper integration between the two features, such as building charts directly from logs.
 
-## How can I track my Log Explorer usage? 
+## How can I track my Log Explorer usage?
 
 Your monthly usage is displayed at the top of the Log Search and Manage Datasets dashboard sections within Log Explorer.
 
@@ -71,32 +71,39 @@ Your monthly usage is displayed at the top of the Log Search and Manage Datasets
 
 ## How do I turn off Log Explorer?
 
-Turning off Log Explorer has two parts:
+To turn off Log Explorer you must:
 
-- To stop incurring additional charges immediately, you must stop log ingestion by disabling any enabled datasets (at both the account level and zone level).
-- To stop renewal, you must cancel the Log Explorer subscription (your subscription may remain active until the end of the current billing cycle).
+1. **Stop log ingestion to immediately stop incurring additional charges.** To stop log ingestion, disable any enabled datasets at both the account level and zone level.
+2. **Cancel the Log Explorer subscription to stop renewal.** Your subscription may remain active until the end of the current billing cycle.
 
-### Stop ingestion (to stop charges immediately)
+### 1. Stop log ingestion
 
-#### 1) Review and disable account-level datasets
-1. In the Cloudflare dashboard, go to **Log Explorer** > **Manage datasets** (account level):
+After performing the following steps, you will immediately stop incurring additional charges for Log Explorer.
 
-    <DashButton url="/?to=/:account/log-explorer/manage-sources" />
+#### Review and disable account-level datasets
 
-2. For each dataset you no longer need, toggle it off and click **Stop ingesting logs**.
-3. Repeat for all account-level datasets.
+1. In the Cloudflare dashboard, go to the account-level **Manage datasets** page.
 
-#### 2) Review and disable zone-level datasets
-1. In the Cloudflare dashboard, go to **Log Explorer** > **Manage datasets** for each zone:
+   <DashButton url="/?to=/:account/log-explorer/manage-sources" />
 
-    <DashButton url="/?to=/:account/:zone/log-explorer/manage-sources" />
+2. Turn off each dataset you no longer need using the toggle. To confirm each operation, select **Stop ingesting logs**.
 
-2. For each dataset you no longer need, toggle it off and click **Stop ingesting logs**.
-3. Repeat for all relevant zones and datasets.
+#### Review and disable zone-level datasets
 
-### Cancel the subscription (to stop renewal)
-1. In the Cloudflare dashboard, go to the **Manage Account** > **Billing** page.
+1. In the Cloudflare dashboard, go to the zone-level **Manage datasets** page.
 
-    <DashButton url="/?to=/:account/billing" />
+   <DashButton url="/?to=/:account/:zone/log-explorer/manage-sources" />
 
-2. Under **Subscriptions**, find the Log Explorer subscription, and select **Cancel**.
+2. Turn off each dataset you no longer need using the toggle. To confirm each operation, select **Stop ingesting logs**.
+
+3. Repeat for all relevant zones.
+
+### 2. Cancel the Log Explorer subscription
+
+This operation will stop Log Explorer's renewal.
+
+1. In the Cloudflare dashboard, go to the **Billing** page.
+
+   <DashButton url="/?to=/:account/billing" />
+
+2. In the **Subscriptions** tab, find the Log Explorer subscription and select **Cancel**.

--- a/src/content/docs/log-explorer/faq.mdx
+++ b/src/content/docs/log-explorer/faq.mdx
@@ -71,10 +71,32 @@ Your monthly usage is displayed at the top of the Log Search and Manage Datasets
 
 ## How do I turn off Log Explorer?
 
-Use the Manage Datasets feature to enable or disable ingestion for individual datasets and zones.
+Turning off Log Explorer has two parts:
 
+- To stop incurring additional charges immediately, you must stop log ingestion by disabling any enabled datasets (at both the account level and zone level).
+- To stop renewal, you must cancel the Log Explorer subscription (your subscription may remain active until the end of the current billing cycle).
+
+### Stop ingestion (to stop charges immediately)
+
+#### 1) Review and disable account-level datasets
+1. In the Cloudflare dashboard, go to **Log Explorer** > **Manage datasets** (account level):
+
+    <DashButton url="/?to=/:account/log-explorer/manage-sources" />
+
+2. For each dataset you no longer need, toggle it off and click **Stop ingesting logs**.
+3. Repeat for all account-level datasets.
+
+#### 2) Review and disable zone-level datasets
+1. In the Cloudflare dashboard, go to **Log Explorer** > **Manage datasets** for each zone:
+
+    <DashButton url="/?to=/:account/:zone/log-explorer/manage-sources" />
+
+2. For each dataset you no longer need, toggle it off and click **Stop ingesting logs**.
+3. Repeat for all relevant zones and datasets.
+
+### Cancel the subscription (to stop renewal)
 1. In the Cloudflare dashboard, go to the **Manage Account** > **Billing** page.
 
-   <DashButton url="/?to=/:account/billing" />
+    <DashButton url="/?to=/:account/billing" />
 
 2. Under **Subscriptions**, find the Log Explorer subscription, and select **Cancel**.

--- a/src/content/docs/log-explorer/manage-datasets.mdx
+++ b/src/content/docs/log-explorer/manage-datasets.mdx
@@ -18,7 +18,7 @@ Account-level Manage datasets:
 Zone-level Manage datasets:
 <DashButton url="/?to=/:account/:zone/log-explorer/manage-sources" />
 
-To disable a dataset, toggle it off and click **Stop ingesting logs**. Repeat for all datasets you no longer need.
+To disable a dataset, turn it off using the toggle and select **Stop ingesting logs** to confirm the operation. Repeat for all datasets you no longer need.
 :::
 
 ## Supported datasets

--- a/src/content/docs/log-explorer/manage-datasets.mdx
+++ b/src/content/docs/log-explorer/manage-datasets.mdx
@@ -10,15 +10,7 @@ import { TabItem, Tabs, Render, DashButton } from "~/components";
 Log Explorer allows you to enable or disable which datasets are available to query in Log Search.
 
 :::note
-Canceling a Log Explorer subscription stops renewal, but it does not automatically stop log ingestion during the current billing cycle. If you want to stop incurring additional charges immediately, disable ingestion for any enabled datasets at both the account level and zone level.
-
-Account-level Manage datasets:
-<DashButton url="/?to=/:account/log-explorer/manage-sources" />
-
-Zone-level Manage datasets:
-<DashButton url="/?to=/:account/:zone/log-explorer/manage-sources" />
-
-To disable a dataset, turn it off using the toggle and select **Stop ingesting logs** to confirm the operation. Repeat for all datasets you no longer need.
+Canceling a Log Explorer subscription stops renewal, but it does not automatically stop log ingestion during the current billing cycle. To completely turn off Log Explorer, refer to [How do I turn off Log Explorer?](/log-explorer/faq/#how-do-i-turn-off-log-explorer).
 :::
 
 ## Supported datasets
@@ -27,8 +19,8 @@ Log Explorer currently supports the following datasets:
 
 ### Zone level
 
-- [HTTP Requests](/logs/logpush/logpush-job/datasets/zone/http_requests/)	(`http_requests`)
-- [Firewall Events](/logs/logpush/logpush-job/datasets/zone/firewall_events/)	(`firewall_events`)
+- [HTTP Requests](/logs/logpush/logpush-job/datasets/zone/http_requests/) (`http_requests`)
+- [Firewall Events](/logs/logpush/logpush-job/datasets/zone/firewall_events/) (`firewall_events`)
 - [DNS Logs](/logs/logpush/logpush-job/datasets/zone/dns_logs/) (`dns_logs`)
 - [NEL Reports](/logs/logpush/logpush-job/datasets/zone/nel_reports/) (`nel_reports`)
 - [Page Shield Events](/logs/logpush/logpush-job/datasets/zone/page_shield_events/) (`page_shield_events`)
@@ -37,22 +29,22 @@ Log Explorer currently supports the following datasets:
 
 ### Account level
 
-- [Access requests](/logs/logpush/logpush-job/datasets/account/access_requests/)	(`access_requests`)
-- [CASB findings](/logs/logpush/logpush-job/datasets/account/casb_findings/)	(`casb_findings`)
+- [Access requests](/logs/logpush/logpush-job/datasets/account/access_requests/) (`access_requests`)
+- [CASB findings](/logs/logpush/logpush-job/datasets/account/casb_findings/) (`casb_findings`)
 - [Device posture results](/logs/logpush/logpush-job/datasets/account/device_posture_results/) (`device_posture_results`)
-- [Gateway DNS](/logs/logpush/logpush-job/datasets/account/gateway_dns/)	(`gateway_dns`)
-- [Gateway HTTP](/logs/logpush/logpush-job/datasets/account/gateway_http/)	(`gateway_http`)
-- [Gateway Network](/logs/logpush/logpush-job/datasets/account/gateway_network/)	(`gateway_network`)
-- [Zero Trust Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/)	(`zero_trust_network_sessions`)
+- [Gateway DNS](/logs/logpush/logpush-job/datasets/account/gateway_dns/) (`gateway_dns`)
+- [Gateway HTTP](/logs/logpush/logpush-job/datasets/account/gateway_http/) (`gateway_http`)
+- [Gateway Network](/logs/logpush/logpush-job/datasets/account/gateway_network/) (`gateway_network`)
+- [Zero Trust Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/) (`zero_trust_network_sessions`)
 - [Audit Logs](/logs/logpush/logpush-job/datasets/account/audit_logs/) (`audit_logs`)
 - [Audit_logs_v2](/logs/logpush/logpush-job/datasets/account/audit_logs_v2/) (`audit_logs_v2`)
 - [Browser Isolation User Actions](/logs/logpush/logpush-job/datasets/account/biso_user_actions/) (`biso_user_actions`)
 - [DNS firewall logs](/logs/logpush/logpush-job/datasets/account/dns_firewall_logs/) (`dns_firewall_logs`)
 - [Email security alerts](/logs/logpush/logpush-job/datasets/account/email_security_alerts/) (`email_security_alerts`)
-- [Magic IDS Detections](/logs/logpush/logpush-job/datasets/account/magic_ids_detections/) (`magic_ids_detections`) 
+- [Magic IDS Detections](/logs/logpush/logpush-job/datasets/account/magic_ids_detections/) (`magic_ids_detections`)
 - [Network Analytics](/logs/logpush/logpush-job/datasets/account/network_analytics_logs/) (`network_analytics_logs`)
 - [Sinkhole HTTP Logs](/logs/logpush/logpush-job/datasets/account/sinkhole_http_logs/) (`sinkhole_http_logs`)
-- [IP Sec Logs](/logs/logpush/logpush-job/datasets/account/ipsec_logs/) (`ipsec_logs`) 
+- [IP Sec Logs](/logs/logpush/logpush-job/datasets/account/ipsec_logs/) (`ipsec_logs`)
 
 ## Enable Log Explorer
 
@@ -62,7 +54,7 @@ In order for Log Explorer to begin storing logs, you need to enable the desired 
 
    <DashButton url="/?to=/:account/log-explorer/manage-sources" />
 
-2. Select **Add dataset** to select the datasets you want to query. 
+2. Select **Add dataset** to select the datasets you want to query.
 3. Choose a dataset and then a zone. Then, select **Add**. You can always return to this page to enable more datasets or manage your existing ones.
 
 :::note
@@ -83,18 +75,18 @@ curl https://api.cloudflare.com/client/v4/zones/{zone_id}/logs/explorer/datasets
 
 ```json output
 {
-  "result": {
-    "dataset": "http_requests",
-    "object_type": "zone",
-    "object_id": "<ZONE ID>",
-    "created_at": "2025-06-03T14:33:16Z",
-    "updated_at": "2025-06-03T14:33:16Z",
-    "dataset_id": "01973635f7e273a1964a02f4d4502499",
-    "enabled": true
-  },
-  "success": true,
-  "errors": [],
-  "messages": []
+	"result": {
+		"dataset": "http_requests",
+		"object_type": "zone",
+		"object_id": "<ZONE ID>",
+		"created_at": "2025-06-03T14:33:16Z",
+		"updated_at": "2025-06-03T14:33:16Z",
+		"dataset_id": "01973635f7e273a1964a02f4d4502499",
+		"enabled": true
+	},
+	"success": true,
+	"errors": [],
+	"messages": []
 }
 ```
 

--- a/src/content/docs/log-explorer/manage-datasets.mdx
+++ b/src/content/docs/log-explorer/manage-datasets.mdx
@@ -9,6 +9,18 @@ import { TabItem, Tabs, Render, DashButton } from "~/components";
 
 Log Explorer allows you to enable or disable which datasets are available to query in Log Search.
 
+:::note
+Canceling a Log Explorer subscription stops renewal, but it does not automatically stop log ingestion during the current billing cycle. If you want to stop incurring additional charges immediately, disable ingestion for any enabled datasets at both the account level and zone level.
+
+Account-level Manage datasets:
+<DashButton url="/?to=/:account/log-explorer/manage-sources" />
+
+Zone-level Manage datasets:
+<DashButton url="/?to=/:account/:zone/log-explorer/manage-sources" />
+
+To disable a dataset, toggle it off and click **Stop ingesting logs**. Repeat for all datasets you no longer need.
+:::
+
 ## Supported datasets
 
 Log Explorer currently supports the following datasets:


### PR DESCRIPTION
## Problem
Support/customer confusion: canceling the Log Explorer subscription stops renewal, but ingestion can continue during the current billing cycle, so usage charges may continue unless datasets are disabled.

## Changes
- Updated Log Explorer FAQ "How do I turn off Log Explorer?" to:
  - Explicitly instruct stopping ingestion for both account-level and zone-level datasets
  - Use DashButton links for both Manage datasets pages
  - Separate "stop ingestion (stop charges immediately)" from "cancel subscription (stop renewal)"
- Added a note to Manage datasets emphasizing that canceling the subscription does not automatically stop ingestion and pointing to the account/zone Manage datasets pages.

## Docs updated
- src/content/docs/log-explorer/faq.mdx
- src/content/docs/log-explorer/manage-datasets.mdx