### PR TITLE
[Stream] Clarify Direct Creator Uploads and tus protocol are separate features

### DIFF
--- a/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
+++ b/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
@@ -26,7 +26,7 @@ click D "#basic-post-request" "See basic POST instructions"
 click E "#direct-creator-uploads-with-tus-protocol" "Learn about tus protocol"
 ```
 
-Whether you use basic POST or tus protocol, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage. This duration will be deducted from your account's available storage until the user's upload is received. Once the upload is processed, its actual duration will be counted and the remaining reservation will be relased. If the video errors or does is not received before the link expires, the entire reservation will be released.
+Whether you use basic POST or tus protocol, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage. This duration will be deducted from your account's available storage until the user's upload is received. Once the upload is processed, its actual duration will be counted and the remaining reservation will be relased. If the video errors or is not received before the link expires, the entire reservation will be released.
 
 ## Basic POST request
 

--- a/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
+++ b/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
@@ -6,7 +6,7 @@ sidebar:
 reviewed: 2020-09-03
 ---
 
-Direct creator uploads let your end users upload videos directly to Cloudflare Stream without exposing your API token to clients. You can implement direct creator uploads using either a basic POST request or the tus protocol, depending on the file size and the user's connection:
+Direct creator uploads let your end users upload videos directly to Cloudflare Stream without exposing your API token to clients. You can implement direct creator uploads using either a [basic POST request](#basic-post-request) or the [tus protocol](#direct-creator-uploads-with-tus-protocol). Use this chart to decide which method to use:
 
 ```mermaid
 flowchart LR
@@ -14,21 +14,23 @@ accTitle: Direct creator uploads decision flow
 accDescr: Decision flow for choosing between basic POST uploads and tus protocol based on file size and connection reliability
 
 A{Is the video over 200 MB?}
-A -->|Yes| B[You must use the tus protocol]
-A -->|No| C{Does the user have a reliable connection?}
-C -->|Yes| D[Basic POST is recommended]
-C -->|No| E[The tus protocol is optional, but recommended]
+A -->|Yes| B[You must use the tus protocol]:::link
+A -->|No| C{Does the end user have a reliable connection?}
+C -->|Yes| D[Basic POST is recommended]:::link
+C -->|No| E[The tus protocol is optional, but recommended]:::link
 
