### PR TITLE
fix(workers-ai): fix broken multipart FormData examples for Flux models

### DIFF
--- a/src/components/models/code/Flux-2.astro
+++ b/src/components/models/code/Flux-2.astro
@@ -23,6 +23,13 @@ export default {
 		form.append('width', '1024');
 		form.append('height', '1024');
 
+		// FormData doesn't expose its serialized body or boundary. Passing it to a
+		// Request (or Response) constructor serializes it and generates the Content-Type
+		// header with the boundary, which is required for the server to parse the multipart fields.
+		const formResponse = new Response(form);
+		const formStream = formResponse.body;
+		const formContentType = formResponse.headers.get('content-type')!;
+
 		const resp = await env.AI.run("${name}", {
 			multipart: {
 				body: formStream,

--- a/src/content/changelog/workers-ai/2026-01-15-flux-2-klein-4b-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-01-15-flux-2-klein-4b-workers-ai.mdx
@@ -34,15 +34,12 @@ form.append("prompt", "a sunset with a dog");
 form.append("width", "1024");
 form.append("height", "1024");
 
-const resp = await env.AI.run("@cf/black-forest-labs/flux-2-klein-4b", {
-	multipart: {
-		body: formStream,
-		contentType: formContentType,
-	},
-});
-const formStream = formRequest.body;
-const formContentType =
-	formRequest.headers.get("content-type") || "multipart/form-data";
+// FormData doesn't expose its serialized body or boundary. Passing it to a
+// Request (or Response) constructor serializes it and generates the Content-Type
+// header with the boundary, which is required for the server to parse the multipart fields.
+const formResponse = new Response(form);
+const formStream = formResponse.body;
+const formContentType = formResponse.headers.get('content-type');
 
 const resp = await env.AI.run("@cf/black-forest-labs/flux-2-klein-4b", {
 	multipart: {
@@ -100,7 +97,6 @@ curl --request POST \
 Through Workers AI Binding:
 
 ```javascript
-
 //helper function to convert ReadableStream to Blob
 async function streamToBlob(stream: ReadableStream, contentType: string): Promise<Blob> {
   const reader = stream.getReader();
@@ -125,11 +121,17 @@ form.append('input_image_0', image_blob0)
 form.append('input_image_1', image_blob1)
 form.append('prompt', 'take the subject of image 1 and style it like image 0')
 
+// FormData doesn't expose its serialized body or boundary. Passing it to a
+// Request (or Response) constructor serializes it and generates the Content-Type
+// header with the boundary, which is required for the server to parse the multipart fields.
+const formResponse = new Response(form);
+const formStream = formResponse.body;
+const formContentType = formResponse.headers.get('content-type');
+
 const resp = await env.AI.run("@cf/black-forest-labs/flux-2-klein-4b", {
     multipart: {
-        body: form,
-        contentType: "multipart/form-data"
+        body: formStream,
+        contentType: formContentType
     }
 })
-
 ```

--- a/src/content/changelog/workers-ai/2026-01-28-flux-2-klein-9b-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-01-28-flux-2-klein-9b-workers-ai.mdx
@@ -34,10 +34,17 @@ form.append("prompt", "a sunset with a dog");
 form.append("width", "1024");
 form.append("height", "1024");
 
+// FormData doesn't expose its serialized body or boundary. Passing it to a
+// Request (or Response) constructor serializes it and generates the Content-Type
+// header with the boundary, which is required for the server to parse the multipart fields.
+const formResponse = new Response(form);
+const formStream = formResponse.body;
+const formContentType = formResponse.headers.get('content-type');
+
 const resp = await env.AI.run("@cf/black-forest-labs/flux-2-klein-9b", {
 	multipart: {
-		body: form,
-		contentType: "multipart/form-data",
+		body: formStream,
+		contentType: formContentType,
 	},
 });
 ```
@@ -112,10 +119,17 @@ form.append('input_image_0', image_blob0)
 form.append('input_image_1', image_blob1)
 form.append('prompt', 'take the subject of image 1 and style it like image 0')
 
+// FormData doesn't expose its serialized body or boundary. Passing it to a
+// Request (or Response) constructor serializes it and generates the Content-Type
+// header with the boundary, which is required for the server to parse the multipart fields.
+const formResponse = new Response(form);
+const formStream = formResponse.body;
+const formContentType = formResponse.headers.get('content-type');
+
 const resp = await env.AI.run("@cf/black-forest-labs/flux-2-klein-9b", {
     multipart: {
-        body: form,
-        contentType: "multipart/form-data"
+        body: formStream,
+        contentType: formContentType
     }
 })
 ```


### PR DESCRIPTION
## Summary

- Fix broken code examples for Flux 2 multipart API in docs
- Add explanatory comment about why the `Response` constructor workaround is needed

## Problem

The existing code examples for Flux 2 models (dev, klein-4b, klein-9b) don't work. They either:
1. Reference undefined variables (`formStream`, `formContentType`)
2. Pass `FormData` directly with a hardcoded `"multipart/form-data"` content-type

Both approaches fail because the AI API requires the multipart boundary parameter in the `Content-Type` header to parse the form fields.

## Solution

`FormData` doesn't expose its serialized body or boundary. Passing it to a `Response` (or `Request`) constructor serializes it and generates the `Content-Type` header with the boundary, which is required for the server to parse the multipart fields.

```js
const formResponse = new Response(form);
const formStream = formResponse.body;
const formContentType = formResponse.headers.get('content-type');
```

## Files Changed

- `src/components/models/code/Flux-2.astro` - shared code example component
- `src/content/changelog/workers-ai/2026-01-15-flux-2-klein-4b-workers-ai.mdx`
- `src/content/changelog/workers-ai/2026-01-28-flux-2-klein-9b-workers-ai.mdx`

## Testing

Verified all 3 models work with the fixed code:
- `@cf/black-forest-labs/flux-2-dev` ✓
- `@cf/black-forest-labs/flux-2-klein-4b` ✓
- `@cf/black-forest-labs/flux-2-klein-9b` ✓