### PR TITLE
Clarify usage of response_format with Anthropic models

### DIFF
--- a/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
@@ -306,6 +306,12 @@ Browser Rendering can use a custom model for which you supply credentials. List 
 - `model` should be formed as `<provider>/<model_name>` and the provider must be one of these [supported providers](/ai-gateway/usage/chat-completion/#supported-providers).
 - `authorization` is the bearer token or API key that allows Browser Rendering to call the provider on your behalf.
 
+:::caution[Anthropic models and response_format]
+
+When using Anthropic models (such as Claude), do not use the `response_format` parameter. Anthropic's API expects `output_schema` instead of `response_format`, which will cause an `invalid_request_error`. Use only the `prompt` parameter with Anthropic models until this is resolved.
+
+:::
+
 This example uses the `custom_ai` parameter to instruct Browser Rendering to use a Anthropic's Claude Sonnet 4 model. The prompt asks the model to extract the main `<h1>` and `<h2>` headings from the target URL and return them in a structured JSON object.
 
 ```bash


### PR DESCRIPTION
Added caution note regarding Anthropic models and response_format.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
