### PR TITLE
Update error-521.mdx - add explicit port check for Error 521

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-521.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-521.mdx
@@ -24,4 +24,5 @@ Contact your hosting provider or site administrator and share the necessary [err
 - Confirm [Cloudflare IP addresses](https://www.cloudflare.com/ips) are not blocked or rate limited.
 - Allow all [Cloudflare IP ranges](https://www.cloudflare.com/ips) in your origin web server's firewall or other security software.
 - Confirm that — if you have your **SSL/TLS mode** set to **Full** or **Full (Strict**) — your origin supports HTTPS and/or you have installed a [Cloudflare Origin Certificate](/ssl/origin-configuration/origin-ca) or a certificate matching the [requirements for these modes](/ssl/origin-configuration/ssl-modes/#custom-ssltls).
+- Ensure that your origin web server application is actively bound and listening on the port required by your SSL/TLS mode - Port 80 for **Flexible**, or Port 443 for **Full** and **Full (Strict)**.
 - Find additional troubleshooting information on the [Cloudflare Community](https://community.cloudflare.com/t/community-tip-fixing-error-521-web-server-is-down/42461).

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-521.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-521.mdx
@@ -24,5 +24,5 @@ Contact your hosting provider or site administrator and share the necessary [err
 - Confirm [Cloudflare IP addresses](https://www.cloudflare.com/ips) are not blocked or rate limited.
 - Allow all [Cloudflare IP ranges](https://www.cloudflare.com/ips) in your origin web server's firewall or other security software.
 - Confirm that — if you have your **SSL/TLS mode** set to **Full** or **Full (Strict**) — your origin supports HTTPS and/or you have installed a [Cloudflare Origin Certificate](/ssl/origin-configuration/origin-ca) or a certificate matching the [requirements for these modes](/ssl/origin-configuration/ssl-modes/#custom-ssltls).
-- Ensure that your origin web server application is actively bound and listening on the port required by your SSL/TLS mode - Port 80 for **Flexible**, or Port 443 for **Full** and **Full (Strict)**.
+- Ensure that your origin web server application is actively bound and listening on the port required by your SSL/TLS mode: Port 80 for **Flexible**, or Port 443 for **Full** and **Full (Strict)**.
 - Find additional troubleshooting information on the [Cloudflare Community](https://community.cloudflare.com/t/community-tip-fixing-error-521-web-server-is-down/42461).


### PR DESCRIPTION
The current documentation for Error 521 attributes the issue to an "Offlined application" or "Blocked requests," and vaguely suggests checking if the origin "supports HTTPS."

From a troubleshooting perspective, this is a bit of a blind spot. A very common middle-ground scenario can occur when the firewall is open and certificates are installed, but the web server (Nginx/Apache) isn't actually listening on the port. For example, a syntax error in a site config can prevent Nginx from binding to Port 443, even if the service is active.

Cloudflare interprets this scenario as a 521 error. Without a direct mention of port status, users can get stuck in a loop checking their certificates, SSL/TLS modes and firewall.

Adding a clear, port-specific verification step would save a lot of time for users who may not have deep technical or networking expertise.

Proposed Change
Add a direct instruction to the Resolution section that directs users to the closed port possibility.

Proposed Line:
Ensure that your origin web server application is actively bound and listening on the port required by your SSL/TLS mode - Port 80 for **Flexible**, or Port 443 for **Full** and **Full (Strict)**.

