### PR TITLE
Correct destination port for WARP traffic

### DIFF
--- a/src/content/partials/networking-services/mconn/network-options/app-aware-policies/warp-traffic.mdx
+++ b/src/content/partials/networking-services/mconn/network-options/app-aware-policies/warp-traffic.mdx
@@ -8,6 +8,6 @@ If you have Magic WAN Connector and WARP clients deployed in your premises, Magi
 You may need to configure your firewall to allow this new traffic. Make sure to allow the following IPs and ports:
 
 - **Destination IPs**: `162.159.193.0/24`, `162.159.197.0/24`
-- **Destination ports**: `443`, `500`, `1701`, `2408`, `4443`, `4500`, `8095`, `844`
+- **Destination ports**: `443`, `500`, `1701`, `2408`, `4443`, `4500`, `8095`, `8443`
 
 Refer to <a href={props.warpFirewallURL}>WARP with firewall</a> for more information on this topic.


### PR DESCRIPTION
There is a typo in the listed WARP ports in the MCONN breakout.

### Summary

The last digit of the last listed port does not match the WARP ports

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
