### PR TITLE
docs(workers): fix start command for local development

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/docusaurus.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/more-web-frameworks/docusaurus.mdx
@@ -55,7 +55,7 @@ Docusaurus is designed to be easy to use and customizable, making it a popular c
 
 		After creating your project, run the following command in your project directory to start a local development server.
 
-		<PackageManagers type="run" args={"dev"} />
+		<PackageManagers type="run" args={"start"} />
 
 3. **Deploy your project.**
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Fixed local development start command for Docusaurus in Workers docs.

When creating a new project with
`pnpm create cloudflare@latest my-docusaurus-app --framework=docusaurus`
the generated package.json does not include a `dev` script. To start the local development server, use `pnpm run start`.

Here is an example of the default scripts section in the file when the project is created:

```json
	"scripts": {
		"docusaurus": "docusaurus",
		"start": "docusaurus start",
		"build": "docusaurus build",
		"swizzle": "docusaurus swizzle",
		"deploy": "pnpm run build && wrangler deploy",
		"clear": "docusaurus clear",
		"serve": "docusaurus serve",
		"write-translations": "docusaurus write-translations",
		"write-heading-ids": "docusaurus write-heading-ids",
		"typecheck": "tsc",
		"preview": "pnpm run build && wrangler dev"
	}
```

### Screenshots (optional)

The change is highlighted with a green box in the screenshot.  `pnpm run dev` is replaced with `pnpm run start`.

<img width="2045" height="1283" alt="image" src="https://github.com/user-attachments/assets/b8baacab-806f-40c5-bc40-dd9e7e60effe" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
