### PR TITLE
Browser Rendering: Add FAQ for troubleshooting missing page content

### DIFF
--- a/src/content/docs/browser-rendering/faq.mdx
+++ b/src/content/docs/browser-rendering/faq.mdx
@@ -26,7 +26,7 @@ This error typically occurs because your Puppeteer launch is not receiving the b
 
 ### Error: 429 browser time limit exceeded
 
-This error (`Unable to create new browser: code: 429: message: Browser time limit exceeded for today`) indicates you have hit the daily browser-instance limit on the Workers Free plan. [Free-plan accounts are capped at 10 minutes of browser use a day](/browser-rendering/limits/#workers-free). Once you exceed that limit, further creation attempts return a 429 error until the next UTC day.
+This error (`Unable to create new browser: code: 429: message: Browser time limit exceeded for today`) indicates you have hit the daily browser-instance limit on the Workers Free plan. [Workers Free plan accounts are capped at 10 minutes of browser use a day](/browser-rendering/limits/#workers-free). Once you exceed that limit, further creation attempts return a 429 error until the next UTC day.
 
 To resolve this error, [upgrade to a Workers Paid plan](/workers/platform/pricing/) which allows for more than 10 minutes of usage a day and has higher [limits](/browser-rendering/limits/#workers-paid). If you recently upgraded but still see this error, try redeploying your Worker to ensure your usage is correctly associated with your new plan.
 

--- a/src/content/docs/browser-rendering/faq.mdx
+++ b/src/content/docs/browser-rendering/faq.mdx
@@ -18,6 +18,61 @@ If you cannot find the answer you are looking for, join us on [Discord](https://
 
 ---
 
+## Errors & Troubleshooting
+
+### Error: Cannot read properties of undefined (reading 'fetch')
+
+This error typically occurs because your Puppeteer launch is not receiving the browser binding. To resolve this error, pass your browser binding into `puppeteer.launch`.
+
+### Error: 429 browser time limit exceeded
+
+This error (`Unable to create new browser: code: 429: message: Browser time limit exceeded for today`) indicates you have hit the daily browser-instance limit on the Workers Free plan. [Free-plan accounts are capped at 10 minutes of browser use a day](/browser-rendering/limits/#workers-free). Once you exceed that limit, further creation attempts return a 429 error until the next UTC day.
+
+To resolve this error, [upgrade to a Workers Paid plan](/workers/platform/pricing/) which allows for more than 10 minutes of usage a day and has higher [limits](/browser-rendering/limits/#workers-paid). If you recently upgraded but still see this error, try redeploying your Worker to ensure your usage is correctly associated with your new plan.
+
+### Error: 422 unprocessable entity
+
+A `422 Unprocessable Entity` error usually means that Browser Rendering wasn't able to complete an action because of an issue with the site.
+
+This can happen if:
+- The website consumes too much memory during rendering.
+- The page itself crashed or returned an error before the action completed.
+- The request exceeded one of the [timeout limits](/browser-rendering/reference/timeouts/) for page load, element load, or an action.
+
+Most often, this error is caused by a timeout. You can review the different timers and their limits in the [REST API timeouts reference](/browser-rendering/reference/timeouts/).
+
+### Why is my page content missing or incomplete?
+
+If your screenshots, PDFs, or scraped content are missing elements that appear when viewing the page in a browser, the page likely has not finished loading before Browser Rendering captures the output.
+
+JavaScript-heavy pages and Single Page Applications (SPAs) often load content dynamically after the initial HTML is parsed. By default, Browser Rendering waits for `domcontentloaded`, which fires before JavaScript has finished rendering the page.
+
+To fix this, use the `goToOptions.waitUntil` parameter with one of these values:
+
+| Value              | Use when                                                                 |
+| ------------------ | ------------------------------------------------------------------------ |
+| `networkidle0`     | The page must be completely idle (no network requests for 500 ms). Best for pages that load all content upfront. |
+| `networkidle2`     | The page can have up to 2 ongoing connections (like analytics or websockets). Best for most dynamic pages. |
+
+REST API example:
+```json
+{
+  "url": "https://example.com",
+  "goToOptions": {
+    "waitUntil": "networkidle2"
+  }
+}
+```
+
+If content is still missing:
+- Use `waitForSelector` to wait for a specific element to appear before capturing.
+- Increase `goToOptions.timeout` (up to 60 seconds) for slow-loading pages.
+- Check if the page requires authentication or returns different content to bots.
+
+For a complete reference, see [REST API timeouts](/browser-rendering/reference/timeouts/).
+
+---
+
 ## Getting started & Development
 
 ### Does local development support all Browser Rendering features?
@@ -83,28 +138,3 @@ This applies to both the [REST API](/browser-rendering/rest-api/) and [Workers B
 For the [REST API](/browser-rendering/rest-api/), generated content is cached by default for five seconds (configurable up to one day via the `cacheTTL` parameter, or set to `0` to disable caching). This cache protects against repeated requests for the same URL by the same account. Customer-submitted HTML content itself is not cached.
 
 For [Workers Bindings](/browser-rendering/workers-bindings/), no caching is used. Content exists only in memory for the duration of the rendering operation and is discarded immediately after the response is returned.
-
----
-
-## Errors & Troubleshooting
-
-### `Cannot read properties of undefined (reading 'fetch')`
-
-This error typically occurs because your Puppeteer launch is not receiving the Browser binding. To resolve: Pass your Browser binding into `puppeteer.launch`.
-
-### `Error processing the request: Unable to create new browser: code: 429: message: Browser time limit exceeded for today`
-
-This error indicates you have hit the daily browser-instance limit on the Workers Free plan. [Free-plan accounts are capped at free plan limit is 10 minutes of browser use a day](/browser-rendering/limits/#workers-free) once you exceed those, further creation attempts return a 429 until the next UTC day.
-
-To resolve: [Upgrade to a Workers Paid plan](/workers/platform/pricing/) which allows for more than 10 minutes of usage a day and has higher [limits](/browser-rendering/limits/#workers-paid). If you recently upgraded but still see this error, try redeploying your Worker to ensure your usage is correctly associated with your new plan.
-
-### `422 Unprocessable Entity`
-
-A `422 Unprocessable Entity` error usually means that Browser Rendering wasn’t able to complete an action because of an issue with the site.
-
-This can happen if:
-- The website consumes too much memory during rendering.
-- The page itself crashed or returned an error before the action completed.
-- The request exceeded one of the [timeout limits](/browser-rendering/reference/timeouts/) for page load, element load, or an action.
-
-Most often, this error is caused by a timeout. You can review the different timers and their limits in the [REST API timeouts reference](/browser-rendering/reference/timeouts/).


### PR DESCRIPTION
## Summary

Adds a new FAQ entry in the **Errors & Troubleshooting** section explaining why page content might be missing and when to use `networkidle0` vs `networkidle2`.

## Changes

- Added new FAQ: "Why is my page content missing or incomplete?"
- Explains the difference between `networkidle0` and `networkidle2` with a clear use-case table
- Includes REST API example
- Links to existing timeouts reference for deeper details

## Why

The timeout/waitUntil documentation already exists in the [timeouts reference](https://developers.cloudflare.com/browser-rendering/reference/timeouts/), but users often look in the FAQ first when troubleshooting. This surfaces that information where users are most likely to find it.