### PR TITLE
Add WRANGLER_CACHE_DIR and MINIFLARE_CACHE_DIR environment variables

### DIFF
--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -124,6 +124,11 @@ Other entry types include:
 - `pages-deploy` - Written by `wrangler pages deploy` with Pages deployment details
 - `command-failed` - Written when a command fails, including error code and message
 
+- `WRANGLER_CACHE_DIR` <Type text="string" /> <MetaInfo text="optional" />
+  - Custom directory for Wrangler's cache files. When set, this overrides the default cache location (`node_modules/.cache/wrangler`). Useful for environments that do not use a traditional `node_modules` directory, such as Yarn PnP.
+
+- `MINIFLARE_CACHE_DIR` <Type text="string" /> <MetaInfo text="optional" />
+  - Custom directory for Miniflare's `cf.json` cache file, used during local development with `wrangler dev`. When set, this overrides the default cache location (`node_modules/.mf`). Useful for environments that do not use a traditional `node_modules` directory, such as Yarn PnP.
 ## Example `.env` file
 
 The following is an example `.env` file:

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -130,7 +130,7 @@ Other entry types include:
 - `version-deploy` - Written by `wrangler versions deploy` with deployment information
 - `pages-deploy` - Written by `wrangler pages deploy` with Pages deployment details
 - `command-failed` - Written when a command fails, including error code and message
--
+
 ## Example `.env` file
 
 The following is an example `.env` file:

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -107,6 +107,13 @@ Wrangler supports the following environment variables:
 
   - Specifies a directory where Wrangler will create a randomly-named file (format: `wrangler-output-<timestamp>-<random>.json`) to write output data in [ND-JSON](https://github.com/ndjson/ndjson-spec) format. This is useful when you want to keep output files organized in a specific directory but do not need to control the exact filename. If both `WRANGLER_OUTPUT_FILE_PATH` and `WRANGLER_OUTPUT_FILE_DIRECTORY` are set, `WRANGLER_OUTPUT_FILE_PATH` takes precedence.
 
+- `WRANGLER_CACHE_DIR` <Type text="string" /> <MetaInfo text="optional" />
+  - Custom directory for Wrangler's cache files. When set, this overrides the default cache location (`node_modules/.cache/wrangler`). Useful for environments that do not use a traditional `node_modules` directory, such as Yarn PnP.
+
+- `MINIFLARE_CACHE_DIR` <Type text="string" /> <MetaInfo text="optional" />
+  - Custom directory for Miniflare's `cf.json` cache file, used during local development with `wrangler dev`. When set, this overrides the default cache location (`node_modules/.mf`). Useful for environments that do not use a traditional `node_modules` directory, such as Yarn PnP.
+
+
 ### Example output file
 
 When these environment variables are set, Wrangler writes one JSON object per line to the output file. Each entry includes a `timestamp` field and a `type` field indicating the kind of operation. Here is an example of what the file might contain after running `wrangler deploy`:
@@ -123,13 +130,7 @@ Other entry types include:
 - `version-deploy` - Written by `wrangler versions deploy` with deployment information
 - `pages-deploy` - Written by `wrangler pages deploy` with Pages deployment details
 - `command-failed` - Written when a command fails, including error code and message
-
-- `WRANGLER_CACHE_DIR` <Type text="string" /> <MetaInfo text="optional" />
-  - Custom directory for Wrangler's cache files. When set, this overrides the default cache location (`node_modules/.cache/wrangler`). Useful for environments that do not use a traditional `node_modules` directory, such as Yarn PnP.
-
-- `MINIFLARE_CACHE_DIR` <Type text="string" /> <MetaInfo text="optional" />
-  - Custom directory for Miniflare's `cf.json` cache file, used during local development with `wrangler dev`. When set, this overrides the default cache location (`node_modules/.mf`). Useful for environments that do not use a traditional `node_modules` directory, such as Yarn PnP.
-
+-
 ## Example `.env` file
 
 The following is an example `.env` file:

--- a/src/content/docs/workers/wrangler/system-environment-variables.mdx
+++ b/src/content/docs/workers/wrangler/system-environment-variables.mdx
@@ -129,6 +129,7 @@ Other entry types include:
 
 - `MINIFLARE_CACHE_DIR` <Type text="string" /> <MetaInfo text="optional" />
   - Custom directory for Miniflare's `cf.json` cache file, used during local development with `wrangler dev`. When set, this overrides the default cache location (`node_modules/.mf`). Useful for environments that do not use a traditional `node_modules` directory, such as Yarn PnP.
+
 ## Example `.env` file
 
 The following is an example `.env` file:


### PR DESCRIPTION
### Summary

Documents two new environment variables introduced in [cloudflare/workers-sdk#12466](https://github.com/cloudflare/workers-sdk/pull/12466):

- **`WRANGLER_CACHE_DIR`** — overrides Wrangler's default cache location (`node_modules/.cache/wrangler`)
- **`MINIFLARE_CACHE_DIR`** — overrides Miniflare's default `cf.json` cache location (`node_modules/.mf`)

Both are useful for environments without a traditional `node_modules` directory, such as Yarn PnP.

#### Things for reviewer to verify
- Descriptions align with the implementation in workers-sdk#12466
- Whether the example `.env` section at the bottom of the page should also include these new variables (currently omitted since they are niche/optional)
- Timing: the source PR may not yet be merged

---

[Link to Devin run](https://app.devin.ai/sessions/71349e1d5eff4f4c9fb2f2be866013e0) | Requested by: @petebacondarwin

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/28364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
