### PR TITLE
Remove emojis from frontmatter and update style guide

### DIFF
--- a/.opencode/command/styleguide.md
+++ b/.opencode/command/styleguide.md
@@ -38,17 +38,20 @@ Look at all the unstaged changes to markdown (.md, .mdx) files, pull out the lin
 
 ## Structure and Formatting
 
-9. **Code blocks**: Ensure code blocks use appropriate components (`TypeScriptExample`, `WranglerConfig`, `PackageManagers`) or proper language hints. Code should include descriptions of what it does.
+9. **Emojis in frontmatter**: Flag any emojis in frontmatter fields, especially `title` and `sidebar` labels. Emojis should not appear in page titles or sidebar labels.
 
-10. **Paragraphs**: Flag extremely long paragraphs (more than 2-3 sentences). Suggest breaking up with headers, lists, or asides.
+10. **Code blocks**: Ensure code blocks use appropriate components (`TypeScriptExample`, `WranglerConfig`, `PackageManagers`) or proper language hints. Code should include descriptions of what it does.
 
-11. **Link text**: Flag links with unhelpful text like "here", "this page", "read more", or "click here". Link text should describe the destination.
+11. **Paragraphs**: Flag extremely long paragraphs (more than 2-3 sentences). Suggest breaking up with headers, lists, or asides.
 
-12. **Links format**: Flag full URLs to developers.cloudflare.com - should use relative paths (e.g., `/workers/get-started/`).
+12. **Link text**: Flag links with unhelpful text like "here", "this page", "read more", or "click here". Link text should describe the destination.
+
+13. **Links format**: Flag full URLs to developers.cloudflare.com - should use relative paths (e.g., `/workers/get-started/`).
 
 ## Output Format
 
 For each issue found, report:
+
 - The problematic text (quote it)
 - Which rule it violates
 - A suggested fix

--- a/.opencode/command/styleguide.md
+++ b/.opencode/command/styleguide.md
@@ -38,20 +38,17 @@ Look at all the unstaged changes to markdown (.md, .mdx) files, pull out the lin
 
 ## Structure and Formatting
 
-9. **Emojis in frontmatter**: Flag any emojis in frontmatter fields, especially `title` and `sidebar` labels. Emojis should not appear in page titles or sidebar labels.
+9. **Code blocks**: Ensure code blocks use appropriate components (`TypeScriptExample`, `WranglerConfig`, `PackageManagers`) or proper language hints. Code should include descriptions of what it does.
 
-10. **Code blocks**: Ensure code blocks use appropriate components (`TypeScriptExample`, `WranglerConfig`, `PackageManagers`) or proper language hints. Code should include descriptions of what it does.
+10. **Paragraphs**: Flag extremely long paragraphs (more than 2-3 sentences). Suggest breaking up with headers, lists, or asides.
 
-11. **Paragraphs**: Flag extremely long paragraphs (more than 2-3 sentences). Suggest breaking up with headers, lists, or asides.
+11. **Link text**: Flag links with unhelpful text like "here", "this page", "read more", or "click here". Link text should describe the destination.
 
-12. **Link text**: Flag links with unhelpful text like "here", "this page", "read more", or "click here". Link text should describe the destination.
-
-13. **Links format**: Flag full URLs to developers.cloudflare.com - should use relative paths (e.g., `/workers/get-started/`).
+12. **Links format**: Flag full URLs to developers.cloudflare.com - should use relative paths (e.g., `/workers/get-started/`).
 
 ## Output Format
 
 For each issue found, report:
-
 - The problematic text (quote it)
 - Which rule it violates
 - A suggested fix

--- a/src/content/docs/cloudflare-one/tutorials/access-workers.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/access-workers.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2023-11-27
-category: 🔐 Access
+category: Access
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Create custom headers for Cloudflare Access-protected origins with Workers

--- a/src/content/docs/cloudflare-one/tutorials/ai-wrapper-tenant-control.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/ai-wrapper-tenant-control.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2025-05-02
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Advanced
 pcx_content_type: tutorial
 title: Create and secure an AI agent wrapper using AI Gateway and Zero Trust

--- a/src/content/docs/cloudflare-one/tutorials/cli.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/cli.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2021-03-23
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Connect through Cloudflare Access using a CLI

--- a/src/content/docs/cloudflare-one/tutorials/clientless-access-private-dns.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/clientless-access-private-dns.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2024-03-04
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Access a web application via its private hostname without WARP

