### PR TITLE
dx: add ci to internal mirror

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,12 @@
+stages:
+  - review
+
+default:
+  id_tokens:
+    VAULT_ID_TOKEN:
+      aud: https://vault.cfdata.org
+
+include:
+  - component: $CI_SERVER_FQDN/cloudflare/ci/ai/opencode@~latest
+    inputs:
+      runOnMR: true


### PR DESCRIPTION
Our internal mirror has a auto-requirement for CI. This is to pass the requirement.