### PR TITLE
Fix R2 bucket binding references in Workers API examples

### DIFF
--- a/src/content/docs/r2/api/workers/workers-api-usage.mdx
+++ b/src/content/docs/r2/api/workers/workers-api-usage.mdx
@@ -96,6 +96,11 @@ import { TabItem, Tabs } from "~/components";
 ```ts
 import { WorkerEntrypoint } from "cloudflare:workers";
 
+interface Env {
+	MY_BUCKET: R2Bucket;
+}
+
+
 export default class extends WorkerEntrypoint<Env> {
   async fetch(request: Request) {
     const url = new URL(request.url);
@@ -103,14 +108,14 @@ export default class extends WorkerEntrypoint<Env> {
 
     switch (request.method) {
       case "PUT": {
-        await this.env.R2.put(key, request.body, {
+        await this.env.MY_BUCKET.put(key, request.body, {
           onlyIf: request.headers,
           httpMetadata: request.headers,
         });
         return new Response(`Put ${key} successfully!`);
       }
       case "GET": {
-        const object = await this.env.R2.get(key, {
+        const object = await this.env.MY_BUCKET.get(key, {
           onlyIf: request.headers,
           range: request.headers,
         });
@@ -130,7 +135,7 @@ export default class extends WorkerEntrypoint<Env> {
         });
       }
       case "DELETE": {
-        await this.env.R2.delete(key);
+        await this.env.MY_BUCKET.delete(key);
         return new Response("Deleted!");
       }
       default:
@@ -153,14 +158,14 @@ export default {
 
     switch (request.method) {
       case "PUT": {
-        await this.env.R2.put(key, request.body, {
+        await env.MY_BUCKET.put(key, request.body, {
           onlyIf: request.headers,
           httpMetadata: request.headers,
         });
         return new Response(`Put ${key} successfully!`);
       }
       case "GET": {
-        const object = await this.env.R2.get(key, {
+        const object = await env.MY_BUCKET.get(key, {
           onlyIf: request.headers,
           range: request.headers,
         });
@@ -180,7 +185,7 @@ export default {
         });
       }
       case "DELETE": {
-        await this.env.R2.delete(key);
+        await env.MY_BUCKET.delete(key);
         return new Response("Deleted!");
       }
       default:
@@ -207,7 +212,7 @@ class Default(WorkerEntrypoint):
 		key = url.path[1:]
 
 		if request.method == "PUT":
-			await self.env.R2.put(
+			await self.env.MY_BUCKET.put(
 				key,
 				request.body,
 				onlyIf=request.headers,
@@ -215,7 +220,7 @@ class Default(WorkerEntrypoint):
 			)
 			return Response(f"Put {key} successfully!")
 		elif request.method == "GET":
-			obj = await self.env.R2.get(
+			obj = await self.env.MY_BUCKET.get(
 				key,
 				onlyIf=request.headers,
 				range=request.headers,
@@ -231,7 +236,7 @@ class Default(WorkerEntrypoint):
 			headers = {"etag": obj.httpEtag}
 			return Response(body, status=status, headers=headers)
 		elif request.method == "DELETE":
-			await self.env.R2.delete(key)
+			await self.env.MY_BUCKET.delete(key)
 			return Response("Deleted!")
 		else:
 			return Response(


### PR DESCRIPTION
## Summary

This PR fixes incorrect R2 bucket binding references in the Workers API usage documentation. All three code examples (TypeScript, JavaScript, and Python) were using incorrect binding names that would cause runtime errors when developers copy and use this code.

## Issues Fixed

### 1. TypeScript Example (Lines 96-146)
- **Issue**: Used `this.env.R2` instead of `this.env.MY_BUCKET`
- **Impact**: Runtime error - binding `R2` does not exist
- **Fix**: Changed to `this.env.MY_BUCKET` to match wrangler.toml configuration
- **Bonus**: Added missing `Env` interface definition for better type safety

### 2. JavaScript Example (Lines 148-196)
- **Issue**: Used `this.env.R2` in default export object where `this` is undefined
- **Impact**: Double error - `this` is undefined AND wrong binding name
- **Fix**: Changed to `env.MY_BUCKET` (correct parameter access)

### 3. Python Example (Lines 199-242)
- **Issue**: Used `self.env.R2` instead of `self.env.MY_BUCKET`
- **Impact**: AttributeError at runtime - binding `R2` does not exist
- **Fix**: Changed to `self.env.MY_BUCKET` to match wrangler.toml configuration

## Review Methodology

This fix was identified through a systematic code review that:
- Categorized each code example (Illustrative/Demonstrative/Executable)
- Scored examples on syntax correctness, style, security, and completeness
- Flagged binding mismatches between code and configuration
- Verified all three critical issues would cause runtime failures

## Testing

All binding references now correctly match the `MY_BUCKET` binding name defined in the wrangler.toml configuration shown earlier in the documentation.