### PR TITLE
Add Cache section header and link to Cache API in Images bindings docs

### DIFF
--- a/src/content/docs/images/transform-images/bindings.mdx
+++ b/src/content/docs/images/transform-images/bindings.mdx
@@ -101,7 +101,9 @@ return response;
 
 - Outputs information about the image, such as `format`, `fileSize`, `width`, and `height`.
 
-Responses from the Images binding are not automatically cached. Workers lets you interact directly with the Cache API to customize cache behavior using Workers. You can implement logic in your script to store transformations in Cloudflare’s cache.
+## Cache
+
+Responses from the Images binding are not automatically cached. Workers lets you interact directly with the [Cache API](/workers/runtime-apis/cache/) to customize cache behavior using Workers. You can implement logic in your script to store transformations in Cloudflare’s cache.
 
 ## Interact with your Images binding locally
 

--- a/src/content/docs/images/transform-images/bindings.mdx
+++ b/src/content/docs/images/transform-images/bindings.mdx
@@ -101,9 +101,11 @@ return response;
 
 - Outputs information about the image, such as `format`, `fileSize`, `width`, and `height`.
 
-## Cache
+:::note
 
-Responses from the Images binding are not automatically cached. Workers lets you interact directly with the [Cache API](/workers/runtime-apis/cache/) to customize cache behavior using Workers. You can implement logic in your script to store transformations in Cloudflare’s cache.
+Responses from the Images binding are not automatically cached. Workers lets you interact directly with the [Cache API](/workers/runtime-apis/cache/) to customize cache behavior. You can implement logic in your script to store transformations in Cloudflare's cache.
+
+:::
 
 ## Interact with your Images binding locally
 


### PR DESCRIPTION
### Summary

Adds header and a URL to the Cache API page, that makes it easier to find information on caching when using Image Transformations via a Worker Binding. 

