### PR TITLE
docs: add documentation for `wrangler pages deployment delete` command

### DIFF
--- a/src/content/docs/pages/configuration/api.mdx
+++ b/src/content/docs/pages/configuration/api.mdx
@@ -64,6 +64,10 @@ After you have deployed the JavaScript Worker, set a cron trigger in your Worker
 
 Cloudflare Pages hosts and serves all project deployments on preview links. Suppose you want to keep your project private and prevent access to your old deployments. You can use the API to delete deployments after a month, so that they are no longer public online. The latest deployment for a branch cannot be deleted.
 
+:::note
+To delete individual deployments from the command line, you can use [`wrangler pages deployment delete`](/workers/wrangler/commands/#deployment-delete).
+:::
+
 ```js
 const endpoint =
 	"https://api.cloudflare.com/client/v4/accounts/{account_id}/pages/projects/{project_name}/deployments";

--- a/src/content/docs/pages/configuration/api.mdx
+++ b/src/content/docs/pages/configuration/api.mdx
@@ -65,7 +65,7 @@ After you have deployed the JavaScript Worker, set a cron trigger in your Worker
 Cloudflare Pages hosts and serves all project deployments on preview links. Suppose you want to keep your project private and prevent access to your old deployments. You can use the API to delete deployments after a month, so that they are no longer public online. The latest deployment for a branch cannot be deleted.
 
 :::note
-To delete individual deployments from the command line, you can use [`wrangler pages deployment delete`](/workers/wrangler/commands/#deployment-delete).
+To delete individual deployments from the command line, you can use [`wrangler pages deployment delete`](/workers/wrangler/commands/pages/#pages-deployment-delete).
 :::
 
 ```js

--- a/src/content/docs/pages/configuration/preview-deployments.mdx
+++ b/src/content/docs/pages/configuration/preview-deployments.mdx
@@ -70,6 +70,20 @@ To view branch aliases within your Pages project, select **View build** for any 
 
 You can attach a Preview alias to a custom domain by [adding a custom domain to a branch](https://developers.cloudflare.com/pages/how-to/custom-branch-aliases/).
 
+## Delete preview deployments
+
+To clean up old preview deployments, you can delete them using Wrangler:
+
+```sh
+npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAME>
+```
+
+Use the `--force` (or `-f`) flag to skip the confirmation prompt, which is useful for CI/CD automation. You can find deployment IDs by running [`wrangler pages deployment list`](/workers/wrangler/commands/#deployment-list).
+
+:::note
+The latest deployment for a branch cannot be deleted.
+:::
+
 ## Preview indexing by search engines
 
 To maintain a healthy SEO profile, it's vital to prevent search engines from finding duplicate content across the web. Because preview deployments are designed to be an exact replica of your production environment, they inherently create this exact situation. Cloudflare Pages by default ensures your search rankings are not harmed by these temporary previews.

--- a/src/content/docs/pages/configuration/preview-deployments.mdx
+++ b/src/content/docs/pages/configuration/preview-deployments.mdx
@@ -78,7 +78,7 @@ To clean up old preview deployments, you can delete them using Wrangler:
 npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAME>
 ```
 
-Use the `--force` (or `-f`) flag to skip the confirmation prompt, and to force deletion of aliased deployments. You can find deployment IDs by running [`wrangler pages deployment list`](/workers/wrangler/commands/#deployment-list).
+Use the `--force` (or `-f`) flag to skip the confirmation prompt, and to force deletion of aliased deployments. You can find deployment IDs by running [`wrangler pages deployment list`](/workers/wrangler/commands/pages/#pages-deployment-list).
 
 :::note
 The latest deployment for a branch cannot be deleted.

--- a/src/content/docs/pages/configuration/preview-deployments.mdx
+++ b/src/content/docs/pages/configuration/preview-deployments.mdx
@@ -78,7 +78,7 @@ To clean up old preview deployments, you can delete them using Wrangler:
 npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAME>
 ```
 
-Use the `--force` (or `-f`) flag to skip the confirmation prompt, which is useful for CI/CD automation. You can find deployment IDs by running [`wrangler pages deployment list`](/workers/wrangler/commands/#deployment-list).
+Use the `--force` (or `-f`) flag to skip the confirmation prompt, and to force deletion of aliased deployments. You can find deployment IDs by running [`wrangler pages deployment list`](/workers/wrangler/commands/#deployment-list).
 
 :::note
 The latest deployment for a branch cannot be deleted.

--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -103,6 +103,14 @@ npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAM
 
 Use the `--force` flag to skip the confirmation prompt and to force deletion of aliased deployments.
 
+To delete _all_ your deployments for a particular project name, you could run the following shell script:
+
+```sh
+npx wrangler pages deployment list --project-name <PROJECT_NAME> --json \
+  | jq -r '.[].Id' \
+  | xargs -I {} npx wrangler pages deployment delete {} --project-name <PROJECT_NAME> --force
+```
+
 ## Use Pages as Origin in Cloudflare Load Balancer
 
 [Cloudflare Load Balancing](/load-balancing/) will not work without the host header set. To use a Pages project as target, make sure to select **Add host header** when [creating a pool](/load-balancing/pools/create-pool/#create-a-pool), and set both the host header value and the endpoint address to your `pages.dev` domain.

--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -95,31 +95,13 @@ If you have an issue that you do not see listed, let the team know in the Cloudf
 
 You may not be able to delete your Pages project if it has a high number (over 100) of deployments. The Cloudflare team is tracking this issue.
 
-As a workaround, review the following steps to delete all deployments in your Pages project. After you delete your deployments, you will be able to delete your Pages project.
-
-1. Download the `delete-all-deployments.zip` file by going to the following link: [https://pub-505c82ba1c844ba788b97b1ed9415e75.r2.dev/delete-all-deployments.zip](https://pub-505c82ba1c844ba788b97b1ed9415e75.r2.dev/delete-all-deployments.zip).
-2. Extract the `delete-all-deployments.zip` file.
-3. Open your terminal and `cd` into the `delete-all-deployments` directory.
-4. In the `delete-all-deployments` directory, run `npm install` to install dependencies.
-5. Review the following commands to decide which deletion you would like to proceed with:
-
-- To delete all deployments except for the live production deployment (excluding [aliased deployments](https://developers.cloudflare.com/pages/configuration/preview-deployments/#preview-aliases)):
+As a workaround, you can use [`wrangler pages deployment delete`](/workers/wrangler/commands/#deployment-delete) to delete deployments individually. After you delete your deployments, you will be able to delete your Pages project.
 
 ```sh
-CF_API_TOKEN=<YOUR_CF_API_TOKEN> CF_ACCOUNT_ID=<ACCOUNT_ID> CF_PAGES_PROJECT_NAME=<PROJECT_NAME> npm start
+npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAME>
 ```
 
-- To delete all deployments except for the live production deployment (including [aliased deployments](https://developers.cloudflare.com/pages/configuration/preview-deployments/#preview-aliases), for example, `staging.example.pages.dev`):
-
-```sh
-CF_API_TOKEN=<YOUR_CF_API_TOKEN> CF_ACCOUNT_ID=<ACCOUNT_ID> CF_PAGES_PROJECT_NAME=<PROJECT_NAME> CF_DELETE_ALIASED_DEPLOYMENTS=true npm start
-```
-
-To find your Cloudflare API token, log in to the [Cloudflare dashboard](https://dash.cloudflare.com), select the user icon on the upper righthand side of your screen > go to **My Profile** > **API Tokens**.
-
-You need a token with `Cloudflare Pages Edit` permissions.
-
-To find your Account ID, refer to [Find your zone and account ID](/fundamentals/account/find-account-and-zone-ids/).
+Use the `--force` flag to skip the confirmation prompt, which is useful for scripting bulk deletions.
 
 ## Use Pages as Origin in Cloudflare Load Balancer
 

--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -101,7 +101,7 @@ As a workaround, you can use [`wrangler pages deployment delete`](/workers/wrang
 npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAME>
 ```
 
-Use the `--force` flag to skip the confirmation prompt, which is useful for scripting bulk deletions.
+Use the `--force` flag to skip the confirmation prompt and to force deletion of aliased deployments.
 
 ## Use Pages as Origin in Cloudflare Load Balancer
 

--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -95,7 +95,7 @@ If you have an issue that you do not see listed, let the team know in the Cloudf
 
 You may not be able to delete your Pages project if it has a high number (over 100) of deployments. The Cloudflare team is tracking this issue.
 
-As a workaround, you can use [`wrangler pages deployment delete`](/workers/wrangler/commands/#deployment-delete) to delete deployments individually. After you delete your deployments, you will be able to delete your Pages project.
+As a workaround, you can use [`wrangler pages deployment delete`](/workers/wrangler/commands/pages/#pages-deployment-delete) to delete deployments individually. After you delete your deployments, you will be able to delete your Pages project.
 
 ```sh
 npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAME>


### PR DESCRIPTION
### Summary

Documents the new `wrangler pages deployment delete` CLI command being added in [cloudflare/workers-sdk#12474](https://github.com/cloudflare/workers-sdk/pull/12474). Changes across three Pages docs pages:

- **preview-deployments.mdx**: Adds a new "Delete preview deployments" section with CLI usage and `--force` flag.
- **api.mdx**: Adds a note callout in the "Deleting old deployments after a week" section pointing to the CLI alternative.
- **known-issues.mdx**: Replaces the old zip-file-based bulk deletion workaround with the new `wrangler pages deployment delete` command.

#### ⚠️ Items for reviewer attention

1. **Anchor link `/workers/wrangler/commands/#deployment-delete`** — The Wrangler commands page auto-generates from the installed `wrangler` package via `WranglerNamespace`. This anchor won't resolve until the `wrangler` dependency in this repo is bumped to include the new command. Confirm this is acceptable to merge ahead of the version bump, or if it should be held.
2. **known-issues.mdx: removal of bulk deletion script** — The old workaround included a downloadable script that could delete all deployments at once (with options for aliased deployments). The replacement only documents deleting one deployment at a time. For users with 100+ deployments, this is more tedious. Consider whether the old instructions should be retained alongside the new CLI command.

---

[Link to Devin run](https://app.devin.ai/sessions/bbe53461988e48008ba2a68c3da43e5b) | Requested by @petebacondarwin

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))?
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/28200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
