### PR TITLE
[DNS] Fix four confirmed doc errors found in code/API audit

### DIFF
--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -27,16 +27,16 @@ At least one **IP address resolution** record is required for each domain on Clo
 
 These records include the following fields:
 
+<Render file="records-name-field" product="dns" />- **IPv4/IPv6 address**: Your
+origin server address (cannot be a [Cloudflare
+IP](https://www.cloudflare.com/ips))
 
-<Render file="records-name-field" product="dns" />
-- **IPv4/IPv6 address**: Your origin server address (cannot be a [Cloudflare IP](https://www.cloudflare.com/ips))
+:::note
 
-  :::note
+Cloudflare uses the [canonical notation](https://www.rfc-editor.org/rfc/rfc5952.html#section-4.2) to store DNS records. This means that an AAAA record with content `fe80::0:0:1` is stored and returned as `fe80::1`, for example.
 
-  Cloudflare uses the [canonical notation](https://www.rfc-editor.org/rfc/rfc5952.html#section-4.2) to store DNS records. This means that an AAAA record with content `fe80::0:0:1` is stored and returned as `fe80::1`, for example.
-
-  Alternative notations of IPv4 addresses (`1.1` for `1.0.0.1`, for example) are not supported for A records.
-  :::
+Alternative notations of IPv4 addresses (`1.1` for `1.0.0.1`, for example) are not supported for A records.
+:::
 
 - **TTL**: Time to live, which controls how long DNS resolvers should cache a response before revalidating it.
   - If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which is 300 seconds.
@@ -100,13 +100,13 @@ When creating A or AAAA records [using the API](/dns/manage-dns-records/how-to/c
 
 These records include the following fields:
 
-
-<Render file="records-name-field" product="dns" />
-- **Target**: The hostname where traffic should be directed (`example.com`).
-- **TTL**: Time to live, which controls how long DNS resolvers should cache a response before revalidating it.
-  - If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which is 300 seconds.
-  - If the **Proxy Status** is **DNS Only**, you can customize the value.
-- **Proxy status**: For more details, refer to [Proxied DNS records](/dns/proxy-status/).
+<Render file="records-name-field" product="dns" />- **Target**: The hostname
+where traffic should be directed (`example.com`). - **TTL**: Time to live, which
+controls how long DNS resolvers should cache a response before revalidating it.
+- If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which
+is 300 seconds. - If the **Proxy Status** is **DNS Only**, you can customize the
+value. - **Proxy status**: For more details, refer to [Proxied DNS
+records](/dns/proxy-status/).
 
 #### Proxied CNAME records
 
@@ -121,7 +121,7 @@ DNS management for **example.com**:
 
 | Type  | Name | Content                | Proxy status |
 | ----- | ---- | ---------------------- | ------------ |
-| CNAME | abc  | `target.external.test` | Proxied     |
+| CNAME | abc  | `target.external.test` | Proxied      |
 
 </Example>
 
@@ -178,7 +178,7 @@ When creating CNAME records [using the API](/dns/manage-dns-records/how-to/creat
 		"zone_id": "<ZONE_ID>",
 		"zone_name": "example.com",
 		"name": "www.example.com",
-		"type": "A",
+		"type": "CNAME",
 		"content": "www.another-example.com",
 		"proxiable": true,
 		"proxied": false,
@@ -418,7 +418,12 @@ You only need to add NS records to your DNS records table in Cloudflare when you
 Your assigned Cloudflare nameservers, custom nameservers, and their corresponding [nameserver TTLs](/dns/nameservers/nameserver-options/#nameserver-ttl) are controlled via dedicated sections on the [**DNS Records**](https://dash.cloudflare.com/?to=/:account/:zone/dns/records) page. For details, refer to [Nameservers](/dns/nameservers/).
 :::
 
+:::caution
+NS records cannot share a name with any other record type. If a record of any other type already exists at a name, you cannot add an NS record at that same name — and vice versa. This applies at creation and when using PUT or PATCH to update existing records.
+:::
+
 #### Limits
+
 <Render file="ns-delegation-name-limit" product="dns" />
 
 ### DS and DNSKEY

--- a/src/content/docs/dns/manage-dns-records/reference/ttl.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/ttl.mdx
@@ -3,7 +3,6 @@ pcx_content_type: reference
 title: Time to Live (TTL)
 sidebar:
   order: 3
-
 ---
 
 import { GlossaryTooltip } from "~/components";
@@ -27,6 +26,12 @@ It may take longer than 5 minutes for you to actually experience record changes,
 For **DNS only** records, you can choose a TTL between **30 seconds** (Enterprise) or **60 seconds** (non-Enterprise) and **1 day**.
 
 A TTL of **Auto** is set to 300 seconds (five minutes).
+
+## API representation
+
+When using the API, TTL values are integers in seconds. The value `1` is a special sentinel that means **Auto** (300 seconds effective TTL) — it does not mean a 1-second TTL.
+
+You will see `"ttl": 1` in API responses for any record set to Auto. To set Auto when creating or updating a record, send `"ttl": 1`.
 
 ## Nameserver TTL
 

--- a/src/content/docs/dns/zone-setups/reference/dns-quick-scan.mdx
+++ b/src/content/docs/dns/zone-setups/reference/dns-quick-scan.mdx
@@ -1,15 +1,24 @@
 ---
 pcx_content_type: concept
 title: Records quick scan
-
 ---
 
-import { Details, Example } from "~/components"
+import { Details, Example } from "~/components";
 
 To help all customers get started when a new zone is created, Cloudflare offers a DNS records quick scan.
 
 :::note[Where to find the quick scan]
 On the dashboard, quick scan is only available as you are onboarding a new domain. Via API, you can manually invoke quick scan with the [Trigger DNS Records Scan endpoint](/api/resources/dns/subresources/records/methods/scan_trigger/).
+:::
+
+:::caution[Deprecated API endpoint]
+The synchronous `POST /zones/{zone_id}/dns_records/scan` endpoint is deprecated. Use the following three-step async flow instead:
+
+1. `POST /zones/{zone_id}/dns_records/scan/trigger` — starts the scan in the background.
+2. `GET /zones/{zone_id}/dns_records/scan/review` — lists records the scan has found so far.
+3. `POST /zones/{zone_id}/dns_records/scan/review` — accepts or rejects each record.
+
+The async scan does **not** automatically add records to your zone. Accepted records are permanently added; rejected records are permanently deleted. The old synchronous endpoint added records automatically without a review step.
 :::
 
 ## How quick scan works
@@ -23,27 +32,26 @@ Since DNS record names are automatically appended with the domain that the recor
 <Example>
 DNS management for **example.com**:
 
-| Type | Name     | Content                 |
-| ---- | -------- | ----------------------- |
-| **A**   | **@**     | `192.0.2.0`  |
-| **CNAME**   | **www**     | `example.com`  |
-| **A**        | **mail**   | `192.0.2.100`      |
-| **MX**        | **@**   | `mail.example.com`      |
-| *CNAME*   | *my-store1900*     | `example-shop.saas.test`  |
+| Type      | Name           | Content                  |
+| --------- | -------------- | ------------------------ |
+| **A**     | **@**          | `192.0.2.0`              |
+| **CNAME** | **www**        | `example.com`            |
+| **A**     | **mail**       | `192.0.2.100`            |
+| **MX**    | **@**          | `mail.example.com`       |
+| _CNAME_   | _my-store1900_ | `example-shop.saas.test` |
 
 </Example>
 
 <Example>
 DNS management for **domain.test**:
 
-| Type | Name     | Content                 |
-| ---- | -------- | ----------------------- |
-| **A**   | **@**     | `192.0.2.8`  |
-| **CNAME**   | **www**     | `domain.test`  |
-| *CNAME*   | *specific-internal-name*     | `services.test.dev`  |
-| **A**        | **mail**   | `192.0.2.20`      |
-| **MX**        | **@**   | `mail.domain.test`      |
-
+| Type      | Name                     | Content             |
+| --------- | ------------------------ | ------------------- |
+| **A**     | **@**                    | `192.0.2.8`         |
+| **CNAME** | **www**                  | `domain.test`       |
+| _CNAME_   | _specific-internal-name_ | `services.test.dev` |
+| **A**     | **mail**                 | `192.0.2.20`        |
+| **MX**    | **@**                    | `mail.domain.test`  |
 
 </Example>
 
@@ -71,9 +79,9 @@ You should always [review your DNS records](/dns/zone-setups/full-setup/setup/#r
 
 <Example>
 
-| Type       | Name | Content  | TTL     |
-| ---------- | ---- | -------- | ------- |
-| `A`        | `@`  | `<IPv4>` | `<TTL>` |
+| Type | Name | Content  | TTL     |
+| ---- | ---- | -------- | ------- |
+| `A`  | `@`  | `<IPv4>` | `<TTL>` |
 
 </Example>
 
@@ -85,45 +93,45 @@ Virtually all zones on a [primary setup (full)](/dns/zone-setups/full-setup/) ar
 
 <Example>
 
-| Type       | Name  | Content    | TTL     |
-| ---------- | ----- | ---------- | ------- |
-| `CNAME`    | `www` | `<TARGET>` | `<TTL>` |
+| Type    | Name  | Content    | TTL     |
+| ------- | ----- | ---------- | ------- |
+| `CNAME` | `www` | `<TARGET>` | `<TTL>` |
 
 </Example>
 
 <Example>
 
-| Type       | Name  | Content  | TTL     |
-| ---------- | ----- | -------- | ------- |
-| `A`        | `www` | `<IPv4>` | `<TTL>` |
+| Type | Name  | Content  | TTL     |
+| ---- | ----- | -------- | ------- |
+| `A`  | `www` | `<IPv4>` | `<TTL>` |
 
 </Example>
 
-Since it is still common that visitors type `www.<DOMAIN>` in their browsers expecting to reach the domain, zones will usually have a  [CNAME](/dns/manage-dns-records/reference/dns-record-types/#cname) or an [A](/dns/manage-dns-records/reference/dns-record-types/#a-and-aaaa) record named `www`. This allows queries for `www.<DOMAIN>` to return the expected result.
+Since it is still common that visitors type `www.<DOMAIN>` in their browsers expecting to reach the domain, zones will usually have a [CNAME](/dns/manage-dns-records/reference/dns-record-types/#cname) or an [A](/dns/manage-dns-records/reference/dns-record-types/#a-and-aaaa) record named `www`. This allows queries for `www.<DOMAIN>` to return the expected result.
 
 ### Email records
 
 <Example>
 
-| Type       | Name | Mail server        | TTL     | Priority     |
-| ---------- | ---- | ------------------ | ------- | ------------ |
-| `MX`       | `@`  | `webmail.<DOMAIN>` | `<TTL>` | `<PRIORITY>` |
+| Type | Name | Mail server        | TTL     | Priority     |
+| ---- | ---- | ------------------ | ------- | ------------ |
+| `MX` | `@`  | `webmail.<DOMAIN>` | `<TTL>` | `<PRIORITY>` |
 
 </Example>
 
 <Example>
 
-| Type       | Name   | Content    | TTL     |
-| ---------- | ------ | ---------- | ------- |
-| `CNAME`    | `mail` | `<TARGET>` | `<TTL>` |
+| Type    | Name   | Content    | TTL     |
+| ------- | ------ | ---------- | ------- |
+| `CNAME` | `mail` | `<TARGET>` | `<TTL>` |
 
 </Example>
 
 <Example>
 
-| Type       | Name      | Content  | TTL     |
-| ---------- | --------- | -------- | ------- |
-| `A`        | `webmail` | `<IPv4>` | `<TTL>` |
+| Type | Name      | Content  | TTL     |
+| ---- | --------- | -------- | ------- |
+| `A`  | `webmail` | `<IPv4>` | `<TTL>` |
 
 </Example>
 


### PR DESCRIPTION
**Seems clear** 
- dns-record-types: fix CNAME response example showing type 'A' instead of 'CNAME' (copy-paste from A record example above)
- ttl: add API representation section clarifying that ttl value 1 means Auto (300s), not a 1-second TTL

**Needs eval about placement, phrasing, etc.**
- dns-quick-scan: add deprecation caution for POST /dns_records/scan, document the three-step async flow, and call out that the new flow does not auto-add records
- dns-record-types: add caution that NS records cannot share a name with any other record type (stated in API notes but absent from docs)