### PR TITLE
[Bonk] Bonk should only run if explicitly asked

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   bonk:
-    if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bonk')
+    if: github.event.sender.type != 'Bot' && (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   bonk:
-    if: github.event.sender.type != 'Bot'
+    if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/bonk')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
We want to avoid triggering a bunch of 1 min builds to get to [this outcome](https://github.com/cloudflare/cloudflare-docs/actions/runs/22355389298/job/64693468794?pr=28527#step:5:62).

cc: @elithrar / @irvinebroque for viz