### PR TITLE
Fix sandbox env vars type annotations

### DIFF
--- a/src/content/docs/sandbox/configuration/environment-variables.mdx
+++ b/src/content/docs/sandbox/configuration/environment-variables.mdx
@@ -183,9 +183,10 @@ Then pass them to your sandbox:
 
 ```typescript
 import { getSandbox } from "@cloudflare/sandbox";
+export { Sandbox } from "@cloudflare/sandbox";
 
 interface Env {
-	Sandbox: DurableObjectNamespace;
+	Sandbox: DurableObjectNamespace<Sandbox>;
 	OPENAI_API_KEY: string;
 	DATABASE_URL: string;
 }
@@ -278,9 +279,10 @@ Bucket mounting requires production deployment. It does not work with `wrangler 
 
 ```typescript
 import { getSandbox } from "@cloudflare/sandbox";
+export { Sandbox } from "@cloudflare/sandbox";
 
 interface Env {
-	Sandbox: DurableObjectNamespace;
+	Sandbox: DurableObjectNamespace<Sandbox>;
 	AWS_ACCESS_KEY_ID: string;
 	AWS_SECRET_ACCESS_KEY: string;
 }

--- a/src/content/docs/sandbox/configuration/environment-variables.mdx
+++ b/src/content/docs/sandbox/configuration/environment-variables.mdx
@@ -27,7 +27,7 @@ Controls the transport protocol for SDK-to-container communication. WebSocket tr
 {
 	"vars": {
 		"SANDBOX_TRANSPORT": "websocket"
-	},
+	}
 }
 ```
 </WranglerConfig>


### PR DESCRIPTION
### Summary

Resolves https://github.com/issues/assigned?issue=cloudflare%7Csandbox-sdk%7C397

<!-- Add context such as the type of documentation being updated or added -->

#### Fix DurableObjectNamespace type annotations in environment variables examples

Two code blocks in the environment variables docs use bare `DurableObjectNamespace` and are missing the `export { Sandbox }` re-export, causing type errors when users copy them. All other sandbox docs (get-started, tutorials) already use the correct pattern.

**Changes:**

- Added `export { Sandbox } from "@cloudflare/sandbox"` to both code blocks
- Changed `DurableObjectNamespace` to `DurableObjectNamespace<Sandbox>` in both `Env` interfaces

_Generated by OpenCode._


### Documentation checklist

<!-- Remove items that do not apply -->

~- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).~
~- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).~
~- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.~
~- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).~
