### PR TITLE
doc: custom hostname PATCH requires type+method when changing CA

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
@@ -124,6 +124,33 @@ Consider the following solutions:
 - Use the [Edit Custom Hostname](/api/resources/custom_hostnames/methods/edit/) endpoint to set the `certificate_authority` parameter to `google`: this sets Google Trust Services as the CA for your custom hostnames. In your API call, make sure to also include `method` and `type` in the `ssl` object.
 - If you are using a custom certificate for your custom hostname, refer to the [custom certificates troubleshooting](/ssl/edge-certificates/custom-certificates/troubleshooting/#lets-encrypt-chain-update).
 
+## Certificate authority change not taking effect via API
+
+When using the [Edit Custom Hostname](/api/resources/custom_hostnames/methods/edit/) PATCH endpoint to change the `certificate_authority` of an existing custom hostname, the `ssl.type` and `ssl.method` fields are also required. Omitting them returns an error.
+
+<Details header="Example API call">
+
+```sh
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>" \
+--header "Content-Type: application/json" \
+--data '{
+  "ssl": {
+      "type": "dv",
+      "method": "http",
+      "certificate_authority": "google"
+  }
+}'
+```
+
+</Details>
+
+If you only want to change the CA without modifying validation settings, use `"type": "dv"` and `"method": "http"` (or `"txt"` if using DNS-based validation). Valid `certificate_authority` values are `"google"`, `"lets_encrypt"`, `"ssl_com"`, or `""` (empty string for default CA). Refer to the [certificate authorities reference](/ssl/reference/certificate-authorities/) for more details.
+
+***
+
 ## Custom hostname fails to verify because the zone is held
 
 The [zone hold feature](/fundamentals/account/account-security/zone-holds/) is a toggle that will prevent their zone from being activated on other Cloudflare account. When enabled, Cloudflare is not able to issue an SSL/TLS certificate on behalf of that domain name for either a zone or custom hostname.

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
@@ -124,30 +124,15 @@ Consider the following solutions:
 - Use the [Edit Custom Hostname](/api/resources/custom_hostnames/methods/edit/) endpoint to set the `certificate_authority` parameter to `google`: this sets Google Trust Services as the CA for your custom hostnames. In your API call, make sure to also include `method` and `type` in the `ssl` object.
 - If you are using a custom certificate for your custom hostname, refer to the [custom certificates troubleshooting](/ssl/edge-certificates/custom-certificates/troubleshooting/#lets-encrypt-chain-update).
 
-## Certificate authority change not taking effect via API
+## Missing required SSL fields when editing custom hostname
 
-When using the [Edit Custom Hostname](/api/resources/custom_hostnames/methods/edit/) PATCH endpoint to change the `certificate_authority` of an existing custom hostname, the `ssl.type` and `ssl.method` fields are also required. Omitting them returns an error.
+The [Edit Custom Hostname](/api/resources/custom_hostnames/methods/edit/) PATCH endpoint requires specific `ssl` fields depending on whether the custom hostname uses a managed certificate or a [custom certificate](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/). Omitting required fields returns an error.
 
-<Details header="Example API call">
+**Managed certificates** — `ssl.type` (`"dv"`) and `ssl.method` (`"http"` or `"txt"`) are always required. For example, changing `certificate_authority` without including `type` and `method` will fail.
 
-```sh
-curl --request PATCH \
-https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
---header "X-Auth-Email: <EMAIL>" \
---header "X-Auth-Key: <API_KEY>" \
---header "Content-Type: application/json" \
---data '{
-  "ssl": {
-      "type": "dv",
-      "method": "http",
-      "certificate_authority": "google"
-  }
-}'
-```
+**Custom certificates** — `ssl.custom_certificate` is always required, plus one of `ssl.custom_key` or `ssl.custom_csr_id`.
 
-</Details>
-
-If you only want to change the CA without modifying validation settings, use `"type": "dv"` and `"method": "http"` (or `"txt"` if using DNS-based validation). Valid `certificate_authority` values are `"google"`, `"lets_encrypt"`, `"ssl_com"`, or `""` (empty string for default CA). Refer to the [certificate authorities reference](/ssl/reference/certificate-authorities/) for more details.
+For the full list of required fields and examples, refer to [Edit custom hostname SSL](/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls/#edit-custom-hostname-ssl).
 
 ***
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates.mdx
@@ -26,7 +26,7 @@ Refer to [this certificate authorities reference page](/ssl/reference/certificat
 
 ## Change certificate authority
 
-To change the CA for an existing custom hostname, use the [Edit Custom Hostname](/api/resources/custom_hostnames/methods/edit/) PATCH endpoint. You must include `ssl.type` and `ssl.method` alongside `ssl.certificate_authority` — omitting `type` or `method` returns an error.
+To change the CA for an existing managed custom hostname, use the [Edit Custom Hostname](/api/resources/custom_hostnames/methods/edit/) PATCH endpoint. You must include `ssl.type` and `ssl.method` alongside `ssl.certificate_authority` — these fields are always required when [editing a managed hostname's SSL settings](/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls/#managed-certificates).
 
 This triggers certificate re-issuance with the new CA.
 
@@ -70,11 +70,7 @@ https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_ho
 
 </Details>
 
-:::note
-
-The only valid value for `type` is `"dv"`. For `method`, use `"http"` or `"txt"` with ACME-based CAs (Let's Encrypt, Google Trust Services). If you only want to change the CA without modifying validation settings, use your existing validation method.
-
-:::
+Valid `certificate_authority` values: `"google"` (Google Trust Services), `"lets_encrypt"` (Let's Encrypt), `"ssl_com"` (SSL.com), or `""` (empty string for default CA).
 
 ## Certificate details and compatibility
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates.mdx
@@ -8,7 +8,7 @@ head:
     content: Issue certificates
 ---
 
-import { Render } from "~/components";
+import { Details, Render } from "~/components";
 
 Cloudflare automatically issues certificates when you [create a custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/create-custom-hostnames/).
 
@@ -23,6 +23,58 @@ There are several required steps before a custom hostname and its certificate ca
 If you create the custom hostname via API, you can leave the `certificate_authority` parameter empty to set it to “default CA”. With this option, Cloudflare checks the CAA records before requesting the certificates, which helps ensure the certificates can be issued from the CA.
 
 Refer to [this certificate authorities reference page](/ssl/reference/certificate-authorities/) to learn more about the CAs that Cloudflare uses to issue SSL/TLS certificates.
+
+## Change certificate authority
+
+To change the CA for an existing custom hostname, use the [Edit Custom Hostname](/api/resources/custom_hostnames/methods/edit/) PATCH endpoint. You must include `ssl.type` and `ssl.method` alongside `ssl.certificate_authority` — omitting `type` or `method` returns an error.
+
+This triggers certificate re-issuance with the new CA.
+
+<Details header="Switch to Google Trust Services">
+
+```sh
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>" \
+--header "Content-Type: application/json" \
+--data '{
+  "ssl": {
+      "type": "dv",
+      "method": "http",
+      "certificate_authority": "google"
+  }
+}'
+```
+
+</Details>
+
+<Details header="Reset to default CA">
+
+To let Cloudflare choose the best CA, set `certificate_authority` to an empty string:
+
+```sh
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>" \
+--header "Content-Type: application/json" \
+--data '{
+  "ssl": {
+      "type": "dv",
+      "method": "http",
+      "certificate_authority": ""
+  }
+}'
+```
+
+</Details>
+
+:::note
+
+The only valid value for `type` is `"dv"`. For `method`, use `"http"` or `"txt"` with ACME-based CAs (Let's Encrypt, Google Trust Services). If you only want to change the CA without modifying validation settings, use your existing validation method.
+
+:::
 
 ## Certificate details and compatibility
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates.mdx
@@ -55,7 +55,7 @@ To let Cloudflare choose the best CA, set `certificate_authority` to an empty st
 
 ```sh
 curl --request PATCH \
-https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id}" \
 --header "X-Auth-Email: <EMAIL>" \
 --header "X-Auth-Key: <API_KEY>" \
 --header "Content-Type: application/json" \

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates.mdx
@@ -33,8 +33,8 @@ This triggers certificate re-issuance with the new CA.
 <Details header="Switch to Google Trust Services">
 
 ```sh
-curl --request PATCH \
-https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+curl --request PATCH 
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id}" \
 --header "X-Auth-Email: <EMAIL>" \
 --header "X-Auth-Key: <API_KEY>" \
 --header "Content-Type: application/json" \

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
@@ -59,7 +59,7 @@ curl --request PATCH \
 
 ```sh
 curl --request PATCH \
-https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id}" \
 --header "X-Auth-Email: <EMAIL>" \
 --header "X-Auth-Key: <API_KEY>" \
 --header "Content-Type: application/json" \

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
@@ -19,25 +19,24 @@ As a SaaS provider, you may want to configure and manage Cloudflare for SaaS [vi
 | [List custom hostnames](/api/resources/custom_hostnames/methods/list/)                                        | Use the `page` parameter to pull additional pages. Add a `hostname` parameter to search for specific hostnames.                         |
 | [Create custom hostname](/api/resources/custom_hostnames/methods/create/)                                      | In the `validation_records` object of the response, use the `txt_name` and `txt_record` listed  to validate the custom hostname.        |
 | [Custom hostname details](/api/resources/custom_hostnames/methods/get/)                                    |                                                                                                                                         |
-| [Edit custom hostname](/api/resources/custom_hostnames/methods/edit/)                                          | When sent with an `ssl` object that matches the existing value, indicates that hostname should restart domain control validation (DCV). Can also [change the certificate authority](#change-certificate-authority). |
+| [Edit custom hostname](/api/resources/custom_hostnames/methods/edit/)                                          | When sent with an `ssl` object that matches the existing value, indicates that hostname should restart domain control validation (DCV). Refer to [Edit custom hostname SSL](#edit-custom-hostname-ssl) for required fields. |
 | [Delete custom hostname](/api/resources/custom_hostnames/methods/delete/) | Also deletes any associated SSL/TLS certificates.                                                                                       |
 
-### Change certificate authority
+### Edit custom hostname SSL
 
-To change the [certificate authority (CA)](/ssl/reference/certificate-authorities/) for an existing custom hostname, send a PATCH request with `ssl.certificate_authority` set to the desired CA. You must also include `ssl.type` and `ssl.method` — omitting them returns an error.
+Custom hostname SSL configurations come in two types, each with different required fields when sending a [PATCH request](/api/resources/custom_hostnames/methods/edit/).
 
-Valid `certificate_authority` values:
+#### Managed certificates
 
-- `"google"` — Google Trust Services
-- `"lets_encrypt"` — Let's Encrypt
-- `"ssl_com"` — SSL.com
-- `""` (empty string) — Default CA (Cloudflare selects the best option)
+Cloudflare handles the certificate lifecycle (ordering, validation, renewal). When editing a managed custom hostname's `ssl` object, `type` and `method` are always required:
 
-Valid `method` values: `"http"`, `"txt"`. Non-ACME CAs also support `"email"` and `"cname"`.
+- `type` — Validation type. The only valid value is `"dv"`.
+- `method` — Validation method. Use `"http"` or `"txt"`.
+- `certificate_authority` — Optional. Valid values: `"google"`, `"lets_encrypt"`, `"ssl_com"`, or `""` (empty string for [default CA](/ssl/reference/certificate-authorities/)).
 
-Changing the CA triggers certificate re-issuance with the new CA.
+Changing the `certificate_authority` triggers certificate re-issuance with the new CA.
 
-<Details header="Switch to Google Trust Services">
+<Details header="Example: Change certificate authority">
 
 ```sh
 curl --request PATCH \
@@ -56,7 +55,7 @@ https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_ho
 
 </Details>
 
-<Details header="Reset to default CA">
+<Details header="Example: Reset to default CA">
 
 ```sh
 curl --request PATCH \
@@ -69,6 +68,32 @@ https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_ho
       "type": "dv",
       "method": "http",
       "certificate_authority": ""
+  }
+}'
+```
+
+</Details>
+
+#### Custom certificates
+
+You provide your own certificate and key material. When editing a [custom certificate](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/) hostname's `ssl` object, `custom_certificate` is always required, plus one of `custom_key` or `custom_csr_id`:
+
+- `custom_certificate` — PEM-encoded certificate. Always required.
+- `custom_key` — PEM-encoded private key. Required unless using a CSR.
+- `custom_csr_id` — ID of a previously created [certificate signing request](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/certificate-signing-requests/). Required if the private key was generated via CSR.
+
+<Details header="Example: Update custom certificate">
+
+```sh
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>" \
+--header "Content-Type: application/json" \
+--data '{
+  "ssl": {
+      "custom_certificate": "<CERTIFICATE_STRING>",
+      "custom_key": "<PRIVATE_KEY_STRING>"
   }
 }'
 ```

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
@@ -86,7 +86,7 @@ You provide your own certificate and key material. When editing a [custom certif
 
 ```sh
 curl --request PATCH \
-https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id}" \
 --header "X-Auth-Email: <EMAIL>" \
 --header "X-Auth-Key: <API_KEY>" \
 --header "Content-Type: application/json" \

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
@@ -40,7 +40,7 @@ Changing the `certificate_authority` triggers certificate re-issuance with the n
 
 ```sh
 curl --request PATCH \
-https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+"https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id}" \
 --header "X-Auth-Email: <EMAIL>" \
 --header "X-Auth-Key: <API_KEY>" \
 --header "Content-Type: application/json" \

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
@@ -6,6 +6,8 @@ sidebar:
 
 ---
 
+import { Details } from "~/components";
+
 As a SaaS provider, you may want to configure and manage Cloudflare for SaaS [via the API](/api/) rather than the [Cloudflare dashboard](https://dash.cloudflare.com/). Below are relevant API calls for creating, editing, and deleting custom hostnames, as well as monitoring, updating, and deleting fallback origins. Further details can be found in the [Cloudflare API documentation](/api/).
 
 ***
@@ -17,8 +19,61 @@ As a SaaS provider, you may want to configure and manage Cloudflare for SaaS [vi
 | [List custom hostnames](/api/resources/custom_hostnames/methods/list/)                                        | Use the `page` parameter to pull additional pages. Add a `hostname` parameter to search for specific hostnames.                         |
 | [Create custom hostname](/api/resources/custom_hostnames/methods/create/)                                      | In the `validation_records` object of the response, use the `txt_name` and `txt_record` listed  to validate the custom hostname.        |
 | [Custom hostname details](/api/resources/custom_hostnames/methods/get/)                                    |                                                                                                                                         |
-| [Edit custom hostname](/api/resources/custom_hostnames/methods/edit/)                                          | When sent with an `ssl` object that matches the existing value, indicates that hostname should restart domain control validation (DCV). |
+| [Edit custom hostname](/api/resources/custom_hostnames/methods/edit/)                                          | When sent with an `ssl` object that matches the existing value, indicates that hostname should restart domain control validation (DCV). Can also [change the certificate authority](#change-certificate-authority). |
 | [Delete custom hostname](/api/resources/custom_hostnames/methods/delete/) | Also deletes any associated SSL/TLS certificates.                                                                                       |
+
+### Change certificate authority
+
+To change the [certificate authority (CA)](/ssl/reference/certificate-authorities/) for an existing custom hostname, send a PATCH request with `ssl.certificate_authority` set to the desired CA. You must also include `ssl.type` and `ssl.method` — omitting them returns an error.
+
+Valid `certificate_authority` values:
+
+- `"google"` — Google Trust Services
+- `"lets_encrypt"` — Let's Encrypt
+- `"ssl_com"` — SSL.com
+- `""` (empty string) — Default CA (Cloudflare selects the best option)
+
+Valid `method` values: `"http"`, `"txt"`. Non-ACME CAs also support `"email"` and `"cname"`.
+
+Changing the CA triggers certificate re-issuance with the new CA.
+
+<Details header="Switch to Google Trust Services">
+
+```sh
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>" \
+--header "Content-Type: application/json" \
+--data '{
+  "ssl": {
+      "type": "dv",
+      "method": "http",
+      "certificate_authority": "google"
+  }
+}'
+```
+
+</Details>
+
+<Details header="Reset to default CA">
+
+```sh
+curl --request PATCH \
+https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id} \
+--header "X-Auth-Email: <EMAIL>" \
+--header "X-Auth-Key: <API_KEY>" \
+--header "Content-Type: application/json" \
+--data '{
+  "ssl": {
+      "type": "dv",
+      "method": "http",
+      "certificate_authority": ""
+  }
+}'
+```
+
+</Details>
 
 ## Fallback origins
 


### PR DESCRIPTION
## Summary

- Documents that `ssl.type` and `ssl.method` are **required** when using PATCH to change `ssl.certificate_authority` on an existing custom hostname — omitting them silently fails or returns error 1434
- Adds examples and valid values across three pages: common API calls, certificate issuance, and troubleshooting

## Changes

### `common-api-calls.mdx`
- Updated "Edit custom hostname" table row to link to new CA switching section
- Added `### Change certificate authority` subsection with valid values, method info, and two collapsible curl examples (switch to Google, reset to default)

### `issue-certificates.mdx`
- Added `## Change certificate authority` section between existing "Certificate authorities" and "Certificate details" sections
- Includes PATCH examples and a note on valid `type`/`method` values

### `troubleshooting.mdx`
- Added `## Certificate authority change not taking effect via API` troubleshooting entry with example and valid CA values

## Context

The PATCH `/zones/{zone_id}/custom_hostnames/{id}` endpoint requires `ssl.type` ("dv") and `ssl.method` ("http"/"txt") when changing `ssl.certificate_authority`, but this wasn't documented. The API reference marks `type` and `method` as optional, which is misleading for this use case. Customers (notably beehiiv) hit error 1434 (`ErrValidationTypeMethodRequired`) when sending only `certificate_authority`.