### PR TITLE
Fix has_value() example variable http.request.headers.names

### DIFF
--- a/src/content/docs/ruleset-engine/rules-language/functions.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/functions.mdx
@@ -227,10 +227,10 @@ Examples:
 
 ```txt
 # Check if there is an HTTP request header with the exact name 'X-My-Header'
-has_value(http.request.headers.name, "X-My-Header")
+has_value(http.request.headers.names, "X-My-Header")
 
 # Check if there is a request header with the exact name provided as the first query argument:
-has_value(http.request.headers.name, http.request.uri.args.names[0])
+has_value(http.request.headers.names, http.request.uri.args.names[0])
 ```
 
 ### `len`


### PR DESCRIPTION

### Summary

Missing `s` in variable name.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/)
