### PR TITLE
docs: typo fix for date-time `today` function example

### DIFF
--- a/src/content/docs/analytics/analytics-engine/sql-reference/date-time-functions.mdx
+++ b/src/content/docs/analytics/analytics-engine/sql-reference/date-time-functions.mdx
@@ -53,7 +53,7 @@ Returns the current time as a DateTime.
 Usage:
 
 ```sql
-now()
+today()
 ```
 
 Returns the current date as a `Date`.


### PR DESCRIPTION
### Summary

Fixed a typo in the usage example for the `today()` function. The code block incorrectly showed `now()` instead of `today()`.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).