### PR TITLE
Document `--json` flag for `pages project list` command

### DIFF
--- a/src/content/docs/pages/get-started/direct-upload.mdx
+++ b/src/content/docs/pages/get-started/direct-upload.mdx
@@ -103,6 +103,12 @@ If you would like to use Wrangler to obtain a list of all available projects for
 npx wrangler pages project list
 ```
 
+To get the output as JSON for programmatic use or scripting, use the `--json` flag:
+
+```sh
+npx wrangler pages project list --json
+```
+
 If you would like to use Wrangler to obtain a list of all unique preview URLs for a particular project, use [`pages deployment list`](/workers/wrangler/commands/pages/#pages-deployment-list):
 
 ```sh


### PR DESCRIPTION
### Summary

Documents the new `--json` flag for `wrangler pages project list` in the Direct Upload guide. This corresponds to [cloudflare/workers-sdk#12465](https://github.com/cloudflare/workers-sdk/pull/12465), which adds JSON output support to the command for programmatic use and scripting workflows.

The auto-generated command reference (via `WranglerNamespace`) will automatically pick up the `--json` flag once the wrangler dependency is bumped to include the change.

**Link to Devin run:** https://app.devin.ai/sessions/b4459c91b7b74c93b13ab3c365b05197
**Requested by:** @petebacondarwin

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/28175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
