### PR TITLE
Removing specific finding names from Cloud and SaaS Remediation

### DIFF
--- a/src/content/docs/cloudflare-one/cloud-and-saas-findings/manage-findings.mdx
+++ b/src/content/docs/cloudflare-one/cloud-and-saas-findings/manage-findings.mdx
@@ -114,17 +114,6 @@ The instance will be moved from **Active** to **Hidden** within the finding. If 
 
 In addition to detecting and surfacing misconfigurations or issues with SaaS and cloud applications, CASB can also remediate findings directly in applications.
 
-CASB supports remediation for findings from the [Microsoft 365 integration](/cloudflare-one/integrations/cloud-and-saas/microsoft-365/):
-
-<Details header="Supported CASB findings for remediation">
-
-- Microsoft: File publicly accessible with edit access
-- Microsoft: File publicly accessible with view access
-- Microsoft: File publicly accessible with edit access with DLP Profile match
-- Microsoft: File publicly accessible with view access with DLP Profile match
-
-</Details>
-
 ### Configure remediation permissions
 
 Before you can remediate findings, [add a new integration](/cloudflare-one/integrations/cloud-and-saas/#add-an-integration) and choose _Read-Write mode_ during setup. Alternatively, you can update an existing integration:


### PR DESCRIPTION
Cloud and SaaS Findings Remediation actions currently support several vendors and actions. These lists will grow in time. To ensure the documentation is up-to-date, this commit removes specific call outs of which vendors and finding types are supported. Instead, customers should reference the Cloudflare Dash directly.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
