### PR TITLE
Fix R2 binding references in Workers API usage examples

### DIFF
--- a/src/content/docs/r2/api/workers/workers-api-usage.mdx
+++ b/src/content/docs/r2/api/workers/workers-api-usage.mdx
@@ -103,14 +103,14 @@ export default class extends WorkerEntrypoint<Env> {
 
     switch (request.method) {
       case "PUT": {
-        await this.env.R2.put(key, request.body, {
+        await this.env.MY_BUCKET.put(key, request.body, {
           onlyIf: request.headers,
           httpMetadata: request.headers,
         });
         return new Response(`Put ${key} successfully!`);
       }
       case "GET": {
-        const object = await this.env.R2.get(key, {
+        const object = await this.env.MY_BUCKET.get(key, {
           onlyIf: request.headers,
           range: request.headers,
         });
@@ -130,7 +130,7 @@ export default class extends WorkerEntrypoint<Env> {
         });
       }
       case "DELETE": {
-        await this.env.R2.delete(key);
+        await this.env.MY_BUCKET.delete(key);
         return new Response("Deleted!");
       }
       default:
@@ -153,14 +153,14 @@ export default {
 
     switch (request.method) {
       case "PUT": {
-        await this.env.R2.put(key, request.body, {
+        await env.MY_BUCKET.put(key, request.body, {
           onlyIf: request.headers,
           httpMetadata: request.headers,
         });
         return new Response(`Put ${key} successfully!`);
       }
       case "GET": {
-        const object = await this.env.R2.get(key, {
+        const object = await env.MY_BUCKET.get(key, {
           onlyIf: request.headers,
           range: request.headers,
         });
@@ -180,7 +180,7 @@ export default {
         });
       }
       case "DELETE": {
-        await this.env.R2.delete(key);
+        await env.MY_BUCKET.delete(key);
         return new Response("Deleted!");
       }
       default:
@@ -207,7 +207,7 @@ class Default(WorkerEntrypoint):
 		key = url.path[1:]
 
 		if request.method == "PUT":
-			await self.env.R2.put(
+			await self.env.MY_BUCKET.put(
 				key,
 				request.body,
 				onlyIf=request.headers,
@@ -215,7 +215,7 @@ class Default(WorkerEntrypoint):
 			)
 			return Response(f"Put {key} successfully!")
 		elif request.method == "GET":
-			obj = await self.env.R2.get(
+			obj = await self.env.MY_BUCKET.get(
 				key,
 				onlyIf=request.headers,
 				range=request.headers,
@@ -231,7 +231,7 @@ class Default(WorkerEntrypoint):
 			headers = {"etag": obj.httpEtag}
 			return Response(body, status=status, headers=headers)
 		elif request.method == "DELETE":
-			await self.env.R2.delete(key)
+			await self.env.MY_BUCKET.delete(key)
 			return Response("Deleted!")
 		else:
 			return Response(
@@ -341,9 +341,6 @@ npx wrangler secret put AUTH_KEY_SECRET
 
 This command will prompt you to enter a secret in your terminal:
 
-```sh
-npx wrangler secret put AUTH_KEY_SECRET
-```
 
 ```sh output
 Enter the secret text you'd like assigned to the variable AUTH_KEY_SECRET on the script named <YOUR_WORKER_NAME>:


### PR DESCRIPTION
## Code Review Summary

This PR fixes incorrect R2 binding references in the Workers API usage documentation that would cause runtime errors for users copying the code examples.

**Overall Results:**

- **Total Examples Reviewed**: 14
- **Issues Fixed**: 4 (3 binding reference errors + 1 duplicate command)
- **Impact**: High - Fixed examples that would fail at runtime

## Issues Fixed

### 1. TypeScript Example (Lines 96-146) - CRITICAL
**Problem**: Used `this.env.R2` instead of `this.env.MY_BUCKET`
**Impact**: Runtime error - "undefined is not an object"
**Fix**: Changed all references to use the correct binding name `MY_BUCKET` as defined in wrangler.toml

### 2. JavaScript Example (Lines 148-196) - CRITICAL  
**Problem**: Used `this.env.R2` instead of `env.MY_BUCKET`
**Impact**: Double error - incorrect use of `this` in object method context + wrong binding name
**Fix**: Changed to `env.MY_BUCKET` (using the function parameter, not `this`)

### 3. Python Example (Lines 199-242)
**Problem**: Used `self.env.R2` instead of `self.env.MY_BUCKET`
**Impact**: Wrong binding reference (syntax was correct but name was wrong)
**Fix**: Changed to use correct binding name `MY_BUCKET`

### 4. Duplicate Command (Lines 344-346)
**Problem**: Duplicate `wrangler secret put` command that added no value
**Fix**: Removed duplicate block

## Why These Issues Matter

The documentation shows the binding configuration as:

```toml
[[r2_buckets]]
binding = 'MY_BUCKET'
bucket_name = '<YOUR_BUCKET_NAME>'
```

This means the binding is available as `MY_BUCKET` in the Worker code, NOT as `R2`. All three code examples were using the wrong name, which would cause:

- **TypeScript/Python**: Runtime error when accessing undefined binding
- **JavaScript**: Immediate failure due to incorrect `this` usage + wrong binding name

Users following this tutorial would encounter errors and be unable to complete the guide successfully.

## Changes Made

- ✅ Fixed TypeScript: `this.env.R2` → `this.env.MY_BUCKET` (3 locations)
- ✅ Fixed JavaScript: `this.env.R2` → `env.MY_BUCKET` (3 locations)  
- ✅ Fixed Python: `self.env.R2` → `self.env.MY_BUCKET` (3 locations)
- ✅ Removed duplicate wrangler secret command

All examples now correctly reference the `MY_BUCKET` binding as configured in wrangler.toml.