### PR TITLE
[Repo] AI tools support via `rulesync`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,11 @@ pnpm-debug.log*
 .idea
 
 tools/relevant_changed_files.txt
+
+# Configuration of AI tools we don't directly support in this repo (generated via rulesync)
+.rulesync/
+.claude/
+CLAUDE.md
+.cursor/
+.github/prompts/
+.github/agents/

--- a/.opencode/agent/docs.md
+++ b/.opencode/agent/docs.md
@@ -91,23 +91,17 @@ Documentation should read as timeless. Do not use:
 
 **You must use the named components below instead of plain code fences whenever they apply.** Do not use a raw ` ```ts ` fence when `TypeScriptExample` is appropriate. Do not use a raw ` ```toml ` or ` ```jsonc ` fence for Wrangler config when `WranglerConfig` is appropriate.
 
-| Scenario                     | Component                                 | Why                                                              |
-| ---------------------------- | ----------------------------------------- | ---------------------------------------------------------------- |
-| TypeScript/JavaScript code   | `TypeScriptExample`                       | Auto-generates a JS tab from TS source; one example to maintain  |
-| Wrangler configuration       | `WranglerConfig`                          | Auto-converts between JSONC and TOML; keeps both formats in sync |
-| Package install/run commands | `PackageManagers`                         | Shows npm/yarn/pnpm tabs automatically                           |
-| Everything else              | Standard code fences with a language hint | Only when no named component fits                                |
+| Scenario | Component | Why |
+|---|---|---|
+| TypeScript/JavaScript code | `TypeScriptExample` | Auto-generates a JS tab from TS source; one example to maintain |
+| Wrangler configuration | `WranglerConfig` | Auto-converts between JSONC and TOML; keeps both formats in sync |
+| Package install/run commands | `PackageManagers` | Shows npm/yarn/pnpm tabs automatically |
+| Everything else | Standard code fences with a language hint | Only when no named component fits |
 
 Import components from `~/components`:
 
 ```mdx
-import {
-	TypeScriptExample,
-	WranglerConfig,
-	PackageManagers,
-} from "~/components";
-
-;
+import { TypeScriptExample, WranglerConfig, PackageManagers } from "~/components";
 ```
 
 Refer to https://developers.cloudflare.com/style-guide/components/ for full component documentation and https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/ for code block formatting.

--- a/.opencode/agent/docs.md
+++ b/.opencode/agent/docs.md
@@ -1,5 +1,6 @@
 ---
 description: ALWAYS use this when writing docs
+mode: subagent
 ---
 
 You are a technical documentation writer for Cloudflare's developer platform. Your job is to write and edit MDX documentation pages that match the existing voice, structure, and component conventions of the Cloudflare Docs site.
@@ -90,17 +91,23 @@ Documentation should read as timeless. Do not use:
 
 **You must use the named components below instead of plain code fences whenever they apply.** Do not use a raw ` ```ts ` fence when `TypeScriptExample` is appropriate. Do not use a raw ` ```toml ` or ` ```jsonc ` fence for Wrangler config when `WranglerConfig` is appropriate.
 
-| Scenario | Component | Why |
-|---|---|---|
-| TypeScript/JavaScript code | `TypeScriptExample` | Auto-generates a JS tab from TS source; one example to maintain |
-| Wrangler configuration | `WranglerConfig` | Auto-converts between JSONC and TOML; keeps both formats in sync |
-| Package install/run commands | `PackageManagers` | Shows npm/yarn/pnpm tabs automatically |
-| Everything else | Standard code fences with a language hint | Only when no named component fits |
+| Scenario                     | Component                                 | Why                                                              |
+| ---------------------------- | ----------------------------------------- | ---------------------------------------------------------------- |
+| TypeScript/JavaScript code   | `TypeScriptExample`                       | Auto-generates a JS tab from TS source; one example to maintain  |
+| Wrangler configuration       | `WranglerConfig`                          | Auto-converts between JSONC and TOML; keeps both formats in sync |
+| Package install/run commands | `PackageManagers`                         | Shows npm/yarn/pnpm tabs automatically                           |
+| Everything else              | Standard code fences with a language hint | Only when no named component fits                                |
 
 Import components from `~/components`:
 
 ```mdx
-import { TypeScriptExample, WranglerConfig, PackageManagers } from "~/components";
+import {
+	TypeScriptExample,
+	WranglerConfig,
+	PackageManagers,
+} from "~/components";
+
+;
 ```
 
 Refer to https://developers.cloudflare.com/style-guide/components/ for full component documentation and https://developers.cloudflare.com/style-guide/formatting/code-block-guidelines/ for code block formatting.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
 		"start": "npx astro dev",
 		"sync": "npx astro sync",
 		"test": "npx vitest",
-		"lint": "npx eslint"
+		"lint": "npx eslint",
+		"ai-setup:import-from-opencode": "npx rulesync import --targets opencode --features rules,commands,subagents",
+		"ai-setup:claudecode": "npm run ai-setup:import-from-opencode && npx rulesync generate --targets claudecode --features rules,commands,subagents",
+		"ai-setup:cursor": "npm run ai-setup:import-from-opencode && npx rulesync generate --targets cursor --features commands,subagents",
+		"ai-setup:copilot": "npm run ai-setup:import-from-opencode && npx rulesync generate --targets copilot --features commands,subagents"
 	},
 	"devDependencies": {
 		"@actions/core": "1.11.1",


### PR DESCRIPTION
### Summary

Adds support for additional AI tools (Claude Code, Cursor, Copilot) via [`rulesync`](https://github.com/dyoshikawa/rulesync). Imports tool components (essentially `commands` and `subagents`) from OpenCode and generates back specific configuration files in the expected locations for other AI tools.

To generate an AI config for other tools, run one of the following commands (or more) based on the tool(s) you want to support:

```bash
# Configure Claude Code
npm run ai-setup:claudecode

# Configure Cursor
npm run ai-setup:cursor

# Configure GitHub Copilot
npm run ai-setup:copilot
```

The `rules` component imported from OpenCode is only generated back for Claude Code because this AI tool doesn't support the `AGENTS.md` file — tracked in https://github.com/anthropics/claude-code/issues/6235. In this case, the `generate` operation with `--features rules` will create an equivalent `CLAUDE.md` file.

Currently running `rulesync` via `npx` instead of adding it as a new dependency because it's not a strict dependency for building the docs.
