### PR TITLE
[Workers] Simplify CI prerendering guide with TanStack Start

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/tanstack-start.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/tanstack-start.mdx
@@ -381,30 +381,17 @@ Requires `@tanstack/react-start` v1.138.0 or later.
 
 :::
 
+### Prerendering data sources
+
 :::caution
 
-Prerendering runs during build and uses local environment variables, secrets, and bindings storage data. Use [remote bindings](/workers/development-testing/#remote-bindings) to prerender with production data.
+Prerendering runs at build time. It uses your local environment variables, secrets, and bindings storage data.
 
 :::
 
-### Prerender in CI environments
+To prerender with production data, use [remote bindings](/workers/development-testing/#remote-bindings).
 
-When prerendering in CI, your Worker code may need environment variables or secrets not available in the build environment. Include a `.env` file with variable references that resolve to values from your CI environment:
+In CI environments, environment variables or secrets may not be available during the build. To make them accessible:
 
-```sh title=".env"
-API_KEY=${API_KEY}
-DATABASE_URL=${DATABASE_URL}
-```
-
-Set `CLOUDFLARE_INCLUDE_PROCESS_ENV=true` in your CI environment and provide the required values as environment variables. If using [Workers Builds](/workers/ci-cd/builds/), update your [build settings](/workers/ci-cd/builds/configuration/#build-settings).
-
-:::note
-
-For local development, create a `.env.local` file with actual values. Do not commit this file to your repository. Values in `.env.local` override references in `.env`:
-
-```sh title=".env.local"
-API_KEY=my-local-dev-key
-DATABASE_URL=postgres://localhost/mydb
-```
-
-:::
+- Set `CLOUDFLARE_INCLUDE_PROCESS_ENV=true` in your CI environment and provide the required values as environment variables.
+- If using [Workers Builds](/workers/ci-cd/builds/), update your [build settings](/workers/ci-cd/builds/configuration/#build-settings).


### PR DESCRIPTION
### Summary

This PR removes the `.env` setup instructions as it turns out `CLOUDFLARE_INCLUDE_PROCESS_ENV=true` already makes CI env vars available to the build.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
