### PR TITLE
[Workers AI] Expand all usage code examples by default on model pages

### DIFF
--- a/src/components/models/code/AutomaticSpeechRecognitionCode.astro
+++ b/src/components/models/code/AutomaticSpeechRecognitionCode.astro
@@ -45,10 +45,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/Bge-Reranker-Base.astro
+++ b/src/components/models/code/Bge-Reranker-Base.astro
@@ -66,14 +66,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Worker">
+<Details header="Worker" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="Python">
+<Details header="Python" open>
 	<Code code={python} lang="py" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/DeepgramAura.astro
+++ b/src/components/models/code/DeepgramAura.astro
@@ -38,11 +38,11 @@ curl --request POST \
 ---
 
 <>
-	<Details header="Worker">
+	<Details header="Worker" open>
 		<Code code={worker} lang="ts" />
 	</Details>
 
-	<Details header="curl">
+	<Details header="curl" open>
 		<Code code={curl} lang="sh" />
 	</Details>
 </>

--- a/src/components/models/code/DeepgramFlux.astro
+++ b/src/components/models/code/DeepgramFlux.astro
@@ -77,15 +77,15 @@ function generateRandomAudio() {
 ---
 
 <>
-	<Details header="Step 1: Create a Worker that establishes a WebSocket connection">
+	<Details header="Step 1: Create a Worker that establishes a WebSocket connection" open>
 		<Code code={worker} lang="ts" />
 	</Details>
 
-	<Details header="Step 2: Deploy your Worker">
+	<Details header="Step 2: Deploy your Worker" open>
 		<Code code={deployWorker} lang="sh" />
 	</Details>
 
-  <Details header="Step 3: Write a client script to connect to your Worker and send audio">
+  <Details header="Step 3: Write a client script to connect to your Worker and send audio" open>
     <Code code={clientScript} lang="js" />
   </Details>
 </>

--- a/src/components/models/code/DeepgramNova.astro
+++ b/src/components/models/code/DeepgramNova.astro
@@ -42,11 +42,11 @@ curl --request POST \
 ---
 
 <>
-	<Details header="Worker">
+	<Details header="Worker" open>
 		<Code code={worker} lang="ts" />
 	</Details>
 
-	<Details header="curl">
+	<Details header="curl" open>
 		<Code code={curl} lang="sh" />
 	</Details>
 </>

--- a/src/components/models/code/Flux-1-Schnell.astro
+++ b/src/components/models/code/Flux-1-Schnell.astro
@@ -62,14 +62,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - Returning a data URI - TypeScript">
+<Details header="Workers - Returning a data URI - TypeScript" open>
 	<Code code={workerReturningDataURI} lang="ts" />
 </Details>
 
-<Details header="Workers - Returning an image - TypeScript">
+<Details header="Workers - Returning an image - TypeScript" open>
 	<Code code={workerReturningImage} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/Flux-2.astro
+++ b/src/components/models/code/Flux-2.astro
@@ -54,10 +54,10 @@ curl --request POST \\
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={workerCode} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/ImageClassificationCode.astro
+++ b/src/components/models/code/ImageClassificationCode.astro
@@ -43,10 +43,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/ImageToTextCode.astro
+++ b/src/components/models/code/ImageToTextCode.astro
@@ -36,6 +36,6 @@ export default {
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>

--- a/src/components/models/code/LlamaGuard.astro
+++ b/src/components/models/code/LlamaGuard.astro
@@ -65,14 +65,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Worker">
+<Details header="Worker" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="Python">
+<Details header="Python" open>
 	<Code code={python} lang="py" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/MelottsCode.astro
+++ b/src/components/models/code/MelottsCode.astro
@@ -28,6 +28,6 @@ export default {
 } satisfies ExportedHandler<Env>;`;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>

--- a/src/components/models/code/ObjectDetectionCode.astro
+++ b/src/components/models/code/ObjectDetectionCode.astro
@@ -43,10 +43,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/OpenAIResponsesTextGenerationCode.astro
+++ b/src/components/models/code/OpenAIResponsesTextGenerationCode.astro
@@ -57,15 +57,15 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/
 ---
 
 <>
-	<Details header="Worker">
+	<Details header="Worker" open>
 		<Code code={worker} lang="ts" />
 	</Details>
 
-	<Details header="Python">
+	<Details header="Python" open>
 		<Code code={python} lang="py" />
 	</Details>
 
-	<Details header="curl">
+	<Details header="curl" open>
 		<Code code={curl} lang="sh" />
 	</Details>
 

--- a/src/components/models/code/StableDiffusion-v1-5-img2imgCode.astro
+++ b/src/components/models/code/StableDiffusion-v1-5-img2imgCode.astro
@@ -51,10 +51,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/StableDiffusion-v1-5-inpaintingCode.astro
+++ b/src/components/models/code/StableDiffusion-v1-5-inpaintingCode.astro
@@ -58,10 +58,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/SummarizationCode.astro
+++ b/src/components/models/code/SummarizationCode.astro
@@ -37,10 +37,10 @@ curl https://api.cloudflare.com/client/v4/accounts/{cf_account_id}/ai/run/${name
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/TextClassificationCode.astro
+++ b/src/components/models/code/TextClassificationCode.astro
@@ -51,14 +51,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="Python">
+<Details header="Python" open>
 	<Code code={python} lang="py" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/TextEmbeddingCode.astro
+++ b/src/components/models/code/TextEmbeddingCode.astro
@@ -69,15 +69,15 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="Python">
+<Details header="Python" open>
 	<Code code={python} lang="py" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>
 

--- a/src/components/models/code/TextGenerationCode.astro
+++ b/src/components/models/code/TextGenerationCode.astro
@@ -123,29 +123,29 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 {
 	lora ? (
 		<>
-			<Details header="Worker">
+			<Details header="Worker" open>
 				<Code code={loraWorker} lang="ts" />
 			</Details>
 
-			<Details header="cURL">
+			<Details header="cURL" open>
 				<Code code={loraCurl} lang="sh" />
 			</Details>
 		</>
 	) : (
 		<>
-			<Details header="Worker - Streaming">
+			<Details header="Worker - Streaming" open>
 				<Code code={streamingWorker} lang="ts" />
 			</Details>
 
-			<Details header="Worker">
+			<Details header="Worker" open>
 				<Code code={worker} lang="ts" />
 			</Details>
 
-			<Details header="Python">
+			<Details header="Python" open>
 				<Code code={python} lang="py" />
 			</Details>
 
-			<Details header="curl">
+			<Details header="curl" open>
 				<Code code={curl} lang="sh" />
 			</Details>
 

--- a/src/components/models/code/TextToImageCode.astro
+++ b/src/components/models/code/TextToImageCode.astro
@@ -45,10 +45,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/TranslationCode.astro
+++ b/src/components/models/code/TranslationCode.astro
@@ -60,14 +60,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 </Details>
 
-<Details header="Python">
+<Details header="Python" open>
 	<Code code={python} lang="py" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>

--- a/src/components/models/code/WhisperBase64Code.astro
+++ b/src/components/models/code/WhisperBase64Code.astro
@@ -81,15 +81,15 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript">
+<Details header="Workers - TypeScript" open>
 	<Code code={worker} lang="ts" />
 	<Render file="nodejs-compat-howto" product="workers" />
 </Details>
 
-<Details header="Python">
+<Details header="Python" open>
 	<Code code={python} lang="py" />
 </Details>
 
-<Details header="curl">
+<Details header="curl" open>
 	<Code code={curl} lang="sh" />
 </Details>


### PR DESCRIPTION
## Summary
- Adds `open` attribute to all `<Details>` components in Workers AI model code examples
- Users can now immediately see Worker, Python, and curl code snippets without clicking to expand
- Affects all 22 model code example components

## Jira
https://jira.cfdata.org/browse/AI-4123