### PR TITLE
[Cloudflare Tunnel] Add content to Configure a tunnel index page

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cipher-suites.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cipher-suites.mdx
@@ -1,6 +1,10 @@
 ---
 pcx_content_type: reference
 title: Cipher suites
+description: |
+  Review the TLS cipher suites supported by `cloudflared` for secure connections between your origin and Cloudflare's network.
+sidebar:
+  order: 11
 ---
 
 Cloudflare Tunnel connections use the cipher suites supported by `cloudflared`, which relies on the Go TLS library for its TLS implementation. These cipher suites apply to both the TLS connection between Cloudflare's network and `cloudflared`, and the HTTPS connection between `cloudflared` and your origin. In both cases, `cloudflared` negotiates the most secure cipher suite supported by both sides.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/index.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: how-to
 title: Configure cloudflared parameters
+description: |
+  Modify tunnel service parameters to control how `cloudflared` runs on your system, including logging, connection settings, and protocol options.
 sidebar:
   order: 1
 ---

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/index.mdx
@@ -3,6 +3,95 @@ title: Configure a tunnel
 pcx_content_type: navigation
 sidebar:
   order: 3
-  group:
-    hideIndex: true
 ---
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+After [creating your Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/), you can configure various aspects of how `cloudflared` runs and connects your infrastructure to Cloudflare's network. This section covers advanced configuration options to optimize tunnel performance, security, and availability.
+
+All tunnel connections between `cloudflared` and Cloudflare's edge are secured with TLS 1.3 and post-quantum encryption by default, ensuring your traffic is protected against current and future cryptographic threats.
+
+## Configuration options
+
+<CardGrid>
+
+<LinkTitleCard
+	title="Configure cloudflared parameters"
+	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/"
+>
+
+Modify tunnel service parameters to control how `cloudflared` runs on your system, including logging, connection settings, and protocol options.
+
+</LinkTitleCard>
+
+<LinkTitleCard
+	title="Tunnel permissions"
+	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions/"
+>
+
+Manage tunnel tokens and control who can run your remotely-managed tunnels.
+
+</LinkTitleCard>
+
+<LinkTitleCard
+	title="Tunnel with firewall"
+	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/"
+>
+
+Configure firewall rules to allow `cloudflared` egress traffic while blocking all ingress, implementing a positive security model.
+
+</LinkTitleCard>
+
+<LinkTitleCard
+	title="Tunnel availability and failover"
+	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/"
+>
+
+Deploy multiple `cloudflared` replicas for high availability and automatic failover across your infrastructure.
+
+</LinkTitleCard>
+
+<LinkTitleCard
+	title="Cipher suites"
+	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cipher-suites/"
+>
+
+Review the TLS cipher suites supported by `cloudflared` for secure connections between your origin and Cloudflare's network.
+
+</LinkTitleCard>
+
+</CardGrid>
+
+## Common configuration scenarios
+
+### Optimize for production
+
+For production deployments, consider:
+
+- **Deploy replicas** - Run multiple `cloudflared` instances for redundancy
+- **Configure logging** - Set appropriate log levels for monitoring and troubleshooting
+- **Review system requirements** - Ensure your infrastructure meets performance needs
+- **Configure firewall rules** - Implement egress-only traffic patterns for security
+
+### Secure your tunnel
+
+Enhance tunnel security by:
+
+- **Managing tunnel tokens** - Control access to your tunnel credentials
+- **Configuring firewall rules** - Allow only necessary outbound connections
+- **Implementing least privilege** - Grant minimal permissions needed for tunnel operation
+
+### Improve reliability
+
+Maximize tunnel uptime with:
+
+- **Multiple replicas** - Deploy `cloudflared` across different hosts
+- **Health monitoring** - Configure logging to track connection status
+- **Load balancing** - Distribute traffic across tunnel connections
+- **Automatic failover** - Leverage built-in connection redundancy
+
+## Next steps
+
+- [Monitor your tunnels](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/) to track performance and troubleshoot issues
+- [Configure routes](/cloudflare-one/networks/routes/) to control how traffic reaches your applications
+- [Set up private networks](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/) for internal resource access

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/index.mdx
@@ -30,7 +30,7 @@ Enhance tunnel security with:
 
 - [Tunnel token management](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions/) - Control access to your tunnel credentials.
 - [Egress-only firewall rules](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/) - Allow only necessary outbound connections.
-- Least privilege permissions - Grant minimal permissions needed for tunnel operation.
+- Least privilege permissions - Run `cloudflared` as a non-root user with minimal permissions needed for tunnel operation.
 
 ### Improve reliability
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/index.mdx
@@ -5,93 +5,45 @@ sidebar:
   order: 3
 ---
 
-import { CardGrid, LinkTitleCard } from "~/components";
+import { DirectoryListing  } from "~/components";
 
 After [creating your Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/), you can configure various aspects of how `cloudflared` runs and connects your infrastructure to Cloudflare's network. This section covers advanced configuration options to optimize tunnel performance, security, and availability.
 
