### PR TITLE
Adds docs for container rollout none option

### DIFF
--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -23,7 +23,7 @@ In this guide, we will build and push a container image alongside your Worker co
 
 ### Deploy without Docker
 
-If you do not have Docker running locally but want to deploy Worker code changes without rebuilding the container image, pass `--containers-rollout=none` to the deploy command:
+If you do not have Docker running locally but want to deploy Worker code changes without rebuilding the container image, pass [`--containers-rollout=none`](/workers/wrangler/commands/#deploy) to the deploy command:
 
 <PackageManagers
 	type="exec"
@@ -31,7 +31,7 @@ If you do not have Docker running locally but want to deploy Worker code changes
 	args="deploy --containers-rollout=none"
 />
 
-This skips the container image build and push steps, deploying your Worker code while reusing the existing container image from a previous deployment. You must have deployed the container at least once with Docker before using this option.
+This skips the container image build and push steps and deploys your Worker code while reusing the existing container image from a previous deployment. You must have deployed the container at least once with Docker before using this option.
 
 ## Deploy your first Container
 

--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -21,8 +21,17 @@ In this guide, we will build and push a container image alongside your Worker co
 
 <Render product="containers" file="docker-setup" />
 
-{/* FUTURE CHANGE: Add some image you can use if you don't have Docker running. */}
-{/* FUTURE CHANGE: Link to docs on alternative build/push options */}
+### Deploy without Docker
+
+If you do not have Docker running locally but want to deploy Worker code changes without rebuilding the container image, pass `--containers-rollout=none` to the deploy command:
+
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="deploy --containers-rollout=none"
+/>
+
+This skips the container image build and push steps, deploying your Worker code while reusing the existing container image from a previous deployment. You must have deployed the container at least once with Docker before using this option.
 
 ## Deploy your first Container
 

--- a/src/content/docs/sandbox/configuration/wrangler.mdx
+++ b/src/content/docs/sandbox/configuration/wrangler.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-import { WranglerConfig } from "~/components";
+import { WranglerConfig, PackageManagers } from "~/components";
 
 ## Minimal configuration
 
@@ -51,6 +51,18 @@ The Sandbox SDK is built on Cloudflare Containers. Your configuration requires t
 3. **migrations** - Initialize the Durable Object class
 
 The minimal configuration shown above includes all required settings. For detailed configuration options, refer to the [Containers configuration documentation](/workers/wrangler/configuration/#containers).
+
+## Deploy without Docker
+
+If you do not have Docker running locally but want to deploy Worker code changes without rebuilding the container image, pass `--containers-rollout=none` to the deploy command:
+
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="deploy --containers-rollout=none"
+/>
+
+This skips the container image build and push steps, deploying your Worker code while reusing the existing container image from a previous deployment. You must have deployed the container at least once with Docker before using this option.
 
 ## Troubleshooting
 

--- a/src/content/docs/sandbox/configuration/wrangler.mdx
+++ b/src/content/docs/sandbox/configuration/wrangler.mdx
@@ -54,7 +54,7 @@ The minimal configuration shown above includes all required settings. For detail
 
 ## Deploy without Docker
 
-If you do not have Docker running locally but want to deploy Worker code changes without rebuilding the container image, pass `--containers-rollout=none` to the deploy command:
+If you do not have Docker running locally but want to deploy Worker code changes without rebuilding the container image, pass [`--containers-rollout=none`](/workers/wrangler/commands/#deploy) to the deploy command:
 
 <PackageManagers
 	type="exec"
@@ -62,7 +62,7 @@ If you do not have Docker running locally but want to deploy Worker code changes
 	args="deploy --containers-rollout=none"
 />
 
-This skips the container image build and push steps, deploying your Worker code while reusing the existing container image from a previous deployment. You must have deployed the container at least once with Docker before using this option.
+This skips the container image build and push steps and deploys your Worker code while reusing the existing container image from a previous deployment. You must have deployed the container at least once with Docker before using this option.
 
 ## Troubleshooting
 

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -336,9 +336,11 @@ None of the options for this command are required. Also, many can be set in your
   - Specify the [Workers for Platforms dispatch namespace](/cloudflare-for-platforms/workers-for-platforms/how-workers-for-platforms-works/#dispatch-namespace) to upload this Worker to.
 - `--metafile` <Type text="string" /> <MetaInfo text="optional" />
   - Specify a file to write the build metadata from esbuild to. If flag is used without a path string, this defaults to `bundle-meta.json` inside the directory specified by `--outdir`. This can be useful for understanding the bundle size.
-- `--containers-rollout` <Type text="immediate | gradual" /> <MetaInfo text="optional" />
-  - Specify the [rollout strategy](/containers/faq#how-do-container-updates-and-rollouts-work) for [Containers](/containers) associated with the Worker. If set to `immediate`, 100% of container instances will be updated in one rollout step, overriding any configuration in `rollout_step_percentage`. Note that `rollout_active_grace_period`, if configured, still applies.
-  - Defaults to `gradual`, where the default rollout is 10% then 100% of instances.
+- `--containers-rollout` <Type text="immediate | gradual | none" /> <MetaInfo text="optional" />
+  - Specify the [rollout strategy](/containers/faq#how-do-container-updates-and-rollouts-work) for [Containers](/containers) associated with the Worker.
+  - `gradual` (default) — Rolls out to 10% then 100% of instances.
+  - `immediate` — Rolls out to 100% of container instances in one step, overriding any configuration in `rollout_step_percentage`. Note that `rollout_active_grace_period`, if configured, still applies.
+  - `none` — Skips building and pushing a new container image. Use this when you do not have Docker running locally but still want to deploy Worker code changes. The deployment uses the existing container image from a previous deploy.
 - `--strict` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
   - Turns on strict mode for the deployment command, meaning that the command will be more defensive and prevent deployments which could introduce potential issues. In particular, this mode prevents deployments if the deployment would potentially override remote settings in non-interactive environments.
 - `--tag` <Type text="string" /> <MetaInfo text="optional" />

--- a/src/content/docs/workers/wrangler/commands.mdx
+++ b/src/content/docs/workers/wrangler/commands.mdx
@@ -340,7 +340,7 @@ None of the options for this command are required. Also, many can be set in your
   - Specify the [rollout strategy](/containers/faq#how-do-container-updates-and-rollouts-work) for [Containers](/containers) associated with the Worker.
   - `gradual` (default) — Rolls out to 10% then 100% of instances.
   - `immediate` — Rolls out to 100% of container instances in one step, overriding any configuration in `rollout_step_percentage`. Note that `rollout_active_grace_period`, if configured, still applies.
-  - `none` — Skips building and pushing a new container image. Use this when you do not have Docker running locally but still want to deploy Worker code changes. The deployment uses the existing container image from a previous deploy.
+  - `none` — Skips building and pushing a new container image. Use this when you do not have Docker running locally but still want to deploy Worker code changes. The deployment uses the existing container image from a previous deployment.
 - `--strict` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
   - Turns on strict mode for the deployment command, meaning that the command will be more defensive and prevent deployments which could introduce potential issues. In particular, this mode prevents deployments if the deployment would potentially override remote settings in non-interactive environments.
 - `--tag` <Type text="string" /> <MetaInfo text="optional" />


### PR DESCRIPTION
### Summary

Added a new option to skip container rollout in Wrangler - https://github.com/cloudflare/workers-sdk/pull/12656 - Adds docs for this.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/28543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
