### PR TITLE
Fix certificate order in user-defined bundling section

### DIFF
--- a/src/content/docs/ssl/edge-certificates/custom-certificates/bundling-methodologies.mdx
+++ b/src/content/docs/ssl/edge-certificates/custom-certificates/bundling-methodologies.mdx
@@ -36,7 +36,7 @@ The related value for the `bundle_method` parameter when using the [API](/api/re
 
 ### User-defined
 
-User-defined allows you to paste your own certificate chain and present that bundle to clients. You must specify the leaf certificate first, follwed by any intermediates you wish to use. If you are using a self-signed certificate (not recommended), you must use this mode.
+User-defined allows you to paste your own certificate chain and present that bundle to clients. You must specify the leaf certificate first, followed by any intermediates you wish to use. If you are using a self-signed certificate (not recommended), you must use this mode.
 
 The related value for the `bundle_method` parameter when using the [API](/api/resources/custom_certificates/methods/create/) is `force`. The order and format of the chain should look like the following:
 

--- a/src/content/docs/ssl/edge-certificates/custom-certificates/bundling-methodologies.mdx
+++ b/src/content/docs/ssl/edge-certificates/custom-certificates/bundling-methodologies.mdx
@@ -36,15 +36,15 @@ The related value for the `bundle_method` parameter when using the [API](/api/re
 
 ### User-defined
 
-User-defined allows you to paste your own certificate chain and present that bundle to clients. You must specify any intermediates you wish to use, followed by the leaf. If you are using a self-signed certificate (not recommended), you must use this mode.
+User-defined allows you to paste your own certificate chain and present that bundle to clients. You must specify the leaf certificate first, follwed by any intermediates you wish to use. If you are using a self-signed certificate (not recommended), you must use this mode.
 
 The related value for the `bundle_method` parameter when using the [API](/api/resources/custom_certificates/methods/create/) is `force`. The order and format of the chain should look like the following:
 
 ```txt
 -----BEGIN CERTIFICATE-----
-<intermediate>
+<leaf>
 -----END CERTIFICATE-----
 -----BEGIN CERTIFICATE-----
-<leaf>
+<intermediate>
 -----END CERTIFICATE-----
 ```


### PR DESCRIPTION
### Summary

Corrected the order of certificates in the user-defined section for clarity. This was confirmed in practical application and feedback from Cloudflare Support on case 01946069.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
