### PR TITLE
[Page Shield] Update page title in link

### DIFF
--- a/src/content/docs/page-shield/reference/page-shield-api.mdx
+++ b/src/content/docs/page-shield/reference/page-shield-api.mdx
@@ -476,7 +476,7 @@ All other scripts would trigger a policy violation, but those scripts would not 
 For more information on <GlossaryTooltip term="content security policy (CSP)">Content Security Policy (CSP)</GlossaryTooltip> directives and values, refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy).
 
 :::note
-For a list of CSP directives and keywords supported by policies, refer to [CSP directives supported by policies](/page-shield/policies/csp-directives/).
+For a list of CSP directives and keywords supported by policies, refer to [Supported CSP directives](/page-shield/policies/csp-directives/).
 :::
 
 <APIRequest


### PR DESCRIPTION
Updates a cross-reference link to use the actual page title instead of a descriptive phrase.