### PR TITLE
Clarify that arrow functions are not exposed over Workers RPC

### DIFF
--- a/src/content/docs/workers/runtime-apis/rpc/visibility.mdx
+++ b/src/content/docs/workers/runtime-apis/rpc/visibility.mdx
@@ -23,6 +23,24 @@ This security model is commonly known as Object Capabilities, or Capability-Base
 
 [Private properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties) of classes are not directly exposed over RPC.
 
+### Arrow functions
+
+Arrow function expressions are not exposed over RPC because they are defined on class instances, not on the class prototype. They [should not be used as class methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#cannot_be_used_as_methods) of `WorkerEntrypoint` classes.
+
+```js
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+export default class extends WorkerEntrypoint {
+  // add() is exposed over RPC.
+  add(a: number, b: number) {
+    return a + b;
+  }
+
+  // subtract() is NOT exposed over RPC.
+  subtract = (a: number, b: number) => a - b;
+}
+```
+
 ### Class instance properties
 
 When you send an instance of an application-defined class, the recipient can only access methods and properties declared on the class, not properties of the instance. For example:


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Added a section explaining that arrow functions `foo = () => {};` are not exposed over RPC in `WorkerEntrypoint` classes.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
