### PR TITLE
Fix cloudflared path for macOS in SSH documentation

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-cloudflared-authentication.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-cloudflared-authentication.mdx
@@ -33,7 +33,7 @@ Client-side `cloudflared` can be used in conjunction with [routing over WARP](/c
    ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h
    ```
 
-   The `cloudflared` path may be different depending on your OS and package manager. For example, if you installed `cloudflared` on macOS with Homebrew, the path is `/usr/local/opt/cloudflared/bin/cloudflared`.
+   The `cloudflared` path may be different depending on your OS and package manager. For example, if you installed `cloudflared` on macOS with Homebrew, check its path by running `brew --prefix cloudflared`.
 
 4. You can now test the connection by running a command to reach the service:
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-cloudflared-authentication.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-cloudflared-authentication.mdx
@@ -33,7 +33,7 @@ Client-side `cloudflared` can be used in conjunction with [routing over WARP](/c
    ProxyCommand /usr/local/bin/cloudflared access ssh --hostname %h
    ```
 
-   The `cloudflared` path may be different depending on your OS and package manager. For example, if you installed `cloudflared` on macOS with Homebrew, the path is `/opt/homebrew/bin/cloudflared`.
+   The `cloudflared` path may be different depending on your OS and package manager. For example, if you installed `cloudflared` on macOS with Homebrew, the path is `/usr/local/opt/cloudflared/bin/cloudflared`.
 
 4. You can now test the connection by running a command to reach the service:
 


### PR DESCRIPTION
### Summary

Fix example path for cloudflared installation 
the old one `/opt/homebrew/bin/cloudflared` is incorrect. correct path in the new one


### Screenshots (optional)

<img width="706" height="207" alt="image" src="https://github.com/user-attachments/assets/37e8953f-2dd7-4fe1-ae6e-559392a4739c" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
