### PR TITLE
Update local development queue configuration details

### DIFF
--- a/src/content/docs/queues/configuration/local-development.mdx
+++ b/src/content/docs/queues/configuration/local-development.mdx
@@ -65,7 +65,7 @@ When the producer Worker sends messages to the queue, the consumer Worker will a
 
 ## Known Issues
 - Queues does not support Wrangler remote mode (`wrangler dev --remote`).
-- For simulated queues to work in local dev environment, both the producer and consumer workers must be run in a single dev instance. If you have separate workers for your queue producer and consumer, you need to use the `-c` flag to run them via a single `wrangler dev` command. 
-  - For example `wrangler dev -c producer-worker.toml -c consumer-worker.toml`
-  - [See this workers-sdk issue for more details](https://github.com/cloudflare/workers-sdk/issues/9795). 
-  - You might also find the [multi-workers documentation](https://developers.cloudflare.com/workers/development-testing/multi-workers/#single-dev-command) helpful. 
+- For simulated Queues to work in the local development environment, both the producer and consumer Workers must be run in a single dev instance. If you have separate Workers for your Queue producer and consumer, you need to use the `-c` flag to run them via a single `npx wrangler@latest dev` command.
+  - For example `npx wrangler@latest dev -c wrangler.jsonc -c consumer-worker/wrangler.jsonc --persist-to .wrangler/state`
+  - [See this workers-sdk issue for more details](https://github.com/cloudflare/workers-sdk/issues/9795).
+  - You might also find the [multi-workers documentation](https://developers.cloudflare.com/workers/development-testing/multi-workers/#single-dev-command) helpful.

--- a/src/content/docs/queues/configuration/local-development.mdx
+++ b/src/content/docs/queues/configuration/local-development.mdx
@@ -65,3 +65,7 @@ When the producer Worker sends messages to the queue, the consumer Worker will a
 
 ## Known Issues
 - Queues does not support Wrangler remote mode (`wrangler dev --remote`).
+- For simulated queues to work in local dev environment, both the producer and consumer workers must be run in a single dev instance. If you have separate workers for your queue producer and consumer, you need to use the `-c` flag to run them via a single `wrangler dev` command. 
+  - For example `wrangler dev -c producer-worker.toml -c consumer-worker.toml`
+  - [See this workers-sdk issue for more details](https://github.com/cloudflare/workers-sdk/issues/9795). 
+  - You might also find the [multi-workers documentation](https://developers.cloudflare.com/workers/development-testing/multi-workers/#single-dev-command) helpful. 


### PR DESCRIPTION
Clarified instructions for running Queues in local dev environment when producer and consumer live in separate workers.

### Summary

After wasting many hours watching my AI agents flail hopelessly trying to figure out why queues were not working in my local dev environment when running my producer and consumer workers via separate `wrangler dev` commands, I finally stumbled upon [this issue](https://github.com/cloudflare/workers-sdk/issues/9795) that explained the problem. This PR adds a note about the problem to the Known Issues at the bottom of the Queue documentation and provides an example solution and links to relevant discussion and documentation. Hopefully it will save some other devs a bit of pain. 