### PR TITLE
Add page for Workflows visualizer

### DIFF
--- a/src/content/docs/workflows/build/visualizer.mdx
+++ b/src/content/docs/workflows/build/visualizer.mdx
@@ -1,0 +1,12 @@
+---
+title: Workflows Visualization
+pcx_content_type: concept
+sidebar:
+  order: 12
+---
+
+View a visual representation of your parsed Workflow code as a diagram on the Cloudflare dashboard.
+
+The diagram illustrates your sequenced & parallel steps, conditionals, loops, and nested logic. To see the Workflow at a high level, view the diagram with loops and conditionals collapsed, or expand for a more detailed view.
+
+Workflow diagrams are currently in beta for all Typescript and Javascript Workers. View your Workflows in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/workflows) to see their diagrams.

--- a/src/content/docs/workflows/build/visualizer.mdx
+++ b/src/content/docs/workflows/build/visualizer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Workflows Visualization
+title: Visualize Workflows
 pcx_content_type: concept
 sidebar:
   order: 12
@@ -8,5 +8,7 @@ sidebar:
 View a visual representation of your parsed Workflow code as a diagram on the Cloudflare dashboard.
 
 The diagram illustrates your sequenced & parallel steps, conditionals, loops, and nested logic. To see the Workflow at a high level, view the diagram with loops and conditionals collapsed, or expand for a more detailed view.
+
+![Example diagram](~/assets/images/changelog/workflows/2026-02-03-workflows-diagram.png)
 
 Workflow diagrams are currently in beta for all Typescript and Javascript Workers. View your Workflows in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/workflows) to see their diagrams.


### PR DESCRIPTION
### Summary

Adding page for Workflows visualizer in Build with Workflows directory

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

