### PR TITLE
[Changelog] Only render descriptions

### DIFF
--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -11,8 +11,6 @@ import { format } from "date-fns";
 import { getChangelogs } from "~/util/changelog";
 import { directoryByGroup } from "~/util/directory";
 
-import { render } from "astro:content";
-
 let notes = await getChangelogs({
 	filter: (entry) => !entry.data.hidden,
 });

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -65,8 +65,6 @@ const props = {
 				.map((group) => group[0])
 				.sort();
 
-			const { Content } = await render(entry);
-
 			return (
 				<div
 					class:list={["mt-0! sm:flex", { "hidden!": idx >= 50 }]}
@@ -98,7 +96,7 @@ const props = {
 									</h3>
 									<ProductPills products={entry.data.products} />
 								</div>
-								<Content />
+								<p>{entry.data.description}</p>
 							</li>
 						</ol>
 					</Steps>


### PR DESCRIPTION
### Summary

The changelog as it is just doesn't work, size-wise (it's loading too many entries that -- at times -- crashes the browser by consuming too much memory).

This is an alternative approach that still supports filtering.
<img width="904" height="769" alt="image" src="https://github.com/user-attachments/assets/98461e45-b796-4b35-aefe-08a1c16ee336" />

