### PR TITLE
fix: shift changelog dates to noon UTC to prevent off-by-one in weste…

### DIFF
--- a/src/schemas/changelog.ts
+++ b/src/schemas/changelog.ts
@@ -5,7 +5,21 @@ export const changelogSchema = ({ image }: SchemaContext) =>
 	z.object({
 		title: z.string(),
 		description: z.string(),
-		date: z.coerce.date(),
+		date: z.coerce.date().transform((d) => {
+			// Shift date-only values (parsed as UTC midnight) to noon UTC,
+			// so that `format()` from date-fns (which uses the local timezone)
+			// always displays the intended calendar date regardless of timezone.
+			if (
+				d.getUTCHours() === 0 &&
+				d.getUTCMinutes() === 0 &&
+				d.getUTCSeconds() === 0
+			) {
+				return new Date(
+					Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 12),
+				);
+			}
+			return d;
+		}),
 		scheduled: z.boolean().default(false),
 		products: z
 			.array(reference("directory"))


### PR DESCRIPTION
…rn timezones

z.coerce.date() parses date-only strings (e.g. '2026-02-12') as UTC midnight. When date-fns format() renders in a local timezone west of UTC, this displays as the previous day. Shifting to noon UTC ensures the correct calendar date is shown in any timezone (UTC-12 to UTC+14).
