### PR TITLE
docs: add documentation for wrangler login in containers

### DIFF
--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -669,37 +669,35 @@ Leave the login flow active. Open a second terminal session. In that second term
 curl <LOCALHOST_URL>
 ```
 
-### Use `wrangler login` in a Docker container
+### Use `wrangler login` in a container
 
-When running Wrangler inside a Docker container, the OAuth callback server cannot listen on `localhost` because `localhost` inside the container is not accessible from your host machine's browser.
+The Cloudflare OAuth provider will always redirect to a callback server at `localhost:8976`. If you are running Wrangler inside a container, this server might not be accessible from your host machine's browser - even after authorizing the connection, your login command will hang.
 
-To work around this, use the `--callback-host` option to make Wrangler listen on all network interfaces:
+You must configure your container to map port `8976` on your host machine to the Wrangler OAuth callback server's port (`8976` by default).
 
-```sh
-npx wrangler login --callback-host=0.0.0.0
-```
-
-The Cloudflare OAuth provider only accepts `localhost:8976` as the redirect URI, so the login URL will always redirect to `http://localhost:8976/oauth/callback` regardless of your `--callback-host` setting. You must configure your Docker container to map port `8976` on your host machine to port `8976` inside the container.
-
-When starting your Docker container, include the port mapping:
+For example, if you are running Wrangler in a Docker container:
 
 ```sh
 docker run -p 8976:8976 <your-image>
 ```
 
-With this configuration, when the browser redirects to `localhost:8976`, the request will be forwarded to Wrangler running inside the container on `0.0.0.0:8976`.
-
-If you need to use a different port inside the container, use both `--callback-host` and `--callback-port`, and adjust your Docker port mapping accordingly:
+And when you run `npx wrangler login` inside your container, set the callback host to listen on all network interfaces:
 
 ```sh
-# Inside the container
-npx wrangler login --callback-host=0.0.0.0 --callback-port=9000
-
-# Docker run command
-docker run -p 8976:9000 <your-image>
+npx wrangler login --callback-host=0.0.0.0
 ```
 
-This maps `localhost:8976` on your host to port `9000` inside the container where Wrangler is listening.
+Now when the browser redirects to `localhost:8976`, the request will be forwarded to Wrangler running inside the container on `0.0.0.0:8976`.
+
+If you need to use a different port inside the container, use `--callback-port` as well and adjust your port mapping accordingly, for example:
+
+```sh
+# When starting your container
+docker run -p 8976:9000 <your-image>
+
+# Inside the container
+npx wrangler login --callback-host=0.0.0.0 --callback-port=9000
+```
 
 ---
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -669,6 +669,38 @@ Leave the login flow active. Open a second terminal session. In that second term
 curl <LOCALHOST_URL>
 ```
 
+### Use `wrangler login` in a Docker container
+
+When running Wrangler inside a Docker container, the OAuth callback server cannot listen on `localhost` because `localhost` inside the container is not accessible from your host machine's browser.
+
+To work around this, use the `--callback-host` option to make Wrangler listen on all network interfaces:
+
+```sh
+npx wrangler login --callback-host=0.0.0.0
+```
+
+The Cloudflare OAuth provider only accepts `localhost:8976` as the redirect URI, so the login URL will always redirect to `http://localhost:8976/oauth/callback` regardless of your `--callback-host` setting. You must configure your Docker container to map port `8976` on your host machine to port `8976` inside the container.
+
+When starting your Docker container, include the port mapping:
+
+```sh
+docker run -p 8976:8976 <your-image>
+```
+
+With this configuration, when the browser redirects to `localhost:8976`, the request will be forwarded to Wrangler running inside the container on `0.0.0.0:8976`.
+
+If you need to use a different port inside the container, use both `--callback-host` and `--callback-port`, and adjust your Docker port mapping accordingly:
+
+```sh
+# Inside the container
+npx wrangler login --callback-host=0.0.0.0 --callback-port=9000
+
+# Docker run command
+docker run -p 8976:9000 <your-image>
+```
+
+This maps `localhost:8976` on your host to port `9000` inside the container where Wrangler is listening.
+
 ---
 
 ## `logout`


### PR DESCRIPTION
### Summary

Adds a new section to the Wrangler `login` command documentation explaining how to configure OAuth login when running Wrangler inside a container.

This documents the use of `--callback-host` and `--callback-port` options for container environments where `localhost` inside the container is not accessible from the host machine's browser. The section explains:

- Why the standard login flow doesn't work in containers (localhost isolation)
- How to configure port mapping from host to container
- How to use `--callback-host=0.0.0.0` to listen on all interfaces
- An example with custom port mapping using `--callback-port`

Related to: https://github.com/cloudflare/workers-sdk/pull/9396

**Requested by:** @petebacondarwin

**Link to Devin run:** https://app.devin.ai/sessions/32f8502dad7e4b699e7048039209ab44

### Updates since last revision

- Updated section content per @emily-shen's [suggested rewrite](https://github.com/cloudflare/cloudflare-docs/pull/27745#discussion_r2708625487)
- Changed section title from "Docker container" to "container" for broader applicability
- Restructured to explain port mapping requirement first, then the callback-host option

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).