### PR TITLE
Adds new subrequest limit docs and changelog

### DIFF
--- a/src/content/changelog/workers/2026-02-11-subrequests-limit.mdx
+++ b/src/content/changelog/workers/2026-02-11-subrequests-limit.mdx
@@ -10,7 +10,7 @@ import { WranglerConfig } from "~/components";
 
 Workers no longer have a limit of 1000 subrequests per invocation, allowing you to make more `fetch()` calls or requests
 to Cloudflare services on every incoming request. This is especially important for long-running Workers requests, such as
-open websockets on Durable Objects or long-running Workflows, as these could often exceed this limit and error.
+open websockets on [Durable Objects](/durable-objects) or long-running [Workflows](/workflows), as these could often exceed this limit and error.
 
 By default, Workers on paid plans are now limited to 10,000 subrequests per invocation, but this
 limit can be increased up to 10 million by setting the new `subrequests` limit in your Wrangler configuration file.

--- a/src/content/changelog/workers/2026-02-11-subrequests-limit.mdx
+++ b/src/content/changelog/workers/2026-02-11-subrequests-limit.mdx
@@ -1,0 +1,46 @@
+---
+title: Workers are no longer limited to 1000 subrequests
+description: Workers no longer have an explicit limit on subrequests per invocation, allowing for more fetch and service calls.
+products:
+  - workers
+date: 2026-02-11
+---
+
+import { WranglerConfig } from "~/components";
+
+Workers no longer have a limit of 1000 subrequests per invocation, allowing you to make more `fetch()` calls or requests
+to Cloudflare services on every incoming request. This is especially important for long-running Workers requests, such as
+open websockets on Durable Objects or long-running Workflows, as these could often exceed this limit and error.
+
+By default, Workers on paid plans are now limited to 10,000 subrequests per invocation, but this
+limit can be increased up to 10 million by setting the new `subrequests` limit in your Wrangler configuration file.
+
+<WranglerConfig>
+
+```jsonc
+{
+	"limits": {
+		"subrequests": 50000,
+	},
+}
+```
+
+</WranglerConfig>
+
+Workers on the free plan remain limited to 50 external subrequests and 1000 subrequests to Cloudflare services per invocation.
+
+To protect against runaway code or unexpected costs, you can also set a lower limit for both subrequests and CPU usage.
+
+<WranglerConfig>
+
+```jsonc
+{
+	"limits": {
+		"subrequests": 10,
+		"cpu_ms": 1000,
+	},
+}
+```
+</WranglerConfig>
+
+For more information, refer to the [Wrangler configuration documentation for limits](/workers/wrangler/configuration/#limits) and [subrequest limits](/workers/platform/limits/#subrequests).

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -11,18 +11,18 @@ import { Render, WranglerConfig, DashButton } from "~/components";
 
 ## Account plan limits
 
-| Feature                                                                          | Workers Free | Workers Paid |
-| -------------------------------------------------------------------------------- | ------------ | ------------ |
-| [Subrequests](#subrequests)                                                      | 50/request   | 1000/request |
-| [Simultaneous outgoing<br/>connections/request](#simultaneous-open-connections)  | 6            | 6            |
-| [Environment variables](#environment-variables)                                  | 64/Worker    | 128/Worker   |
-| [Environment variable<br/>size](#environment-variables)                          | 5 KB         | 5 KB         |
-| [Worker size](#worker-size)                                                      | 3 MB         | 10 MB        |
-| [Worker startup time](#worker-startup-time)                                      | 1 second     | 1 second     |
-| [Number of Workers](#number-of-workers)<sup>1</sup>                              | 100          | 500          |
-| Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per account | 5            | 250          |
-| Number of [Static Asset](#static-assets) files per Worker version                | 20,000       | 100,000      |
-| Individual [Static Asset](#static-assets) file size                              | 25 MiB       | 25 MiB       |
+| Feature                                                                          | Workers Free | Workers Paid   |
+| -------------------------------------------------------------------------------- | ------------ | -------------- |
+| [Subrequests](#subrequests)                                                      | 50/request   | 10,000/request |
+| [Simultaneous outgoing<br/>connections/request](#simultaneous-open-connections)  | 6            | 6              |
+| [Environment variables](#environment-variables)                                  | 64/Worker    | 128/Worker     |
+| [Environment variable<br/>size](#environment-variables)                          | 5 KB         | 5 KB           |
+| [Worker size](#worker-size)                                                      | 3 MB         | 10 MB          |
+| [Worker startup time](#worker-startup-time)                                      | 1 second     | 1 second       |
+| [Number of Workers](#number-of-workers)<sup>1</sup>                              | 100          | 500            |
+| Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per account | 5            | 250            |
+| Number of [Static Asset](#static-assets) files per Worker version                | 20,000       | 100,000        |
+| Individual [Static Asset](#static-assets) file size                              | 25 MiB       | 25 MiB         |
 
 <sup>1</sup> If you are running into limits, your project may be a good fit for
 [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/).
@@ -187,9 +187,12 @@ If you make a subrequest from your Worker to a target Worker that runs on a [Cus
 
 ### How many subrequests can I make?
 
-You can make 50 subrequests per request on Workers Free, and 1,000 subrequests per request on Workers Paid. Each subrequest in a redirect chain counts against this limit. This means that the number of subrequests a Worker makes could be greater than the number of `fetch(request)` calls in the Worker.
+You can make 50 subrequests per invocation on Workers Free, and 10,000 subrequests per invocation on Workers Paid by default. Workers Paid
+users can increase this limit up to 10 Million. Each subrequest in a redirect chain counts against this limit. This means that the number of subrequests a Worker makes could be greater than the number of `fetch(request)` calls in the Worker.
 
-For subrequests to internal services like Workers KV and Durable Objects, the subrequest limit is 1,000 per request, regardless of the [usage model](/workers/platform/pricing/#workers) configured for the Worker.
+For subrequests to internal services like Workers KV and Durable Objects, the subrequest limit is 1,000 per invocation on free plans.
+
+You can change your subrequest limit per Worker using the [`limits` configuration](/workers/wrangler/configuration/#limits) in your Wrangler configuration file.
 
 ### How long can a subrequest take?
 

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -190,7 +190,7 @@ If you make a subrequest from your Worker to a target Worker that runs on a [Cus
 You can make 50 subrequests per invocation on Workers Free, and 10,000 subrequests per invocation on Workers Paid by default. Workers Paid
 users can increase this limit up to 10 Million. Each subrequest in a redirect chain counts against this limit. This means that the number of subrequests a Worker makes could be greater than the number of `fetch(request)` calls in the Worker.
 
-For subrequests to internal services like Workers KV and Durable Objects, the subrequest limit is 1,000 per invocation on free plans.
+For subrequests to internal services like Workers KV and Durable Objects, the subrequest limit is 1,000 per invocation on free plans, and will match your configured subrequest limit on paid plans (default of 10,000).
 
 You can change your subrequest limit per Worker using the [`limits` configuration](/workers/wrangler/configuration/#limits) in your Wrangler configuration file.
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -486,7 +486,7 @@ can be set to a maximum of 300,000 milliseconds (5 minutes).
   - The maximum CPU time allowed per invocation, in milliseconds.
 
 - `subrequests` <Type text="number" /> <MetaInfo text="optional" />
-  - The maximum number of subrequests allowed per invocation. Refer to [subrequest limits](/workers/platform/limits/#subrequests) for default values.
+  - The maximum number of subrequests allowed per invocation. This value defaults to 50 for free accounts and 10,000 for paid accounts. The free account maximum is 50 and the paid account maximum is 10,000,000. Refer to [subrequest limits](/workers/platform/limits/#subrequests) for more information.
 
 Example:
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -485,6 +485,9 @@ can be set to a maximum of 300,000 milliseconds (5 minutes).
 - `cpu_ms` <Type text="number" /> <MetaInfo text="optional" />
   - The maximum CPU time allowed per invocation, in milliseconds.
 
+- `subrequests` <Type text="number" /> <MetaInfo text="optional" />
+  - The maximum number of subrequests allowed per invocation. Refer to [subrequest limits](/workers/platform/limits/#subrequests) for default values.
+
 Example:
 
 <WranglerConfig>
@@ -492,7 +495,8 @@ Example:
 ```jsonc
 {
 	"limits": {
-		"cpu_ms": 100
+		"cpu_ms": 100,
+		"subrequests": 150
 	}
 }
 ```


### PR DESCRIPTION
### Summary

Adds changelog + docs changes for higher subrequest limits


### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
