### PR TITLE
[Workers AI] Sync models, add Chat Completions support for GPT-OSS, enumerate tool calling bug fixes

### DIFF
--- a/src/components/models/code/OpenAIResponsesTextGenerationCode.astro
+++ b/src/components/models/code/OpenAIResponsesTextGenerationCode.astro
@@ -1,6 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
+import { Aside, Code } from "@astrojs/starlight/components";
 import Details from "~/components/Details.astro";
 
 type Props = z.infer<typeof props>;
@@ -69,3 +69,25 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/
 		<Code code={curl} lang="sh" />
 	</Details>
 
+	<Aside type="note" title="Multiple API format support">
+		This model supports three different API formats:
+		<ul>
+			<li>
+				<strong>Responses API</strong> (<code>/ai/v1/responses</code>) - Native
+				OpenAI responses format shown above with <code>input</code> parameter
+			</li>
+			<li>
+				<strong>Workers AI Run</strong> (<code>/ai/run</code>) - Dynamic format
+				detection, accepts Chat Completions (<code>messages</code>), legacy Completions
+				(<code>prompt</code>), or Responses API (<code>input</code>)
+			</li>
+			<li>
+				<strong>Chat Completions</strong> (<code>/v1/chat/completions</code>) -
+				OpenAI-compatible endpoint with <code>messages</code> array. Refer to{" "}
+				<a href="/workers-ai/configuration/open-ai-compatibility/">
+					OpenAI Compatibility
+				</a>{" "}
+				for details.
+			</li>
+		</ul>
+	</Aside>

--- a/src/content/release-notes/workers-ai.yaml
+++ b/src/content/release-notes/workers-ai.yaml
@@ -3,6 +3,16 @@ link: "/workers-ai/changelog/"
 productName: Workers AI
 productLink: "/workers-ai/"
 entries:
+  - publish_date: "2026-02-17"
+    title: Chat Completions API support for gpt-oss models and tool calling improvements
+    description: |-
+      - [`@cf/openai/gpt-oss-120b`](/workers-ai/models/gpt-oss-120b/) and [`@cf/openai/gpt-oss-20b`](/workers-ai/models/gpt-oss-20b/) now support Chat Completions API format. Use `/v1/chat/completions` with a `messages` array, or use `/ai/run` which dynamically detects your input format and accepts Chat Completions (`messages`), legacy Completions (`prompt`), or Responses API (`input`).
+      - **[Bug fix]** Fixed a bug in the schema for multiple text generation models where the `content` field in message objects only accepted string values. The field now properly accepts both string content and array content (structured content parts for multi-modal inputs). This fix applies to all affected chat models including GPT-OSS models, Llama 3.x, Mistral, Qwen, and others.
+      - **[Bug fix]** Tool call round-trips now work correctly. The binding no longer rejects `tool_call_id` values that it generated itself, fixing issues with multi-turn tool calling conversations.
+      - **[Bug fix]** Assistant messages with `content: null` and `tool_calls` are now accepted in both the Workers AI binding and REST API (`/v1/chat/completions`), fixing tool call round-trip failures.
+      - **[Bug fix]** Streaming responses now correctly report `finish_reason` only on the usage chunk, matching OpenAI's streaming behavior and preventing duplicate finish events.
+      - **[Bug fix]** `/v1/chat/completions` now preserves original tool call IDs from models instead of regenerating them. Previously, the endpoint was generating new IDs which broke multi-turn tool calling because AI SDK clients could not match tool results to their original calls.
+      - **[Bug fix]** `/v1/chat/completions` now correctly reports `finish_reason: "tool_calls"` in the final usage chunk when tools are used. Previously, it was hardcoding `finish_reason: "stop"` which caused AI SDK clients to think the conversation was complete instead of executing tool calls.
   - publish_date: "2026-02-13"
     title: GLM-4.7-Flash, @cloudflare/tanstack-ai, and workers-ai-provider v3.1.1
     description: |-

