### PR TITLE
RL rule expression error

### DIFF
--- a/src/content/docs/waf/detections/leaked-credentials/examples.mdx
+++ b/src/content/docs/waf/detections/leaked-credentials/examples.mdx
@@ -24,7 +24,7 @@ The following example rule applies rate limiting to requests with a specific [AT
 <Example>
 
 **When incoming requests match**:<br/>
-`(any(cf.bot_management.detection_ids[*] eq 201326593 and cf.waf.credential_check.username_and_password_leaked))`
+`(any(cf.bot_management.detection_ids[*] eq 201326593) and cf.waf.credential_check.username_and_password_leaked)`
 
 **With the same characteristics**: _IP_
 


### PR DESCRIPTION
There is an error with the parentheses on this example. First parentheses needs to close after the Detection ID part, otherwise it throws the error: 

'(any(cf.bot_management.detection_ids[*] eq 201326593 and cf.waf.credential_check.username_and_password_leaked))' is not a valid value for counting_expression because could not parse filter expression: Filter parsing error (1:54): (any(cf.bot_management.detection_ids[*] eq 201326593 and cf.waf.credential_check.username_and_password_leaked)) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected literal ","

### Summary

This observation came through a ticket from a customer. Ticket ID: 01555428

### Screenshots (optional)

<img width="1647" height="1002" alt="image" src="https://github.com/user-attachments/assets/634bb34b-57ce-4712-a5ba-a9b42c92faa1" />

