### PR TITLE
[Sandbox] Replace exposedAt with url across docs

### DIFF
--- a/src/content/docs/sandbox/api/ports.mdx
+++ b/src/content/docs/sandbox/api/ports.mdx
@@ -180,14 +180,14 @@ Get information about all currently exposed ports.
 const response = await sandbox.getExposedPorts(): Promise<GetExposedPortsResponse>
 ```
 
-**Returns**: `Promise<GetExposedPortsResponse>` with `ports` array (containing `port`, `exposedAt`, `name`)
+**Returns**: `Promise<GetExposedPortsResponse>` with `ports` array (containing `port`, `url`, `name`)
 
 <TypeScriptExample>
 ```
 const { ports } = await sandbox.getExposedPorts();
 
 for (const port of ports) {
-  console.log(`${port.name || port.port}: ${port.exposedAt}`);
+  console.log(`${port.name || port.port}: ${port.url}`);
 }
 ```
 </TypeScriptExample>

--- a/src/content/docs/sandbox/concepts/containers.mdx
+++ b/src/content/docs/sandbox/concepts/containers.mdx
@@ -69,7 +69,7 @@ npm install express
 const { hostname } = new URL(request.url);
 await sandbox.startProcess('python -m http.server 8000');
 const exposed = await sandbox.exposePort(8000, { hostname });
-console.log(exposed.exposedAt); // Public URL
+console.log(exposed.url); // Public URL
 ```
 
 :::note[Local development]

--- a/src/content/docs/sandbox/guides/expose-services.mdx
+++ b/src/content/docs/sandbox/guides/expose-services.mdx
@@ -54,11 +54,11 @@ export default {
     const exposed = await sandbox.exposePort(8000, { hostname });
 
     // 4. Preview URL is now available (public by default)
-    console.log('Server accessible at:', exposed.exposedAt);
+    console.log('Server accessible at:', exposed.url);
     // Production: https://8000-abc123.yourdomain.com
     // Local dev: http://localhost:8787/...
 
-    return Response.json({ url: exposed.exposedAt });
+    return Response.json({ url: exposed.url });
   }
 };
 ```
@@ -155,8 +155,8 @@ const frontend = await sandbox.exposePort(5173, {
 });
 
 console.log('Services:');
-console.log('- API:', api.exposedAt);
-console.log('- Frontend:', frontend.exposedAt);
+console.log('- API:', api.url);
+console.log('- Frontend:', frontend.url);
 ```
 </TypeScriptExample>
 
@@ -230,8 +230,8 @@ const api = await sandbox.exposePort(8080, { hostname, name: 'api' });
 const frontend = await sandbox.exposePort(5173, { hostname, name: 'frontend' });
 
 return Response.json({
-  api: api.exposedAt,
-  frontend: frontend.exposedAt
+  api: api.url,
+  frontend: frontend.url
 });
 ```
 </TypeScriptExample>
@@ -247,7 +247,7 @@ const { ports, count } = await sandbox.getExposedPorts();
 console.log(`${count} ports currently exposed:`);
 
 for (const port of ports) {
-  console.log(`  Port ${port.port}: ${port.exposedAt}`);
+  console.log(`  Port ${port.port}: ${port.url}`);
   if (port.name) {
     console.log(`    Name: ${port.name}`);
   }

--- a/src/content/docs/sandbox/guides/production-deployment.mdx
+++ b/src/content/docs/sandbox/guides/production-deployment.mdx
@@ -87,7 +87,7 @@ const sandbox = getSandbox(env.Sandbox, 'test-sandbox');
 await sandbox.startProcess('python -m http.server 8080');
 const exposed = await sandbox.exposePort(8080, { hostname });
 
-console.log(exposed.exposedAt);
+console.log(exposed.url);
 // https://8080-test-sandbox.yourdomain.com
 ```
 

--- a/src/content/docs/sandbox/guides/websocket-connections.mdx
+++ b/src/content/docs/sandbox/guides/websocket-connections.mdx
@@ -121,11 +121,11 @@ export default {
     const sandbox = getSandbox(env.Sandbox, 'echo-service');
 
     // Expose the port to get preview URL
-    const { exposedAt } = await sandbox.exposePort(8080, { hostname });
+    const { url } = await sandbox.exposePort(8080, { hostname });
 
     // Return URL to clients
     if (request.url.includes('/ws-url')) {
-      return Response.json({ url: exposedAt.replace('https', 'wss') });
+      return Response.json({ url: url.replace('https', 'wss') });
     }
 
     return new Response('Not found', { status: 404 });


### PR DESCRIPTION
## Summary

- Replaces all 12 occurrences of the deprecated `exposedAt` property with `url` across 5 sandbox doc files
- `exposePort()` returns `{ port, url, name }` and `getExposedPorts()` returns a `ports` array with the same `url` property — `exposedAt` no longer exists

## Files changed

| File | Occurrences |
|------|-------------|
| `api/ports.mdx` | 2 |
| `concepts/containers.mdx` | 1 |
| `guides/expose-services.mdx` | 6 |
| `guides/production-deployment.mdx` | 1 |
| `guides/websocket-connections.mdx` | 2 |

## Test plan

- [x] Verify zero remaining occurrences of `exposedAt` in `src/content/docs/sandbox/`
- [x] Confirm all code examples use `exposed.url`, `api.url`, `port.url`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)