### PR TITLE
docs: clarify common cloudflared service install error

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/as-a-service/linux.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/as-a-service/linux.mdx
@@ -30,18 +30,13 @@ By default, Cloudflare Tunnel expects all of the configuration to exist in the `
    ```sh
    cloudflared service install
    ```
-> **Note**
-> Installing the `cloudflared` systemd service on Linux typically
-> requires elevated privileges. When the install command is run with
-> `sudo`, `$HOME` points to `/root`, which may prevent `cloudflared` from
-> locating a configuration file created in
-> `/home/<USER>/.cloudflared/config.yml`.
->
-> In this case, the config path can be passed explicitly:
->
-> ```sh
-> sudo cloudflared --config /home/<USER>/.cloudflared/config.yml service install
-> ```
+
+	:::note
+	Installing the `cloudflared` systemd service on Linux typically requires elevated privileges. When the install command is run with `sudo`, `$HOME` points to `/root`, which may prevent `cloudflared` from locating a configuration file created in `/home/<USER>/.cloudflared/config.yml`. In this case, the config path can be passed explicitly:
+	```sh
+	sudo cloudflared --config /home/<USER>/.cloudflared/config.yml service install
+	```
+	:::
 
 2. Start the service.
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/as-a-service/linux.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/as-a-service/linux.mdx
@@ -30,6 +30,18 @@ By default, Cloudflare Tunnel expects all of the configuration to exist in the `
    ```sh
    cloudflared service install
    ```
+> **Note**
+> Installing the `cloudflared` systemd service on Linux typically
+> requires elevated privileges. When the install command is run with
+> `sudo`, `$HOME` points to `/root`, which may prevent `cloudflared` from
+> locating a configuration file created in
+> `/home/<USER>/.cloudflared/config.yml`.
+>
+> In this case, the config path can be passed explicitly:
+>
+> ```sh
+> sudo cloudflared --config /home/<USER>/.cloudflared/config.yml service install
+> ```
 
 2. Start the service.
 


### PR DESCRIPTION
### Summary

This PR adds a small clarification to the Linux “run as a service” docs
around installing the `cloudflared` systemd service with `sudo`.

On most systems the install step needs elevated privileges, which means
`$HOME` resolves to `/root`. When that happens, `cloudflared` may not find
a config file created under a user’s home directory unless the config
path is passed explicitly.

This behavior is already tracked in an earlier issue and closed as
not planned. The note just documents the workaround so users don’t get
stuck on this step.

Related issue:
https://github.com/cloudflare/cloudflared/issues/1457

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).