### PR TITLE
[Email security] Add Overview

### DIFF
--- a/src/content/docs/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/index.mdx
+++ b/src/content/docs/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/index.mdx
@@ -5,6 +5,7 @@ sidebar:
   order: 1
 ---
 
-BCC/Journaling deployment is a post-delivery type of deployment. Every time you receive an email, your email provider will send a blind copy to Cloudflare for an analysis.
+BCC/Journaling deployment is a post-delivery type of deployment. Cloudflare analyzer emails after they reach the user's inbox. Every time you receive an email, your email provider will send a blind copy to Cloudflare for an analysis.
 
-Choose [BCC](/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/bcc-setup/gmail-bcc-setup/gmail-bcc-setup/) if your email provider is Gmail, otherwise, choose [Journaling](/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/journaling-setup/m365-journaling/) if your email provider is Microsoft 365.
+- Choose [BCC](/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/bcc-setup/gmail-bcc-setup/gmail-bcc-setup/) if your email provider is Gmail.
+- Choose [Journaling](/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/journaling-setup/m365-journaling/) if your email provider is Microsoft 365.

--- a/src/content/docs/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/index.mdx
+++ b/src/content/docs/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-BCC/Journaling deployment is a post-delivery type of deployment. Cloudflare analyzer emails after they reach the user's inbox. Every time you receive an email, your email provider will send a blind copy to Cloudflare for an analysis.
+BCC/Journaling deployment is a post-delivery type of deployment. Cloudflare analyzes emails after they reach the user's inbox. Every time you receive an email, your email provider will send a blind copy to Cloudflare for an analysis.
 
 - Choose [BCC](/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/bcc-setup/gmail-bcc-setup/gmail-bcc-setup/) if your email provider is Gmail.
 - Choose [Journaling](/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/journaling-setup/m365-journaling/) if your email provider is Microsoft 365.

--- a/src/content/docs/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/index.mdx
+++ b/src/content/docs/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/index.mdx
@@ -3,11 +3,8 @@ title: BCC/Journaling
 pcx_content_type: concept
 sidebar:
   order: 1
-  group:
-   hideIndex: true
 ---
 
 BCC/Journaling deployment is a post-delivery type of deployment. Every time you receive an email, your email provider will send a blind copy to Cloudflare for an analysis.
 
-
-![Journaling deployment M365](~/assets/images/email-security/deployment/api-setup/journaling/CF_Email_Security_DeploymentAPI_Diagram.png)
+Choose [BCC](/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/bcc-setup/gmail-bcc-setup/gmail-bcc-setup/) if your email provider is Gmail, otherwise, choose [Journaling](/cloudflare-one/email-security/setup/post-delivery-deployment/bcc-journaling/journaling-setup/m365-journaling/) if your email provider is Microsoft 365.


### PR DESCRIPTION
The dashboard currently has a **BCC/Journaling setup documentation** hyperlink that currently throws a 404. I'm adding an overview page to fix the problem.