### PR TITLE
workers: placement docs improvements

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -1891,7 +1891,8 @@
 /workers/configuration/deploy-button/ /workers/platform/deploy-buttons/ 301
 /workers/platform/deployments/ /workers/configuration/versions-and-deployments/ 301
 /workers/platform/environment-variables/ /workers/configuration/environment-variables/ 301
-/workers/platform/smart-placement/ /workers/configuration/smart-placement/ 301
+/workers/platform/smart-placement/ /workers/configuration/placement/ 301
+/workers/configuration/smart-placement/ /workers/configuration/placement/ 301
 /workers/runtime-apis/email-event/ /email-routing/email-workers/runtime-api/ 301
 /workers/runtime-apis/scheduled-event/ /workers/runtime-apis/handlers/scheduled/ 301
 /workers/runtime-apis/fetch-event/ /workers/runtime-apis/handlers/fetch/ 301

--- a/src/content/changelog/workers/2025-02-03-workers-metrics-revamp.mdx
+++ b/src/content/changelog/workers/2025-02-03-workers-metrics-revamp.mdx
@@ -23,6 +23,6 @@ Now you can easily compare metrics across Worker versions, understand the curren
 
 - Monitor and compare active gradual deployments.
 - Track error rates across versions with grouping both by version and by invocation status.
-- Measure how [Smart Placement](/workers/configuration/smart-placement/) improves request duration.
+- Measure how [Smart Placement](/workers/configuration/placement/) improves request duration.
 
 Learn more about [metrics](/workers/observability/metrics-and-analytics).

--- a/src/content/changelog/workers/2025-03-22-smart-placement-stablization.mdx
+++ b/src/content/changelog/workers/2025-03-22-smart-placement-stablization.mdx
@@ -7,7 +7,7 @@ products:
 date: 2025-03-22
 ---
 
-[Smart Placement](/workers/configuration/smart-placement/) is a unique Cloudflare feature that can make decisions to move your Worker to run in a more optimal location (such as closer to a database). Instead of always running in the default location (the one closest to where the request is received), Smart Placement uses certain “heuristics” (rules and thresholds) to decide if a different location might be faster or more efficient.
+[Smart Placement](/workers/configuration/placement/) is a unique Cloudflare feature that can make decisions to move your Worker to run in a more optimal location (such as closer to a database). Instead of always running in the default location (the one closest to where the request is received), Smart Placement uses certain “heuristics” (rules and thresholds) to decide if a different location might be faster or more efficient.
 
 Previously, if these heuristics weren't consistently met, your Worker would revert to running in the default location—even after it had been optimally placed. This meant that if your Worker received minimal traffic for a period of time, the system would reset to the default location, rather than remaining in the optimal one.
 

--- a/src/content/changelog/workers/2026-01-22-explicit-placement-hints.mdx
+++ b/src/content/changelog/workers/2026-01-22-explicit-placement-hints.mdx
@@ -10,7 +10,7 @@ import { WranglerConfig } from "~/components";
 
 You can now configure Workers to run close to infrastructure in legacy cloud regions to minimize latency to existing services and databases. This is most useful when your Worker makes multiple round trips.
 
