### PR TITLE
Add `purgeCache` docs to Miniflare cache page

### DIFF
--- a/src/content/docs/workers/testing/miniflare/storage/cache.md
+++ b/src/content/docs/workers/testing/miniflare/storage/cache.md
@@ -81,6 +81,21 @@ res = await mf.dispatchFetch("http://localhost:8787");
 console.log(await res.text()); // 2
 ```
 
+## Purging
+
+You can programmatically purge all entries from a cache using the `purgeCache` method on the `Miniflare` instance. This is useful during development when cached assets need to be cleared without restarting the instance:
+
+```js
+const mf = new Miniflare({ /* options */ });
+
+// Purge the default cache and get the number of entries purged
+const count = await mf.purgeCache();
+console.log(`Purged ${count} entries`);
+
+// Purge a specific named cache
+await mf.purgeCache("my-named-cache");
+```
+
 ## Disabling
 
 Both default and named caches can be disabled with the `disableCache` option.


### PR DESCRIPTION
### Summary

Documents the new `Miniflare#purgeCache()` method being added in [cloudflare/workers-sdk#12462](https://github.com/cloudflare/workers-sdk/pull/12462). This adds a "Purging" section to the [Miniflare Cache storage page](/workers/testing/miniflare/storage/cache/) with a usage example showing how to purge the default cache and named caches programmatically.

**Note:** This docs update should land alongside or after the corresponding implementation PR ships.

---

Link to Devin run: https://app.devin.ai/sessions/1707687ee91a4aadb16777130f161724
Requested by: @petebacondarwin

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).