### PR TITLE
fix: correct references for Tanstack Start

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/tanstack-start.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/tanstack-start.mdx
@@ -127,7 +127,7 @@ TanStack Start uses `@tanstack/react-start/server-entry` as your default entrypo
 
 1. Create a custom server entrypoint file:
 
-   <TypeScriptExample filename="app/server.ts">
+   <TypeScriptExample filename="src/server.ts">
 
    ```ts
    import handler from "@tanstack/react-start/server-entry";
@@ -255,7 +255,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { env } from "cloudflare:workers";
 
 const verifyUser = createServerFn()
-	.validator((token: string) => token)
+	.inputValidator((token: string) => token)
 	.handler(async ({ data: token }) => {
 		const result = await env.AUTH_SERVICE.verify(token);
 		return result;


### PR DESCRIPTION
### Summary

https://github.com/TanStack/router/pull/6488#issuecomment-3835684682 @canrau helpfully pointed out a few invalid references here, `validator` is `inputValidator`, and TanStack bases itself in a `src` directory not `app`.
