### PR TITLE
Fix Bonk getting stuck on tool approval in CI

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -5,19 +5,17 @@ description: Reviews Workers and Cloudflare Developer Platform code for type cor
 
 Your knowledge of Cloudflare Workers APIs, types, and wrangler configuration may be outdated. **Prefer retrieval over pre-training** for any Workers code review task.
 
-## Retrieval Sources
+## Reference Sources
 
-Fetch the **latest** versions before reviewing. The current repo may have outdated dependencies — always validate against what is currently published, not what is locally installed.
+Use the repo's local copies — do **not** run `npm pack` or install packages to fetch types.
 
-| Source                 | How to retrieve                                         | Use for                                                |
-| ---------------------- | ------------------------------------------------------- | ------------------------------------------------------ |
-| Wrangler config schema | See `references/wrangler-config.md` for retrieval steps | Config fields, binding shapes, allowed values          |
-| Workers types          | See `references/workers-types.md` for retrieval steps   | API usage, handler signatures, binding types           |
-| Cloudflare docs        | `https://developers.cloudflare.com/workers/`            | API reference, compatibility dates/flags, binding docs |
+| Source                 | Where to find it                                                 | Use for                                                |
+| ---------------------- | ---------------------------------------------------------------- | ------------------------------------------------------ |
+| Wrangler config schema | `node_modules/wrangler/config-schema.json`                       | Config fields, binding shapes, allowed values          |
+| Workers types          | `node_modules/@cloudflare/workers-types/index.d.ts`              | API usage, handler signatures, binding types           |
+| Cloudflare docs search | Use the `cloudflare-docs` search tool or read files in this repo | API reference, compatibility dates/flags, binding docs |
 
-## FIRST: Fetch Latest References
-
-Retrieve the latest wrangler schema and workers types before reviewing. See the reference files for specific retrieval commands. If the current repo's `node_modules` has an older version, **prefer the latest published version** — documentation should reflect the current state of the platform, not a pinned dependency.
+Read these files directly when you need to verify a type, config field, or API signature. The reference guides in `references/` describe what to validate — not how to fetch packages.
 
 ## Review Process
 

--- a/.agents/skills/code-review/references/common-patterns.md
+++ b/.agents/skills/code-review/references/common-patterns.md
@@ -6,13 +6,13 @@ Do not memorize patterns. Retrieve current examples from Cloudflare docs and ver
 
 When reviewing a pattern you are unsure about, fetch the current reference:
 
-| Topic                 | Where to look                                                                                                                   |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Handler signatures    | Latest `@cloudflare/workers-types` (see `references/workers-types.md`) — search for `ExportedHandler`, `WorkerEntrypoint`, etc. |
-| Binding APIs          | Same types file — search for the binding type name (e.g., `KVNamespace`, `R2Bucket`)                                            |
-| Wrangler config shape | Latest wrangler config schema (see `references/wrangler-config.md`)                                                             |
-| Platform base classes | Search for imports from `"cloudflare:workers"` in the type definitions                                                          |
-| Cloudflare docs       | `https://developers.cloudflare.com/workers/` for guides, examples, and API reference                                            |
+| Topic                 | Where to look                                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Handler signatures    | `node_modules/@cloudflare/workers-types/index.d.ts` — search for `ExportedHandler`, `WorkerEntrypoint`, etc. |
+| Binding APIs          | Same types file — search for the binding type name (e.g., `KVNamespace`, `R2Bucket`)                         |
+| Wrangler config shape | `node_modules/wrangler/config-schema.json`                                                                   |
+| Platform base classes | Search for imports from `"cloudflare:workers"` in the type definitions                                       |
+| Cloudflare docs       | Use the `cloudflare-docs` search tool, or read files directly in `src/content/docs/`                         |
 
 ## Binding Access
 

--- a/.agents/skills/code-review/references/workers-types.md
+++ b/.agents/skills/code-review/references/workers-types.md
@@ -2,29 +2,13 @@
 
 ## How to Retrieve Current Types
 
