### PR TITLE
Fix leading double quotes in FAQ subtitle

### DIFF
--- a/src/content/docs/warp-client/known-issues-and-faq.mdx
+++ b/src/content/docs/warp-client/known-issues-and-faq.mdx
@@ -29,7 +29,7 @@ If you grant a website access to your microphone or camera, traffic will [bypass
 
 Cloudflare WARP is in part powered by [1.1.1.1](/1.1.1.1/), the world's fastest DNS resolver. When visiting sites or going to a new location on the Internet, you should see fast DNS lookups. WARP, however, is built to trade some throughput for enhanced privacy, by encrypting all traffic both to and from your device. While this is not noticeable at most mobile speeds, on desktop systems in countries where high-speed broadband is available, you may notice a drop. We think the tradeoff is worth it and continue to work on improving performance all over the system.
 
-## "What about the performance of the WARP app?
+## What about the performance of the WARP app?
 
 Cloudflare WARP and the 1.1.1.1 with WARP applications go through performance testing that includes battery, network and CPU on a regular basis. In addition, both applications are used by millions of users worldwide that help us stay on top of issues across a wide variety of devices, networks, sites and applications.
 


### PR DESCRIPTION
### Summary

There was a leading double quotes in the title of one of the FAQ questions, just removed it :)

### Screenshots (optional)

<img width="794" height="261" alt="image" src="https://github.com/user-attachments/assets/8c8c3079-380d-4c68-a791-2b6b8b3cec31" />

[From here](https://developers.cloudflare.com/warp-client/known-issues-and-faq/)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
