### PR TITLE
Add changelog: Cloudflare One product name updates

### DIFF
--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -20,6 +20,6 @@ Starting on **February 18th**, you will see updated names across your dashboard 
 
 ## What's NOT changing
 
-**No action is required by you** — functionality remains exactly the same. Your existing configurations, billing, and the Magic Transit, Cloudflare Tunnel, WARP Client, and WARP Connector names will stay as they are. This is a visual update to help your teams navigate our platform more effectively.
+**No action is required by you** — functionality remains exactly the same. Your existing configurations and billing will remain unchanged. This is a visual update to help your teams navigate our platform more effectively.
 
 For more information, visit the [Cloudflare One documentation](/cloudflare-one/).

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -1,0 +1,25 @@
+---
+title: Cloudflare One Product Name Updates
+description: We're updating product names to better align with the Cloudflare One brand and make our SASE offering clearer and more intuitive.
+date: 2026-02-17
+products:
+  - cloudflare-one
+  - cloudflare-wan
+  - cloudflare-network-firewall
+---
+
+To better align with our customers' zero trust and SASE journeys, we're making changes to our product naming to better reflect the Cloudflare One brand. Our goal is simple: to make our SASE (Secure Access Service Edge) offering as clear and intuitive as possible. We're retiring some older brand names in favor of names that describe exactly what the products do within your network.
+
+## What's changing
+
+Starting on **February 18th**, you will see updated names across your dashboard and documentation:
+
+- **Magic WAN** → **Cloudflare WAN**
+- **Magic WAN Connector** → **Cloudflare One Appliance**
+- **Magic Firewall** → **Cloudflare Network Firewall**
+
+## What's NOT changing
+
+**No action is required by you** — functionality remains exactly the same. Your existing configurations, billing, and the Magic Transit, Cloudflare Tunnel, WARP Client, and WARP Connector names will stay as they are. This is a visual update to help your teams navigate our platform more effectively.
+
+For more information, visit the [Cloudflare One documentation](/cloudflare-one/).

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -1,34 +1,29 @@
 ---
 title: Cloudflare One Product Name Updates
-description: We're updating product names to better align with the Cloudflare One brand and make our SASE offering clearer and more intuitive.
+description: Some product names are being updated to make product relationships more intuitive and accessible.
 date: 2026-02-17
 products:
   - cloudflare-one
   - cloudflare-wan
   - cloudflare-network-firewall
-  - multi-cloud-networking
   - network-flow
-  - network-interconnect
 ---
 
-To better align with our customers' zero trust and SASE journeys, we're making changes to our product naming to better reflect the Cloudflare One brand. Our goal is simple: to make our SASE (Secure Access Service Edge) offering as clear and intuitive as possible. We're retiring some older brand names in favor of names that describe exactly what the products do within your network.
+We're updating naming related to some of our Networking products to better clarify their place in the Zero Trust and SASE journey. 
+
+We're retiring some older brand names in favor of names that describe exactly what the products do within your network. We're doing this to help customers build better, clearer mental models for comprehensive SASE architecture delivered on Cloudflare.
 
 ## What's changing
-
-Starting on **February 18th**, you will see updated names across your dashboard and documentation:
 
 - **Magic WAN** → **Cloudflare WAN**
 - **Magic WAN IPsec** → **Cloudflare IPsec**
 - **Magic WAN GRE** → **Cloudflare GRE**
 - **Magic WAN Connector** → **Cloudflare One Appliance**
 - **Magic Firewall** → **Cloudflare Network Firewall**
-- **Magic Cloud Networking** → **Cloudflare One Multi-Cloud Networking**
-- **Magic network overlay/fabric** → **Cloudflare Virtual Network**
-- **CF1 Virtual Network** → **Cloudflare Virtual Network**
 - **Magic Network Monitoring** → **Network Flow**
 
 ## What's NOT changing
 
-**No action is required by you** — functionality remains exactly the same. Your existing configurations, billing, and the Magic Transit, Cloudflare Tunnel, and Cloudflare Network Interconnect names will stay as they are.
+**No action is required by you** — all functionality, existing configurations, and billing will remain exactly the same.
 
 For more information, visit the [Cloudflare One documentation](/cloudflare-one/).

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -20,6 +20,6 @@ Starting on **February 18th**, you will see updated names across your dashboard 
 
 ## What's NOT changing
 
-**No action is required by you** — functionality remains exactly the same. Your existing configurations, billing, and the Magic Transit and Cloudflare Tunnel names will stay as they are. This is a visual update to help your teams navigate our platform more effectively.
+**No action is required by you** — functionality remains exactly the same. Your existing configurations, billing, and the Magic Transit and Cloudflare Tunnel names will stay as they are.
 
 For more information, visit the [Cloudflare One documentation](/cloudflare-one/).

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -6,6 +6,9 @@ products:
   - cloudflare-one
   - cloudflare-wan
   - cloudflare-network-firewall
