### PR TITLE
Add agents.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ pnpm-debug.log*
 .idea
 
 tools/relevant_changed_files.txt
+
+# Personal workflow documentation
+agents.md
+AGENTS.md


### PR DESCRIPTION
Adds agents.md and AGENTS.md to .gitignore to prevent accidentally committing personal workflow documentation to the repo.