### PR TITLE
Fix self-referencing link in Workflows TypeScript documentation

### DIFF
--- a/src/content/partials/workflows/workflows-type-parameters.mdx
+++ b/src/content/partials/workflows/workflows-type-parameters.mdx
@@ -11,4 +11,4 @@ Providing a type parameter does _not_ validate that the incoming event matches y
 
 :::
 
-You can also provide a type parameter to the `Workflows` type when creating (triggering) a Workflow instance using the `create` method of the [Workers API](/workflows/build/workers-api/#workflow). Note that this does _not_ propagate type information into the Workflow itself, as TypeScript types are a build-time construct. To provide the type of an incoming `WorkflowEvent`, refer to the [TypeScript and type parameters](/workflows/build/events-and-parameters/#typescript-and-type-parameters) section of the Workflows documentation.
+You can also provide a type parameter to the `Workflows` type when creating (triggering) a Workflow instance using the `create` method of the [Workers API](/workflows/build/workers-api/#workflow). Note that this does _not_ propagate type information into the Workflow itself, as TypeScript types are a build-time construct.


### PR DESCRIPTION
Fixes #27855

Removes a self-referencing link in the Workflows documentation where the 'TypeScript and type parameters' section linked to itself.

Removed the sentence "To provide the type of an incoming `WorkflowEvent`, refer to the [TypeScript and type parameters]..." from the `workflows-type-parameters.mdx` partial
