### PR TITLE
[RealtimeKit] Add documentation for active speakers on Mobile SDKs

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/display-active-speakers.mdx
+++ b/src/content/docs/realtime/realtimekit/core/display-active-speakers.mdx
@@ -351,7 +351,7 @@ meeting.participants.active.on("participantLeft", (participant) => {
 
 <RTKCodeSnippet id="mobile-android">
 
-Use the `active` list to show multiple participants with prominent audio activity, typically in a grid layout:
+Use the `active` list to show multiple participants with prominent audio activity, in a grid layout:
 
 ```kotlin
 val activeParticipants = meeting.participants.active

--- a/src/content/docs/realtime/realtimekit/core/display-active-speakers.mdx
+++ b/src/content/docs/realtime/realtimekit/core/display-active-speakers.mdx
@@ -15,15 +15,15 @@ RealtimeKit automatically detects and tracks participants who are actively speak
 
 An active speaker in RealtimeKit is a remote participant with prominent audio activity at any given moment. The SDK maintains two types of data to help you build your UI:
 
-- **Active speaker** — A single remote participant who is currently speaking most prominently, tracked via `meeting.participants.lastActiveSpeaker`.
-- **Active participants** — A set of remote participants with the most prominent audio activity, tracked via `meeting.participants.active`.
+- **Active speaker** — A single remote participant who is currently speaking most prominently.
+- **Active participants** — A set of remote participants with the most prominent audio activity.
 
 The SDK automatically updates these properties and subscribes to participant media as speaking activity changes. It prioritizes prominent audio activity, so a participant not currently visible in your UI can replace a visible participant if their audio becomes more active.
 
 :::note
 The SDK tracks active speakers only when the local participant is viewing or rendering participants in ACTIVE mode (page 0). Refer to the [Remote participants](/realtime/realtimekit/core/remote-participants/#participant-view-modes) page to learn about participant view modes.
 
-Active speaker properties contain only remote participants. Use `meeting.self` to display the local participant.
+Active speaker properties contain only remote participants. The local participant is available separately.
 :::
 
 The maximum number of participants in the `active` map is one less than the grid size configured in the local participant's [Preset](/realtime/realtimekit/concepts/preset/).
@@ -112,6 +112,116 @@ The SDK emits an `activeSpeaker` event on `meeting.participants` when a differen
 meeting.participants.on("activeSpeaker", ({ peerId, volume }) => {
 	const activeSpeaker = meeting.participants.joined.get(peerId);
 	// Update your UI to display the new active speaker
+});
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+Use `activeSpeaker` to show the most recently active participant in your UI.
+
+Access the `activeSpeaker` property to get the current active speaker:
+
+```kotlin
+val activeSpeaker = meeting.participants.activeSpeaker
+
+if (activeSpeaker != null) {
+	// Render the active speaker video
+}
+```
+
+Refer to [Display participant videos](/realtime/realtimekit/core/remote-participants/#display-participant-videos) to learn how to render the participant video in your UI.
+
+The SDK emits an event when a different participant becomes the active speaker. Listen to this event using `RtkParticipantsEventListener`:
+
+```kotlin
+meeting.addParticipantsEventListener(object : RtkParticipantsEventListener {
+	override fun onActiveSpeakerChanged(participant: RtkRemoteParticipant?) {
+		// Update your UI to display the new active speaker
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+Use `activeSpeaker` to show the most recently active participant in your UI.
+
+Access the `activeSpeaker` property to get the current active speaker:
+
+```swift
+let activeSpeaker = meeting.participants.activeSpeaker
+
+if let activeSpeaker = activeSpeaker {
+	// Render the active speaker video
+}
+```
+
+Refer to [Display participant videos](/realtime/realtimekit/core/remote-participants/#display-participant-videos) to learn how to render the participant video in your UI.
+
+The SDK emits an event when a different participant becomes the active speaker. Listen to this event by implementing `RtkParticipantsEventListener`:
+
+```swift
+extension MeetingViewModel: RtkParticipantsEventListener {
+	func onActiveSpeakerChanged(participant: RtkRemoteParticipant?) {
+		// Update your UI to display the new active speaker
+	}
+}
+
+meeting.addParticipantsEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+Use `activeSpeaker` to show the most recently active participant in your UI.
+
+The Flutter SDK tracks active speakers through the `onActiveSpeakerChanged` event listener:
+
+```dart
+class ParticipantsNotifier extends RtkParticipantsEventListener {
+	@override
+	void onActiveSpeakerChanged(RtkRemoteParticipant? participant) {
+		if (participant != null) {
+			// Update your UI to display the new active speaker
+		}
+	}
+}
+
+meeting.addParticipantsEventListener(ParticipantsNotifier());
+```
+
+Refer to [Display participant videos](/realtime/realtimekit/core/remote-participants/#display-participant-videos) to learn how to render the participant video in your UI.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Use `lastActiveSpeaker` to show the most recently active participant in your UI. Access the current active speaker with the `useRealtimeKitSelector` hook:
+
+```tsx
+const activeSpeaker = useRealtimeKitSelector((meeting) => {
+	const activeSpeakerId = meeting.participants.lastActiveSpeaker;
+	return meeting.participants.joined.get(activeSpeakerId);
+});
+
+if (activeSpeaker) {
+	// Render the active speaker video
+}
+```
+
+The `useRealtimeKitSelector` hook automatically updates your component when the active speaker changes.
+
+Refer to [Display participant videos](/realtime/realtimekit/core/remote-participants/#display-participant-videos) to learn how to render the participant video in your UI.
+
+The SDK also emits an `activeSpeaker` event on `meeting.participants` when a different participant becomes the active speaker. For imperative updates or side effects, listen to this event:
+
+```tsx
+meeting.participants.on("activeSpeaker", (participant) => {
+	// Update your UI or trigger side effects
 });
 ```
 
@@ -239,6 +349,136 @@ meeting.participants.active.on("participantLeft", (participant) => {
 
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id="mobile-android">
+
+Use the `active` list to show multiple participants with prominent audio activity, typically in a grid layout:
+
+```kotlin
+val activeParticipants = meeting.participants.active
+
+// Render active participants in your grid
+activeParticipants.forEach { participant ->
+	// Render participant video tile
+}
+```
+
+Refer to [Display participant videos](/realtime/realtimekit/core/remote-participants/#display-participant-videos) to learn how to render the participant video in your UI.
+
+The SDK emits an event when the set of active speakers changes. Listen to this event using `RtkParticipantsEventListener`:
+
+```kotlin
+meeting.addParticipantsEventListener(object : RtkParticipantsEventListener {
+	override fun onActiveParticipantsChanged(active: List<RtkRemoteParticipant>) {
+		// Update your grid UI with the new active participants
+	}
+})
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+Use the `active` list to show multiple participants with prominent audio activity, typically in a grid layout:
+
+```swift
+let activeParticipants = meeting.participants.active
+
+// Render active participants in your grid
+for participant in activeParticipants {
+	// Render participant video tile
+}
+```
+
+Refer to [Display participant videos](/realtime/realtimekit/core/remote-participants/#display-participant-videos) to learn how to render the participant video in your UI.
+
+The SDK emits an event when the set of active speakers changes. Listen to this event by implementing `RtkParticipantsEventListener`:
+
+```swift
+extension MeetingViewModel: RtkParticipantsEventListener {
+	func onActiveParticipantsChanged(active: [RtkRemoteParticipant]) {
+		// Update your grid UI with the new active participants
+	}
+}
+
+meeting.addParticipantsEventListener(self)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+Use the `active` list to show multiple participants with prominent audio activity, typically in a grid layout:
+
+```dart
+final activeParticipants = meeting.participants.active;
+
+// Render active participants in your grid
+for (var participant in activeParticipants) {
+	// Render participant video tile
+}
+```
+
+Refer to [Display participant videos](/realtime/realtimekit/core/remote-participants/#display-participant-videos) to learn how to render the participant video in your UI.
+
+The SDK emits an event when the set of active speakers changes. Listen to this event using `RtkParticipantsEventListener`:
+
+```dart
+class ParticipantsNotifier extends RtkParticipantsEventListener {
+	@override
+	void onActiveParticipantsChanged(List<RtkRemoteParticipant> active) {
+		// Update your grid UI with the new active participants
+	}
+}
+
+meeting.addParticipantsEventListener(ParticipantsNotifier());
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Use the `active` map to show multiple participants with prominent audio activity, typically in a grid layout. Access the current active participants with the `useRealtimeKitSelector` hook:
+
+```tsx
+const activeMap = useRealtimeKitSelector(
+	(meeting) => meeting.participants.active,
+);
+
+const activeParticipants = activeMap.toArray();
+
+// Render active participants in your grid
+activeParticipants.forEach((participant) => {
+	// Render participant video tile
+});
+```
+
+The `useRealtimeKitSelector` hook automatically updates your component when the set of active speakers changes.
+
+Refer to [Display participant videos](/realtime/realtimekit/core/remote-participants/#display-participant-videos) to learn how to render the participant video in your UI.
+
+The SDK also emits a `participantsUpdate` event on the `active` map when the set of active speakers changes. For imperative updates or side effects when the `active` map changes, listen to this event:
+
+```tsx
+meeting.participants.active.on("participantsUpdate", () => {
+	const activeParticipants = meeting.participants.active.toArray();
+	// Perform side effects
+});
+```
+
+(Optional) If your application needs to respond when a specific participant is added to or removed from the active map, listen for `participantJoined` and `participantLeft` on `meeting.participants.active` map:
+
+```tsx
+meeting.participants.active.on("participantJoined", (participant) => {
+	console.log("Participant added to active map:", participant.id);
+});
+
+meeting.participants.active.on("participantLeft", (participant) => {
+	console.log("Participant removed from active map:", participant.id);
+});
+```
+
+</RTKCodeSnippet>
+
 ## Visualize audio activity
 
 <RTKCodeSnippet id="web-react">
@@ -256,6 +496,30 @@ You can create custom audio visualizations using audio data from a participant's
 <RTKCodeSnippet id="web-angular">
 
 You can create custom audio visualizations using audio data from a participant's audio track. Extract volume information from the audio track to calculate amplitude series. Use this data to render waveforms, speech indicators, or audio level meters in your UI.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+Audio activity visualization is not supported on Android.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+Audio activity visualization is not supported on iOS.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+Audio activity visualization is not supported on Flutter.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-react-native">
+
+Audio activity visualization is not supported on React Native.
 
 </RTKCodeSnippet>
 


### PR DESCRIPTION
### Summary

Added documentation for managing active speakers on RealtimeKit Mobile SDKs
Page Modified: https://developers.cloudflare.com/realtime/realtimekit/core/display-active-speakers/