-click B "/stream/uploading-videos/resumable-uploads/" "Learn about tus protocol"
-click D "#basic-uploads" "See basic upload instructions"
-click E "/stream/uploading-videos/resumable-uploads/" "Learn about tus protocol"
+classDef link text-decoration:underline,color:#F38020
+
+click B "#direct-creator-uploads-with-tus-protocol" "Learn about tus protocol"
+click D "#basic-post-request" "See basic POST instructions"
+click E "#direct-creator-uploads-with-tus-protocol" "Learn about tus protocol"
 ```
 
-In either case, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage.
+Whether you use basic POST or tus protocol, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage.
 
 ## Basic POST request
 
-If your end user's video is under 200 MB and their connection is reliable, we recommend using this method. If your end user's connection is unreliable, we recommend using the tus protocol instead.
+If your end user's video is under 200 MB and their connection is reliable, we recommend using this method. If your end user's connection is unreliable, we recommend using the [tus protocol](#direct-creator-uploads-with-tus-protocol) instead.
 
 To enable direct creator uploads with a POST request:
 
@@ -69,15 +71,15 @@ curl --request POST \
 A successful upload will receive a `200` HTTP status code response. If the upload does not meet
 the upload constraints defined at time of creation or is larger than 200 MB in size, you will receive a `4xx` HTTP status code response.
 
-## Tus protocol
+## Direct Creator Uploads with tus protocol
 
-If your end user's video is over 200 MB, you must use the tus protocol. If then end user's connection is potentially unreliable, we recommend using the tus protocol because it is resumable.
+If your end user's video is over 200 MB, you must use the tus protocol. Even if the file is under 200 MB, if the end user's connection is potentially unreliable, Cloudflare recommends using the tus protocol because it is resumable. For detailed information about tus protocol requirements, additional client examples, and upload options, refer to [Resumable and large files (tus)](/stream/uploading-videos/resumable-uploads/).
 
 To enable direct creator uploads with the tus protocol:
 
 1. Create your own API endpoint that returns an upload URL.
 
-The example below shows how to build a Worker to get a URL you can use to upload your video. The one-time upload URL is returned in the `Location` header of the response, not in the response body.
+The example below shows how to build a Worker to get a URL your end users can use to upload their video. The one-time upload URL is returned in the `Location` header of the response, not in the response body.
 
 ```javascript {23} title="Example API endpoint"
 export async function onRequest(context) {

--- a/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
+++ b/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
@@ -26,7 +26,7 @@ click D "#basic-post-request" "See basic POST instructions"
 click E "#direct-creator-uploads-with-tus-protocol" "Learn about tus protocol"
 ```
 
-Whether you use basic POST or tus protocol, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage.
+Whether you use basic POST or tus protocol, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage. This duration will be deducted from your account's available storage until the user's upload is received. Once the upload is processed, its actual duration will be counted and the remaining reservation will be relased. If the video errors or does is not received before the link expires, the entire reservation will be released.
 
 ## Basic POST request
 

--- a/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
+++ b/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
@@ -26,13 +26,13 @@ click D "#basic-post-request" "See basic POST instructions"
 click E "#direct-creator-uploads-with-tus-protocol" "Learn about tus protocol"
 ```
 
-Whether you use basic POST or tus protocol, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage. This duration will be deducted from your account's available storage until the user's upload is received. Once the upload is processed, its actual duration will be counted and the remaining reservation will be relased. If the video errors or is not received before the link expires, the entire reservation will be released.
+Whether you use basic `POST` or tus protocol, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage. This duration will be deducted from your account's available storage until the user's upload is received. Once the upload is processed, its actual duration will be counted and the remaining reservation will be relased. If the video errors or is not received before the link expires, the entire reservation will be released.
 
 ## Basic POST request
 
 If your end user's video is under 200 MB and their connection is reliable, we recommend using this method. If your end user's connection is unreliable, we recommend using the [tus protocol](#direct-creator-uploads-with-tus-protocol) instead.
 
-To enable direct creator uploads with a POST request:
+To enable direct creator uploads with a `POST` request:
 
 1. Generate a unique, one-time upload URL using the [Direct upload API](/api/resources/stream/subresources/direct_upload/methods/create/).
 

--- a/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
+++ b/src/content/docs/stream/uploading-videos/direct-creator-uploads.mdx
@@ -6,17 +6,31 @@ sidebar:
 reviewed: 2020-09-03
 ---
 
-Direct creator uploads let your end users upload videos directly to Cloudflare Stream without exposing your API token to clients.
+Direct creator uploads let your end users upload videos directly to Cloudflare Stream without exposing your API token to clients. You can implement direct creator uploads using either a basic POST request or the tus protocol, depending on the file size and the user's connection:
 
-- If your video is a [basic upload](/stream/uploading-videos/direct-creator-uploads/#basic-uploads) under 200 MB and users do not need resumable uploads, generate a URL that accepts an HTTP post request.
+```mermaid
+flowchart LR
+accTitle: Direct creator uploads decision flow
+accDescr: Decision flow for choosing between basic POST uploads and tus protocol based on file size and connection reliability
 
-- If your video is over 200 MB or if you need to allow users to [resume interrupted uploads](/stream/uploading-videos/direct-creator-uploads/#resumable-uploads), generate a URL using the tus protocol.
+A{Is the video over 200 MB?}
+A -->|Yes| B[You must use the tus protocol]
+A -->|No| C{Does the user have a reliable connection?}
+C -->|Yes| D[Basic POST is recommended]
+C -->|No| E[The tus protocol is optional, but recommended]
+
+click B "/stream/uploading-videos/resumable-uploads/" "Learn about tus protocol"
+click D "#basic-uploads" "See basic upload instructions"
+click E "/stream/uploading-videos/resumable-uploads/" "Learn about tus protocol"
+```
 
 In either case, you must specify a maximum duration to reserve for the user's upload to ensure it can be accommodated within your available storage.
 
-## Basic uploads
+## Basic POST request
 
-Use this option if your users upload videos under 200 MB, and you do not need to allow resumable uploads.
+If your end user's video is under 200 MB and their connection is reliable, we recommend using this method. If your end user's connection is unreliable, we recommend using the tus protocol instead.
+
+To enable direct creator uploads with a POST request:
 
 1. Generate a unique, one-time upload URL using the [Direct upload API](/api/resources/stream/subresources/direct_upload/methods/create/).
 
@@ -55,7 +69,11 @@ curl --request POST \
 A successful upload will receive a `200` HTTP status code response. If the upload does not meet
 the upload constraints defined at time of creation or is larger than 200 MB in size, you will receive a `4xx` HTTP status code response.
 
-## Resumable uploads
+## Tus protocol
+
+If your end user's video is over 200 MB, you must use the tus protocol. If then end user's connection is potentially unreliable, we recommend using the tus protocol because it is resumable.
+
+To enable direct creator uploads with the tus protocol:
 
 1. Create your own API endpoint that returns an upload URL.
 

--- a/src/content/docs/stream/uploading-videos/resumable-uploads.mdx
+++ b/src/content/docs/stream/uploading-videos/resumable-uploads.mdx
@@ -7,7 +7,11 @@ sidebar:
 
 import { PackageManagers } from "~/components";
 
-If you have a video over 200 MB, we recommend using the [tus protocol](https://tus.io/) for resumable file uploads. A resumable upload ensures that the upload can be interrupted and resumed without uploading the previous data again.
+If you need to upload a video that is over 200 MB, you must use the [tus protocol](https://tus.io/). Even if the video is under 200 MB, if your connection is potentially unreliable, Cloudflare recommends using the tus protocol because it is resumable. A resumable upload ensures that the upload can be interrupted and resumed without uploading the previous data again.
+
+To use the tus protocol with end user videos, refer to [Direct Creator Uploads with tus](/stream/uploading-videos/direct-creator-uploads/#direct-creator-uploads-with-tus-protocol).
+
+If your video is under 200 MB and your connection is reliable, you can use a basic POST request instead. For direct API uploads using your API token, refer to [Upload via link](/stream/uploading-videos/upload-video-file/). For end user uploads, refer to [Basic POST request for Direct Creator Uploads](/stream/uploading-videos/direct-creator-uploads/#basic-post-request).
 
 ## Requirements
 

--- a/src/content/docs/stream/uploading-videos/resumable-uploads.mdx
+++ b/src/content/docs/stream/uploading-videos/resumable-uploads.mdx
@@ -11,7 +11,7 @@ If you need to upload a video that is over 200 MB, you must use the [tus protoco
 
 To use the tus protocol with end user videos, refer to [Direct Creator Uploads with tus](/stream/uploading-videos/direct-creator-uploads/#direct-creator-uploads-with-tus-protocol).
 
-If your video is under 200 MB and your connection is reliable, you can use a basic POST request instead. For direct API uploads using your API token, refer to [Upload via link](/stream/uploading-videos/upload-video-file/). For end user uploads, refer to [Basic POST request for Direct Creator Uploads](/stream/uploading-videos/direct-creator-uploads/#basic-post-request).
+If your video is under 200 MB and your connection is reliable, you can use a basic `POST` request instead. For direct API uploads using your API token, refer to [Upload via link](/stream/uploading-videos/upload-video-file/). For end user uploads, refer to [Basic POST request for Direct Creator Uploads](/stream/uploading-videos/direct-creator-uploads/#basic-post-request).
 
 ## Requirements
 


### PR DESCRIPTION
This PR addresses user confusion by clarifying that Direct Creator Uploads (DCU) and the tus protocol are separate, independent features that can be used together or separately.

Changes include:
- Added a mermaid diagram to help users choose between basic POST and tus for DCU
- Renamed the "Tus protocol" section to "Direct Creator Uploads with tus protocol" to distinguish it from general tus documentation
- Improved cross-linking between DCU and tus protocol documentation
- Clarified that DCU is about authentication (letting end users upload without API tokens) while tus is about upload reliability (resumable uploads)