### PR TITLE
Fix preview URL localhost format and token character spec

### DIFF
--- a/src/content/docs/sandbox/concepts/preview-urls.mdx
+++ b/src/content/docs/sandbox/concepts/preview-urls.mdx
@@ -20,7 +20,7 @@ const exposed = await sandbox.exposePort(8000, { hostname });
 
 console.log(exposed.url);
 // Production: https://8000-sandbox-id-abc123random4567.yourdomain.com
-// Local dev: http://localhost:8787/...
+// Local dev: http://8000-sandbox-id-abc123random4567.localhost:{port}/
 ```
 
 ## URL Format
@@ -28,9 +28,9 @@ console.log(exposed.url);
 **Production**: `https://{port}-{sandbox-id}-{token}.yourdomain.com`
 
 - With auto-generated token: `https://8080-abc123-random16chars12.yourdomain.com`
-- With custom token: `https://8080-abc123-my-api-v1.yourdomain.com`
+- With custom token: `https://8080-abc123-my_api_v1.yourdomain.com`
 
-**Local development**: `http://localhost:8787/...`
+**Local development**: `http://{port}-{sandbox-id}-{token}.localhost:{dev-server-port}`
 
 ## Token Types
 
@@ -52,15 +52,15 @@ For production deployments or shared URLs, specify a custom token to maintain co
 ```typescript
 const stable = await sandbox.exposePort(8000, { 
   hostname, 
-  token: 'api-v1' 
+  token: 'api_v1' 
 });
-// https://8000-sandbox-id-api-v1.yourdomain.com
+// https://8000-sandbox-id-api_v1.yourdomain.com
 // Same URL every time ✓
 ```
 
 **Token requirements:**
 - 1-16 characters long
-- Lowercase letters (a-z), numbers (0-9), hyphens (-), and underscores (_) only
+- Lowercase letters (a-z), numbers (0-9), and underscores (_) only
 - Must be unique within each sandbox
 
 **Use cases for custom tokens:**


### PR DESCRIPTION
### Summary

Resolves https://github.com/issues/assigned?issue=cloudflare%7Csandbox-sdk%7C372

<!-- Add context such as the type of documentation being updated or added -->

#### Fix preview URL localhost format and token character spec
Two documentation inaccuracies in the Sandbox preview URLs concept page:

1. **Localhost URL format** — The docs showed `http://localhost:8787/...` (path-based), but the SDK actually generates subdomain-based URLs identical to production: `http://{port}-{sandbox-id}-{token}.localhost:{dev-server-port}`. Updated the format pattern and inline example to match.

2. **Custom token allowed characters** — The docs listed hyphens as allowed in custom tokens, but the SDK validation regex (`/^[a-z0-9_]+$/`) rejects them. Hyphens can't be allowed because they're the delimiter in the `{port}-{sandboxId}-{token}` URL pattern. Removed hyphens from the spec and updated examples to use underscores (e.g., `api_v1` instead of `api-v1`).

> Companion SDK-side changes (JSDoc + tests) are in a separate PR to `cloudflare/sandbox-sdk`.

### Documentation checklist

<!-- Remove items that do not apply -->

~- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).~
~- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).~
~- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.~
~- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).~



_Generated by OpenCode._
