### PR TITLE
Fix DocSearch footer alignment

### DIFF
--- a/src/components/overrides/Footer.astro
+++ b/src/components/overrides/Footer.astro
@@ -142,9 +142,11 @@ if (
 </div>
 
 <style>
-	:global(footer) {
+	:global(footer:not(.DocSearch-Footer)) {
 		flex-direction: column-reverse !important;
+	}
 
+	:global(footer) {
 		.meta {
 			margin-top: 0 !important;
 		}


### PR DESCRIPTION
### Summary

The footer of the DocSearch Modal was misaligned due to some global selectors for the `footer` element.

### Screenshots (optional)

Before fix
<img width="589" height="231" alt="cloudflare_docsearch_before" src="https://github.com/user-attachments/assets/17d235c6-0ea7-4173-b452-72db5dedf21a" />

After fix
<img width="586" height="229" alt="cloudflare_docsearch_after" src="https://github.com/user-attachments/assets/30533be9-216d-4b94-ba4e-66c88535c43e" />


### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
