### PR TITLE
chore: add pull_request_review trigger to Bonk workflow

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -5,6 +5,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}


### PR DESCRIPTION
## Summary

Adds `pull_request_review` (type: `submitted`) as a workflow trigger for the Bonk workflow.

## Why this is needed

Real examples of `/bonk` not triggering:

https://github.com/cloudflare/cloudflare-docs/pull/28432#pullrequestreview-3822911204
https://github.com/cloudflare/cloudflare-docs/pull/28434#pullrequestreview-3822942123

The workflow already triggers on `pull_request_review_comment`, but that is a **different GitHub event**. GitHub has three distinct comment-related events on PRs:

| Event | What triggers it | Example |
|---|---|---|
| `issue_comment` | Comment in the **conversation tab** | Typing in the main comment box and hitting "Comment" |
| `pull_request_review_comment` | **Inline comment on a specific line of the diff** | Clicking the `+` on a diff line and commenting |
| `pull_request_review` | The **top-level review body** submitted via "Review changes > Submit review" | Writing a message in the review dialog and hitting "Submit review" with Comment/Approve/Request changes |

The workflow already had the first two, but **not** the third. When someone writes `/bonk` in the review body and hits "Submit review", GitHub fires a `pull_request_review` event — not `pull_request_review_comment` or `issue_comment`. Without this trigger, that `/bonk` is silently ignored.

This is exactly what happened [here](https://github.com/cloudflare/cloudflare-docs/pull/28420#pullrequestreview-2685131565) — a `/bonk` submitted as a PR review at 2026-02-19T00:53:35Z never triggered the workflow because the event type wasn't in the trigger list.

## What this changes

Two lines added to `.github/workflows/bonk.yml`:

```yaml
pull_request_review:
  types: [submitted]
```

No other changes needed — the [ask-bonk action already handles this event type](https://github.com/ask-bonk/ask-bonk/blob/093640b57fcfc36382787f6d6f7ee1b9322145c0/github/action.yml#L63-L64) (reads `$REVIEW_BODY` and skips the reaction since the GitHub REST API doesn't support reactions on review submissions).

**Note:** Because the REST API doesn't support reactions on PR reviews, there won't be a 👍 ack on the review itself when Bonk picks it up. The work will still proceed normally.