### PR TITLE
Experimenting with making directory listing buttons

### DIFF
--- a/src/components/DirectoryListing.astro
+++ b/src/components/DirectoryListing.astro
@@ -12,18 +12,19 @@ interface PageNode {
 type Props = z.infer<typeof props>;
 
 const props = z.object({
+	button: z.boolean().default(false),
 	descriptions: z.boolean().default(false),
 	folder: z.string().optional(),
 	maxDepth: z.number().default(1),
 	tag: z.string().optional(),
 });
 
-let { descriptions, folder, maxDepth, tag } = props.parse(Astro.props);
+let { button, descriptions, folder, maxDepth, tag } = props.parse(Astro.props);
 
 if (!folder) folder = Astro.params.slug!;
 
 // Strip leading or trailing slashes
-folder = folder.replace(/^\/|\/$/g, '')
+folder = folder.replace(/^\/|\/$/g, "");
 
 const baseDepth = folder.split("/").length;
 
@@ -60,16 +61,75 @@ function buildPageTree(parentPath: string, currentDepth: number): PageNode[] {
 const pageTree = buildPageTree(folder, baseDepth + 1);
 
 if (pageTree.length === 0) {
-	throw new Error (
-		`[DirectoryListing] Bad folder parameter (determined by current folder OR the "folder" input) of "${folder}". Check to make sure "${folder}" exists, has child pages, .`
-	)
+	throw new Error(
+		`[DirectoryListing] Bad folder parameter (determined by current folder OR the "folder" input) of "${folder}". Check to make sure "${folder}" exists, has child pages, .`,
+	);
 }
 ---
 
-<ul>
-	{
-		pageTree.map((node) => (
-			<DirectoryListingItem node={node} descriptions={descriptions} />
-		))
+{
+	button ? (
+		<div class="directory-button-grid">
+			{[...pageTree]
+				.sort((a, b) => a.page.data.title.localeCompare(b.page.data.title))
+				.map((node) => (
+					<a
+						class="directory-button-card"
+						href={node.page.data.external_link ?? "/" + node.page.id + "/"}
+					>
+						<span class="directory-button-title">{node.page.data.title}</span>
+					</a>
+				))}
+		</div>
+	) : (
+		<ul>
+			{pageTree.map((node) => (
+				<DirectoryListingItem node={node} descriptions={descriptions} />
+			))}
+		</ul>
+	)
+}
+
+<style>
+	.directory-button-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 1rem;
 	}
-</ul>
+
+	@media (max-width: 50rem) {
+		.directory-button-grid {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	@media (max-width: 30rem) {
+		.directory-button-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.directory-button-card {
+		display: flex;
+		align-items: center;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.5rem;
+		padding: 1rem;
+		box-shadow: var(--sl-shadow-sm);
+		text-decoration: none;
+		color: var(--sl-color-white);
+		word-break: break-word;
+		overflow-wrap: anywhere;
+	}
+
+	.directory-button-card:hover {
+		background: var(--sl-color-gray-7, var(--sl-color-gray-6));
+		border-color: var(--sl-color-gray-2);
+	}
+
+	.directory-button-title {
+		font-weight: 600;
+		font-size: var(--sl-text-lg);
+		line-height: var(--sl-line-height-headings);
+	}
+</style>

--- a/src/content/docs/ai-crawl-control/features/index.mdx
+++ b/src/content/docs/ai-crawl-control/features/index.mdx
@@ -2,9 +2,11 @@
 title: Features
 pcx_content_type: navigation
 sidebar:
+  group:
+    hideIndex: true
   order: 5
 ---
 
 import { DirectoryListing } from "~/components";
 
-<DirectoryListing button={true} />
+<DirectoryListing />

--- a/src/content/docs/ai-crawl-control/features/index.mdx
+++ b/src/content/docs/ai-crawl-control/features/index.mdx
@@ -2,11 +2,9 @@
 title: Features
 pcx_content_type: navigation
 sidebar:
-  group:
-    hideIndex: true
   order: 5
 ---
 
 import { DirectoryListing } from "~/components";
 
-<DirectoryListing />
+<DirectoryListing button={true} />

--- a/src/content/docs/style-guide/components/directory-listing.mdx
+++ b/src/content/docs/style-guide/components/directory-listing.mdx
@@ -29,6 +29,11 @@ import { DirectoryListing } from "~/components";
 	<strong>Descriptions</strong>
 </p>
 <DirectoryListing folder="workers/wrangler" descriptions />
+
+<p>
+	<strong>Button</strong>
+</p>
+<DirectoryListing folder="workers/wrangler" button />
 ```
 
 ## Props
@@ -38,6 +43,13 @@ import { DirectoryListing } from "~/components";
 **type:** `string`
 
 The folder path to list contents from. If not provided, defaults to the current page's path.
+
+### `button`
+
+**type:** `boolean`
+**default:** `false`
+
+When enabled, displays the listing as a 3-column grid of button-style cards (sorted alphabetically) instead of a bullet list. The cards match the style of Starlight's `LinkCard` component.
 
 ### `descriptions`
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

I thought it would be cool to have the individual links a little more polished than a list of hyperlinks.

This only works when we default to the depth=1 level (as it wouldn't make sense to have buttons if we're surfacing higher depth of folders.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

Without `button={true}` flag:

<img width="1717" height="868" alt="image" src="https://github.com/user-attachments/assets/69970b09-9c8f-4ac9-bf19-d1e21ee479f3" />

With `button={true}` flag:

<img width="1723" height="853" alt="image" src="https://github.com/user-attachments/assets/42cc6733-78ca-40b0-a963-efb9e89cf7de" />

This also works when there are many items.

<img width="1715" height="863" alt="image" src="https://github.com/user-attachments/assets/899c5391-3064-4df7-840e-3479cd69cf9e" />

<img width="1717" height="869" alt="image" src="https://github.com/user-attachments/assets/fc171a9d-4f5c-432b-9653-bf3e4bd8a753" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
