### PR TITLE
R2 SQL: add approximate aggregation functions

### DIFF
--- a/src/content/changelog/r2-sql/2026-02-09-approximate-aggregation-functions.mdx
+++ b/src/content/changelog/r2-sql/2026-02-09-approximate-aggregation-functions.mdx
@@ -2,9 +2,6 @@
 title: R2 SQL now supports approximate aggregation functions
 description: Five new approximate functions for percentiles, medians, distinct counts, and top-k analysis on Apache Iceberg tables in R2 Data Catalog.
 date: 2026-02-09
-products:
-  - r2-sql
-hidden: false
 ---
 
 R2 SQL now supports five approximate aggregation functions for fast analysis of large datasets. These functions trade minor precision for improved performance on high-cardinality data.

--- a/src/content/changelog/r2-sql/2026-02-09-approximate-aggregation-functions.mdx
+++ b/src/content/changelog/r2-sql/2026-02-09-approximate-aggregation-functions.mdx
@@ -1,0 +1,62 @@
+---
+title: R2 SQL now supports approximate aggregation functions
+description: Five new approximate functions for percentiles, medians, distinct counts, and top-k analysis on Apache Iceberg tables in R2 Data Catalog.
+date: 2026-02-09
+products:
+  - r2-sql
+hidden: false
+---
+
+R2 SQL now supports five approximate aggregation functions for fast analysis of large datasets. These functions trade minor precision for improved performance on high-cardinality data.
+
+## New functions
+
+- `APPROX_PERCENTILE_CONT(column, percentile)` — Returns the approximate value at a given percentile (0.0 to 1.0). Works on integer and decimal columns.
+- `APPROX_PERCENTILE_CONT_WITH_WEIGHT(column, weight, percentile)` — Weighted percentile calculation where each row contributes proportionally to its weight column value.
+- `APPROX_MEDIAN(column)` — Returns the approximate median. Equivalent to `APPROX_PERCENTILE_CONT(column, 0.5)`.
+- `APPROX_DISTINCT(column)` — Returns the approximate number of distinct values. Works on any column type.
+- `APPROX_TOP_K(column, k)` — Returns the `k` most frequent values with their counts as a JSON array.
+
+All functions support `WHERE` filters. All except `APPROX_TOP_K` support `GROUP BY`.
+
+## Examples
+
+```sql
+-- Percentile analysis on revenue data
+SELECT approx_percentile_cont(total_amount, 0.25),
+       approx_percentile_cont(total_amount, 0.5),
+       approx_percentile_cont(total_amount, 0.75)
+FROM my_namespace.sales_data
+```
+
+```sql
+-- Median per department
+SELECT department, approx_median(total_amount)
+FROM my_namespace.sales_data
+GROUP BY department
+```
+
+```sql
+-- Approximate distinct customers by region
+SELECT region, approx_distinct(customer_id)
+FROM my_namespace.sales_data
+GROUP BY region
+```
+
+```sql
+-- Top 5 most frequent departments
+SELECT approx_top_k(department, 5)
+FROM my_namespace.sales_data
+```
+
+```sql
+-- Combine approximate and standard aggregations
+SELECT COUNT(*),
+       AVG(total_amount),
+       approx_percentile_cont(total_amount, 0.5),
+       approx_distinct(customer_id)
+FROM my_namespace.sales_data
+WHERE region = 'North'
+```
+
+For the full syntax and additional examples, refer to the [SQL reference](/r2-sql/sql-reference/).

--- a/src/content/docs/r2-sql/sql-reference.mdx
+++ b/src/content/docs/r2-sql/sql-reference.mdx
@@ -104,7 +104,7 @@ GROUP BY column_list
 
 ### Supported Functions
 
-- **COUNT(\*)**: Counts total rows **note**: only `*` is supported
+- **COUNT(*)**: Counts total rows **note**: only `*` is supported
 - **SUM(column)**: Sums numeric values
 - **AVG(column)**: Calculates average of numeric values
 - **MIN(column)**: Finds minimum value
@@ -161,7 +161,7 @@ FROM table_name
 - **APPROX_PERCENTILE_CONT_WITH_WEIGHT(column, weight, percentile)**: Returns the approximate percentile weighted by the `weight` column. The `percentile` parameter must be between `0.0` and `1.0` inclusive. Works on integer and decimal columns.
 - **APPROX_MEDIAN(column)**: Returns the approximate median value. Equivalent to `APPROX_PERCENTILE_CONT(column, 0.5)`. Works on integer and decimal columns.
 - **APPROX_DISTINCT(column)**: Returns the approximate number of distinct values in a column. Works on any column type.
