### PR TITLE
Improve Wrangler v3 to v4 migration guide

### DIFF
--- a/src/content/docs/workers/wrangler/migration/update-v3-to-v4.mdx
+++ b/src/content/docs/workers/wrangler/migration/update-v3-to-v4.mdx
@@ -16,6 +16,7 @@ While many users should expect a no-op upgrade, the following sections outline t
 To upgrade to the latest version of Wrangler v4 within your Worker project, run:
 
 <PackageManagers pkg="wrangler@4" dev />
+
 After upgrading, you can verify the installation:
 
 <PackageManagers type="exec" pkg="wrangler" args="--version" />
@@ -63,47 +64,6 @@ Wrangler v4 upgrades esbuild from **v0.17.19** to **v0.24**, bringing improvemen
 - **Dynamic imports:** Wildcard imports (for example, `import('./data/' + kind + '.json')`) now automatically include all matching files in the bundle.
 
 Users relying on wildcard dynamic imports may see unwanted files bundled. Prior to esbuild v0.19, `import` statements with dynamic paths (like `import('./data/' + kind + '.json')`) did not bundle all files matching the glob pattern (`*.json`). Only files explicitly referenced or included using `find_additional_modules` were bundled. With esbuild v0.19, wildcard imports now automatically bundle all files matching the glob pattern. This could result in unwanted files being bundled, so users might want to avoid wildcard dynamic imports and use explicit imports instead.
-
-<Details header="Am I affected?">
-
-Search your codebase for dynamic imports with variable paths:
-
-```sh
-# Search for patterns like import('./path/' + variable)
-grep -rE "import\s*\(\s*['\`]\..*\s*\+" --include="*.js" --include="*.ts" --include="*.mjs" .
-
-# Search for patterns like require('./path/' + variable)
-grep -rE "require\s*\(\s*['\`]\..*\s*\+" --include="*.js" --include="*.ts" --include="*.cjs" .
-```
-
-**You need to take action if you find patterns like:**
-
-- `import('./locales/' + lang + '.json')`
-- `require('./data/' + kind + '.js')`
-- ``import(`./templates/${name}.html`)``
-
-**What to do:**
-
-1. Replace dynamic wildcard imports with explicit imports where possible.
-2. If you need dynamic imports, ensure the matching directory only contains files you want bundled.
-3. Consider moving dynamic imports to a dedicated subdirectory to limit the files included.
-
-**Example fix:**
-
-```js
-// Before: may bundle all JSON files in ./locales/
-const messages = await import("./locales/" + lang + ".json");
-
-// After: explicit imports
-const locales = {
-	en: () => import("./locales/en.json"),
-	es: () => import("./locales/es.json"),
-	fr: () => import("./locales/fr.json"),
-};
-const messages = await locales[lang]();
-```
-
-</Details>
 
 ### Commands default to local mode
 

--- a/src/content/docs/workers/wrangler/migration/update-v3-to-v4.mdx
+++ b/src/content/docs/workers/wrangler/migration/update-v3-to-v4.mdx
@@ -5,9 +5,27 @@ sidebar:
   order: 1
 ---
 
