### PR TITLE
[Sandbox] Add changelog for backup and restore API

### DIFF
--- a/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
+++ b/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
@@ -1,35 +1,34 @@
 ---
 title: Backup and restore API for Sandbox SDK
-description: Create point-in-time snapshots of sandbox directories and restore them with copy-on-write overlays using R2 storage.
+description: Snapshot and restore sandbox directories in seconds with the new createBackup() and restoreBackup() methods.
 products:
   - agents
   - r2
 date: 2026-02-23
 ---
 
-The Sandbox SDK now supports `createBackup()` and `restoreBackup()` methods for creating point-in-time snapshots of sandbox directories and restoring them with copy-on-write overlays.
+The Sandbox SDK now supports `createBackup()` and `restoreBackup()` methods for creating point-in-time snapshots of sandbox directories and restoring them.
 
-Use backups to checkpoint work before risky operations, roll back to a known-good state, or persist directory snapshots across requests.
+The main use case is fast environment restoration. Instead of running `git clone` and `npm install` on every new session — which can take minutes — you can back up a fully-initialized `/workspace` directory and restore it in seconds. This makes it practical to pick up exactly where a user left off across requests without repeating expensive setup steps. You can also use backups to checkpoint work before risky operations and roll back if something goes wrong.
 
 ```ts
 import { getSandbox } from "@cloudflare/sandbox";
 
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
-// Create a backup of /workspace
+// Back up a fully-initialized workspace
 const backup = await sandbox.createBackup({ dir: "/workspace" });
 
-// Restore the backup after a failed operation
+// On next request, restore instead of re-cloning and reinstalling
 await sandbox.restoreBackup(backup);
 ```
-
-Backups are stored as compressed squashfs archives in an [R2](/r2/) bucket using presigned URLs for direct container-to-R2 transfers. Restores use FUSE overlayfs with copy-on-write semantics, so the original backup remains unchanged as new writes go to a separate upper layer.
 
 Key capabilities:
 
 - **Named backups** with optional human-readable labels
 - **Configurable TTL** (default: 3 days) enforced at restore time
-- **Serializable handles** that can be stored in KV, D1, or Durable Object storage for cross-request access
-- **Specific error codes** (`INVALID_BACKUP_CONFIG`, `BACKUP_CREATE_FAILED`, `BACKUP_NOT_FOUND`, `BACKUP_EXPIRED`, `BACKUP_RESTORE_FAILED`) for precise error handling
+- **Persist and reuse across requests** — store backup handles in KV, D1, or Durable Object storage so any subsequent request can restore the same environment
 
-To get started, configure a `BACKUP_BUCKET` R2 binding and R2 presigned URL credentials in your Wrangler configuration. Refer to the [backup and restore guide](/sandbox/guides/backup-restore/) for setup instructions and usage patterns, or the [Backups API reference](/sandbox/api/backups/) for full method documentation.
+Backups are stored in an [R2](/r2/) bucket. Restores currently use a FUSE overlay with copy-on-write semantics, so the original backup remains unchanged as new writes go to a separate layer. Soon, we will ship native snapshotting that is faster and works at a lower level — with the same API and no changes needed on your side.
+
+To get started, refer to the [backup and restore guide](/sandbox/guides/backup-restore/) for setup instructions and usage patterns, or the [Backups API reference](/sandbox/api/backups/) for full method documentation.

--- a/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
+++ b/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
@@ -9,7 +9,7 @@ date: 2026-02-23
 
 The Sandbox SDK now supports `createBackup()` and `restoreBackup()` methods for creating point-in-time snapshots of sandbox directories and restoring them.
 
