### PR TITLE
Add `ratelimits` to list of non-inheritable keys in Wrangler config reference

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -274,6 +274,9 @@ Non-inheritable keys are configurable at the top-level, but cannot be inherited 
 - `tail_consumers` <Type text="object" /> <MetaInfo text="optional" />
   - A list of the Tail Workers your Worker sends data to. Refer to [Tail Workers](/workers/observability/logs/tail-workers/).
 
+- `ratelimits` <Type text="object[]" /> <MetaInfo text="optional" />
+  - A list of rate limiters that your Worker should be bound to. Refer to [Rate Limiting](/workers/runtime-apis/bindings/rate-limit/).
+
 ## Types of routes
 
 There are three types of [routes](/workers/configuration/routing/): [Custom Domains](/workers/configuration/routing/custom-domains/), [routes](/workers/configuration/routing/routes/), and [`workers.dev`](/workers/configuration/routing/workers-dev/).


### PR DESCRIPTION
### Summary

The rate limiting configuration key "ratelimits" is treated as a non-inheritable key by Wrangler but is not referenced in the list of non-inheritable keys.

- https://developers.cloudflare.com/workers/wrangler/configuration/#non-inheritable-keys
- https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
