### PR TITLE
fix: correct typo 'Docusarus' to 'Docusaurus' in pages framework guide

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-docusaurus-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-docusaurus-site.mdx
@@ -34,7 +34,7 @@ To use `create-cloudflare` to create a new Docusaurus project, run the following
 <Render
 	file="deploy-to-pages-steps-with-preset"
 	product="pages"
-	params={{ name: "Docusarus" }}
+	params={{ name: "Docusaurus" }}
 />
 
 <PagesBuildPreset framework="docusaurus" />


### PR DESCRIPTION
### Summary

URL: https://developers.cloudflare.com/pages/framework-guides/deploy-a-docusaurus-site/
In the guide, I was just confused with the wrong letter.

### Screenshots (optional)

<img width="1312" height="725" alt="image" src="https://github.com/user-attachments/assets/db94a855-0f76-4f9f-b134-3ba1efac6858" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
