### PR TITLE
[Images] Clarify orientation behavior

### DIFF
--- a/src/content/partials/images/metadata.mdx
+++ b/src/content/partials/images/metadata.mdx
@@ -4,7 +4,7 @@
 
 import { Tabs, TabItem } from "~/components";
 
-Controls the amount of invisible EXIF metadata that should be preserved. Even if EXIF metadata is discarded, Cloudflare maintains the correct color profiles and pixel orientations of the original images.
+Controls amount of invisible metadata (EXIF data) that should be preserved. Color profiles and EXIF rotation are applied to the image even if the metadata is discarded. Content Credentials (C2PA metadata) may be preserved if the [setting is enabled](/images/transform-images/preserve-content-credentials).
 
 Content Credentials (C2PA metadata) may be preserved if [Content Credentials preservation is enabled](/images/transform-images/preserve-content-credentials).
 

--- a/src/content/partials/images/metadata.mdx
+++ b/src/content/partials/images/metadata.mdx
@@ -6,7 +6,6 @@ import { Tabs, TabItem } from "~/components";
 
 Controls amount of invisible metadata (EXIF data) that should be preserved. Color profiles and EXIF rotation are applied to the image even if the metadata is discarded. Content Credentials (C2PA metadata) may be preserved if the [setting is enabled](/images/transform-images/preserve-content-credentials).
 
-Content Credentials (C2PA metadata) may be preserved if [Content Credentials preservation is enabled](/images/transform-images/preserve-content-credentials).
 
 Available options are `copyright`, `keep`, and `none`. The default for all JPEG images is `copyright`. WebP and PNG output formats will always discard EXIF metadata.
 

--- a/src/content/partials/images/metadata.mdx
+++ b/src/content/partials/images/metadata.mdx
@@ -4,9 +4,9 @@
 
 import { Tabs, TabItem } from "~/components";
 
-Controls amount of invisible metadata (EXIF data) that should be preserved.
+Controls the amount of invisible EXIF metadata that should be preserved. Even if EXIF metadata is discarded, Cloudflare maintains the correct color profiles and pixel orientations of the original images.
 
-Color profiles and EXIF rotation are applied to the image even if the metadata is discarded. Content Credentials (C2PA metadata) may be preserved if the [setting is enabled](/images/transform-images/preserve-content-credentials).
+Content Credentials (C2PA metadata) may be preserved if [Content Credentials preservation is enabled](/images/transform-images/preserve-content-credentials).
 
 Available options are `copyright`, `keep`, and `none`. The default for all JPEG images is `copyright`. WebP and PNG output formats will always discard EXIF metadata.
 


### PR DESCRIPTION
Clarified that images display correctly whether EXIF metadata is kept or discarded, since Cloudflare preserves the original pixel orientation without needing to read EXIF orientation values.