### PR TITLE
Fix #27889 and #27811: Correct Turnstile hostname limit and clarify x-forwarded-for header rules

### DIFF
--- a/src/content/docs/rules/transform/request-header-modification/index.mdx
+++ b/src/content/docs/rules/transform/request-header-modification/index.mdx
@@ -54,7 +54,7 @@ You can create a request header transform rule [in the dashboard](/rules/transfo
 
 - Due to protocol compliance reasons, modifying or removing request headers with [forbidden header names](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) (such as `Accept-Encoding`) is generally not allowed in Request Header Transform Rules.
 
-- You cannot modify the value of any header commonly used to identify the website visitor's IP address or initial protocol, such as `x-forwarded-for`, `true-client-ip`, `x-real-ip`, or `x-forwarded-proto`. Additionally, you cannot remove the `x-forwarded-for` and `x-forwarded-proto` headers.
+- You cannot modify the value of any header commonly used to identify the website visitor's IP address or initial protocol, such as `x-forwarded-for`, `true-client-ip`, `x-real-ip`, or `x-forwarded-proto`. You cannot modify the `x-forwarded-for` header value, and you cannot remove the `x-forwarded-for` and `x-forwarded-proto` headers.
 
 - You cannot set or modify the value of `cookie` HTTP request headers, but you can remove these headers. Configuring a rule that removes the `cookie` HTTP request header will remove all `cookie` headers in matching requests.
 

--- a/src/content/docs/turnstile/additional-configuration/hostname-management/index.mdx
+++ b/src/content/docs/turnstile/additional-configuration/hostname-management/index.mdx
@@ -95,6 +95,6 @@ However, it will not work on:
 
 ## Limitations
 
-Free users are entitled to a maximum of 15 hostnames per widget.
+Free users are entitled to a maximum of 10 hostnames per widget.
 
 Enterprise customers can have up to 200 hostnames per widget.


### PR DESCRIPTION
## Changes

- **Fix #27889**: Corrected Turnstile free tier hostname limit from 15 to 10 per widget
- **Fix #27811**: Clarified x-forwarded-for header documentation - you cannot modify the value of x-forwarded-for, and you cannot remove x-forwarded-for and x-forwarded-proto headers

## Files Changed
- `src/content/docs/turnstile/additional-configuration/hostname-management/index.mdx`
- `src/content/docs/rules/transform/request-header-modification/index.mdx`