### PR TITLE
[Workers AI] Convert model page code examples from accordion to tabs

### DIFF
--- a/src/components/models/code/AutomaticSpeechRecognitionCode.astro
+++ b/src/components/models/code/AutomaticSpeechRecognitionCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -45,10 +44,11 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/AutomaticSpeechRecognitionCode.astro
+++ b/src/components/models/code/AutomaticSpeechRecognitionCode.astro
@@ -46,7 +46,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/Bge-Reranker-Base.astro
+++ b/src/components/models/code/Bge-Reranker-Base.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -66,14 +65,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Worker" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="Python" open>
-	<Code code={python} lang="py" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="Python" icon="seti:python">
+		<Code code={python} lang="py" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/Bge-Reranker-Base.astro
+++ b/src/components/models/code/Bge-Reranker-Base.astro
@@ -67,10 +67,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="Python" icon="seti:python">
-		<Code code={python} lang="py" />
+		<Code code={python} lang="py" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/DeepgramAura.astro
+++ b/src/components/models/code/DeepgramAura.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -37,12 +36,11 @@ curl --request POST \
 `;
 ---
 
-<>
-	<Details header="Worker" open>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
 		<Code code={worker} lang="ts" />
-	</Details>
-
-	<Details header="curl" open>
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />
-	</Details>
-</>
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/DeepgramAura.astro
+++ b/src/components/models/code/DeepgramAura.astro
@@ -38,7 +38,7 @@ curl --request POST \
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/DeepgramNova.astro
+++ b/src/components/models/code/DeepgramNova.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -41,12 +40,11 @@ curl --request POST \
 `;
 ---
 
-<>
-	<Details header="Worker" open>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
 		<Code code={worker} lang="ts" />
-	</Details>
-
-	<Details header="curl" open>
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />
-	</Details>
-</>
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/DeepgramNova.astro
+++ b/src/components/models/code/DeepgramNova.astro
@@ -42,7 +42,7 @@ curl --request POST \
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/Flux-1-Schnell.astro
+++ b/src/components/models/code/Flux-1-Schnell.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -62,14 +61,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - Returning a data URI - TypeScript" open>
-	<Code code={workerReturningDataURI} lang="ts" />
-</Details>
-
-<Details header="Workers - Returning an image - TypeScript" open>
-	<Code code={workerReturningImage} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="Worker (Data URI)" icon="seti:typescript">
+		<Code code={workerReturningDataURI} lang="ts" />
+	</TabItem>
+	<TabItem label="Worker (Image)" icon="seti:typescript">
+		<Code code={workerReturningImage} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/Flux-2.astro
+++ b/src/components/models/code/Flux-2.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -54,10 +53,11 @@ curl --request POST \\
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={workerCode} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={workerCode} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/Flux-2.astro
+++ b/src/components/models/code/Flux-2.astro
@@ -55,7 +55,7 @@ curl --request POST \\
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={workerCode} lang="ts" />
+		<Code code={workerCode} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/ImageClassificationCode.astro
+++ b/src/components/models/code/ImageClassificationCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -43,10 +42,11 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/ImageClassificationCode.astro
+++ b/src/components/models/code/ImageClassificationCode.astro
@@ -44,7 +44,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/ImageToTextCode.astro
+++ b/src/components/models/code/ImageToTextCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
 import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
 
 type Props = z.infer<typeof props>;
 
