### PR TITLE
Add example of sitemap index to docs

### DIFF
--- a/src/content/docs/ai-search/configuration/data-source/website.mdx
+++ b/src/content/docs/ai-search/configuration/data-source/website.mdx
@@ -115,6 +115,24 @@ Use these attributes to control crawling behavior:
 | `<changefreq>` | Expected change frequency     | Use when `<lastmod>` is not available. Values: `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly`, `never`. |
 | `<priority>`   | Relative importance (0.0-1.0) | Set higher values for important pages. AI Search indexes pages in priority order.                                   |
 
+You can also use a Sitemap Index to bundle other, domain specific sitemaps:
+
+```xml title="sitemap-index.xml"
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.example.com/sitemap-blog.xml</loc>
+    <lastmod>2024-08-15T10:00:00+00:00</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.example.com/sitemap-docs.xml</loc>
+    <lastmod>2024-08-10T12:00:00+00:00</lastmod>
+  </sitemap>
+</sitemapindex>
+```
+
+When parsing a Sitemap Index, AI Search collects all child sitemaps and then crawls them recursively, collecting all relevant URLs present in your sitemaps.
+
 ### Recommendations
 
 - **Include `<lastmod>`** on all URLs to enable efficient change detection during syncs.


### PR DESCRIPTION
### Summary

Documents that users can use sitemap Indices to reference other sitemaps in their websites.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
