### PR TITLE
[Images] Clarify Image transformation pricing with bindings

### DIFF
--- a/src/content/docs/images/pricing.mdx
+++ b/src/content/docs/images/pricing.mdx
@@ -47,7 +47,7 @@ Alternatively, Images Stored and Images Delivered apply only to images that are 
 
 ### Images Transformed
 
-A unique transformation is a request to transform an original image based on a set of [supported parameters](/images/transform-images/transform-via-url/#options). This metric is used only when optimizing images that are stored outside of Images.
+Every request to transform an original image via URL with a unique set of [supported parameters](/images/transform-images/transform-via-url/#options) counts as one unique transformation. Similarly, every call to an [Images binding](/images/transform-images/bindings/) with unique parameters counts as one unique transformation. This metric is used only when optimizing images that are stored outside of Images.
 
 For example, if you transform `thumbnail.jpg` as 100x100, then this counts as one unique transformation. If you transform the same `thumbnail.jpg` as 200x200, then this counts as a separate unique transformation.
 

--- a/src/content/docs/images/pricing.mdx
+++ b/src/content/docs/images/pricing.mdx
@@ -47,7 +47,8 @@ Alternatively, Images Stored and Images Delivered apply only to images that are 
 
 ### Images Transformed
 
-Every request to transform an original image via URL with a unique set of [supported parameters](/images/transform-images/transform-via-url/#options) counts as one unique transformation. Similarly, every call to an [Images binding](/images/transform-images/bindings/) with unique parameters counts as one unique transformation. This metric is used only when optimizing images that are stored outside of Images.
+A unique transformation is a request to transform an original image based on a set of [supported parameters](/images/transform-images/transform-via-url/#options). This metric is used only when optimizing images that are stored outside of Images.
+When using the [Images binding](/images/transform-images/bindings/) in Workers, every call to the binding counts as a transformation, regardless of whether the image or parameters are unique.
 
 For example, if you transform `thumbnail.jpg` as 100x100, then this counts as one unique transformation. If you transform the same `thumbnail.jpg` as 200x200, then this counts as a separate unique transformation.
 

--- a/src/content/docs/images/transform-images/bindings.mdx
+++ b/src/content/docs/images/transform-images/bindings.mdx
@@ -19,6 +19,12 @@ For example, when you allow Workers to interact with Images, you can:
 
 Bindings can be configured in the Cloudflare dashboard for your Worker or in the Wrangler configuration file in your project's directory.
 
+:::note[Billing]
+
+Every call to an Images binding counts as one unique transformation. Refer to [Images pricing](/images/pricing/) for more information about transformation billing.
+
+:::
+
 ## Setup
 
 The Images binding is enabled on a per-Worker basis.

--- a/src/content/docs/images/transform-images/bindings.mdx
+++ b/src/content/docs/images/transform-images/bindings.mdx
@@ -21,7 +21,7 @@ Bindings can be configured in the Cloudflare dashboard for your Worker or in the
 
 :::note[Billing]
 
-Every call to an Images binding counts as one unique transformation. Refer to [Images pricing](/images/pricing/) for more information about transformation billing.
+Every call to the Images binding counts as one unique transformation. Refer to [Images pricing](/images/pricing/) for more information about transformation billing.
 
 :::
 


### PR DESCRIPTION
Clarify that every call to an Images Binding counts as a new unique transformation.