-- **APPROX_TOP_K(column, k)**: Returns the `k` most frequent values in a column along with their approximate counts. The `k` parameter must be a positive integer. Returns a JSON array of `\{"value", "count"\}` objects. Works on string columns.
+- **APPROX_TOP_K(column, k)**: Returns the `k` most frequent values in a column along with their approximate counts. The `k` parameter must be a positive integer. Returns a JSON array of `{"value", "count"}` objects. Works on string columns.
 
 ### Examples
 

--- a/src/content/docs/r2-sql/sql-reference.mdx
+++ b/src/content/docs/r2-sql/sql-reference.mdx
@@ -104,7 +104,7 @@ GROUP BY column_list
 
 ### Supported Functions
 
-- **COUNT(*)**: Counts total rows **note**: only `*` is supported
+- **COUNT(\*)**: Counts total rows **note**: only `*` is supported
 - **SUM(column)**: Sums numeric values
 - **AVG(column)**: Calculates average of numeric values
 - **MIN(column)**: Finds minimum value
@@ -157,11 +157,11 @@ FROM table_name
 
 ### Supported Functions
 
-- **APPROX_PERCENTILE_CONT(column, percentile)**: Returns the approximate value at the given percentile. The `percentile` parameter must be between `0.0` and `1.0` inclusive. Works on integer and decimal columns.
-- **APPROX_PERCENTILE_CONT_WITH_WEIGHT(column, weight, percentile)**: Returns the approximate percentile weighted by the `weight` column. The `percentile` parameter must be between `0.0` and `1.0` inclusive. Works on integer and decimal columns.
-- **APPROX_MEDIAN(column)**: Returns the approximate median value. Equivalent to `APPROX_PERCENTILE_CONT(column, 0.5)`. Works on integer and decimal columns.
-- **APPROX_DISTINCT(column)**: Returns the approximate number of distinct values in a column. Works on any column type.
-- **APPROX_TOP_K(column, k)**: Returns the `k` most frequent values in a column along with their approximate counts. The `k` parameter must be a positive integer. Returns a JSON array of `{"value", "count"}` objects. Works on string columns.
+- **APPROX_PERCENTILE_CONT(column, percentile)**: Uses a t-digests algorithm to return the approximate value at the given percentile. The `percentile` parameter must be between `0.0` and `1.0` inclusive. Works on integer and decimal columns.
+- **APPROX_PERCENTILE_CONT_WITH_WEIGHT(column, weight, percentile)**: Uses a t-digests algorithm to return the approximate percentile weighted by the `weight` column. The `percentile` parameter must be between `0.0` and `1.0` inclusive. Works on integer and decimal columns.
+- **APPROX_MEDIAN(column)**: Uses a t-digests algorithm to return the approximate median value. Equivalent to `APPROX_PERCENTILE_CONT(column, 0.5)`. Works on integer and decimal columns.
+- **APPROX_DISTINCT(column)**: Uses HyperLogLog to return the approximate number of distinct values in a column. Works on any column type.
+- **APPROX_TOP_K(column, k)**: Uses a filtered space-saving algorithm to return the `k` most frequent values in a column along with their approximate counts. The `k` parameter must be a positive integer. Returns a JSON array of `\{"value", "count"\}` objects. Works on string columns.
 
 ### Examples
 

--- a/src/content/docs/r2-sql/sql-reference.mdx
+++ b/src/content/docs/r2-sql/sql-reference.mdx
@@ -144,7 +144,9 @@ SELECT COUNT(department) FROM my_namespace.sales_data
 
 ## Approximate Aggregation Functions
 
-R2 SQL supports approximate aggregation functions for fast analysis of large datasets. These functions trade minor precision loss for better performance.
+Approximate aggregation functions produce statistically estimated results while using significantly less memory and compute than their exact counterparts. On large datasets, approximate functions can return results orders of magnitude faster than equivalent exact aggregations such as `COUNT(DISTINCT ...)`, typically with an average relative error of only a few percent.
+
+Use approximate functions when you are analyzing large datasets and an approximate result is acceptable — for example, understanding traffic distributions, identifying top values, or estimating cardinality across high-volume tables. Use exact aggregation functions when precise results are required, such as for billing or compliance reporting.
 
 ### Syntax
 

