### PR TITLE
Fix error code 400020: Add 'flexible' to valid widget sizes

### DIFF
--- a/src/content/docs/turnstile/troubleshooting/client-side-errors/error-codes.mdx
+++ b/src/content/docs/turnstile/troubleshooting/client-side-errors/error-codes.mdx
@@ -45,7 +45,7 @@ When an error code is marked with `***`, it means that the remaining numbers can
 | `200100`   | Widget not found                 | No    | Ensure the container element exists.                                                 |
 | `200500`   | Widget state error               | Yes   | Reset widget with `turnstile.reset()`.                                               |
 | `300*`     | Generic challenge failure        | No    | Bot behavior detected. Refer to [troubleshooting](#troubleshooting).                 |
-| `400020`   | Invalid widget size              | No    | Use valid size: `normal`, `compact`.                                                 |
+| `400020`   | Invalid widget size              | No    | Use valid size: `normal`, `compact`, `flexible`.                                                 |
 | `400030`   | Invalid appearance               | No    | Use valid appearance: `always`, `execute`, `interaction-only`.                       |
 | `400040`   | Invalid theme                    | No    | Use valid theme: `light`, `dark`, `auto`.                                            |
 | `600*`     | Generic challenge failure        | No    | Bot behavior detected. Refer to [troubleshooting](#troubleshooting).                 |


### PR DESCRIPTION
Fixes #27864

The documentation for error code 400020 was missing 'flexible' as a valid widget size option. This PR adds 'flexible' to the list of valid sizes: normal, compact, flexible.