### PR TITLE
docs(realtimekit): updated end session page under realtimekit core sdk

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/end-a-session.mdx
+++ b/src/content/docs/realtime/realtimekit/core/end-a-session.mdx
@@ -64,6 +64,58 @@ Ending a session is different from leaving a meeting. Leaving disconnects only t
 
     </RTKCodeSnippet>
 
+    <RTKCodeSnippet id="mobile-android">
+
+    ```kotlin
+    val canEndSession = meeting.localUser.permissions.host.canKickParticipant
+
+    if (!canEndSession) {
+        // Disable the "End meeting/session" control in your UI.
+        // You can also show a message to explain why the action is not available.
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-ios">
+
+    ```swift
+    let canEndSession = meeting.localUser.permissions.host.canKickParticipant
+
+    if !canEndSession {
+        // Disable the "End meeting/session" control in your UI.
+        // You can also show a message to explain why the action is not available.
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-flutter">
+
+    ```dart
+    final canEndSession = meeting.localUser.permissions.host.canKickParticipant;
+
+    if (!canEndSession) {
+      // Disable the "End meeting/session" control in your UI.
+      // You can also show a message to explain why the action is not available.
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-react-native">
+
+    ```javascript
+    const canEndSession = meeting.self.permissions.kickParticipant === true;
+
+    if (!canEndSession) {
+    	// Disable the "End meeting/session" control in your UI.
+    	// You can also show a message to explain why the action is not available.
+    }
+    ```
+
+    </RTKCodeSnippet>
+
 2.  End the session by removing all participants.
 
     <RTKCodeSnippet id="web-react">
@@ -123,6 +175,84 @@ Ending a session is different from leaving a meeting. Leaving disconnects only t
 
     </RTKCodeSnippet>
 
+    <RTKCodeSnippet id="mobile-android">
+
+    If the participant does not have the required permission, `kickAll()` returns a `HostError`.
+
+    ```kotlin
+    val error: HostError? = meeting.participants.kickAll()
+
+    if (error != null) {
+        when (error) {
+            is HostError.KickPermissionDenied -> {
+                // The participant does not have permission to end the session.
+                // Update your UI to indicate that the action is not allowed.
+            }
+        }
+    } else {
+        // Successfully initiated session end
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-ios">
+
+    If the participant does not have the required permission, `kickAll()` returns a `HostError`.
+
+    ```swift
+    let error: HostError? = meeting.participants.kickAll()
+
+    if let error = error {
+        switch error {
+        case .kickPermissionDenied:
+            // The participant does not have permission to end the session.
+            // Update your UI to indicate that the action is not allowed.
+            break
+        default:
+            break
+        }
+    } else {
+        // Successfully initiated session end
+    }
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-flutter">
+
+    ```dart
+    meeting.participants.kickAll(onResult: (error) {
+      if (error != null) {
+        // The participant does not have permission to end the session.
+        // Update your UI to indicate that the action is not allowed.
+      } else {
+        // Successfully initiated session end
+      }
+    });
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-react-native">
+
+    If the participant does not have the required permission, `kickAll()` throws a ClientError with error code `1201`.
+
+    ```javascript
+    try {
+    	await meeting.participants.kickAll();
+    } catch (err) {
+    	if (err?.code === 1201) {
+    		// The participant does not have permission to end the session.
+    		// Update your UI to indicate that the action is not allowed.
+    		return;
+    	}
+    	throw err;
+    }
+    ```
+
+    </RTKCodeSnippet>
+
 3.  Listen for the session end event.
 
     <RTKCodeSnippet id="web-react">
@@ -158,6 +288,70 @@ Ending a session is different from leaving a meeting. Leaving disconnects only t
     When the session ends, all participants leave the session. The SDK emits a `roomLeft` event with `state` set to `ended`.
 
     ```ts
+    meeting.self.on("roomLeft", ({ state }) => {
+    	if (state === "ended") {
+    		// Update your UI to show that the meeting session has ended.
+    	}
+    });
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-android">
+
+    When the session ends, all participants leave the session. You can subscribe to the event listeners to handle the session end.
+
+    ```kotlin
+    meeting.addMeetingRoomEventListener(object : RtkMeetingRoomEventListener {
+        override fun onMeetingEnded() {
+            // Update your UI to show that the meeting session has ended.
+        }
+    })
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-ios">
+
+    When the session ends, all participants leave the session. You can subscribe to the event listeners to handle the session end.
+
+    ```swift
+    // Implement the delegate method
+    extension MeetingViewModel: RtkMeetingRoomEventListener {
+      func onMeetingEnded() {
+          // Update your UI to show that the meeting session has ended.
+      }
+    }
+    
+    meeting.addMeetingRoomEventListener(self)
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-flutter">
+
+    When the session ends, all participants leave the session. You can subscribe to the event listeners to handle the session end.
+
+    ```dart
+    class MeetingRoomListener extends RtkMeetingRoomEventListener {
+      @override
+      void onMeetingEnded() {
+        // Update your UI to show that the meeting session has ended.
+      }
+    }
+
+    // Add the listener
+    meeting.addMeetingRoomEventListener(MeetingRoomListener());
+
+    ```
+
+    </RTKCodeSnippet>
+
+    <RTKCodeSnippet id="mobile-react-native">
+
+    When the session ends, all participants leave the session. The SDK emits a `roomLeft` event with `state` set to `ended`.
+
+    ```javascript
     meeting.self.on("roomLeft", ({ state }) => {
     	if (state === "ended") {
     		// Update your UI to show that the meeting session has ended.


### PR DESCRIPTION

### Summary

 - Documented End Session references for mobile platforms in RealtimeKit SDK

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