-Prefer generated types over baked-in knowledge. Types change with compatibility dates and new bindings. The repo you are working in may have an older `@cloudflare/workers-types` version — **always validate against the latest published types**.
+Prefer generated types over baked-in knowledge. Types change with compatibility dates and new bindings.
 
-### Primary: fetch latest `@cloudflare/workers-types`
-
-```bash
-# Fetch the latest type definitions to a temp directory
-mkdir -p /tmp/workers-types-latest && \
-  npm pack @cloudflare/workers-types --pack-destination /tmp/workers-types-latest && \
-  tar -xzf /tmp/workers-types-latest/cloudflare-workers-types-*.tgz -C /tmp/workers-types-latest
-# Types are now at /tmp/workers-types-latest/package/index.d.ts
-```
-
-Search this file for the specific type, class, or interface under review. Do not guess type names — look them up.
-
-### Alternative: `wrangler types`
-
-If working in a project with a wrangler config, `npx wrangler types` generates a `.d.ts` file with a typed `Env` interface derived from the config. This is useful for binding types but reflects the locally installed wrangler version.
-
-### Fallback: local `node_modules`
-
-Read `node_modules/@cloudflare/workers-types/index.d.ts` if the above approaches are unavailable. Note the installed version and flag if it appears significantly outdated.
+Read `node_modules/@cloudflare/workers-types/index.d.ts` directly. Do **not** run `npm pack` or install packages — use whatever version is in the repo's `node_modules`.
 
 The package provides date-versioned entrypoints (e.g., `2023-07-01/`) and `latest/`. Check the project's `tsconfig.json` to determine which entrypoint is in use.
+
+Search this file for the specific type, class, or interface under review. Do not guess type names — look them up.
 
 ## What to Validate
 

--- a/.agents/skills/code-review/references/wrangler-config.md
+++ b/.agents/skills/code-review/references/wrangler-config.md
@@ -4,17 +4,7 @@
 
 The authoritative schema is bundled with the `wrangler` npm package as `config-schema.json`. It is a JSON Schema (draft-07) document defining the full `RawConfig` type.
 
-**Always fetch the latest published schema** — the repo you are working in may have an older wrangler version pinned. To retrieve the latest:
-
-```bash
-# Fetch the latest schema to a temp directory
-mkdir -p /tmp/wrangler-latest && \
-  npm pack wrangler --pack-destination /tmp/wrangler-latest && \
-  tar -xzf /tmp/wrangler-latest/wrangler-*.tgz -C /tmp/wrangler-latest
-# Schema is now at /tmp/wrangler-latest/package/config-schema.json
-```
-
-If that fails, fall back to reading `./node_modules/wrangler/config-schema.json` from the current project — but note the version may be outdated.
+Read `node_modules/wrangler/config-schema.json` directly. Do **not** run `npm pack` or install packages — use whatever version is in the repo's `node_modules`.
 
 Do not guess field names or structures — look them up in the schema.
 

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -14,6 +14,7 @@ jobs:
   bonk:
     if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: write

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://opencode.ai/config.json",
+	"permission": "allow",
+	"experimental": {
+		"continue_loop_on_deny": true,
+	},
+}


### PR DESCRIPTION
Bonk keeps getting stuck in CI waiting for tool approval when the code-review skill tells it to `npm pack` packages. Example: https://github.com/cloudflare/cloudflare-docs/actions/runs/21962906948/job/63444925338

- Add `opencode.jsonc` with `permission: "allow"` and `continue_loop_on_deny: true` so the agent does not block on approval prompts in GitHub Actions
- Remove `npm pack` retrieval steps from the code-review skill — point it at `node_modules/` instead, which avoids the bash commands that trigger the stuck loop
- Add `timeout-minutes: 30` to the Bonk workflow so stuck runs get killed instead of burning 6 hours