### PR TITLE
Add concurrency settings to bonk workflow

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -10,7 +10,7 @@ jobs:
   bonk:
     if: github.event.sender.type != 'Bot'
     concurrency:
-      group: pr-${{ github.event.pull_request.number }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot'
+    concurrency:
+      group: pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Implement concurrency settings for the bonk job to manage pull request executions.

Subsequent invocations on the PR will be queued instead of running and conflicting when they attempt to update the PR branch.