### PR TITLE
fix(docs): Update Sandbox Env interface to specify Sandbox type

### DIFF
--- a/src/content/docs/sandbox/configuration/environment-variables.mdx
+++ b/src/content/docs/sandbox/configuration/environment-variables.mdx
@@ -183,10 +183,10 @@ Then pass them to your sandbox:
 
 ```typescript
 import { getSandbox } from "@cloudflare/sandbox";
-export { Sandbox } from '@cloudflare/sandbox';
+export { Sandbox } from "@cloudflare/sandbox";
 
 interface Env {
-  Sandbox: DurableObjectNamespace<Sandbox>;
+	Sandbox: DurableObjectNamespace<Sandbox>;
 	OPENAI_API_KEY: string;
 	DATABASE_URL: string;
 }
@@ -279,9 +279,10 @@ Bucket mounting requires production deployment. It does not work with `wrangler 
 
 ```typescript
 import { getSandbox } from "@cloudflare/sandbox";
+export { Sandbox } from "@cloudflare/sandbox";
 
 interface Env {
-	Sandbox: DurableObjectNamespace;
+	Sandbox: DurableObjectNamespace<Sandbox>;
 	AWS_ACCESS_KEY_ID: string;
 	AWS_SECRET_ACCESS_KEY: string;
 }

--- a/src/content/docs/sandbox/configuration/environment-variables.mdx
+++ b/src/content/docs/sandbox/configuration/environment-variables.mdx
@@ -183,9 +183,10 @@ Then pass them to your sandbox:
 
 ```typescript
 import { getSandbox } from "@cloudflare/sandbox";
+export { Sandbox } from '@cloudflare/sandbox';
 
 interface Env {
-	Sandbox: DurableObjectNamespace;
+  Sandbox: DurableObjectNamespace<Sandbox>;
 	OPENAI_API_KEY: string;
 	DATABASE_URL: string;
 }


### PR DESCRIPTION

### Summary

Solution to issue brought up in https://github.com/cloudflare/sandbox-sdk/issues/397

In the Docs on https://developers.cloudflare.com/sandbox/configuration/environment-variables/#pass-worker-secrets-to-sandbox we are shown how to be able to have access to envs from the Env interface, but using that code directly has some type errors.

Following the example given in the Tutorial for persistent storage https://developers.cloudflare.com/sandbox/tutorials/persistent-storage/#3-build-the-data-processor which is correct.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
