### PR TITLE
changelog: quick editor inspector deprecation

### DIFF
--- a/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
+++ b/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
@@ -3,15 +3,14 @@ title: Quick Editor devtools replaced with log viewer
 description: The Workers Quick Editor devtools inspector has been deprecated and replaced with a lightweight log viewer.
 products:
   - workers
-date: 2026-02-13
+date: 2026-02-16
 ---
 
 Cloudflare has deprecated the Workers Quick Editor dev tools inspector and replaced it with a lightweight log viewer.
 
-This gives us the opportunity to better focus our efforts on new products which would not be possible to deliver otherwise.
+This aligns our logging with `wrangler tail` and gives us the opportunity to focus our efforts on bringing benefits from the work we have invested in observability, which would not be possible otherwise.
 
-We understand that those who are heavy users of the Quick Editor may be disappointed by this change. We do have intention to bring more developer tooling to this experience again, but have no firm commitments to share at the moment.
 
 We have made improvements to this logging viewer based on your feedback such that you can log object and array types, and easily clear the list of logs. This does not include class instances. Limitations are documented in the [Workers Playground docs](/workers/playground/).
 
-If you do need to develop your Worker with a more complete devtools experience, you can still do this using Wrangler locally. Cloning a project from your quick editor to your computer for local development can be done with the `wrangler init --from-dash` command. For more information, refer to [Wrangler commands](/workers/wrangler/commands/#init).
+If you do need to develop your Worker with a remote inspector, you can still do this using Wrangler locally. Cloning a project from your quick editor to your computer for local development can be done with the `wrangler init --from-dash` command. For more information, refer to [Wrangler commands](/workers/wrangler/commands/#init).

--- a/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
+++ b/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
@@ -10,7 +10,6 @@ Cloudflare has deprecated the Workers Quick Editor dev tools inspector and repla
 
 This aligns our logging with `wrangler tail` and gives us the opportunity to focus our efforts on bringing benefits from the work we have invested in observability, which would not be possible otherwise.
 
-
 We have made improvements to this logging viewer based on your feedback such that you can log object and array types, and easily clear the list of logs. This does not include class instances. Limitations are documented in the [Workers Playground docs](/workers/playground/).
 
 If you do need to develop your Worker with a remote inspector, you can still do this using Wrangler locally. Cloning a project from your quick editor to your computer for local development can be done with the `wrangler init --from-dash` command. For more information, refer to [Wrangler commands](/workers/wrangler/commands/#init).

--- a/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
+++ b/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
@@ -14,4 +14,4 @@ We understand that those who are heavy users of the Quick Editor may be disappoi
 
 We have made improvements to this logging viewer based on your feedback such that you can log object and array types, and easily clear the list of logs. This does not include class instances. Limitations are documented in the [Workers Playground docs](/workers/playground/).
 
-If you do need to develop your Worker with a more complete experience, you can still do this using Wrangler locally. Cloning a project from your quick editor to your computer for local development can be done with the `wrangler init --from-dash` command. For more information, refer to [Wrangler commands](/workers/wrangler/commands/#init).
+If you do need to develop your Worker with a more complete devtools experience, you can still do this using Wrangler locally. Cloning a project from your quick editor to your computer for local development can be done with the `wrangler init --from-dash` command. For more information, refer to [Wrangler commands](/workers/wrangler/commands/#init).

--- a/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
+++ b/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
@@ -8,7 +8,7 @@ date: 2026-02-12
 
 Cloudflare has deprecated the Workers Quick Editor dev tools inspector and replaced it with a lightweight log viewer.
 
-This gives us the opportunity to better focus our efforts on new products which would not be possible to deliver without this change.
+This gives us the opportunity to better focus our efforts on new products which would not be possible to deliver otherwise.
 
 We understand that those who are heavy users of the Quick Editor may be disappointed by this change. We do have intention to bring more developer tooling to this experience again, but have no firm commitments to share at the moment.
 

--- a/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
+++ b/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
@@ -3,7 +3,7 @@ title: Quick Editor devtools replaced with log viewer
 description: The Workers Quick Editor devtools inspector has been deprecated and replaced with a lightweight log viewer.
 products:
   - workers
-date: 2026-02-12
+date: 2026-02-13
 ---
 
 Cloudflare has deprecated the Workers Quick Editor dev tools inspector and replaced it with a lightweight log viewer.

--- a/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
+++ b/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
@@ -1,0 +1,17 @@
+---
+title: Quick Editor devtools replaced with log viewer
+description: The Workers Quick Editor devtools inspector has been deprecated and replaced with a lightweight log viewer.
+products:
+  - workers
+date: 2026-02-12
+---
+
+Cloudflare has deprecated the Workers Quick Editor dev tools inspector and replaced it with a lightweight log viewer.
+
+This gives us the opportunity to better focus our efforts on new products which would not be possible to deliver without this change.
+
+We understand that those who are heavy users of the Quick Editor may be disappointed by this change. We do have intention to bring more developer tooling to this experience again, but have no firm commitments to share at the moment.
+
+We have made improvements to this logging viewer based on your feedback such that you can log object and array types, and easily clear the list of logs. This does not include class instances. We will be documenting the limitations in the [Workers Playground docs](/workers/playground/).
+
+If you do need to develop your Worker with a more complete experience, you can still do this using Wrangler locally. Cloning a project from your quick editor to your computer for local development can be done with the `wrangler init --from-dash` command. For more information, refer to [Wrangler commands](/workers/wrangler/commands/#init).

--- a/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
+++ b/src/content/changelog/workers/2026-02-12-quick-editor-dev-tools-deprecation.mdx
@@ -12,6 +12,6 @@ This gives us the opportunity to better focus our efforts on new products which 
 
 We understand that those who are heavy users of the Quick Editor may be disappointed by this change. We do have intention to bring more developer tooling to this experience again, but have no firm commitments to share at the moment.
 
-We have made improvements to this logging viewer based on your feedback such that you can log object and array types, and easily clear the list of logs. This does not include class instances. We will be documenting the limitations in the [Workers Playground docs](/workers/playground/).
+We have made improvements to this logging viewer based on your feedback such that you can log object and array types, and easily clear the list of logs. This does not include class instances. Limitations are documented in the [Workers Playground docs](/workers/playground/).
 
 If you do need to develop your Worker with a more complete experience, you can still do this using Wrangler locally. Cloning a project from your quick editor to your computer for local development can be done with the `wrangler init --from-dash` command. For more information, refer to [Wrangler commands](/workers/wrangler/commands/#init).

--- a/src/content/docs/workers/playground.mdx
+++ b/src/content/docs/workers/playground.mdx
@@ -70,7 +70,7 @@ The log viewer supports the following:
 - Logging primitive values, objects, and arrays.
 - Clearing the log output between runs.
 
-At this time, the log viewer does not support logging class instances or their properties (eg. `request.url`).
+At this time, the log viewer does not support logging class instances or their properties (for example, `request.url`).
 
 If you need a more complete development experience with full debugging capabilities, you can use [Wrangler](/workers/wrangler/install-and-update/) locally. To clone an existing Worker from your dashboard for local development, sign up and use the [`wrangler init --from-dash`](/workers/wrangler/commands/#init) command once your worker is deployed.
 

--- a/src/content/docs/workers/playground.mdx
+++ b/src/content/docs/workers/playground.mdx
@@ -61,21 +61,18 @@ As you edit the default code, the Worker will auto-update such that the preview 
 
 To test a raw HTTP request (for example, to test a `POST` request), go to the **HTTP** tab and select **Send**. You can add and edit headers via this panel, as well as edit the body of a request.
 
-## DevTools
+## Log viewer
 
-For debugging Workers inside the Playground, use the developer tools at the bottom of the Playground's preview panel to view `console.logs`, network requests, memory and CPU usage. The developer tools for the Workers Playground work similarly to the developer tools in Chrome or Firefox, and are the same developer tools users have access to in the [Wrangler CLI](/workers/wrangler/install-and-update/) and the authenticated dashboard.
+The Playground and the quick editor in the Workers dashboard include a lightweight log viewer at the bottom of the preview panel. The log viewer displays the output of any calls to `console.log` made during preview runs.
 
-### Network tab
+The log viewer supports the following:
 
-**Network** shows the outgoing requests from your Worker — that is, any calls to `fetch` inside your Worker code.
+- Logging primitive values, objects, and arrays.
+- Clearing the log output between runs.
 
-### Console Logs
+At this time, the log viewer does not support logging class instances or their properties (eg. `request.url`).
 
-The console displays the output of any calls to `console.log` that were called for the current preview run as well as any other preview runs in that session.
-
-### Sources
-
-**Sources** displays the sources that make up your Worker. Note that KV, text, and secret bindings are only accessible when authenticated with an account. This means you must be logged in to the dashboard, or use [`wrangler dev`](/workers/wrangler/commands/#dev) with your account credentials.
+If you need a more complete development experience with full debugging capabilities, you can use [Wrangler](/workers/wrangler/install-and-update/) locally. To clone an existing Worker from your dashboard for local development, sign up and use the [`wrangler init --from-dash`](/workers/wrangler/commands/#init) command once your worker is deployed.
 
 ## Share
 


### PR DESCRIPTION
### Summary

This changelog both updates users in the community on changes we have made to the quick editor inspector, provides workaround instructions, and updates our docs on the playground similarly.


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
