### PR TITLE
[Logs] Add AS202623 to Logpush egress ASN lists

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/egress-ip.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/egress-ip.mdx
@@ -107,11 +107,11 @@ In the proxy zone, go to **Security** > **WAF** > **Custom rules** and create a 
 
 ### Add ASN-based filtering
 
-For defense in depth, add a rule to only allow traffic from Cloudflare's ASN. Logpush traffic originates from Cloudflare's network (ASN 13335 or 132892).
+For defense in depth, add a rule to only allow traffic from Cloudflare's ASNs. Logpush traffic originates from Cloudflare's network (ASN 13335, 132892, or 202623).
 
 - **Expression:**
   ```txt
-  (http.host eq "logpush.yourdestinationendpoint.com" and not ip.geoip.asnum in {13335 132892})
+  (http.host eq "logpush.yourdestinationendpoint.com" and not ip.geoip.asnum in {13335 132892 202623})
   ```
 - **Action:** Block
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/splunk.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/splunk.mdx
@@ -197,13 +197,13 @@ If your logpush destination hostname is proxied through Cloudflare, and you have
    | Hostname         | `equals`   | Your Splunk endpoint hostname. For example: `splunk.cf-analytics.com` |
    | URI Path         | `equals`   | `/services/collector/raw`                                             |
    | URI Query String | `contains` | `channel`                                                             |
-   | AS Num           | `equals`   | `132892`                                                              |
+   | AS Num           | `is in`    | `13335`, `132892`, `202623`                                           |
    | User Agent       | `equals`   | `Go-http-client/2.0`                                                  |
 
 5. After inputting the values as shown in the table, you should have an Expression Preview with the values you added for your specific rule. The example below reflects the hostname `splunk.cf-analytics.com`.
 
    ```txt
-   (http.request.method eq "POST" and http.host eq "splunk.cf-analytics.com" and http.request.uri.path eq "/services/collector/raw" and http.request.uri.query contains "channel" and ip.src.asnum eq 132892 and http.user_agent eq "Go-http-client/2.0")
+   (http.request.method eq "POST" and http.host eq "splunk.cf-analytics.com" and http.request.uri.path eq "/services/collector/raw" and http.request.uri.query contains "channel" and ip.geoip.asnum in {13335 132892 202623} and http.user_agent eq "Go-http-client/2.0")
    ```
 
 6. Under the **Then** > **Choose an action** dropdown, select _Skip_.
@@ -222,13 +222,13 @@ If your logpush destination hostname is proxied through Cloudflare, and you have
    | Hostname         | `equals`   | Your Splunk endpoint hostname. For example: `splunk.cf-analytics.com` |
    | URI Path         | `equals`   | `/services/collector/raw`                                             |
    | URI Query String | `contains` | `channel`                                                             |
-   | AS Num           | `equals`   | `132892`                                                              |
+   | AS Num           | `is in`    | `13335`, `132892`, `202623`                                           |
    | User Agent       | `equals`   | `Go-http-client/2.0`                                                  |
 
 4. After inputting the values as shown in the table, you should have an Expression Preview with the values you added for your specific rule. The example below reflects the hostname `splunk.cf-analytics.com`.
 
    ```txt
-   (http.request.method eq "POST" and http.host eq "splunk.cf-analytics.com" and http.request.uri.path eq "/services/collector/raw" and http.request.uri.query contains "channel" and ip.src.asnum eq 132892 and http.user_agent eq "Go-http-client/2.0")
+   (http.request.method eq "POST" and http.host eq "splunk.cf-analytics.com" and http.request.uri.path eq "/services/collector/raw" and http.request.uri.query contains "channel" and ip.geoip.asnum in {13335 132892 202623} and http.user_agent eq "Go-http-client/2.0")
    ```
 
 5. Under the **Then** > **Choose an action** dropdown, select _Skip_.


### PR DESCRIPTION
**Summary**

Add missing Cloudflare ASN (202623) to Logpush egress IP documentation and Splunk destination WAF rule examples.

## What changed

**Updated**: `/content/docs/logs/logpush/logpush-job/enable-destinations/egress-ip.mdx`
- Added AS202623 to the ASN text and WAF custom rule expression.

**Updated**: `rc/content/docs/logs/logpush/logpush-job/enable-destinations/splunk.mdx`
- Changed AS Num filter from single-ASN equals to multi-ASN is in across both dashboard tab variants.
- Updated both expression previews from ip.src.asnum eq 132892 to ip.geoip.asnum in {13335 132892 202623}.

## Why

Logpush load-balances log delivery across multiple core datacenters for resilience. Traffic can originate from ASN 13335, 132892, or 202623, but the docs only listed the first two. Customers using ASN-based filtering were inadvertently blocking legitimate Logpush traffic and losing logs.

The egress IP page was missing one ASN. The Splunk page was more incomplete — it only referenced a single ASN (132892) with an equals operator, which would also block traffic from AS13335.