### PR TITLE
[Consumer WARP] Fix curl trace url in linux.mdx

### DIFF
--- a/src/content/docs/warp-client/get-started/linux.mdx
+++ b/src/content/docs/warp-client/get-started/linux.mdx
@@ -34,7 +34,7 @@ To connect for the very first time:
 
 1. Register the client `warp-cli registration new`.
 2. Connect `warp-cli connect`.
-3. Run `curl https://www.cloudflare.com/cdn-cgi/trace/` and verify that `warp=on`.
+3. Run `curl https://www.cloudflare.com/cdn-cgi/trace` and verify that `warp=on`.
 
 ### Switch modes
 


### PR DESCRIPTION
### Summary

Update consumer warp linux guide at https://developers.cloudflare.com/warp-client/get-started/linux/

Fix: curl trace url has an extraneous trailing `/` resulting in 404.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).