### PR TITLE
Updating docs for upcoming queues free tier

### DIFF
--- a/src/content/docs/queues/index.mdx
+++ b/src/content/docs/queues/index.mdx
@@ -19,7 +19,7 @@ Send and receive messages with guaranteed delivery and no charges for egress ban
 
 </Description>
 
-<Plan type="paid" />
+<Plan type="workers-all" />
 
 Cloudflare Queues integrate with [Cloudflare Workers](/workers/) and enable you to build applications that can [guarantee delivery](/queues/reference/delivery-guarantees/), [offload work from a request](/queues/reference/how-queues-works/), [send data from Worker to Worker](/queues/configuration/configure-queues/), and [buffer or batch data](/queues/configuration/batching-retries/).
 

--- a/src/content/docs/queues/platform/limits.mdx
+++ b/src/content/docs/queues/platform/limits.mdx
@@ -32,7 +32,7 @@ import { Render, WranglerConfig } from "~/components"
 
 <sup>2</sup> Exceeding the maximum message throughput will cause the `send()` and `sendBatch()` methods to throw an exception with a `Too Many Requests` error until your producer falls below the limit.
 
-<sup>3</sup> Messages in a queue that reach the maximum message retention are deleted from the queue. Queues does not delete messages in the same queue that have not reached this limit.
+<sup>3</sup> Messages in a queue that reach the maximum message retention are deleted from the queue. Queues does not delete messages in the same queue that have not reached this limit. Queues on Workers Free have a retention limit of 24 hours.
 
 <sup>4</sup> Individual queues that reach this limit will receive a `Storage Limit Exceeded` error when calling `send()` or `sendBatch()` on the queue.
 

--- a/src/content/docs/queues/platform/limits.mdx
+++ b/src/content/docs/queues/platform/limits.mdx
@@ -18,7 +18,8 @@ import { Render, WranglerConfig } from "~/components"
 | Maximum messages per `sendBatch` call         									| 100 (or 256KB in total)                                       |
 | Maximum Batch wait time                       									| 60 seconds                                                    |
 | Per-queue message throughput    																| 5,000 messages per second <sup>2</sup>                        |
