### PR TITLE
[RealtimeKit] Document store APIs for mobile

### DIFF
--- a/src/content/docs/realtime/realtimekit/collaborative-stores/index.mdx
+++ b/src/content/docs/realtime/realtimekit/collaborative-stores/index.mdx
@@ -11,7 +11,7 @@ import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnipp
 
 The RealtimeKit Stores API allows you to create multiple key-value pair realtime stores. Users can subscribe to changes in a store and receive real-time updates. Data is stored until a [session](/realtime/realtimekit/concepts/meeting/#session) is active.
 
-<RTKSDKSelector />
+<RTKSDKSelector disabledPlatforms={["mobile-flutter"]} />
 
 ### Create a Store
 
@@ -23,7 +23,7 @@ You can create a realtime store (changes are synced with other users):
 
 To create a store:
 
-<RTKCodeSnippet id="web-react">
+<RTKCodeSnippet id={["web-react", "mobile-react-native"]}>
 
 ```ts
 const stores = useRealtimeKitSelector((m) => m.stores);
@@ -44,6 +44,30 @@ const store = meeting.stores.create('myStore');
 ````
 </RTKCodeSnippet>
 
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+val meeting = RealtimeKitMeetingBuilder.build(activity)
+val store = meeting.stores.create("myStore")
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+let meeting = RealtimeKitiOSClientBuilder().build()
+let store = meeting.stores.create(name: "myStore")
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-flutter">
+
+This feature is not currently supported in the Flutter SDK
+
+</RTKCodeSnippet>
+
 :::note
 This method must be executed for every user.
 :::
@@ -57,7 +81,7 @@ You can add, update or delete entires in a store:
 | `key`   | string     | Unique identifier used to store/update a value in the store | Yes      |
 | `value` | StoreValue | Value that can be stored agains a key                       | Yes      |
 
-<RTKCodeSnippet id="web-react">
+<RTKCodeSnippet id={"web-react", "mobile-react-native"}>
 
 ```ts
 type StoreValue = string | number | object | array;
@@ -108,6 +132,25 @@ await store.set("user", { name: "John Doe" });
 await store.update("user", { age: 34 }); // { name: 'John Doe', age: 34 }
 
 await store.delete("user");
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+val store = meeting.stores.get("myStore")
+
+store.set("user", mapOf("name" to "John Doe"))
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+let store = meeting.stores.get(name: "myStore")
+store.set("user", ["name": "John Doe"])
 ```
 
 </RTKCodeSnippet>
@@ -122,7 +165,7 @@ For example, if the stored value is `['a', 'b']` and you call `update` with `['c
 
 You can attach event listeners on a store's key, which fire when the value changes.
 
-<RTKCodeSnippet id="web-react">
+<RTKCodeSnippet id={"web-react", "mobile-react-native"}>
 
 ```ts
 const stores = useRealtimeKitSelector((m) => m.stores.stores);
@@ -177,6 +220,44 @@ console.log(data);
 
 store.unsubscribe('key');
 ````
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+val store = meeting.stores.create("myStore")
+val keyChangeCallback = { key: String, value: Any? ->
+  println(value)
+}
+store.subscribe("key", keyChangeCallback)
+
+// Subscribe to all keys
+store.subscribe(RtkStore.WILDCARD_KEY) { key, value ->
+  println(value)
+}
+
+store.unsubscribe("key", keyChangeCallback)
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+let store = meeting.stores.create(name: "myStore")
+let keyChangeCallback: ((String, (Any?)) -> Void) = { key, value in
+    print(value ?? "null")
+}
+store.subscribe(key: "key", onChange: keyChangeCallback)
+
+// Subscribe to all keys
+store.subscribe(key: RtkStore.Companion().WILDCARD_KEY) { key, value in
+    print(value ?? "null")
+}
+
+store.unsubscribe(key: "key", onChange: keyChangeCallback)
+```
 
 </RTKCodeSnippet>
 
@@ -184,7 +265,7 @@ store.unsubscribe('key');
 
 You can fetch the data stored in the store:
 
-<RTKCodeSnippet id="web-react">
+<RTKCodeSnippet id={["web-react", "mobile-react-native"]}>
 
 ```ts
 const stores = useRealtimeKitSelector((m) => m.stores.stores);
@@ -228,5 +309,33 @@ const data = store.get('key');
 // fetch all the data in the store
 const data = store.getAll();
 ````
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+val store = meeting.stores.create("myStore")
+
+// fetch value for a specific key
+val data = store.get("key")
+
+// fetch all the data in the store
+val data = store.getAll()
+```
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+let store = meeting.stores.create(name: "myStore")
+
+// fetch value for a specific key
+store.get(key: "key")
+
+// fetch all the data in the store
+store.getAll()
+```
 
 </RTKCodeSnippet>

--- a/src/content/docs/realtime/realtimekit/collaborative-stores/index.mdx
+++ b/src/content/docs/realtime/realtimekit/collaborative-stores/index.mdx
@@ -25,28 +25,22 @@ To create a store:
 
 <RTKCodeSnippet id="web-react">
 
-    ```ts
-
+```ts
 const stores = useRealtimeKitSelector((m) => m.stores);
 const store = stores.create('myStore');
-
 ````
 </RTKCodeSnippet>
 <RTKCodeSnippet id="web-angular">
 
-    ```ts
-
+```ts
 const store = meeting.stores.create('myStore');
-
 ````
 
 </RTKCodeSnippet>
 <RTKCodeSnippet id="web-web-components">
 
-    ```ts
-
+```ts
 const store = meeting.stores.create('myStore');
-
 ````
 </RTKCodeSnippet>
 
@@ -129,10 +123,11 @@ For example, if the stored value is `['a', 'b']` and you call `update` with `['c
 You can attach event listeners on a store's key, which fire when the value changes.
 
 <RTKCodeSnippet id="web-react">
+
 ```ts
 const stores = useRealtimeKitSelector((m) => m.stores.stores);
 const store = stores.get('myStore');
-store.subscribe('key', (data) => { 
+store.subscribe('key', (data) => {
     console.log(data);
 });
 
@@ -142,12 +137,12 @@ console.log(data);
 });
 
 store.unsubscribe('key');
-
 ````
 
 </RTKCodeSnippet>
 
 <RTKCodeSnippet id="web-angular">
+
 ```ts
 const { stores } = meeting.stores;
 const store = stores.get('myStore');
@@ -167,10 +162,11 @@ store.unsubscribe('key');
 </RTKCodeSnippet>
 
 <RTKCodeSnippet id="web-web-components">
+
 ```ts
 const { stores } = meeting.stores;
 const store = stores.get('myStore');
-store.subscribe('key', (data) => { 
+store.subscribe('key', (data) => {
     console.log(data);
 });
 
@@ -180,7 +176,6 @@ console.log(data);
 });
 
 store.unsubscribe('key');
-
 ````
 
 </RTKCodeSnippet>
@@ -190,6 +185,7 @@ store.unsubscribe('key');
 You can fetch the data stored in the store:
 
 <RTKCodeSnippet id="web-react">
+
 ```ts
 const stores = useRealtimeKitSelector((m) => m.stores.stores);
 const store = stores.get('myStore');
@@ -204,6 +200,7 @@ const data = store.getAll();
 </RTKCodeSnippet>
 
 <RTKCodeSnippet id="web-angular">
+
 ```ts
 const { stores } = meeting.stores;
 const store = stores.get('myStore');
@@ -220,6 +217,7 @@ const data = store.getAll();
 
 
 <RTKCodeSnippet id="web-web-components">
+
 ```ts
 const { stores } = meeting.stores;
 const store = stores.get('myStore');


### PR DESCRIPTION
### Summary

Adds mobile docs to the `/realtime/realtimekit/broadcast-apis/` page

~~Depends on #27814~~ merged ✅ 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
