### PR TITLE
Switch to relative file loader path to accommodate Windows for middlecache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
               -not -name '*.yml' \
               -not -name '*.yaml' \
               -not -name '*.txt' \
-              -not -name 'collections/.*'
+              -not -name 'src/content/collections/.*'
           )
 
           if [ -n "$FILES" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
               -not -name '*.yml' \
               -not -name '*.yaml' \
               -not -name '*.txt' \
-              -not -name 'collection.*'
+              -not -name 'collections/.*'
           )
 
           if [ -n "$FILES" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
               -not -name '*.yml' \
               -not -name '*.yaml' \
               -not -name '*.txt' \
-              -not -name 'src/content/collections/.*'
+              -not -name 'src/content/collections/*'
           )
 
           if [ -n "$FILES" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
               -not -name '*.yml' \
               -not -name '*.yaml' \
               -not -name '*.txt' \
-              -not -name 'src/content/collections/*'
+              -not -wholename 'src/content/collections/*'
           )
 
           if [ -n "$FILES" ]; then

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,7 +5,7 @@ import { docsSchema, i18nSchema } from "@astrojs/starlight/schema";
 
 import { glob, file } from "astro/loaders";
 
-import { productAvailabilityCollectionConfig } from "./content/collection.product-availability";
+import { productAvailabilityCollectionConfig } from "./content/collections/product-availability";
 
 import {
 	appsSchema,

--- a/src/content/collections/product-availability.ts
+++ b/src/content/collections/product-availability.ts
@@ -1,6 +1,6 @@
 import { z } from "astro/zod";
 
-import { middlecacheLoader } from "../util/custom-loaders";
+import { middlecacheLoader } from "../../util/custom-loaders";
 
 const productAvailabilityCollectionSchema = z.string().nullable();
 

--- a/src/util/custom-loaders.ts
+++ b/src/util/custom-loaders.ts
@@ -5,7 +5,8 @@ import { file } from "astro/loaders";
 
 import { fileURLToPath } from "node:url";
 import fs from "fs";
-import { dirname } from "path";
+//import path from "path";
+import { dirname, join } from "path";
 
 /**
  * middlecache loader expects a middlecache path
@@ -34,9 +35,12 @@ export function middlecacheLoader(
 			let middlecacheBaseUrl = "https://middlecache.ced.cloudflare.com/";
 			if (options.url) middlecacheBaseUrl = options.url;
 
+			const pathParts = path.split('/');
+			const universalPath = join(...pathParts)
+
 			const tmpPath = fileURLToPath(new URL("../../.tmp", import.meta.url));
 
-			const destination = `${tmpPath}/middlecache/${path}`;
+			const destination = join( tmpPath,'middlecache', universalPath );
 
 			context.logger.debug(`Remote to local load from: ${destination}`);
 

--- a/src/util/custom-loaders.ts
+++ b/src/util/custom-loaders.ts
@@ -56,7 +56,9 @@ export function middlecacheLoader(
 				context.logger.debug(`Download of ${path} completed.`);
 			}
 
-			const fileLoader = file(destination, options as any);
+
+			const fileLoader = file(`.tmp/middlecache/${path}`, options as any);
+
 			// re-use all the functionality of the built-in file loader
 			return await fileLoader.load(context);
 		},

--- a/src/util/custom-loaders.ts
+++ b/src/util/custom-loaders.ts
@@ -5,7 +5,6 @@ import { file } from "astro/loaders";
 
 import { fileURLToPath } from "node:url";
 import fs from "fs";
-//import path from "path";
 import { dirname, join } from "path";
 
 /**
@@ -35,12 +34,12 @@ export function middlecacheLoader(
 			let middlecacheBaseUrl = "https://middlecache.ced.cloudflare.com/";
 			if (options.url) middlecacheBaseUrl = options.url;
 
-			const pathParts = path.split('/');
-			const universalPath = join(...pathParts)
+			const pathParts = path.split("/");
+			const universalPath = join(...pathParts);
 
 			const tmpPath = fileURLToPath(new URL("../../.tmp", import.meta.url));
 
-			const destination = join( tmpPath,'middlecache', universalPath );
+			const destination = join(tmpPath, "middlecache", universalPath);
 
 			context.logger.debug(`Remote to local load from: ${destination}`);
 
@@ -55,7 +54,6 @@ export function middlecacheLoader(
 				fs.writeFileSync(destination, content);
 				context.logger.debug(`Download of ${path} completed.`);
 			}
-
 
 			const fileLoader = file(`.tmp/middlecache/${path}`, options as any);
 


### PR DESCRIPTION
- Use file system independent directory separator functions
- Switch to relative path parameter for file loader to accommodate Windows
- Move new content collections to `src/content/collections` path