-Wrangler v4 is a major release focused on updates to underlying systems and dependencies, along with improvements to keep Wrangler commands consistent and clear. Unlike previous major versions of Wrangler, which were [foundational rewrites](https://blog.cloudflare.com/wrangler-v2-beta/) and [rearchitectures](https://blog.cloudflare.com/wrangler3/) — Version 4 of Wrangler includes a much smaller set of changes. If you use Wrangler today, your workflow is very unlikely to change.
+import { Details, PackageManagers } from "~/components";
+
+Wrangler v4 is a major release focused on updates to underlying systems and dependencies, along with improvements to keep Wrangler commands consistent and clear. Unlike previous major versions of Wrangler, which were [foundational rewrites](https://blog.cloudflare.com/wrangler-v2-beta/) and [rearchitectures](https://blog.cloudflare.com/wrangler3/) — Version 4 of Wrangler includes a much smaller set of changes. If you use Wrangler today, your workflow is very unlikely to change.
 
 While many users should expect a no-op upgrade, the following sections outline the more significant changes and steps for migrating where necessary.
+
+## Upgrade to Wrangler v4
+
+To upgrade to the latest version of Wrangler within your Worker project, run:
+
+<PackageManagers pkg="wrangler@latest" dev />
+
+To install a specific Wrangler v4 version, specify the major version number:
+
+<PackageManagers pkg="wrangler@4" dev />
+
+After upgrading, verify the installation:
+
+```sh
+npx wrangler --version
+```
 
 ### Summary of changes
 
@@ -31,13 +49,68 @@ Wrangler now supports only Node.js versions that align with [Node.js's official 
 
 Wrangler tests no longer run on v16, and users still on this version may encounter unsupported behavior. Users still using Node.js v16 must upgrade to a supported version to continue receiving support and compatibility with Wrangler.
 
+<Details header="Am I affected?">
+
+Run the following command to check your Node.js version:
+
+```sh
+node --version
+```
+
+**You need to take action if** your version starts with `v16` (for example, `v16.20.0`).
+
+**To upgrade Node.js**, use a version manager like [nvm](https://github.com/nvm-sh/nvm) or [Volta](https://volta.sh/), or download directly from [nodejs.org](https://nodejs.org/). Cloudflare recommends using the latest LTS version of Node.js.
+
+</Details>
+
 ### Upgraded esbuild version
 
 Wrangler v4 upgrades esbuild from **v0.17.19** to **v0.24**, bringing improvements (such as the ability to use the `using` keyword with RPC) and changes to bundling behavior:
 
 - **Dynamic imports:** Wildcard imports (for example, `import('./data/' + kind + '.json')`) now automatically include all matching files in the bundle.
 
-Users relying on wildcard dynamic imports may see unwanted files bundled. Prior to esbuild v0.19, `import` statements with dynamic paths ( like `import('./data/' + kind + '.json')`) did not bundle all files matches the glob pattern (`*.json`) . Only files explicitly referenced or included using `find_additional_modules` were bundled. With esbuild v0.19, wildcard imports now automatically bundle all files matching the glob pattern. This could result in unwanted files being bundled, so users might want to avoid wildcard dynamic imports and use explicit imports instead.
+Users relying on wildcard dynamic imports may see unwanted files bundled. Prior to esbuild v0.19, `import` statements with dynamic paths (like `import('./data/' + kind + '.json')`) did not bundle all files matching the glob pattern (`*.json`). Only files explicitly referenced or included using `find_additional_modules` were bundled. With esbuild v0.19, wildcard imports now automatically bundle all files matching the glob pattern. This could result in unwanted files being bundled, so users might want to avoid wildcard dynamic imports and use explicit imports instead.
+
+<Details header="Am I affected?">
+
+Search your codebase for dynamic imports with variable paths:
+
+```sh
+# Search for patterns like import('./path/' + variable)
+grep -rE "import\s*\(\s*['\`]\..*\s*\+" --include="*.js" --include="*.ts" --include="*.mjs" .
+
+# Search for patterns like require('./path/' + variable)
+grep -rE "require\s*\(\s*['\`]\..*\s*\+" --include="*.js" --include="*.ts" --include="*.cjs" .
+```
+
+**You need to take action if you find patterns like:**
+
+- `import('./locales/' + lang + '.json')`
+- `require('./data/' + kind + '.js')`
+- ``import(`./templates/${name}.html`)``
+
+**What to do:**
+
+1. Replace dynamic wildcard imports with explicit imports where possible.
+2. If you need dynamic imports, ensure the matching directory only contains files you want bundled.
+3. Consider moving dynamic imports to a dedicated subdirectory to limit the files included.
+
+**Example fix:**
+
+```js
+// Before: may bundle all JSON files in ./locales/
+const messages = await import("./locales/" + lang + ".json");
+
+// After: explicit imports
+const locales = {
+	en: () => import("./locales/en.json"),
+	es: () => import("./locales/es.json"),
+	fr: () => import("./locales/fr.json"),
+};
+const messages = await locales[lang]();
+```
+
+</Details>
 
 ### Commands default to local mode
 
@@ -45,17 +118,100 @@ All commands now run in **local mode by default.** Wrangler has many commands fo
 
 For example:
 
-- **Previous Behavior (Wrangler v3):** `wrangler kv get` queried remotely by default.
-- **New Behavior (Wrangler v4):** `wrangler kv get` queries locally unless `--remote` is specified.
+- **Previous Behavior (Wrangler v3):** `wrangler kv key get` queried remotely by default.
+- **New Behavior (Wrangler v4):** `wrangler kv key get` queries locally unless `--remote` is specified.
 
 Those using `wrangler kv key` and/or `wrangler r2 object` commands to query or write to their data store will need to add the `--remote` flag in order to replicate previous behavior.
 
+<Details header="Am I affected?">
+
+Check if you use any of these commands in scripts, CI/CD pipelines, or manual workflows:
+
+**KV commands:**
+
+- `wrangler kv key get`
+- `wrangler kv key put`
+- `wrangler kv key delete`
+- `wrangler kv key list`
+- `wrangler kv bulk put`
+- `wrangler kv bulk delete`
+
+**R2 commands:**
+
+- `wrangler r2 object get`
+- `wrangler r2 object put`
+- `wrangler r2 object delete`
+
+**You need to take action if:**
+
+- You run these commands expecting them to interact with your remote/production data.
+- You have scripts or CI/CD pipelines that use these commands without the `--local` or `--remote` flag.
+
+Search your codebase and CI/CD configs:
+
+```sh
+grep -rE "wrangler (kv|r2)" --include="*.sh" --include="*.yml" --include="*.yaml" --include="Makefile" --include="package.json" .
+```
+
+**What to do:**
+
+Add `--remote` to commands that should interact with your Cloudflare account:
+
+```sh
+# Before (Wrangler v3 - queried remote by default)
+wrangler kv key get --binding MY_KV "my-key"
+
+# After (Wrangler v4 - must specify --remote)
+wrangler kv key get --binding MY_KV "my-key" --remote
+```
+
+</Details>
+
 ### Deprecated commands and configurations removed
 
-All previously deprecated features in [Wrangler v2](https://developers.cloudflare.com/workers/wrangler/deprecations/#wrangler-v2) and in [Wrangler v3](https://developers.cloudflare.com/workers/wrangler/deprecations/#wrangler-v3) are now removed. Additionally, the following features that were deprecated during the Wrangler v3 release are also now removed:
+All previously deprecated features in [Wrangler v2](/workers/wrangler/deprecations/#wrangler-v2) and in [Wrangler v3](/workers/wrangler/deprecations/#wrangler-v3) are now removed. Additionally, the following features that were deprecated during the Wrangler v3 release are also now removed:
 
-- Legacy Assets (using `wrangler dev/deploy --legacy-assets` or the `legacy_assets` config file property). Instead, we recommend you [migrate to Workers assets](https://developers.cloudflare.com/workers/static-assets/).
-- Legacy Node.js compatibility (using `wrangler dev/deploy --node-compat` or the `node_compat` config file property). Instead, use the [`nodejs_compat` compatibility flag](https://developers.cloudflare.com/workers/runtime-apis/nodejs). This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs.
+- Legacy Assets (using `wrangler dev/deploy --legacy-assets` or the `legacy_assets` config file property). Instead, we recommend you [migrate to Workers Static Assets](/workers/static-assets/).
+- Legacy Node.js compatibility (using `wrangler dev/deploy --node-compat` or the `node_compat` config file property). Instead, use the [`nodejs_compat` compatibility flag](/workers/runtime-apis/nodejs/). This includes the functionality from legacy `node_compat` polyfills and natively implemented Node.js APIs.
 - `wrangler version`. Instead, use `wrangler --version` to check the current version of Wrangler.
-- `getBindingsProxy()` (via `import { getBindingsProxy } from "wrangler"`). Instead, use the [`getPlatformProxy()` API](https://developers.cloudflare.com/workers/wrangler/api/#getplatformproxy), which takes exactly the same arguments.
+- `getBindingsProxy()` (via `import { getBindingsProxy } from "wrangler"`). Instead, use the [`getPlatformProxy()` API](/workers/wrangler/api/#getplatformproxy), which takes exactly the same arguments.
 - `usage_model`. This no longer has any effect, after the [rollout of Workers Standard Pricing](https://blog.cloudflare.com/workers-pricing-scale-to-zero/).
+
+<Details header="Am I affected?">
+
+**Check your Wrangler configuration file** (`wrangler.toml`, `wrangler.json`, or `wrangler.jsonc`) for deprecated settings:
+
+```sh
+# For TOML files
+grep -E "(legacy_assets|node_compat|usage_model)\s*=" wrangler.toml
+
+# For JSON files
+grep -E "\"(legacy_assets|node_compat|usage_model)\"" wrangler.json wrangler.jsonc
+```
+
+**Check your commands and scripts** for deprecated flags:
+
+```sh
+grep -rE "wrangler.*(--legacy-assets|--node-compat)" --include="*.sh" --include="*.yml" --include="*.yaml" --include="Makefile" --include="package.json" .
+```
+
+**Check for deprecated API usage** in your code:
+
+```sh
+grep -rE "getBindingsProxy" --include="*.js" --include="*.ts" --include="*.mjs" .
+```
+
+**You need to take action if you find any of the following:**
+
+| Deprecated                                       | Replacement                                                                          |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `legacy_assets` config or `--legacy-assets` flag | [Migrate to Workers Static Assets](/workers/static-assets/)                          |
+| `node_compat` config or `--node-compat` flag     | Use the [`nodejs_compat` compatibility flag](/workers/runtime-apis/nodejs/)          |
+| `usage_model` config                             | Remove it (no longer has any effect)                                                 |
+| `wrangler version` command                       | Use `wrangler --version`                                                             |
+| `getBindingsProxy()` import                      | Use [`getPlatformProxy()`](/workers/wrangler/api/#getplatformproxy) (same arguments) |
+| `wrangler publish` command                       | Use `wrangler deploy`                                                                |
+| `wrangler generate` command                      | Use `npm create cloudflare@latest`                                                   |
+| `wrangler pages publish` command                 | Use `wrangler pages deploy`                                                          |
+
+</Details>

--- a/src/content/docs/workers/wrangler/migration/update-v3-to-v4.mdx
+++ b/src/content/docs/workers/wrangler/migration/update-v3-to-v4.mdx
@@ -13,19 +13,12 @@ While many users should expect a no-op upgrade, the following sections outline t
 
 ## Upgrade to Wrangler v4
 
-To upgrade to the latest version of Wrangler within your Worker project, run:
-
-<PackageManagers pkg="wrangler@latest" dev />
-
-To install a specific Wrangler v4 version, specify the major version number:
+To upgrade to the latest version of Wrangler v4 within your Worker project, run:
 
 <PackageManagers pkg="wrangler@4" dev />
+After upgrading, you can verify the installation:
 
-After upgrading, verify the installation:
-
-```sh
-npx wrangler --version
-```
+<PackageManagers type="exec" pkg="wrangler" args="--version" />
 
 ### Summary of changes
 
@@ -57,9 +50,9 @@ Run the following command to check your Node.js version:
 node --version
 ```
 
-**You need to take action if** your version starts with `v16` (for example, `v16.20.0`).
+**You need to take action if** your version starts with `v16` or `v18` (for example, `v16.20.0` or `v18.20.0`).
 
-**To upgrade Node.js**, use a version manager like [nvm](https://github.com/nvm-sh/nvm) or [Volta](https://volta.sh/), or download directly from [nodejs.org](https://nodejs.org/). Cloudflare recommends using the latest LTS version of Node.js.
+**To upgrade Node.js**, refer to the [Wrangler system requirements](/workers/wrangler/install-and-update/). Cloudflare recommends using the latest LTS version of Node.js.
 
 </Details>
 


### PR DESCRIPTION
## Summary

- Adds explicit upgrade instructions showing users how to upgrade to Wrangler v4
- Adds collapsible `<Details>` panels for each breaking change to help users determine if they are affected
- Converts absolute links to relative links
- Fixes minor typos and command examples

## Changes

### New "Upgrade to Wrangler v4" section
- Shows upgrade commands using the `<PackageManagers>` component for npm/yarn/pnpm
- Includes option to pin to major version 4
- Adds version verification command

### Detection details for each breaking change

**Node.js Support Policy:**
- Command to check current Node.js version
- Clear criteria for when action is needed

**esbuild Upgrade:**
- `grep` commands to search for dynamic wildcard imports
- Examples of problematic patterns and how to fix them

**Commands Default to Local Mode:**
- Complete list of affected KV and R2 commands
- Search commands for scripts and CI/CD configs
- Before/after examples

**Deprecated Commands and Configurations:**
- Search commands for config files and scripts
- Comprehensive table mapping deprecated features to replacements

> [!NOTE]
> This PR was partially authored using OpenCode (Claude) and reviewed by a human.