### PR TITLE
[Workers] Add wrangler whoami --json documentation

### DIFF
--- a/src/content/changelog/workers/2026-02-10-wrangler-whoami-json.mdx
+++ b/src/content/changelog/workers/2026-02-10-wrangler-whoami-json.mdx
@@ -1,0 +1,25 @@
+---
+title: JSON output for `wrangler whoami`
+description: The `wrangler whoami` command now supports a `--json` flag that outputs structured JSON and exits with a non-zero status code when not authenticated.
+products:
+  - workers
+date: 2026-02-10
+---
+
+The `wrangler whoami` command now supports a `--json` flag for machine-readable output. This makes it easy to check authentication status in shell scripts without parsing text output.
+
+When authenticated, the command outputs a JSON object containing your auth type, email, accounts, and token permissions. When not authenticated, it outputs `{"loggedIn": false}` and exits with a non-zero status code.
+
+```sh
+# Check if authenticated
+if wrangler whoami --json > /dev/null 2>&1; then
+  echo "Authenticated"
+else
+  echo "Not authenticated"
+fi
+
+# Get account info
+wrangler whoami --json | jq '.accounts'
+```
+
+For more information, refer to the [`wrangler whoami` documentation](/workers/wrangler/commands/#whoami).

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -763,6 +763,37 @@ An error is returned if no authentication method is available, or if API key/ema
 
 <WranglerCommand command="whoami" />
 
+When `--json` is passed, the command outputs structured JSON and exits with a non-zero status code if you are not authenticated. This is useful for scripting:
+
+```sh
+# Check auth status in a shell script
+if wrangler whoami --json > /dev/null 2>&1; then
+  echo "Authenticated"
+else
+  echo "Not authenticated — please run: wrangler login"
+  exit 1
+fi
+
+# Parse account info with jq
+wrangler whoami --json | jq '.accounts'
+```
+
+When authenticated, the JSON output has the following shape:
+
+```json
+{
+  "loggedIn": true,
+  "authType": "OAuth Token",
+  "email": "user@example.com",
+  "accounts": [
+    { "name": "My Account", "id": "account-id" }
+  ],
+  "tokenPermissions": ["account:read", "workers:write"]
+}
+```
+
+When not authenticated, the output is `{"loggedIn":false}` and the exit code is non-zero.
+
 ---
 
 ## `versions`


### PR DESCRIPTION
### Summary

Adds documentation for the new `--json` flag on `wrangler whoami`, which outputs structured JSON and exits with a non-zero status code when not authenticated. This accompanies the feature PR in workers-sdk.

- Added usage examples and JSON output shape to the `whoami` section in `commands.mdx`
- Added changelog entry for the feature

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).