### PR TITLE
docs: document inline comments in _redirects files

### DIFF
--- a/src/content/partials/workers/redirects.mdx
+++ b/src/content/partials/workers/redirects.mdx
@@ -45,7 +45,18 @@ Only one redirect can be defined per line and must follow this format, otherwise
 
   - Optional parameter
 
+### Comments
+
 Lines starting with a `#` will be treated as comments.
+
+You can also add inline comments to redirect rules. Any `#` token that appears after the `source` and `destination` (and optional `code`) will be treated as the start of a comment and ignored. URL fragments (for example, `/page#section`) are not affected because they do not have a space before the `#`.
+
+```txt
+# Full-line comment explaining the next group of redirects
+/old-page /new-page 301 # Moved during site redesign
+/blog/* /articles/:splat # Blog URL migration
+/page /page2#section 301 # URL fragment is preserved
+```
 
 ### Per file
 
@@ -67,7 +78,7 @@ A complete example with multiple redirects may look like the following:
 /trailing /trailing/ 301
 /notrailing/ /nottrailing 301
 /page/ /page2/#fragment 301
-/blog/* https://blog.my.domain/:splat
+/blog/* https://blog.my.domain/:splat # Blog migration
 /products/:code/:name /products?code=:code&name=:name
 ```
 


### PR DESCRIPTION
### Summary

Documents the new inline comment support for `_redirects` files, added in [cloudflare/workers-sdk#12467](https://github.com/cloudflare/workers-sdk/pull/12467).

Changes to `src/content/partials/workers/redirects.mdx`:
- Adds a new `### Comments` subsection documenting both full-line and inline comment syntax
- Explains how inline comments interact with URL fragments (space-delimited `#` starts a comment; `#` within a URL like `/page#section` is preserved)
- Adds a code example demonstrating full-line comments, inline comments, and fragment preservation
- Adds an inline comment to the existing "complete example" block for consistency

> [!IMPORTANT]
> **Do not merge** until the backend is running the new version of `workers-shared` that includes inline comment support. The feature is implemented in `workers-shared` ([PR](https://github.com/cloudflare/workers-sdk/pull/12467)) and won't be live until the backend picks up the new package version.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