--- a/src/content/docs/cloudflare-one/tutorials/entra-id-conditional-access.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/entra-id-conditional-access.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2024-01-12
-category: 🔐 Access
+category: Access
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Use Microsoft Entra ID Conditional Access policies in Cloudflare Access

--- a/src/content/docs/cloudflare-one/tutorials/entra-id-risky-users.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/entra-id-risky-users.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2023-01-06
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Advanced
 pcx_content_type: tutorial
 title: Isolate risky Entra ID users

--- a/src/content/docs/cloudflare-one/tutorials/extend-sso-with-workers.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/extend-sso-with-workers.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2024-09-30
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Advanced
 pcx_content_type: tutorial
 title: Send SSO attributes to Access-protected origins with Workers

--- a/src/content/docs/cloudflare-one/tutorials/fastapi.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/fastapi.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2023-06-09
-category: 🔐 Access
+category: Access
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Validate the Access token with FastAPI

--- a/src/content/docs/cloudflare-one/tutorials/gitlab.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/gitlab.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2020-12-10
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Advanced
 pcx_content_type: tutorial
 title: Zero Trust GitLab SSH & HTTP

--- a/src/content/docs/cloudflare-one/tutorials/grafana.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/grafana.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2023-12-06
-category: 🌐 Connections
+category: Connections
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Monitor Cloudflare Tunnel with Grafana

--- a/src/content/docs/cloudflare-one/tutorials/integrate-microsoft-mcas-teams.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/integrate-microsoft-mcas-teams.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2021-08-19
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Integrate Microsoft MCAS with Cloudflare Zero Trust

--- a/src/content/docs/cloudflare-one/tutorials/kubectl.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2022-07-19
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Advanced
 pcx_content_type: tutorial
 title: Connect through Cloudflare Access using kubectl

--- a/src/content/docs/cloudflare-one/tutorials/m365-dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/m365-dedicated-egress-ips.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2023-12-08
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Protect access to Microsoft 365 with dedicated egress IPs

--- a/src/content/docs/cloudflare-one/tutorials/mongodb-tunnel.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/mongodb-tunnel.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2020-12-29
-category: 🌐 Connections
+category: Connections
 difficulty: Advanced
 pcx_content_type: tutorial
 title: MongoDB SSH

--- a/src/content/docs/cloudflare-one/tutorials/mysql-network-policy.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/mysql-network-policy.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2024-03-11
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Access and secure a MySQL database using Cloudflare Tunnel and network policies

--- a/src/content/docs/cloudflare-one/tutorials/okta-u2f.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/okta-u2f.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2020-12-07
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Require U2F with Okta

--- a/src/content/docs/cloudflare-one/tutorials/r2-logs.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/r2-logs.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2023-11-30
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Use Cloudflare R2 as a Zero Trust log destination

--- a/src/content/docs/cloudflare-one/tutorials/regional-private-dns-resolver-policies.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/regional-private-dns-resolver-policies.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2025-11-19
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Advanced
 pcx_content_type: tutorial
 title: Implement regional private DNS servers with Gateway resolver policies

--- a/src/content/docs/cloudflare-one/tutorials/s3-buckets.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/s3-buckets.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2023-10-25
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Advanced
 pcx_content_type: tutorial
 title: Protect access to Amazon S3 buckets with Cloudflare Zero Trust

--- a/src/content/docs/cloudflare-one/tutorials/tunnel-kubectl.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/tunnel-kubectl.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2024-10-02
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Use Cloudflare Tunnels with Kubernetes client-go plugin

--- a/src/content/docs/cloudflare-one/tutorials/user-selectable-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/user-selectable-egress-ips.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2024-03-18
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Intermediate
 pcx_content_type: tutorial
 title: Use virtual networks to change user egress IPs

--- a/src/content/docs/cloudflare-one/tutorials/warp-on-headless-linux.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/warp-on-headless-linux.mdx
@@ -1,6 +1,6 @@
 ---
 reviewed: 2025-09-26
-category: 🔐 Zero Trust
+category: Zero Trust
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Deploy WARP on headless Linux machines

--- a/src/content/docs/style-guide/documentation-content-strategy/component-attributes/titles.mdx
+++ b/src/content/docs/style-guide/documentation-content-strategy/component-attributes/titles.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: concept
 title: Titles
-
 ---
 
 ## Definition
@@ -17,6 +16,15 @@ All content types
 ## Structure
 
 Structure varies by content type. Visit a content type page to see its corresponding title guidelines. In all cases, do not use gerund phrases.
