### PR TITLE
Use head_ref for concurrency

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -7,7 +7,7 @@ on:
     types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -10,7 +10,7 @@ jobs:
   bonk:
     if: github.event.sender.type != 'Bot'
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -6,12 +6,13 @@ on:
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
+  cancel-in-progress: false
+
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot'
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
ref blocks all invocations that target production vs their own PR branch.

this fixes that by using head_ref