### PR TITLE
Fix warning in CF1 Source Internal IP selector

### DIFF
--- a/src/content/partials/cloudflare-one/gateway/selectors/source-internal-ip.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/source-internal-ip.mdx
@@ -4,7 +4,7 @@ inputParameters: policyType;;APIprefix
 
 import { Markdown } from "~/components";
 
-Use this selector to apply {props.one} policies to a private IP address, assigned by a user's local network, that requests arrive to Gateway from. This selector will only apply to users connected through a [Magic GRE or IPSec tunnel](/magic-wan/zero-trust/cloudflare-gateway/).
+Use this selector to apply {props.one} policies to a private IP address, assigned by a user's local network, that requests arrive to Gateway from.
 
 | UI name            | API example                                   |
 | ------------------ | --------------------------------------------- |


### PR DESCRIPTION
#27992 ## Summary

Removes warning about CF1 Source Internal IP selector that is no longer accurate.
A recent change made this selector work for Magic on-ramps.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
