### PR TITLE
Update WFP with new platform template example

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/index.mdx
+++ b/src/content/docs/cloudflare-for-platforms/index.mdx
@@ -28,16 +28,16 @@ Get a working platform running in minutes. Choose a template based on what you a
 
 ### Platform Starter Kit
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/worker-publisher-template)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/workers-for-platforms-template)
 
-An example of a platform where users can deploy code at scale. Each snippet becomes its own isolated Worker, served at `example.com/{app-name}`. Deploying this starter kit automatically configures Workers for Platforms with routing handled for you.
+An example of a platform where users can deploy code at scale. Each code snippet becomes its own isolated Worker within a dispatch namespace. Sites are accessible via subdomain (`app-name.yourdomain.com`) or users can connect their own custom domains, with Cloudflare automatically provisioning and renewing TLS certificates for those domains.
 
-<LinkButton href="https://worker-publisher-template.templates.workers.dev/">
+<LinkButton href="https://workers-for-platforms-template.templates.workers.dev/">
 	View demo
 </LinkButton>
 <LinkButton
 	variant="secondary"
-	href="https://github.com/cloudflare/templates/tree/main/worker-publisher-template"
+	href="https://github.com/cloudflare/templates/tree/main/workers-for-platforms-template"
 >
 	View on GitHub
 </LinkButton>


### PR DESCRIPTION
Update WFP to include new starter platform example that automatically integrates with custom hostnames. 