### PR TITLE
Correct grammar in pages build skipping section

### DIFF
--- a/src/content/docs/pages/configuration/git-integration/github-integration.mdx
+++ b/src/content/docs/pages/configuration/git-integration/github-integration.mdx
@@ -23,7 +23,7 @@ Every time you open a new pull request on your GitHub repository, Cloudflare Pag
 
 ### Skipping a build via a commit message
 
-Without any configuration required, you can choose to skip a deployment on an ad hoc basis. By adding the `[CI Skip]`, `[CI-Skip]`, `[Skip CI]`, `[Skip-CI]`, or `[CF-Pages-Skip]` flag as a prefix in your commit message, and Pages will omit that deployment. The prefixes are not case sensitive.
+Without any configuration required, you can choose to skip a deployment on an ad hoc basis. By adding the `[CI Skip]`, `[CI-Skip]`, `[Skip CI]`, `[Skip-CI]`, or `[CF-Pages-Skip]` flag as a prefix in your commit message, Pages will omit that deployment. The prefixes are not case sensitive.
 
 ### Check runs
 


### PR DESCRIPTION
### Summary

Corrects grammar in the pages build skipping section.

This changes the following line:

> By adding the `[CI Skip]`, `[CI-Skip]`, `[Skip CI]`, `[Skip-CI]`, or `[CF-Pages-Skip]` flag as a prefix in your commit message, <ins>**and**</ins> Pages will omit that deployment.

to:

> By adding the `[CI Skip]`, `[CI-Skip]`, `[Skip CI]`, `[Skip-CI]`, or `[CF-Pages-Skip]` flag as a prefix in your commit message, Pages will omit that deployment.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
