### PR TITLE
[Workers] Split cohort-based deployments and version overrides into standalone pages

### DIFF
--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -27,7 +27,7 @@ Preview URLs can be:
 - Used for collaboration between teams to test code changes in a live environment and verify updates.
 - Used to test new API endpoints, validate data formats, and ensure backward compatibility with existing services.
 
-When testing zone level performance or security features for a version, we recommend using [version overrides](/workers/configuration/versions-and-deployments/gradual-deployments/#version-overrides) so that your zone's performance and security settings apply.
+When testing zone level performance or security features for a version, we recommend using [version overrides](/workers/configuration/versions-and-deployments/version-overrides/) so that your zone's performance and security settings apply.
 
 :::note
 Preview URLs are only available for Worker versions uploaded after 2024-09-25.

--- a/src/content/docs/workers/configuration/versions-and-deployments/cohort-based-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/cohort-based-deployments.mdx
@@ -1,0 +1,226 @@
+---
+pcx_content_type: configuration
+title: Cohort-based deployments
+description: Route requests to different Worker version configurations based on named user segments using cohort-based deployments.
+---
+
+import { Example, TypeScriptExample } from "~/components";
+
+Cohort-based deployments extend [gradual deployments](/workers/configuration/versions-and-deployments/gradual-deployments/) by routing requests to different version configurations based on named user segments. Instead of applying one percentage split to all traffic, you define independent version percentages for each cohort.
+
+Use cohort-based deployments to:
+
+- Test changes with internal users or beta testers before external customers.
+- Roll out to free-tier customers before enterprise customers to limit blast radius.
+- Hold back specific user segments during incident response.
+
+## How cohort-based deployments work
+
+A standard gradual deployment has a single `versions` array that applies to every request. A cohort-based deployment adds a `cohorts` array alongside that default. Each cohort defines its own name and version configuration.
+
+When a request arrives, the system decides which version configuration to use in two steps:
+
+**Step 1 — Select the version configuration.**
+
+1. If the request has a `Cloudflare-Workers-Version-Overrides` header that matches a version ID present anywhere in the deployment (default or any cohort), that version is used immediately. No further routing applies. For more information, refer to [Version overrides](/workers/configuration/versions-and-deployments/version-overrides/).
+2. If the request has a `Cloudflare-Workers-Cohort` header that matches a defined cohort name, that cohort's `versions` array replaces the default for the next step.
+3. Otherwise, the default `versions` array is used.
+
+**Step 2 — Select a version within the chosen configuration.**
+
+1. If the request has a `Cloudflare-Workers-Version-Key` header, deterministic hashing selects a version from the configuration chosen in Step 1.
+2. Otherwise, a version is selected randomly based on configured percentages.
+
+A request can carry both a cohort header and a version key. In that case, the cohort narrows the version configuration and the version key provides deterministic selection within that cohort.
+
+## Create a cohort-based deployment
+
+Create a cohort-based deployment through the API. The following example sends 100% of default traffic to a stable version, while the `canary` cohort splits traffic 50/50 between the stable version and a new version:
+
+```json
+{
+	"strategy": "percentage",
+	"versions": [
+		{
+			"version_id": "abc123-stable-version",
+			"percentage": 100
+		}
+	],
+	"cohorts": [
+		{
+			"name": "canary",
+			"versions": [
+				{
+					"version_id": "abc123-stable-version",
+					"percentage": 50
+				},
+				{
+					"version_id": "def456-new-version",
+					"percentage": 50
+				}
+			]
+		},
+		{
+			"name": "enterprise",
+			"versions": [
+				{
+					"version_id": "abc123-stable-version",
+					"percentage": 100
+				}
+			]
+		}
+	]
+}
+```
+
+Percentages within each cohort's `versions` array must sum to 100. Each cohort operates independently — changing the `canary` split does not affect `enterprise` or the default.
+
+## Set the cohort header
+
+To route a request to a specific cohort, set the `Cloudflare-Workers-Cohort` header on the incoming request.
+
+```sh
+curl -s https://example.com -H 'Cloudflare-Workers-Cohort: canary'
+```
+
+Cohort matching is case-insensitive. `CANARY`, `Canary`, and `canary` all resolve to the same cohort.
+
+### Using Transform Rules
+
+You can use [Transform Rules](/rules/transform/request-header-modification/) to set the cohort header based on request properties such as cookies, URL patterns, or other headers. This allows you to assign cohorts without modifying your application code.
+
+For example, to set the cohort based on a cookie value:
+
+<Example>
+
+Text in **Expression Editor**:
+
+```txt
+http.cookie contains "cohort="
+```
+
+Selected operation under **Modify request header**: _Set dynamic_
+
+**Header name**: `Cloudflare-Workers-Cohort`
+
+**Value**: `regex_replace(http.cookie, ".*cohort=([^;]+).*", "${1}")`
+
+</Example>
+
+### Authenticated cohort assignment
+
+If cohort membership must be enforced (for example, only actual beta testers can access canary code), set the header server-side after authenticating the user. This prevents clients from spoofing their cohort.
+
+The following pattern uses an upstream Worker to:
+
+1. Authenticate the user.
+2. Determine their cohort based on trusted user data.
+3. Set the cohort header before forwarding to the target Worker.
+
+<TypeScriptExample>
+
+```ts
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		// 1. Authenticate the user (your auth logic here)
+		const user = await authenticateUser(request);
+
+		// 2. Determine cohort from trusted user data
+		const cohort = user.isBetaTester ? "canary" : "enterprise";
+
+		// 3. Set header and forward to downstream Worker
+		const modifiedRequest = new Request(request, {
+			headers: new Headers(request.headers),
+		});
+		modifiedRequest.headers.set("Cloudflare-Workers-Cohort", cohort);
+
+		return env.DOWNSTREAM_SERVICE.fetch(modifiedRequest);
+	},
+};
+```
+
+</TypeScriptExample>
+
+With this pattern, even if a client sends `Cloudflare-Workers-Cohort: canary`, your upstream Worker overwrites it with the correct value based on their actual user attributes.
+
+## Routing behavior
+
+Routing follows the two-step model described in [How cohort-based deployments work](#how-cohort-based-deployments-work). Two details are worth highlighting:
+
+**Version overrides search across all branches.** The `Cloudflare-Workers-Version-Overrides` header matches against version IDs in the default configuration and in every cohort. A version override can select a version that only appears in a specific cohort's configuration, even without a `Cloudflare-Workers-Cohort` header.
+
+**Version key works within a cohort.** When a request carries both `Cloudflare-Workers-Cohort` and `Cloudflare-Workers-Version-Key`, the cohort selects the version configuration and the version key provides deterministic selection within that configuration. The version key does not compete with or override the cohort header.
+
+## Cohort limitations
+
+The following constraints apply to cohort-based deployments.
+
+### Naming rules
+
+| Rule | Detail |
+| :--- | :----- |
+| Allowed characters | Alphanumeric, hyphens (`-`), and underscores (`_`) |
+| Maximum length | 10 characters |
+| Case sensitivity | Case-insensitive (`CANARY` and `canary` resolve to the same cohort) |
+| Uniqueness | Each cohort name must be unique within a deployment |
+
+Invalid or duplicate cohort names cause the deployment to fail with a `400` error.
+
+### Deployment limits
+
+| Limit | Value |
+| :---- | :---- |
+| Maximum cohorts per deployment | 5 |
+| Maximum unique version IDs across default and all cohorts | 2 |
+
+The unique version limit means that you can use at most two distinct version IDs in a single deployment, but you can reference those same IDs in multiple cohorts.
+
+The following deployment **fails** because it references three unique version IDs (`v1`, `v2`, and `v3`):
+
+```json
+{
+	"versions": [{ "version_id": "v1", "percentage": 100 }],
+	"cohorts": [
+		{
+			"name": "canary",
+			"versions": [
+				{ "version_id": "v2", "percentage": 50 },
+				{ "version_id": "v3", "percentage": 50 }
+			]
+		}
+	]
+}
+```
+
+The following deployment **works** because it reuses only two unique version IDs (`v1` and `v2`):
+
+```json
+{
+	"versions": [{ "version_id": "v1", "percentage": 100 }],
+	"cohorts": [
+		{
+			"name": "canary",
+			"versions": [
+				{ "version_id": "v1", "percentage": 50 },
+				{ "version_id": "v2", "percentage": 50 }
+			]
+		}
+	]
+}
+```
+
+### Service bindings
+
+Cohort routing applies to the initial request only. Cohorts do not automatically propagate across [service bindings](/workers/runtime-apis/bindings/service-bindings/). When Worker A calls Worker B through a service binding, Worker B uses its own deployment configuration independently.
+
+### Durable Objects
+
+:::caution
+Cohort-based deployments do not affect [Durable Object](/durable-objects/) version routing. Durable Objects ignore the `Cloudflare-Workers-Cohort` header and follow the standard [gradual deployments behavior for Durable Objects](/workers/configuration/versions-and-deployments/gradual-deployments/#gradual-deployments-for-durable-objects).
+:::
+
+## Error handling
+
+At deploy time, invalid cohort names, duplicate names, exceeding the cohort or version limits, or percentages that do not sum to 100 cause the deployment to fail with a `400` error.
+
+At runtime, if the `Cloudflare-Workers-Cohort` header value does not match any defined cohort name, the request falls back to the default `versions` configuration. No error is returned to the client.

--- a/src/content/docs/workers/configuration/versions-and-deployments/cohort-based-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/cohort-based-deployments.mdx
@@ -157,21 +157,21 @@ The following constraints apply to cohort-based deployments.
 
 ### Naming rules
 
-| Rule | Detail |
-| :--- | :----- |
-| Allowed characters | Alphanumeric, hyphens (`-`), and underscores (`_`) |
-| Maximum length | 10 characters |
-| Case sensitivity | Case-insensitive (`CANARY` and `canary` resolve to the same cohort) |
-| Uniqueness | Each cohort name must be unique within a deployment |
+| Rule               | Detail                                                              |
+| :----------------- | :------------------------------------------------------------------ |
+| Allowed characters | Alphanumeric, hyphens (`-`), and underscores (`_`)                  |
+| Maximum length     | 10 characters                                                       |
+| Case sensitivity   | Case-insensitive (`CANARY` and `canary` resolve to the same cohort) |
+| Uniqueness         | Each cohort name must be unique within a deployment                 |
 
 Invalid or duplicate cohort names cause the deployment to fail with a `400` error.
 
 ### Deployment limits
 
-| Limit | Value |
-| :---- | :---- |
-| Maximum cohorts per deployment | 5 |
-| Maximum unique version IDs across default and all cohorts | 2 |
+| Limit                                                     | Value |
+| :-------------------------------------------------------- | :---- |
+| Maximum cohorts per deployment                            | 5     |
+| Maximum unique version IDs across default and all cohorts | 2     |
 
 The unique version limit means that you can use at most two distinct version IDs in a single deployment, but you can reference those same IDs in multiple cohorts.
 
@@ -224,3 +224,100 @@ Cohort-based deployments do not affect [Durable Object](/durable-objects/) versi
 At deploy time, invalid cohort names, duplicate names, exceeding the cohort or version limits, or percentages that do not sum to 100 cause the deployment to fail with a `400` error.
 
 At runtime, if the `Cloudflare-Workers-Cohort` header value does not match any defined cohort name, the request falls back to the default `versions` configuration. No error is returned to the client.
+
+## Gateway entrypoint pattern
+
+This pattern uses your Worker's default entrypoint to determine the cohort, then calls itself on a separate entrypoint via a [loopback binding](/workers/runtime-apis/context/#exports) with the resolved cohort. This keeps cohort resolution logic in one place and lets the rest of your Worker code remain cohort-unaware.
+
+```ts
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+// Default entrypoint — resolves cohort and forwards to Service entrypoint
+export default {
+	async fetch(request, env, ctx) {
+		// Step 1: Determine cohort based on your application logic
+		const accountId = request.headers.get("cf-account-id");
+
+		const cohort = accountId
+			? resolveCohortFromAccountId(request, env, accountId)
+			: resolveCohortFromUrl(request, env);
+
+		// Step 2: Call yourself via loopback binding with the resolved cohort
+		return ctx.exports.Service({ version: { cohort } }).handle(request);
+	},
+};
+
+function resolveCohortFromAccountId(request, env, accountId) {
+	const plan = lookupAccountPlan(accountId, env);
+
+	if (isCloudflareEmployee(request)) return "employee";
+	if (plan === "free") return "free";
+	if (plan === "enterprise") return "ent";
+	return "paid";
+}
+
+function resolveCohortFromUrl(request, env) {
+	// URL pattern example: https://<ACCOUNT_ID>.r2.cloudflarestorage.com/bucket/key
+	const url = new URL(request.url);
+	const hostname = url.hostname;
+	const accountMatch = hostname.match(
+		/^([a-f0-9]+)\.r2\.cloudflarestorage\.com$/i,
+	);
+
+	// Default when account cannot be determined
+	if (!accountMatch) {
+		return "ent";
+	}
+
+	const accountId = accountMatch[1];
+	const plan = lookupAccountPlan(accountId, env);
+
+	if (plan === "free") return "free";
+	if (plan === "some-special-entitlement") return "ent";
+	return "paid";
+}
+
+export class Service extends WorkerEntrypoint {
+	async handle(request) {
+		// The rest of your code goes here
+	}
+}
+```
+
+The `version` option passed to the loopback binding sets the cohort for the downstream call. When the `Service` entrypoint is invoked, the platform uses the specified cohort to select a version according to your deployment's cohort configuration.
+
+:::note
+To use `ctx.exports`, you must enable the [`enable_ctx_exports` compatibility flag](/workers/configuration/compatibility-flags/#enable-ctxexports) in your Wrangler configuration.
+:::
+
+## Accessing cohort in your code
+
+You can use `ctx.version` to access cohort and version selection metadata for observability or application logic:
+
+```ts
+export default {
+	async fetch(request, env, ctx) {
+		const { cohort, override, key, metadata } = ctx.version;
+
+		// cohort: the cohort used for version selection (if any)
+		// override: the version specified by an override header (if any)
+		// key: the version specified by an affinity key header (if any)
+		// metadata: { id, tag, timestamp } of selected version
+
+		console.log(`Serving request with cohort: ${cohort}`);
+		// ...
+	},
+};
+```
+
+| Property   | Description                                                                                      |
+| :--------- | :----------------------------------------------------------------------------------------------- |
+| `cohort`   | The cohort name used for version selection, if a `Cloudflare-Workers-Cohort` header was present. |
+| `override` | The version ID specified by a `Cloudflare-Workers-Version-Overrides` header, if present.         |
+| `key`      | The version key specified by a `Cloudflare-Workers-Version-Key` header, if present.              |
+| `metadata` | An object containing `id`, `tag`, and `timestamp` of the selected version.                       |
+
+## Related resources
+
+- [Gradual deployments](/workers/configuration/versions-and-deployments/gradual-deployments/) — Learn how percentage-based traffic splitting works, including version affinity, static assets handling, and Durable Objects behavior.
+- [Version overrides](/workers/configuration/versions-and-deployments/version-overrides/) — Send a specific request to a specific version of your Worker, bypassing percentage-based and cohort-based routing.

--- a/src/content/docs/workers/configuration/versions-and-deployments/cohort-based-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/cohort-based-deployments.mdx
@@ -2,6 +2,8 @@
 pcx_content_type: configuration
 title: Cohort-based deployments
 description: Route requests to different Worker version configurations based on named user segments using cohort-based deployments.
+sidebar:
+  order: 3
 ---
 
 import { Example, TypeScriptExample } from "~/components";
@@ -75,9 +77,83 @@ Create a cohort-based deployment through the API. The following example sends 10
 
 Percentages within each cohort's `versions` array must sum to 100. Each cohort operates independently — changing the `canary` split does not affect `enterprise` or the default.
 
-## Set the cohort header
+## Assign cohorts to requests
 
-To route a request to a specific cohort, set the `Cloudflare-Workers-Cohort` header on the incoming request.
+Once you have created a cohort-based deployment, you need a way to assign incoming requests to the correct cohort. There are two approaches:
+
+- **Gateway entrypoint pattern** — Your Worker resolves the cohort internally using application logic, then calls itself on a separate entrypoint via a loopback binding. The cohort is determined in code, so it never appears on the external request.
+- **External cohort header** — The `Cloudflare-Workers-Cohort` header is set on the incoming request before it reaches your Worker. The header can be set by a client, a Transform Rule, or an upstream Worker.
+
+Both approaches are fully supported. Choose the one that best fits your architecture.
+
+### Gateway entrypoint pattern
+
+This pattern uses your Worker's default entrypoint to determine the cohort, then calls itself on a separate entrypoint via a [loopback binding](/workers/runtime-apis/context/#exports) with the resolved cohort. This keeps cohort resolution logic in one place and lets the rest of your Worker code remain cohort-unaware.
+
+```ts
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+// Default entrypoint — resolves cohort and forwards to Service entrypoint
+export default {
+	async fetch(request, env, ctx) {
+		// Step 1: Determine cohort based on your application logic
+		const accountId = request.headers.get("cf-account-id");
+
+		const cohort = accountId
+			? resolveCohortFromAccountId(request, env, accountId)
+			: resolveCohortFromUrl(request, env);
+
+		// Step 2: Call yourself via loopback binding with the resolved cohort
+		return ctx.exports.Service({ version: { cohort } }).handle(request);
+	},
+};
+
+function resolveCohortFromAccountId(request, env, accountId) {
+	const plan = lookupAccountPlan(accountId, env);
+
+	if (isCloudflareEmployee(request)) return "employee";
+	if (plan === "free") return "free";
+	if (plan === "enterprise") return "ent";
+	return "paid";
+}
+
+function resolveCohortFromUrl(request, env) {
+	// URL pattern example: https://<ACCOUNT_ID>.r2.cloudflarestorage.com/bucket/key
+	const url = new URL(request.url);
+	const hostname = url.hostname;
+	const accountMatch = hostname.match(
+		/^([a-f0-9]+)\.r2\.cloudflarestorage\.com$/i,
+	);
+
+	// Default when account cannot be determined
+	if (!accountMatch) {
+		return "ent";
+	}
+
+	const accountId = accountMatch[1];
+	const plan = lookupAccountPlan(accountId, env);
+
+	if (plan === "free") return "free";
+	if (plan === "some-special-entitlement") return "ent";
+	return "paid";
+}
+
+export class Service extends WorkerEntrypoint {
+	async handle(request) {
+		// The rest of your code goes here
+	}
+}
+```
+
+The `version` option passed to the loopback binding sets the cohort for the downstream call. When the `Service` entrypoint is invoked, the platform uses the specified cohort to select a version according to your deployment's cohort configuration.
+
+:::note
+To use `ctx.exports`, you must enable the [`enable_ctx_exports` compatibility flag](/workers/configuration/compatibility-flags/#enable-ctxexports) in your Wrangler configuration.
+:::
+
+### External cohort header
+
+To route a request to a specific cohort, set the `Cloudflare-Workers-Cohort` header on the incoming request before it reaches your Worker.
 
 ```sh
 curl -s https://example.com -H 'Cloudflare-Workers-Cohort: canary'
@@ -85,7 +161,7 @@ curl -s https://example.com -H 'Cloudflare-Workers-Cohort: canary'
 
 Cohort matching is case-insensitive. `CANARY`, `Canary`, and `canary` all resolve to the same cohort.
 
-### Using Transform Rules
+#### Using Transform Rules
 
 You can use [Transform Rules](/rules/transform/request-header-modification/) to set the cohort header based on request properties such as cookies, URL patterns, or other headers. This allows you to assign cohorts without modifying your application code.
 
@@ -107,7 +183,7 @@ Selected operation under **Modify request header**: _Set dynamic_
 
 </Example>
 
-### Authenticated cohort assignment
+#### Authenticated cohort assignment
 
 If cohort membership must be enforced (for example, only actual beta testers can access canary code), set the header server-side after authenticating the user. This prevents clients from spoofing their cohort.
 
@@ -142,6 +218,33 @@ export default {
 </TypeScriptExample>
 
 With this pattern, even if a client sends `Cloudflare-Workers-Cohort: canary`, your upstream Worker overwrites it with the correct value based on their actual user attributes.
+
+## Accessing cohort in your code
+
+You can use `ctx.version` to access cohort and version selection metadata for observability or application logic:
+
+```ts
+export default {
+	async fetch(request, env, ctx) {
+		const { cohort, override, key, metadata } = ctx.version;
+
+		// cohort: the cohort used for version selection (if any)
+		// override: the version specified by an override header (if any)
+		// key: the version specified by an affinity key header (if any)
+		// metadata: { id, tag, timestamp } of selected version
+
+		console.log(`Serving request with cohort: ${cohort}`);
+		// ...
+	},
+};
+```
+
+| Property   | Description                                                                                      |
+| :--------- | :----------------------------------------------------------------------------------------------- |
+| `cohort`   | The cohort name used for version selection, if a `Cloudflare-Workers-Cohort` header was present. |
+| `override` | The version ID specified by a `Cloudflare-Workers-Version-Overrides` header, if present.         |
+| `key`      | The version key specified by a `Cloudflare-Workers-Version-Key` header, if present.              |
+| `metadata` | An object containing `id`, `tag`, and `timestamp` of the selected version.                       |
 
 ## Routing behavior
 
@@ -224,98 +327,6 @@ Cohort-based deployments do not affect [Durable Object](/durable-objects/) versi
 At deploy time, invalid cohort names, duplicate names, exceeding the cohort or version limits, or percentages that do not sum to 100 cause the deployment to fail with a `400` error.
 
 At runtime, if the `Cloudflare-Workers-Cohort` header value does not match any defined cohort name, the request falls back to the default `versions` configuration. No error is returned to the client.
-
-## Gateway entrypoint pattern
-
-This pattern uses your Worker's default entrypoint to determine the cohort, then calls itself on a separate entrypoint via a [loopback binding](/workers/runtime-apis/context/#exports) with the resolved cohort. This keeps cohort resolution logic in one place and lets the rest of your Worker code remain cohort-unaware.
-
-```ts
-import { WorkerEntrypoint } from "cloudflare:workers";
-
-// Default entrypoint — resolves cohort and forwards to Service entrypoint
-export default {
-	async fetch(request, env, ctx) {
-		// Step 1: Determine cohort based on your application logic
-		const accountId = request.headers.get("cf-account-id");
-
-		const cohort = accountId
-			? resolveCohortFromAccountId(request, env, accountId)
-			: resolveCohortFromUrl(request, env);
-
-		// Step 2: Call yourself via loopback binding with the resolved cohort
-		return ctx.exports.Service({ version: { cohort } }).handle(request);
-	},
-};
-
-function resolveCohortFromAccountId(request, env, accountId) {
-	const plan = lookupAccountPlan(accountId, env);
-
-	if (isCloudflareEmployee(request)) return "employee";
-	if (plan === "free") return "free";
-	if (plan === "enterprise") return "ent";
-	return "paid";
-}
-
-function resolveCohortFromUrl(request, env) {
-	// URL pattern example: https://<ACCOUNT_ID>.r2.cloudflarestorage.com/bucket/key
-	const url = new URL(request.url);
-	const hostname = url.hostname;
-	const accountMatch = hostname.match(
-		/^([a-f0-9]+)\.r2\.cloudflarestorage\.com$/i,
-	);
-
-	// Default when account cannot be determined
-	if (!accountMatch) {
-		return "ent";
-	}
-
-	const accountId = accountMatch[1];
-	const plan = lookupAccountPlan(accountId, env);
-
-	if (plan === "free") return "free";
-	if (plan === "some-special-entitlement") return "ent";
-	return "paid";
-}
-
-export class Service extends WorkerEntrypoint {
-	async handle(request) {
-		// The rest of your code goes here
-	}
-}
-```
-
-The `version` option passed to the loopback binding sets the cohort for the downstream call. When the `Service` entrypoint is invoked, the platform uses the specified cohort to select a version according to your deployment's cohort configuration.
-
-:::note
-To use `ctx.exports`, you must enable the [`enable_ctx_exports` compatibility flag](/workers/configuration/compatibility-flags/#enable-ctxexports) in your Wrangler configuration.
-:::
-
-## Accessing cohort in your code
-
-You can use `ctx.version` to access cohort and version selection metadata for observability or application logic:
-
-```ts
-export default {
-	async fetch(request, env, ctx) {
-		const { cohort, override, key, metadata } = ctx.version;
-
-		// cohort: the cohort used for version selection (if any)
-		// override: the version specified by an override header (if any)
-		// key: the version specified by an affinity key header (if any)
-		// metadata: { id, tag, timestamp } of selected version
-
-		console.log(`Serving request with cohort: ${cohort}`);
-		// ...
-	},
-};
-```
-
-| Property   | Description                                                                                      |
-| :--------- | :----------------------------------------------------------------------------------------------- |
-| `cohort`   | The cohort name used for version selection, if a `Cloudflare-Workers-Cohort` header was present. |
-| `override` | The version ID specified by a `Cloudflare-Workers-Version-Overrides` header, if present.         |
-| `key`      | The version key specified by a `Cloudflare-Workers-Version-Key` header, if present.              |
-| `metadata` | An object containing `id`, `tag`, and `timestamp` of the selected version.                       |
 
 ## Related resources
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
@@ -153,7 +153,7 @@ Selected operation under **Modify request header**: _Set dynamic_
 
 ## Cohort-based deployments
 
-Cohort-based deployments extend gradual deployments by allowing you to route requests to different version configurations based on named user segments. Instead of applying the same percentage split to all traffic, you can define independent version percentages for each cohort.
+Cohort-based deployments extend [gradual deployments](/workers/configuration/versions-and-deployments/gradual-deployments/) by routing requests to different version configurations based on named user segments. Instead of applying one percentage split to all traffic, you define independent version percentages for each cohort.
 
 Use cohort-based deployments to:
 
@@ -163,16 +163,26 @@ Use cohort-based deployments to:
 
 ### How cohort-based deployments work
 
-A cohort-based deployment includes:
+A standard gradual deployment has a single `versions` array that applies to every request. A cohort-based deployment adds a `cohorts` array alongside that default. Each cohort defines its own name and version configuration.
 
-- A default `versions` array that applies to requests without a matching cohort.
-- A `cohorts` array where each cohort has its own name and version configuration.
+When a request arrives, the system decides which version configuration to use in two steps:
 
-When a request arrives, the system checks the `Cloudflare-Workers-Cohort` header. If the header value matches a defined cohort name, that cohort's version configuration is used. Otherwise, the default `versions` array applies.
+**Step 1 — Select the version configuration.**
 
-### Deployment configuration
+1. If the request has a `Cloudflare-Workers-Version-Overrides` header that matches a version ID present anywhere in the deployment (default or any cohort), that version is used immediately. No further routing applies.
+2. If the request has a `Cloudflare-Workers-Cohort` header that matches a defined cohort name, that cohort's `versions` array replaces the default for the next step.
+3. Otherwise, the default `versions` array is used.
 
-Create a cohort-based deployment using the API. The following example shows a deployment where the default configuration sends 100% of traffic to one version, while the `canary` cohort splits traffic 50/50 between two versions:
+**Step 2 — Select a version within the chosen configuration.**
+
+1. If the request has a `Cloudflare-Workers-Version-Key` header, deterministic hashing selects a version from the configuration chosen in Step 1.
+2. Otherwise, a version is selected randomly based on configured percentages.
+
+A request can carry both a cohort header and a version key. In that case, the cohort narrows the version configuration and the version key provides deterministic selection within that cohort.
+
+### Create a cohort-based deployment
+
+Create a cohort-based deployment through the API. The following example sends 100% of default traffic to a stable version, while the `canary` cohort splits traffic 50/50 between the stable version and a new version:
 
 ```json
 {
@@ -210,16 +220,7 @@ Create a cohort-based deployment using the API. The following example shows a de
 }
 ```
 
-#### Cohort naming rules
-
-Cohort names must follow these rules:
-
-- Alphanumeric characters, hyphens (`-`), and underscores (`_`) only.
-- Maximum 20 characters.
-- Case-insensitive matching (for example, `CANARY` and `canary` route to the same cohort).
-- Each cohort name must be unique within a deployment.
-
-Invalid cohort names or duplicate names cause the deployment to fail with a `400` error.
+Percentages within each cohort's `versions` array must sum to 100. Each cohort operates independently — changing the `canary` split does not affect `enterprise` or the default.
 
 ### Set the cohort header
 
@@ -229,9 +230,11 @@ To route a request to a specific cohort, set the `Cloudflare-Workers-Cohort` hea
 curl -s https://example.com -H 'Cloudflare-Workers-Cohort: canary'
 ```
 
+Cohort matching is case-insensitive. `CANARY`, `Canary`, and `canary` all resolve to the same cohort.
+
 #### Using Transform Rules
 
-You can use [Transform Rules](/rules/transform/request-header-modification/) to set the cohort header based on request properties such as cookies, URL patterns, or other headers. This allows you to implement cohort routing without modifying your application code.
+You can use [Transform Rules](/rules/transform/request-header-modification/) to set the cohort header based on request properties such as cookies, URL patterns, or other headers. This allows you to assign cohorts without modifying your application code.
 
 For example, to set the cohort based on a cookie value:
 
@@ -287,239 +290,87 @@ export default {
 
 With this pattern, even if a client sends `Cloudflare-Workers-Cohort: canary`, your upstream Worker overwrites it with the correct value based on their actual user attributes.
 
-### Routing precedence
+### Routing behavior
 
-When multiple routing signals are present, they are evaluated in this order:
+Routing follows the two-step model described in [How cohort-based deployments work](#how-cohort-based-deployments-work). Two details are worth highlighting:
 
-1. **Version Override** (`Cloudflare-Workers-Version-Overrides` header)
-2. **Cohort Header** (`Cloudflare-Workers-Cohort` header)
-3. **Version Key** (`Cloudflare-Workers-Version-Key` header)
-4. **Random percentage** (based on configured percentages)
+**Version overrides search across all branches.** The `Cloudflare-Workers-Version-Overrides` header matches against version IDs in the default configuration and in every cohort. A version override can select a version that only appears in a specific cohort's configuration, even without a `Cloudflare-Workers-Cohort` header.
 
-### Accessing the current cohort
+**Version key works within a cohort.** When a request carries both `Cloudflare-Workers-Cohort` and `Cloudflare-Workers-Version-Key`, the cohort selects the version configuration and the version key provides deterministic selection within that configuration. The version key does not compete with or override the cohort header.
 
-You can access the cohort that was used to route the current request via `ctx.options.cohort`:
+### Cohort limitations
 
-<TypeScriptExample>
+The following constraints apply to cohort-based deployments.
 
-```ts
-export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		const cohort = ctx.options?.cohort; // "canary", "enterprise", or undefined
+#### Naming rules
 
-		// Log or use the cohort value
-		console.log(`Request routed via cohort: ${cohort ?? "default"}`);
+| Rule | Detail |
+| :--- | :----- |
+| Allowed characters | Alphanumeric, hyphens (`-`), and underscores (`_`) |
+| Maximum length | 10 characters |
+| Case sensitivity | Case-insensitive (`CANARY` and `canary` resolve to the same cohort) |
+| Uniqueness | Each cohort name must be unique within a deployment |
 
-		// You can include it in responses for debugging
-		return new Response(`Hello from ${cohort ?? "default"} cohort`);
-	},
-};
-```
+Invalid or duplicate cohort names cause the deployment to fail with a `400` error.
 
-</TypeScriptExample>
+#### Deployment limits
 
-If the request did not match any cohort and used the default `versions` array, `ctx.options.cohort` will be `undefined`.
+| Limit | Value |
+| :---- | :---- |
+| Maximum cohorts per deployment | 5 |
+| Maximum unique version IDs across default and all cohorts | 2 |
 
-### Cohort propagation in service bindings
+The unique version limit means that you can use at most two distinct version IDs in a single deployment, but you can reference those same IDs in multiple cohorts.
 
-Cohorts do not automatically propagate across [service bindings](/workers/runtime-apis/bindings/service-bindings/). When Worker A calls Worker B via a service binding, Worker B receives no cohort information unless explicitly passed.
-
-To propagate a cohort to a downstream Worker, use the `.with()` method:
-
-<TypeScriptExample>
-
-```ts
-// Worker A - sending cohort to Worker B
-export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		const cohort =
-			request.headers.get("Cloudflare-Workers-Cohort") || "default";
-
-		// Pass cohort to downstream Worker
-		return env.WORKER_B.with({ cohort }).fetch(request);
-	},
-};
-```
-
-</TypeScriptExample>
-
-The receiving Worker can access the cohort via `ctx.options.cohort`:
-
-<TypeScriptExample>
-
-```ts
-// Worker B - receiving cohort from Worker A
-export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		// Access the cohort passed via .with()
-		const cohort = ctx.options?.cohort;
-
-		console.log(`Received cohort: ${cohort}`); // "canary"
-
-		// Worker B's version was selected based on this cohort
-		return new Response(`Running in cohort: ${cohort}`);
-	},
-};
-```
-
-</TypeScriptExample>
-
-The `.with()` method affects which version of Worker B is invoked and makes the cohort value available in `ctx.options.cohort`. The override does not persist through further hops — if Worker B calls Worker C, it must also use `.with()` to propagate the cohort.
-
-#### Multi-hop propagation
-
-The `.with()` method only affects the immediate downstream call. Each Worker in the chain must explicitly propagate the cohort:
-
-<TypeScriptExample>
-
-```ts
-// Worker A (entry point)
-export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
-		const cohort = request.headers.get("Cloudflare-Workers-Cohort");
-
-		// Explicitly pass cohort to Worker B
-		return env.WORKER_B.with({ cohort }).fetch(request);
-	},
-};
-```
-
-</TypeScriptExample>
-
-<TypeScriptExample>
-
-```ts
-// Worker B (middle of chain)
-export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		const cohort = ctx.options?.cohort; // "canary" from Worker A
-
-		// Must explicitly pass to Worker C — cohort does not auto-propagate
-		return env.WORKER_C.with({ cohort }).fetch(request);
-	},
-};
-```
-
-</TypeScriptExample>
-
-<TypeScriptExample>
-
-```ts
-// Worker C (end of chain)
-export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		const cohort = ctx.options?.cohort; // "canary" from Worker B
-		return new Response(`Final cohort: ${cohort}`);
-	},
-};
-```
-
-</TypeScriptExample>
-
-If Worker B does not call `.with()`, Worker C receives no cohort and uses its default version configuration:
-
-<TypeScriptExample>
-
-```ts
-// Worker B - does NOT propagate cohort
-export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		const cohort = ctx.options?.cohort; // "canary"
-
-		// Worker C will NOT receive the cohort
-		return env.WORKER_C.fetch(request); // No .with()!
-	},
-};
-```
-
-</TypeScriptExample>
-
-<TypeScriptExample>
-
-```ts
-// Worker C receives no cohort
-export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext,
-	): Promise<Response> {
-		const cohort = ctx.options?.cohort; // undefined
-		// Uses default version configuration
-		return new Response("Running default version");
-	},
-};
-```
-
-</TypeScriptExample>
-
-### Cohort-based deployments for Durable Objects
-
-When using cohort-based deployments with [Durable Objects](/durable-objects/), the cohort of the **first request** to a Durable Object instance determines which version that instance runs. Subsequent requests to the same Durable Object use that version, regardless of their cohort header.
-
-#### How version assignment works
-
-1. A request arrives with `Cloudflare-Workers-Cohort: canary`.
-2. The request creates or accesses Durable Object instance `room-123`.
-3. The Durable Object instance is assigned a version based on the `canary` cohort's configuration.
-4. All future requests to `room-123` use that version, even if they have a different cohort header.
-
-This ensures Durable Object state consistency — multiple versions of code do not operate on the same persistent state simultaneously.
-
-#### Example
-
-Given this deployment configuration:
+The following deployment **fails** because it references three unique version IDs (`v1`, `v2`, and `v3`):
 
 ```json
 {
-	"versions": [{ "version_id": "v1-stable", "percentage": 100 }],
+	"versions": [{ "version_id": "v1", "percentage": 100 }],
 	"cohorts": [
 		{
 			"name": "canary",
-			"versions": [{ "version_id": "v2-new", "percentage": 100 }]
+			"versions": [
+				{ "version_id": "v2", "percentage": 50 },
+				{ "version_id": "v3", "percentage": 50 }
+			]
 		}
 	]
 }
 ```
 
-The following table shows how version assignment works:
+The following deployment **works** because it reuses only two unique version IDs (`v1` and `v2`):
 
-| Request | Cohort   | DO Instance | Version Used | Reason                                              |
-| :------ | :------- | :---------- | :----------- | :-------------------------------------------------- |
-| 1st     | `canary` | `room-123`  | `v2-new`     | First request, canary cohort config applies         |
-| 2nd     | `stable` | `room-123`  | `v2-new`     | Same DO instance, version locked from first request |
-| 3rd     | `canary` | `room-456`  | `v2-new`     | New DO instance, canary cohort config applies       |
-| 4th     | (none)   | `room-789`  | `v1-stable`  | New DO instance, default config applies             |
+```json
+{
+	"versions": [{ "version_id": "v1", "percentage": 100 }],
+	"cohorts": [
+		{
+			"name": "canary",
+			"versions": [
+				{ "version_id": "v1", "percentage": 50 },
+				{ "version_id": "v2", "percentage": 50 }
+			]
+		}
+	]
+}
+```
 
-The cohort header on subsequent requests does not change which version a Durable Object runs. Version assignment is locked on first access.
+#### Service bindings
+
+Cohort routing applies to the initial request only. Cohorts do not automatically propagate across [service bindings](/workers/runtime-apis/bindings/service-bindings/). When Worker A calls Worker B through a service binding, Worker B uses its own deployment configuration independently.
+
+#### Durable Objects
+
+:::caution
+Cohort-based deployments do not affect [Durable Object](/durable-objects/) version routing. Durable Objects ignore the `Cloudflare-Workers-Cohort` header and follow the standard [gradual deployments behavior for Durable Objects](/workers/configuration/versions-and-deployments/gradual-deployments/#gradual-deployments-for-durable-objects).
+:::
 
 ### Error handling
 
-At runtime, invalid or unknown cohort header values fall back to the default `versions` configuration. At deploy time, invalid cohort names or duplicates will cause the deployment to fail with a `400` error.
+At deploy time, invalid cohort names, duplicate names, exceeding the cohort or version limits, or percentages that do not sum to 100 cause the deployment to fail with a `400` error.
+
+At runtime, if the `Cloudflare-Workers-Cohort` header value does not match any defined cohort name, the request falls back to the default `versions` configuration. No error is returned to the client.
 
 ## Version overrides
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
@@ -3,6 +3,8 @@ pcx_content_type: configuration
 title: Gradual deployments
 head: []
 description: Incrementally deploy code changes to your Workers with gradual deployments.
+sidebar:
+  order: 1
 ---
 
 import { Example, DashButton } from "~/components";

--- a/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
@@ -5,113 +5,25 @@ head: []
 description: Incrementally deploy code changes to your Workers with gradual deployments.
 ---
 
-import { Example, DashButton, TypeScriptExample } from "~/components";
+import { Example, DashButton } from "~/components";
 
-Gradual Deployments give you the ability to incrementally deploy new [versions](/workers/configuration/versions-and-deployments/#versions) of Workers by splitting traffic across versions.
+Gradual deployments give you the ability to incrementally deploy new [versions](/workers/configuration/versions-and-deployments/#versions) of Workers by splitting traffic across versions.
 
 ![Gradual Deployments](~/assets/images/workers/platform/versions-and-deployments/gradual-deployments.png)
 
 Using gradual deployments, you can:
 
 - Gradually shift traffic to a newer version of your Worker.
-- Monitor error rates and exceptions across versions using [analytics and logs](/workers/configuration/versions-and-deployments/gradual-deployments/#observability) tooling.
+- Monitor error rates and exceptions across versions using [analytics and logs](#observability) tooling.
 - [Roll back](/workers/configuration/versions-and-deployments/rollbacks/) to a previously stable version if you notice issues when deploying a new version.
+- Route requests to different version configurations based on named user segments using [cohort-based deployments](/workers/configuration/versions-and-deployments/cohort-based-deployments/).
+- Send requests to a specific version of your Worker using [version overrides](/workers/configuration/versions-and-deployments/version-overrides/).
 
-## Use gradual deployments
+## How it works
 
-The following section guides you through an example usage of gradual deployments. You will choose to use either [Wrangler](/workers/configuration/versions-and-deployments/gradual-deployments/#via-wrangler) or the Cloudflare dashboard to:
+When you create a gradual deployment, you assign a percentage of traffic to each of two versions of your Worker. Each incoming request is routed to one of the two versions based on the configured percentages. For example, you can send 10% of traffic to a new version and 90% to the current stable version, then increase the new version's share as you gain confidence.
 
-- Create a new Worker.
-- Publish a new version of that Worker without deploying it.
-- Create a gradual deployment between the two versions.
-- Progress the deployment of the new version to 100% of traffic.
-
-### Via Wrangler
-
-:::note
-
-Minimum required Wrangler version: 3.40.0. Versions before 3.73.0 require you to specify a `--x-versions` flag.
-
-:::
-
-#### 1. Create and deploy a new Worker
-
-Create a new `"Hello World"` Worker using the [`create-cloudflare` CLI (C3)](/pages/get-started/c3/) and deploy it.
-
-```sh
-npm create cloudflare@latest <NAME> -- --type=hello-world
-```
-
-Answer `yes` or `no` to using TypeScript. Answer `yes` to deploying your application. This is the first version of your Worker.
-
-#### 2. Create a new version of the Worker
-
-To create a new version of the Worker, edit the Worker code by changing the `Response` content to your desired text and upload the Worker by using the [`wrangler versions upload`](/workers/wrangler/commands/#versions-upload) command.
-
-```sh
-npx wrangler versions upload
-```
-
-This will create a new version of the Worker that is not automatically deployed.
-
-#### 3. Create a new deployment
-
-Use the [`wrangler versions deploy`](/workers/wrangler/commands/#versions-deploy) command to
-create a new deployment that splits traffic between two versions of the Worker. Follow the interactive prompts to create a deployment with the versions uploaded in [step #1](/workers/configuration/versions-and-deployments/gradual-deployments/#1-create-and-deploy-a-new-worker) and [step #2](/workers/configuration/versions-and-deployments/gradual-deployments/#2-create-a-new-version-of-the-worker). Select your desired percentages for each version.
-
-```sh
-npx wrangler versions deploy
-```
-
-#### 4. Test the split deployment
-
-Run a cURL command on your Worker to test the split deployment.
-
-```bash
-for j in {0..10}
-do
-    curl -s https://$WORKER_NAME.$SUBDOMAIN.workers.dev
-done
-```
-
-You should see 10 responses. Responses will reflect the content returned by the versions in your deployment. Responses will vary depending on the percentages configured in [step #3](/workers/configuration/versions-and-deployments/gradual-deployments/#3-create-a-new-deployment).
-
-You can test also target a specific version using [version overrides](#version-overrides).
-
-#### 5. Set your new version to 100% deployment
-
-Run `wrangler versions deploy` again and follow the interactive prompts. Select the version uploaded in [step 2](/workers/configuration/versions-and-deployments/gradual-deployments/#2-create-a-new-version-of-the-worker) and set it to 100% deployment.
-
-```sh
-npx wrangler versions deploy
-```
-
-### Via the Cloudflare dashboard
-
-1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
-
-   <DashButton url="/?to=/:account/workers-and-pages" />
-
-2. Select **Create application** > **Hello World** template > deploy your Worker.
-3. Once the Worker is deployed, go to the online code editor through **Edit code**. Edit the Worker code (change the `Response` content) and upload the Worker.
-4. To save changes, select the **down arrow** next to **Deploy** > **Save**. This will create a new version of your Worker.
-5. Create a new deployment that splits traffic between the two versions created in step 3 and 5 by going to **Deployments** and selecting **Deploy Version**.
-6. cURL your Worker to test the split deployment.
-
-```bash
-for j in {0..10}
-do
-    curl -s https://$WORKER_NAME.$SUBDOMAIN.workers.dev
-done
-```
-
-You should see 10 responses. Responses will reflect the content returned by the versions in your deployment. Responses will vary depending on the percentages configured in step #6.
-
-## Gradual deployments with static assets
-
-When your Worker serves [static assets](/workers/static-assets/), gradual deployments can cause asset compatibility issues where users receive HTML from one version that references assets only available in another version, leading to 404 errors.
-
-For detailed guidance on handling static assets during gradual rollouts, including specific examples and configuration steps, refer to [Gradual rollouts](/workers/static-assets/routing/advanced/gradual-rollouts/).
+By default, each request is independently assigned to a version based on the configured percentages. If you need requests from the same user or session to consistently reach the same version, you can configure [version affinity](#version-affinity).
 
 ## Version affinity
 
@@ -151,278 +63,11 @@ Selected operation under **Modify request header**: _Set dynamic_
 
 </Example>
 
-## Cohort-based deployments
+## Gradual deployments with static assets
 
-Cohort-based deployments extend [gradual deployments](/workers/configuration/versions-and-deployments/gradual-deployments/) by routing requests to different version configurations based on named user segments. Instead of applying one percentage split to all traffic, you define independent version percentages for each cohort.
+When your Worker serves [static assets](/workers/static-assets/), gradual deployments can cause asset compatibility issues where users receive HTML from one version that references assets only available in another version, leading to 404 errors.
 
-Use cohort-based deployments to:
-
-- Test changes with internal users or beta testers before external customers.
-- Roll out to free-tier customers before enterprise customers to limit blast radius.
-- Hold back specific user segments during incident response.
-
-### How cohort-based deployments work
-
-A standard gradual deployment has a single `versions` array that applies to every request. A cohort-based deployment adds a `cohorts` array alongside that default. Each cohort defines its own name and version configuration.
-
-When a request arrives, the system decides which version configuration to use in two steps:
-
-**Step 1 — Select the version configuration.**
-
-1. If the request has a `Cloudflare-Workers-Version-Overrides` header that matches a version ID present anywhere in the deployment (default or any cohort), that version is used immediately. No further routing applies.
-2. If the request has a `Cloudflare-Workers-Cohort` header that matches a defined cohort name, that cohort's `versions` array replaces the default for the next step.
-3. Otherwise, the default `versions` array is used.
-
-**Step 2 — Select a version within the chosen configuration.**
-
-1. If the request has a `Cloudflare-Workers-Version-Key` header, deterministic hashing selects a version from the configuration chosen in Step 1.
-2. Otherwise, a version is selected randomly based on configured percentages.
-
-A request can carry both a cohort header and a version key. In that case, the cohort narrows the version configuration and the version key provides deterministic selection within that cohort.
-
-### Create a cohort-based deployment
-
-Create a cohort-based deployment through the API. The following example sends 100% of default traffic to a stable version, while the `canary` cohort splits traffic 50/50 between the stable version and a new version:
-
-```json
-{
-	"strategy": "percentage",
-	"versions": [
-		{
-			"version_id": "abc123-stable-version",
-			"percentage": 100
-		}
-	],
-	"cohorts": [
-		{
-			"name": "canary",
-			"versions": [
-				{
-					"version_id": "abc123-stable-version",
-					"percentage": 50
-				},
-				{
-					"version_id": "def456-new-version",
-					"percentage": 50
-				}
-			]
-		},
-		{
-			"name": "enterprise",
-			"versions": [
-				{
-					"version_id": "abc123-stable-version",
-					"percentage": 100
-				}
-			]
-		}
-	]
-}
-```
-
-Percentages within each cohort's `versions` array must sum to 100. Each cohort operates independently — changing the `canary` split does not affect `enterprise` or the default.
-
-### Set the cohort header
-
-To route a request to a specific cohort, set the `Cloudflare-Workers-Cohort` header on the incoming request.
-
-```sh
-curl -s https://example.com -H 'Cloudflare-Workers-Cohort: canary'
-```
-
-Cohort matching is case-insensitive. `CANARY`, `Canary`, and `canary` all resolve to the same cohort.
-
-#### Using Transform Rules
-
-You can use [Transform Rules](/rules/transform/request-header-modification/) to set the cohort header based on request properties such as cookies, URL patterns, or other headers. This allows you to assign cohorts without modifying your application code.
-
-For example, to set the cohort based on a cookie value:
-
-<Example>
-
-Text in **Expression Editor**:
-
-```txt
-http.cookie contains "cohort="
-```
-
-Selected operation under **Modify request header**: _Set dynamic_
-
-**Header name**: `Cloudflare-Workers-Cohort`
-
-**Value**: `regex_replace(http.cookie, ".*cohort=([^;]+).*", "${1}")`
-
-</Example>
-
-#### Authenticated cohort assignment
-
-If cohort membership must be enforced (for example, only actual beta testers can access canary code), set the header server-side after authenticating the user. This prevents clients from spoofing their cohort.
-
-The following pattern uses an upstream Worker to:
-
-1. Authenticate the user.
-2. Determine their cohort based on trusted user data.
-3. Set the cohort header before forwarding to the target Worker.
-
-<TypeScriptExample>
-
-```ts
-export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
-		// 1. Authenticate the user (your auth logic here)
-		const user = await authenticateUser(request);
-
-		// 2. Determine cohort from trusted user data
-		const cohort = user.isBetaTester ? "canary" : "enterprise";
-
-		// 3. Set header and forward to downstream Worker
-		const modifiedRequest = new Request(request, {
-			headers: new Headers(request.headers),
-		});
-		modifiedRequest.headers.set("Cloudflare-Workers-Cohort", cohort);
-
-		return env.DOWNSTREAM_SERVICE.fetch(modifiedRequest);
-	},
-};
-```
-
-</TypeScriptExample>
-
-With this pattern, even if a client sends `Cloudflare-Workers-Cohort: canary`, your upstream Worker overwrites it with the correct value based on their actual user attributes.
-
-### Routing behavior
-
-Routing follows the two-step model described in [How cohort-based deployments work](#how-cohort-based-deployments-work). Two details are worth highlighting:
-
-**Version overrides search across all branches.** The `Cloudflare-Workers-Version-Overrides` header matches against version IDs in the default configuration and in every cohort. A version override can select a version that only appears in a specific cohort's configuration, even without a `Cloudflare-Workers-Cohort` header.
-
-**Version key works within a cohort.** When a request carries both `Cloudflare-Workers-Cohort` and `Cloudflare-Workers-Version-Key`, the cohort selects the version configuration and the version key provides deterministic selection within that configuration. The version key does not compete with or override the cohort header.
-
-### Cohort limitations
-
-The following constraints apply to cohort-based deployments.
-
-#### Naming rules
-
-| Rule | Detail |
-| :--- | :----- |
-| Allowed characters | Alphanumeric, hyphens (`-`), and underscores (`_`) |
-| Maximum length | 10 characters |
-| Case sensitivity | Case-insensitive (`CANARY` and `canary` resolve to the same cohort) |
-| Uniqueness | Each cohort name must be unique within a deployment |
-
-Invalid or duplicate cohort names cause the deployment to fail with a `400` error.
-
-#### Deployment limits
-
-| Limit | Value |
-| :---- | :---- |
-| Maximum cohorts per deployment | 5 |
-| Maximum unique version IDs across default and all cohorts | 2 |
-
-The unique version limit means that you can use at most two distinct version IDs in a single deployment, but you can reference those same IDs in multiple cohorts.
-
-The following deployment **fails** because it references three unique version IDs (`v1`, `v2`, and `v3`):
-
-```json
-{
-	"versions": [{ "version_id": "v1", "percentage": 100 }],
-	"cohorts": [
-		{
-			"name": "canary",
-			"versions": [
-				{ "version_id": "v2", "percentage": 50 },
-				{ "version_id": "v3", "percentage": 50 }
-			]
-		}
-	]
-}
-```
-
-The following deployment **works** because it reuses only two unique version IDs (`v1` and `v2`):
-
-```json
-{
-	"versions": [{ "version_id": "v1", "percentage": 100 }],
-	"cohorts": [
-		{
-			"name": "canary",
-			"versions": [
-				{ "version_id": "v1", "percentage": 50 },
-				{ "version_id": "v2", "percentage": 50 }
-			]
-		}
-	]
-}
-```
-
-#### Service bindings
-
-Cohort routing applies to the initial request only. Cohorts do not automatically propagate across [service bindings](/workers/runtime-apis/bindings/service-bindings/). When Worker A calls Worker B through a service binding, Worker B uses its own deployment configuration independently.
-
-#### Durable Objects
-
-:::caution
-Cohort-based deployments do not affect [Durable Object](/durable-objects/) version routing. Durable Objects ignore the `Cloudflare-Workers-Cohort` header and follow the standard [gradual deployments behavior for Durable Objects](/workers/configuration/versions-and-deployments/gradual-deployments/#gradual-deployments-for-durable-objects).
-:::
-
-### Error handling
-
-At deploy time, invalid cohort names, duplicate names, exceeding the cohort or version limits, or percentages that do not sum to 100 cause the deployment to fail with a `400` error.
-
-At runtime, if the `Cloudflare-Workers-Cohort` header value does not match any defined cohort name, the request falls back to the default `versions` configuration. No error is returned to the client.
-
-## Version overrides
-
-You can use version overrides to send a request to a specific version of your Worker in your gradual deployment.
-
-To specify a version override in your request, you can set the `Cloudflare-Workers-Version-Overrides` header on the request to your Worker. For example:
-
-```sh
-curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
-```
-
-`Cloudflare-Workers-Version-Overrides` is a [Dictionary Structured Header](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
-
-The dictionary can contain multiple key-value pairs. Each key indicates the name of the Worker the override should be applied to. The value indicates the version ID that should be used and must be a [String](https://www.rfc-editor.org/rfc/rfc8941#name-strings).
-
-A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list`](/workers/wrangler/commands/#deployments-list) command or on the **Workers & Pages** page of the Cloudflare dashboard > Select your Workers > Deployments > Active Deployment.
-
-:::note[Verifying that the version override was applied]
-
-There are a number of reasons why a request's version override may not be applied. For example:
-
-- The deployment containing the specified version may not have propagated yet.
-- The header value may not be a valid [Dictionary](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
-
-In the case that a request's version override is not applied, the request will be routed according to the percentages set in the gradual deployment configuration.
-
-To make sure that the request's version override was applied correctly, you can [observe](#observability) the version of your Worker that was invoked. You could even automate this check by using the [runtime binding](#runtime-binding) to return the version in the Worker's response.
-
-:::
-
-### Example
-
-You may want to test a new version in production before gradually deploying it to an increasing proportion of external traffic.
-
-In this example, your deployment is initially configured to route all traffic to a single version:
-
-|              Version ID              | Percentage |
-| :----------------------------------: | :--------: |
-| db7cd8d3-4425-4fe7-8c81-01bf963b6067 |    100%    |
-
-Create a new deployment using [`wrangler versions deploy`](/workers/wrangler/commands/#versions-deploy) and specify 0% for the new version whilst keeping the previous version at 100%.
-
-|              Version ID              | Percentage |
-| :----------------------------------: | :--------: |
-| dc8dcd28-271b-4367-9840-6c244f84cb40 |     0%     |
-| db7cd8d3-4425-4fe7-8c81-01bf963b6067 |    100%    |
-
-Now test the new version with a version override before gradually progressing the new version to 100%:
-
-```sh
-curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
-```
+For detailed guidance on handling static assets during gradual rollouts, including specific examples and configuration steps, refer to [Gradual rollouts](/workers/static-assets/routing/advanced/gradual-rollouts/).
 
 ## Gradual deployments for Durable Objects
 
@@ -508,10 +153,100 @@ scriptVersion: {
 
 ### Runtime binding
 
-Use the [Version metadata binding](/workers/runtime-apis/bindings/version-metadata/) in to access version ID or version tag in your Worker.
+Use the [Version metadata binding](/workers/runtime-apis/bindings/version-metadata/) to access version ID or version tag in your Worker.
 
 ## Limits
 
 ### Deployments limit
 
 You can only create a new deployment with the last 100 uploaded versions of your Worker.
+
+## Get started
+
+The following section guides you through an example usage of gradual deployments. You will choose to use either [Wrangler](#via-wrangler) or the [Cloudflare dashboard](#via-the-cloudflare-dashboard) to:
+
+- Create a new Worker.
+- Publish a new version of that Worker without deploying it.
+- Create a gradual deployment between the two versions.
+- Progress the deployment of the new version to 100% of traffic.
+
+### Via Wrangler
+
+:::note
+
+Minimum required Wrangler version: 3.40.0. Versions before 3.73.0 require you to specify a `--x-versions` flag.
+
+:::
+
+#### 1. Create and deploy a new Worker
+
+Create a new `"Hello World"` Worker using the [`create-cloudflare` CLI (C3)](/pages/get-started/c3/) and deploy it.
+
+```sh
+npm create cloudflare@latest <NAME> -- --type=hello-world
+```
+
+Answer `yes` or `no` to using TypeScript. Answer `yes` to deploying your application. This is the first version of your Worker.
+
+#### 2. Create a new version of the Worker
+
+To create a new version of the Worker, edit the Worker code by changing the `Response` content to your desired text and upload the Worker by using the [`wrangler versions upload`](/workers/wrangler/commands/#versions-upload) command.
+
+```sh
+npx wrangler versions upload
+```
+
+This will create a new version of the Worker that is not automatically deployed.
+
+#### 3. Create a new deployment
+
+Use the [`wrangler versions deploy`](/workers/wrangler/commands/#versions-deploy) command to
+create a new deployment that splits traffic between two versions of the Worker. Follow the interactive prompts to create a deployment with the versions uploaded in [step #1](#1-create-and-deploy-a-new-worker) and [step #2](#2-create-a-new-version-of-the-worker). Select your desired percentages for each version.
+
+```sh
+npx wrangler versions deploy
+```
+
+#### 4. Test the split deployment
+
+Run a cURL command on your Worker to test the split deployment.
+
+```bash
+for j in {0..10}
+do
+    curl -s https://$WORKER_NAME.$SUBDOMAIN.workers.dev
+done
+```
+
+You should see 10 responses. Responses will reflect the content returned by the versions in your deployment. Responses will vary depending on the percentages configured in [step #3](#3-create-a-new-deployment).
+
+You can also target a specific version using [version overrides](/workers/configuration/versions-and-deployments/version-overrides/).
+
+#### 5. Set your new version to 100% deployment
+
+Run `wrangler versions deploy` again and follow the interactive prompts. Select the version uploaded in [step 2](#2-create-a-new-version-of-the-worker) and set it to 100% deployment.
+
+```sh
+npx wrangler versions deploy
+```
+
+### Via the Cloudflare dashboard
+
+1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
+
+   <DashButton url="/?to=/:account/workers-and-pages" />
+
+2. Select **Create application** > **Hello World** template > deploy your Worker.
+3. Once the Worker is deployed, go to the online code editor through **Edit code**. Edit the Worker code (change the `Response` content) and upload the Worker.
+4. To save changes, select the **down arrow** next to **Deploy** > **Save**. This will create a new version of your Worker.
+5. Create a new deployment that splits traffic between the two versions created in step 3 and 5 by going to **Deployments** and selecting **Deploy Version**.
+6. cURL your Worker to test the split deployment.
+
+```bash
+for j in {0..10}
+do
+    curl -s https://$WORKER_NAME.$SUBDOMAIN.workers.dev
+done
+```
+
+You should see 10 responses. Responses will reflect the content returned by the versions in your deployment. Responses will vary depending on the percentages configured in step #6.

--- a/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
@@ -250,3 +250,8 @@ done
 ```
 
 You should see 10 responses. Responses will reflect the content returned by the versions in your deployment. Responses will vary depending on the percentages configured in step #6.
+
+## Related resources
+
+- [Cohort-based deployments](/workers/configuration/versions-and-deployments/cohort-based-deployments/) — Route requests to different version configurations based on named user segments instead of a single percentage split.
+- [Version overrides](/workers/configuration/versions-and-deployments/version-overrides/) — Send a specific request to a specific version of your Worker, bypassing the percentage-based routing.

--- a/src/content/docs/workers/configuration/versions-and-deployments/rollbacks.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/rollbacks.mdx
@@ -3,7 +3,10 @@ pcx_content_type: configuration
 title: Rollbacks
 head: []
 description: Revert to an older version of your Worker.
+sidebar:
+  order: 2
 ---
+
 import { DashButton } from "~/components";
 
 You can roll back to a previously deployed [version](/workers/configuration/versions-and-deployments/#versions) of your Worker using [Wrangler](/workers/wrangler/commands/#rollback) or the Cloudflare dashboard. Rolling back to a previous version of your Worker will immediately create a new [deployment](/workers/configuration/versions-and-deployments/#deployments) with the version specified and become the active deployment across all your deployed routes and domains.
@@ -15,6 +18,7 @@ To roll back to a specified version of your Worker via Wrangler, use the [`wrang
 ## Via the Cloudflare Dashboard
 
 To roll back to a specified version of your Worker via the Cloudflare dashboard:
+
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
@@ -48,5 +52,5 @@ We plan to address this limitation soon to allow displaying all 100 available ve
 
 You cannot roll back to a previous version of your Worker if the [Cloudflare Developer Platform resources](/workers/runtime-apis/bindings/) (such as [KV](/kv/) and [D1](/d1/)) have been deleted or modified between the version selected to roll back to and the version in the active deployment. Specifically, rollbacks will not be allowed if:
 
-* A [Durable Object migration](/durable-objects/reference/durable-objects-migrations/) has occurred between the version in the active deployment and the version selected to roll back to.
-* If the target deployment has a [binding](/workers/runtime-apis/bindings/) to an R2 bucket, KV namespace, or queue that no longer exists.
+- A [Durable Object migration](/durable-objects/reference/durable-objects-migrations/) has occurred between the version in the active deployment and the version selected to roll back to.
+- If the target deployment has a [binding](/workers/runtime-apis/bindings/) to an R2 bucket, KV namespace, or queue that no longer exists.

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -2,6 +2,8 @@
 pcx_content_type: configuration
 title: Version overrides
 description: Send requests to a specific version of your Worker in a gradual deployment using version overrides.
+sidebar:
+  order: 4
 ---
 
 You can use version overrides to send a request to a specific version of your Worker in your [gradual deployment](/workers/configuration/versions-and-deployments/gradual-deployments/).

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -1,0 +1,55 @@
+---
+pcx_content_type: configuration
+title: Version overrides
+description: Send requests to a specific version of your Worker in a gradual deployment using version overrides.
+---
+
+You can use version overrides to send a request to a specific version of your Worker in your [gradual deployment](/workers/configuration/versions-and-deployments/gradual-deployments/).
+
+To specify a version override in your request, set the `Cloudflare-Workers-Version-Overrides` header on the request to your Worker. For example:
+
+```sh
+curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
+```
+
+`Cloudflare-Workers-Version-Overrides` is a [Dictionary Structured Header](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
+
+The dictionary can contain multiple key-value pairs. Each key indicates the name of the Worker the override should be applied to. The value indicates the version ID that should be used and must be a [String](https://www.rfc-editor.org/rfc/rfc8941#name-strings).
+
+A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list`](/workers/wrangler/commands/#deployments-list) command or on the **Workers & Pages** page of the Cloudflare dashboard > select your Worker > **Deployments** > **Active Deployment**.
+
+:::note[Verifying that the version override was applied]
+
+There are a number of reasons why a request's version override may not be applied. For example:
+
+- The deployment containing the specified version may not have propagated yet.
+- The header value may not be a valid [Dictionary](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
+
+In the case that a request's version override is not applied, the request will be routed according to the percentages set in the gradual deployment configuration.
+
+To make sure that the request's version override was applied correctly, you can observe the version of your Worker that was invoked using [Logpush](/workers/observability/logs/logpush/) or the [version metadata binding](/workers/runtime-apis/bindings/version-metadata/). You could even automate this check by using the version metadata binding to return the version in the Worker's response.
+
+:::
+
+## Example
+
+You may want to test a new version in production before gradually deploying it to an increasing proportion of external traffic.
+
+In this example, your deployment is initially configured to route all traffic to a single version:
+
+|              Version ID              | Percentage |
+| :----------------------------------: | :--------: |
+| db7cd8d3-4425-4fe7-8c81-01bf963b6067 |    100%    |
+
+Create a new deployment using [`wrangler versions deploy`](/workers/wrangler/commands/#versions-deploy) and specify 0% for the new version whilst keeping the previous version at 100%.
+
+|              Version ID              | Percentage |
+| :----------------------------------: | :--------: |
+| dc8dcd28-271b-4367-9840-6c244f84cb40 |     0%     |
+| db7cd8d3-4425-4fe7-8c81-01bf963b6067 |    100%    |
+
+Now test the new version with a version override before gradually progressing the new version to 100%:
+
+```sh
+curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
+```

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -53,3 +53,8 @@ Now test the new version with a version override before gradually progressing th
 ```sh
 curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
 ```
+
+## Related resources
+
+- [Gradual deployments](/workers/configuration/versions-and-deployments/gradual-deployments/) — Learn how percentage-based traffic splitting works, including version affinity and observability.
+- [Cohort-based deployments](/workers/configuration/versions-and-deployments/cohort-based-deployments/) — Route requests to different version configurations based on named user segments instead of a single percentage split.

--- a/src/content/release-notes/workers.yaml
+++ b/src/content/release-notes/workers.yaml
@@ -159,7 +159,7 @@ entries:
       - Fixed a bug where when writing to an HTTP Response body would sometimes hang when the client disconnected (and sometimes throw an exception). It will now always throw an exception.
   - publish_date: "2024-07-01"
     description: |-
-      - When using [Gradual Deployments](/workers/configuration/versions-and-deployments/gradual-deployments/), you can now use [version overrides](/workers/configuration/versions-and-deployments/gradual-deployments/#version-overrides) to send a request to a specific version of your Worker.
+      - When using [Gradual Deployments](/workers/configuration/versions-and-deployments/gradual-deployments/), you can now use [version overrides](/workers/configuration/versions-and-deployments/version-overrides/) to send a request to a specific version of your Worker.
   - publish_date: "2024-06-28"
     description: |-
       - Fixed a bug which caused `Date.now()` to return skewed results if called before the first I/O of the first request after a Worker first started up. The value returned would be offset backwards by the amount of CPU time spent starting the Worker (compiling and running global scope), making it seem like the first I/O (e.g. first fetch()) was slower than it really was. This skew had nothing to do with Spectre mitigations; it was simply a longstanding bug.


### PR DESCRIPTION
## Summary

Restructures the gradual deployments documentation by extracting two large sections into their own dedicated pages, and refocuses the parent page on core concepts.

## Changes

### New pages created

- **`cohort-based-deployments.mdx`** — standalone page for cohort-based deployments (previously an H2 section inside `gradual-deployments.mdx`). Contains all the original content: how cohort routing works, creating a cohort-based deployment via API, setting the cohort header, Transform Rules example, authenticated cohort assignment with TypeScript example, routing behavior details, naming rules, deployment limits, service bindings caveat, Durable Objects caveat, and error handling.

- **`version-overrides.mdx`** — standalone page for version overrides (previously an H2 section inside `gradual-deployments.mdx`). Contains all the original content: header format, dictionary structured header spec, when overrides apply, verification note, and the 0%-deployment testing example. Adds an explicit mention of Logpush as an observability option alongside the version metadata binding.

### Restructured `gradual-deployments.mdx`

**Before:** A 500+ line page that mixed core gradual deployment concepts with the full cohort-based deployments reference, the full version overrides reference, and a step-by-step tutorial — all at the same level.

**After:** The page is reorganized into a clearer flow:
1. **Intro** — what gradual deployments are, with bullet points that now cross-link to the new cohort-based deployments and version overrides pages.
2. **How it works** — new short section explaining the percentage-based routing model and linking to version affinity.
3. **Version affinity** — unchanged.
4. **Gradual deployments with static assets** — moved up from its previous position (was buried after the tutorial).
5. **Gradual deployments for Durable Objects** — unchanged.
6. **Observability** — unchanged.
7. **Limits** — unchanged.
8. **Get started** — the Wrangler + Dashboard tutorial moved to the bottom of the page so conceptual content comes first. Internal anchor links updated to match new heading positions.

### Link updates

- **`previews.mdx`**: version overrides link updated from `gradual-deployments/#version-overrides` → `version-overrides/`.
- **`workers.yaml`** (release notes): same version overrides link update.
- **`gradual-deployments.mdx`**: internal `#version-overrides` reference changed to cross-link to the new page. Self-referential full-path anchors simplified to relative `#anchors`.
- Removed unused `TypeScriptExample` import from `gradual-deployments.mdx` (the TypeScript example moved to the cohort page).
- Fixed minor typo: "in to access" → "to access" in the runtime binding section.