### PR TITLE
Vectorize: changelog + limits update to 10MM

### DIFF
--- a/src/content/changelog/vectorize/2026-01-23-increased-index-capacity.mdx
+++ b/src/content/changelog/vectorize/2026-01-23-increased-index-capacity.mdx
@@ -1,0 +1,11 @@
+---
+title: Vectorize indexes now support up to 10 million vectors
+description: Vectorize indexes now support up to 10 million vectors.
+products:
+  - vectorize
+date: 2026-01-23
+---
+
+You can now store up to 10 million vectors in a single Vectorize index, doubling the previous limit of 5 million vectors. This enables larger-scale semantic search, recommendation systems, and retrieval-augmented generation (RAG) applications without splitting data across multiple indexes.
+
+Vectorize continues to support indexes with up to 1536 dimensions per vector at 32-bit precision. Refer to the [Vectorize limits documentation](/vectorize/platform/limits/) for complete details.

--- a/src/content/changelog/vectorize/2026-01-23-increased-index-capacity.mdx
+++ b/src/content/changelog/vectorize/2026-01-23-increased-index-capacity.mdx
@@ -8,4 +8,4 @@ date: 2026-01-23
 
 You can now store up to 10 million vectors in a single Vectorize index, doubling the previous limit of 5 million vectors. This enables larger-scale semantic search, recommendation systems, and retrieval-augmented generation (RAG) applications without splitting data across multiple indexes.
 
-Vectorize continues to support indexes with up to 1536 dimensions per vector at 32-bit precision. Refer to the [Vectorize limits documentation](/vectorize/platform/limits/) for complete details.
+Vectorize continues to support indexes with up to 1,536 dimensions per vector at 32-bit precision. Refer to the [Vectorize limits documentation](/vectorize/platform/limits/) for complete details.

--- a/src/content/docs/vectorize/platform/limits.mdx
+++ b/src/content/docs/vectorize/platform/limits.mdx
@@ -23,7 +23,7 @@ To request an adjustment to a limit, complete the [Limit Increase Request Form](
 | Maximum upsert batch size (per batch)                         | 1000 (Workers) / 5000 (HTTP API)    |
 | Maximum vectors in a list-vectors page                        | 1000                                |
 | Maximum index name length                                     | 64 bytes                            |
-| Maximum vectors per index                                     | 5,000,000                           |
+| Maximum vectors per index                                     | 10,000,000                          |
 | Maximum namespaces per index                                  | 50,000 (Workers Paid) / 1000 (Free) |
 | Maximum namespace name length                                 | 64 bytes                            |
 | Maximum vectors upload size                                   | 100 MB                              |


### PR DESCRIPTION
### Summary

Vectorize indexes now support up to 10 million vectors changelog + limits update to 10MM

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
