### PR TITLE
Add Node.js setup to bonk workflow

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main
         env:


### PR DESCRIPTION
The bonk workflow was failing to run `npm run check` because it used whatever Node version comes pre-installed on `ubuntu-latest` instead of Node 22 required by this repo.

- Add `setup-node` step with `node-version-file: "package.json"` (reads Volta config)
- Add `npm ci` to install dependencies before bonk runs

Fixes validation failures like https://github.com/cloudflare/cloudflare-docs/actions/runs/21967964265