### PR TITLE
docs: add SEO descriptions to all docs missing description

### DIFF
--- a/bin/add-missing-descriptions.ts
+++ b/bin/add-missing-descriptions.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env tsx
+
+/**
+ * Adds SEO description to docs that are missing one.
+ * Derives description from page title and first paragraph of content (no external API).
+ *
+ * Usage: npx tsx bin/add-missing-descriptions.ts [--dry-run] [--product workers]
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import matter from "gray-matter";
+import globby from "fast-glob";
+
+const DOCS_DIR = path.join(process.cwd(), "src/content/docs");
+const MAX_DESCRIPTION_LENGTH = 160; // SEO meta description length
+
+function looksLikeCode(s: string): boolean {
+	const t = s.trim();
+	return (
+		/^\s*import\s/.test(t) ||
+		/\s+from\s+["']/.test(t) ||
+		/^[{}[\]<>]/.test(t) ||
+		/^<\/?[A-Z]/.test(t) ||
+		/^export\s/.test(t)
+	);
+}
+
+function extractFirstParagraph(content: string): string {
+	if (!content || !content.trim()) return "";
+
+	// Remove import statements (whole lines, including multiline)
+	let text = content.replace(/^import\s+[\s\S]*?from\s+["'][^"']+["'];?\s*$/gm, "");
+
+	// Remove JSX/component blocks for simplicity - take text between
+	text = text
+		.replace(/<[A-Z][^>]*>[\s\S]*?<\/[A-Z][^>]*>/g, " ")
+		.replace(/<[A-Za-z][^/>]*\/>/g, " ")
+		.replace(/<Render[^>]*\/>/g, " ")
+		.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1"); // links -> link text
+
+	// Get first block of prose (split by double newline or heading)
+	const blocks = text.split(/\n\n+/);
+	for (const block of blocks) {
+		const line = block
+			.replace(/^#+\s*/m, "")
+			.replace(/^[-*]\s*/gm, "")
+			.trim();
+		if (line.length > 20 && /[a-zA-Z]/.test(line) && !looksLikeCode(line)) {
+			const oneLine = line.replace(/\s+/g, " ").trim();
+			if (oneLine.length > 0) return oneLine;
+		}
+	}
+
+	// Fallback: first line with letters that is not code
+	const firstLine = text
+		.split("\n")
+		.find((l) => l.trim().length > 20 && /[a-zA-Z]/.test(l) && !looksLikeCode(l));
+	return firstLine ? firstLine.replace(/^#+\s*/, "").replace(/\s+/g, " ").trim() : "";
+}
+
+function truncateToLength(s: string, max: number): string {
+	s = s.trim();
+	if (s.length <= max) return s;
+	const cut = s.slice(0, max + 1);
+	const lastSpace = cut.lastIndexOf(" ");
+	return lastSpace > max - 20 ? cut.slice(0, lastSpace).trim() : cut.slice(0, max).trim();
+}
+
+function generateDescription(title: string, content: string): string {
+	const first = extractFirstParagraph(content);
+	if (first.length >= 30) {
+		return truncateToLength(first, MAX_DESCRIPTION_LENGTH);
+	}
+	// Fallback from title
+	const fallback = `Learn about ${title} in Cloudflare documentation.`;
+	return truncateToLength(fallback, MAX_DESCRIPTION_LENGTH);
+}
+
+async function updateFrontmatter(
+	filePath: string,
+	description: string,
+): Promise<boolean> {
+	const originalContent = await fs.readFile(filePath, "utf-8");
+	const { data: frontmatter } = matter(originalContent);
+	if (frontmatter.description) return false;
+
+	const frontmatterMatch = originalContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+	if (!frontmatterMatch) return false;
+
+	const originalFrontmatter = frontmatterMatch[1];
+	// YAML: quote and escape so colons/quotes don't break
+	const escaped = description.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, " ");
+	const newFrontmatter = `${originalFrontmatter.trim()}\ndescription: "${escaped}"`;
+	const updatedContent = originalContent.replace(
+		/^---\r?\n[\s\S]*?\r?\n---/,
+		`---\n${newFrontmatter}\n---`,
+	);
+	await fs.writeFile(filePath, updatedContent, "utf-8");
+	return true;
+}
+
+async function main() {
+	const args = process.argv.slice(2);
+	const dryRun = args.includes("--dry-run");
+	const productArg = args.find((a) => a.startsWith("--product="));
+	const productFilter = productArg?.split("=")[1];
+
+	const pattern = productFilter
+		? path.join(DOCS_DIR, productFilter, "**/*.mdx")
+		: path.join(DOCS_DIR, "**/*.mdx");
+
+	const files = await globby(pattern, { absolute: true });
+	let updated = 0;
+	let skipped = 0;
+	let errors = 0;
+
+	for (const filePath of files) {
+		try {
+			const content = await fs.readFile(filePath, "utf-8");
+			const { data: frontmatter, content: body } = matter(content);
+			if (frontmatter.description) {
+				skipped++;
+				continue;
+			}
+			const title = (frontmatter.title as string) || path.basename(filePath, ".mdx");
+			const description = generateDescription(title, body);
+			if (dryRun) {
+				console.log(`[dry-run] ${path.relative(process.cwd(), filePath)} -> ${description.slice(0, 60)}...`);
+				updated++;
+				continue;
+			}
+			const done = await updateFrontmatter(filePath, description);
+			if (done) {
+				updated++;
+				if (updated % 100 === 0) console.log(`Updated ${updated} files...`);
+			}
+		} catch (err) {
+			errors++;
+			console.error(`Error ${filePath}:`, err);
+		}
+	}
+
+	console.log("\nDone. Updated:", updated, "Skipped (had description):", skipped, "Errors:", errors);
+}
+
+main();


### PR DESCRIPTION
### Summary

Add bin/add-missing-descriptions.ts, a script that adds a description to every doc under src/content/docs that doesn’t have one. Descriptions are derived from the page title and the first paragraph of the body (no external API or AI Worker).

### Why it’s needed
- SEO: Meta descriptions improve search snippets and click-through; the style guide recommends them.
- Consistency: Many pages (e.g. most framework guides) had no description; only a minority did.
- Existing script isn’t automatic: bin/generate-descriptions.ts depends on a local AI Worker on localhost:8787, a full build, and distmd/; it’s not run in CI, so descriptions were never applied at scale. This script runs with no external services and can be re-run anytime.

### Usage
Add descriptions to any docs that still lack one (e.g. after adding new pages):
`npx tsx bin/add-missing-descriptions.ts`
Preview only (no file changes):
`npx tsx bin/add-missing-descriptions.ts --dry-run`
Limit to one product:
`npx tsx bin/add-missing-descriptions.ts --product=workers`

### Closes: #28509 

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