+  - multi-cloud-networking
+  - network-flow
+  - network-interconnect
 ---
 
 To better align with our customers' zero trust and SASE journeys, we're making changes to our product naming to better reflect the Cloudflare One brand. Our goal is simple: to make our SASE (Secure Access Service Edge) offering as clear and intuitive as possible. We're retiring some older brand names in favor of names that describe exactly what the products do within your network.

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -22,8 +22,6 @@ We're retiring some older brand names in favor of names that describe exactly wh
 - **Magic Firewall** → **Cloudflare Network Firewall**
 - **Magic Network Monitoring** → **Network Flow**
 
-## What's NOT changing
-
 **No action is required by you** — all functionality, existing configurations, and billing will remain exactly the same.
 
 For more information, visit the [Cloudflare One documentation](/cloudflare-one/).

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -9,9 +9,9 @@ products:
   - network-flow
 ---
 
-We're updating naming related to some of our Networking products to better clarify their place in the Zero Trust and SASE journey. 
+We are updating naming related to some of our Networking products to better clarify their place in the Zero Trust and Secure Access Service Edge (SASE) journey. 
 
-We're retiring some older brand names in favor of names that describe exactly what the products do within your network. We're doing this to help customers build better, clearer mental models for comprehensive SASE (Secure Access Service Edge) architecture delivered on Cloudflare.
+We are retiring some older brand names in favor of names that describe exactly what the products do within your network. We are doing this to help customers build better, clearer mental models for comprehensive SASE architecture delivered on Cloudflare.
 
 ## What's changing
 

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -11,7 +11,7 @@ products:
 
 We're updating naming related to some of our Networking products to better clarify their place in the Zero Trust and SASE journey. 
 
-We're retiring some older brand names in favor of names that describe exactly what the products do within your network. We're doing this to help customers build better, clearer mental models for comprehensive SASE architecture delivered on Cloudflare.
+We're retiring some older brand names in favor of names that describe exactly what the products do within your network. We're doing this to help customers build better, clearer mental models for comprehensive SASE (Secure Access Service Edge) architecture delivered on Cloudflare.
 
 ## What's changing
 

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -15,11 +15,17 @@ To better align with our customers' zero trust and SASE journeys, we're making c
 Starting on **February 18th**, you will see updated names across your dashboard and documentation:
 
 - **Magic WAN** → **Cloudflare WAN**
+- **Magic WAN IPsec** → **Cloudflare IPsec**
+- **Magic WAN GRE** → **Cloudflare GRE**
 - **Magic WAN Connector** → **Cloudflare One Appliance**
 - **Magic Firewall** → **Cloudflare Network Firewall**
+- **Magic Cloud Networking** → **Cloudflare One Multi-Cloud Networking**
+- **Magic network overlay/fabric** → **Cloudflare Virtual Network**
+- **CF1 Virtual Network** → **Cloudflare Virtual Network**
+- **Magic Network Monitoring** → **Network Flow**
 
 ## What's NOT changing
 
-**No action is required by you** — functionality remains exactly the same. Your existing configurations, billing, and the Magic Transit and Cloudflare Tunnel names will stay as they are.
+**No action is required by you** — functionality remains exactly the same. Your existing configurations, billing, and the Magic Transit, Cloudflare Tunnel, and Cloudflare Network Interconnect names will stay as they are.
 
 For more information, visit the [Cloudflare One documentation](/cloudflare-one/).

--- a/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
+++ b/src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx
@@ -20,6 +20,6 @@ Starting on **February 18th**, you will see updated names across your dashboard 
 
 ## What's NOT changing
 
-**No action is required by you** — functionality remains exactly the same. Your existing configurations and billing will remain unchanged. This is a visual update to help your teams navigate our platform more effectively.
+**No action is required by you** — functionality remains exactly the same. Your existing configurations, billing, and the Magic Transit and Cloudflare Tunnel names will stay as they are. This is a visual update to help your teams navigate our platform more effectively.
 
 For more information, visit the [Cloudflare One documentation](/cloudflare-one/).


### PR DESCRIPTION
## Summary

This changelog documents the product name updates for Cloudflare One products, effective February 18th, 2026.

## Product Name Changes

- Magic WAN → Cloudflare WAN
- Magic WAN Connector → Cloudflare One Appliance
- Magic Firewall → Cloudflare Network Firewall

## Key Points

- Visual update only - no customer action required
- Functionality remains unchanged
- Existing configurations and billing unaffected
- Magic Transit, Cloudflare Tunnel, WARP Client, and WARP Connector names remain the same

## Checklist

- [x] Changelog follows the content guidelines
- [x] Proper frontmatter with date, title, description, and product tags
- [x] Customer-focused messaging
- [x] Clear and concise format

## Related

- Changelog location: `src/content/changelog/cloudflare-one/2026-02-17-product-name-updates.mdx`
- Product tags: cloudflare-one, cloudflare-wan, cloudflare-network-firewall
- Publish date: 2026-02-17