### PR TITLE
Fix ambiguous pronoun in "Customize Cloudflare IP addresses" section

### DIFF
--- a/src/content/docs/fundamentals/concepts/cloudflare-ip-addresses.mdx
+++ b/src/content/docs/fundamentals/concepts/cloudflare-ip-addresses.mdx
@@ -78,7 +78,7 @@ For further recommendations on securing your origin server, refer to our guide o
 
 ### Customize Cloudflare IP addresses
 
-If they do not want to use Cloudflare IP addresses — which are shared by all proxied hostnames — Enterprise customers have two potential alternatives:
+Enterprise customers who do not want to use Cloudflare IP addresses — which are shared by all proxied hostnames — have two potential alternatives:
 
 * [**Bring Your Own IP (BYOIP)**](/byoip/): Cloudflare announces your IPs (an IP address range you lease/own) in all of our [locations](https://www.cloudflare.com/network/).
 * **Static IP addresses**: Cloudflare sets static IP addresses for your domain. For more details, contact your account team.


### PR DESCRIPTION
The original sentence began with "If they do not want to use Cloudflare IP addresses...", where the pronoun "they" had no clear antecedent — the subject "Enterprise customers" only appeared later in the same sentence. This forward-reference makes the sentence harder to parse.

Rephrased to: "Enterprise customers who do not want to use Cloudflare IP addresses — which are shared by all proxied hostnames — have two potential alternatives:" to make the subject clear from the start.