+
+## Emojis
+
+Do not use emojis in page titles or sidebar labels. Emojis can cause issues with search indexing, accessibility tools, and consistent rendering across platforms.
+
+| Do                                | Do not                               |
+| --------------------------------- | ------------------------------------ |
+| `title: Migrating from Version 2` | `title: ⬆️ Migrating from Version 2` |
+| `title: WebSockets`               | `title: "✉️ WebSockets"`             |
 
 ## Subtitles
 

--- a/src/content/docs/workers/testing/miniflare/core/compatibility.mdx
+++ b/src/content/docs/workers/testing/miniflare/core/compatibility.mdx
@@ -1,6 +1,6 @@
 ---
 order: 8
-title: "📅 Compatibility Dates"
+title: Compatibility Dates
 ---
 
 - [Compatibility Dates Reference](/workers/configuration/compatibility-dates)

--- a/src/content/docs/workers/testing/miniflare/core/fetch.mdx
+++ b/src/content/docs/workers/testing/miniflare/core/fetch.mdx
@@ -1,6 +1,6 @@
 ---
 order: 0
-title: "📨 Fetch Events"
+title: Fetch Events
 ---
 
 - [`FetchEvent` Reference](/workers/runtime-apis/handlers/fetch/)

--- a/src/content/docs/workers/testing/miniflare/core/modules.md
+++ b/src/content/docs/workers/testing/miniflare/core/modules.md
@@ -1,6 +1,6 @@
 ---
 order: 3
-title: "📚 Modules"
+title: Modules
 ---
 
 - [Modules Reference](/workers/reference/migrate-to-module-workers/)

--- a/src/content/docs/workers/testing/miniflare/core/multiple-workers.md
+++ b/src/content/docs/workers/testing/miniflare/core/multiple-workers.md
@@ -1,6 +1,6 @@
 ---
 order: 9
-title: "🔌 Multiple Workers"
+title: Multiple Workers
 ---
 
 Miniflare allows you to run multiple workers in the same instance. All Workers can be defined at the same level, using the `workers` option.

--- a/src/content/docs/workers/testing/miniflare/core/queues.md
+++ b/src/content/docs/workers/testing/miniflare/core/queues.md
@@ -1,6 +1,6 @@
 ---
 order: 8
-title: "🚥 Queues"
+title: Queues
 ---
 
 - [Queues Reference](/queues/)

--- a/src/content/docs/workers/testing/miniflare/core/scheduled.md
+++ b/src/content/docs/workers/testing/miniflare/core/scheduled.md
@@ -1,6 +1,6 @@
 ---
 order: 1
-title: "⏰ Scheduled Events"
+title: Scheduled Events
 ---
 
 - [`ScheduledEvent` Reference](/workers/runtime-apis/handlers/scheduled/)

--- a/src/content/docs/workers/testing/miniflare/core/standards.md
+++ b/src/content/docs/workers/testing/miniflare/core/standards.md
@@ -1,6 +1,6 @@
 ---
 order: 6
-title: "🕸 Web Standards"
+title: Web Standards
 ---
 
 - [Web Standards Reference](/workers/runtime-apis/web-standards)

--- a/src/content/docs/workers/testing/miniflare/core/variables-secrets.md
+++ b/src/content/docs/workers/testing/miniflare/core/variables-secrets.md
@@ -1,6 +1,6 @@
 ---
 order: 2
-title: "🔑 Variables and Secrets"
+title: Variables and Secrets
 ---
 
 ## Bindings

--- a/src/content/docs/workers/testing/miniflare/core/web-sockets.md
+++ b/src/content/docs/workers/testing/miniflare/core/web-sockets.md
@@ -1,6 +1,6 @@
 ---
 order: 4
-title: "✉️ WebSockets"
+title: WebSockets
 ---
 
 - [WebSockets Reference](/workers/runtime-apis/websockets)

--- a/src/content/docs/workers/testing/miniflare/developing/debugger.mdx
+++ b/src/content/docs/workers/testing/miniflare/developing/debugger.mdx
@@ -1,6 +1,6 @@
 ---
 order: 4
-title: "🐛 Attaching a Debugger"
+title: Attaching a Debugger
 ---
 
 :::caution

--- a/src/content/docs/workers/testing/miniflare/developing/live-reload.mdx
+++ b/src/content/docs/workers/testing/miniflare/developing/live-reload.mdx
@@ -1,6 +1,6 @@
 ---
 order: 2
