### PR TITLE
Update caution note on sensitive information sharing

### DIFF
--- a/src/content/docs/support/contacting-cloudflare-support.mdx
+++ b/src/content/docs/support/contacting-cloudflare-support.mdx
@@ -21,7 +21,7 @@ Cloudflare Support _cannot_ perform the following actions:
 :::caution
 
 **Do not share** any sensitive information, such as passwords, credit
-card numbers, private keys, or API keys with Cloudflare.
+card numbers, private keys, or API keys with Cloudflare Support.
 :::
 
 Before notifying Cloudflare of an issue with your site, refer to the [Cloudflare Status Page](https://www.cloudflarestatus.com/). If reporting issues with your site, ensure to provide adequate details in the support case _(refer to [Getting help with an issue](#getting-help-with-an-issue) for more information)_.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
The caution note on the "Contacting Cloudflare Support" page warns against sharing sensitive information with Cloudflare. This warning implies that one should never share things like credit card information or API keys with Cloudflare, when it is meant to say that these should not be shared with Support.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
