### PR TITLE
sandbox: update Dockerfile docs to reflect SDK v0.7.0 changes

### DIFF
--- a/src/content/docs/sandbox/configuration/dockerfile.mdx
+++ b/src/content/docs/sandbox/configuration/dockerfile.mdx
@@ -7,37 +7,63 @@ sidebar:
 
 Customize the sandbox container image with your own packages, tools, and configurations by extending the base runtime image.
 
-## Base image
+## Base images
 
-The Sandbox SDK uses a Ubuntu-based Linux container with Python, Node.js (via Bun), and common development tools pre-installed:
+The Sandbox SDK provides multiple Ubuntu-based image variants. Choose the one that fits your use case:
+
+| Image    | Tag suffix  | Use case                                       |
+| -------- | ----------- | ---------------------------------------------- |
+| Default  | (none)      | Lean image for JavaScript/TypeScript workloads |
+| Python   | `-python`   | Data science, ML, Python code execution        |
+| OpenCode | `-opencode` | AI coding agents with OpenCode CLI             |
 
 ```dockerfile
-FROM docker.io/cloudflare/sandbox:0.3.3
+# Default - lean, no Python
+FROM docker.io/cloudflare/sandbox:0.7.0
+
+# Python - includes Python 3.11 + data science packages
+FROM docker.io/cloudflare/sandbox:0.7.0-python
+
+# OpenCode - includes OpenCode CLI for AI coding
+FROM docker.io/cloudflare/sandbox:0.7.0-opencode
 ```
 
 :::caution[Version synchronization required]
-Always match the Docker image version to your npm package version. If you're using `@cloudflare/sandbox@0.3.3`, use `docker.io/cloudflare/sandbox:0.3.3` as your base image.
+Always match the Docker image version to your npm package version. If you're using `@cloudflare/sandbox@0.7.0`, use `docker.io/cloudflare/sandbox:0.7.0` (or variant) as your base image.
 
 **Why this matters**: The SDK automatically checks version compatibility on startup. Mismatched versions can cause features to break or behave unexpectedly. If versions don't match, you'll see warnings in your logs.
 
 See [Version compatibility](/sandbox/concepts/sandboxes/#version-compatibility) for troubleshooting version mismatch warnings.
 :::
 
-**What's included:**
+### Default image
+
+The default image is optimized for JavaScript and TypeScript workloads:
 
 - Ubuntu 22.04 LTS base
-- Python 3.11.14 with pip and venv
 - Node.js 20 LTS with npm
 - Bun 1.x (JavaScript/TypeScript runtime)
-- Pre-installed Python packages: matplotlib, numpy, pandas, ipython
 - System utilities: curl, wget, git, jq, zip, unzip, file, procps, ca-certificates
+
+### Python image
+
+The `-python` variant includes everything in the default image plus:
+
+- Python 3.11 with pip and venv
+- Pre-installed packages: matplotlib, numpy, pandas, ipython
+
+### OpenCode image
+
+The `-opencode` variant includes everything in the default image plus:
+
+- [OpenCode CLI](https://opencode.ai) for AI-powered coding agents
 
 ## Creating a custom image
 
 Create a `Dockerfile` in your project root:
 
 ```dockerfile title="Dockerfile"
-FROM docker.io/cloudflare/sandbox:0.3.3
+FROM docker.io/cloudflare/sandbox:0.7.0-python
 
 # Install additional Python packages
 RUN pip install --no-cache-dir \
@@ -70,16 +96,48 @@ Update `wrangler.jsonc` to reference your Dockerfile:
 
 When you run `wrangler dev` or `wrangler deploy`, Wrangler automatically builds your Docker image and pushes it to Cloudflare's container registry. You don't need to manually build or publish images.
 
-## Custom startup scripts
+## Using arbitrary base images
 
-Run services automatically when the container starts by creating a custom startup script:
+You can add sandbox capabilities to any Docker image using the standalone binary. This approach lets you use your existing images without depending on the Cloudflare base images:
 
 ```dockerfile title="Dockerfile"
-FROM docker.io/cloudflare/sandbox:0.3.3
+FROM your-custom-image:tag
+
+# Copy the sandbox binary from the official image
+COPY --from=docker.io/cloudflare/sandbox:0.7.0 /container-server/sandbox /sandbox
+
+ENTRYPOINT ["/sandbox"]
+```
+
+The `/sandbox` binary starts the HTTP API server that enables SDK communication. You can optionally run your own startup command:
+
+```dockerfile title="Dockerfile"
+FROM node:20-slim
+
+COPY --from=docker.io/cloudflare/sandbox:0.7.0 /container-server/sandbox /sandbox
+
+# Copy your application
+COPY . /app
+WORKDIR /app
+
+ENTRYPOINT ["/sandbox"]
+CMD ["node", "server.js"]
+```
+
+When using `CMD`, the sandbox binary runs your command as a child process with proper signal forwarding.
+
+## Custom startup scripts
+
+For more complex startup sequences, create a custom startup script:
+
+```dockerfile title="Dockerfile"
+FROM docker.io/cloudflare/sandbox:0.7.0-python
 
 COPY my-app.js /workspace/my-app.js
 COPY startup.sh /workspace/startup.sh
 RUN chmod +x /workspace/startup.sh
+
+ENTRYPOINT ["/sandbox"]
 CMD ["/workspace/startup.sh"]
 ```
 
@@ -89,28 +147,21 @@ CMD ["/workspace/startup.sh"]
 # Start your services in the background
 node /workspace/my-app.js &
 
-# Must end with this command
-exec bun /container-server/dist/index.js
-```
-
-Your startup script must end with `exec bun /container-server/dist/index.js` to start the SDK's control plane.
-
-### Multiple services
-
-```bash title="startup.sh"
-#!/bin/bash
-
+# Start additional services
 redis-server --daemonize yes
 until redis-cli ping; do sleep 1; done
 
-node /workspace/api-server.js &
-
-exec bun /container-server/dist/index.js
+# Keep the script running (the sandbox binary handles the API server)
+wait
 ```
+
+:::note[Legacy startup scripts]
+If you have existing startup scripts that end with `exec bun /container-server/dist/index.js`, they will continue to work for backwards compatibility. However, we recommend migrating to the new approach using `ENTRYPOINT ["/sandbox"]` with `CMD` for your startup script.
+:::
 
 ## Related resources
 
-- [Image Management](/containers/platform-details/image-management/) - Building and pushing images to Cloudflare\'s registry
+- [Image Management](/containers/platform-details/image-management/) - Building and pushing images to Cloudflare's registry
 - [Wrangler configuration](/sandbox/configuration/wrangler/) - Using custom images in wrangler.jsonc
 - [Docker documentation](https://docs.docker.com/reference/dockerfile/) - Complete Dockerfile syntax
 - [Container concepts](/sandbox/concepts/containers/) - Understanding the runtime environment


### PR DESCRIPTION
## Summary

Updates the Sandbox Dockerfile reference documentation to align with the latest SDK changes (v0.7.0).

- Update version references from 0.3.3 to 0.7.0
- Document new image variants (default, python, opencode)
- Add standalone binary approach for arbitrary base images
- Update startup script guidance to use new `/sandbox` entrypoint
- Clarify that Python is only available in the `-python` variant

## Context

The current docs reference SDK version 0.3.3, but the SDK is now at v0.7.0 with significant changes:
- Multiple image variants instead of a single image
- New standalone binary for adding sandbox to any Dockerfile
- New entrypoint approach replacing the old `exec bun /container-server/dist/index.js`

Reference: https://github.com/cloudflare/sandbox-sdk