@@ -36,6 +35,4 @@ export default {
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
+<Code code={worker} lang="ts" />

--- a/src/components/models/code/LlamaGuard.astro
+++ b/src/components/models/code/LlamaGuard.astro
@@ -66,10 +66,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="Python" icon="seti:python">
-		<Code code={python} lang="py" />
+		<Code code={python} lang="py" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/LlamaGuard.astro
+++ b/src/components/models/code/LlamaGuard.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -65,14 +64,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Worker" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="Python" open>
-	<Code code={python} lang="py" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="Python" icon="seti:python">
+		<Code code={python} lang="py" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/MelottsCode.astro
+++ b/src/components/models/code/MelottsCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
 import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
 
 type Props = z.infer<typeof props>;
 
@@ -28,6 +27,4 @@ export default {
 } satisfies ExportedHandler<Env>;`;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
+<Code code={worker} lang="ts" />

--- a/src/components/models/code/ObjectDetectionCode.astro
+++ b/src/components/models/code/ObjectDetectionCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -43,10 +42,11 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/ObjectDetectionCode.astro
+++ b/src/components/models/code/ObjectDetectionCode.astro
@@ -44,7 +44,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/OpenAIResponsesTextGenerationCode.astro
+++ b/src/components/models/code/OpenAIResponsesTextGenerationCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Aside, Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -56,38 +55,37 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/
 `;
 ---
 
-<>
-	<Details header="Worker" open>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
 		<Code code={worker} lang="ts" />
-	</Details>
-
-	<Details header="Python" open>
+	</TabItem>
+	<TabItem label="Python" icon="seti:python">
 		<Code code={python} lang="py" />
-	</Details>
-
-	<Details header="curl" open>
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />
-	</Details>
+	</TabItem>
+</Tabs>
 
-	<Aside type="note" title="Multiple API format support">
-		This model supports three different API formats:
-		<ul>
-			<li>
-				<strong>Responses API</strong> (<code>/ai/v1/responses</code>) - Native
-				OpenAI responses format shown above with <code>input</code> parameter
-			</li>
-			<li>
-				<strong>Workers AI Run</strong> (<code>/ai/run</code>) - Dynamic format
-				detection, accepts Chat Completions (<code>messages</code>), legacy Completions
-				(<code>prompt</code>), or Responses API (<code>input</code>)
-			</li>
-			<li>
-				<strong>Chat Completions</strong> (<code>/v1/chat/completions</code>) -
-				OpenAI-compatible endpoint with <code>messages</code> array. Refer to{" "}
-				<a href="/workers-ai/configuration/open-ai-compatibility/">
-					OpenAI Compatibility
-				</a>{" "}
-				for details.
-			</li>
-		</ul>
-	</Aside>
+<Aside type="note" title="Multiple API format support">
+	This model supports three different API formats:
+	<ul>
+		<li>
+			<strong>Responses API</strong> (<code>/ai/v1/responses</code>) - Native
+			OpenAI responses format shown above with <code>input</code> parameter
+		</li>
+		<li>
+			<strong>Workers AI Run</strong> (<code>/ai/run</code>) - Dynamic format
+			detection, accepts Chat Completions (<code>messages</code>), legacy Completions
+			(<code>prompt</code>), or Responses API (<code>input</code>)
+		</li>
+		<li>
+			<strong>Chat Completions</strong> (<code>/v1/chat/completions</code>) -
+			OpenAI-compatible endpoint with <code>messages</code> array. Refer to{" "}
+			<a href="/workers-ai/configuration/open-ai-compatibility/">
+				OpenAI Compatibility
+			</a>{" "}
+			for details.
+		</li>
+	</ul>
+</Aside>

--- a/src/components/models/code/OpenAIResponsesTextGenerationCode.astro
+++ b/src/components/models/code/OpenAIResponsesTextGenerationCode.astro
@@ -57,10 +57,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="Python" icon="seti:python">
-		<Code code={python} lang="py" />
+		<Code code={python} lang="py" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/StableDiffusion-v1-5-img2imgCode.astro
+++ b/src/components/models/code/StableDiffusion-v1-5-img2imgCode.astro
@@ -52,7 +52,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/StableDiffusion-v1-5-img2imgCode.astro
+++ b/src/components/models/code/StableDiffusion-v1-5-img2imgCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -51,10 +50,11 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/StableDiffusion-v1-5-inpaintingCode.astro
+++ b/src/components/models/code/StableDiffusion-v1-5-inpaintingCode.astro
@@ -59,7 +59,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/StableDiffusion-v1-5-inpaintingCode.astro
+++ b/src/components/models/code/StableDiffusion-v1-5-inpaintingCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -58,10 +57,11 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/SummarizationCode.astro
+++ b/src/components/models/code/SummarizationCode.astro
@@ -38,7 +38,7 @@ curl https://api.cloudflare.com/client/v4/accounts/{cf_account_id}/ai/run/${name
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/SummarizationCode.astro
+++ b/src/components/models/code/SummarizationCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -37,10 +36,11 @@ curl https://api.cloudflare.com/client/v4/accounts/{cf_account_id}/ai/run/${name
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/TextClassificationCode.astro
+++ b/src/components/models/code/TextClassificationCode.astro
@@ -52,10 +52,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="Python" icon="seti:python">
-		<Code code={python} lang="py" />
+		<Code code={python} lang="py" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/TextClassificationCode.astro
+++ b/src/components/models/code/TextClassificationCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -51,14 +50,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="Python" open>
-	<Code code={python} lang="py" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="Python" icon="seti:python">
+		<Code code={python} lang="py" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/TextEmbeddingCode.astro
+++ b/src/components/models/code/TextEmbeddingCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Aside, Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -69,17 +68,17 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="Python" open>
-	<Code code={python} lang="py" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="Python" icon="seti:python">
+		<Code code={python} lang="py" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>
 
 <Aside type="note" title="OpenAI compatible endpoints">
 	Workers AI also supports OpenAI compatible API endpoints for{" "}

--- a/src/components/models/code/TextEmbeddingCode.astro
+++ b/src/components/models/code/TextEmbeddingCode.astro
@@ -70,10 +70,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="Python" icon="seti:python">
-		<Code code={python} lang="py" />
+		<Code code={python} lang="py" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/TextGenerationCode.astro
+++ b/src/components/models/code/TextGenerationCode.astro
@@ -123,7 +123,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 	lora ? (
 		<Tabs syncKey="workersAiExamples">
 			<TabItem label="TypeScript" icon="seti:typescript">
-				<Code code={loraWorker} lang="ts" />
+				<Code code={loraWorker} lang="ts" title="" />
 			</TabItem>
 			<TabItem label="curl" icon="seti:shell">
 				<Code code={loraCurl} lang="sh" />
@@ -136,10 +136,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 					<Code code={streamingWorker} lang="ts" />
 				</TabItem>
 				<TabItem label="TypeScript" icon="seti:typescript">
-					<Code code={worker} lang="ts" />
+					<Code code={worker} lang="ts" title="" />
 				</TabItem>
 				<TabItem label="Python" icon="seti:python">
-					<Code code={python} lang="py" />
+					<Code code={python} lang="py" title="" />
 				</TabItem>
 				<TabItem label="curl" icon="seti:shell">
 					<Code code={curl} lang="sh" />

--- a/src/components/models/code/TextGenerationCode.astro
+++ b/src/components/models/code/TextGenerationCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Aside, Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -122,32 +121,30 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 {
 	lora ? (
-		<>
-			<Details header="Worker" open>
+		<Tabs syncKey="workersAiExamples">
+			<TabItem label="TypeScript" icon="seti:typescript">
 				<Code code={loraWorker} lang="ts" />
-			</Details>
-
-			<Details header="cURL" open>
+			</TabItem>
+			<TabItem label="curl" icon="seti:shell">
 				<Code code={loraCurl} lang="sh" />
-			</Details>
-		</>
+			</TabItem>
+		</Tabs>
 	) : (
 		<>
-			<Details header="Worker - Streaming" open>
-				<Code code={streamingWorker} lang="ts" />
-			</Details>
-
-			<Details header="Worker" open>
-				<Code code={worker} lang="ts" />
-			</Details>
-
-			<Details header="Python" open>
-				<Code code={python} lang="py" />
-			</Details>
-
-			<Details header="curl" open>
-				<Code code={curl} lang="sh" />
-			</Details>
+			<Tabs syncKey="workersAiExamples">
+				<TabItem label="Worker (Streaming)" icon="seti:typescript">
+					<Code code={streamingWorker} lang="ts" />
+				</TabItem>
+				<TabItem label="TypeScript" icon="seti:typescript">
+					<Code code={worker} lang="ts" />
+				</TabItem>
+				<TabItem label="Python" icon="seti:python">
+					<Code code={python} lang="py" />
+				</TabItem>
+				<TabItem label="curl" icon="seti:shell">
+					<Code code={curl} lang="sh" />
+				</TabItem>
+			</Tabs>
 
 			<Aside type="note" title="OpenAI compatible endpoints">
 				Workers AI also supports OpenAI compatible API endpoints for{" "}

--- a/src/components/models/code/TextToImageCode.astro
+++ b/src/components/models/code/TextToImageCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -45,10 +44,11 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/TextToImageCode.astro
+++ b/src/components/models/code/TextToImageCode.astro
@@ -46,7 +46,7 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/TranslationCode.astro
+++ b/src/components/models/code/TranslationCode.astro
@@ -61,10 +61,10 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 	</TabItem>
 	<TabItem label="Python" icon="seti:python">
-		<Code code={python} lang="py" />
+		<Code code={python} lang="py" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />

--- a/src/components/models/code/TranslationCode.astro
+++ b/src/components/models/code/TranslationCode.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 type Props = z.infer<typeof props>;
 
@@ -60,14 +59,14 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-</Details>
-
-<Details header="Python" open>
-	<Code code={python} lang="py" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+	</TabItem>
+	<TabItem label="Python" icon="seti:python">
+		<Code code={python} lang="py" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/WhisperBase64Code.astro
+++ b/src/components/models/code/WhisperBase64Code.astro
@@ -1,7 +1,6 @@
 ---
 import { z } from "astro:schema";
-import { Code } from "@astrojs/starlight/components";
-import Details from "~/components/Details.astro";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import Render from "~/components/Render.astro";
 
 type Props = z.infer<typeof props>;
@@ -81,15 +80,15 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 `;
 ---
 
-<Details header="Workers - TypeScript" open>
-	<Code code={worker} lang="ts" />
-	<Render file="nodejs-compat-howto" product="workers" />
-</Details>
-
-<Details header="Python" open>
-	<Code code={python} lang="py" />
-</Details>
-
-<Details header="curl" open>
-	<Code code={curl} lang="sh" />
-</Details>
+<Tabs syncKey="workersAiExamples">
+	<TabItem label="TypeScript" icon="seti:typescript">
+		<Code code={worker} lang="ts" />
+		<Render file="nodejs-compat-howto" product="workers" />
+	</TabItem>
+	<TabItem label="Python" icon="seti:python">
+		<Code code={python} lang="py" />
+	</TabItem>
+	<TabItem label="curl" icon="seti:shell">
+		<Code code={curl} lang="sh" />
+	</TabItem>
+</Tabs>

--- a/src/components/models/code/WhisperBase64Code.astro
+++ b/src/components/models/code/WhisperBase64Code.astro
@@ -82,11 +82,11 @@ curl https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run
 
 <Tabs syncKey="workersAiExamples">
 	<TabItem label="TypeScript" icon="seti:typescript">
-		<Code code={worker} lang="ts" />
+		<Code code={worker} lang="ts" title="" />
 		<Render file="nodejs-compat-howto" product="workers" />
 	</TabItem>
 	<TabItem label="Python" icon="seti:python">
-		<Code code={python} lang="py" />
+		<Code code={python} lang="py" title="" />
 	</TabItem>
 	<TabItem label="curl" icon="seti:shell">
 		<Code code={curl} lang="sh" />


### PR DESCRIPTION
<img width="780" height="710" alt="image" src="https://github.com/user-attachments/assets/e92f95d0-beaa-40fd-9c04-2b1547530d3a" />

## Summary

Converts code examples on Workers AI model detail pages from accordion-style (`<Details>`) to tabbed layout (`<Tabs>`/`<TabItem>`), improving UX consistency with the rest of the documentation site.

### Changes

- **18 components** converted to tabbed layout with `syncKey="workersAiExamples"` for persistent language preference across pages
- **2 single-example components** (`ImageToTextCode`, `MelottsCode`) converted to bare `<Code>` blocks
- **1 component** (`DeepgramFlux`) unchanged as it uses step-by-step workflow pattern

### Before/After

**Before:** Accordion-style collapsible sections (all expanded by default)
**After:** Tabbed interface matching the pattern used elsewhere in the docs (e.g., TypeScriptExample, WranglerConfig)

### Files Modified

21 files in `src/components/models/code/`

### Validation

- `npm run check` passes with 0 errors

---

Jira: [AIG-853](https://jira.cfdata.org/browse/AIG-853)