### PR TITLE
sandbox: update docs to reflect SDK v0.7.0 API changes

### DIFF
--- a/src/content/docs/sandbox/api/commands.mdx
+++ b/src/content/docs/sandbox/api/commands.mdx
@@ -106,6 +106,7 @@ const process = await sandbox.startProcess(command: string, options?: ProcessOpt
 - `getLogs()` - Get accumulated logs
 - `waitForPort()` - Wait for process to listen on a port
 - `waitForLog()` - Wait for pattern in process output
+- `waitForExit()` - Wait for process to terminate and return exit code
 
 <TypeScriptExample>
 ```
@@ -315,6 +316,36 @@ await server.waitForLog('Ready', 30000);
 **Throws**:
 - `ProcessReadyTimeoutError` - If pattern is not found within timeout
 - `ProcessExitedBeforeReadyError` - If process exits before pattern appears
+
+### `process.waitForExit()`
+
+Wait for a process to terminate and return the exit code.
+
+```ts
+const result = await process.waitForExit(timeout?: number): Promise<WaitForExitResult>
+```
+
+**Parameters**:
+- `timeout` - Maximum wait time in milliseconds (optional)
+
+**Returns**: `Promise<WaitForExitResult>` with:
+- `exitCode` - The process exit code
+
+<TypeScriptExample>
+```
+const build = await sandbox.startProcess('npm run build');
+
+// Wait for build to complete
+const result = await build.waitForExit();
+console.log('Build finished with exit code:', result.exitCode);
+
+// With timeout
+const result = await build.waitForExit(60000); // 60 second timeout
+```
+</TypeScriptExample>
+
+**Throws**:
+- `ProcessReadyTimeoutError` - If process does not exit within timeout
 
 ## Related resources
 

--- a/src/content/docs/sandbox/api/ports.mdx
+++ b/src/content/docs/sandbox/api/ports.mdx
@@ -29,6 +29,7 @@ const response = await sandbox.exposePort(port: number, options: ExposePortOptio
 - `options`:
   - `hostname` - Your Worker's domain name (e.g., `'example.com'`). Required to construct preview URLs with wildcard subdomains like `https://8080-sandbox-abc123.example.com`. Cannot be a `.workers.dev` domain as it doesn't support wildcard DNS patterns.
   - `name` - Friendly name for the port (optional)
+  - `token` - Custom token for stable preview URLs (optional, 1-16 characters: lowercase letters, numbers, underscores). When provided, the preview URL remains consistent across container restarts and deployments.
 
 **Returns**: `Promise<ExposePortResponse>` with `port`, `url` (preview URL), `name`
 
@@ -40,8 +41,16 @@ const { hostname } = new URL(request.url);
 await sandbox.startProcess('python -m http.server 8000');
 const exposed = await sandbox.exposePort(8000, { hostname });
 
-console.log('Available at:', exposed.exposedAt);
-// https://8000-abc123.yourdomain.com
+console.log('Available at:', exposed.url);
+// https://8000-sandbox-id-abc123random.example.com
+
+// With custom token for stable URLs across restarts
+const stable = await sandbox.exposePort(8080, {
+  hostname,
+  token: 'my_service_v1' // 1-16 chars: a-z, 0-9, _
+});
+console.log('Stable URL:', stable.url);
+// https://8080-sandbox-id-my_service_v1.example.com
 
 // Multiple services with names
 await sandbox.startProcess('node api.js');
@@ -89,7 +98,7 @@ const response = await sandbox.getExposedPorts(): Promise<GetExposedPortsRespons
 const { ports } = await sandbox.getExposedPorts();
 
 for (const port of ports) {
-console.log(`${port.name || port.port}: ${port.exposedAt}`);
+  console.log(`${port.name || port.port}: ${port.exposedAt}`);
 }
 ```
 </TypeScriptExample>

--- a/src/content/docs/sandbox/api/storage.mdx
+++ b/src/content/docs/sandbox/api/storage.mdx
@@ -2,75 +2,79 @@
 title: Storage
 pcx_content_type: concept
 sidebar:
-  order: 8
+  order: 4
 ---
 
 import { TypeScriptExample } from "~/components";
 
-Mount S3-compatible object storage as local filesystem paths for persistent storage across sandbox lifecycles.
-
-:::caution[Production only]
-Bucket mounting does not work with `wrangler dev` because it requires FUSE support that wrangler does not currently provide. Deploy your Worker to use this feature. See [Mount buckets guide](/sandbox/guides/mount-buckets/) for details.
-:::
+Mount S3-compatible storage buckets (R2, S3, GCS) into the sandbox filesystem for persistent data access.
 
 ## Methods
 
 ### `mountBucket()`
 
-Mount an S3-compatible bucket as a local directory.
+Mount an S3-compatible bucket to a local path in the sandbox.
 
 ```ts
 await sandbox.mountBucket(
-	bucket: string,
-	mountPath: string,
-	options: MountBucketOptions
+  bucket: string,
+  mountPath: string,
+  options: MountBucketOptions
 ): Promise<void>
 ```
 
 **Parameters**:
+
 - `bucket` - Bucket name (e.g., `"my-r2-bucket"`)
 - `mountPath` - Local filesystem path to mount at (e.g., `"/data"`)
 - `options` - Mount configuration (see [`MountBucketOptions`](#mountbucketoptions))
 
 <TypeScriptExample>
-```typescript
-// Mount R2 bucket
-await sandbox.mountBucket('my-r2-bucket', '/data', {
-	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'
+```
+// Mount R2 bucket to /data
+await sandbox.mountBucket('my-bucket', '/data', {
+  endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
+  provider: 'r2'
 });
 
-// Access mounted bucket
-await sandbox.exec('ls', { args: ['/data'] });
+// Read/write files directly
+const data = await sandbox.readFile('/data/config.json');
 await sandbox.writeFile('/data/results.json', JSON.stringify(data));
 
 // Mount with explicit credentials
 await sandbox.mountBucket('my-bucket', '/storage', {
-	endpoint: 'https://s3.amazonaws.com',
-	credentials: {
-		accessKeyId: env.AWS_ACCESS_KEY_ID,
-		secretAccessKey: env.AWS_SECRET_ACCESS_KEY
-	}
+  endpoint: 'https://s3.amazonaws.com',
+  credentials: {
+    accessKeyId: env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: env.AWS_SECRET_ACCESS_KEY
+  }
 });
 
 // Read-only mount
 await sandbox.mountBucket('datasets', '/datasets', {
-	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
-	readOnly: true
+  endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
+  readOnly: true
+});
+
+// Mount a subdirectory within the bucket
+await sandbox.mountBucket('shared-bucket', '/user-data', {
+  endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
+  prefix: '/users/user-123'
 });
 ```
 </TypeScriptExample>
 
 **Throws**:
-- `MissingCredentialsError` - No credentials found in environment or options
-- `InvalidMountConfigError` - Invalid endpoint, bucket name, or mount path
-- `S3FSMountError` - Mount operation failed (network, permissions, bucket not found)
+- `InvalidMountPointError` - Invalid mount path or conflicts with existing mounts
+- `BucketAccessError` - Bucket does not exist or insufficient permissions
 
-:::note[Automatic credential detection]
-The SDK automatically detects `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from environment variables if credentials are not explicitly provided.
-:::
+:::note[Authentication]
+Credentials can be provided via:
+1. Explicit `credentials` in options
+2. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
+3. Automatic detection from bound R2 buckets
 
-:::note[Available on sessions]
-Both `sandbox.mountBucket()` and `session.mountBucket()` are supported. Mounts affect the entire sandbox filesystem and are visible across all sessions.
+See the [Mount Buckets guide](/sandbox/guides/mount-buckets/) for detailed authentication options.
 :::
 
 ### `unmountBucket()`
@@ -82,13 +86,13 @@ await sandbox.unmountBucket(mountPath: string): Promise<void>
 ```
 
 **Parameters**:
+
 - `mountPath` - Path where the bucket is mounted (e.g., `"/data"`)
 
 <TypeScriptExample>
-```typescript
-await sandbox.mountBucket('my-bucket', '/data', { endpoint: '...' });
-
-// Do work
+```
+// Mount, process, unmount
+await sandbox.mountBucket('data', '/data', { endpoint: '...' });
 await sandbox.exec('python process.py');
 
 // Unmount
@@ -97,14 +101,12 @@ await sandbox.unmountBucket('/data');
 </TypeScriptExample>
 
 :::note[Automatic cleanup]
-Mounted buckets are automatically unmounted when the sandbox is destroyed. Manual unmounting is optional.
+Mounted buckets are automatically unmounted when the container is destroyed.
 :::
 
 ## Types
 
 ### `MountBucketOptions`
-
-Configuration for mounting a bucket.
 
 ```ts
 interface MountBucketOptions {
@@ -112,73 +114,49 @@ interface MountBucketOptions {
 	provider?: BucketProvider;
 	credentials?: BucketCredentials;
 	readOnly?: boolean;
-	s3fsOptions?: Record<string, string>;
+	prefix?: string;
+	s3fsOptions?: string[];
 }
 ```
 
 **Fields**:
 
 - `endpoint` (required) - S3-compatible endpoint URL
-  - R2: `https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com`
-  - S3: `https://s3.amazonaws.com` or regional endpoint
-  - GCS: `https://storage.googleapis.com`
+  - R2: `'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'`
+  - S3: `'https://s3.amazonaws.com'`
+  - GCS: `'https://storage.googleapis.com'`
 
-- `provider` (optional) - Storage provider hint (`'r2'` | `'s3'` | `'gcs'`)
-  - Default: Auto-detected from endpoint URL
+- `provider` (optional) - Storage provider hint
+  - Enables provider-specific optimizations
+  - Values: `'r2'`, `'s3'`, `'gcs'`
 
-- `credentials` (optional) - S3 access credentials
-  - Default: Uses `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
+- `credentials` (optional) - API credentials
+  - Contains `accessKeyId` and `secretAccessKey`
+  - If not provided, uses environment variables
 
 - `readOnly` (optional) - Mount in read-only mode
   - Default: `false`
 
-- `s3fsOptions` (optional) - Advanced s3fs mount flags
-  - Example: `{ 'use_cache': '/tmp/cache' }`
+- `prefix` (optional) - Mount a subdirectory within the bucket
+  - Must start with `/` (e.g., `'/sessions/user123'` or `'/data/uploads/'`)
+  - Enables multi-tenant isolation within a single bucket
+
+- `s3fsOptions` (optional) - Advanced s3fs mount flags as string array
+  - Example: `['use_cache=/tmp/cache']`
 
 ### `BucketProvider`
 
 Storage provider hint for automatic s3fs flag optimization.
 
 ```ts
-type BucketProvider = 'r2' | 's3' | 'gcs';
+type BucketProvider = "r2" | "s3" | "gcs";
 ```
 
 - `'r2'` - Cloudflare R2 (recommended, applies `nomixupload` flag)
 - `'s3'` - Amazon S3
 - `'gcs'` - Google Cloud Storage
 
-The SDK auto-detects the provider from the endpoint URL and applies optimized flags. For other S3-compatible providers (Backblaze, MinIO, etc.), omit this field or use the `s3fsOptions` parameter for custom configuration.
-
-### `BucketCredentials`
-
-S3-compatible access credentials.
-
-```ts
-interface BucketCredentials {
-	accessKeyId: string;
-	secretAccessKey: string;
-}
-```
-
-<TypeScriptExample>
-```typescript
-await sandbox.mountBucket('my-bucket', '/data', {
-	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
-	credentials: {
-		accessKeyId: env.AWS_ACCESS_KEY_ID,
-		secretAccessKey: env.AWS_SECRET_ACCESS_KEY
-	}
-});
-```
-</TypeScriptExample>
-
-:::caution[Security]
-Never hardcode credentials. Use Worker secrets or environment variables.
-:::
-
 ## Related resources
 
-- [Mount buckets guide](/sandbox/guides/mount-buckets/) - Complete mounting reference
-- [Persistent storage tutorial](/sandbox/tutorials/persistent-storage/) - Example with R2
-- [Environment variables](/sandbox/configuration/environment-variables/) - Credential configuration
-- [R2 documentation](/r2/) - Learn about Cloudflare R2
+- [Mount Buckets guide](/sandbox/guides/mount-buckets/) - Complete bucket mounting walkthrough
+- [Files API](/sandbox/api/files/) - Read and write files

--- a/src/content/docs/sandbox/concepts/sandboxes.mdx
+++ b/src/content/docs/sandbox/concepts/sandboxes.mdx
@@ -136,21 +136,27 @@ await sandbox.exec("python process.py");
 The SDK automatically checks that your npm package version matches the Docker container image version. **Version mismatches can cause features to break or behave unexpectedly.**
 
 **What happens**:
+
 - On sandbox startup, the SDK queries the container's version
 - If versions don't match, a warning is logged
 - Some features may not work correctly if versions are incompatible
 
 **When you might see warnings**:
+
 - You updated the npm package (`npm install @cloudflare/sandbox@latest`) but forgot to update the `FROM` line in your Dockerfile
 
 **How to fix**:
-Update your Dockerfile to match your npm package version. For example, if using `@cloudflare/sandbox@0.3.3`:
+Update your Dockerfile to match your npm package version. For example, if using `@cloudflare/sandbox@0.7.0`:
 
 ```dockerfile
-FROM docker.io/cloudflare/sandbox:0.3.3  # Match your npm version
+# Default image (JavaScript/TypeScript)
+FROM docker.io/cloudflare/sandbox:0.7.0
+
+# Or Python image if you need Python support
+FROM docker.io/cloudflare/sandbox:0.7.0-python
 ```
 
-See [Dockerfile reference](/sandbox/configuration/dockerfile/) for details on extending the base image.
+See [Dockerfile reference](/sandbox/configuration/dockerfile/) for details on image variants and extending the base image.
 
 ## Best practices
 

--- a/src/content/docs/sandbox/configuration/environment-variables.mdx
+++ b/src/content/docs/sandbox/configuration/environment-variables.mdx
@@ -26,6 +26,12 @@ await sandbox.setEnvVars({
 
 await sandbox.exec("python migrate.py"); // Has DATABASE_URL and API_KEY
 await sandbox.exec("python seed.py"); // Has DATABASE_URL and API_KEY
+
+// Unset variables by passing undefined
+await sandbox.setEnvVars({
+	API_KEY: "new-key", // Updates API_KEY
+	OLD_SECRET: undefined, // Unsets OLD_SECRET
+});
 ```
 
 **Use when:** You need the same environment variables for multiple commands.
@@ -51,6 +57,10 @@ await sandbox.startProcess("python server.py", {
 ```
 
 **Use when:** You need different environment variables for different commands, or want to override sandbox-level variables.
+
+:::note
+Per-command environment variables with `undefined` values are skipped (treated as "not configured"), unlike `setEnvVars()` where `undefined` explicitly unsets a variable.
+:::
 
 ### 3. Session-level with createSession()
 
@@ -151,6 +161,7 @@ await Promise.all([
 When mounting S3-compatible object storage, the SDK uses **s3fs-fuse** under the hood, which requires AWS-style credentials. For R2, generate API tokens from the Cloudflare dashboard and provide them using AWS environment variable names:
 
 **Get R2 API tokens:**
+
 1. Go to [**R2** > **Overview**](https://dash.cloudflare.com/?to=/:account/r2) in the Cloudflare dashboard
 2. Select **Manage R2 API Tokens**
 3. Create a token with **Object Read & Write** permissions
@@ -181,18 +192,18 @@ interface Env {
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
-		const sandbox = getSandbox(env.Sandbox, 'data-processor');
+		const sandbox = getSandbox(env.Sandbox, "data-processor");
 
 		// Credentials automatically detected from environment
-		await sandbox.mountBucket('my-r2-bucket', '/data', {
-			endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'
+		await sandbox.mountBucket("my-r2-bucket", "/data", {
+			endpoint: "https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com",
 		});
 
 		// Access mounted bucket using standard file operations
-		await sandbox.exec('python', { args: ['process.py', '/data/input.csv'] });
+		await sandbox.exec("python", { args: ["process.py", "/data/input.csv"] });
 
 		return Response.json({ success: true });
-	}
+	},
 };
 ```
 
@@ -201,12 +212,12 @@ The SDK automatically detects `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` fr
 **Pass credentials explicitly** (if using custom secret names):
 
 ```typescript
-await sandbox.mountBucket('my-r2-bucket', '/data', {
-	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
+await sandbox.mountBucket("my-r2-bucket", "/data", {
+	endpoint: "https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com",
 	credentials: {
 		accessKeyId: env.R2_ACCESS_KEY_ID,
-		secretAccessKey: env.R2_SECRET_ACCESS_KEY
-	}
+		secretAccessKey: env.R2_SECRET_ACCESS_KEY,
+	},
 });
 ```
 


### PR DESCRIPTION
## Summary

Updates Sandbox SDK documentation to align with SDK v0.7.0 and recent releases.

### Changes

**Sandboxes concept page:**
- Update version reference from 0.3.3 to 0.7.0
- Mention image variants (default, python)

**Ports API:**
- Add `token` option to `exposePort()` for stable preview URLs across deployments (v0.7.0)
- Fix example to use `url` property instead of `exposedAt`

**Storage API:**
- Add `prefix` option to `mountBucket()` for mounting bucket subdirectories (v0.6.11)
- Fix `s3fsOptions` type from `Record<string, string>` to `string[]`

**Commands API:**
- Add `waitForExit()` method documentation to Process interface (v0.6.6)

**Environment Variables:**
- Document `undefined` value support in `setEnvVars()` for unsetting variables (v0.7.0)
- Add note clarifying difference between `setEnvVars()` and per-command env handling of `undefined`

## Related

- Depends on #27867 for Dockerfile reference updates
- Reference: https://github.com/cloudflare/sandbox-sdk/releases