### PR TITLE
Add Azure OpenAI Anthropic models and Unified API with BYOK docs

### DIFF
--- a/src/content/changelog/ai-gateway/2025-01-21-azure-anthropic-unified-api.mdx
+++ b/src/content/changelog/ai-gateway/2025-01-21-azure-anthropic-unified-api.mdx
@@ -1,0 +1,46 @@
+---
+title: AI Gateway adds Anthropic models on Azure and Azure OpenAI on Unified API
+description: AI Gateway now supports Anthropic models through Azure and Azure OpenAI on the Unified API with BYOK.
+products:
+  - ai-gateway
+date: 2025-01-21
+---
+
+[AI Gateway](/ai-gateway/) now supports two new capabilities for Azure OpenAI users:
+
+## Anthropic models on Azure
+
+You can now use Anthropic models deployed through Azure OpenAI with AI Gateway. To access Anthropic models, use the `/azure/{resource_name}/anthropic` endpoint:
+
+```bash title="Example request"
+curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/azure/{azure_resource_name}/anthropic/v1/messages' \
+  --header 'cf-aig-authorization: {cf_token}' \
+  --header 'x-api-key: {azure_api_key}' \
+  --header 'anthropic-version: 2023-06-01' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "model": "claude-sonnet-4-5",
+    "max_tokens": 1024,
+    "messages": [
+      { "role": "user", "content": "What is Cloudflare?" }
+    ]
+  }'
+```
+
+## Azure OpenAI on Unified API with BYOK
+
+Azure OpenAI is now supported on the [Unified API (OpenAI-compatible endpoint)](/ai-gateway/usage/chat-completion/) when you have [BYOK](/ai-gateway/configuration/bring-your-own-keys/) configured. With BYOK, you can link a resource name to each stored key, and AI Gateway automatically infers the resource name from your configuration.
+
+```bash title="Unified API with BYOK"
+curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions' \
+  --header 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "model": "azure-openai/{deployment_name}",
+    "messages": [
+      { "role": "user", "content": "What is Cloudflare?" }
+    ]
+  }'
+```
+
+Learn more in the [Azure OpenAI provider documentation](/ai-gateway/usage/providers/azureopenai/).

--- a/src/content/docs/ai-gateway/usage/chat-completion.mdx
+++ b/src/content/docs/ai-gateway/usage/chat-completion.mdx
@@ -7,11 +7,7 @@ sidebar:
   order: 2
 ---
 
-import {
-	Details,
-  Tabs,
-  TabItem
-} from "~/components";
+import { Details, Tabs, TabItem } from "~/components";
 import CodeSnippets from "~/components/ai-gateway/code-examples.astro";
 
 Cloudflare's AI Gateway offers an OpenAI-compatible `/chat/completions` endpoint, enabling integration with multiple AI providers using a single URL. This feature simplifies the integration process, allowing for seamless switching between different models without significant code modifications.
@@ -44,6 +40,7 @@ The OpenAI-compatible endpoint supports models from the following providers:
 
 - [Anthropic](/ai-gateway/usage/providers/anthropic/)
 - [OpenAI](/ai-gateway/usage/providers/openai/)
+- [Azure OpenAI](/ai-gateway/usage/providers/azureopenai/) (requires [BYOK](/ai-gateway/configuration/bring-your-own-keys/))
 - [Groq](/ai-gateway/usage/providers/groq/)
 - [Mistral](/ai-gateway/usage/providers/mistral/)
 - [Cohere](/ai-gateway/usage/providers/cohere/)

--- a/src/content/docs/ai-gateway/usage/providers/azureopenai.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/azureopenai.mdx
@@ -3,7 +3,9 @@ title: Azure OpenAI
 pcx_content_type: get-started
 ---
 
