### PR TITLE
Update troubleshooting instructions for Docker

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/warp/troubleshooting/client-errors.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/warp/troubleshooting/client-errors.mdx
@@ -92,7 +92,7 @@ On macOS, you may see `mDNSResponder` instead of the specific application name -
 
 Below is a non-exhaustive list of third-party software that are known to cause `mDNSResponder` to bind to port `53`. Rather than try to stop `mDNSResponder`, you should either configure the third-party software so that they no longer use port `53`, or temporarily disable them before connecting to WARP.
 
-- **Docker**: [Turn off kernel networking for UDP](https://github.com/docker/for-mac/issues/7008#issuecomment-1746653802) in Docker.
+- **Docker**: [Turn off kernel networking for UDP](https://github.com/docker/for-mac/issues/7008#issuecomment-1746653802) in Docker. Alternatively, uncheck `Start Docker Desktop when you sign in to your computer` under [Settings > General](https://docs.docker.com/desktop/settings-and-maintenance/settings/#general). Disabling the automatic startup process will prevent Docker from binding to port 53 before WARP.
 - **Internet Sharing feature**: To disable Internet Sharing:
   1. On macOS, go to **System Settings** > **General** > **Sharing**.
   2. Turn off **Internet Sharing**.

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/warp/troubleshooting/client-errors.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/warp/troubleshooting/client-errors.mdx
@@ -92,7 +92,7 @@ On macOS, you may see `mDNSResponder` instead of the specific application name -
 
 Below is a non-exhaustive list of third-party software that are known to cause `mDNSResponder` to bind to port `53`. Rather than try to stop `mDNSResponder`, you should either configure the third-party software so that they no longer use port `53`, or temporarily disable them before connecting to WARP.
 
-- **Docker**: [Turn off kernel networking for UDP](https://github.com/docker/for-mac/issues/7008#issuecomment-1746653802) in Docker. Alternatively, uncheck `Start Docker Desktop when you sign in to your computer` under [Settings > General](https://docs.docker.com/desktop/settings-and-maintenance/settings/#general). Disabling the automatic startup process will prevent Docker from binding to port 53 before WARP.
+- **Docker**: [Turn off kernel networking for UDP](https://github.com/docker/for-mac/issues/7008#issuecomment-1746653802) in Docker. Alternatively, uncheck **Start Docker Desktop when you sign in to your computer** under [**Settings** > **General**](https://docs.docker.com/desktop/settings-and-maintenance/settings/#general). Disabling the automatic startup process will prevent Docker from binding to port `53` before WARP.
 - **Internet Sharing feature**: To disable Internet Sharing:
   1. On macOS, go to **System Settings** > **General** > **Sharing**.
   2. Turn off **Internet Sharing**.


### PR DESCRIPTION
Added additional instructions for Docker configuration to prevent binding to port 53.

### Summary

As Docker was binding on port 53 and made it impossible for WARP to bind on the same port, disabling the auto start solved the issue.

### Screenshots (optional)
<img width="1199" height="673" alt="Screenshot 2026-02-24 at 17 28 16" src="https://github.com/user-attachments/assets/cecaa64b-36dc-4b11-83f9-d8a953c840bd" />




### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
