### PR TITLE
Add changelog entry for encode_base64 and sha256 functions

### DIFF
--- a/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
+++ b/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
@@ -23,7 +23,7 @@ The `sha256()` function is available as an Enterprise add-on and requires a spec
 
 ### Examples
 
-**Encodes a string to Base64 format:**
+**Encode a string to Base64 format:**
 
 ```txt
 base64_encode("hello world")
@@ -31,7 +31,7 @@ base64_encode("hello world")
 
 Returns: `aGVsbG8gd29ybGQ`
 
-**Encodes a string to Base64 format with padding:**
+**Encode a string to Base64 format with padding:**
 
 ```txt
 base64_encode("hello world", "p")
@@ -39,7 +39,7 @@ base64_encode("hello world", "p")
 
 Returns: `aGVsbG8gd29ybGQ=`
 
-**Performs a URL-safe Base64 encoding of a string:**
+**Perform a URL-safe Base64 encoding of a string:**
 
 ```txt
 base64_encode("hello world", "u")
@@ -47,7 +47,7 @@ base64_encode("hello world", "u")
 
 Returns: `aGVsbG8gd29ybGQ`
 
-**Computes the SHA256 hash of a secret token:**
+**Compute the SHA256 hash of a secret token:**
 
 ```txt
 sha256("my-token")
@@ -55,7 +55,7 @@ sha256("my-token")
 
 Returns a hash that your origin can validate to authenticate requests.
 
-**Computes the SHA256 hash of a string and encodes the result to Base64 format:**
+**Compute the SHA256 hash of a string and encodes the result to Base64 format:**
 
 ```txt
 base64_encode(sha256("my-token"))

--- a/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
+++ b/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
@@ -1,0 +1,68 @@
+---
+title: New cryptographic functions — base64_encode and sha256
+description: Rulesets now support base64_encode and sha256 functions for generating signed request headers directly in expressions.
+date: 2026-01-21
+---
+
+## New cryptographic functions for Rulesets
+
+Cloudflare Rulesets now includes `base64_encode()` and `sha256()` functions, enabling you to generate signed request headers directly in rule expressions. These functions support common patterns like constructing a canonical string from request attributes, computing a SHA256 digest, and Base64-encoding the result.
+
+---
+
+### New functions
+
+| Function | Description | Availability |
+| --- | --- | --- |
+| `base64_encode(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, which some systems require). By default, output is standard Base64 without padding. | All plans |
+| `sha256(input)` | Computes a SHA256 hash of the input string. | Requires enablement |
+
+:::note
+The `sha256()` function requires an entitlement. Contact your account team to enable it.
+:::
+
+---
+
+### Examples
+
+**Base64 encode a string:**
+
+```txt
+base64_encode("hello world")
+```
+
+Returns: `aGVsbG8gd29ybGQ`
+
+**Base64 encode with padding:**
+
+```txt
+base64_encode("hello world", "p")
+```
+
+Returns: `aGVsbG8gd29ybGQ=`
+
+**URL-safe Base64 encoding:**
+
+```txt
+base64_encode("hello world", "u")
+```
+
+Returns: `aGVsbG8gd29ybGQ`
+
+**SHA256 hash a secret token:**
+
+```txt
+sha256("my-token")
+```
+
+Returns a hash that your origin can validate to authenticate requests.
+
+**SHA256 hash with Base64 encoding:**
+
+```txt
+base64_encode(sha256("my-token"))
+```
+
+Combines hashing and encoding for systems that expect Base64-encoded signatures.
+
+For more information, refer to the [Functions reference](/ruleset-engine/rules-language/functions/).

--- a/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
+++ b/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
@@ -55,7 +55,7 @@ sha256("my-token")
 
 Returns a hash that your origin can validate to authenticate requests.
 