-The main use case is fast environment restoration. Instead of running `git clone` and `npm install` on every new session — which can take minutes — you can back up a fully-initialized `/workspace` directory and restore it in seconds. This makes it practical to pick up exactly where a user left off across requests without repeating expensive setup steps. You can also use backups to checkpoint work before risky operations and roll back if something goes wrong.
+The main use case is fast environment restoration. Instead of running `git clone` and `npm install` on every new session — which can take minutes — you can back up a fully-initialized `/workspace` directory and restore it in seconds. This makes it practical to pick up exactly where a user left off across requests without repeating expensive setup steps. 
 
 ```ts
 import { getSandbox } from "@cloudflare/sandbox";
@@ -29,6 +29,7 @@ Key capabilities:
 - **Configurable TTL** (default: 3 days) enforced at restore time
 - **Persist and reuse across requests** — store backup handles in KV, D1, or Durable Object storage so any subsequent request can restore the same environment
 
-Backups are stored in an [R2](/r2/) bucket. Restores currently use a FUSE overlay with copy-on-write semantics, so the original backup remains unchanged as new writes go to a separate layer. Soon, we will ship native snapshotting that is faster and works at a lower level — with the same API and no changes needed on your side.
+Backups are stored in an [R2](/r2/) bucket. Restores currently use a FUSE overlay with copy-on-write semantics, so the original backup remains unchanged as new writes go to a separate layer. 
+Soon, we will ship native snapshotting that is faster and works at a lower level — with the same API and no changes needed on your side.
 
 To get started, refer to the [backup and restore guide](/sandbox/guides/backup-restore/) for setup instructions and usage patterns, or the [Backups API reference](/sandbox/api/backups/) for full method documentation.

--- a/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
+++ b/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
@@ -9,7 +9,7 @@ date: 2026-02-23
 
 The Sandbox SDK now supports `createBackup()` and `restoreBackup()` methods for creating point-in-time snapshots of sandbox directories and restoring them.
 
-The main use case is fast environment restoration. Instead of running `git clone` and `npm install` on every new session — which can take minutes — you can back up a fully-initialized `/workspace` directory and restore it in seconds. This makes it practical to pick up exactly where a user left off across requests without repeating expensive setup steps. 
+The main use case is fast environment restoration. Instead of running `git clone` and `npm install` on every new session — which can take minutes — you can back up a fully-initialized `/workspace` directory and restore it in seconds. This makes it practical to pick up exactly where a user left off across requests without repeating expensive setup steps.
 
 ```ts
 import { getSandbox } from "@cloudflare/sandbox";
@@ -29,7 +29,6 @@ Key capabilities:
 - **Configurable TTL** (default: 3 days) enforced at restore time
 - **Persist and reuse across requests** — store backup handles in KV, D1, or Durable Object storage so any subsequent request can restore the same environment
 
-Backups are stored in an [R2](/r2/) bucket. Restores currently use a FUSE overlay with copy-on-write semantics, so the original backup remains unchanged as new writes go to a separate layer. 
-Soon, we will ship native snapshotting that is faster and works at a lower level — with the same API and no changes needed on your side.
+Backups are stored in an [R2](/r2/) bucket. Backup and restore currently uses a FUSE overlay. Soon, native snapshotting at a lower level will be added to Containers and Sandboxes that will improve speed and ergonomics of storing in R2. The current backup functionality provides a significant speed improvement over manually recreating a file system, but it will be further optimized in the future. The new snapshotting system will use a similar API, so changing to this system will be simple once it is available.
 
 To get started, refer to the [backup and restore guide](/sandbox/guides/backup-restore/) for setup instructions and usage patterns, or the [Backups API reference](/sandbox/api/backups/) for full method documentation.

--- a/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
+++ b/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
@@ -2,7 +2,7 @@
 title: Backup and restore API for Sandbox SDK
 description: Create point-in-time snapshots of sandbox directories and restore them with copy-on-write overlays using R2 storage.
 products:
-  - sandbox
+  - agents
   - r2
 date: 2026-02-23
 ---

--- a/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
+++ b/src/content/changelog/agents/2026-02-23-sandbox-backup-restore-api.mdx
@@ -4,31 +4,48 @@ description: Snapshot and restore sandbox directories in seconds with the new cr
 products:
   - agents
   - r2
+  - containers
 date: 2026-02-23
 ---
 
-The Sandbox SDK now supports `createBackup()` and `restoreBackup()` methods for creating point-in-time snapshots of sandbox directories and restoring them.
+[Sandboxes](/sandbox/) now support `createBackup()` and `restoreBackup()` methods for creating and restoring point-in-time snapshots of directories.
 
-The main use case is fast environment restoration. Instead of running `git clone` and `npm install` on every new session — which can take minutes — you can back up a fully-initialized `/workspace` directory and restore it in seconds. This makes it practical to pick up exactly where a user left off across requests without repeating expensive setup steps.
+This allows you to restore environments quickly. For instance, in order to develop in a sandbox, you may need to include a user's codebase and run a build step.
+Unfortunately `git clone` and `npm install` can take minutes, and you don't want to run these steps every time the user starts their sandbox.
+
+Now, after the initial setup, you can just call `createBackup()`, then `restoreBackup()` the next time this environment is needed. This makes it practical to pick up exactly
+where a user left off, even after days of inactivity, without repeating expensive setup steps.
 
 ```ts
-import { getSandbox } from "@cloudflare/sandbox";
-
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
-// Back up a fully-initialized workspace
+// Make non-trivial changes to the file system
+await sandbox.gitCheckout(endUserRepo, { targetDir: "/workspace" });
+await sandbox.exec("npm install", { cwd: "/workspace" });
+
+// Create a point-in-time backup of the directory
 const backup = await sandbox.createBackup({ dir: "/workspace" });
 
-// On next request, restore instead of re-cloning and reinstalling
+// Store the handle for later use
+await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
+
+// ... in a future session...
+
+// Restore instead of re-cloning and reinstalling
 await sandbox.restoreBackup(backup);
 ```
 
