### PR TITLE
PCX: AI Review of Basic Auth code example

### DIFF
--- a/src/content/docs/workers/examples/basic-auth.mdx
+++ b/src/content/docs/workers/examples/basic-auth.mdx
@@ -284,12 +284,12 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         "/admin" => {
             // The "Authorization" header is sent when authenticated.
             let authorization = req.headers().get("Authorization")?;
-            if authorization == None {
+            if authorization.is_none() {
                 let mut headers = Headers::new();
                 // Prompts the user for credentials.
                 headers.set(
                     "WWW-Authenticate",
-                    "Basic realm='my scope', charset='UTF-8'",
+                    "Basic realm=\"my scope\", charset=\"UTF-8\"",
                 )?;
                 return Ok(Response::error("You need to login.", 401)?.with_headers(headers));
             }
@@ -301,10 +301,12 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 return Response::error("Malformed authorization header.", 400);
             }
 
-            let scheme = auth[0];
             let encoded = auth[1];
 
-            let buff = BASE64_STANDARD.decode(encoded).unwrap();
+            let buff = match BASE64_STANDARD.decode(encoded) {
+                Ok(b) => b,
+                Err(_) => return Response::error("Invalid base64 in authorization header.", 400),
+            };
             let credentials = String::from_utf8_lossy(&buff);
             // The username & password are split by the first colon.
             //=> example: "username:password"
@@ -321,7 +323,7 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 // Prompts the user for credentials.
                 headers.set(
                     "WWW-Authenticate",
-                    "Basic realm='my scope', charset='UTF-8'",
+                    "Basic realm=\"my scope\", charset=\"UTF-8\"",
                 )?;
                 return Ok(Response::error("You need to login.", 401)?.with_headers(headers));
             }

--- a/src/content/docs/workers/examples/basic-auth.mdx
+++ b/src/content/docs/workers/examples/basic-auth.mdx
@@ -283,8 +283,7 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         "/logout" => Response::error("Logged out.", 401),
         "/admin" => {
             // The "Authorization" header is sent when authenticated.
-            let authorization = req.headers().get("Authorization")?;
-            if authorization.is_none() {
+            let Some(authorization) = req.headers().get("Authorization")? else {
                 let mut headers = Headers::new();
                 // Prompts the user for credentials.
                 headers.set(
@@ -292,16 +291,15 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                     "Basic realm=\"my scope\", charset=\"UTF-8\"",
                 )?;
                 return Ok(Response::error("You need to login.", 401)?.with_headers(headers));
-            }
-            let authorization = authorization.unwrap();
-            let auth: Vec<&str> = authorization.split(" ").collect();
+            };
 
             // The Authorization header must start with Basic, followed by a space.
-            if auth.len() < 2 || auth[0] != "Basic" || auth[1].is_empty() {
+            let mut parts = authorization.splitn(2, ' ');
+            let scheme = parts.next().unwrap_or("");
+            let encoded = parts.next().unwrap_or("");
+            if scheme != "Basic" || encoded.is_empty() {
                 return Response::error("Malformed authorization header.", 400);
             }
-
-            let encoded = auth[1];
 
             let buff = match BASE64_STANDARD.decode(encoded) {
                 Ok(b) => b,
@@ -310,11 +308,9 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
             let credentials = String::from_utf8_lossy(&buff);
             // The username & password are split by the first colon.
             //=> example: "username:password"
-            let index = credentials.find(':');
-            if index.is_none() {
+            let Some(index) = credentials.find(':') else {
                 return Response::error("Malformed credentials.", 400);
-            }
-            let index = index.unwrap();
+            };
             let user = &credentials[..index];
             let pass = &credentials[index + 1..];
 

--- a/src/content/docs/workers/examples/basic-auth.mdx
+++ b/src/content/docs/workers/examples/basic-auth.mdx
@@ -1,5 +1,4 @@
 ---
-
 summary: Shows how to restrict access using the HTTP Basic schema.
 tags:
   - Security
@@ -296,21 +295,26 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
             }
             let authorization = authorization.unwrap();
             let auth: Vec<&str> = authorization.split(" ").collect();
-            let scheme = auth[0];
-            let encoded = auth[1];
 
             // The Authorization header must start with Basic, followed by a space.
-            if encoded == "" || scheme != "Basic" {
+            if auth.len() < 2 || auth[0] != "Basic" || auth[1].is_empty() {
                 return Response::error("Malformed authorization header.", 400);
             }
+
+            let scheme = auth[0];
+            let encoded = auth[1];
 
             let buff = BASE64_STANDARD.decode(encoded).unwrap();
             let credentials = String::from_utf8_lossy(&buff);
             // The username & password are split by the first colon.
             //=> example: "username:password"
-            let credentials: Vec<&str> = credentials.split(':').collect();
-            let user = credentials[0];
-            let pass = credentials[1];
+            let index = credentials.find(':');
+            if index.is_none() {
+                return Response::error("Malformed credentials.", 400);
+            }
+            let index = index.unwrap();
+            let user = &credentials[..index];
+            let pass = &credentials[index + 1..];
 
             if user != basic_user || pass != basic_pass {
                 let mut headers = Headers::new();
@@ -347,7 +351,6 @@ import { basicAuth } from "hono/basic-auth";
 // Define environment interface
 interface Env {
 	Bindings: {
-		USERNAME: string;
 		PASSWORD: string;
 	};
 }
@@ -359,12 +362,20 @@ app.get("/", (c) => {
 	return c.text("Anyone can access the homepage.");
 });
 
+// Logout route - invalidate credentials
+app.get("/logout", (c) => {
+	// Invalidate the "Authorization" header by returning a HTTP 401.
+	// We do not send a "WWW-Authenticate" header, as this would trigger
+	// a popup in the browser, immediately asking for credentials again.
+	return c.text("Logged out.", 401);
+});
+
 // Admin route - protected with Basic Auth
 app.get(
 	"/admin",
 	async (c, next) => {
 		const auth = basicAuth({
-			username: c.env.USERNAME,
+			username: "admin",
 			password: c.env.PASSWORD,
 		});
 


### PR DESCRIPTION
## Summary

- Fix potential panics in Rust example by adding bounds checking for malformed authorization headers and credentials
- Update Hono example to use only `PASSWORD` binding (hardcode username as `"admin"`) for consistency with JS/TS/Rust examples
- Add `/logout` route to Hono example for consistency with other examples