### PR TITLE
Update Incorrect API links for Create Participant API

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/index.mdx
+++ b/src/content/docs/realtime/realtimekit/core/index.mdx
@@ -12,7 +12,7 @@ import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnipp
 
 ### Initialize Core SDK
 
-To integrate the Core SDK, you will need to initialize it with a [participant's auth token](/api/resources/realtime_kit/#create-a-participant), and then use the provided SDK APIs to control the peer in the session.
+To integrate the Core SDK, you will need to initialize it with a [participant's auth token](/api/node/resources/realtime_kit/subresources/meetings/methods/add_participant/), and then use the provided SDK APIs to control the peer in the session.
 
 Initialization might differ slightly based on your tech stack. Please choose your preferred tech stack below.
 
@@ -54,7 +54,7 @@ export default function App() {
 
 ```
 
-Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+Use the [Create Participant API](/api/node/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 
@@ -89,7 +89,7 @@ You can initialise the SDK using `RealtimeKitClient.init`.
 	});
 ```
 
-Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+Use the [Create Participant API](/api/node/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 
@@ -120,7 +120,7 @@ class AppComponent {
 }
 ```
 
-Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+Use the [Create Participant API](/api/node/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 
@@ -131,7 +131,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
     val meeting = RealtimeKitMeetingBuilder.build(activity)
     ```
 
-    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/resources/realtime_kit/#create-a-participant).
+    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/node/resources/realtime_kit/subresources/meetings/methods/add_participant/).
 
     ```kotlin
     val meetingInfo =
@@ -169,7 +169,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
     meeting.addSelfEventListener(selfEventListener: self)
     ```
 
-    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/resources/realtime_kit/#create-a-participant).
+    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/node/resources/realtime_kit/subresources/meetings/methods/add_participant/).
 
     ```swift
     let meetingInfo = RtkMeetingInfo(authToken: authToken,
@@ -192,7 +192,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
     final meeting = RealtimeKitClient();
     ```
 
-    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/resources/realtime_kit/#create-a-participant).
+    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/node/resources/realtime_kit/subresources/meetings/methods/add_participant/).
 
     ```dart
     final meetingInfo = RtkMeetingInfo(
@@ -257,7 +257,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
     }
     ```
 
-    Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+    Use the [Create Participant API](/api/node/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 


### PR DESCRIPTION
### Summary

Updating incorrect documentation links that don't go anywhere to the correct links.

### Screenshots (optional)

n/a

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
