### PR TITLE
Add changelog entry for new array and map functions (split, join, has…

### DIFF
--- a/src/content/changelog/rules/2026-01-20-array-map-functions.mdx
+++ b/src/content/changelog/rules/2026-01-20-array-map-functions.mdx
@@ -1,0 +1,44 @@
+---
+title: New functions for array and map operations
+description: Rulesets now support split, join, has_key, and has_value functions for advanced expression logic.
+date: 2026-01-20
+---
+
+## New functions for array and map operations
+
+Cloudflare Rulesets now include new functions that enable advanced expression logic for evaluating arrays and maps. These functions allow you to build rules that match against lists of values in request or response headers, enabling use cases like country-based blocking using custom headers.
+
+---
+
+### New functions
+
+| Function | Description |
+| --- | --- |
+| `split(source, delimiter)` | Splits a string into an array of strings using the specified delimiter. |
+| `join(array, delimiter)` | Joins an array of strings into a single string using the specified delimiter. |
+| `has_key(map, key)` | Returns `true` if the specified key exists in the map. |
+| `has_value(map, value)` | Returns `true` if the specified value exists in the map. |
+
+---
+
+### Example use cases
+
+**Check if a country code exists in a header list:**
+
+```txt
+has_value(split(http.response.headers["x-allow-country"][0], ","), ip.src.country)
+```
+
+**Check if a specific header key exists:**
+
+```txt
+has_key(http.request.headers, "x-custom-header")
+```
+
+**Join array values for logging or comparison:**
+
+```txt
+join(http.request.headers.names, ", ")
+```
+
+For more information, refer to the [Functions reference](/ruleset-engine/rules-language/functions/).


### PR DESCRIPTION
…_key, has_value)

## Summary
 
Adds a changelog entry for the new Rulesets functions: `split`, `join`, `has_key`, and `has_value`.
 
These functions enable advanced expression logic for evaluating arrays and maps in request and response headers.
 
## Related tickets
 
- SHIP-13222
- RM-25402

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