--- a/src/content/workers-ai-models/deepseek-coder-6.7b-base-awq.json
+++ b/src/content/workers-ai-models/deepseek-coder-6.7b-base-awq.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/deepseek-coder-6.7b-instruct-awq.json
+++ b/src/content/workers-ai-models/deepseek-coder-6.7b-instruct-awq.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/deepseek-math-7b-instruct.json
+++ b/src/content/workers-ai-models/deepseek-math-7b-instruct.json
@@ -139,8 +139,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/deepseek-r1-distill-qwen-32b.json
+++ b/src/content/workers-ai-models/deepseek-r1-distill-qwen-32b.json
@@ -142,8 +142,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/discolm-german-7b-v1-awq.json
+++ b/src/content/workers-ai-models/discolm-german-7b-v1-awq.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/falcon-7b-instruct.json
+++ b/src/content/workers-ai-models/falcon-7b-instruct.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/gemma-2b-it-lora.json
+++ b/src/content/workers-ai-models/gemma-2b-it-lora.json
@@ -131,8 +131,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/gemma-7b-it-lora.json
+++ b/src/content/workers-ai-models/gemma-7b-it-lora.json
@@ -131,8 +131,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/gemma-7b-it.json
+++ b/src/content/workers-ai-models/gemma-7b-it.json
@@ -139,8 +139,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/gemma-sea-lion-v4-27b-it.json
+++ b/src/content/workers-ai-models/gemma-sea-lion-v4-27b-it.json
@@ -138,8 +138,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [
@@ -496,8 +517,29 @@
                                                             "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                                         },
                                                         "content": {
-                                                            "type": "string",
-                                                            "description": "The content of the message as a string."
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The content of the message as a string."
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "description": "Array of text content parts.",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Type of the content (text)"
+                                                                            },
+                                                                            "text": {
+                                                                                "type": "string",
+                                                                                "description": "Text content"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     },
                                                     "required": [

--- a/src/content/workers-ai-models/gpt-oss-120b.json
+++ b/src/content/workers-ai-models/gpt-oss-120b.json
@@ -36,6 +36,381 @@
             "oneOf": [
                 {
                     "type": "object",
+                    "oneOf": [
+                        {
+                            "title": "Prompt",
+                            "properties": {
+                                "prompt": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "description": "The input text prompt for the model to generate a response."
+                                },
+                                "lora": {
+                                    "type": "string",
+                                    "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                                },
+                                "response_format": {
+                                    "title": "JSON Mode",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "json_object",
+                                                "json_schema"
+                                            ]
+                                        },
+                                        "json_schema": {}
+                                    }
+                                },
+                                "raw": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                                },
+                                "stream": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                                },
+                                "max_tokens": {
+                                    "type": "integer",
+                                    "default": 256,
+                                    "description": "The maximum number of tokens to generate in the response."
+                                },
+                                "temperature": {
+                                    "type": "number",
+                                    "default": 0.6,
+                                    "minimum": 0,
+                                    "maximum": 5,
+                                    "description": "Controls the randomness of the output; higher values produce more random results."
+                                },
+                                "top_p": {
+                                    "type": "number",
+                                    "minimum": 0.001,
+                                    "maximum": 1,
+                                    "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                                },
+                                "top_k": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 50,
+                                    "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                                },
+                                "seed": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 9999999999,
+                                    "description": "Random seed for reproducibility of the generation."
+                                },
+                                "repetition_penalty": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 2,
+                                    "description": "Penalty for repeated tokens; higher values discourage repetition."
+                                },
+                                "frequency_penalty": {
+                                    "type": "number",
+                                    "minimum": -2,
+                                    "maximum": 2,
+                                    "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                                },
+                                "presence_penalty": {
+                                    "type": "number",
+                                    "minimum": -2,
+                                    "maximum": 2,
+                                    "description": "Increases the likelihood of the model introducing new topics."
+                                }
+                            },
+                            "required": [
+                                "prompt"
+                            ]
+                        },
+                        {
+                            "title": "Messages",
+                            "properties": {
+                                "messages": {
+                                    "type": "array",
+                                    "description": "An array of message objects representing the conversation history.",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "role": {
+                                                "type": "string",
+                                                "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                            },
+                                            "content": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "description": "The content of the message as a string."
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "description": "Array of text content parts.",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "Type of the content (text)"
+                                                                },
+                                                                "text": {
+                                                                    "type": "string",
+                                                                    "description": "Text content"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "role",
+                                            "content"
+                                        ]
+                                    }
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "code": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "code"
+                                        ]
+                                    }
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools available for the assistant to use.",
+                                    "items": {
+                                        "type": "object",
+                                        "oneOf": [
+                                            {
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the tool. More descriptive the better."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the tool does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the tool.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            },
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "Specifies the type of tool (e.g., 'function')."
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "description": "Details of the function tool.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A brief description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "Schema defining the parameters accepted by the function.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "description": "The type of the parameters object (usually 'object')."
+                                                                    },
+                                                                    "required": {
+                                                                        "type": "array",
+                                                                        "description": "List of required parameter names.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "properties": {
+                                                                        "type": "object",
+                                                                        "description": "Definitions of each parameter.",
+                                                                        "additionalProperties": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "description": "The data type of the parameter."
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "description": "A description of the expected parameter."
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "description"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "properties"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name",
+                                                            "description",
+                                                            "parameters"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "response_format": {
+                                    "title": "JSON Mode",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "json_object",
+                                                "json_schema"
+                                            ]
+                                        },
+                                        "json_schema": {}
+                                    }
+                                },
+                                "raw": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                                },
+                                "stream": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                                },
+                                "max_tokens": {
+                                    "type": "integer",
+                                    "default": 256,
+                                    "description": "The maximum number of tokens to generate in the response."
+                                },
+                                "temperature": {
+                                    "type": "number",
+                                    "default": 0.6,
+                                    "minimum": 0,
+                                    "maximum": 5,
+                                    "description": "Controls the randomness of the output; higher values produce more random results."
+                                },
+                                "top_p": {
+                                    "type": "number",
+                                    "minimum": 0.001,
+                                    "maximum": 1,
+                                    "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                                },
+                                "top_k": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 50,
+                                    "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                                },
+                                "seed": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 9999999999,
+                                    "description": "Random seed for reproducibility of the generation."
+                                },
+                                "repetition_penalty": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 2,
+                                    "description": "Penalty for repeated tokens; higher values discourage repetition."
+                                },
+                                "frequency_penalty": {
+                                    "type": "number",
+                                    "minimum": -2,
+                                    "maximum": 2,
+                                    "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                                },
+                                "presence_penalty": {
+                                    "type": "number",
+                                    "minimum": -2,
+                                    "maximum": 2,
+                                    "description": "Increases the likelihood of the model introducing new topics."
+                                }
+                            },
+                            "required": [
+                                "messages"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "object",
                     "title": "Responses",
                     "properties": {
                         "input": {
@@ -80,7 +455,7 @@
                 },
                 {
                     "type": "object",
-                    "title": "Async Request",
+                    "title": "Responses_Async",
                     "properties": {
                         "requests": {
                             "type": "array",

--- a/src/content/workers-ai-models/gpt-oss-20b.json
+++ b/src/content/workers-ai-models/gpt-oss-20b.json
@@ -36,6 +36,381 @@
             "oneOf": [
                 {
                     "type": "object",
+                    "oneOf": [
+                        {
+                            "title": "Prompt",
+                            "properties": {
+                                "prompt": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "description": "The input text prompt for the model to generate a response."
+                                },
+                                "lora": {
+                                    "type": "string",
+                                    "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                                },
+                                "response_format": {
+                                    "title": "JSON Mode",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "json_object",
+                                                "json_schema"
+                                            ]
+                                        },
+                                        "json_schema": {}
+                                    }
+                                },
+                                "raw": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                                },
+                                "stream": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                                },
+                                "max_tokens": {
+                                    "type": "integer",
+                                    "default": 256,
+                                    "description": "The maximum number of tokens to generate in the response."
+                                },
+                                "temperature": {
+                                    "type": "number",
+                                    "default": 0.6,
+                                    "minimum": 0,
+                                    "maximum": 5,
+                                    "description": "Controls the randomness of the output; higher values produce more random results."
+                                },
+                                "top_p": {
+                                    "type": "number",
+                                    "minimum": 0.001,
+                                    "maximum": 1,
+                                    "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                                },
+                                "top_k": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 50,
+                                    "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                                },
+                                "seed": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 9999999999,
+                                    "description": "Random seed for reproducibility of the generation."
+                                },
+                                "repetition_penalty": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 2,
+                                    "description": "Penalty for repeated tokens; higher values discourage repetition."
+                                },
+                                "frequency_penalty": {
+                                    "type": "number",
+                                    "minimum": -2,
+                                    "maximum": 2,
+                                    "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                                },
+                                "presence_penalty": {
+                                    "type": "number",
+                                    "minimum": -2,
+                                    "maximum": 2,
+                                    "description": "Increases the likelihood of the model introducing new topics."
+                                }
+                            },
+                            "required": [
+                                "prompt"
+                            ]
+                        },
+                        {
+                            "title": "Messages",
+                            "properties": {
+                                "messages": {
+                                    "type": "array",
+                                    "description": "An array of message objects representing the conversation history.",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "role": {
+                                                "type": "string",
+                                                "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                            },
+                                            "content": {
+                                                "oneOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "description": "The content of the message as a string."
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "description": "Array of text content parts.",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "Type of the content (text)"
+                                                                },
+                                                                "text": {
+                                                                    "type": "string",
+                                                                    "description": "Text content"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "role",
+                                            "content"
+                                        ]
+                                    }
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "code": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "code"
+                                        ]
+                                    }
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools available for the assistant to use.",
+                                    "items": {
+                                        "type": "object",
+                                        "oneOf": [
+                                            {
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the tool. More descriptive the better."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the tool does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the tool.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            },
+                                            {
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "Specifies the type of tool (e.g., 'function')."
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "description": "Details of the function tool.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A brief description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "Schema defining the parameters accepted by the function.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "description": "The type of the parameters object (usually 'object')."
+                                                                    },
+                                                                    "required": {
+                                                                        "type": "array",
+                                                                        "description": "List of required parameter names.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "properties": {
+                                                                        "type": "object",
+                                                                        "description": "Definitions of each parameter.",
+                                                                        "additionalProperties": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "description": "The data type of the parameter."
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "description": "A description of the expected parameter."
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "description"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "properties"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name",
+                                                            "description",
+                                                            "parameters"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "response_format": {
+                                    "title": "JSON Mode",
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": [
+                                                "json_object",
+                                                "json_schema"
+                                            ]
+                                        },
+                                        "json_schema": {}
+                                    }
+                                },
+                                "raw": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                                },
+                                "stream": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                                },
+                                "max_tokens": {
+                                    "type": "integer",
+                                    "default": 256,
+                                    "description": "The maximum number of tokens to generate in the response."
+                                },
+                                "temperature": {
+                                    "type": "number",
+                                    "default": 0.6,
+                                    "minimum": 0,
+                                    "maximum": 5,
+                                    "description": "Controls the randomness of the output; higher values produce more random results."
+                                },
+                                "top_p": {
+                                    "type": "number",
+                                    "minimum": 0.001,
+                                    "maximum": 1,
+                                    "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                                },
+                                "top_k": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 50,
+                                    "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                                },
+                                "seed": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 9999999999,
+                                    "description": "Random seed for reproducibility of the generation."
+                                },
+                                "repetition_penalty": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 2,
+                                    "description": "Penalty for repeated tokens; higher values discourage repetition."
+                                },
+                                "frequency_penalty": {
+                                    "type": "number",
+                                    "minimum": -2,
+                                    "maximum": 2,
+                                    "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                                },
+                                "presence_penalty": {
+                                    "type": "number",
+                                    "minimum": -2,
+                                    "maximum": 2,
+                                    "description": "Increases the likelihood of the model introducing new topics."
+                                }
+                            },
+                            "required": [
+                                "messages"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "object",
                     "title": "Responses",
                     "properties": {
                         "input": {

--- a/src/content/workers-ai-models/granite-4.0-h-micro.json
+++ b/src/content/workers-ai-models/granite-4.0-h-micro.json
@@ -142,8 +142,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/hermes-2-pro-mistral-7b.json
+++ b/src/content/workers-ai-models/hermes-2-pro-mistral-7b.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-2-13b-chat-awq.json
+++ b/src/content/workers-ai-models/llama-2-13b-chat-awq.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-2-7b-chat-fp16.json
+++ b/src/content/workers-ai-models/llama-2-7b-chat-fp16.json
@@ -146,8 +146,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-2-7b-chat-hf-lora.json
+++ b/src/content/workers-ai-models/llama-2-7b-chat-hf-lora.json
@@ -131,8 +131,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-2-7b-chat-int8.json
+++ b/src/content/workers-ai-models/llama-2-7b-chat-int8.json
@@ -123,8 +123,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-3-8b-instruct-awq.json
+++ b/src/content/workers-ai-models/llama-3-8b-instruct-awq.json
@@ -146,8 +146,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-3-8b-instruct.json
+++ b/src/content/workers-ai-models/llama-3-8b-instruct.json
@@ -146,8 +146,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct-awq.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct-awq.json
@@ -142,8 +142,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct-fp8.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct-fp8.json
@@ -142,8 +142,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-3.2-1b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.2-1b-instruct.json
@@ -142,8 +142,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-3.2-3b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.2-3b-instruct.json
@@ -142,8 +142,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/llama-3.3-70b-instruct-fp8-fast.json
+++ b/src/content/workers-ai-models/llama-3.3-70b-instruct-fp8-fast.json
@@ -150,8 +150,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.1-awq.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.1-awq.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.1.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.1.json
@@ -146,8 +146,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.2-lora.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.2-lora.json
@@ -131,8 +131,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.2.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.2.json
@@ -147,8 +147,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/neural-chat-7b-v3-1-awq.json
+++ b/src/content/workers-ai-models/neural-chat-7b-v3-1-awq.json
@@ -131,8 +131,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/openchat-3.5-0106.json
+++ b/src/content/workers-ai-models/openchat-3.5-0106.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/openhermes-2.5-mistral-7b-awq.json
+++ b/src/content/workers-ai-models/openhermes-2.5-mistral-7b-awq.json
@@ -131,8 +131,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/phi-2.json
+++ b/src/content/workers-ai-models/phi-2.json
@@ -131,8 +131,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/qwen1.5-0.5b-chat.json
+++ b/src/content/workers-ai-models/qwen1.5-0.5b-chat.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/qwen1.5-1.8b-chat.json
+++ b/src/content/workers-ai-models/qwen1.5-1.8b-chat.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/qwen1.5-14b-chat-awq.json
+++ b/src/content/workers-ai-models/qwen1.5-14b-chat-awq.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/qwen1.5-7b-chat-awq.json
+++ b/src/content/workers-ai-models/qwen1.5-7b-chat-awq.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/qwen3-30b-a3b-fp8.json
+++ b/src/content/workers-ai-models/qwen3-30b-a3b-fp8.json
@@ -146,8 +146,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [
@@ -504,8 +525,29 @@
                                                             "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                                         },
                                                         "content": {
-                                                            "type": "string",
-                                                            "description": "The content of the message as a string."
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The content of the message as a string."
+                                                                },
+                                                                {
+                                                                    "type": "array",
+                                                                    "description": "Array of text content parts.",
+                                                                    "items": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Type of the content (text)"
+                                                                            },
+                                                                            "text": {
+                                                                                "type": "string",
+                                                                                "description": "Text content"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ]
                                                         }
                                                     },
                                                     "required": [

--- a/src/content/workers-ai-models/qwen3-embedding-0.6b.json
+++ b/src/content/workers-ai-models/qwen3-embedding-0.6b.json
@@ -12,6 +12,10 @@
     "tags": [],
     "properties": [
         {
+            "property_id": "context_window",
+            "value": "8192"
+        },
+        {
             "property_id": "price",
             "value": [
                 {

--- a/src/content/workers-ai-models/sqlcoder-7b-2.json
+++ b/src/content/workers-ai-models/sqlcoder-7b-2.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/starling-lm-7b-beta.json
+++ b/src/content/workers-ai-models/starling-lm-7b-beta.json
@@ -147,8 +147,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/tinyllama-1.1b-chat-v1.0.json
+++ b/src/content/workers-ai-models/tinyllama-1.1b-chat-v1.0.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/una-cybertron-7b-v2-bf16.json
+++ b/src/content/workers-ai-models/una-cybertron-7b-v2-bf16.json
@@ -131,8 +131,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [

--- a/src/content/workers-ai-models/whisper-large-v3-turbo.json
+++ b/src/content/workers-ai-models/whisper-large-v3-turbo.json
@@ -12,6 +12,10 @@
     "tags": [],
     "properties": [
         {
+            "property_id": "async_queue",
+            "value": "true"
+        },
+        {
             "property_id": "price",
             "value": [
                 {
@@ -27,8 +31,23 @@
             "type": "object",
             "properties": {
                 "audio": {
-                    "type": "string",
-                    "description": "Base64 encoded value of the audio data."
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "description": "Base64 encoded value of the audio data."
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "body": {
+                                    "type": "object"
+                                },
+                                "contentType": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    ]
                 },
                 "task": {
                     "type": "string",
@@ -50,7 +69,36 @@
                 },
                 "prefix": {
                     "type": "string",
-                    "description": "The prefix it appended the the beginning of the output of the transcription and can guide the transcription result."
+                    "description": "The prefix appended to the beginning of the output of the transcription and can guide the transcription result."
+                },
+                "beam_size": {
+                    "type": "integer",
+                    "default": 5,
+                    "description": "The number of beams to use in beam search decoding. Higher values may improve accuracy at the cost of speed."
+                },
+                "condition_on_previous_text": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to condition on previous text during transcription. Setting to false may help prevent hallucination loops."
+                },
+                "no_speech_threshold": {
+                    "type": "number",
+                    "default": 0.6,
+                    "description": "Threshold for detecting no-speech segments. Segments with no-speech probability above this value are skipped."
+                },
+                "compression_ratio_threshold": {
+                    "type": "number",
+                    "default": 2.4,
+                    "description": "Threshold for filtering out segments with high compression ratio, which often indicate repetitive or hallucinated text."
+                },
+                "log_prob_threshold": {
+                    "type": "number",
+                    "default": -1,
+                    "description": "Threshold for filtering out segments with low average log probability, indicating low confidence."
+                },
+                "hallucination_silence_threshold": {
+                    "type": "number",
+                    "description": "Optional threshold (in seconds) to skip silent periods that may cause hallucinations."
                 }
             },
             "required": [

--- a/src/content/workers-ai-models/zephyr-7b-beta-awq.json
+++ b/src/content/workers-ai-models/zephyr-7b-beta-awq.json
@@ -135,8 +135,29 @@
                                         "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
                                     },
                                     "content": {
-                                        "type": "string",
-                                        "description": "The content of the message as a string."
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
                                     }
                                 },
                                 "required": [


### PR DESCRIPTION
 Model API Sync (45 files)
- **Content field fix:** Changed from `string` to `oneOf` (string/array) for multi-modal support across 40+ models
- **GPT-OSS-120B/20B:** Added Chat Completions API support via `/ai/run` (dynamic) and `/v1/chat/completions`
- **qwen3-embedding-0.6b:** Added `context_window` property
- **whisper-large-v3-turbo:** Added `async_queue` and new transcription parameters

 Release Notes
- Added 2026-02-17 entry covering GPT-OSS Chat Completions support and all bug fixes.

 UI Updates
- GPT-OSS model pages now show note about three API format options