-All tunnel connections between `cloudflared` and Cloudflare's edge are secured with TLS 1.3 and post-quantum encryption by default, ensuring your traffic is protected against current and future cryptographic threats.
-
-## Configuration options
-
-<CardGrid>
-
-<LinkTitleCard
-	title="Configure cloudflared parameters"
-	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/"
->
-
-Modify tunnel service parameters to control how `cloudflared` runs on your system, including logging, connection settings, and protocol options.
-
-</LinkTitleCard>
-
-<LinkTitleCard
-	title="Tunnel permissions"
-	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions/"
->
-
-Manage tunnel tokens and control who can run your remotely-managed tunnels.
-
-</LinkTitleCard>
-
-<LinkTitleCard
-	title="Tunnel with firewall"
-	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/"
->
-
-Configure firewall rules to allow `cloudflared` egress traffic while blocking all ingress, implementing a positive security model.
-
-</LinkTitleCard>
-
-<LinkTitleCard
-	title="Tunnel availability and failover"
-	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/"
->
-
-Deploy multiple `cloudflared` replicas for high availability and automatic failover across your infrastructure.
-
-</LinkTitleCard>
-
-<LinkTitleCard
-	title="Cipher suites"
-	href="/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cipher-suites/"
->
-
-Review the TLS cipher suites supported by `cloudflared` for secure connections between your origin and Cloudflare's network.
-
-</LinkTitleCard>
-
-</CardGrid>
+<DirectoryListing descriptions />
 
 ## Common configuration scenarios
 
 ### Optimize for production
 
-For production deployments, consider:
+For production deployments, consider the following steps:
 
-- **Deploy replicas** - Run multiple `cloudflared` instances for redundancy
-- **Configure logging** - Set appropriate log levels for monitoring and troubleshooting
-- **Review system requirements** - Ensure your infrastructure meets performance needs
-- **Configure firewall rules** - Implement egress-only traffic patterns for security
+- [Deploy replicas](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/deploy-replicas/) - Run multiple `cloudflared` instances for redundancy.
+- [Configure logging](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters/#loglevel) - Set appropriate log levels for monitoring and troubleshooting.
+- [Review system requirements](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/system-requirements/) - Ensure your infrastructure meets performance needs.
+- [Configure firewall rules](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/) - Implement egress-only traffic patterns for security.
 
 ### Secure your tunnel
 
-Enhance tunnel security by:
+All tunnel connections between `cloudflared` and Cloudflare's network are secured with TLS 1.3 and post-quantum encryption by default, ensuring your traffic is protected against current and future cryptographic threats.
 
-- **Managing tunnel tokens** - Control access to your tunnel credentials
-- **Configuring firewall rules** - Allow only necessary outbound connections
-- **Implementing least privilege** - Grant minimal permissions needed for tunnel operation
+Enhance tunnel security with:
+
+- [Tunnel token management](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions/) - Control access to your tunnel credentials.
+- [Egress-only firewall rules](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/) - Allow only necessary outbound connections.
+- Least privilege permissions - Grant minimal permissions needed for tunnel operation.
 
 ### Improve reliability
 
 Maximize tunnel uptime with:
 
-- **Multiple replicas** - Deploy `cloudflared` across different hosts
-- **Health monitoring** - Configure logging to track connection status
-- **Load balancing** - Distribute traffic across tunnel connections
-- **Automatic failover** - Leverage built-in connection redundancy
+- [Multiple replicas](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/#cloudflared-replicas) - Deploy `cloudflared` across different hosts.
+- [Health alerts](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/notifications/) - Get notified when your tunnel is degraded or goes down.
+- [Health metrics](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters/#metrics) - Monitor tunnel resource usage to identify potential bottlenecks.
+- [Load balancing](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/#cloudflare-load-balancers/) - Distribute traffic across tunnel connections.
+- [Automatic failover](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/) - Leverage built-in connection redundancy.
 
 ## Next steps
 
-- [Monitor your tunnels](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/) to track performance and troubleshoot issues
-- [Configure routes](/cloudflare-one/networks/routes/) to control how traffic reaches your applications
-- [Set up private networks](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/) for internal resource access
+- [Monitor your tunnels](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/) to track performance and troubleshoot issues.
+- [Configure routes](/cloudflare-one/networks/routes/) to control how traffic reaches your applications.
+- [Set up private networks](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/) for internal resource access.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: how-to
 title: Tunnel permissions
+description: |
+  Manage tunnel tokens and control who can run your remotely-managed tunnels.
 sidebar:
   order: 10
 ---

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/index.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: concept
 title: Tunnel availability and failover
+description: |
+  Deploy multiple `cloudflared` replicas for high availability and automatic failover across your infrastructure.
 sidebar:
   order: 4
 ---

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall.mdx
@@ -1,6 +1,8 @@
 ---
 pcx_content_type: reference
 title: Tunnel with firewall
+description: |
+  Configure firewall rules to allow `cloudflared` egress traffic while blocking all ingress, implementing a positive security model.
 sidebar:
   order: 3
 ---


### PR DESCRIPTION
This page is actively returned by Cloudy and other AI agents as an entry point to documentation about Cloudflare Tunnel. As such, it can't be blank and must have engaging overview covering main Tunnel features.