### PR TITLE
Update instructions on how to paste the key for Supabase

### DIFF
--- a/src/content/docs/workers/databases/third-party-integrations/supabase.mdx
+++ b/src/content/docs/workers/databases/third-party-integrations/supabase.mdx
@@ -46,16 +46,22 @@ To set up an integration with Supabase:
 
 4. Configure the Supabase database credentials in your Worker:
 
-   You need to add your Supabase URL and anon key as secrets to your Worker. Get these from your [Supabase Dashboard](https://supabase.com/dashboard) under **Settings** > **API**, then add them as secrets using Wrangler:
+You need to add your Supabase project URL and a key as secrets in your Cloudflare Worker. You can find both values in the **Supabase Dashboard**.
 
-   ```sh
-   # Add the Supabase URL as a secret
-   npx wrangler secret put SUPABASE_URL
-   # When prompted, paste your Supabase project URL
+Go to **Settings → Data API → API Settings** and copy the **Project URL**.  
+Go to **Settings → API Keys → Publishable key** and copy the **Publishable key**.  
 
-   # Add the Supabase anon key as a secret
-   npx wrangler secret put SUPABASE_KEY
-   # When prompted, paste your Supabase anon/public key
+Next, add them as secrets using Wrangler:
+
+```sh
+# Add the Supabase project URL
+npx wrangler secret put SUPABASE_URL
+# Paste your Supabase Project URL when prompted
+
+# Add the Supabase publishable key
+npx wrangler secret put PUBLISHABLE key
+# Paste your Supabase key when prompted
+
    ```
 
 5. In your Worker, install the `@supabase/supabase-js` driver to connect to your database and start manipulating data:

--- a/src/content/docs/workers/databases/third-party-integrations/supabase.mdx
+++ b/src/content/docs/workers/databases/third-party-integrations/supabase.mdx
@@ -59,7 +59,7 @@ npx wrangler secret put SUPABASE_URL
 # Paste your Supabase Project URL when prompted
 
 # Add the Supabase publishable key
-npx wrangler secret put PUBLISHABLE key
+npx wrangler secret put PUBLISHABLE_KEY
 # Paste your Supabase key when prompted
 
    ```


### PR DESCRIPTION
### Summary

I've tried to to set up the connection, but failed when setting up the key and URL, because the instructions where outdated.

### Screenshots (optional)

Here's how the new supabase key interface looks like.
It also says that anon keys are legacy, and there's a new "Publishable key" that I've used in my project
<img width="2048" height="788" alt="image" src="https://github.com/user-attachments/assets/66bd3880-c6e5-49d8-a998-55739c35224a" />
<img width="1548" height="1148" alt="image" src="https://github.com/user-attachments/assets/d516c190-4cad-42ee-b652-f008ea635ae3" />

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