--- a/src/content/docs/r2-sql/sql-reference.mdx
+++ b/src/content/docs/r2-sql/sql-reference.mdx
@@ -19,7 +19,7 @@ This page documents the R2 SQL syntax based on the currently supported grammar i
 ## Query Syntax
 
 ```sql
-SELECT column_list | aggregation_function
+SELECT column_list | aggregation_function | approximate_function
 FROM table_name
 WHERE conditions --optional
 [GROUP BY column_list]
@@ -104,7 +104,7 @@ GROUP BY column_list
 
 ### Supported Functions
 
-- **COUNT(*)**: Counts total rows **note**: only `*` is supported
+- **COUNT(\*)**: Counts total rows **note**: only `*` is supported
 - **SUM(column)**: Sums numeric values
 - **AVG(column)**: Calculates average of numeric values
 - **MIN(column)**: Finds minimum value
@@ -138,6 +138,86 @@ SELECT department, COUNT(*) AS total FROM my_namespace.sales_data GROUP BY depar
 
 -- Invalid: COUNT column name
 SELECT COUNT(department) FROM my_namespace.sales_data
+```
+
+---
+
+## Approximate Aggregation Functions
+
+R2 SQL supports approximate aggregation functions for fast analysis of large datasets. These functions trade minor precision loss for better performance.
+
+### Syntax
+
+```sql
+SELECT approximate_function(column_name [, ...])
+FROM table_name
+[WHERE conditions]
+[GROUP BY column_list]
+```
+
+### Supported Functions
+
+- **APPROX_PERCENTILE_CONT(column, percentile)**: Returns the approximate value at the given percentile. The `percentile` parameter must be between `0.0` and `1.0` inclusive. Works on integer and decimal columns.
+- **APPROX_PERCENTILE_CONT_WITH_WEIGHT(column, weight, percentile)**: Returns the approximate percentile weighted by the `weight` column. The `percentile` parameter must be between `0.0` and `1.0` inclusive. Works on integer and decimal columns.
+- **APPROX_MEDIAN(column)**: Returns the approximate median value. Equivalent to `APPROX_PERCENTILE_CONT(column, 0.5)`. Works on integer and decimal columns.
+- **APPROX_DISTINCT(column)**: Returns the approximate number of distinct values in a column. Works on any column type.
+- **APPROX_TOP_K(column, k)**: Returns the `k` most frequent values in a column along with their approximate counts. The `k` parameter must be a positive integer. Returns a JSON array of `\{"value", "count"\}` objects. Works on string columns.
+
+### Examples
+
+```sql
+-- Approximate percentiles on a numeric column
+SELECT approx_percentile_cont(total_amount, 0.25),
+       approx_percentile_cont(total_amount, 0.5),
+       approx_percentile_cont(total_amount, 0.75)
+FROM my_namespace.sales_data
+
+-- Percentile with GROUP BY
+SELECT department, approx_percentile_cont(total_amount, 0.5)
+FROM my_namespace.sales_data
+GROUP BY department
+
+-- Weighted percentile (rows weighted by quantity)
+SELECT approx_percentile_cont_with_weight(unit_price, quantity, 0.5)
+FROM my_namespace.sales_data
+
+-- Approximate median
+SELECT department, approx_median(total_amount)
+FROM my_namespace.sales_data
+GROUP BY department
+
+-- Approximate distinct count
+SELECT approx_distinct(customer_id)
+FROM my_namespace.sales_data
+
+-- Multiple distinct counts in one query
+SELECT approx_distinct(department),
+       approx_distinct(region),
+       approx_distinct(customer_id)
+FROM my_namespace.sales_data
+
+-- Top-k most frequent values
+SELECT approx_top_k(department, 3)
+FROM my_namespace.sales_data
+
+-- Combine approximate and standard aggregations
+SELECT COUNT(*),
+       SUM(total_amount),
+       AVG(total_amount),
+       approx_percentile_cont(total_amount, 0.5)
+FROM my_namespace.sales_data
+
+-- With WHERE filter
+SELECT approx_median(total_amount),
+       approx_distinct(customer_id)
+FROM my_namespace.sales_data
+WHERE region = 'North'
+
+-- Invalid: percentile out of range
+SELECT approx_percentile_cont(total_amount, 1.5) FROM my_namespace.sales_data
+
+-- Invalid: k must be positive
+SELECT approx_top_k(department, 0) FROM my_namespace.sales_data
 ```
 
 ---


### PR DESCRIPTION
Documents five new approximate aggregation functions for R2 SQL, enabling fast analysis of large datasets with minor precision tradeoffs.

- Add APPROX_PERCENTILE_CONT, APPROX_PERCENTILE_CONT_WITH_WEIGHT, APPROX_MEDIAN, APPROX_DISTINCT, APPROX_TOP_K to SQL reference
- Add changelog entry for the new functions
- Fix escaped COUNT(*) rendering in existing docs
- Update top-level query syntax to include approximate_function

**Note on syntax highlighting:** The approximate function names (e.g. `approx_percentile_cont`, `approx_median`) will not receive SQL keyword highlighting in the rendered code blocks. This is expected — the Shiki SQL grammar used by Expressive Code only highlights standard SQL keywords and does not recognize engine-specific function names. The functions render as unhighlighted text within otherwise-highlighted SQL blocks.