### PR TITLE
Add note about `upload_source_maps` inference in Vite plugin

### DIFF
--- a/src/content/docs/workers/vite-plugin/reference/migrating-from-wrangler-dev.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/migrating-from-wrangler-dev.mdx
@@ -57,6 +57,6 @@ See [Vite Environments](/workers/vite-plugin/reference/vite-environments/) for m
 
 ### Inferred
 
-If [build.sourcemap](https://vite.dev/config/build-options#build-sourcemap) is enabled for a given Worker environment in the Vite config, `"upload_source_maps": true` is automatically added to the output `wrangler.json` file.
+If [build.sourcemap](https://vite.dev/config/build-options#build-sourcemap) is enabled for a given Worker environment in the Vite config, `"upload_source_maps": true` is automatically added to the output Wrangler configuration file.
 This means that generated sourcemaps are uploaded by default.
 To override this setting, you can set the value of `upload_source_maps` explicitly in the input Worker config.

--- a/src/content/docs/workers/vite-plugin/reference/migrating-from-wrangler-dev.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/migrating-from-wrangler-dev.mdx
@@ -46,11 +46,17 @@ The following build-related options are handled by Vite and are not applicable w
 
 The following options have Vite equivalents that should be used instead:
 
-| Wrangler option | Vite equivalent |
-| --- | --- |
-| `define` | [`define`](https://vite.dev/config/shared-options.html#define) |
-| `alias` | [`resolve.alias`](https://vite.dev/config/shared-options.html#resolve-alias) |
-| `minify` | [`build.minify`](https://vite.dev/config/build-options.html#build-minify) |
-| Local dev settings (`ip`, `port`, `local_protocol`, etc.) | [Server options](https://vite.dev/config/server-options.html) |
+| Wrangler option                                           | Vite equivalent                                                              |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `define`                                                  | [`define`](https://vite.dev/config/shared-options.html#define)               |
+| `alias`                                                   | [`resolve.alias`](https://vite.dev/config/shared-options.html#resolve-alias) |
+| `minify`                                                  | [`build.minify`](https://vite.dev/config/build-options.html#build-minify)    |
+| Local dev settings (`ip`, `port`, `local_protocol`, etc.) | [Server options](https://vite.dev/config/server-options.html)                |
 
 See [Vite Environments](/workers/vite-plugin/reference/vite-environments/) for more information about configuring your Worker environments in Vite.
+
+### Inferred
+
+If [build.sourcemap](https://vite.dev/config/build-options#build-sourcemap) is enabled for a given Worker environment in the Vite config, `"upload_source_maps": true` is automatically added to the output `wrangler.json` file.
+This means that generated sourcemaps are uploaded by default.
+To override this setting, you can set the value of `upload_source_maps` explicitly in the input Worker config.


### PR DESCRIPTION
### Summary

Add note about `upload_source_maps` inference in Vite plugin

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
