### PR TITLE
Add saved views feature for Threat Events dashboard

### DIFF
--- a/src/content/changelog/security-center/2026-02-23-Saved-views-in-threat-events.mdx
+++ b/src/content/changelog/security-center/2026-02-23-Saved-views-in-threat-events.mdx
@@ -1,0 +1,14 @@
+---
+title: Saved views for Threat Events
+description: Create, save, and share custom filtered views of the threat landscape to accelerate your investigation workflows.
+date: 2026-02-23
+---
+
+**TL;DR:** You can now create and save custom configurations of the Threat Events dashboard, allowing you to instantly return to specific filtered views—such as industry-specific attacks or regional Sankey flows—without manual reconfiguration.
+
+### Why this matters
+Threat intelligence is most effective when it is personalized. Previously, analysts had to manually re-apply complex filters (like combining specific industry datasets with geographic origins) every time they logged in. This update provides material value by:
+* Analysts can now jump straight into "Known Ransomware Infrastructure" or "Retail Sector Targets" views with a single click, eliminating repetitive setup tasks
+* Teams can ensure everyone is looking at the same data subsets by using standardized saved views, reducing the risk of missing critical patterns due to inconsistent filtering.
+
+Cloudforce One subscribers can start saving their custom views now in [Application Security > Threat Intelligence > Threat Events](https://dash.cloudflare.com/?to=/:account/security-center/threat-intelligence/threat-events).

--- a/src/content/changelog/security-center/2026-02-23-Saved-views-in-threat-events.mdx
+++ b/src/content/changelog/security-center/2026-02-23-Saved-views-in-threat-events.mdx
@@ -6,7 +6,8 @@ date: 2026-02-23
 
 **TL;DR:** You can now create and save custom configurations of the Threat Events dashboard, allowing you to instantly return to specific filtered views — such as industry-specific attacks or regional Sankey flows — without manual reconfiguration.
 
-### Why this matters
+## Why this matters
+
 Threat intelligence is most effective when it is personalized. Previously, analysts had to manually re-apply complex filters (like combining specific industry datasets with geographic origins) every time they logged in. This update provides material value by:
 * Analysts can now jump straight into "Known Ransomware Infrastructure" or "Retail Sector Targets" views with a single click, eliminating repetitive setup tasks
 * Teams can ensure everyone is looking at the same data subsets by using standardized saved views, reducing the risk of missing critical patterns due to inconsistent filtering.

--- a/src/content/changelog/security-center/2026-02-23-Saved-views-in-threat-events.mdx
+++ b/src/content/changelog/security-center/2026-02-23-Saved-views-in-threat-events.mdx
@@ -4,7 +4,7 @@ description: Create, save, and share custom filtered views of the threat landsca
 date: 2026-02-23
 ---
 
-**TL;DR:** You can now create and save custom configurations of the Threat Events dashboard, allowing you to instantly return to specific filtered views—such as industry-specific attacks or regional Sankey flows—without manual reconfiguration.
+**TL;DR:** You can now create and save custom configurations of the Threat Events dashboard, allowing you to instantly return to specific filtered views — such as industry-specific attacks or regional Sankey flows — without manual reconfiguration.
 
 ### Why this matters
 Threat intelligence is most effective when it is personalized. Previously, analysts had to manually re-apply complex filters (like combining specific industry datasets with geographic origins) every time they logged in. This update provides material value by:


### PR DESCRIPTION
This update allows users to create, save, and share custom filtered views of the Threat Events dashboard, enhancing investigation workflows by eliminating repetitive setup tasks.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
