### PR TITLE
[Sandbox] Document path permissions for backup API

### DIFF
--- a/src/content/docs/sandbox/api/backups.mdx
+++ b/src/content/docs/sandbox/api/backups.mdx
@@ -63,6 +63,10 @@ await sandbox.restoreBackup(backup);
 You must configure a `BACKUP_BUCKET` R2 binding and R2 presigned URL credentials (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `CLOUDFLARE_ACCOUNT_ID`, `BACKUP_BUCKET_NAME`) in your `wrangler.jsonc` before using backup methods. Refer to the [Wrangler configuration](/sandbox/configuration/wrangler/) for binding setup.
 :::
 
+:::caution[Path permissions]
+The backup process uses `mksquashfs`, which must have read access to every file and subdirectory in the target path. If any file has restrictive permissions (for example, directories owned by a different user), the backup fails with a `BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied` error. Run `chmod -R a+rX` on the target directory before backing up, or refer to the [path permissions guide](/sandbox/guides/backup-restore/#path-permissions) for other options.
+:::
+
 :::caution[Partial writes]
 Partially-written files may not be captured consistently. Only completed writes are guaranteed to be included in the backup.
 :::

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -371,6 +371,51 @@ try {
 
 </TypeScriptExample>
 
+## Path permissions
+
+The `createBackup()` method uses `mksquashfs` to create a compressed archive of the target directory. This process must be able to read every file and subdirectory within the path you are backing up. If any file or directory has restrictive permissions that prevent the archiver from reading it, the backup fails with a `BackupCreateError` and a "Permission denied" message.
+
+### Common causes
+
+- **Directories owned by other users** — If the target directory contains subdirectories created by a different user or process (for example, `/home/sandbox/.claude`), the archiver may not have read access.
+- **Restrictive file modes** — Files with modes like `0600` or directories with `0700` that belong to a different user than the one running the backup process.
+- **Runtime-generated config directories** — Tools and applications often create configuration directories (such as `.cache`, `.config`, or tool-specific dotfiles) with restrictive permissions.
+
+### Fix permissions before backing up
+
+Ensure the backup process can read all files in the target directory. You can adjust permissions before creating a backup:
+
+```ts
+// Fix permissions before backup
+await sandbox.exec("chmod -R a+rX /home/sandbox/.secret");
+const backup = await sandbox.createBackup({ dir: "/home/sandbox" });
+```
+
+The `a+rX` flag grants read access to all files and execute (traverse) access to all directories, without changing write permissions.
+
+### Back up a parent directory selectively
+
+If you cannot change permissions on certain paths, back up a directory that does not contain restricted subdirectories, or remove the problematic paths first:
+
+```ts
+// Option 1: Back up only the directory you control
+const backup = await sandbox.createBackup({ dir: "/workspace" });
+
+// Option 2: Remove restricted paths before backup
+await sandbox.exec("rm -rf /home/sandbox/.secret/restricted-dir");
+const backup = await sandbox.createBackup({ dir: "/home/sandbox" });
+```
+
+### Example error
+
+If the backup encounters a permission issue, you will see an error like:
+
+```txt
+BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied
+```
+
+This means `mksquashfs` could not read one or more files inside the directory you passed to `createBackup()`. Check the permissions of all files and subdirectories within that path.
+
 ## Best practices
 
 - **Stop writes before restoring** - Stop processes writing to the target directory before calling `restoreBackup()`

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -381,28 +381,23 @@ The `createBackup()` method uses `mksquashfs` to create a compressed archive of 
 - **Restrictive file modes** — Files with modes like `0600` or directories with `0700` that belong to a different user than the one running the backup process.
 - **Runtime-generated config directories** — Tools and applications often create configuration directories (such as `.cache`, `.config`, or tool-specific dotfiles) with restrictive permissions.
 
-### Fix permissions before backing up
+### Fix permissions at build time
 
-Ensure the backup process can read all files in the target directory. You can adjust permissions before creating a backup:
+The recommended approach is to set permissions in your Dockerfile so that every container starts with the correct access. This avoids running `chmod` at runtime before every backup:
 
-```ts
-// Fix permissions before backup
-await sandbox.exec("chmod -R a+rX /home/sandbox/.secret");
-const backup = await sandbox.createBackup({ dir: "/home/sandbox" });
+```dockerfile
+# Ensure the backup target directory is readable
+RUN mkdir -p /home/sandbox && chmod -R a+rX /home/sandbox
 ```
 
 The `a+rX` flag grants read access to all files and execute (traverse) access to all directories, without changing write permissions.
 
-### Back up a parent directory selectively
+### Fix permissions at runtime
 
-If you cannot change permissions on certain paths, back up a directory that does not contain restricted subdirectories, or remove the problematic paths first:
+If the restrictive permissions come from files created at runtime (for example, a tool that generates config files with `0600` mode), fix them before calling `createBackup()`:
 
 ```ts
-// Option 1: Back up only the directory you control
-const backup = await sandbox.createBackup({ dir: "/workspace" });
-
-// Option 2: Remove restricted paths before backup
-await sandbox.exec("rm -rf /home/sandbox/.secret/restricted-dir");
+await sandbox.exec("chmod -R a+rX /home/sandbox/.claude");
 const backup = await sandbox.createBackup({ dir: "/home/sandbox" });
 ```
 


### PR DESCRIPTION
## Summary

- Adds a "Path permissions" section to the backup and restore guide explaining that `mksquashfs` requires read access to all files in the target directory, with common causes and fixes
- Adds a caution admonition to the Backups API reference linking to the new section

This addresses a common issue where `createBackup()` fails with `BackupCreateError: mksquashfs failed: Could not create destination file: Permission denied` when the target directory contains files or subdirectories with restrictive permissions (e.g. `/home/sandbox/.claude` owned by a different user).