-[Azure OpenAI](https://azure.microsoft.com/en-gb/products/ai-services/openai-service/) allows you apply natural language algorithms on your data.
+import { Render } from "~/components";
+
+[Azure OpenAI](https://azure.microsoft.com/en-gb/products/ai-services/openai-service/) allows you to apply natural language algorithms on your data.
 
 ## Endpoint
 
@@ -19,7 +21,7 @@ When making requests to Azure OpenAI, you will need:
 - AI Gateway gateway name
 - Azure OpenAI API key
 - Azure OpenAI resource name
-- Azure OpenAI deployment name (aka model name)
+- Azure OpenAI deployment name (also known as model name)
 
 ## URL structure
 
@@ -49,14 +51,81 @@ curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway}/azure-openai/{
 import { AzureOpenAI } from "openai";
 
 const azure_openai = new AzureOpenAI({
-  apiKey: "{azure_api_key}",
-  baseURL: `https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway}/azure-openai/{resource_name}/`,
-  apiVersion: "2023-05-15",
-  defaultHeaders: { "cf-aig-authorization": "{cf-api-token}" }, // if authenticated
+	apiKey: "{azure_api_key}",
+	baseURL: `https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway}/azure-openai/{resource_name}/`,
+	apiVersion: "2023-05-15",
+	defaultHeaders: { "cf-aig-authorization": "{cf-api-token}" }, // if authenticated
 });
 
 const result = await azure_openai.chat.completions.create({
-  model: '{deployment_name}',
-  messages: [{ role: "user", content: "Hello" }],
+	model: "{deployment_name}",
+	messages: [{ role: "user", content: "Hello" }],
 });
 ```
+
+## Anthropic models on Azure
+
+AI Gateway supports Anthropic models deployed through Azure OpenAI. To use Anthropic models, append `/anthropic` to your Azure resource path.
+
+### Endpoint
+
+```txt
+https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/azure/{azure_resource_name}/anthropic
+```
+
+### Example
+
+```bash title="Anthropic on Azure"
+curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/azure/{azure_resource_name}/anthropic/v1/messages' \
+  --header 'cf-aig-authorization: {cf_token}' \
+  --header 'x-api-key: {azure_api_key}' \
+  --header 'anthropic-version: 2023-06-01' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "max_tokens": 1000,
+    "temperature": 0.7,
+    "system": "You are a helpful assistant.",
+    "messages": [
+      { "role": "user", "content": "What is Cloudflare?" }
+    ],
+    "model": "claude-sonnet-4-5"
+  }'
+```
+
+## Unified API with BYOK
+
+You can use Azure OpenAI with the [Unified API (OpenAI-compatible endpoint)](/ai-gateway/usage/chat-completion/) when you have [BYOK (Bring Your Own Keys)](/ai-gateway/configuration/bring-your-own-keys/) configured.
+
+With BYOK, you can link a resource name to each stored key. AI Gateway automatically infers the resource name from the stored key configuration, so you only need to pass the model name in your request.
+
+### Configure BYOK for Azure OpenAI
+
+When adding your Azure OpenAI API key in the BYOK configuration, specify the resource name associated with the key. This allows AI Gateway to route requests to the correct Azure resource.
+
+### Example
+
+```bash title="Unified API with BYOK"
+curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions' \
+  --header 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "model": "azure-openai/{deployment_name}",
+    "messages": [
+      { "role": "user", "content": "What is Cloudflare?" }
+    ]
+  }'
+```
+
+<Render
+	file="chat-completions-providers"
+	product="ai-gateway"
+	params={{
+		name: "Azure OpenAI",
+		jsonexample: `
+{
+		"model": "azure-openai/{deployment_name}"
+}`
+
+    }}
+
+/>


### PR DESCRIPTION
- Add documentation for Anthropic models support via Azure (`/anthropic` endpoint)
- Add documentation for Azure OpenAI on Unified API with BYOK configuration
- Add Azure OpenAI to supported providers list in chat-completion.mdx
- Add changelog entry for these features

### Summary

This PR adds documentation for two new AI Gateway capabilities for Azure OpenAI users:

1. **Anthropic models on Azure** - Users can now access Anthropic models (like Claude) deployed through Azure OpenAI using the `/azure/{resource_name}/anthropic` endpoint.

2. **Azure OpenAI on Unified API with BYOK** - Azure OpenAI is now supported on the OpenAI-compatible Unified API when BYOK is configured. With BYOK, users can link a resource name to each stored key, and AI Gateway automatically infers the resource name from the configuration.

### Screenshots (optional)

N/A

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] ~~If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.~~ (N/A - updating existing page)
- [ ] ~~Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).~~ (N/A - no files renamed or moved)