-title: ⚡️ Live Reload
+title: Live Reload
 ---
 
 Miniflare automatically refreshes your browser when your Worker script

--- a/src/content/docs/workers/testing/miniflare/migrations/from-v2.mdx
+++ b/src/content/docs/workers/testing/miniflare/migrations/from-v2.mdx
@@ -1,6 +1,6 @@
 ---
 order: 3
-title: ⬆️ Migrating from Version 2
+title: Migrating from Version 2
 ---
 
 Miniflare v3 now uses [`workerd`](https://github.com/cloudflare/workerd), the
@@ -44,7 +44,6 @@ open-source `workerd` runtime. See the [Getting Started guide for the new API do
     mapping binding names to queue names, or a `string[]` of binding names to
     queues of the same name.
 - `queueConsumers`
-
   - Either accepts a `Record<string, QueueConsumerOptions>` mapping queue names
     to consumer options, or a `string[]` of queue names to consume with default
     options. `QueueConsumerOptions` has the following type:
@@ -97,7 +96,6 @@ open-source `workerd` runtime. See the [Getting Started guide for the new API do
     triggering scheduled events yet. This option may be added back in a future
     release.
 - `mounts`
-
   - Miniflare no longer has the concept of parent and child Workers. Instead,
     all Workers can be defined at the same level, using the new `workers`
     option. Here's an example that uses a service binding to increment a value
@@ -133,13 +131,13 @@ open-source `workerd` runtime. See the [Getting Started guide for the new API do
               // Get the message defined outside
               const response = await env.CUSTOM.fetch("http://host/");
               const message = await response.text();
-
+    
               // Increment the count 3 times
               await env.INCREMENTER.fetch("http://host/");
               await env.INCREMENTER.fetch("http://host/");
               await env.INCREMENTER.fetch("http://host/");
               const count = await env.COUNTS.get("count");
-
+    
               return new Response(message + count);
             }
           }`,

--- a/src/content/docs/workers/testing/miniflare/storage/cache.md
+++ b/src/content/docs/workers/testing/miniflare/storage/cache.md
@@ -1,6 +1,6 @@
 ---
 order: 4
-title: ✨ Cache
+title: Cache
 ---
 
 - [Cache Reference](/workers/runtime-apis/cache)

--- a/src/content/docs/workers/testing/miniflare/storage/d1.md
+++ b/src/content/docs/workers/testing/miniflare/storage/d1.md
@@ -1,6 +1,6 @@
 ---
 order: 3
-title: 💾 D1
+title: D1
 ---
 
 - [D1 Reference](/d1/)
@@ -11,9 +11,9 @@ Specify D1 Databases to add to your environment as follows:
 
 ```js
 const mf = new Miniflare({
-  d1Databases:{
-    DB:"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  }
+	d1Databases: {
+		DB: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+	},
 });
 ```
 

--- a/src/content/docs/workers/testing/miniflare/storage/durable-objects.md
+++ b/src/content/docs/workers/testing/miniflare/storage/durable-objects.md
@@ -1,6 +1,6 @@
 ---
 order: 1
-title: 📌 Durable Objects
+title: Durable Objects
 ---
 
 - [Durable Objects Reference](/durable-objects/api/)

--- a/src/content/docs/workers/testing/miniflare/storage/kv.md
+++ b/src/content/docs/workers/testing/miniflare/storage/kv.md
@@ -1,6 +1,6 @@
 ---
 order: 0
-title: 📦 KV
+title: KV
 ---
 
 - [KV Reference](/kv/api/)

--- a/src/content/docs/workers/testing/miniflare/storage/r2.md
+++ b/src/content/docs/workers/testing/miniflare/storage/r2.md
@@ -1,6 +1,6 @@
 ---
 order: 2
-title: 🪣 R2
+title: R2
 ---
 
 - [R2 Reference](/r2/api/workers/workers-api-reference/)


### PR DESCRIPTION
## Summary

- Remove emojis from 17 Miniflare documentation `title` fields
- Remove emojis from 22 Cloudflare One tutorial `category` fields
- Add emoji guidance to the [Titles](/style-guide/documentation-content-strategy/component-attributes/titles/) style guide page
- Add emoji validation rule to the OpenCode styleguide

> [!NOTE]
> This PR was written by [OpenCode](https://github.com/anthropics/opencode) and reviewed by @mattietk.