### PR TITLE
Workers VPC: make binding names match on overview page

### DIFF
--- a/src/content/docs/workers-vpc/index.mdx
+++ b/src/content/docs/workers-vpc/index.mdx
@@ -69,7 +69,7 @@ export default {
 		"compatibility_date": "2025-02-04",
 		"vpc_services": [
 			{
-				"binding": "VPC_SERVICE",
+				"binding": "PRIVATE_API",
 				"service_id": "ENTER_SERVICE_ID",
 				"remote": true
 			}


### PR DESCRIPTION
### Summary

On the Workers VPC Overview page, there is a mismatch between binding name on the Example wrangler.json and index.ts.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