+Backups are stored in [R2](/r2) and can take advantage of [R2 object lifecycle rules](/sandbox/guides/backup-restore/#configure-r2-lifecycle-rules-for-automatic-cleanup) to ensure they do not persist forever.
+
 Key capabilities:
 
-- **Named backups** with optional human-readable labels
-- **Configurable TTL** (default: 3 days) enforced at restore time
-- **Persist and reuse across requests** — store backup handles in KV, D1, or Durable Object storage so any subsequent request can restore the same environment
+- **Persist and reuse across sandbox sessions** — Easily store backup handles in KV, D1, or Durable Object storage for use in subsequent sessions
+- **Usable across multiple instances** — Fork a backup across many sandboxes for parallel work
+- **Named backups** — Provide optional human-readable labels for easier management
+- **TTLs** — Set time-to-live durations so backups are automatically removed from storage once they are no longer neeeded
 
-Backups are stored in an [R2](/r2/) bucket. Backup and restore currently uses a FUSE overlay. Soon, native snapshotting at a lower level will be added to Containers and Sandboxes that will improve speed and ergonomics of storing in R2. The current backup functionality provides a significant speed improvement over manually recreating a file system, but it will be further optimized in the future. The new snapshotting system will use a similar API, so changing to this system will be simple once it is available.
+:::note
+Backup and restore currently uses a FUSE overlay. Soon, native snapshotting at a lower level will be added to Containers and Sandboxes, improving speed and ergonomics. The current backup functionality provides a significant speed improvement over manually recreating a file system, but it will be further optimized in the future. The new snapshotting system will use a similar API, so changing to this system will be simple once it is available.
+:::
 
 To get started, refer to the [backup and restore guide](/sandbox/guides/backup-restore/) for setup instructions and usage patterns, or the [Backups API reference](/sandbox/api/backups/) for full method documentation.

--- a/src/content/changelog/sandbox/2026-02-23-backup-restore-api.mdx
+++ b/src/content/changelog/sandbox/2026-02-23-backup-restore-api.mdx
@@ -1,0 +1,35 @@
+---
+title: Backup and restore API for Sandbox SDK
+description: Create point-in-time snapshots of sandbox directories and restore them with copy-on-write overlays using R2 storage.
+products:
+  - sandbox
+  - r2
+date: 2026-02-23
+---
+
+The Sandbox SDK now supports `createBackup()` and `restoreBackup()` methods for creating point-in-time snapshots of sandbox directories and restoring them with copy-on-write overlays.
+
+Use backups to checkpoint work before risky operations, roll back to a known-good state, or persist directory snapshots across requests.
+
+```ts
+import { getSandbox } from "@cloudflare/sandbox";
+
+const sandbox = getSandbox(env.Sandbox, "my-sandbox");
+
+// Create a backup of /workspace
+const backup = await sandbox.createBackup({ dir: "/workspace" });
+
+// Restore the backup after a failed operation
+await sandbox.restoreBackup(backup);
+```
+
+Backups are stored as compressed squashfs archives in an [R2](/r2/) bucket using presigned URLs for direct container-to-R2 transfers. Restores use FUSE overlayfs with copy-on-write semantics, so the original backup remains unchanged as new writes go to a separate upper layer.
+
+Key capabilities:
+
+- **Named backups** with optional human-readable labels
+- **Configurable TTL** (default: 3 days) enforced at restore time
+- **Serializable handles** that can be stored in KV, D1, or Durable Object storage for cross-request access
+- **Specific error codes** (`INVALID_BACKUP_CONFIG`, `BACKUP_CREATE_FAILED`, `BACKUP_NOT_FOUND`, `BACKUP_EXPIRED`, `BACKUP_RESTORE_FAILED`) for precise error handling
+
+To get started, configure a `BACKUP_BUCKET` R2 binding and R2 presigned URL credentials in your Wrangler configuration. Refer to the [backup and restore guide](/sandbox/guides/backup-restore/) for setup instructions and usage patterns, or the [Backups API reference](/sandbox/api/backups/) for full method documentation.


### PR DESCRIPTION
## Summary

- Adds the first changelog entry for the Sandbox SDK product, documenting the new `createBackup()` and `restoreBackup()` API methods
- Based on the documentation work in #28449 (backup/restore API docs from [cloudflare/sandbox-sdk#396](https://github.com/cloudflare/sandbox-sdk/pull/396))
- Creates `src/content/changelog/sandbox/` directory and `2026-02-23-backup-restore-api.mdx` entry covering the feature overview, code example, key capabilities, and links to the full guide and API reference