### PR TITLE
docs: update setup commands to a single uvx command

### DIFF
--- a/src/content/docs/workers/languages/python/index.mdx
+++ b/src/content/docs/workers/languages/python/index.mdx
@@ -57,10 +57,8 @@ To set it up, first, ensure [uv](https://docs.astral.sh/uv/#installation) and [N
 
 Then set up your development environment:
 
-```
-uv init
-uv tool install workers-py
-uv run pywrangler init
+```bash
+uvx --from workers-py pywrangler init
 ```
 
 This will create a `pyproject.toml` file with `workers-py` as a development


### PR DESCRIPTION
### Summary

Current commands create a project inside a project situation which is not favorable. This solves that by changing it to a single uvx command. 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
