### PR TITLE
[Chore] Update stale workflow to include PRs

### DIFF
--- a/.github/workflows/close-stale-issues-prs.yml
+++ b/.github/workflows/close-stale-issues-prs.yml
@@ -23,4 +23,9 @@ jobs:
           days-before-stale: 35
           # setting to a negative number means they'll never be autoclosed
           days-before-close: -1
+          # we are okay with PRs being auto-closed
+          days-before-pr-close: 25
+          exempt-pr-labels: "never-stale"
+          close-pr-message: "Hey there, we've closed out this pull request because it's been stale for a while and there's been no additional action on it. If these changes are still relevant, open a new pull request (or flag to us in a GitHub issue)."
+          close-pr-label: "closed-as-stale"
           operations-per-run: 100


### PR DESCRIPTION
### Summary

This will auto-close PRs that have sat in `stale` for too long.

This will never auto-close issues, because those need to always be triaged before closing.

[Reference](https://github.com/actions/stale/blob/main/README.md)