### PR TITLE
Image Transformation Nits: Make Aliases more visible + Remove unwanted JS annotations on URL blocks

### DIFF
--- a/src/content/partials/images/anim.mdx
+++ b/src/content/partials/images/anim.mdx
@@ -7,7 +7,7 @@ Whether to preserve animation frames from input files. Default is `true`. Settin
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     anim=false
     ```
   </TabItem>

--- a/src/content/partials/images/background.mdx
+++ b/src/content/partials/images/background.mdx
@@ -8,7 +8,7 @@ Background color to add underneath the image. Applies to images with transparenc
 
 <Tabs>
   <TabItem label="URL format">
-  ```js
+  ```txt
 background=%23RRGGBB
 
 OR

--- a/src/content/partials/images/blur.mdx
+++ b/src/content/partials/images/blur.mdx
@@ -7,7 +7,7 @@ Blur radius between `1` (slight blur) and `250` (maximum). Be aware that you can
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     blur=50
     ```
   </TabItem>

--- a/src/content/partials/images/brightness.mdx
+++ b/src/content/partials/images/brightness.mdx
@@ -7,7 +7,7 @@ Increase brightness by a factor. A value of `1.0` equals no change, a value of `
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     brightness=0.5
     ```
   </TabItem>

--- a/src/content/partials/images/compression.mdx
+++ b/src/content/partials/images/compression.mdx
@@ -7,7 +7,7 @@ Slightly reduces latency on a cache miss by selecting a quickest-to-compress fil
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     compression=fast
     ```
   </TabItem>

--- a/src/content/partials/images/contrast.mdx
+++ b/src/content/partials/images/contrast.mdx
@@ -7,7 +7,7 @@ Increase contrast by a factor. A value of `1.0` equals no change, a value of `0.
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     contrast=0.5
     ```
   </TabItem>

--- a/src/content/partials/images/dpr.mdx
+++ b/src/content/partials/images/dpr.mdx
@@ -7,7 +7,7 @@ Device Pixel Ratio. Default is `1`. Multiplier for `width`/`height` that makes i
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     dpr=1
     ```
   </TabItem>

--- a/src/content/partials/images/fit.mdx
+++ b/src/content/partials/images/fit.mdx
@@ -20,7 +20,7 @@ Affects interpretation of `width` and `height`. All resizing modes preserve aspe
   Resizes the image to the exact width and height specified. This mode does not preserve the original aspect ratio and will cause the image to appear stretched or squashed.
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     fit=scale-down
     ```
   </TabItem>

--- a/src/content/partials/images/flip.mdx
+++ b/src/content/partials/images/flip.mdx
@@ -15,7 +15,7 @@ Available options are:
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     flip=h
     ```
   </TabItem>

--- a/src/content/partials/images/format.mdx
+++ b/src/content/partials/images/format.mdx
@@ -14,14 +14,16 @@ Other supported options:
 - `baseline-jpeg`: Generate images in baseline sequential JPEG format. It should be used in cases when target devices don't support progressive JPEG or other modern file formats.
 - `json`: Instead of generating an image, outputs information about the image in JSON format. The JSON object will contain data such as image size (before and after resizing), source image's MIME type, and file size.
 
+**Alias:** `f`
+
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     format=auto
     ```
   </TabItem>
   <TabItem label="URL format alias">
-  ```js
+  ```txt
   f=auto
   ```
   </TabItem>

--- a/src/content/partials/images/gamma.mdx
+++ b/src/content/partials/images/gamma.mdx
@@ -7,7 +7,7 @@ Increase exposure by a factor. A value of `1.0` equals no change, a value of `0.
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     gamma=0.5
     ```
   </TabItem>

--- a/src/content/partials/images/gravity.mdx
+++ b/src/content/partials/images/gravity.mdx
@@ -25,9 +25,11 @@ You must subtract the height of the image before you calculate the focal point.
 
 	This feature uses an open-source model called RetinaFace through WorkersAI. Our model pipeline is limited only to facial detection, or identifying the pixels that represent a human face. We do not support facial identification or recognition. Read more about Cloudflare's [approach to responsible AI](https://www.cloudflare.com/trust-hub/responsible-ai/).
 
+**Alias:** `g`
+
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     gravity=auto
 
     OR
@@ -45,7 +47,7 @@ You must subtract the height of the image before you calculate the focal point.
 
   </TabItem>
   <TabItem label="URL format alias">
-    ```js
+    ```txt
     g=auto
 
     OR

--- a/src/content/partials/images/height.mdx
+++ b/src/content/partials/images/height.mdx
@@ -5,14 +5,16 @@ import { Tabs, TabItem } from "~/components"
 
 Specifies maximum height of the image in pixels. Exact behavior depends on the `fit` mode (described below).
 
