### PR TITLE
Fix Pages changelog date: 2025 -> 2026

### DIFF
--- a/src/content/changelog/pages/2026-01-23-pages-file-limit-increase.mdx
+++ b/src/content/changelog/pages/2026-01-23-pages-file-limit-increase.mdx
@@ -3,7 +3,7 @@ title: Increased Pages file limit to 100,000 for paid plans
 description: Paid plans can now deploy Pages sites with up to 100,000 files, increased from the previous limit of 20,000 files.
 products:
   - pages
-date: 2025-01-23
+date: 2026-01-23
 ---
 
 Paid plans can now have up to 100,000 files per Pages site, increased from the previous limit of 20,000 files.


### PR DESCRIPTION
## Summary
- Fixes the date in the Pages file limit changelog entry from 2025 to 2026
- Renames the file to match the correct date