### PR TITLE
docs: update all compatibility_date values to $today

### DIFF
--- a/src/content/changelog/workers/2025-10-24-tanstack-start.mdx
+++ b/src/content/changelog/workers/2025-10-24-tanstack-start.mdx
@@ -54,7 +54,7 @@ export default defineConfig({
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-tanstack-start-app",
-	"compatibility_date": "2025-10-11",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/agents/api-reference/configuration.mdx
+++ b/src/content/docs/agents/api-reference/configuration.mdx
@@ -41,7 +41,7 @@ Below is a minimal `wrangler.jsonc` file that defines the configuration for an A
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "agents-example",
 	"main": "src/index.ts",
-	"compatibility_date": "2025-02-23",
+	"compatibility_date": "$today",
 	"compatibility_flags": ["nodejs_compat"],
 	"durable_objects": {
 		"bindings": [

--- a/src/content/docs/agents/guides/chatgpt-app.mdx
+++ b/src/content/docs/agents/guides/chatgpt-app.mdx
@@ -80,7 +80,7 @@ npm install -D @cloudflare/vite-plugin @vitejs/plugin-react vite vite-plugin-sin
 {
   "name": "my-chess-app",
   "main": "src/index.ts",
-  "compatibility_date": "2025-01-01",
+  "compatibility_date": "$today",
   "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [

--- a/src/content/docs/agents/guides/human-in-the-loop.mdx
+++ b/src/content/docs/agents/guides/human-in-the-loop.mdx
@@ -75,7 +75,7 @@ OPENAI_API_KEY="your-openai-api-key"
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "human-in-the-loop",
 	"main": "./src/server.ts",
-	"compatibility_date": "2025-02-21",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat",
 		"nodejs_compat_populate_process_env"

--- a/src/content/docs/agents/guides/slack-agent.mdx
+++ b/src/content/docs/agents/guides/slack-agent.mdx
@@ -123,7 +123,7 @@ The `OPENAI_BASE_URL` is optional but recommended. Using [Cloudflare AI Gateway]
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-slack-agent",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-01-01",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/playwright/index.mdx
+++ b/src/content/docs/browser-rendering/playwright/index.mdx
@@ -51,7 +51,7 @@ To use the latest version of `@cloudflare/playwright`, your Worker configuration
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "2025-09-17",
+	"compatibility_date": "$today", // Minimum: 2025-09-15
 	"upload_source_maps": true,
 	"browser": {
 		"binding": "MYBROWSER"
@@ -210,7 +210,7 @@ Then, add the KV namespace to your Wrangler configuration file:
 	"name": "storage-state-examples",
 	"main": "src/index.ts",
 	"compatibility_flags": ["nodejs_compat"],
-	"compatibility_date": "2025-09-17",
+	"compatibility_date": "$today", // Minimum: 2025-09-15
 	"browser": {
 		"binding": "MYBROWSER"
 	},

--- a/src/content/docs/browser-rendering/playwright/index.mdx
+++ b/src/content/docs/browser-rendering/playwright/index.mdx
@@ -51,7 +51,7 @@ To use the latest version of `@cloudflare/playwright`, your Worker configuration
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "$today"
+	"compatibility_date": "$today",
 	"upload_source_maps": true,
 	"browser": {
 		"binding": "MYBROWSER"
@@ -210,7 +210,7 @@ Then, add the KV namespace to your Wrangler configuration file:
 	"name": "storage-state-examples",
 	"main": "src/index.ts",
 	"compatibility_flags": ["nodejs_compat"],
-	"compatibility_date": "$today"
+	"compatibility_date": "$today",
 	"browser": {
 		"binding": "MYBROWSER"
 	},

--- a/src/content/docs/browser-rendering/playwright/index.mdx
+++ b/src/content/docs/browser-rendering/playwright/index.mdx
@@ -51,7 +51,7 @@ To use the latest version of `@cloudflare/playwright`, your Worker configuration
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "$today", // Minimum: 2025-09-15
+	"compatibility_date": "$today"
 	"upload_source_maps": true,
 	"browser": {
 		"binding": "MYBROWSER"
@@ -210,7 +210,7 @@ Then, add the KV namespace to your Wrangler configuration file:
 	"name": "storage-state-examples",
 	"main": "src/index.ts",
 	"compatibility_flags": ["nodejs_compat"],
-	"compatibility_date": "$today", // Minimum: 2025-09-15
+	"compatibility_date": "$today"
 	"browser": {
 		"binding": "MYBROWSER"
 	},

--- a/src/content/docs/browser-rendering/playwright/playwright-mcp.mdx
+++ b/src/content/docs/browser-rendering/playwright/playwright-mcp.mdx
@@ -61,7 +61,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "playwright-mcp-example",
 	"main": "src/index.ts",
-	"compatibility_date": "2025-09-17",
+	"compatibility_date": "$today", // Minimum: 2025-09-15
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/playwright/playwright-mcp.mdx
+++ b/src/content/docs/browser-rendering/playwright/playwright-mcp.mdx
@@ -61,7 +61,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "playwright-mcp-example",
 	"main": "src/index.ts",
-	"compatibility_date": "$today"
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/playwright/playwright-mcp.mdx
+++ b/src/content/docs/browser-rendering/playwright/playwright-mcp.mdx
@@ -61,7 +61,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "playwright-mcp-example",
 	"main": "src/index.ts",
-	"compatibility_date": "$today", // Minimum: 2025-09-15
+	"compatibility_date": "$today"
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/stagehand.mdx
+++ b/src/content/docs/browser-rendering/stagehand.mdx
@@ -62,7 +62,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 				"name": "stagehand-example",
 				"main": "src/index.ts",
 				"compatibility_flags": ["nodejs_compat"],
-				"compatibility_date": "2025-09-17",
+				"compatibility_date": "$today", // Minimum: 2025-09-15
 				"observability": {
 					"enabled": true
 				},

--- a/src/content/docs/browser-rendering/stagehand.mdx
+++ b/src/content/docs/browser-rendering/stagehand.mdx
@@ -62,7 +62,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 				"name": "stagehand-example",
 				"main": "src/index.ts",
 				"compatibility_flags": ["nodejs_compat"],
-				"compatibility_date": "$today"
+				"compatibility_date": "$today",
 				"observability": {
 					"enabled": true
 				},

--- a/src/content/docs/browser-rendering/stagehand.mdx
+++ b/src/content/docs/browser-rendering/stagehand.mdx
@@ -62,7 +62,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 				"name": "stagehand-example",
 				"main": "src/index.ts",
 				"compatibility_flags": ["nodejs_compat"],
-				"compatibility_date": "$today", // Minimum: 2025-09-15
+				"compatibility_date": "$today"
 				"observability": {
 					"enabled": true
 				},

--- a/src/content/docs/browser-rendering/workers-bindings/browser-rendering-with-DO.mdx
+++ b/src/content/docs/browser-rendering/workers-bindings/browser-rendering-with-DO.mdx
@@ -74,7 +74,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "rendering-api-demo",
 	"main": "src/index.js",
-	"compatibility_date": "$today", // Minimum: 2025-09-15
+	"compatibility_date": "$today"
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/workers-bindings/browser-rendering-with-DO.mdx
+++ b/src/content/docs/browser-rendering/workers-bindings/browser-rendering-with-DO.mdx
@@ -74,7 +74,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "rendering-api-demo",
 	"main": "src/index.js",
-	"compatibility_date": "2025-09-17",
+	"compatibility_date": "$today", // Minimum: 2025-09-15
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/workers-bindings/browser-rendering-with-DO.mdx
+++ b/src/content/docs/browser-rendering/workers-bindings/browser-rendering-with-DO.mdx
@@ -74,7 +74,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "rendering-api-demo",
 	"main": "src/index.js",
-	"compatibility_date": "$today"
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/workers-bindings/reuse-sessions.mdx
+++ b/src/content/docs/browser-rendering/workers-bindings/reuse-sessions.mdx
@@ -52,7 +52,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "browser-worker",
 	"main": "src/index.ts",
-	"compatibility_date": "$today", // Minimum: 2025-09-15
+	"compatibility_date": "$today"
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/workers-bindings/reuse-sessions.mdx
+++ b/src/content/docs/browser-rendering/workers-bindings/reuse-sessions.mdx
@@ -52,7 +52,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "browser-worker",
 	"main": "src/index.ts",
-	"compatibility_date": "$today"
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/browser-rendering/workers-bindings/reuse-sessions.mdx
+++ b/src/content/docs/browser-rendering/workers-bindings/reuse-sessions.mdx
@@ -52,7 +52,7 @@ Your Worker configuration must include the `nodejs_compat` compatibility flag an
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "browser-worker",
 	"main": "src/index.ts",
-	"compatibility_date": "2025-09-17",
+	"compatibility_date": "$today", // Minimum: 2025-09-15
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/configuration/static-assets.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/configuration/static-assets.mdx
@@ -247,7 +247,7 @@ Create or update your [Wrangler configuration file](/workers/wrangler/configurat
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-static-site",
 	"main": "./src/index.js",
-	"compatibility_date": "2025-01-29",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "./public",
 		"binding": "ASSETS",

--- a/src/content/docs/cloudflare-one/access-controls/policies/external-evaluation.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/policies/external-evaluation.mdx
@@ -65,7 +65,7 @@ You can set up External Evaluation rules using any API service, but to get start
      "$schema": "./node_modules/wrangler/config-schema.json",
      "name": "my-worker",
      "workers_dev": true,
-     "compatibility_date": "2024-08-06",
+     "compatibility_date": "$today",
      "main": "index.js",
      "kv_namespaces": [
        {

--- a/src/content/docs/cloudflare-one/tutorials/entra-id-risky-users.mdx
+++ b/src/content/docs/cloudflare-one/tutorials/entra-id-risky-users.mdx
@@ -91,7 +91,7 @@ To get started quickly, deploy our example Cloudflare Workers script by followin
    {
      "$schema": "./node_modules/wrangler/config-schema.json",
      "name": "risky-users",
-     "compatibility_date": "2023-01-04",
+     "compatibility_date": "$today",
      "main": "src/index.js",
      "workers_dev": false,
      "account_id": "<ACCOUNT-ID>",

--- a/src/content/docs/d1/examples/query-d1-from-python-workers.mdx
+++ b/src/content/docs/d1/examples/query-d1-from-python-workers.mdx
@@ -68,7 +68,7 @@ In your Wrangler file, create a new `[[d1_databases]]` configuration block and s
 	"compatibility_flags": [ // Required for Python Workers
 		"python_workers"
 	],
-	"compatibility_date": "2024-03-29",
+	"compatibility_date": "$today",
 	"d1_databases": [
 		{
 			"binding": "DB", // This will be how you refer to your database in your Worker

--- a/src/content/docs/d1/tutorials/build-a-comments-api.mdx
+++ b/src/content/docs/d1/tutorials/build-a-comments-api.mdx
@@ -210,7 +210,7 @@ After you have logged in, confirm that your Wrangler file is configured similarl
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "d1-example",
 	"main": "src/worker.js",
-	"compatibility_date": "2022-07-15",
+	"compatibility_date": "$today",
 	"d1_databases": [
 		{
 			"binding": "DB", // available in your Worker on env.DB

--- a/src/content/docs/d1/tutorials/build-a-staff-directory-app.mdx
+++ b/src/content/docs/d1/tutorials/build-a-staff-directory-app.mdx
@@ -78,7 +78,7 @@ This binding enables your application to interact with Cloudflare resources such
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "staff-directory",
-	"compatibility_date": "2023-12-01"
+	"compatibility_date": "$today"
 }
 ```
 
@@ -449,7 +449,7 @@ After successful login, confirm that your Wrangler file is configured similarly 
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "staff-directory",
-	"compatibility_date": "2023-12-01",
+	"compatibility_date": "$today",
 	"r2_buckets": [
 		{
 			"binding": "MY_BUCKET",

--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
@@ -142,7 +142,7 @@ Copy the last part of the command output and paste it into your Wrangler file. I
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "prisma-d1-example",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-03-20",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/durable-objects/examples/testing-with-durable-objects.mdx
+++ b/src/content/docs/durable-objects/examples/testing-with-durable-objects.mdx
@@ -129,7 +129,7 @@ Make sure your Wrangler configuration includes the Durable Object binding and SQ
 {
   "name": "counter-worker",
   "main": "src/index.ts",
-  "compatibility_date": "2024-12-01",
+  "compatibility_date": "$today",
   "durable_objects": {
     "bindings": [
       { "name": "COUNTER", "class_name": "Counter" }

--- a/src/content/docs/hyperdrive/configuration/rotate-credentials.mdx
+++ b/src/content/docs/hyperdrive/configuration/rotate-credentials.mdx
@@ -33,7 +33,7 @@ The command above will output the ID of your Hyperdrive. Set this ID in the [Wra
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "2024-09-23",
+	"compatibility_date": "$today",
 	"hyperdrive": [
 		{
 			"binding": "HYPERDRIVE",

--- a/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale.mdx
+++ b/src/content/docs/hyperdrive/tutorials/serverless-timeseries-api-with-timescale.mdx
@@ -148,7 +148,7 @@ This command outputs your Hyperdrive ID. You can now bind your Hyperdrive config
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "timescale-api",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-09-23",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/pages/functions/bindings.mdx
+++ b/src/content/docs/pages/functions/bindings.mdx
@@ -638,7 +638,7 @@ PostgreSQL drivers like [`Postgres.js`](https://github.com/porsager/postgres) de
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "2024-09-23"
+	"compatibility_date": "$today"
 }
 ```
 

--- a/src/content/docs/pages/functions/wrangler-configuration.mdx
+++ b/src/content/docs/pages/functions/wrangler-configuration.mdx
@@ -177,7 +177,7 @@ The Wrangler configuration file applies locally when using `wrangler pages dev`.
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-pages-app",
 	"pages_build_output_dir": "./dist",
-	"compatibility_date": "2023-10-12",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/pages/tutorials/localize-a-website.mdx
+++ b/src/content/docs/pages/tutorials/localize-a-website.mdx
@@ -266,7 +266,7 @@ To deploy your application to a `*.pages.dev` subdomain, you need to specify a d
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "i18n-example",
 	"pages_build_output_dir": "./public",
-	"compatibility_date": "2024-01-29"
+	"compatibility_date": "$today"
 }
 ```
 

--- a/src/content/docs/queues/tutorials/handle-rate-limits/index.mdx
+++ b/src/content/docs/queues/tutorials/handle-rate-limits/index.mdx
@@ -110,7 +110,7 @@ Your final Wrangler file should look similar to the example below.
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "resend-rate-limit-queue",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-09-09",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx
+++ b/src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx
@@ -185,7 +185,7 @@ Your final Wrangler file should look similar to the one below.
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "web-crawler",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-07-25",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
+++ b/src/content/docs/r2/tutorials/upload-logs-event-notifications.mdx
@@ -93,7 +93,7 @@ In your Worker project's [[Wrangler configuration file](/workers/wrangler/config
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "event-notification-writer",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-03-29",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/radar/investigate/bgp-anomalies.mdx
+++ b/src/content/docs/radar/investigate/bgp-anomalies.mdx
@@ -208,7 +208,7 @@ of configuring the workers to run the script five minutes.
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "hijack-alerts",
 	"main": "src/index.js",
-	"compatibility_date": "2023-04-27",
+	"compatibility_date": "$today",
 	"triggers": {
 		"crons": [
 			"*/5 * * * *"

--- a/src/content/docs/style-guide/components/wrangler-config.mdx
+++ b/src/content/docs/style-guide/components/wrangler-config.mdx
@@ -10,7 +10,6 @@ This component can be used to automatically generate a `jsonc` version of the `t
 
 ```mdx
 import { WranglerConfig } from "~/components";
-
 ```
 
 ## Usage
@@ -28,7 +27,9 @@ database_id = "<unique-ID-for-your-database>"
 </WranglerConfig>
 ````
 
-A `$today` value can be used in this component to automatically insert the today's date. This is useful for suggesting that users set the latest compatibility date.
+## Compatibility date
+
+Always use `$today` for the `compatibility_date` value. This magic string is automatically replaced with the current date at build time, ensuring documentation always suggests the latest date.
 
 ````mdx live
 import { WranglerConfig } from "~/components";
@@ -38,6 +39,24 @@ import { WranglerConfig } from "~/components";
 {
 	"name": "my-worker",
 	"compatibility_date": "$today"
+}
+```
+</WranglerConfig>
+````
+
+### Minimum compatibility dates
+
+Some features require a minimum compatibility date. When documenting these features, add an inline comment after the date to indicate the minimum requirement:
+
+````mdx live
+import { WranglerConfig } from "~/components";
+
+<WranglerConfig>
+```jsonc
+{
+	"name": "my-worker",
+	"compatibility_date": "$today", // Minimum: 2024-09-23
+	"compatibility_flags": ["nodejs_compat"]
 }
 ```
 </WranglerConfig>

--- a/src/content/docs/style-guide/components/wrangler-config.mdx
+++ b/src/content/docs/style-guide/components/wrangler-config.mdx
@@ -29,7 +29,7 @@ database_id = "<unique-ID-for-your-database>"
 
 ## Compatibility date
 
-Always use `$today` for the `compatibility_date` value. This magic string is automatically replaced with the current date at build time, ensuring documentation always suggests the latest date.
+You should generally use `$today` for the `compatibility_date` value for new projects. This magic string is automatically replaced with the current date at build time, ensuring documentation always suggests the latest date. If you need to specify a fixed date, you can do so as well, but you may miss out on the latest features and performance improvements. You can disable specific features by using [compatibility flags](/workers/configuration/compatibility-flags/).
 
 ````mdx live
 import { WranglerConfig } from "~/components";
@@ -46,21 +46,17 @@ import { WranglerConfig } from "~/components";
 
 ### Minimum compatibility dates
 
-Some features require a minimum compatibility date. When documenting these features, add an inline comment after the date to indicate the minimum requirement:
+Some features require a minimum compatibility date. When documenting these features, use a `:::note` component to communicate the requirement clearly on the docs page:
 
-````mdx live
-import { WranglerConfig } from "~/components";
-
-<WranglerConfig>
-```jsonc
-{
-	"name": "my-worker",
-	"compatibility_date": "$today", // Minimum: 2024-09-23
-	"compatibility_flags": ["nodejs_compat"]
-}
+```mdx
+:::note
+This feature requires a `compatibility_date` of `2024-09-23` or later.
+:::
 ```
-</WranglerConfig>
-````
+
+:::note
+This feature requires a `compatibility_date` of `2024-09-23` or later.
+:::
 
 The `removeSchema` prop can be used to remove the `$schema` reference from the generated JSON file. This can be useful if you want to add snippets of configuration files that are easier to copy paste, and are providing toml as the source config format.
 

--- a/src/content/docs/workers-ai/guides/tutorials/build-a-workers-ai-whisper-with-chunking.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/build-a-workers-ai-whisper-with-chunking.mdx
@@ -84,7 +84,7 @@ In your wrangler file, add or update the following settings to enable Node.js AP
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "2024-09-23"
+	"compatibility_date": "$today"
 }
 ```
 

--- a/src/content/docs/workers-vpc/examples/private-api.mdx
+++ b/src/content/docs/workers-vpc/examples/private-api.mdx
@@ -63,7 +63,7 @@ Update your Wrangler configuration file:
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "private-api-gateway",
 	"main": "src/index.js",
-	"compatibility_date": "2024-01-01",
+	"compatibility_date": "$today",
 	"vpc_services": [
 		{
 			"binding": "INTERNAL_API",

--- a/src/content/docs/workers-vpc/examples/private-s3-bucket.mdx
+++ b/src/content/docs/workers-vpc/examples/private-s3-bucket.mdx
@@ -102,7 +102,7 @@ Update your Wrangler configuration file:
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "private-s3-gateway",
 	"main": "src/index.js",
-	"compatibility_date": "2024-01-01",
+	"compatibility_date": "$today",
 	"vpc_services": [
 		{
 			"binding": "S3_STORAGE",

--- a/src/content/docs/workers-vpc/examples/route-across-private-services.mdx
+++ b/src/content/docs/workers-vpc/examples/route-across-private-services.mdx
@@ -44,7 +44,7 @@ Update your Wrangler configuration file:
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "api-gateway",
 	"main": "src/index.js",
-	"compatibility_date": "2024-01-01",
+	"compatibility_date": "$today",
 	"vpc_services": [
 		{
 			"binding": "USER_SERVICE",

--- a/src/content/docs/workers-vpc/get-started.mdx
+++ b/src/content/docs/workers-vpc/get-started.mdx
@@ -162,7 +162,7 @@ Add the VPC Service binding to your Wrangler configuration file:
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "workers-vpc-app",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-01-01",
+	"compatibility_date": "$today",
 	"vpc_services": [
 		{
 			"binding": "VPC_SERVICE",

--- a/src/content/docs/workers/configuration/compatibility-dates.mdx
+++ b/src/content/docs/workers/configuration/compatibility-dates.mdx
@@ -32,7 +32,7 @@ The compatibility date can be set in a Worker's [Wrangler configuration file](/w
 ```jsonc
 {
 	// Opt into backwards-incompatible changes through April 5, 2022.
-	"compatibility_date": "2022-04-05"
+	"compatibility_date": "$today"
 }
 ```
 

--- a/src/content/docs/workers/configuration/compatibility-dates.mdx
+++ b/src/content/docs/workers/configuration/compatibility-dates.mdx
@@ -32,7 +32,7 @@ The compatibility date can be set in a Worker's [Wrangler configuration file](/w
 ```jsonc
 {
 	// Opt into backwards-incompatible changes through April 5, 2022.
-	"compatibility_date": "$today"
+	"compatibility_date": "2022-04-05"
 }
 ```
 

--- a/src/content/docs/workers/configuration/compatibility-flags.mdx
+++ b/src/content/docs/workers/configuration/compatibility-flags.mdx
@@ -27,7 +27,7 @@ This example enables the specific flag `formdata_parser_supports_files`, which i
 ```jsonc
 {
 	// Opt into backwards-incompatible changes through September 14, 2021.
-	"compatibility_date": "$today",
+	"compatibility_date": "2021-09-14",
 	// Also opt into an upcoming fix to the FormData API.
 	"compatibility_flags": [
 		"formdata_parser_supports_files"

--- a/src/content/docs/workers/configuration/compatibility-flags.mdx
+++ b/src/content/docs/workers/configuration/compatibility-flags.mdx
@@ -27,7 +27,7 @@ This example enables the specific flag `formdata_parser_supports_files`, which i
 ```jsonc
 {
 	// Opt into backwards-incompatible changes through September 14, 2021.
-	"compatibility_date": "2021-09-14",
+	"compatibility_date": "$today",
 	// Also opt into an upcoming fix to the FormData API.
 	"compatibility_flags": [
 		"formdata_parser_supports_files"

--- a/src/content/docs/workers/framework-guides/web-apps/tanstack-start.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/tanstack-start.mdx
@@ -77,7 +77,7 @@ If you have an existing TanStack Start application, configure it to run on Cloud
    {
    	"$schema": "node_modules/wrangler/config-schema.json",
    	"name": "<YOUR_PROJECT_NAME>",
-   	"compatibility_date": "2025-01-01",
+   	"compatibility_date": "$today",
    	"compatibility_flags": ["nodejs_compat"],
    	"main": "@tanstack/react-start/server-entry",
    	"observability": {

--- a/src/content/docs/workers/languages/python/basics.mdx
+++ b/src/content/docs/workers/languages/python/basics.mdx
@@ -88,7 +88,7 @@ For example, let us try setting and using an environment variable in a Python Wo
 	"compatibility_flags": [
 		"python_workers"
 	],
-	"compatibility_date": "2025-11-02",
+	"compatibility_date": "$today",
 	"vars": {
 		"API_HOST": "example.com"
 	}

--- a/src/content/docs/workers/languages/python/how-python-workers-work.mdx
+++ b/src/content/docs/workers/languages/python/how-python-workers-work.mdx
@@ -35,7 +35,7 @@ class Default(WorkerEntrypoint):
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "hello-world-python-worker",
 	"main": "src/entry.py",
-	"compatibility_date": "2024-04-01"
+	"compatibility_date": "$today"
 }
 ```
 

--- a/src/content/docs/workers/observability/logs/logpush.mdx
+++ b/src/content/docs/workers/observability/logs/logpush.mdx
@@ -90,7 +90,7 @@ Enable logging on your Worker by adding a new property, `logpush = true`, to you
 	// Top-level configuration
 	"name": "my-worker",
 	"main": "src/index.js",
-	"compatibility_date": "2022-07-12",
+	"compatibility_date": "$today",
 	"workers_dev": false,
 	"logpush": true,
 	"route": {

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -28,7 +28,7 @@ To enable built-in Node.js APIs and add polyfills, add the `nodejs_compat` compa
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "2024-09-23"
+	"compatibility_date": "$today"
 }
 ```
 

--- a/src/content/docs/workers/static-assets/binding.mdx
+++ b/src/content/docs/workers/static-assets/binding.mdx
@@ -34,7 +34,7 @@ The folder of static assets to be served. For many frameworks, this is the `./pu
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-worker",
-	"compatibility_date": "2024-09-19",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "./public/"
 	}
@@ -76,7 +76,7 @@ Controls whether to invoke the Worker script regardless of a request which would
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-worker",
-	"compatibility_date": "2024-09-19",
+	"compatibility_date": "$today",
 	"main": "src/index.ts",
 	// The following configuration unconditionally invokes the Worker script at
 	// `src/index.ts`, which can programatically fetch assets via the ASSETS binding
@@ -131,7 +131,7 @@ Configuring the optional [binding](/workers/runtime-apis/bindings) gives you acc
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-worker",
 	"main": "./src/index.js",
-	"compatibility_date": "2024-09-19",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "./public/",
 		"binding": "ASSETS"

--- a/src/content/docs/workers/static-assets/index.mdx
+++ b/src/content/docs/workers/static-assets/index.mdx
@@ -65,7 +65,7 @@ The **assets directory** specified in your [Wrangler configuration file](/worker
       "$schema": "./node_modules/wrangler/config-schema.json",
       "name": "my-spa",
       "main": "src/index.js",
-      "compatibility_date": "2025-01-01",
+      "compatibility_date": "$today",
       "assets": {
         "directory": "./dist",
         "binding": "ASSETS"

--- a/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
+++ b/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
@@ -70,7 +70,7 @@ Now, with **Cloudflare Workers**:
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "./dist/client/"
 	}
@@ -98,7 +98,7 @@ For a Single Page Application (SPA):
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "./dist/client/",
 		"not_found_handling": "single-page-application"
@@ -115,7 +115,7 @@ For custom 404 pages:
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "./dist/client/",
 		"not_found_handling": "404-page"
@@ -156,7 +156,7 @@ Then, update your configuration file's `main` field to point to the location of 
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"main": "./dist/client/_worker.js", // or some other location if you moved the script out of the static asset directory
 	"assets": {
 		"directory": "./dist/client/"
@@ -185,7 +185,7 @@ Once the Worker script has been compiled, you can update your configuration file
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"main": "./dist/worker/index.js",
 	"assets": {
 		"directory": "./dist/client/"
@@ -206,7 +206,7 @@ Workers, on the other hand, will default to serving static assets ahead of your 
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"main": "./dist/worker/index.js",
 	"assets": {
 		"directory": "./dist/client/",
@@ -240,7 +240,7 @@ export default class extends WorkerEntrypoint {
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"main": "./worker/index.ts",
 	"assets": {
 		"directory": "./dist/client/"
@@ -259,7 +259,7 @@ Pages automatically provided [an `ASSETS` binding](/pages/functions/api-referenc
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"main": "./worker/index.ts",
 	"assets": {
 		"directory": "./dist/client/",
@@ -279,7 +279,7 @@ If you had customized [placement](/workers/configuration/placement/), or set a [
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"compatibility_flags": ["nodejs_compat"],
 	"main": "./worker/index.ts",
 	"placement": {
@@ -328,7 +328,7 @@ To get a similar experience in Workers, you must:
    ```json
    {
    	"name": "my-worker",
-   	"compatibility_date": "2025-04-01",
+   	"compatibility_date": "$today",
    	"main": "./worker/index.ts",
    	"assets": {
    		"directory": "./dist/client/"
@@ -362,7 +362,7 @@ Where previously you were offered a `pages.dev` subdomain for your Pages project
 ```json
 {
 	"name": "my-worker",
-	"compatibility_date": "2025-04-01",
+	"compatibility_date": "$today",
 	"main": "./worker/index.ts",
 	"workers_dev": true
 }

--- a/src/content/docs/workers/static-assets/migration-guides/netlify-to-workers.mdx
+++ b/src/content/docs/workers/static-assets/migration-guides/netlify-to-workers.mdx
@@ -54,7 +54,7 @@ For a **Single Page Application**, you will need to add the following to your Wr
 ```jsonc
 {
 	"name": "<your-project-name>",
-	"compatibility_date": "2025-04-23",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "<your-build-directory>",
 		"not_found_handling": "single-page-application",

--- a/src/content/docs/workers/static-assets/migration-guides/vercel-to-workers.mdx
+++ b/src/content/docs/workers/static-assets/migration-guides/vercel-to-workers.mdx
@@ -38,7 +38,7 @@ For a **static site**, you will need to add the following to your wrangler file.
 ```jsonc
 {
 	"name": "<your-project-name>",
-	"compatibility_date": "2025-04-23",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "<your-build-directory>",
 	},
@@ -54,7 +54,7 @@ For a **single page application**, you will need to add the following to your wr
 ```jsonc
 {
 	"name": "<your-project-name>",
-	"compatibility_date": "2025-04-23",
+	"compatibility_date": "$today",
 	"assets": {
 		"directory": "<your-build-directory>",
 		"not_found_handling": "single-page-application",

--- a/src/content/docs/workers/testing/vitest-integration/isolation-and-concurrency.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/isolation-and-concurrency.mdx
@@ -73,7 +73,7 @@ The Wrangler configuration file does not specify either `nodejs_compat` or `node
 ```jsonc
 { "name": "test",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-12-16"
+	"compatibility_date": "$today"
 	# no nodejs_compat flags here
 }
 ```

--- a/src/content/docs/workers/tutorials/handle-form-submissions-with-airtable.mdx
+++ b/src/content/docs/workers/tutorials/handle-form-submissions-with-airtable.mdx
@@ -247,7 +247,7 @@ Add a `vars` table at the end of your Wrangler file:
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "workers-airtable-form",
 	"main": "src/index.js",
-	"compatibility_date": "2023-06-13",
+	"compatibility_date": "$today",
 	"vars": {
 		"AIRTABLE_BASE_ID": "exampleBaseId",
 		"AIRTABLE_TABLE_NAME": "Form Submissions"

--- a/src/content/docs/workers/tutorials/mysql.mdx
+++ b/src/content/docs/workers/tutorials/mysql.mdx
@@ -85,7 +85,7 @@ This command outputs the Hyperdrive configuration `id` that will be used for you
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "hyperdrive-example",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-08-21",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/workers/tutorials/postgres.mdx
+++ b/src/content/docs/workers/tutorials/postgres.mdx
@@ -346,7 +346,7 @@ This command outputs the Hyperdrive configuration `id` that will be used for you
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "hyperdrive-example",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-08-21",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/workers/vite-plugin/get-started.mdx
+++ b/src/content/docs/workers/vite-plugin/get-started.mdx
@@ -61,7 +61,7 @@ Refer to the [API reference](/workers/vite-plugin/reference/api/) for configurat
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "cloudflare-vite-get-started",
-	"compatibility_date": "2025-04-03",
+	"compatibility_date": "$today",
 	"main": "./src/index.ts"
 }
 ```

--- a/src/content/docs/workers/vite-plugin/reference/cloudflare-environments.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/cloudflare-environments.mdx
@@ -18,7 +18,7 @@ Consider the following example Worker config file:
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-worker",
-	"compatibility_date": "2025-04-03",
+	"compatibility_date": "$today",
 	"main": "./src/index.ts",
 	"vars": {
 		"MY_VAR": "Top-level var"
@@ -85,7 +85,7 @@ Consider again the previous example:
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-worker",
-	"compatibility_date": "2025-04-03",
+	"compatibility_date": "$today",
 	"main": "./src/index.ts",
 	"vars": {
 		"MY_VAR": "Top-level var"

--- a/src/content/docs/workers/vite-plugin/reference/vite-environments.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/vite-environments.mdx
@@ -36,7 +36,7 @@ We use the Vite config to set global constant replacements for this environment:
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "my-worker",
-	"compatibility_date": "2025-04-03",
+	"compatibility_date": "$today",
 	"main": "./src/index.ts"
 }
 ```

--- a/src/content/docs/workers/vite-plugin/tutorial.mdx
+++ b/src/content/docs/workers/vite-plugin/tutorial.mdx
@@ -65,7 +65,7 @@ Refer to the [API reference](/workers/vite-plugin/reference/api/) for configurat
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "cloudflare-vite-tutorial",
-	"compatibility_date": "2025-04-03",
+	"compatibility_date": "$today",
 	"assets": {
 		"not_found_handling": "single-page-application"
 	}
@@ -143,7 +143,7 @@ This tutorial, however, will show you how to go a step further and add an API Wo
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "cloudflare-vite-tutorial",
-	"compatibility_date": "2025-04-03",
+	"compatibility_date": "$today",
 	"assets": {
 		"not_found_handling": "single-page-application"
 	},
@@ -190,7 +190,7 @@ This opts out of interpreting the `Sec-Fetch-Mode` header.
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "cloudflare-vite-tutorial",
-	"compatibility_date": "2025-04-03",
+	"compatibility_date": "$today",
 	"assets": {
 		"not_found_handling": "single-page-application",
 		"run_worker_first": [

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -46,7 +46,7 @@ It is best practice to treat Wrangler's configuration file as the [source of tru
 	// Top-level configuration
 	"name": "my-worker",
 	"main": "src/index.js",
-	"compatibility_date": "2022-07-12",
+	"compatibility_date": "$today",
 	"workers_dev": false,
 	"route": {
 		"pattern": "example.org/*",

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -41,7 +41,7 @@ To bind to a Workflow from your Workers code, you need to define a [binding](/wo
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "workflows-tutorial",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-10-22",
+	"compatibility_date": "$today",
 	"workflows": [
 		{
 			// The name of the Workflow

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -174,7 +174,7 @@ For example, to bind to a Workflow called `workflows-starter` and to make it ava
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "workflows-starter",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-10-22",
+	"compatibility_date": "$today",
 	"workflows": [
 		{
 			// name of your workflow
@@ -209,7 +209,7 @@ For example, if your Workflow is defined in a Worker script named `billing-worke
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "web-api-worker",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-10-22",
+	"compatibility_date": "$today",
 	"workflows": [
 		{
 			// name of your workflow

--- a/src/content/docs/workflows/examples/backup-d1.mdx
+++ b/src/content/docs/workflows/examples/backup-d1.mdx
@@ -139,7 +139,7 @@ Here is a [Wrangler configuration file](/workers/wrangler/configuration/):
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "backup-d1",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-12-27",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/workflows/examples/send-invoices.mdx
+++ b/src/content/docs/workflows/examples/send-invoices.mdx
@@ -207,7 +207,7 @@ And finally [Wrangler configuration file](/workers/wrangler/configuration/):
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "cart-invoices",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-10-22",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/docs/workflows/examples/wait-for-event.mdx
+++ b/src/content/docs/workflows/examples/wait-for-event.mdx
@@ -62,7 +62,7 @@ The Workflow configuration is defined in the `wrangler.jsonc` file. This file in
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "workflows-waitforevent",
 	"main": "src/index.ts",
-	"compatibility_date": "2025-04-14",
+	"compatibility_date": "$today",
 	"observability": {
 		"enabled": true,
 		"head_sampling_rate": 1,

--- a/src/content/docs/workflows/get-started/durable-agents.mdx
+++ b/src/content/docs/workflows/get-started/durable-agents.mdx
@@ -331,7 +331,7 @@ This is especially important for:
    	"$schema": "node_modules/wrangler/config-schema.json",
    	"name": "durable-ai-agent",
    	"main": "src/index.ts",
-   	"compatibility_date": "2025-01-01",
+   	"compatibility_date": "$today",
    	"observability": {
    		"enabled": true
    	},

--- a/src/content/docs/workflows/get-started/guide.mdx
+++ b/src/content/docs/workflows/get-started/guide.mdx
@@ -143,7 +143,7 @@ Follow the steps below to learn how to build a Workflow from scratch.
    	"$schema": "node_modules/wrangler/config-schema.json",
    	"name": "my-workflow",
    	"main": "src/index.ts",
-   	"compatibility_date": "2025-12-21",
+   	"compatibility_date": "$today",
    	"observability": {
    		"enabled": true
    	},

--- a/src/content/docs/workflows/python/bindings.mdx
+++ b/src/content/docs/workflows/python/bindings.mdx
@@ -27,7 +27,7 @@ From the configuration perspective, enabling Python Workflows requires adding th
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "workflows-starter",
 	"main": "src/index.ts",
-	"compatibility_date": "$today", // Minimum: 2025-08-01
+	"compatibility_date": "$today"
 	"compatibility_flags": [
 		"python_workflows",
 		"python_workers"

--- a/src/content/docs/workflows/python/bindings.mdx
+++ b/src/content/docs/workflows/python/bindings.mdx
@@ -27,7 +27,7 @@ From the configuration perspective, enabling Python Workflows requires adding th
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "workflows-starter",
 	"main": "src/index.ts",
-	"compatibility_date": "2025-10-24",
+	"compatibility_date": "$today", // Minimum: 2025-08-01
 	"compatibility_flags": [
 		"python_workflows",
 		"python_workers"

--- a/src/content/docs/workflows/python/bindings.mdx
+++ b/src/content/docs/workflows/python/bindings.mdx
@@ -27,7 +27,7 @@ From the configuration perspective, enabling Python Workflows requires adding th
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "workflows-starter",
 	"main": "src/index.ts",
-	"compatibility_date": "$today"
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"python_workflows",
 		"python_workers"

--- a/src/content/docs/workflows/python/index.mdx
+++ b/src/content/docs/workflows/python/index.mdx
@@ -66,7 +66,7 @@ You must add both `python_workflows` and `python_workers` compatibility flags to
 		"experimental",
 		"python_workflows"
 	],
-	"compatibility_date": "2024-03-29",
+	"compatibility_date": "$today",
 	"workflows": [
 		{
 			"name": "workflows-demo",

--- a/src/content/partials/browser-rendering/example-workers-binding-screenshots-from-web.mdx
+++ b/src/content/partials/browser-rendering/example-workers-binding-screenshots-from-web.mdx
@@ -56,7 +56,7 @@ Update your [Wrangler configuration file](/workers/wrangler/configuration/) with
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "browser-worker",
 	"main": "src/index.js",
-	"compatibility_date": "2023-03-14",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/partials/hyperdrive/create-hyperdrive-config-mysql.mdx
+++ b/src/content/partials/hyperdrive/create-hyperdrive-config-mysql.mdx
@@ -43,7 +43,7 @@ This command outputs a binding for the [Wrangler configuration file](/workers/wr
 	"$schema": "./node_modules/wrangler/config-schema.json",
 	"name": "hyperdrive-example",
 	"main": "src/index.ts",
-	"compatibility_date": "2024-08-21",
+	"compatibility_date": "$today",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],

--- a/src/content/partials/hyperdrive/create-hyperdrive-config.mdx
+++ b/src/content/partials/hyperdrive/create-hyperdrive-config.mdx
@@ -54,7 +54,7 @@ To create a Hyperdrive configuration with the [Wrangler CLI](/workers/wrangler/i
 		"$schema": "./node_modules/wrangler/config-schema.json",
 		"name": "hyperdrive-example",
 		"main": "src/index.ts",
-		"compatibility_date": "2024-08-21",
+		"compatibility_date": "$today",
 		"compatibility_flags": [
 			"nodejs_compat"
 		],

--- a/src/content/partials/hyperdrive/hyperdrive-node-compatibility-requirement.mdx
+++ b/src/content/partials/hyperdrive/hyperdrive-node-compatibility-requirement.mdx
@@ -12,7 +12,7 @@ import { WranglerConfig } from "~/components";
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "2024-09-23",
+	"compatibility_date": "$today",
 	"hyperdrive": [
 		{
 			"binding": "HYPERDRIVE",

--- a/src/content/partials/workers/nodejs_compat.mdx
+++ b/src/content/partials/workers/nodejs_compat.mdx
@@ -13,7 +13,7 @@ To enable both built-in runtime APIs and polyfills for your Worker or Pages proj
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
-	"compatibility_date": "2024-09-23"
+	"compatibility_date": "$today"
 }
 ```
 


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by OpenCode (Claude) and reviewed by @MattieTK.

## Summary

- Updates all hardcoded `compatibility_date` values in WranglerConfig blocks to use `$today`
- Adds style guide documentation for how to handle compatibility dates
- ~Adds inline comments for features with minimum date requirements~

This is a more extensive version of #27887, covering all documentation files.

## Why

AI agents and users accessing documentation pages should be encouraged to use the current date for `compatibility_date`. The `$today` magic string in the WranglerConfig component automatically renders as the current date at build time, ensuring docs always suggest the latest date.

## Changes

### 67 documentation files updated

Replaced hardcoded dates like `"2025-09-17"` with `"$today"` across:
- Workers configuration and tutorials
- Browser Rendering (Playwright, Puppeteer, Stagehand)
- Workflows (TypeScript and Python)
- Hyperdrive
- D1, R2, KV, Queues
- Durable Objects
- Pages Functions
- And more

### Minimum date requirements

~For features that require a minimum compatibility date, added inline comments to preserve this information:~

This was decided to be excessive.

**Known minimum compatibility dates based on documentation:**

| Feature | Minimum date | Reason |
|---------|--------------|--------|
| `nodejs_compat` (v2 behavior) | `2024-09-23` | Enables bundled polyfills and globals |
| RPC | `2024-04-03` | Feature introduction date |
| Workflows binding | `2024-10-22` | Required for binding from Workers |
| Python Workflows | `2025-08-01` | Platform requirement |
| `@cloudflare/playwright` | `2025-09-15` | Requires native `node.fs` API |

### Style guide updated

Added guidance to `/style-guide/components/wrangler-config/` explaining:
- Always use `$today` for compatibility dates
- ~How to add minimum date comments when documenting features that require them~

## Not included (future work)

~8 files use manual `<Tabs>/<TabItem>` for wrangler configs instead of the `<WranglerConfig>` component. These need manual conversion:
- `src/content/docs/kv/index.mdx`
- `src/content/docs/kv/examples/*.mdx` (4 files)
- `src/content/docs/workers-vpc/index.mdx`
- `src/content/docs/hyperdrive/index.mdx`
- `src/content/docs/cloudflare-one/tutorials/ai-wrapper-tenant-control.mdx`