-**Compute the SHA256 hash of a string and encodes the result to Base64 format:**
+**Compute the SHA256 hash of a string and encode the result to Base64 format:**
 
 ```txt
 base64_encode(sha256("my-token"))

--- a/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
+++ b/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
@@ -1,19 +1,19 @@
 ---
-title: New cryptographic functions — base64_encode() and sha256()
-description: Rulesets now support base64_encode() and sha256() functions for generating signed request headers directly in expressions.
+title: New cryptographic functions — encode_base64() and sha256()
+description: Rulesets now support encode_base64() and sha256() functions for generating signed request headers directly in expressions.
 date: 2026-01-21
 ---
 
-Cloudflare Rulesets now includes `base64_encode()` and `sha256()` functions, enabling you to generate signed request headers directly in rule expressions. These functions support common patterns like constructing a canonical string from request attributes, computing a SHA256 digest, and Base64-encoding the result.
+Cloudflare Rulesets now includes `encode_base64()` and `sha256()` functions, enabling you to generate signed request headers directly in rule expressions. These functions support common patterns like constructing a canonical string from request attributes, computing a SHA256 digest, and Base64-encoding the result.
 
 ---
 
 ### New functions
 
-| Function                      | Description                                                                                                                                                                                                                                                    | Availability        |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `base64_encode(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, as required by some systems). By default, output is standard Base64 without padding. | All plans           |
-| `sha256(input)`               | Computes a SHA256 hash of the input string.                                                                                                                                                                                                                    | Requires enablement |
+| Function                      | Description                                                                                                                                                                                                                                                    | Availability                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `encode_base64(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, as required by some systems). By default, output is standard Base64 without padding. | All plans (transform rules/rewrite action parameters) |
+| `sha256(input)`               | Computes a SHA256 hash of the input string.                                                                                                                                                                                                                    | Requires enablement                                   |
 
 :::note
 The `sha256()` function is available as an Enterprise add-on and requires a specific entitlement. Contact your account team to enable it.
@@ -26,7 +26,7 @@ The `sha256()` function is available as an Enterprise add-on and requires a spec
 **Encode a string to Base64 format:**
 
 ```txt
-base64_encode("hello world")
+encode_base64("hello world")
 ```
 
 Returns: `aGVsbG8gd29ybGQ`
@@ -34,7 +34,7 @@ Returns: `aGVsbG8gd29ybGQ`
 **Encode a string to Base64 format with padding:**
 
 ```txt
-base64_encode("hello world", "p")
+encode_base64("hello world", "p")
 ```
 
 Returns: `aGVsbG8gd29ybGQ=`
@@ -42,7 +42,7 @@ Returns: `aGVsbG8gd29ybGQ=`
 **Perform a URL-safe Base64 encoding of a string:**
 
 ```txt
-base64_encode("hello world", "u")
+encode_base64("hello world", "u")
 ```
 
 Returns: `aGVsbG8gd29ybGQ`
@@ -58,7 +58,7 @@ Returns a hash that your origin can validate to authenticate requests.
 **Compute the SHA256 hash of a string and encode the result to Base64 format:**
 
 ```txt
-base64_encode(sha256("my-token"))
+encode_base64(sha256("my-token"))
 ```
 
 Combines hashing and encoding for systems that expect Base64-encoded signatures.

--- a/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
+++ b/src/content/changelog/rules/2026-01-21-sha256-base64-encode-functions.mdx
@@ -1,10 +1,8 @@
 ---
-title: New cryptographic functions — base64_encode and sha256
-description: Rulesets now support base64_encode and sha256 functions for generating signed request headers directly in expressions.
+title: New cryptographic functions — base64_encode() and sha256()
+description: Rulesets now support base64_encode() and sha256() functions for generating signed request headers directly in expressions.
 date: 2026-01-21
 ---
-
-## New cryptographic functions for Rulesets
 
 Cloudflare Rulesets now includes `base64_encode()` and `sha256()` functions, enabling you to generate signed request headers directly in rule expressions. These functions support common patterns like constructing a canonical string from request attributes, computing a SHA256 digest, and Base64-encoding the result.
 
@@ -12,20 +10,20 @@ Cloudflare Rulesets now includes `base64_encode()` and `sha256()` functions, ena
 
 ### New functions
 
-| Function | Description | Availability |
-| --- | --- | --- |
-| `base64_encode(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, which some systems require). By default, output is standard Base64 without padding. | All plans |
-| `sha256(input)` | Computes a SHA256 hash of the input string. | Requires enablement |
+| Function                      | Description                                                                                                                                                                                                                                                    | Availability        |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `base64_encode(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, as required by some systems). By default, output is standard Base64 without padding. | All plans           |
+| `sha256(input)`               | Computes a SHA256 hash of the input string.                                                                                                                                                                                                                    | Requires enablement |
 
 :::note
-The `sha256()` function requires an entitlement. Contact your account team to enable it.
+The `sha256()` function is available as an Enterprise add-on and requires a specific entitlement. Contact your account team to enable it.
 :::
 
 ---
 
 ### Examples
 
-**Base64 encode a string:**
+**Encodes a string to Base64 format:**
 
 ```txt
 base64_encode("hello world")
