### PR TITLE
fix: update prisma migration command

### DIFF
--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
@@ -213,7 +213,7 @@ Open the `schema.prisma` file and add the following `User` model to your schema:
 Now, run the following command in your terminal to generate the SQL statement that creates a `User` table equivalent to the `User` model above:
 
 ```sh
-npx prisma migrate diff --from-empty --to-schema-datamodel ./prisma/schema.prisma --script --output migrations/0001_create_user_table.sql
+npx prisma migrate diff --from-empty --to-schema ./prisma/schema.prisma --script --output migrations/0001_create_user_table.sql
 ```
 
 This stores a SQL statement to create a new `User` table in your migration file from before, here is what it looks like:

--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
@@ -230,7 +230,7 @@ npx prisma migrate diff --from-empty --to-schema-datamodel ./prisma/schema.prism
 
 </TabItem>
 </Tabs>
-
+ 
 This stores a SQL statement to create a new `User` table in your migration file from before, here is what it looks like:
 
 <GitHubCode

--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
@@ -17,6 +17,8 @@ import {
 	FileTree,
 	PackageManagers,
 	GitHubCode,
+	Tabs,
+	TabItem,
 } from "~/components";
 
 ## What is Prisma ORM?
@@ -212,9 +214,22 @@ Open the `schema.prisma` file and add the following `User` model to your schema:
 
 Now, run the following command in your terminal to generate the SQL statement that creates a `User` table equivalent to the `User` model above:
 
+<Tabs syncKey="prisma">
+<TabItem label="Prisma (v7)">
+
 ```sh
 npx prisma migrate diff --from-empty --to-schema ./prisma/schema.prisma --script --output migrations/0001_create_user_table.sql
 ```
+
+</TabItem>
+<TabItem label="Prisma (v6)">
+
+```sh
+npx prisma migrate diff --from-empty --to-schema-datamodel ./prisma/schema.prisma --script --output migrations/0001_create_user_table.sql
+```
+
+</TabItem>
+</Tabs>
 
 This stores a SQL statement to create a new `User` table in your migration file from before, here is what it looks like:
 


### PR DESCRIPTION
### Summary

As in prisma 7.0.0, for prisma migrate diff, there was a removal the following flags:
- `prisma --[from/to]-schema-datamodel` - This is now replaced with just `--[from/to]-schema` with the same usage. [ref](https://github.com/prisma/prisma/releases/tag/7.0.0)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).