-| Message retention period <sup>3</sup>         									| 4 days (default). [Configurable to 14 days](/queues/configuration/configure-queues/#queue-configuration)                                                       |
+| Message retention period <sup>3</sup>         									| 4 days (Workers Paid). [Configurable to 14 days](/queues/configuration/configure-queues/#queue-configuration).
+24 hours (Workers Free) |
 | Per-queue backlog size <sup>4</sup>           									| 25GB                                                          |
 | Concurrent consumer invocations               									| 250 <sup>push-based only</sup>                                |
 | Consumer duration (wall clock time) 														| 15 minutes <sup>5</sup>                                       |
@@ -32,7 +33,7 @@ import { Render, WranglerConfig } from "~/components"
 
 <sup>2</sup> Exceeding the maximum message throughput will cause the `send()` and `sendBatch()` methods to throw an exception with a `Too Many Requests` error until your producer falls below the limit.
 
-<sup>3</sup> Messages in a queue that reach the maximum message retention are deleted from the queue. Queues does not delete messages in the same queue that have not reached this limit. Queues on Workers Free have a retention limit of 24 hours.
+<sup>3</sup> Messages in a queue that reach the maximum message retention are deleted from the queue. Queues does not delete messages in the same queue that have not reached this limit. 
 
 <sup>4</sup> Individual queues that reach this limit will receive a `Storage Limit Exceeded` error when calling `send()` or `sendBatch()` on the queue.
 

--- a/src/content/docs/r2/tutorials/summarize-pdf.mdx
+++ b/src/content/docs/r2/tutorials/summarize-pdf.mdx
@@ -291,12 +291,6 @@ npm run dev
 
 ## 4. Create a queue
 
-:::note
-
-You will need a [Workers Paid plan](/workers/platform/pricing/) to create and use [Queues](/queues/) and Cloudflare Workers to consume event notifications.
-
-:::
-
 Event notifications capture changes to data in your R2 bucket. You will need to create a new queue `pdf-summarize` to receive notifications:
 
 ```sh

--- a/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
+++ b/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
@@ -36,12 +36,6 @@ npx wrangler r2 bucket create example-log-sink-bucket
 
 ## 3. Create a queue
 
-:::note
-
-You will need a [Workers Paid plan](/workers/platform/pricing/) to create and use [Queues](/queues/) and Cloudflare Workers to consume event notifications.
-
-:::
-
 Event notifications capture changes to data in `example-upload-bucket`. You will need to create a new queue to receive notifications:
 
 ```sh

--- a/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
+++ b/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
@@ -16,12 +16,6 @@ This example provides a step-by-step guide on using [event notifications](/r2/bu
 
 ![Push-Based R2 Event Notifications](~/assets/images/reference-architecture/event-notifications-for-storage/pushed-based-event-notification.svg)
 
-## Prerequisites
-
-To continue, you will need:
-
-- A subscription to [Workers Paid](/workers/platform/pricing/#workers), required for using queues.
-
 ## 1. Install Wrangler
 
 To begin, refer to [Install/Update Wrangler](/workers/wrangler/install-and-update/#install-wrangler) to install Wrangler, the Cloudflare Developer Platform CLI.

--- a/src/content/partials/queues/enable-queues.mdx
+++ b/src/content/partials/queues/enable-queues.mdx
@@ -4,7 +4,7 @@
 
 import { DashButton } from "~/components";
 
-Queues are included in the monthly subscription cost of your Workers Paid plan, and charges based on operations against your queues. Refer to [Pricing](/queues/platform/pricing/) for more details.
+Queues is included in the monthly subscription cost of your Workers Paid plan, and charges based on operations against your queues. A limited version of Queues is also available on the Workers Free plan. Refer to [Pricing](/queues/platform/pricing/) for more details.
 
 Before you can use Queues, you must enable it via [the Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/queues). You need a Workers Paid plan to enable Queues.
 

--- a/src/content/partials/workers/queues_pricing.mdx
+++ b/src/content/partials/workers/queues_pricing.mdx
@@ -1,27 +1,19 @@
 ---
 {}
-
 ---
-
-:::note
-
-
-Cloudflare Queues requires the [Workers Paid plan](/workers/platform/pricing/#workers) to use, but does not increase your monthly subscription cost.
-
-
-:::
 
 Cloudflare Queues charges for the total number of operations against each of your queues during a given month.
 
-* An operation is counted for each 64 KB of data that is written, read, or deleted.
-* Messages larger than 64 KB are charged as if they were multiple messages: for example, a 65 KB message and a 127 KB message would both incur two operation charges when written, read, or deleted.
-* A KB is defined as 1,000 bytes, and each message includes approximately 100 bytes of internal metadata.
-* Operations are per message, not per batch. A batch of 10 messages (the default batch size), if processed, would incur 10x write, 10x read, and 10x delete operations: one for each message in the batch.
-* There are no data transfer (egress) or throughput (bandwidth) charges.
+- An operation is counted for each 64 KB of data that is written, read, or deleted.
+- Messages larger than 64 KB are charged as if they were multiple messages: for example, a 65 KB message and a 127 KB message would both incur two operation charges when written, read, or deleted.
+- A KB is defined as 1,000 bytes, and each message includes approximately 100 bytes of internal metadata.
+- Operations are per message, not per batch. A batch of 10 messages (the default batch size), if processed, would incur 10x write, 10x read, and 10x delete operations: one for each message in the batch.
+- There are no data transfer (egress) or throughput (bandwidth) charges.
 
-|                     | Workers Paid                                                   |
-| ------------------- | -------------------------------------------------------------- |
-| Standard operations | 1,000,000 operations/month included + $0.40/million operations |
+|                     | Workers Free                   | Workers Paid                                                   |
+| ------------------- | ------------------------------ | -------------------------------------------------------------- |
+| Standard operations | 10,000 operations/day included | 1,000,000 operations/month included + $0.40/million operations |
+| Message retention   | 24 hours (non-configurable)    | 4 days default, configurable up to 14 days                     |
 
 In most cases, it takes 3 operations to deliver a message: 1 write, 1 read, and 1 delete. Therefore, you can use the following formula to estimate your monthly bill:
 
@@ -31,6 +23,6 @@ In most cases, it takes 3 operations to deliver a message: 1 write, 1 read, and 
 
 Additionally:
 
-* Each retry incurs a read operation. A batch of 10 messages that is retried would incur 10 operations for each retry.
-* Messages that reach the maximum retries and that are written to a [Dead Letter Queue](/queues/configuration/batching-retries/) incur a write operation for each 64 KB chunk. A message that was retried 3 times (the default), fails delivery on the fourth time and is written to a Dead Letter Queue would incur five (5) read operations.
-* Messages that are written to a queue, but that reach the maximum persistence duration (or "expire") before they are read, incur only a write and delete operation per 64 KB chunk.
+- Each retry incurs a read operation. A batch of 10 messages that is retried would incur 10 operations for each retry.
+- Messages that reach the maximum retries and that are written to a [Dead Letter Queue](/queues/configuration/batching-retries/) incur a write operation for each 64 KB chunk. A message that was retried 3 times (the default), fails delivery on the fourth time and is written to a Dead Letter Queue would incur five (5) read operations.
+- Messages that are written to a queue, but that reach the maximum persistence duration (or "expire") before they are read, incur only a write and delete operation per 64 KB chunk.


### PR DESCRIPTION
### Summary

Removing references to Queues paid requirements & adding free tier limits into documentation

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
