### PR TITLE
Hide sdk.yaml tile

### DIFF
--- a/src/content/products/sdk.yaml
+++ b/src/content/products/sdk.yaml
@@ -5,6 +5,7 @@ product:
   url: /sdk/
   group: Core platform
   additional_groups: [Developer platform]
+  show: false
 
 meta:
   title: Cloudflare SDK


### PR DESCRIPTION
This tile leads to a 404. I don't see an intended destination section to change the URL to, so hiding the tile for now.