-To [set a placement hint](/workers/configuration/smart-placement/#use-placement-hints), set the `placement.region` property in your Wrangler configuration file:
+To [set a placement hint](/workers/configuration/placement/#use-placement-hints), set the `placement.region` property in your Wrangler configuration file:
 
 <WranglerConfig>
 
@@ -52,7 +52,7 @@ If your existing infrastructure is not in these cloud providers, expose it to pl
 
 </WranglerConfig>
 
-This is an extension of [Smart Placement](/workers/configuration/smart-placement/#use-smart-placement), which automatically places your Workers closer to back-end APIs based on measured latency. When you do not know the location of your back-end APIs or have multiple back-end APIs, set `mode: "smart"`:
+This is an extension of [Smart Placement](/workers/configuration/placement/#use-smart-placement), which automatically places your Workers closer to back-end APIs based on measured latency. When you do not know the location of your back-end APIs or have multiple back-end APIs, set `mode: "smart"`:
 
 <WranglerConfig>
 

--- a/src/content/docs/containers/platform-details/architecture.mdx
+++ b/src/content/docs/containers/platform-details/architecture.mdx
@@ -22,7 +22,7 @@ This allows you to gracefully shutdown any running instances during a rollout. R
 Recall that Containers are backed by [Durable Objects](/durable-objects/) and [Workers](/workers/).
 Requests are first routed through a Worker, which is generally handled
 by a datacenter in a location with the best latency between itself and the requesting user.
-A different datacenter may be selected to optimize overall latency, if [Smart Placement](/workers/configuration/smart-placement/)
+A different datacenter may be selected to optimize overall latency, if [Smart Placement](/workers/configuration/placement/)
 is on, or if the nearest location is under heavy load.
 
 Because all Container requests are passed through a Worker, end-users cannot make non-HTTP TCP or

--- a/src/content/docs/hyperdrive/concepts/how-hyperdrive-works.mdx
+++ b/src/content/docs/hyperdrive/concepts/how-hyperdrive-works.mdx
@@ -51,6 +51,8 @@ Hyperdrive automatically manages the connection pool properties for you, includi
 
 Learn more about connection pooling behavior and configuration in [Connection pooling](/hyperdrive/concepts/connection-pooling/).
 
+<Render file="placement-hint-partial" product="hyperdrive" />
+
 ### 3. Query Caching
 
 Hyperdrive supports caching of non-mutating (read) queries to your database.

--- a/src/content/docs/hyperdrive/get-started.mdx
+++ b/src/content/docs/hyperdrive/get-started.mdx
@@ -402,6 +402,8 @@ For example, if the URL of your new Worker is `hyperdrive-tutorial.<YOUR_SUBDOMA
 
 By finishing this tutorial, you have created a Hyperdrive configuration, a Worker to access that database and deployed your project globally.
 
+<Render file="placement-hint-partial" product="hyperdrive" />
+
 ## Next steps
 
 - Learn more about [how Hyperdrive works](/hyperdrive/concepts/how-hyperdrive-works/).

--- a/src/content/docs/hyperdrive/reference/faq.mdx
+++ b/src/content/docs/hyperdrive/reference/faq.mdx
@@ -27,6 +27,12 @@ and how Hyperdrive solves this.
 
 D1 does not require round trips to create database connections. D1 is designed to be performant for access from Workers by default, without needing Hyperdrive.
 
+### Should I use Placement with Hyperdrive?
+
+Yes, if your Worker makes multiple queries per request. [Placement](/workers/configuration/placement/) runs your Worker near your database, reducing per-query latency from 20-30ms to 1-3ms. Hyperdrive handles connection pooling and setup. Placement reduces the network distance for query execution.
+
+Use `placement.region` if your database runs in AWS, GCP, or Azure. Use `placement.host` for databases hosted elsewhere.
+
 ## Pricing
 
 ### Does Hyperdrive charge for data transfer / egress?

--- a/src/content/docs/pages/functions/smart-placement.mdx
+++ b/src/content/docs/pages/functions/smart-placement.mdx
@@ -22,7 +22,7 @@ Smart Placement on Pages currently has some caveats. While assets are always mea
 
 :::note
 
-To understand how Smart Placement works, refer to [Smart Placement](/workers/configuration/smart-placement/).
+To understand how Smart Placement works, refer to [Smart Placement](/workers/configuration/placement/).
 
 :::
 
@@ -37,6 +37,7 @@ To enable Smart Placement via the dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Select **Settings** > **Runtime**.
 4. Under **Placement**, choose **Smart**.

--- a/src/content/docs/pages/functions/wrangler-configuration.mdx
+++ b/src/content/docs/pages/functions/wrangler-configuration.mdx
@@ -310,35 +310,27 @@ API_KEY = "6567875fvgt"
 Inheritable keys are configurable at the top-level, and can be inherited (or overridden) by environment-specific configuration.
 
 - `name` <Type text="string" /> <MetaInfo text="required" />
-
   - The name of your Pages project. Alphanumeric and dashes only.
 
 - `pages_build_output_dir` <Type text="string" /> <MetaInfo text="required" />
-
   - The path to your project's build output folder. For example: `./dist`.
 
 - `compatibility_date` <Type text="string" /> <MetaInfo text="required" />
-
   - A date in the form `yyyy-mm-dd`, which will be used to determine which version of the Workers runtime is used. Refer to [Compatibility dates](/workers/configuration/compatibility-dates/).
 
 - `compatibility_flags` string\[] optional
-
   - A list of flags that enable features from upcoming features of the Workers runtime, usually used together with `compatibility_date`. Refer to [compatibility dates](/workers/configuration/compatibility-dates/).
 
 - `send_metrics` <Type text="boolean" /> <MetaInfo text="optional" />
-
   - Whether Wrangler should send usage data to Cloudflare for this project. Defaults to `true`. You can learn more about this in our [data policy](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler/telemetry.md).
 
 - `limits` Limits optional
-
   - Configures limits to be imposed on execution at runtime. Refer to [Limits](#limits).
 
 - `placement` Placement optional
-
-  - Specify how Pages Functions should be located to minimize round-trip time. Refer to [Smart Placement](/workers/configuration/smart-placement/).
+  - Specify how Pages Functions should be located to minimize round-trip time. Refer to [Smart Placement](/workers/configuration/placement/).
 
 - `upload_source_maps` boolean
-
   - When `upload_source_maps` is set to `true`, Wrangler will upload any server-side source maps part of your Pages project to give corrected stack traces in logs.
 
 ## Non-inheritable keys
@@ -371,47 +363,36 @@ API_KEY = "8901234bfgd"
 This will work for local development, but will fail to validate when you try to deploy.
 
 - `vars` <Type text="object" /> <MetaInfo text="optional" />
-
   - A map of environment variables to set when deploying your Function. Refer to [Environment variables](/pages/functions/bindings/#environment-variables).
 
 - `d1_databases` <Type text="object" /> <MetaInfo text="optional" />
-
   - A list of D1 databases that your Function should be bound to. Refer to [D1 databases](/pages/functions/bindings/#d1-databases).
 
 - `durable_objects` <Type text="object" /> <MetaInfo text="optional" />
-
   - A list of Durable Objects that your Function should be bound to. Refer to [Durable Objects](/pages/functions/bindings/#durable-objects).
 
 - `hyperdrive` <Type text="object" /> <MetaInfo text="optional" />
-
   - Specifies Hyperdrive configs that your Function should be bound to. Refer to [Hyperdrive](/pages/functions/bindings/#r2-buckets).
 
 - `kv_namespaces` <Type text="object" /> <MetaInfo text="optional" />
-
   - A list of KV namespaces that your Function should be bound to. Refer to [KV namespaces](/pages/functions/bindings/#kv-namespaces).
 
 - `queues.producers` <Type text="object" /> <MetaInfo text="optional" />
-
   - Specifies Queues Producers that are bound to this Function. Refer to [Queues Producers](/queues/get-started/#4-set-up-your-producer-worker).
 
 - `r2_buckets` <Type text="object" /> <MetaInfo text="optional" />
-
   - A list of R2 buckets that your Function should be bound to. Refer to [R2 buckets](/pages/functions/bindings/#r2-buckets).
 
 - `vectorize` <Type text="object" /> <MetaInfo text="optional" />
-
   - A list of Vectorize indexes that your Function should be bound to. Refer to [Vectorize indexes](/vectorize/get-started/intro/#3-bind-your-worker-to-your-index).
 
 - `services` <Type text="object" /> <MetaInfo text="optional" />
-
   - A list of service bindings that your Function should be bound to. Refer to [service bindings](/pages/functions/bindings/#service-bindings).
 
 - `analytics_engine_datasets` <Type text="object" /> <MetaInfo text="optional" />
-
   - Specifies analytics engine datasets that are bound to this Function. Refer to [Workers Analytics Engine](/analytics/analytics-engine/get-started/).
 
 - `ai` <Type text="object" /> <MetaInfo text="optional" />
-
   - Specifies an AI binding to this Function. Refer to [Workers AI](/pages/functions/bindings/#workers-ai).
 
 ## Limits

--- a/src/content/docs/rules/snippets/when-to-use.mdx
+++ b/src/content/docs/rules/snippets/when-to-use.mdx
@@ -88,7 +88,7 @@ Snippets are ideal for fast, cost-free request and response modifications at the
 | Analyze execution [logs](/workers/observability/logs/workers-logs/) and track performance metrics                                                                                                             |    ❌    |   ✅    |
 | Deploy via [command-line interface (CLI)](/workers/wrangler/)                                                                                                                                                 |    ❌    |   ✅    |
 | Roll out gradually, roll back to previous [versions](/workers/configuration/versions-and-deployments/)                                                                                                        |    ❌    |   ✅    |
-| Optimize execution with [Smart Placement](/workers/configuration/smart-placement/)                                                                                                                            |    ❌    |   ✅    |
+| Optimize execution with [Smart Placement](/workers/configuration/placement/)                                                                                                                                  |    ❌    |   ✅    |
 
 ---
 

--- a/src/content/docs/workers/configuration/multipart-upload-metadata.mdx
+++ b/src/content/docs/workers/configuration/multipart-upload-metadata.mdx
@@ -43,11 +43,9 @@ At a minimum, the `main_module` key is required to upload a Worker.
 :::
 
 - `main_module` <Type text="string" /> <MetaInfo text="required" />
-
   - The part name that contains the module entry point of the Worker that will be executed. For example, `main.js`.
 
 - `assets` <Type text="object" /> <MetaInfo text="optional" />
-
   - [Asset](/workers/static-assets/) configuration for a Worker.
   - `config` <Type text="object" /> <MetaInfo text="optional" />
     - [html_handling](/workers/static-assets/routing/advanced/html-handling/) determines the redirects and rewrites of requests for HTML content.
@@ -55,24 +53,19 @@ At a minimum, the `main_module` key is required to upload a Worker.
   - `jwt` field provides a token authorizing assets to be attached to a Worker.
 
 - `keep_assets` <Type text="boolean" /> <MetaInfo text="optional" />
-
   - Specifies whether assets should be retained from a previously uploaded Worker version; used in lieu of providing a completion token.
 
 - `bindings` array\[object] optional
-
   - [Bindings](#bindings) to expose in the Worker.
 
 - `placement` <Type text="object" /> <MetaInfo text="optional" />
-
-  - [Smart placement](/workers/configuration/smart-placement/) object for the Worker.
+  - [Smart placement](/workers/configuration/placement/) object for the Worker.
   - `mode` field only supports `smart` for automatic placement.
 
 - `compatibility_date` <Type text="string" /> <MetaInfo text="optional" />
-
   - [Compatibility Date](/workers/configuration/compatibility-dates/#setting-compatibility-date) indicating targeted support in the Workers runtime. Backwards incompatible fixes to the runtime following this date will not affect this Worker. Highly recommended to set a `compatibility_date`, otherwise if on upload via the API, it defaults to the oldest compatibility date before any flags took effect (2021-11-02).
 
 - `compatibility_flags` array\[string] optional
-
   - [Compatibility Flags](/workers/configuration/compatibility-flags/#setting-compatibility-flags) that enable or disable certain features in the Workers runtime. Used to enable upcoming features or opt in or out of specific changes not included in a `compatibility_date`.
 
 ## Additional attributes: [Workers Script Upload API](/api/resources/workers/subresources/scripts/methods/update/)
@@ -85,19 +78,15 @@ These attributes are **not available** for version uploads.
 :::
 
 - `migrations` array\[object] optional
-
   - [Durable Objects migrations](/durable-objects/reference/durable-objects-migrations/) to apply.
 
 - `logpush` <Type text="boolean" /> <MetaInfo text="optional" />
-
   - Whether [Logpush](/cloudflare-for-platforms/cloudflare-for-saas/hostname-analytics/#logpush) is turned on for the Worker.
 
 - `tail_consumers` array\[object] optional
-
   - [Tail Workers](/workers/observability/logs/tail-workers/) that will consume logs from the attached Worker.
 
 - `tags` array\[string] optional
-
   - List of strings to use as tags for this Worker.
 
 ## Additional attributes: [Version Upload API](/api/resources/workers/subresources/scripts/subresources/versions/methods/create/)
@@ -110,7 +99,6 @@ These attributes are **not available** for immediately deployed uploads.
 :::
 
 - `annotations` <Type text="object" /> <MetaInfo text="optional" />
-
   - Annotations object specific to the Worker version.
   - `workers/message` specifies a custom message for the version.
   - `workers/tag` specifies a custom identifier for the version.

--- a/src/content/docs/workers/configuration/placement.mdx
+++ b/src/content/docs/workers/configuration/placement.mdx
@@ -8,7 +8,7 @@ sidebar:
     text: Beta
 ---
 
-import { WranglerConfig, DashButton } from "~/components";
+import { WranglerConfig, DashButton, Tabs, TabItem } from "~/components";
 
 By default, [Workers](/workers/) and [Pages Functions](/pages/functions/) run in a data center closest to where the request was received. If your Worker makes requests to back-end infrastructure such as databases or APIs, it may be more performant to run that Worker closer to your back-end than the end user.
 
@@ -161,7 +161,7 @@ If your infrastructure runs in AWS, GCP, or Azure, set the `placement.region` pr
 ```jsonc
 {
 	"placement": {
-		"region": "aws:us-east-1",
+		"region": "aws:us-east-1", // Explicit cloud region to run your Worker closest to - e.g. "gcp:us-east4" or "aws:us-east-1"
 	},
 }
 ```
@@ -185,7 +185,7 @@ Set `placement.host` to identify a layer 4 service. Cloudflare uses TCP CONNECT 
 ```jsonc
 {
 	"placement": {
-		"host": "my_database_host.com:5432",
+		"host": "my_database_host.com:5432", // A host to probe (TCP/layer 4) - e.g. a database host - and place your Worker closest to
 	},
 }
 ```
@@ -199,7 +199,7 @@ Set `placement.hostname` to identify a layer 7 service. Cloudflare uses HTTP HEA
 ```jsonc
 {
 	"placement": {
-		"hostname": "my_api_server.com",
+		"hostname": "my_api_server.com", // A hostname to probe (HTTP/layer 7) - e.g. an API endpoint - and place your Worker closest to
 	},
 }
 ```
@@ -226,16 +226,18 @@ Workers Placement behaves in similar fashion when either Smart Placement or Plac
 
 ### Review limitations
 
-The following limitations apply to both smart placement and placement hints: 
+The following limitations apply to both smart placement and placement hints:
+
 - Smart Placement only affects the execution of [fetch event handlers](/workers/runtime-apis/handlers/fetch/). It does not affect [RPC methods](/workers/runtime-apis/rpc/) or [named entrypoints](/workers/runtime-apis/bindings/service-bindings/rpc/#named-entrypoints).
-	- Workers without a fetch event handler are ignored by Smart Placement.
-	- [Static assets](/workers/static-assets/) are always served from the location nearest to the incoming request. If your code retrieves assets via the [static assets binding](/workers/static-assets/binding/), assets are served from the location where your Worker runs.
+  - Workers without a fetch event handler are ignored by Smart Placement.
+  - [Static assets](/workers/static-assets/) are always served from the location nearest to the incoming request. If your code retrieves assets via the [static assets binding](/workers/static-assets/binding/), assets are served from the location where your Worker runs.
 
 ### `cf-placement` header
 
 Cloudflare adds a `cf-placement` header to all requests when placement is enabled. Use this header to check whether a request was routed with Smart Placement and where the Worker processed the request.
 
 The header value includes a placement type and an airport code indicating the data center location:
+
 - `remote-LHR` — The request was routed using Smart Placement to a data center near London.
 - `local-EWR` — The request was not routed using Smart Placement. The Worker ran in the default location near Newark.
 
@@ -243,10 +245,160 @@ The header value includes a placement type and an airport code indicating the da
 The `cf-placement` header may be removed before Smart Placement exits beta.
 :::
 
-## Best practices
+## Multiple Workers
 
-If you are building full-stack applications on Workers, split your front-end and back-end logic into separate Workers. Use [Service Bindings](/workers/runtime-apis/bindings/service-bindings/) to connect them.
+If you are building full-stack applications on Workers, split your edge logic (authentication, routing) and back-end logic (database queries, API calls) into separate Workers. Use [Service Bindings](/workers/runtime-apis/bindings/service-bindings/) to connect them with type-safe RPC.
 
 ![Smart Placement and Service Bindings](~/assets/images/workers/platform/smart-placement-service-bindings.png)
 
-Enable placement on your back-end Worker to invoke it close to your back-end service, while the front-end Worker serves requests close to the user. This architecture maintains fast, reactive front-ends while improving latency when the back-end Worker is called.
+Enable placement on your back-end Worker to invoke it close to your database, while the edge Worker handles authentication close to the user.
+
+### Example: Edge authentication with a placed back-end
+
+This example shows two Workers:
+
+- `auth-worker` — runs at the edge (no placement), handles authentication
+- `app-worker` — placed near your database, handles data queries
+
+<Tabs>
+<TabItem label="auth-worker">
+
+<WranglerConfig filename="auth-worker/wrangler.jsonc">
+
+```jsonc
+{
+	"name": "auth-worker",
+	"main": "src/index.ts",
+	"services": [{ "binding": "APP", "service": "app-worker" }],
+}
+```
+
+</WranglerConfig>
+
+```ts title="auth-worker/src/index.ts"
+import { AppWorker } from "../app-worker/src/index";
+
+interface Env {
+	APP: Service<AppWorker>;
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const authHeader = request.headers.get("Authorization");
+		if (!authHeader?.startsWith("Bearer ")) {
+			return new Response("Unauthorized", { status: 401 });
+		}
+
+		const userId = await validateToken(authHeader.slice(7));
+		if (!userId) {
+			return new Response("Invalid token", { status: 403 });
+		}
+
+		// Call the placed back-end Worker via RPC
+		const data = await env.APP.getUser(userId);
+		return Response.json(data);
+	},
+};
+
+async function validateToken(token: string): Promise<string | null> {
+	return token === "valid" ? "user-123" : null;
+}
+```
+
+</TabItem>
+<TabItem label="app-worker">
+
+<WranglerConfig filename="app-worker/wrangler.jsonc">
+
+```jsonc
+{
+	"name": "app-worker",
+	"main": "src/index.ts",
+	"placement": {
+		// Use one of the following options (mutually exclusive):
+		// "mode": "smart", // Cloudflare automatically places your Worker closest to the upstream with the most requests
+		"region": "aws:us-east-1", // Explicit cloud region to run your Worker closest to - e.g. "gcp:us-east4" or "aws:us-east-1"
+		// "host": "db.example.com:5432", // A host to probe (TCP/layer 4) - e.g. a database host - and place your Worker closest to
+		// "hostname": "api.example.com", // A hostname to probe (HTTP/layer 7) - e.g. an API endpoint - and place your Worker closest to
+	},
+}
+```
+
+</WranglerConfig>
+
+```ts title="app-worker/src/index.ts"
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+export default class AppWorker extends WorkerEntrypoint {
+	async fetch() {
+		return new Response(null, { status: 404 });
+	}
+
+	// Each method runs near your database - multiple queries stay fast
+	async getUser(userId: string) {
+		const user = await this.env.DB.prepare("SELECT * FROM users WHERE id = ?")
+			.bind(userId)
+			.first();
+		return user;
+	}
+
+	async getUserListings(userId: string) {
+		// Multiple round-trips to the DB are low-latency when placed nearby
+		const user = await this.env.DB.prepare("SELECT * FROM users WHERE id = ?")
+			.bind(userId)
+			.first();
+		const listings = await this.env.DB.prepare(
+			"SELECT * FROM listings WHERE owner_id = ?",
+		)
+			.bind(userId)
+			.all();
+		const reviews = await this.env.DB.prepare(
+			"SELECT * FROM reviews WHERE listing_id IN (SELECT id FROM listings WHERE owner_id = ?)",
+		)
+			.bind(userId)
+			.all();
+
+		return { user, listings: listings.results, reviews: reviews.results };
+	}
+}
+```
+
+</TabItem>
+</Tabs>
+
+The `auth-worker` runs at the edge to reject unauthorized requests quickly. Authenticated requests are forwarded via RPC to `app-worker`, which runs near your database for fast queries.
+
+### Durable Objects
+
+[Durable Objects](/durable-objects/) provide automatic placement without configuration. Queries to a Durable Object's embedded [SQLite database](/durable-objects/api/sqlite-storage-api/) are effectively [zero-latency](https://blog.cloudflare.com/sqlite-in-durable-objects/) because compute runs in the same process as the data.
+
+Do as much work as possible within the Durable Object and return a composite result, rather than making multiple round-trips from your Worker:
+
+```ts title="src/index.ts"
+import { DurableObject } from "cloudflare:workers";
+
+type Session = { id: string; user_id: string; created_at: number };
+type PromptHistory = {
+	id: string;
+	session_id: string;
+	role: string;
+	content: string;
+};
+
+export class AgentHistory extends DurableObject {
+	async getSessionContext(sessionId: string) {
+		// All queries execute with zero network latency — compute and data are colocated
+		const session = this.ctx.storage.sql
+			.exec<Session>("SELECT * FROM sessions WHERE id = ?", sessionId)
+			.one();
+		const prompts = this.ctx.storage.sql
+			.exec<PromptHistory>(
+				"SELECT * FROM prompt_history WHERE session_id = ? ORDER BY created_at",
+				sessionId,
+			)
+			.toArray();
+
+		return { session, prompts };
+	}
+}
+```

--- a/src/content/docs/workers/databases/third-party-integrations/index.mdx
+++ b/src/content/docs/workers/databases/third-party-integrations/index.mdx
@@ -1,22 +1,20 @@
 ---
 pcx_content_type: navigation
-title: 3rd Party Integrations 
+title: 3rd Party Integrations
 head: []
 description: Connect to third-party databases such as Supabase,
-  Turso and PlanetScale) 
-
+  Turso and PlanetScale)
 ---
 
-import { DirectoryListing } from "~/components"
+import { DirectoryListing } from "~/components";
 
 ## Background
 
-Connect to databases by configuring connection strings and credentials as [secrets](/workers/configuration/secrets/) in your Worker. 
+Connect to databases by configuring connection strings and credentials as [secrets](/workers/configuration/secrets/) in your Worker.
 
 :::note[Connecting to a regional database from a Worker?]
 
-
-If your Worker is connecting to a regional database, you can reduce your query latency by using [Hyperdrive](/hyperdrive) and [Smart Placement](/workers/configuration/smart-placement/) which are both included in any Workers plan. Hyperdrive will pool your databases connections globally across Cloudflare's network. Smart Placement will monitor your application to run your Workers closest to your backend infrastructure when this reduces the latency of your Worker invocations. Learn more about [how Smart Placement works](/workers/configuration/smart-placement/).
+If your Worker is connecting to a regional database, you can reduce your query latency by using [Hyperdrive](/hyperdrive) and [Smart Placement](/workers/configuration/placement/) which are both included in any Workers plan. Hyperdrive will pool your databases connections globally across Cloudflare's network. Smart Placement will monitor your application to run your Workers closest to your backend infrastructure when this reduces the latency of your Worker invocations. Learn more about [how Smart Placement works](/workers/configuration/placement/).
 :::
 
 ## Database credentials

--- a/src/content/docs/workers/index.mdx
+++ b/src/content/docs/workers/index.mdx
@@ -12,10 +12,13 @@ head:
 import { Description, RelatedProduct, LinkButton } from "~/components";
 
 <Description>
-A serverless platform for building, deploying, and scaling apps across [Cloudflare's global network](https://www.cloudflare.com/network/) with a single command  —  no infrastructure to manage, no complex configuration
+	A serverless platform for building, deploying, and scaling apps across
+	[Cloudflare's global network](https://www.cloudflare.com/network/) with a
+	single command — no infrastructure to manage, no complex configuration
 </Description>
 
 With Cloudflare Workers, you can expect to:
+
 - Deliver fast performance with high reliability anywhere in the world
 - Build full-stack apps with your framework of choice, including [React](/workers/framework-guides/web-apps/react/), [Vue](/workers/framework-guides/web-apps/vue/), [Svelte](/workers/framework-guides/web-apps/sveltekit/), [Next](/workers/framework-guides/web-apps/nextjs/), [Astro](/workers/framework-guides/web-apps/astro/), [React Router](/workers/framework-guides/web-apps/react-router/), [and more](/workers/framework-guides/)
 - Use your preferred language, including [JavaScript](/workers/languages/javascript/), [TypeScript](/workers/languages/typescript/), [Python](/workers/languages/python/), [Rust](/workers/languages/rust/), [and more](/workers/runtime-apis/webassembly/)
@@ -24,11 +27,12 @@ With Cloudflare Workers, you can expect to:
 
 Get started with your first project:
 
-<LinkButton href="https://dash.cloudflare.com/?to=/:account/workers-and-pages/templates">Deploy a template</LinkButton>
-
+<LinkButton href="https://dash.cloudflare.com/?to=/:account/workers-and-pages/templates">
+	Deploy a template
+</LinkButton>
 
 <LinkButton href="/workers/get-started/guide/" variant="minimal">
-  Deploy with Wrangler CLI
+	Deploy with Wrangler CLI
 </LinkButton>
 
 ---
@@ -44,7 +48,7 @@ Get started with your first project:
 <div>
 #### Back-end applications
 
-<span>Build APIs and connect to data stores with [Smart Placement](/workers/configuration/smart-placement/) to optimize latency</span>
+<span>Build APIs and connect to data stores with [Smart Placement](/workers/configuration/placement/) to optimize latency</span>
 </div>
 
 <div>
@@ -148,7 +152,6 @@ Global caching for high-performance, low-latency delivery.
 Streamlined image infrastructure from a single API.
 
 </RelatedProduct>
-
 
 ---
 

--- a/src/content/docs/workers/observability/metrics-and-analytics.mdx
+++ b/src/content/docs/workers/observability/metrics-and-analytics.mdx
@@ -109,7 +109,7 @@ To further investigate exceptions, use [`wrangler tail`](/workers/wrangler/comma
 
 ### Request duration
 
-The request duration chart shows how long it took your Worker to respond to requests, including code execution and time spent waiting on I/O. The request duration chart is currently only available when your Worker has [Smart Placement](/workers/configuration/smart-placement) enabled.
+The request duration chart shows how long it took your Worker to respond to requests, including code execution and time spent waiting on I/O. The request duration chart is currently only available when your Worker has [Smart Placement](/workers/configuration/placement/) enabled.
 
 In contrast to [execution duration](/workers/observability/metrics-and-analytics/#execution-duration-gb-seconds), which measures only the time a Worker is active, request duration measures from the time a request comes into a data center until a response is delivered.
 

--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/index.mdx
@@ -7,7 +7,6 @@ head:
   - tag: title
     content: Service bindings - Runtime APIs
 description: Facilitate Worker-to-Worker communication.
-
 ---
 
 import { WranglerConfig } from "~/components";
@@ -18,7 +17,7 @@ Service bindings allow one Worker to call into another, without going through a 
 
 Service bindings provide the separation of concerns that microservice or service-oriented architectures provide, without configuration pain, performance overhead or need to learn RPC protocols.
 
-- **Service bindings are fast.** When you use Service Bindings, there is zero overhead or added latency. By default, both Workers run on the same thread of the same Cloudflare server. And when you enable [Smart Placement](/workers/configuration/smart-placement/), each Worker runs in the optimal location for overall performance.
+- **Service bindings are fast.** When you use Service Bindings, there is zero overhead or added latency. By default, both Workers run on the same thread of the same Cloudflare server. And when you enable [Smart Placement](/workers/configuration/placement/), each Worker runs in the optimal location for overall performance.
 - **Service bindings are not just HTTP.** Worker A can expose methods that can be directly called by Worker B. Communicating between services only requires writing JavaScript methods and classes.
 - **Service bindings don't increase costs.** You can split apart functionality into multiple Workers, without incurring additional costs. Learn more about [pricing for Service Bindings](/workers/platform/pricing/#service-bindings).
 
@@ -26,9 +25,9 @@ Service bindings provide the separation of concerns that microservice or service
 
 Service bindings are commonly used to:
 
-* **Provide a shared internal service to multiple Workers.** For example, you can deploy an authentication service as its own Worker, and then have any number of separate Workers communicate with it via Service bindings.
-* **Isolate services from the public Internet.** You can deploy a Worker that is not reachable via the public Internet, and can only be reached via an explicit Service binding that another Worker declares.
-* **Allow teams to deploy code independently.** Team A can deploy their Worker on their own release schedule, and Team B can deploy their Worker separately.
+- **Provide a shared internal service to multiple Workers.** For example, you can deploy an authentication service as its own Worker, and then have any number of separate Workers communicate with it via Service bindings.
+- **Isolate services from the public Internet.** You can deploy a Worker that is not reachable via the public Internet, and can only be reached via an explicit Service binding that another Worker declares.
+- **Allow teams to deploy code independently.** Team A can deploy their Worker on their own release schedule, and Team B can deploy their Worker separately.
 
 ## Configuration
 
@@ -46,8 +45,8 @@ services = [
 
 </WranglerConfig>
 
-* `binding`: The name of the key you want to expose on the `env` object.
-* `service`: The name of the target Worker you would like to communicate with. This Worker must be on your Cloudflare account.
+- `binding`: The name of the key you want to expose on the `env` object.
+- `service`: The name of the target Worker you would like to communicate with. This Worker must be on your Cloudflare account.
 
 ## Interfaces
 
@@ -60,7 +59,6 @@ Worker A that declares a Service binding to Worker B can call Worker B in two di
 
 This example [extends the `WorkerEntrypoint` class](/workers/runtime-apis/bindings/service-bindings/rpc/#the-workerentrypoint-class) to support RPC-based Service bindings.
 First, create the Worker that you want to communicate with. Let's call this "Worker B". Worker B exposes the public method, `add(a, b)`:
-
 
 <WranglerConfig>
 
@@ -75,16 +73,18 @@ main = "./src/workerB.js"
 import { WorkerEntrypoint } from "cloudflare:workers";
 
 export default class WorkerB extends WorkerEntrypoint {
-  // Currently, entrypoints without a named handler are not supported
-  async fetch() { return new Response(null, {status: 404}); }
+	// Currently, entrypoints without a named handler are not supported
+	async fetch() {
+		return new Response(null, { status: 404 });
+	}
 
-  async add(a, b) { return a + b; }
+	async add(a, b) {
+		return a + b;
+	}
 }
 ```
 
 Next, create the Worker that will call Worker B. Let's call this "Worker A". Worker A declares a binding to Worker B. This is what gives it permission to call public methods on Worker B.
-
-
 
 <WranglerConfig>
 
@@ -100,11 +100,11 @@ services = [
 
 ```js
 export default {
-  async fetch(request, env) {
-    const result = await env.WORKER_B.add(1, 2);
-    return new Response(result);
-  }
-}
+	async fetch(request, env) {
+		const result = await env.WORKER_B.add(1, 2);
+		return new Response(result);
+	},
+};
 ```
 
 To run both Worker A and Worker B in local development, you must run two instances of [Wrangler](/workers/wrangler) in your terminal. For each Worker, open a new terminal and run [`npx wrangler@latest dev`](/workers/wrangler/commands#dev).
@@ -137,6 +137,7 @@ Wrangler also supports running multiple Workers at once with one command. To try
 Support for running multiple Workers at once with one Wrangler command is experimental, and subject to change as we work on the experience. If you run into bugs or have any feedback, [open an issue on the workers-sdk repository](https://github.com/cloudflare/workers-sdk/issues/new)
 
 :::
+
 ## Deployment
 
 Workers using Service bindings are deployed separately.
@@ -145,24 +146,24 @@ When getting started and deploying for the first time, this means that the targe
 
 When making changes to existing Workers, in most cases you should:
 
-* Deploy changes to Worker B first, in a way that is compatible with the existing Worker A. For example, add a new method to Worker B.
-* Next, deploy changes to Worker A. For example, call the new method on Worker B, from Worker A.
-* Finally, remove any unused code. For example, delete the previously used method on Worker B.
+- Deploy changes to Worker B first, in a way that is compatible with the existing Worker A. For example, add a new method to Worker B.
+- Next, deploy changes to Worker A. For example, call the new method on Worker B, from Worker A.
+- Finally, remove any unused code. For example, delete the previously used method on Worker B.
 
 ## Smart Placement
 
-[Smart Placement](/workers/configuration/smart-placement) automatically places your Worker in an optimal location that minimizes latency.
+[Smart Placement](/workers/configuration/placement/) automatically places your Worker in an optimal location that minimizes latency.
 
 You can use Smart Placement together with Service bindings to split your Worker into two services:
 
 ![Smart Placement and Service Bindings](~/assets/images/workers/platform/smart-placement-service-bindings.png)
 
-Refer to the [docs on Smart Placement](/workers/configuration/smart-placement/#best-practices) for more.
+Refer to the [docs on Smart Placement](/workers/configuration/placement/#multiple-workers) for more.
 
 ## Limits
 
 Service bindings have the following limits:
 
-* Each request to a Worker via a Service binding counts toward your [subrequest limit](/workers/platform/limits/#subrequests).
-* A single request has a maximum of 32 Worker invocations, and each call to a Service binding counts towards this limit. Subsequent calls will throw an exception.
-* Calling a service binding does not count towards [simultaneous open connection limits](/workers/platform/limits/#simultaneous-open-connections)
+- Each request to a Worker via a Service binding counts toward your [subrequest limit](/workers/platform/limits/#subrequests).
+- A single request has a maximum of 32 Worker invocations, and each call to a Service binding counts towards this limit. Subsequent calls will throw an exception.
+- Calling a service binding does not count towards [simultaneous open connection limits](/workers/platform/limits/#simultaneous-open-connections)

--- a/src/content/docs/workers/runtime-apis/rpc/index.mdx
+++ b/src/content/docs/workers/runtime-apis/rpc/index.mdx
@@ -184,7 +184,7 @@ await counter.increment();
 
 </TypeScriptExample>
 
-But consider the case where the Worker service that you are calling may be far away across the network, as in the case of [Smart Placement](/workers/runtime-apis/bindings/service-bindings/#smart-placement) or [Durable Objects](/durable-objects). The code above makes two round trips, once when calling `getCounter()`, and again when calling `.increment()`. We'd like to avoid this.
+But consider the case where the Worker service that you are calling may be far away across the network, as in the case of [Smart Placement](/workers/configuration/placement/) or [Durable Objects](/durable-objects). The code above makes two round trips, once when calling `getCounter()`, and again when calling `.increment()`. We'd like to avoid this.
 
 With most RPC systems, the only way to avoid the problem would be to combine the two calls into a single "batch" call, perhaps called `getCounterAndIncrement()`. However, this makes the interface worse. You wouldn't design a local interface this way.
 
@@ -285,7 +285,7 @@ In this video, we explore how Cloudflare Workers support Remote Procedure Calls 
 
 ## Limitations
 
-- [Smart Placement](/workers/configuration/smart-placement/) is currently ignored when making RPC calls. If Smart Placement is enabled for Worker A, and Worker B declares a [Service Binding](/workers/runtime-apis/bindings) to it, when Worker B calls Worker A via RPC, Worker A will run locally, on the same machine.
+- [Smart Placement](/workers/configuration/placement/) is currently ignored when making RPC calls. If Smart Placement is enabled for Worker A, and Worker B declares a [Service Binding](/workers/runtime-apis/bindings) to it, when Worker B calls Worker A via RPC, Worker A will run locally, on the same machine.
 
 - The maximum serialized RPC limit is 32 MiB. Consider using [`ReadableStream`](/workers/runtime-apis/streams/readablestream/) when returning more data.
 

--- a/src/content/docs/workers/static-assets/binding.mdx
+++ b/src/content/docs/workers/static-assets/binding.mdx
@@ -194,7 +194,7 @@ For the various static asset routing configuration options, refer to [Routing](/
 
 ## Smart Placement
 
-[Smart Placement](/workers/configuration/smart-placement/) can be used to place a Worker's code close to your back-end infrastructure. Smart Placement will only have an effect if you specified a `main`, pointing to your Worker code.
+[Smart Placement](/workers/configuration/placement/) can be used to place a Worker's code close to your back-end infrastructure. Smart Placement will only have an effect if you specified a `main`, pointing to your Worker code.
 
 ### Smart Placement with Worker Code First
 
@@ -202,7 +202,7 @@ If you desire to run your [Worker code ahead of assets](/workers/static-assets/r
 
 Use Smart Placement with `run_worker_first=true` when you need to integrate with other backend services, authenticate requests before serving any assets, or if your want to make modifications to your assets before serving them.
 
-If you want some assets served as quickly as possible to the user, but others to be served behind a smart-placed Worker, considering splitting your app into multiple Workers and [using service bindings to connect them](/workers/configuration/smart-placement/#best-practices).
+If you want some assets served as quickly as possible to the user, but others to be served behind a smart-placed Worker, considering splitting your app into multiple Workers and [using service bindings to connect them](/workers/configuration/placement/#multiple-workers).
 
 ### Smart Placement with Assets First
 

--- a/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
+++ b/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
@@ -272,7 +272,7 @@ Pages automatically provided [an `ASSETS` binding](/pages/functions/api-referenc
 
 #### Runtime
 
-If you had customized [placement](/workers/configuration/smart-placement/), or set a [compatibility date](/workers/configuration/compatibility-dates/) or any [compatibility flags](/workers/configuration/compatibility-flags/) in your Pages project, you can define the same in your Wrangler configuration file:
+If you had customized [placement](/workers/configuration/placement/), or set a [compatibility date](/workers/configuration/compatibility-dates/) or any [compatibility flags](/workers/configuration/compatibility-flags/) in your Pages project, you can define the same in your Wrangler configuration file:
 
 <WranglerConfig>
 
@@ -422,7 +422,7 @@ This compatibility matrix compares the features of Workers and Pages. Unless oth
 | [Custom HTTP headers for static assets](/workers/static-assets/headers/)                                    | ✅      | ✅      |
 | [Middleware](/workers/static-assets/binding/#run_worker_first)                                              | ✅ [^1] | ✅      |
 | [Redirects](/workers/static-assets/redirects/)                                                              | ✅      | ✅      |
-| [Smart Placement](/workers/configuration/smart-placement/)                                                  | ✅      | ✅      |
+| [Smart Placement](/workers/configuration/placement/)                                                        | ✅      | ✅      |
 | [Serve assets on a path](/workers/static-assets/routing/advanced/serving-a-subdirectory/)                   | ✅      | ❌      |
 | **Observability**                                                                                           |         |         |
 | [Workers Logs](/workers/observability/)                                                                     | ✅      | ❌      |

--- a/src/content/docs/workers/static-assets/routing/worker-script.mdx
+++ b/src/content/docs/workers/static-assets/routing/worker-script.mdx
@@ -19,7 +19,7 @@ This allows you to easily combine together these two features to create powerful
 You can configure the [`assets.run_worker_first` setting](/workers/static-assets/binding/#run_worker_first) to control when your Worker script runs relative to static asset serving. This gives you more control over exactly how and when those assets are served and can be used to implement "middleware" for requests.
 
 :::caution
-If you are using [Smart Placement](/workers/configuration/smart-placement/) in combination with `assets.run_worker_first`, you may find that placement decisions are not optimized correctly as, currently, the entire Worker script is placed as a single unit. This may not accurately reflect the desired "split" in behavior of edge-first vs. smart-placed compute for your application. This is a limitation that we are currently working to resolve.
+If you are using [Smart Placement](/workers/configuration/placement/) in combination with `assets.run_worker_first`, you may find that placement decisions are not optimized correctly as, currently, the entire Worker script is placed as a single unit. This may not accurately reflect the desired "split" in behavior of edge-first vs. smart-placed compute for your application. This is a limitation that we are currently working to resolve.
 :::
 
 ### Run Worker before each request
@@ -71,6 +71,7 @@ export default class extends WorkerEntrypoint<Env> {
 	}
 }
 ```
+
 </TypeScriptExample>
 
 ### Run Worker first for selective paths
@@ -114,11 +115,12 @@ export default class extends WorkerEntrypoint<Env> {
 		// Redirect back to the index, but set a cookie that the front-end will use.
 		return new Response(null, {
 			headers: {
-				"Location": "/",
-				"Set-Cookie": `session_token=${sessionIdentifier}; HttpOnly; Secure; SameSite=Lax; Path=/`
-			}
+				Location: "/",
+				"Set-Cookie": `session_token=${sessionIdentifier}; HttpOnly; Secure; SameSite=Lax; Path=/`,
+			},
 		});
 	}
 }
 ```
+
 </TypeScriptExample>

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -221,7 +221,7 @@ The `main` key is optional for assets-only Workers.
   - Maps a Durable Object from a class name to a runtime state. This communicates changes to the Durable Object (creation / deletion / rename / transfer) to the Workers runtime and provides the runtime with instructions on how to deal with those changes. Refer to [Durable Objects migrations](/durable-objects/reference/durable-objects-migrations/#durable-object-migrations-in-wranglertoml).
 
 * `placement` <Type text="object"/> <MetaInfo text="optional"/>
-  - Configures where your Worker runs to minimize latency to back-end services. Refer to [Placement](/workers/configuration/smart-placement/).
+  - Configures where your Worker runs to minimize latency to back-end services. Refer to [Placement](/workers/configuration/placement/).
   - `mode` <Type text="string"/> — Set to `"smart"` to automatically place your Worker near back-end services based on observed latency.
   - `region` <Type text="string"/> — Specify a cloud region (for example, `"aws:us-east-1"`, `"gcp:europe-west1"`, or `"azure:westeurope"`) to place your Worker near infrastructure in that region.
   - `host` <Type text="string"/> — Specify a hostname and port for a single-homed layer 4 service (for example, `"my_database_host.com:5432"`) to place your Worker near that service.

--- a/src/content/partials/durable-objects/durable-objects-vs-d1.mdx
+++ b/src/content/partials/durable-objects/durable-objects-vs-d1.mdx
@@ -12,7 +12,7 @@ D1 fits into a familiar architecture for developers, where application servers c
 
 D1 aims for a "batteries included" feature set, including the above HTTP API, [database schema management](/d1/reference/migrations/#_top), [data import/export](/d1/best-practices/import-export-data/), and [database query insights](/d1/observability/metrics-analytics/#query-insights).
 
-With D1, your application code and SQL database queries are not colocated which can impact application performance. If performance is a concern with D1, Workers has [Smart Placement](/workers/configuration/smart-placement/#_top) to dynamically run your Worker in the best location to reduce total Worker request latency, considering everything your Worker talks to, including D1.
+With D1, your application code and SQL database queries are not colocated which can impact application performance. If performance is a concern with D1, Workers has [Smart Placement](/workers/configuration/placement/#_top) to dynamically run your Worker in the best location to reduce total Worker request latency, considering everything your Worker talks to, including D1.
 
 **SQLite in Durable Objects is a lower-level compute with storage building block for distributed systems.**
 

--- a/src/content/partials/hyperdrive/placement-hint-partial.mdx
+++ b/src/content/partials/hyperdrive/placement-hint-partial.mdx
@@ -1,0 +1,19 @@
+---
+{}
+---
+
+:::note[Reduce latency with Placement]
+
+If your Worker makes **multiple sequential queries** per request, use [Placement](/workers/configuration/placement/) to run your Worker close to your database. Each query adds round-trip latency: 20-30ms from a distant region, or 1-3ms when placed nearby. Multiple queries compound this difference.
+
+If your Worker makes only one query per request, placement does not improve end-to-end latency. The total round-trip time is the same whether it happens near the user or near the database.
+
+```jsonc title="wrangler.jsonc"
+{
+	"placement": {
+		"region": "aws:us-east-1", // Match your database region, for example "gcp:us-east4" or "azure:eastus"
+	},
+}
+```
+
+:::

--- a/src/content/partials/hyperdrive/planetscale-placement-partial.mdx
+++ b/src/content/partials/hyperdrive/planetscale-placement-partial.mdx
@@ -4,7 +4,7 @@
 
 :::note
 
-To reduce latency, use a [Placement Hint](/workers/configuration/smart-placement/#use-placement-hints) to run your Worker close to your PlanetScale database. This is especially useful when a single request makes multiple queries.
+To reduce latency, use a [Placement Hint](/workers/configuration/placement/#use-placement-hints) to run your Worker close to your PlanetScale database. This is especially useful when a single request makes multiple queries.
 
 ```jsonc title="wrangler.jsonc"
 {

--- a/src/content/release-notes/pages.yaml
+++ b/src/content/release-notes/pages.yaml
@@ -66,7 +66,7 @@ entries:
   - publish_date: "2023-05-16"
     title: Support for Smart Placement
     description: |-
-      * [Smart placement](/workers/configuration/smart-placement/) can now be enabled for Pages within your Pages Project by going to **Settings** > [**Functions**](https://dash.cloudflare.com?to=/:account/pages/view/:pages-project/settings/functions).
+      * [Smart placement](/workers/configuration/placement/) can now be enabled for Pages within your Pages Project by going to **Settings** > [**Functions**](https://dash.cloudflare.com?to=/:account/pages/view/:pages-project/settings/functions).
   - publish_date: "2023-03-23"
     title: Git projects can now see files uploaded
     description: |-

--- a/src/content/release-notes/workers.yaml
+++ b/src/content/release-notes/workers.yaml
@@ -77,7 +77,7 @@ entries:
       - [Workers Builds](/workers/ci-cd/builds/) now supports building projects that use **pnpm 10** as the package manager. If your build previously failed due to this unsupported version, retry your build. No config changes needed.
   - publish_date: "2025-02-13"
     description: |-
-      - [Smart Placement](/workers/configuration/smart-placement/) no longer runs Workers in the same location as D1 databases they are bound to. The same [placement logic](/workers/configuration/smart-placement/#understand-how-smart-placement-works) now applies to all Workers that use Smart Placement, regardless of whether they use D1 bindings.
+      - [Smart Placement](/workers/configuration/placement/) no longer runs Workers in the same location as D1 databases they are bound to. The same [placement logic](/workers/configuration/placement/#understand-how-smart-placement-works) now applies to all Workers that use Smart Placement, regardless of whether they use D1 bindings.
   - publish_date: "2025-02-11"
     description: |-
       - When Workers generate an "internal error" exception in response to certain failures, the exception message may provide a reference ID that customers can include in support communication for easier error identification.  For example, an exception with the new message might look like: `internal error; reference = 0123456789abcdefghijklmn`.
@@ -175,7 +175,7 @@ entries:
       - Blob and Body objects now include a new `bytes()` method, reflecting [recent](https://w3c.github.io/FileAPI/#bytes-method-algo) [additions](https://fetch.spec.whatwg.org/#dom-body-bytes) to web standards.
   - publish_date: "2024-06-03"
     description: |-
-      - Workers with [Smart Placement](/workers/configuration/smart-placement/) enabled now support [Gradual Deployments](/workers/configuration/versions-and-deployments/gradual-deployments/).
+      - Workers with [Smart Placement](/workers/configuration/placement/) enabled now support [Gradual Deployments](/workers/configuration/versions-and-deployments/gradual-deployments/).
   - publish_date: "2024-05-17"
     description: |-
       - Updated v8 to version 12.6.


### PR DESCRIPTION
Improves the recently updated placement docs:

- Just /placement/ (including all incoming links + set up a redirect)
- Expand on how to use Service Bindings to communicate across two Workers
- How Durable Objects work here
- Updated Hyperdrive docs with similar guidance 