### PR TITLE
docs: document WRANGLER_COMMAND environment variable for custom builds

### DIFF
--- a/src/content/docs/workers/wrangler/custom-builds.mdx
+++ b/src/content/docs/workers/wrangler/custom-builds.mdx
@@ -45,3 +45,29 @@ Example:
 ```
 
 </WranglerConfig>
+
+## `WRANGLER_COMMAND` environment variable
+
+When Wrangler runs your custom build command, it sets the `WRANGLER_COMMAND` environment variable so your build script can detect which Wrangler command triggered the build. This allows you to customize the build process based on the deployment context.
+
+The possible values are:
+
+| Value              | Wrangler command triggered               |
+| ------------------ | ---------------------------------------- |
+| `dev`              | `wrangler dev`                           |
+| `deploy`           | `wrangler deploy`                        |
+| `versions upload`  | `wrangler versions upload`               |
+| `types`            | `wrangler types`                         |
+
+For example, you can use this to apply different build settings for development and production:
+
+```bash
+#!/bin/bash
+if [ "$WRANGLER_COMMAND" = "dev" ]; then
+  echo "Building for development..."
+  # run a development build
+else
+  echo "Building for production..."
+  # run a production build
+fi
+```


### PR DESCRIPTION
### Summary

Documents the new `WRANGLER_COMMAND` environment variable added to Wrangler's custom build commands in [cloudflare/workers-sdk#12470](https://github.com/cloudflare/workers-sdk/pull/12470).

Adds a new section to the [Custom builds](/workers/wrangler/custom-builds/) page covering:
- What `WRANGLER_COMMAND` is and when it's set
- Table of possible values (`dev`, `deploy`, `versions upload`, `types`)
- Example bash script showing how to branch build logic based on the variable

### Things for reviewers to verify

- The table of `WRANGLER_COMMAND` values matches the implementation in workers-sdk#12470
- Whether the [Configuration page's Custom builds section](/workers/wrangler/configuration/#custom-builds) should also mention this env var (currently it just links to the custom-builds page)
- Whether a changelog entry is needed for this addition

---

Link to Devin run: https://app.devin.ai/sessions/83e0c23d36b74427afe8df40388591db
Requested by: @petebacondarwin

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/28207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
