### PR TITLE
[Fundamentals] Update Dashboard SSO docs for academic domain approval

### DIFF
--- a/src/content/changelog/fundamentals/2026-02-17-sso-academic-domain-approval.mdx
+++ b/src/content/changelog/fundamentals/2026-02-17-sso-academic-domain-approval.mdx
@@ -1,0 +1,17 @@
+---
+title: Academic domains now supported for Dashboard SSO with approval
+description: Cloudflare Dashboard SSO now supports academic top-level domains like .edu, .ac.uk, and .edu.au with a manual approval process.
+products:
+  - fundamentals
+date: 2026-02-17
+---
+
+Academic top-level domains (such as `.edu`, `.ac.uk`, and `.edu.au`) are now supported for Cloudflare Dashboard SSO. Previously, these domains were blocked entirely due to concerns about shared email domains between students, faculty, and IT staff.
+
+With this change, you can create and verify an SSO connector for academic domains, but activation requires manual approval from Cloudflare. This ensures that SSO enforcement does not inadvertently lock out users who signed up before SSO was configured.
+
+To request approval for an academic domain SSO connector, [contact Cloudflare support](https://support.cloudflare.com/) after verifying your domain.
+
+## For more information
+
+- [Cloudflare Dashboard SSO](/fundamentals/manage-members/dashboard-sso/)

--- a/src/content/docs/fundamentals/manage-members/dashboard-sso.mdx
+++ b/src/content/docs/fundamentals/manage-members/dashboard-sso.mdx
@@ -25,8 +25,9 @@ Cloudflare Dashboard SSO is available for free to all plans.
 ## Prerequisites
 
 1. You must control your email domain and be able to add a TXT record to verify this.
+
    - Public email providers such as `@gmail.com` are not allowed.
-   - Every user with that email domain must be an employee in your organization. For example, university domains such as `@harvard.edu` are not allowed because they include student emails.
+   - Academic domains (such as `.edu`, `.ac.uk`, `.edu.au`) require manual approval from Cloudflare before activation. Refer to [Register your domain with Cloudflare for SSO](#2-register-your-domain-with-cloudflare-for-sso) for details.
 
 2. You must be a super administrator and be able to access the Cloudflare API.
 
@@ -58,7 +59,7 @@ You must create an [Account API token](/fundamentals/api/get-started/create-toke
 3. Enter your email domain and select **Create** to move to the verification step.
 
 :::note
-Some top level domains, such as `.edu`, are prohibited from being used as SSO domains.
+Academic top-level domains, such as `.edu`, `.ac.uk`, and `.edu.au`, require manual approval from Cloudflare before they can be enabled. You can create and verify a connector for these domains, but you will need to [contact Cloudflare support](https://support.cloudflare.com/) to request activation approval.
 :::
 
 </TabItem>


### PR DESCRIPTION
### Summary

Updates the Dashboard SSO documentation to reflect that academic TLDs
(`.edu`, `.ac.uk`, `.edu.au`) are no longer blocked from SSO. Instead,
they can be registered and verified but require manual Cloudflare
approval before activation.

- Updated Prerequisites to replace the blanket prohibition with the
  new approval requirement
- Updated the note in Step 2 (Register your domain) to explain the
  approval workflow
- Added a changelog entry for the policy change

### Documentation checklist

- [x] Is there a changelog entry?
- [x] The change adheres to the documentation style guide.
- [ ] If a larger change, an issue has been opened.
- [ ] Files which have changed name or location have been allocated
      redirects.