### PR TITLE
[Workers] Fix directory name typo in Vite plugin tutorial

### DIFF
--- a/src/content/docs/workers/vite-plugin/tutorial.mdx
+++ b/src/content/docs/workers/vite-plugin/tutorial.mdx
@@ -265,7 +265,7 @@ npm run build
 If you inspect the `dist` directory, you will see that it contains two subdirectories:
 
 - `client` - the client code that runs in the browser
-- `cloudflare-vite-tutorial` - the Worker code alongside the output `wrangler.json` configuration file
+- `cloudflare_vite_tutorial` - the Worker code alongside the output `wrangler.json` configuration file
 
 ### Preview your application
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

The documented directory name did not match the actual output in `dist`.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

<img width="213" height="145" alt="image" src="https://github.com/user-attachments/assets/ef0d4610-2a03-476d-8df3-d3cf6711393b" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
