### PR TITLE
durable objects: ws.close docs improved

### DIFF
--- a/src/content/docs/durable-objects/api/base.mdx
+++ b/src/content/docs/durable-objects/api/base.mdx
@@ -46,66 +46,146 @@ class MyDurableObject(DurableObject):
 
 ### `fetch`
 
-- <code>fetch(<Type text="Request"/>)</code>: <Type text="Response"/> | <Type text="Promise <Response>"/>
+- <code>fetch(request <Type text="Request"/>)</code>: <Type text="Response"/> | <Type text="Promise<Response>"/>
 
-  - Takes an HTTP request object and returns an HTTP response object. This method allows the Durable Object to emulate an HTTP server where a Worker with a binding to that object is the client.
+  - `request` - the incoming HTTP [Request](https://developers.cloudflare.com/workers/runtime-apis/request/) object.
 
-  - This method can be `async`.
+Takes an HTTP request and returns an HTTP response. This method allows the Durable Object to emulate an HTTP server where a Worker with a binding to that object is the client.
 
-  - Durable Objects support [RPC calls](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/) as of a compatibility date greater or equal to [2024-04-03](/workers/configuration/compatibility-flags/#durable-object-stubs-and-service-bindings-support-rpc). Users should call RPC methods over `fetch()` if their application design does not follow HTTP request/response flow.
+This method can be `async`.
+
+Durable Objects support [RPC calls](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/) as of compatibility date [2024-04-03](/workers/configuration/compatibility-flags/#durable-object-stubs-and-service-bindings-support-rpc). RPC methods are preferred over `fetch()` when your application does not follow HTTP request/response flow.
+
+```ts
+export class MyDurableObject extends DurableObject<Env> {
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		if (url.pathname === "/hello") {
+			return new Response("Hello, World!");
+		}
+		return new Response("Not found", { status: 404 });
+	}
+}
+```
 
 ### `alarm`
 
-- <code>alarm(`alarmInfo`<Type text="Object"/>)</code>: <Type text="Promise <void>"/>
+- <code>alarm(alarmInfo? <Type text="AlarmInfo"/>)</code>: <Type text="void"/> | <Type text="Promise<void>"/>
 
-  - Called by the system when a scheduled alarm time is reached.
+  - `alarmInfo` (optional) - an object containing retry information:
+    - `retryCount` <Type text="number"/> - the number of times this alarm event has been retried.
+    - `isRetry` <Type text="boolean"/> - `true` if this alarm event is a retry, `false` otherwise.
 
-  - The optional parameter `alarmInfo` object has two properties:
-    - `retryCount` <Type text="number"/>: The number of times this alarm event has been retried.
-    - `isRetry` <Type text="boolean"/>: A boolean value to indicate if the alarm has been retried. This value is `true` if this alarm event is a retry.
+Called by the system when a scheduled alarm time is reached.
 
-  - The `alarm()` handler has guaranteed at-least-once execution and will be retried upon failure using exponential backoff, starting at two second delays for up to six retries. Retries will be performed if the method fails with an uncaught exception.
+The `alarm()` handler has guaranteed at-least-once execution and will be retried upon failure using exponential backoff, starting at two second delays for up to six retries. Retries will be performed if the method fails with an uncaught exception.
 
-  - This method can be `async`.
+This method can be `async`.
 
-  - Refer to [`alarm`](/durable-objects/api/alarms/#alarm) for more information.
+Refer to [Alarms](/durable-objects/api/alarms/) for more information.
+
+```ts
+export class MyDurableObject extends DurableObject<Env> {
+	async alarm(alarmInfo?: AlarmInfo): Promise<void> {
+		if (alarmInfo?.isRetry) {
+			console.log(`Alarm retry attempt ${alarmInfo.retryCount}`);
+		}
+		// Perform scheduled work
+		await this.processScheduledTask();
+	}
+}
+```
 
 ### `webSocketMessage`
 
-- <code> webSocketMessage(ws <Type text="WebSocket" />, message{" "} <Type text="string | ArrayBuffer" />)</code>: <Type text="void" />
+- <code>webSocketMessage(ws <Type text="WebSocket" />, message <Type text="string | ArrayBuffer" />)</code>: <Type text="void"/> | <Type text="Promise<void>"/>
 
-  - Called by the system when an accepted WebSocket receives a message.
+  - `ws` - the [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) that received the message. Use this reference to send responses or access serialized attachments.
+  - `message` - the message data. Text messages arrive as `string`, binary messages as `ArrayBuffer`.
 
-  - This method can be `async`.
+Called by the system when an accepted WebSocket receives a message.
 
-  - This method is not called for WebSocket control frames. The system will respond to an incoming [WebSocket protocol ping](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2) automatically without interrupting hibernation.
+This method is not called for WebSocket control frames. The system will respond to an incoming [WebSocket protocol ping](https://www.rfc-editor.org/rfc/rfc6455#section-5.5.2) automatically without interrupting hibernation.
+
+This method can be `async`.
+
+```ts
+export class MyDurableObject extends DurableObject<Env> {
+	async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
+		if (typeof message === "string") {
+			// Echo text messages back to the client
+			ws.send(`Received: ${message}`);
+		} else {
+			// Handle binary data
+			ws.send(`Received ${message.byteLength} bytes`);
+		}
+	}
+}
+```
 
 ### `webSocketClose`
 
-- <code> webSocketClose(ws <Type text="WebSocket" />, code <Type text="number" />, reason <Type text="string" />, wasClean <Type text="boolean" />)</code>: <Type text="void" />
+- <code>webSocketClose(ws <Type text="WebSocket" />, code <Type text="number" />, reason <Type text="string" />, wasClean <Type text="boolean" />)</code>: <Type text="void"/> | <Type text="Promise<void>"/>
 
-  - Called by the system when a WebSocket is closed. `wasClean()` is true if the connection closed cleanly, false otherwise.
+  - `ws` - the [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) that was closed.
+  - `code` - the [WebSocket close code](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code) sent by the client (e.g., `1000` for normal closure, `1001` for going away).
+  - `reason` - a string indicating why the connection was closed (may be empty).
+  - `wasClean` - `true` if the connection closed cleanly with a proper closing handshake, `false` otherwise.
 
-  - This method can be `async`.
+Called by the system when a WebSocket connection is closed.
+
+You **must** call `ws.close(code, reason)` inside this handler to complete the WebSocket close handshake. Failing to reciprocate the close will result in `1006` errors on the client, representing an abnormal close per the WebSocket specification.
+
+This method can be `async`.
+
+```ts
+export class MyDurableObject extends DurableObject<Env> {
+	async webSocketClose(
+		ws: WebSocket,
+		code: number,
+		reason: string,
+		wasClean: boolean
+	) {
+		// Complete the close handshake
+		ws.close(code, reason);
+		// Clean up any session state
+		console.log(`WebSocket closed: code=${code}, reason=${reason}`);
+	}
+}
+```
 
 ### `webSocketError`
 
-- <code> webSocketError(ws <Type text="WebSocket" />, error <Type text="any" />)</code> : <Type text="void" />
+- <code>webSocketError(ws <Type text="WebSocket" />, error <Type text="unknown" />)</code>: <Type text="void"/> | <Type text="Promise<void>"/>
 
-  - Called by the system when any non-disconnection related errors occur.
+  - `ws` - the [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) that encountered an error.
+  - `error` - the error that occurred. May be an `Error` object or another type depending on the error source.
 
-  - This method can be `async`.
+Called by the system when a non-disconnection error occurs on a WebSocket connection. Use this handler to log errors and perform cleanup.
+
+This method can be `async`.
+
+```ts
+export class MyDurableObject extends DurableObject<Env> {
+	async webSocketError(ws: WebSocket, error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`WebSocket error: ${message}`);
+	}
+}
+```
 
 ## Properties
 
-### `DurableObjectState`
+### `ctx`
 
-See [`DurableObjectState` documentation](/durable-objects/api/state/).
+The [DurableObjectState](/durable-objects/api/state/) for this Durable Object instance. Provides access to storage, WebSocket management, and other instance-specific functionality.
 
-### `Env`
+### `env`
 
-A list of bindings which are available to the Durable Object.
+The environment bindings available to this Durable Object, as defined in your Wrangler configuration.
 
 ## Related resources
 
-- Refer to [Use WebSockets](/durable-objects/best-practices/websockets/) for more information on examples of WebSocket methods and best practices.
+- [Use WebSockets](/durable-objects/best-practices/websockets/) for WebSocket handler best practices.
+- [Alarms API](/durable-objects/api/alarms/) for scheduling future work.
+- [RPC methods](/durable-objects/best-practices/create-durable-object-stubs-and-send-requests/) for type-safe method calls.

--- a/src/content/docs/durable-objects/best-practices/rules-of-durable-objects.mdx
+++ b/src/content/docs/durable-objects/best-practices/rules-of-durable-objects.mdx
@@ -1124,6 +1124,8 @@ export class ChatRoom extends DurableObject<Env> {
 		reason: string,
 		wasClean: boolean
 	) {
+		// Calling close() completes the WebSocket handshake
+		ws.close(code, reason);
 		console.log(`WebSocket closed: ${code} ${reason}`);
 	}
 
@@ -1136,6 +1138,11 @@ export class ChatRoom extends DurableObject<Env> {
 </TypeScriptExample>
 
 With the Hibernation API, your Durable Object can go to sleep when there is no active JavaScript execution, but WebSocket connections remain open. When a message arrives, the Durable Object wakes up automatically.
+
+Best practices:
+
+- The [WebSocket Hibernation API](/durable-objects/best-practices/websockets/#durable-objects-hibernation-websocket-api) exposes `webSocketError`, `webSocketMessage`, and `webSocketClose` handlers for their respective WebSocket events.
+- When implementing `webSocketClose`, you **must** reciprocate the close by calling `ws.close()` to avoid swallowing the WebSocket close frame. Failing to do so results in `1006` errors, representing an abnormal close per the WebSocket specification.
 
 Refer to [WebSockets](/durable-objects/best-practices/websockets/) for more details.
 
@@ -1205,7 +1212,9 @@ export class ChatRoom extends DurableObject<Env> {
 		this.broadcast(chatMessage);
 	}
 
-	async webSocketClose(ws: WebSocket) {
+	async webSocketClose(ws: WebSocket, code: number, reason: string) {
+		// Calling close() completes the WebSocket handshake
+		ws.close(code, reason);
 		const state = ws.deserializeAttachment() as ConnectionState;
 		this.broadcast(`${state.username} left the chat`);
 	}

--- a/src/content/docs/durable-objects/best-practices/websockets.mdx
+++ b/src/content/docs/durable-objects/best-practices/websockets.mdx
@@ -84,8 +84,8 @@ export class WebSocketHibernationServer extends DurableObject {
 	}
 
 	async webSocketClose(ws, code, reason, wasClean) {
-		// If the client closes the connection, the runtime will invoke the webSocketClose() handler.
-		ws.close(code, "Durable Object is closing WebSocket");
+		// Calling close() on the server completes the WebSocket close handshake
+		ws.close(code, reason);
 	}
 }
 ```
@@ -132,8 +132,8 @@ export class WebSocketHibernationServer extends DurableObject {
 		reason: string,
 		wasClean: boolean,
 	) {
-		// If the client closes the connection, the runtime will invoke the webSocketClose() handler.
-		ws.close(code, "Durable Object is closing WebSocket");
+		// Calling close() on the server completes the WebSocket close handshake
+		ws.close(code, reason);
 	}
 }
 ```
@@ -173,8 +173,8 @@ class WebSocketHibernationServer(DurableObject):
         )
 
     async def webSocketClose(self, ws, code, reason, was_clean):
-        # If the client closes the connection, the runtime will invoke the webSocketClose() handler.
-        ws.close(code, "Durable Object is closing WebSocket")
+        # Calling close() on the server completes the WebSocket close handshake
+        ws.close(code, reason)
 ```
 </TabItem>
 </Tabs>

--- a/src/content/docs/durable-objects/examples/websocket-hibernation-server.mdx
+++ b/src/content/docs/durable-objects/examples/websocket-hibernation-server.mdx
@@ -151,9 +151,9 @@ export class WebSocketHibernationServer extends DurableObject {
   }
 
   async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
-    // If the client closes the connection, the runtime will invoke the webSocketClose() handler.
+    // Calling close() on the server completes the WebSocket close handshake
+    ws.close(code, reason);
     this.sessions.delete(ws);
-    ws.close(code, 'Durable Object is closing WebSocket');
   }
 }
 ```
@@ -266,12 +266,12 @@ class WebSocketHibernationServer(DurableObject):
 				session.ws.send(f"[Durable Object] message: {message}, from: {session_id}, to: all clients except the initiating client. Total connections: {len(self.sessions)}")
 
 	async def webSocketClose(self, ws, code, reason, wasClean):
-		# If the client closes the connection, the runtime will invoke the webSocketClose() handler.
+		# Calling close() on the server completes the WebSocket close handshake
+		ws.close(code, reason)
 		# Get the session ID from the WebSocket attachment to remove it from sessions
 		session_id = ws.deserializeAttachment()
 		if session_id:
 			self.sessions.pop(session_id, None)
-		ws.close(code, 'Durable Object is closing WebSocket')
 ```
 
 </TabItem>


### PR DESCRIPTION
- All `webSocketClose` examples now reciprocate the close by calling `ws.close(code, reason)`
- API reference for DO base class expanded with argument docs and usage examples
- Added best practices section explaining `1006` errors when close is not reciprocated