### PR TITLE
[Sandbox] Remove DinD limitation, link to Docker-in-Docker guide

### DIFF
--- a/src/content/docs/sandbox/concepts/containers.mdx
+++ b/src/content/docs/sandbox/concepts/containers.mdx
@@ -102,10 +102,10 @@ const sandbox = getSandbox(env.Sandbox, `user-${userId}`);
 
 **Cannot**:
 - Load kernel modules or access host hardware
-- Run nested containers (no Docker-in-Docker)
 
 ## Related resources
 
 - [Architecture](/sandbox/concepts/architecture/) - How containers fit in the system
 - [Security model](/sandbox/concepts/security/) - Container isolation details
 - [Sandbox lifecycle](/sandbox/concepts/sandboxes/) - Container lifecycle management
+- [Docker-in-Docker](/sandbox/guides/docker-in-docker/) - Run Docker containers inside a Sandbox


### PR DESCRIPTION
## Summary

- Removes \"Run nested containers (no Docker-in-Docker)\" from the `containers.mdx` limitations list, as Docker-in-Docker is now officially supported
- Adds a link to the [Docker-in-Docker guide](/sandbox/guides/docker-in-docker/) in the Related resources section

## Test plan

- [x] Verify the Limitations section no longer mentions Docker-in-Docker as unsupported
- [x] Verify the Related resources section links to `/sandbox/guides/docker-in-docker/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)