### PR TITLE
fix: turnstile JS examples

### DIFF
--- a/src/content/docs/turnstile/get-started/server-side-validation.mdx
+++ b/src/content/docs/turnstile/get-started/server-side-validation.mdx
@@ -52,7 +52,7 @@ The API accepts both `application/x-www-form-urlencoded` and `application/json` 
 - Single use: Each token can only be validated once
 - Automatic expiry: Tokens automatically expire and cannot be reused
 
-The validation token issued by Turnstile is valid for five minutes. If a user submits the form after this period, the token is considered expired. In this scenario, the server-side verification API will return a failure, and the `error-codes` field in the response will include `timeout-or-duplicate`. 
+The validation token issued by Turnstile is valid for five minutes. If a user submits the form after this period, the token is considered expired. In this scenario, the server-side verification API will return a failure, and the `error-codes` field in the response will include `timeout-or-duplicate`.
 
 To ensure a successful validation, the visitor must initiate the request and submit the token to your backend within the five-minute window. Otherwise, the Turnstile widget needs to be refreshed to generate a new token. This can be done using the `turnstile.reset` function.
 
@@ -61,81 +61,89 @@ To ensure a successful validation, the visitor must initiate the request and sub
 ## Basic validation examples
 
 <Tabs syncKey="workersExamples">
-<TabItem label="Form Data" icon="seti:javascript">
+<TabItem label="JavaScript" icon="seti:javascript">
+
+#### JSON
+
 ```js
-  const SECRET_KEY = 'your-secret-key';
+const SECRET_KEY = "your-secret-key";
 
 async function validateTurnstile(token, remoteip) {
-const formData = new FormData();
-formData.append('secret', SECRET_KEY);
-formData.append('response', token);
-formData.append('remoteip', remoteip);
+	try {
+		const response = await fetch(
+			"https://challenges.cloudflare.com/turnstile/v0/siteverify",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					secret: SECRET_KEY,
+					response: token,
+					remoteip: remoteip,
+				}),
+			},
+		);
 
-      try {
-          const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-              method: 'POST',
-              body: formData
-          });
+		const result = await response.json();
+		return result;
+	} catch (error) {
+		console.error("Turnstile validation error:", error);
+		return { success: false, "error-codes": ["internal-error"] };
+	}
+}
+```
 
-          const result = await response.json();
-          return result;
-      } catch (error) {
-          console.error('Turnstile validation error:', error);
-          return { success: false, 'error-codes': ['internal-error'] };
-      }
+#### Form Data
 
+```js
+const SECRET_KEY = "your-secret-key";
+
+async function validateTurnstile(token, remoteip) {
+	const formData = new FormData();
+	formData.append("secret", SECRET_KEY);
+	formData.append("response", token);
+	formData.append("remoteip", remoteip);
+
+	try {
+		const response = await fetch(
+			"https://challenges.cloudflare.com/turnstile/v0/siteverify",
+			{
+				method: "POST",
+				body: formData,
+			},
+		);
+
+		const result = await response.json();
+		return result;
+	} catch (error) {
+		console.error("Turnstile validation error:", error);
+		return { success: false, "error-codes": ["internal-error"] };
+	}
 }
 
 // Usage in form handler
 async function handleFormSubmission(request) {
-const body = await request.formData();
-const token = body.get('cf-turnstile-response');
-const ip = request.headers.get('CF-Connecting-IP') ||
-request.headers.get('X-Forwarded-For') ||
-'unknown';
+	const body = await request.formData();
+	const token = body.get("cf-turnstile-response");
+	const ip =
+		request.headers.get("CF-Connecting-IP") ||
+		request.headers.get("X-Forwarded-For") ||
+		"unknown";
 
-      const validation = await validateTurnstile(token, ip);
+	const validation = await validateTurnstile(token, ip);
 
-      if (validation.success) {
-          // Token is valid - process the form
-          console.log('Valid submission from:', validation.hostname);
-          return processForm(body);
-      } else {
-          // Token is invalid - reject the submission
-          console.log('Invalid token:', validation['error-codes']);
-          return new Response('Invalid verification', { status: 400 });
-      }
-
+	if (validation.success) {
+		// Token is valid - process the form
+		console.log("Valid submission from:", validation.hostname);
+		return processForm(body);
+	} else {
+		// Token is invalid - reject the submission
+		console.log("Invalid token:", validation["error-codes"]);
+		return new Response("Invalid verification", { status: 400 });
+	}
 }
-
-````
-</TabItem>
-<TabItem label="JSON" icon="seti:json">
-```json
-const SECRET_KEY = 'your-secret-key';
-
-async function validateTurnstile(token, remoteip) {
-    try {
-        const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                secret: SECRET_KEY,
-                response: token,
-                remoteip: remoteip
-            })
-        });
-
-        const result = await response.json();
-        return result;
-    } catch (error) {
-        console.error('Turnstile validation error:', error);
-        return { success: false, 'error-codes': ['internal-error'] };
-    }
-}
-````
+```
 
 </TabItem>
 <TabItem label="PHP" icon="seti:php">


### PR DESCRIPTION
### Summary

I fixed the confusing tab structure in the Turnstile server-side validation documentation where "Form Data" and "JSON" were separate tabs even though both contained JavaScript code. Now there's a single "JavaScript" tab with two clearly labeled subsections: "JSON" and "Form Data", showing both implementation approaches in one place. The JSON example is now displayed first as it's the more modern approach

### Screenshots (optional)

#### Before
<img width="737" height="794" alt="image" src="https://github.com/user-attachments/assets/39a86b97-1e11-437b-9115-e5727c728dde" />

#### After
<img width="737" height="1229" alt="image" src="https://github.com/user-attachments/assets/1cdae498-a0fd-4027-a894-c467569ae95c" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
