### PR TITLE
Add note on WAF rules possibly blocking Hyperdrive

### DIFF
--- a/src/content/docs/hyperdrive/configuration/connect-to-private-database.mdx
+++ b/src/content/docs/hyperdrive/configuration/connect-to-private-database.mdx
@@ -241,3 +241,4 @@ If you successfully receive the list of tables from your database when you acces
 If you encounter issues when setting up your Hyperdrive configuration with tunnels to a private database, consider these common solutions, in addition to [general troubleshooting steps](/hyperdrive/observability/troubleshooting/) for Hyperdrive:
 
 - Ensure your database is configured to use TLS (SSL). Hyperdrive requires TLS (SSL) to connect.
+- If you receive a HTTP 403 error when connecting Hyperdrive to your Tunnel public hostname, ensure no WAF rules are blocking traffic to the hostname. WAF rules still apply to tunnel backed public hostnames, and can block traffic coming from Hyperdrive resulting in a 403 during the Hyperdrive wizard.


### PR DESCRIPTION
We found that if a WAF rule blocks traffic to the same public hostname used to attach Hyperdrive to a tunnel backed hostname, the Hyperdrive wizard can fail with a HTTP 403, but there's no obvious note that the error is due to the WAF.

Added a note to check WAF rules if the Hyperdrive wizard fails with a  403.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