+**Alias:** `h`
+
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     height=250
     ```
   </TabItem>
   <TabItem label="URL format alias">
-  ```js
+  ```txt
   h=250
   ```
   </TabItem>

--- a/src/content/partials/images/metadata.mdx
+++ b/src/content/partials/images/metadata.mdx
@@ -27,7 +27,7 @@ Options include:
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     metadata=none
     ```
   </TabItem>

--- a/src/content/partials/images/onerror.mdx
+++ b/src/content/partials/images/onerror.mdx
@@ -12,7 +12,7 @@ In case of a [fatal error](/images/reference/troubleshooting/#error-responses-fr
 
 <Tabs>
 	<TabItem label="URL format">
-		```js
+		```txt
 		onerror=redirect
 		```
 	</TabItem>

--- a/src/content/partials/images/quality.mdx
+++ b/src/content/partials/images/quality.mdx
@@ -8,9 +8,11 @@ Specifies quality for images in JPEG, WebP, and AVIF formats. The quality is in 
 
 We also allow setting one of the perceptual quality levels `high|medium-high|medium-low|low`
 
+**Alias:** `q`
+
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     quality=50
 
     OR
@@ -19,7 +21,7 @@ We also allow setting one of the perceptual quality levels `high|medium-high|med
     ```
   </TabItem>
   <TabItem label="URL format alias">
-  ```js
+  ```txt
   q=50
 
 OR

--- a/src/content/partials/images/rotate.mdx
+++ b/src/content/partials/images/rotate.mdx
@@ -7,7 +7,7 @@ Number of degrees (`90`, `180`, or `270`) to rotate the image by. `width` and `h
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     rotate=90
     ```
   </TabItem>

--- a/src/content/partials/images/saturation.mdx
+++ b/src/content/partials/images/saturation.mdx
@@ -7,7 +7,7 @@ Increases saturation by a factor. A value of `1.0` equals no change, a value of 
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     saturation=0.5
     ```
   </TabItem>

--- a/src/content/partials/images/segment.mdx
+++ b/src/content/partials/images/segment.mdx
@@ -9,7 +9,7 @@ Automatically isolates the subject of an image by replacing the background with 
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     segment=foreground
     ```
   </TabItem>

--- a/src/content/partials/images/sharpen.mdx
+++ b/src/content/partials/images/sharpen.mdx
@@ -7,7 +7,7 @@ Specifies strength of sharpening filter to apply to the image. The value is a fl
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     sharpen=2
     ```
   </TabItem>

--- a/src/content/partials/images/slow-connection-quality.mdx
+++ b/src/content/partials/images/slow-connection-quality.mdx
@@ -8,14 +8,16 @@ Allows overriding `quality` value whenever a slow connection is detected.
 
 Available options are same as [quality](/images/transform-images/transform-via-url/#quality).
 
+**Alias:** `scq`
+
 <Tabs>
 	<TabItem label="URL format">
-		```js
+		```txt
 		slow-connection-quality=50
 		```
 	</TabItem>
 	<TabItem label="URL format alias">
-		```js
+		```txt
 		scq=50
 		```
 	</TabItem>

--- a/src/content/partials/images/trim.mdx
+++ b/src/content/partials/images/trim.mdx
@@ -7,7 +7,7 @@ Specifies a number of pixels to cut off on each side. Allows removal of borders 
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     trim=20;30;20;0
     trim.width=678
     trim.height=678
@@ -35,7 +35,7 @@ The number of pixels of the original border to leave untrimmed.
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     trim=border
 
     OR

--- a/src/content/partials/images/width.mdx
+++ b/src/content/partials/images/width.mdx
@@ -7,14 +7,16 @@ Specifies maximum width of the image. Exact behavior depends on the `fit` mode; 
 
 Available options are a specified width in pixels or `auto`.
 
+**Alias:** `w`
+
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     width=250
     ```
   </TabItem>
   <TabItem label="URL format alias">
-    ```js
+    ```txt
     w=250
     ```
   </TabItem>

--- a/src/content/partials/images/zoom.mdx
+++ b/src/content/partials/images/zoom.mdx
@@ -10,12 +10,12 @@ This controls the threshold for how much of the surrounding pixels around the fa
 
 <Tabs>
   <TabItem label="URL format">
-    ```js
+    ```txt
     zoom=0.1
     ```
   </TabItem>
   <TabItem label="URL format alias">
-    ```js
+    ```txt
     zoom=0.2
     OR
 


### PR DESCRIPTION
### Summary

Some small changes based on internal user feedback

### Screenshots (optional)

Old: 
<img width="775" height="302" alt="image" src="https://github.com/user-attachments/assets/b1e4ccf3-04d5-475d-9fc2-975c723a7b41" />


New:
<img width="1524" height="628" alt="image" src="https://github.com/user-attachments/assets/5b0927cc-4e4e-468d-bb8e-d4852ede847f" />

