### PR TITLE
[Pages] Add SEO descriptions to framework guide pages

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-blazor-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-blazor-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Blazor
+description: Deploy a Blazor SPA built with C# and WebAssembly to Cloudflare Pages.
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-brunch-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-brunch-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Brunch
+description: Deploy a Brunch front-end web application to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-docusaurus-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-docusaurus-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Docusaurus
+description: Deploy a Docusaurus static documentation site to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-gatsby-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-gatsby-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Gatsby
+description: Deploy a Gatsby React-based static site to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-gridsome-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-gridsome-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Gridsome
+description: Deploy a Gridsome Vue.js-powered Jamstack site to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-hexo-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hexo-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Hexo
+description: Deploy a Hexo static site powered by Node.js to Cloudflare Pages.
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-hono-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hono-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Hono
+description: Deploy a Hono lightweight web framework application to Cloudflare Pages.
 tags:
   - Hono
 ---

--- a/src/content/docs/pages/framework-guides/deploy-a-hugo-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-hugo-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Hugo
+description: Deploy a Hugo static site generator project to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render, TabItem, Tabs } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-jekyll-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-jekyll-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Jekyll
+description: Deploy a Jekyll static site built with Ruby and Markdown to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-pelican-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-pelican-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Pelican
+description: Deploy a Pelican Python-based static site to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-preact-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-preact-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Preact
+description: Deploy a Preact lightweight React alternative application to Cloudflare Pages.
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-qwik-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-qwik-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Qwik
+description: Deploy a Qwik resumable web application to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-react-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-react-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: React
+description: Deploy a React front-end application to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render, PackageManagers, DashButton } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-remix-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-remix-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Remix
+description: Deploy a Remix full-stack web application to Cloudflare Pages.
 tags: [Remix]
 ---
 

--- a/src/content/docs/pages/framework-guides/deploy-a-solid-start-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-solid-start-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: SolidStart
+description: Deploy a SolidStart application built with the Solid meta-framework to Cloudflare Pages.
 ---
 
 import { Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-sphinx-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-sphinx-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Sphinx
+description: Deploy a Sphinx Python documentation site to Cloudflare Pages.
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-vite3-project.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vite3-project.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Vite 3
+description: Deploy a Vite 3 front-end application to Cloudflare Pages.
 ---
 
 import { Render, PackageManagers, DashButton } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-vitepress-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vitepress-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: VitePress
+description: Deploy a VitePress static documentation site to Cloudflare Pages.
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-a-vue-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-vue-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Vue
+description: Deploy a Vue.js progressive JavaScript application to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Zola
+description: Deploy a Zola fast static site generator project to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-angular-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Angular
+description: Deploy an Angular front-end application to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render, PackageManagers } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-astro-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-astro-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Astro
+description: Deploy an Astro content-focused web application to Cloudflare Pages.
 ---
 
 import {

--- a/src/content/docs/pages/framework-guides/deploy-an-elderjs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-elderjs-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Elder.js
+description: Deploy an Elder.js SEO-focused static site to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-eleventy-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-eleventy-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Eleventy
+description: Deploy an Eleventy static site to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-emberjs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-emberjs-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Ember
+description: Deploy an Ember.js web application to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-an-mkdocs-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-mkdocs-site.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: MkDocs
+description: Deploy an MkDocs documentation site to Cloudflare Pages.
 ---
 
 import { PagesBuildPreset, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/deploy-anything.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-anything.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Static HTML
+description: Deploy any static HTML website to Cloudflare Pages without a framework.
 ---
 
 import { Details, Render } from "~/components";

--- a/src/content/docs/pages/framework-guides/index.mdx
+++ b/src/content/docs/pages/framework-guides/index.mdx
@@ -1,7 +1,7 @@
 ---
-
 pcx_content_type: navigation
 title: Framework guides
+description: Guides for deploying popular web frameworks and static site generators to Cloudflare Pages.
 sidebar:
   order: 3
   group:


### PR DESCRIPTION
Summary
Adds missing SEO description frontmatter to all 28 framework guide pages under `framework-guides` that lacked them. Previously only 5 of 33 files had descriptions (Next.js, Nuxt, Analog, SvelteKit, static Next.js). This improves search snippets, click-through rates, and metadata consistency across the docs.

Closes #28509

Screenshots (optional)
N/A — frontmatter-only changes with no visual impact on page content.

Documentation checklist
 The change adheres to the `documentation style guide`.
 If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.