### PR TITLE
granular controls available in content collection "granular-control-applications"

### DIFF
--- a/src/content/collections/granular-control-applications.ts
+++ b/src/content/collections/granular-control-applications.ts
@@ -3,9 +3,25 @@ import type { CollectionConfig } from "astro/content/config";
 
 import { middlecacheLoader } from "../../util/custom-loaders";
 
+const itemSchema = z.object({
+	operation_name: z.string(),
+	operation_id: z.number(),
+	application_control: z.string().nullable(),
+	application_control_id: z.number().nullable(),
+	contains_payload: z.boolean(),
+	operation_group: z.string(),
+	operation_group_id: z.number(),
+});
+
+const controlsSchema = z.object({
+	label: z.string(),
+	items: z.array(itemSchema),
+});
+
 const applicationSchema = z.object({
 	name: z.string(),
 	display_name: z.string(),
+	controls: z.array(controlsSchema),
 });
 
 const granularControlApplicationsSchema = z.object({
@@ -20,31 +36,34 @@ type GranularControlApplications = z.infer<
 const granularControlApplicationsCollectionConfig: CollectionConfig<
 	typeof granularControlApplicationsSchema
 > = {
-	loader: middlecacheLoader("v1/application-controls/applications.json", {
-		parser: (fileContent: string) => {
-			const data = JSON.parse(fileContent);
+	loader: middlecacheLoader(
+		"v1/application-controls/applications-with-controls.json",
+		{
+			parser: (fileContent: string) => {
+				const data = JSON.parse(fileContent);
 
-			const lookup: Record<string, GranularControlApplications> = {};
+				const lookup: Record<string, GranularControlApplications> = {};
 
-			for (const item of data) {
-				let display_id = "Uncategorized";
-				if (item.category && typeof item.category === "string")
-					display_id = item.category
-						.replace(/-/g, " ")
-						.replace(
-							/\w\S*/g,
-							(txt: string) =>
-								txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase(),
-						);
+				for (const item of data) {
+					let display_id = "Uncategorized";
+					if (item.category && typeof item.category === "string")
+						display_id = item.category
+							.replace(/-/g, " ")
+							.replace(
+								/\w\S*/g,
+								(txt: string) =>
+									txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase(),
+							);
 
-				lookup[item.category] = {
-					display_id: display_id,
-					applications: item.applications,
-				};
-			}
-			return lookup;
+					lookup[item.category] = {
+						display_id: display_id,
+						applications: item.applications,
+					};
+				}
+				return lookup;
+			},
 		},
-	}),
+	),
 	schema: granularControlApplicationsSchema,
 };
 


### PR DESCRIPTION
- refactor "downloadToDotTempIfNotPresent" logic into its own function and out of the middlecache loader
- consume applications-with-controls.json from middlecache and add the corresponding schema for content collection