### PR TITLE
Fix codemode docs: clarify JavaScript execution

### DIFF
--- a/src/content/changelog/agents/2026-02-20-codemode-sdk-rewrite.mdx
+++ b/src/content/changelog/agents/2026-02-20-codemode-sdk-rewrite.mdx
@@ -11,7 +11,7 @@ import { TypeScriptExample, WranglerConfig } from "~/components";
 
 The [`@cloudflare/codemode`](https://www.npmjs.com/package/@cloudflare/codemode) package has been rewritten into a modular, runtime-agnostic SDK.
 
-[Code Mode](https://blog.cloudflare.com/code-mode/) enables LLMs to write and execute JavaScript that orchestrates your tools, instead of calling them one at a time. This can (and does) yield significant token savings, reduces context window pressure and improves overall model performance on a task.
+[Code Mode](https://blog.cloudflare.com/code-mode/) enables LLMs to write and execute code that orchestrates your tools, instead of calling them one at a time. This can (and does) yield significant token savings, reduces context window pressure and improves overall model performance on a task.
 
 The new `Executor` interface is runtime agnostic and comes with a prebuilt `DynamicWorkerExecutor` to run generated code in a [Dynamic Worker Loader](/workers/runtime-apis/bindings/worker-loader/).
 

--- a/src/content/changelog/agents/2026-02-20-codemode-sdk-rewrite.mdx
+++ b/src/content/changelog/agents/2026-02-20-codemode-sdk-rewrite.mdx
@@ -11,7 +11,7 @@ import { TypeScriptExample, WranglerConfig } from "~/components";
 
 The [`@cloudflare/codemode`](https://www.npmjs.com/package/@cloudflare/codemode) package has been rewritten into a modular, runtime-agnostic SDK.
 
-[Code Mode](https://blog.cloudflare.com/code-mode/) enables LLMs to write and execute TypeScript that orchestrates your tools, instead of calling them one at a time. This can (and does) yield significant token savings, reduces context window pressure and improves overall model performance on a task.
+[Code Mode](https://blog.cloudflare.com/code-mode/) enables LLMs to write and execute JavaScript that orchestrates your tools, instead of calling them one at a time. This can (and does) yield significant token savings, reduces context window pressure and improves overall model performance on a task.
 
 The new `Executor` interface is runtime agnostic and comes with a prebuilt `DynamicWorkerExecutor` to run generated code in a [Dynamic Worker Loader](/workers/runtime-apis/bindings/worker-loader/).
 
@@ -26,6 +26,7 @@ The new `Executor` interface is runtime agnostic and comes with a prebuilt `Dyna
 - **`Executor` interface** — Minimal `execute(code, fns)` contract. Implement for any code sandboxing primitive or runtime.
 
 ### `DynamicWorkerExecutor`
+
 Runs code in a [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/). It comes with the following features:
 
 - **Network isolation** — `fetch()` and `connect()` blocked by default (`globalOutbound: null`) when using `DynamicWorkerExecutor`

--- a/src/content/docs/agents/api-reference/codemode.mdx
+++ b/src/content/docs/agents/api-reference/codemode.mdx
@@ -7,13 +7,18 @@ sidebar:
   order: 19
 ---
 
-import { TypeScriptExample, WranglerConfig, LinkCard, InlineBadge } from "~/components";
+import {
+	TypeScriptExample,
+	WranglerConfig,
+	LinkCard,
+	InlineBadge,
+} from "~/components";
 
 <InlineBadge preset="beta" />
 
-Codemode lets LLMs write and execute code that orchestrates your tools, instead of calling them one at a time. Inspired by [CodeAct](https://machinelearning.apple.com/research/codeact), it works because LLMs are better at writing code than making individual tool calls — they have seen millions of lines of real-world TypeScript but only contrived tool-calling examples.
+Codemode lets LLMs write and execute code that orchestrates your tools, instead of calling them one at a time. Inspired by [CodeAct](https://machinelearning.apple.com/research/codeact), it works because LLMs are better at writing code than making individual tool calls — they have seen millions of lines of real-world code but only contrived tool-calling examples.
 
-The `@cloudflare/codemode` package converts your tools into typed TypeScript APIs, gives the LLM a single "write code" tool, and executes the generated code in a secure, isolated Worker sandbox.
+The `@cloudflare/codemode` package generates TypeScript type definitions from your tools, gives the LLM a single "write code" tool, and executes the generated JavaScript in a secure, isolated Worker sandbox.
 
 :::caution
 Codemode is experimental and may have breaking changes in future releases. Use with caution in production.
@@ -268,21 +273,21 @@ interface ExecuteResult {
 
 Returns an AI SDK compatible `Tool`.
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `tools` | `ToolSet \| ToolDescriptors` | required | Your tools (AI SDK `tool()` or raw descriptors) |
-| `executor` | `Executor` | required | Where to run the generated code |
-| `description` | `string` | auto-generated | Custom tool description. Use `\{\{types\}\}` for type defs |
+| Option        | Type                         | Default        | Description                                                |
+| ------------- | ---------------------------- | -------------- | ---------------------------------------------------------- |
+| `tools`       | `ToolSet \| ToolDescriptors` | required       | Your tools (AI SDK `tool()` or raw descriptors)            |
+| `executor`    | `Executor`                   | required       | Where to run the generated code                            |
+| `description` | `string`                     | auto-generated | Custom tool description. Use `\{\{types\}\}` for type defs |
 
 ### `DynamicWorkerExecutor`
 
 Executes code in an isolated Cloudflare Worker via `WorkerLoader`.
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `loader` | `WorkerLoader` | required | Worker Loader binding from `env.LOADER` |
-| `timeout` | `number` | `30000` | Execution timeout in ms |
-| `globalOutbound` | `Fetcher \| null` | `null` | Network access control. `null` = blocked, `Fetcher` = routed |
+| Option           | Type              | Default  | Description                                                  |
+| ---------------- | ----------------- | -------- | ------------------------------------------------------------ |
+| `loader`         | `WorkerLoader`    | required | Worker Loader binding from `env.LOADER`                      |
+| `timeout`        | `number`          | `30000`  | Execution timeout in ms                                      |
+| `globalOutbound` | `Fetcher \| null` | `null`   | Network access control. `null` = blocked, `Fetcher` = routed |
 
 ### `generateTypes(tools)`
 


### PR DESCRIPTION
## Summary
- Codemode's Dynamic Worker executor only accepts JavaScript, but docs described it as TypeScript execution
- Changed "write and execute TypeScript" → "write and execute JavaScript" in changelog
- Clarified that the package generates TypeScript type definitions for LLM context, but executes generated JavaScript
- Removed misleading "real-world TypeScript" phrasing in the API reference intro

Closes cloudflare/agents#959

## Test plan
- [ ] Verify rendered changelog page no longer claims TypeScript execution
- [ ] Verify API reference intro accurately describes JavaScript execution with TypeScript type generation