### PR TITLE
Use dynamic date for nodejs_compat compatibility_date examples

### DIFF
--- a/src/content/docs/hyperdrive/configuration/rotate-credentials.mdx
+++ b/src/content/docs/hyperdrive/configuration/rotate-credentials.mdx
@@ -30,7 +30,8 @@ The command above will output the ID of your Hyperdrive. Set this ID in the [Wra
 ```toml
 # required for database drivers to function
 compatibility_flags = [ "nodejs_compat" ]
-compatibility_date = "2024-09-23"
+# Use today's date (must be 2024-09-23 or later)
+compatibility_date = "$today"
 
 [[hyperdrive]]
 binding = "HYPERDRIVE"

--- a/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale.mdx
+++ b/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale.mdx
@@ -3,7 +3,7 @@ reviewed: 2023-10-30
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Create a serverless, globally distributed time-series API with Timescale
-products:	[workers]
+products: [workers]
 tags:
   - PostgreSQL
   - TypeScript
@@ -146,7 +146,8 @@ This command outputs your Hyperdrive ID. You can now bind your Hyperdrive config
 ```toml
 name = "timescale-api"
 main = "src/index.ts"
-compatibility_date = "2024-09-23"
+# Use today's date (must be 2024-09-23 or later)
+compatibility_date = "$today"
 compatibility_flags = [ "nodejs_compat"]
 
 [[hyperdrive]]

--- a/src/content/docs/pages/functions/bindings.mdx
+++ b/src/content/docs/pages/functions/bindings.mdx
@@ -7,7 +7,13 @@ sidebar:
   order: 7
 ---
 
-import { Render, TabItem, Tabs, WranglerConfig, DashButton } from "~/components";
+import {
+	Render,
+	TabItem,
+	Tabs,
+	WranglerConfig,
+	DashButton,
+} from "~/components";
 
 A [binding](/workers/runtime-apis/bindings/) enables your Pages Functions to interact with resources on the Cloudflare developer platform. Use bindings to integrate your Pages Functions with Cloudflare resources like [KV](/kv/concepts/how-kv-works/), [Durable Objects](/durable-objects/), [R2](/r2/), and [D1](/d1/). You can set bindings for both production and preview environments.
 
@@ -30,6 +36,7 @@ To configure a KV namespace binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Bindings** > **Add** > **KV namespace**.
 4. Give your binding a name under **Variable name**.
@@ -90,6 +97,7 @@ To configure a Durable Object binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Bindings** > **Add** > **Durable Object**.
 4. Give your binding a name under **Variable name**.
@@ -154,6 +162,7 @@ To configure a R2 bucket binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Bindings** > **Add** > **R2 bucket**.
 4. Give your binding a name under **Variable name**.
@@ -226,6 +235,7 @@ To configure a D1 database binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Bindings** > **Add**> **D1 database bindings**.
 4. Give your binding a name under **Variable name**.
@@ -302,12 +312,13 @@ To configure a Vectorize index binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Choose whether you would like to set up the binding in your **Production** or **Preview** environment.
 3. Select your Pages project > **Settings**.
 4. Go to **Bindings** > **Add** > **Vectorize index**.
 5. Give your binding a name under **Variable name**.
 6. Under **Vectorize index**, select your desired Vectorize index.
-8. Redeploy your project for the binding to take effect.
+7. Redeploy your project for the binding to take effect.
 
 ### Use Vectorize index bindings
 
@@ -442,6 +453,7 @@ To configure a Workers AI binding via the Cloudflare dashboard:
 1. Go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project > **Settings**.
 3. Select your Pages environment > **Bindings** > **Add** > **Workers AI**.
 4. Give your binding a name under **Variable name**.
@@ -515,6 +527,7 @@ To configure a Service binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Bindings** > **Add** > **Service binding**.
 4. Give your binding a name under **Variable name**.
@@ -579,6 +592,7 @@ To configure a queue producer binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Bindings** > **Add** > **Queue**.
 4. Give your binding a name under **Variable name**.
@@ -635,7 +649,8 @@ PostgreSQL drivers like [`Postgres.js`](https://github.com/porsager/postgres) de
 
 ```toml title="wrangler.toml"
 compatibility_flags = [ "nodejs_compat" ]
-compatibility_date = "2024-09-23"
+# Use today's date (must be 2024-09-23 or later)
+compatibility_date = "$today"
 ```
 
 </WranglerConfig>
@@ -651,6 +666,7 @@ To configure a Hyperdrive binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Bindings** > **Add** > **Hyperdrive**.
 4. Give your binding a name under **Variable name**.
@@ -724,6 +740,7 @@ To configure an Analytics Engine binding via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Bindings** > **Add** > **Analytics engine**.
 4. Give your binding a name under **Variable name**.
@@ -785,6 +802,7 @@ To configure an environment variable via the Cloudflare dashboard:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Variables and Secrets** > **Add** .
 4. After setting a variable name and value, select **Save**.
@@ -843,6 +861,7 @@ To add secrets to your Pages project:
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
+
 2. Select your Pages project.
 3. Go to **Settings** > **Variables and Secrets** > **Add**.
 4. Set a variable name and value.

--- a/src/content/docs/workers-ai/guides/tutorials/build-a-workers-ai-whisper-with-chunking.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/build-a-workers-ai-whisper-with-chunking.mdx
@@ -78,7 +78,8 @@ In your wrangler file, add or update the following settings to enable Node.js AP
 
 ```toml title="wrangler.toml"
 compatibility_flags = [ "nodejs_compat" ]
-compatibility_date = "2024-09-23"
+# Use today's date (must be 2024-09-23 or later)
+compatibility_date = "$today"
 ```
 
 </WranglerConfig>

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -25,7 +25,8 @@ To enable built-in Node.js APIs and add polyfills, add the `nodejs_compat` compa
 
 ```toml title="wrangler.toml"
 compatibility_flags = [ "nodejs_compat" ]
-compatibility_date = "2024-09-23"
+# Use today's date (must be 2024-09-23 or later)
+compatibility_date = "$today"
 ```
 
 </WranglerConfig>

--- a/src/content/partials/hyperdrive/hyperdrive-node-compatibility-requirement.mdx
+++ b/src/content/partials/hyperdrive/hyperdrive-node-compatibility-requirement.mdx
@@ -9,7 +9,8 @@ import { WranglerConfig } from "~/components";
 ```toml
 # required for database drivers to function
 compatibility_flags = ["nodejs_compat"]
-compatibility_date = "2024-09-23"
+# Use today's date (must be 2024-09-23 or later)
+compatibility_date = "$today"
 
 [[hyperdrive]]
 binding = "HYPERDRIVE"

--- a/src/content/partials/workers/nodejs_compat.mdx
+++ b/src/content/partials/workers/nodejs_compat.mdx
@@ -10,7 +10,8 @@ To enable both built-in runtime APIs and polyfills for your Worker or Pages proj
 
 ```toml title="wrangler.toml"
 compatibility_flags = [ "nodejs_compat" ]
-compatibility_date = "2024-09-23"
+# Use today's date (must be 2024-09-23 or later)
+compatibility_date = "$today"
 ```
 
 </WranglerConfig>


### PR DESCRIPTION
## Summary

- Updates `compatibility_date` examples to use `$today` instead of hardcoded dates
- Adds comments clarifying the minimum required date (2024-09-23) for Node.js compatibility
- Changes apply to the Node.js compatibility docs and reusable partials for Workers and Hyperdrive

The `WranglerConfig` component automatically replaces `$today` with the current date at build time, ensuring readers always see the latest recommended date.

## Context

We have noticed users creating projects with outdated compatibility dates, which we suspect is due to AI tools reading and reproducing the hardcoded dates from our documentation. Using dynamic dates should help ensure AI-assisted code generation uses current dates.