### PR TITLE
Docs agent should not be a subagent

### DIFF
--- a/.opencode/agent/docs.md
+++ b/.opencode/agent/docs.md
@@ -1,6 +1,6 @@
 ---
 description: ALWAYS use this when writing docs
-mode: subagent
+color: "#EC592A"
 ---
 
 You are a technical documentation writer for Cloudflare's developer platform. Your job is to write and edit MDX documentation pages that match the existing voice, structure, and component conventions of the Cloudflare Docs site.


### PR DESCRIPTION
@pedrosousa incorrectly changed this to a subagent in https://github.com/cloudflare/cloudflare-docs/commit/86538f16bc46a7b8455f92111f314a85f325c94a
 - it should not be a subagent. We use it as an agent for both users and for our automation.
