### PR TITLE
chore: add changelog for Terraform provider v5.16.0 release

### DIFF
--- a/src/content/changelog/terraform/2025-01-20-terraform-v5.16.0-provider.mdx
+++ b/src/content/changelog/terraform/2025-01-20-terraform-v5.16.0-provider.mdx
@@ -8,7 +8,7 @@ date: 2025-01-20
 
 In January 2025, we announced the launch of the new Terraform v5 Provider. We greatly appreciate the proactive engagement and valuable feedback from the Cloudflare community following the v5 release. In response, we've established a consistent and rapid [2-3 week cadence](https://github.com/cloudflare/terraform-provider-cloudflare/issues/5774) for releasing targeted improvements, demonstrating our commitment to stability and reliability.
 
-With the help of the community, we have a growing number of resources that we have marked as [stable](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237), with that list continuing to grow with every release. The most used [resources](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237) are on track to be stable by the end of March 2026, where we will also be releasing a new migration tool to you migrate from v4 to v5 with ease.
+With the help of the community, we have a growing number of resources that we have marked as [stable](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237), with that list continuing to grow with every release. The most used [resources](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237) are on track to be stable by the end of March 2026, when we will also be releasing a new migration tool to you migrate from v4 to v5 with ease.
 
 Thank you for continuing to raise issues. They make our provider stronger and help us build products that reflect your needs.
 

--- a/src/content/changelog/terraform/2025-01-20-terraform-v5.16.0-provider.mdx
+++ b/src/content/changelog/terraform/2025-01-20-terraform-v5.16.0-provider.mdx
@@ -6,7 +6,9 @@ products:
 date: 2025-01-20
 ---
 
-Earlier this year, we announced the launch of the new Terraform v5 Provider. We are aware of the high number of issues reported by the Cloudflare community related to the v5 release. We have committed to releasing improvements on a [2-3 week cadence](https://github.com/cloudflare/terraform-provider-cloudflare/issues/5774) to ensure its stability and reliability, including the v5.15 release. We have also pivoted from an [issue-to-issue approach to a resource-per-resource approach](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237) - we will be focusing on specific resources to not only stabilize the resource but also ensure it is migration-friendly for those migrating from v4 to v5.
+In January 2025, we announced the launch of the new Terraform v5 Provider. We greatly appreciate the proactive engagement and valuable feedback from the Cloudflare community following the v5 release. In response, we've established a consistent and rapid [2-3 week cadence](https://github.com/cloudflare/terraform-provider-cloudflare/issues/5774) for releasing targeted improvements, demonstrating our commitment to stability and reliability.
+
+With the help of the community, we have a growing number of resources that we have marked as [stable](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237), with that list continuing to grow with every release. The most used [resources](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237) are on track to be stable by the end of March 2026, where we will also be releasing a new migration tool to you migrate from v4 to v5 with ease.
 
 Thank you for continuing to raise issues. They make our provider stronger and help us build products that reflect your needs.
 
@@ -51,3 +53,4 @@ This release includes bug fixes, the stabilization of even more popular resource
 ### For more information
 - [Terraform Provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs)
 - [Documentation on using Terraform with Cloudflare](/terraform/)
+- [List of stabilized resources](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237)

--- a/src/content/changelog/terraform/2025-01-20-terraform-v5.16.0-provider.mdx
+++ b/src/content/changelog/terraform/2025-01-20-terraform-v5.16.0-provider.mdx
@@ -1,0 +1,52 @@
+---
+title: Terraform v5.16.0 now available
+description: Terraform v5.16.0 stabilizes a number of resources and known issues
+products:
+  - fundamentals
+date: 2025-01-20
+---
+
+Earlier this year, we announced the launch of the new Terraform v5 Provider. We are aware of the high number of issues reported by the Cloudflare community related to the v5 release. We have committed to releasing improvements on a [2-3 week cadence](https://github.com/cloudflare/terraform-provider-cloudflare/issues/5774) to ensure its stability and reliability, including the v5.15 release. We have also pivoted from an [issue-to-issue approach to a resource-per-resource approach](https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237) - we will be focusing on specific resources to not only stabilize the resource but also ensure it is migration-friendly for those migrating from v4 to v5.
+
+Thank you for continuing to raise issues. They make our provider stronger and help us build products that reflect your needs.
+
+This release includes bug fixes, the stabilization of even more popular resources, and more.
+
+### Features
+
+* **custom_pages:** add "waf_challenge" as new supported error page type identifier in both resource and data source schemas
+* **list:** enhance CIDR validator to check for normalized CIDR notation requiring network address for IPv4 and IPv6
+* **magic_wan_gre_tunnel:** add automatic_return_routing attribute for automatic routing control
+* **magic_wan_gre_tunnel:** add BGP configuration support with new BGP model attribute
+* **magic_wan_gre_tunnel:** add bgp_status computed attribute for BGP connection status information
+* **magic_wan_gre_tunnel:** enhance schema with BGP-related attributes and validators
+* **magic_wan_ipsec_tunnel:** add automatic_return_routing attribute for automatic routing control
+* **magic_wan_ipsec_tunnel:** add BGP configuration support with new BGP model attribute
+* **magic_wan_ipsec_tunnel:** add bgp_status computed attribute for BGP connection status information
+* **magic_wan_ipsec_tunnel:** add custom_remote_identities attribute for custom identity configuration
+* **magic_wan_ipsec_tunnel:** enhance schema with BGP and identity-related attributes
+* **ruleset:** add request body buffering support
+* **ruleset:** enhance ruleset data source with additional configuration options
+* **workers_script:** add observability logs attributes to list data source model
+* **workers_script:** enhance list data source schema with additional configuration options
+
+### Bug Fixes
+
+* **dns_record:** remove unnecessary fmt.Sprintf wrapper around LoadTestCase call in test configuration helper function
+* **load_balancer:** fix session_affinity_ttl type expectations to match Float64 in initial creation and Int64 after migration
+* **workers_kv:** handle special characters correctly in URL encoding
+
+### Documentation
+
+* **account_subscription:** update schema description for rate_plan.sets attribute to clarify it returns an array of strings
+* **api_shield:** add resource-level description for API Shield management of auth ID characteristics
+* **api_shield:** enhance auth_id_characteristics.name attribute description to include JWT token configuration format requirements
+* **api_shield:** specify JSONPath expression format for JWT claim locations
+* **hyperdrive_config:** add description attribute to name attribute explaining its purpose in dashboard and API identification
+* **hyperdrive_config:** apply description improvements across resource, data source, and list data source schemas
+* **hyperdrive_config:** improve schema descriptions for cache settings to clarify default values
+* **hyperdrive_config:** update port description to clarify defaults for different database types
+
+### For more information
+- [Terraform Provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs)
+- [Documentation on using Terraform with Cloudflare](/terraform/)

--- a/src/content/changelog/terraform/2025-01-20-terraform-v5.16.0-provider.mdx
+++ b/src/content/changelog/terraform/2025-01-20-terraform-v5.16.0-provider.mdx
@@ -32,6 +32,7 @@ This release includes bug fixes, the stabilization of even more popular resource
 
 ### Bug Fixes
 
+* **account_member**: fix resource importability issues
 * **dns_record:** remove unnecessary fmt.Sprintf wrapper around LoadTestCase call in test configuration helper function
 * **load_balancer:** fix session_affinity_ttl type expectations to match Float64 in initial creation and Int64 after migration
 * **workers_kv:** handle special characters correctly in URL encoding


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
This is a changelog entry for the v5.16.0 release of our Cloudflare Terraform provider.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