@@ -33,7 +31,7 @@ base64_encode("hello world")
 
 Returns: `aGVsbG8gd29ybGQ`
 
-**Base64 encode with padding:**
+**Encodes a string to Base64 format with padding:**
 
 ```txt
 base64_encode("hello world", "p")
@@ -41,7 +39,7 @@ base64_encode("hello world", "p")
 
 Returns: `aGVsbG8gd29ybGQ=`
 
-**URL-safe Base64 encoding:**
+**Performs a URL-safe Base64 encoding of a string:**
 
 ```txt
 base64_encode("hello world", "u")
@@ -49,7 +47,7 @@ base64_encode("hello world", "u")
 
 Returns: `aGVsbG8gd29ybGQ`
 
-**SHA256 hash a secret token:**
+**Computes the SHA256 hash of a secret token:**
 
 ```txt
 sha256("my-token")
@@ -57,7 +55,7 @@ sha256("my-token")
 
 Returns a hash that your origin can validate to authenticate requests.
 
-**SHA256 hash with Base64 encoding:**
+**Computes the SHA256 hash of a string and encodes the result to Base64 format:**
 
 ```txt
 base64_encode(sha256("my-token"))

--- a/src/content/changelog/rules/2026-01-22-sha256-base64-encode-functions.mdx
+++ b/src/content/changelog/rules/2026-01-22-sha256-base64-encode-functions.mdx
@@ -10,10 +10,10 @@ Cloudflare Rulesets now includes `encode_base64()` and `sha256()` functions, ena
 
 ### New functions
 
-| Function                      | Description                                                                                                                                                                                                                                                    | Availability                   |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `encode_base64(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, as required by some systems). By default, output is standard Base64 without padding. | All plans (in Transform Rules) |
-| `sha256(input)`               | Computes a SHA256 hash of the input string.                                                                                                                                                                                                                    | Requires enablement            |
+| Function                      | Description                                                                                                                                                                                                                                                    | Availability                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `encode_base64(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, as required by some systems). By default, output is standard Base64 without padding. | All plans (in header transform rules) |
+| `sha256(input)`               | Computes a SHA256 hash of the input string.                                                                                                                                                                                                                    | Requires enablement                   |
 
 :::note
 The `sha256()` function is available as an Enterprise add-on and requires a specific entitlement. Contact your account team to enable it.

--- a/src/content/changelog/rules/2026-01-22-sha256-base64-encode-functions.mdx
+++ b/src/content/changelog/rules/2026-01-22-sha256-base64-encode-functions.mdx
@@ -1,7 +1,7 @@
 ---
 title: New cryptographic functions — encode_base64() and sha256()
 description: Rulesets now support encode_base64() and sha256() functions for generating signed request headers directly in expressions.
-date: 2026-01-21
+date: 2026-01-22
 ---
 
 Cloudflare Rulesets now includes `encode_base64()` and `sha256()` functions, enabling you to generate signed request headers directly in rule expressions. These functions support common patterns like constructing a canonical string from request attributes, computing a SHA256 digest, and Base64-encoding the result.
@@ -10,10 +10,10 @@ Cloudflare Rulesets now includes `encode_base64()` and `sha256()` functions, ena
 
 ### New functions
 
-| Function                      | Description                                                                                                                                                                                                                                                    | Availability                                          |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `encode_base64(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, as required by some systems). By default, output is standard Base64 without padding. | All plans (transform rules/rewrite action parameters) |
-| `sha256(input)`               | Computes a SHA256 hash of the input string.                                                                                                                                                                                                                    | Requires enablement                                   |
+| Function                      | Description                                                                                                                                                                                                                                                    | Availability                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `encode_base64(input, flags)` | Encodes a string to Base64 format. Optional `flags` parameter: `u` for URL-safe encoding, `p` for padding (adds `=` characters to make the output length a multiple of 4, as required by some systems). By default, output is standard Base64 without padding. | All plans (in Transform Rules) |
+| `sha256(input)`               | Computes a SHA256 hash of the input string.                                                                                                                                                                                                                    | Requires enablement            |
 
 :::note
 The `sha256()` function is available as an Enterprise add-on and requires a specific entitlement. Contact your account team to enable it.


### PR DESCRIPTION
## Summary
- Adds changelog entry for new `encode_base64()` and `sha256()` functions in Rulesets
- `encode_base64()` available to all plans (Transform Rules only)
- `sha256()` is ENT add-on and requires a specific entitlement

Related: SHIP-13699