### PR TITLE
SandboxSDK DIND docs

### DIFF
--- a/src/content/changelog/containers/2026-02-16-docker-in-docker.mdx
+++ b/src/content/changelog/containers/2026-02-16-docker-in-docker.mdx
@@ -1,0 +1,17 @@
+---
+title: Docker-in-Docker support added to Containers and Sandboxes
+description: Run Docker in Docker inside Containers and Sandboxes
+products:
+  - containers
+date: 2026-02-16
+---
+
+[Sandboxes](/sandbox/) and [Containers](/containers/) now support running Docker for "Docker-in-Docker" setups. This is particularly useful when your end users or [agents](/agents) want to run a full sandboxed development environment.
+
+This allows you to:
+- Developing containerized applications
+- Run isolated test environments
+- Build container images as part of CI/CD workflows
+- Deploy arbitrary images supplied at runtime within a container
+
+For [Sandbox SDK](/sandbox/) users, see the [Docker-in-Docker guide](/sandbox/guides/docker-in-docker/) for instructions on combining Docker with the SandboxSDK. For general Containers usage, see the [Containers FAQ](/containers/faq/#can-i-run-docker-inside-a-container-docker-in-docker).

--- a/src/content/changelog/containers/2026-02-16-docker-in-docker.mdx
+++ b/src/content/changelog/containers/2026-02-16-docker-in-docker.mdx
@@ -9,7 +9,8 @@ date: 2026-02-16
 [Sandboxes](/sandbox/) and [Containers](/containers/) now support running Docker for "Docker-in-Docker" setups. This is particularly useful when your end users or [agents](/agents) want to run a full sandboxed development environment.
 
 This allows you to:
-- Developing containerized applications
+
+- Develop containerized applications
 - Run isolated test environments
 - Build container images as part of CI/CD workflows
 - Deploy arbitrary images supplied at runtime within a container

--- a/src/content/changelog/containers/2026-02-17-docker-in-docker.mdx
+++ b/src/content/changelog/containers/2026-02-17-docker-in-docker.mdx
@@ -10,8 +10,8 @@ date: 2026-02-17
 
 This allows you to:
 
-- Develop containerized applications
-- Run isolated test environments
+- Develop containerized applications with your Sandbox
+- Run isolated test environments for images
 - Build container images as part of CI/CD workflows
 - Deploy arbitrary images supplied at runtime within a container
 

--- a/src/content/changelog/containers/2026-02-17-docker-in-docker.mdx
+++ b/src/content/changelog/containers/2026-02-17-docker-in-docker.mdx
@@ -3,7 +3,7 @@ title: Docker-in-Docker support added to Containers and Sandboxes
 description: Run Docker in Docker inside Containers and Sandboxes
 products:
   - containers
-date: 2026-02-16
+date: 2026-02-17
 ---
 
 [Sandboxes](/sandbox/) and [Containers](/containers/) now support running Docker for "Docker-in-Docker" setups. This is particularly useful when your end users or [agents](/agents) want to run a full sandboxed development environment.

--- a/src/content/docs/containers/faq.mdx
+++ b/src/content/docs/containers/faq.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 10
 ---
 
-import { WranglerConfig } from "~/components";
+import { Render, WranglerConfig } from "~/components";
 
 Frequently Asked Questions:
 
@@ -169,6 +169,8 @@ done
 
 exec /path/to/your-app
 ```
+
+<Render file="dind-network-host-caveat" product="containers" />
 
 For a complete working example, see the [Docker-in-Docker Containers example](https://github.com/th0m/containers-dind).
 

--- a/src/content/docs/sandbox/guides/docker-in-docker.mdx
+++ b/src/content/docs/sandbox/guides/docker-in-docker.mdx
@@ -1,0 +1,100 @@
+---
+title: Run Docker-in-Docker
+pcx_content_type: how-to
+sidebar:
+  order: 10
+description: Run Docker commands inside a sandbox container.
+---
+
+import { Render, TypeScriptExample } from "~/components";
+
+This guide shows you how to run Docker inside a Sandbox, enabling you to build and run container images from within a secure sandbox.
+
+## When to use Docker-in-Docker
+
+Use Docker-in-Docker when you need to:
+
+- **Develop containerized applications** - Run `docker build` to create images from Dockerfiles
+- **Run docker as part of CI/CD** - Respond to code changes and build and push images using Cloudflare Containers
+- **Run arbitrary container images** - Start containers from an end-user provided image
+
+## Create a Docker-enabled image
+
+Cloudflare Containers run without root privileges, so you must use the rootless Docker image. Create a custom Dockerfile that combines the sandbox binary with Docker:
+
+```dockerfile title="Dockerfile"
+FROM docker:dind-rootless
+USER root
+
+# Use the musl build so it runs on Alpine-based docker:dind-rootless
+COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /container-server/sandbox /sandbox
+COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /bin/bash /bin/bash
+COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /usr/lib/libreadline.so.8 /usr/lib/libreadline.so.8
+COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /usr/lib/libreadline.so.8.2 /usr/lib/libreadline.so.8.2
+
+# # Create startup script that starts dockerd with
+# # iptables disabled, waits for readiness, then keeps running
+RUN printf '#!/bin/sh\n\
+  set -eu\n\
+  dockerd-entrypoint.sh dockerd --iptables=false --ip6tables=false &\n\
+  until docker version >/dev/null 2>&1; do sleep 0.2; done\n\
+  echo "Docker is ready"\n\
+  wait\n' > /home/rootless/boot-docker-for-dind.sh && chmod +x /home/rootless/boot-docker-for-dind.sh
+
+ENTRYPOINT ["/sandbox"]
+CMD ["/home/rootless/boot-docker-for-dind.sh"]
+
+```
+
+<Render file="dind-network-host-caveat" product="containers" />
+
+## Use Docker in your sandbox
+
+Once deployed, you can run Docker commands through the sandbox:
+
+<TypeScriptExample>
+
+```ts
+import { getSandbox } from "@cloudflare/sandbox";
+
+const sandbox = getSandbox(env.Sandbox, "docker-sandbox");
+
+// Build an image
+await sandbox.writeFile(
+	"/workspace/Dockerfile",
+	`
+FROM alpine:latest
+RUN apk add --no-cache curl
+CMD ["echo", "Hello from Docker!"]
+`,
+);
+
+const build = await sandbox.exec(
+	"docker build --network=host -t my-image /workspace",
+);
+if (!build.success) {
+	console.error("Build failed:", build.stderr);
+}
+
+// Run a container
+const run = await sandbox.exec("docker run --network=host --rm my-image");
+console.log(run.stdout); // "Hello from Docker!"
+```
+
+</TypeScriptExample>
+
+## Limitations
+
+Docker-in-Docker in Cloudflare Containers has the following limitations:
+
+- **No iptables** - Network isolation features that rely on iptables are not available
+- **Rootless mode only** - You cannot use privileged containers or features requiring root
+- **Ephemeral storage** - Built images and containers are lost when the sandbox sleeps. You must persist them manually.
+
+## Related resources
+
+- [Dockerfile reference](/sandbox/configuration/dockerfile/) - Customize your sandbox image
+- [Execute commands](/sandbox/guides/execute-commands/) - Run commands in the sandbox
+- [Background processes](/sandbox/guides/background-processes/) - Manage long-running processes

--- a/src/content/docs/sandbox/guides/docker-in-docker.mdx
+++ b/src/content/docs/sandbox/guides/docker-in-docker.mdx
@@ -15,7 +15,7 @@ This guide shows you how to run Docker inside a Sandbox, enabling you to build a
 Use Docker-in-Docker when you need to:
 
 - **Develop containerized applications** - Run `docker build` to create images from Dockerfiles
-- **Run docker as part of CI/CD** - Respond to code changes and build and push images using Cloudflare Containers
+- **Run Docker as part of CI/CD** - Respond to code changes and build and push images using Cloudflare Containers
 - **Run arbitrary container images** - Start containers from an end-user provided image
 
 ## Create a Docker-enabled image
@@ -34,8 +34,8 @@ COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /bin/bash /bin/bash
 COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /usr/lib/libreadline.so.8 /usr/lib/libreadline.so.8
 COPY --from=docker.io/cloudflare/sandbox:0.7.4-musl /usr/lib/libreadline.so.8.2 /usr/lib/libreadline.so.8.2
 
-# # Create startup script that starts dockerd with
-# # iptables disabled, waits for readiness, then keeps running
+# Create startup script that starts dockerd with
+# iptables disabled, waits for readiness, then keeps running
 RUN printf '#!/bin/sh\n\
   set -eu\n\
   dockerd-entrypoint.sh dockerd --iptables=false --ip6tables=false &\n\

--- a/src/content/partials/containers/dind-network-host-caveat.mdx
+++ b/src/content/partials/containers/dind-network-host-caveat.mdx
@@ -1,7 +1,7 @@
 :::note[Working with disabled iptables]
 Cloudflare Containers do not support iptables manipulation. The `--iptables=false` and `--ip6tables=false` flags prevent Docker from attempting to configure network rules, which would otherwise fail.
 
-To egress or ingress from a container running within Docker-in-Docker, use the `--network=host` flag when running Docker commands.
+To send or receive traffic from a container running within Docker-in-Docker, use the `--network=host` flag when running Docker commands.
 
 This allows you to connect to the container, but it means each inner container has access to your outer container's network stack. Ensure you understand the security implications of this setup before proceeding.
 :::

--- a/src/content/partials/containers/dind-network-host-caveat.mdx
+++ b/src/content/partials/containers/dind-network-host-caveat.mdx
@@ -1,0 +1,7 @@
+:::note[Working with disabled iptables]
+Cloudflare Containers do not support iptables manipulation. The `--iptables=false` and `--ip6tables=false` flags prevent Docker from attempting to configure network rules, which would otherwise fail.
+
+To egress or ingress from a container running within Docker-in-Docker, use the `--network=host` flag when running Docker commands.
+
+This allows you to connect to the container, but it means each inner container has access to your outer container's network stack. Ensure you understand the security implications of this setup before proceeding.
+:::


### PR DESCRIPTION
### Summary

Adds Docker-in-Docker docs for SandboxSDK and a changelog

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
