### PR TITLE
Refactor llms.txt and add per-product llms.txt

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -144,6 +144,7 @@ export default defineConfig({
 									"/http/resources/**",
 									"/llms.txt",
 									"/llms-full.txt",
+									"**/llms.txt",
 									"{props.*}",
 									"/",
 									"/glossary/",

--- a/src/content/partials/style-guide/llms-txt.mdx
+++ b/src/content/partials/style-guide/llms-txt.mdx
@@ -6,8 +6,7 @@ import { Width } from "~/components";
 
 We have implemented `llms.txt` and `llms-full.txt` as follows:
 
-- [`llms.txt`](/llms.txt) — A directory of all Cloudflare documentation products, grouped by category. Each entry links to that product's own `llms.txt` file. Use this as the starting point for discovering what documentation is available.
-- `/$product/llms.txt` — A per-product page index listing every documentation page for that product in Markdown format. For example, [`/workers/llms.txt`](/workers/llms.txt). Use this when you need to find a specific page within a product.
+- [`llms.txt`](/llms.txt) — A directory of all Cloudflare documentation products, grouped by category. Each entry links to that product's own `llms.txt` — for example, [`/workers/llms.txt`](/workers/llms.txt) — which lists every page for that product in Markdown format.
 - [`llms-full.txt`](/llms-full.txt) — The full contents of all Cloudflare documentation in a single file, intended for offline indexing, bulk vectorization, or large-context models. We also provide a `llms-full.txt` file on a per-product basis — for example, [`/workers/llms-full.txt`](/workers/llms-full.txt).
 
 To obtain a Markdown version of a single documentation page, you can:

--- a/src/content/partials/style-guide/llms-txt.mdx
+++ b/src/content/partials/style-guide/llms-txt.mdx
@@ -7,7 +7,7 @@ import { Width } from "~/components";
 We have implemented `llms.txt` and `llms-full.txt` as follows:
 
 - [`llms.txt`](/llms.txt) — A directory of all Cloudflare documentation products, grouped by category. Each entry links to that product's own `llms.txt` file. Use this as the starting point for discovering what documentation is available.
-- `/{product}/llms.txt` — A per-product page index listing every documentation page for that product in Markdown format. For example, [`/workers/llms.txt`](/workers/llms.txt). Use this when you need to find a specific page within a product.
+- `/$product/llms.txt` — A per-product page index listing every documentation page for that product in Markdown format. For example, [`/workers/llms.txt`](/workers/llms.txt). Use this when you need to find a specific page within a product.
 - [`llms-full.txt`](/llms-full.txt) — The full contents of all Cloudflare documentation in a single file, intended for offline indexing, bulk vectorization, or large-context models. We also provide a `llms-full.txt` file on a per-product basis — for example, [`/workers/llms-full.txt`](/workers/llms-full.txt).
 
 To obtain a Markdown version of a single documentation page, you can:

--- a/src/content/partials/style-guide/llms-txt.mdx
+++ b/src/content/partials/style-guide/llms-txt.mdx
@@ -6,8 +6,9 @@ import { Width } from "~/components";
 
 We have implemented `llms.txt` and `llms-full.txt` as follows:
 
-- [`llms.txt`](/llms.txt) — An LLM-friendly directory of all available documentation pages for Dev Platform products in Markdown format.
-- [`llms-full.txt`](/llms-full.txt) — The full contents of the Developer Docs for LLM consumption in Markdown format. We also provide a `llms-full.txt` file on a per-product basis - for example, [`/workers/llms-full.txt`](/workers/llms-full.txt).
+- [`llms.txt`](/llms.txt) — A directory of all Cloudflare documentation products, grouped by category. Each entry links to that product's own `llms.txt` file. Use this as the starting point for discovering what documentation is available.
+- `/{product}/llms.txt` — A per-product page index listing every documentation page for that product in Markdown format. For example, [`/workers/llms.txt`](/workers/llms.txt). Use this when you need to find a specific page within a product.
+- [`llms-full.txt`](/llms-full.txt) — The full contents of all Cloudflare documentation in a single file, intended for offline indexing, bulk vectorization, or large-context models. We also provide a `llms-full.txt` file on a per-product basis — for example, [`/workers/llms-full.txt`](/workers/llms-full.txt).
 
 To obtain a Markdown version of a single documentation page, you can:
 

--- a/src/pages/[product]/llms.txt.ts
+++ b/src/pages/[product]/llms.txt.ts
@@ -1,0 +1,62 @@
+import type { APIRoute, GetStaticPaths, InferGetStaticPropsType } from "astro";
+import { getCollection } from "astro:content";
+import dedent from "dedent";
+
+export const getStaticPaths = (async () => {
+	const directory = await getCollection("directory", (p) => {
+		return !!p.data.entry.group;
+	});
+
+	const docs = await getCollection("docs");
+
+	return directory
+		.map((entry) => {
+			const prefix = entry.data.entry.url.slice(1, -1);
+			const pages = docs.filter(
+				(e) => e.id.startsWith(prefix + "/") || e.id === prefix,
+			);
+
+			if (pages.length === 0) return null;
+
+			return {
+				params: { product: entry.id },
+				props: { entry, pages },
+			};
+		})
+		.filter((p) => p !== null);
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+export const GET: APIRoute<Props> = async ({ props }) => {
+	const { entry, pages } = props;
+	const { title, url } = entry.data.entry;
+	const description = entry.data.meta?.description;
+
+	const pageLinks = pages
+		.map((e) => {
+			const line = `- [${e.data.title}](https://developers.cloudflare.com/${e.id}/index.md)`;
+			return e.data.description ? line.concat(`: ${e.data.description}`) : line;
+		})
+		.join("\n");
+
+	const markdown = dedent(`
+		# ${title}
+
+		${description ?? ""}
+
+		> Use [${title} llms-full.txt](https://developers.cloudflare.com${url}llms-full.txt) for the complete ${title} documentation in a single file. That file is intended for offline indexing, bulk vectorization, or large-context models.
+		>
+		> For other Cloudflare products, see the [Cloudflare documentation directory](https://developers.cloudflare.com/llms.txt).
+
+		## ${title} documentation pages
+
+		${pageLinks}
+	`);
+
+	return new Response(markdown, {
+		headers: {
+			"content-type": "text/plain",
+		},
+	});
+};

--- a/src/pages/[product]/llms.txt.ts
+++ b/src/pages/[product]/llms.txt.ts
@@ -28,14 +28,15 @@ export const getStaticPaths = (async () => {
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
-export const GET: APIRoute<Props> = async ({ props }) => {
+export const GET: APIRoute<Props> = async ({ props, url }) => {
+	const base = url.origin;
 	const { entry, pages } = props;
-	const { title, url } = entry.data.entry;
+	const { title, url: productUrl } = entry.data.entry;
 	const description = entry.data.meta?.description;
 
 	const pageLinks = pages
 		.map((e) => {
-			const line = `- [${e.data.title}](https://developers.cloudflare.com/${e.id}/index.md)`;
+			const line = `- [${e.data.title}](${base}/${e.id}/index.md)`;
 			return e.data.description ? line.concat(`: ${e.data.description}`) : line;
 		})
 		.join("\n");
@@ -45,9 +46,9 @@ export const GET: APIRoute<Props> = async ({ props }) => {
 
 		${description ?? ""}
 
-		> Use [${title} llms-full.txt](https://developers.cloudflare.com${url}llms-full.txt) for the complete ${title} documentation in a single file. That file is intended for offline indexing, bulk vectorization, or large-context models.
+		> Use [${title} llms-full.txt](${base}${productUrl}llms-full.txt) for the complete ${title} documentation in a single file. That file is intended for offline indexing, bulk vectorization, or large-context models.
 		>
-		> For other Cloudflare products, see the [Cloudflare documentation directory](https://developers.cloudflare.com/llms.txt).
+		> For other Cloudflare products, see the [Cloudflare documentation directory](${base}/llms.txt).
 
 		## ${title} documentation pages
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -3,48 +3,51 @@ import { getCollection } from "astro:content";
 import dedent from "dedent";
 
 export const GET: APIRoute = async () => {
-	const products = await getCollection("directory", (p) => {
-		return p.data.entry.group?.toLowerCase() === "developer platform";
+	const directory = await getCollection("directory", (p) => {
+		return !!p.data.entry.group;
 	});
 
-	const docs = await getCollection("docs", (e) => {
-		return products.some((p) => e.id.startsWith(p.data.entry.url.slice(1, -1)));
-	});
+	const docs = await getCollection("docs");
 
-	const grouped = Object.entries(
-		Object.groupBy(docs, (e) => {
-			const product = products.find((p) =>
-				e.id.startsWith(p.data.entry.url.slice(1, -1)),
-			);
-
-			if (!product) throw new Error(`Unable to find product for ${e.id}`);
-
-			return product.data.entry.title;
-		}),
+	// Build a set of product IDs that actually have docs pages
+	const productsWithDocs = new Set(
+		directory
+			.filter((entry) => {
+				const prefix = entry.data.entry.url.slice(1, -1);
+				return docs.some(
+					(e) => e.id.startsWith(prefix + "/") || e.id === prefix,
+				);
+			})
+			.map((entry) => entry.id),
 	);
+
+	// Group products by their group, skipping any without docs pages
+	const grouped = Object.entries(
+		Object.groupBy(
+			directory.filter((entry) => productsWithDocs.has(entry.id)),
+			(entry) => entry.data.entry.group as string,
+		),
+	).sort(([a], [b]) => a.localeCompare(b));
 
 	const markdown = dedent(`
 		# Cloudflare Developer Documentation
 
-		Easily build and deploy full-stack applications everywhere,
-		thanks to integrated compute, storage, and networking.
+		Cloudflare's platform spans developer tools, network security, application performance, Zero Trust, and more.
+
+		> For the complete documentation archive in a single file, use the [Full Documentation Archive](https://developers.cloudflare.com/llms-full.txt). That file is intended for offline indexing, bulk vectorization, or large-context models.
+		>
+		> For a specific product's full page index, follow that product's llms.txt link below.
 
 		${grouped
-			.map(([product, entries]) => {
+			.map(([group, entries]) => {
 				return dedent(`
-				## ${product}
+				## ${group}
 
 				${entries
-					?.map((e) => {
-						const line = `- [${e.data.title}](https://developers.cloudflare.com/${e.id}/index.md)`;
-
-						const description = e.data.description;
-
-						if (description) {
-							return line.concat(`: ${description}`);
-						}
-
-						return line;
+					?.map((entry) => {
+						const line = `- [${entry.data.entry.title}](https://developers.cloudflare.com/${entry.id}/llms.txt)`;
+						const description = entry.data.meta?.description;
+						return description ? line.concat(`: ${description}`) : line;
 					})
 					.join("\n")}
 			`);

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -2,7 +2,8 @@ import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 import dedent from "dedent";
 
-export const GET: APIRoute = async () => {
+export const GET: APIRoute = async ({ url }) => {
+	const base = url.origin;
 	const directory = await getCollection("directory", (p) => {
 		return !!p.data.entry.group;
 	});
@@ -32,9 +33,9 @@ export const GET: APIRoute = async () => {
 	const markdown = dedent(`
 		# Cloudflare Developer Documentation
 
-		Cloudflare's platform spans developer tools, network security, application performance, Zero Trust, and more.
+		Explore guides and tutorials to start building on Cloudflare's platform.
 
-		> For the complete documentation archive in a single file, use the [Full Documentation Archive](https://developers.cloudflare.com/llms-full.txt). That file is intended for offline indexing, bulk vectorization, or large-context models.
+		> For the complete documentation archive in a single file, use the [Full Documentation Archive](${base}/llms-full.txt). That file is intended for offline indexing, bulk vectorization, or large-context models.
 		>
 		> For a specific product's full page index, follow that product's llms.txt link below.
 
@@ -45,7 +46,7 @@ export const GET: APIRoute = async () => {
 
 				${entries
 					?.map((entry) => {
-						const line = `- [${entry.data.entry.title}](https://developers.cloudflare.com/${entry.id}/llms.txt)`;
+						const line = `- [${entry.data.entry.title}](${base}/${entry.id}/llms.txt)`;
 						const description = entry.data.meta?.description;
 						return description ? line.concat(`: ${description}`) : line;
 					})

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -35,9 +35,9 @@ export const GET: APIRoute = async ({ url }) => {
 
 		Explore guides and tutorials to start building on Cloudflare's platform.
 
-		> For the complete documentation archive in a single file, use the [Full Documentation Archive](${base}/llms-full.txt). That file is intended for offline indexing, bulk vectorization, or large-context models.
+		> Each product below links to its own llms.txt, which contains a full index of that product's documentation pages and is the recommended way to explore a specific product's content.
 		>
-		> For a specific product's full page index, follow that product's llms.txt link below.
+		> For the complete documentation archive in a single file, use the [Full Documentation Archive](${base}/llms-full.txt). That file is intended for offline indexing, bulk vectorization, or large-context models. Each product's llms.txt also links to a product-scoped llms-full.txt.
 
 		${grouped
 			.map(([group, entries]) => {

--- a/src/util/sidebar.ts
+++ b/src/util/sidebar.ts
@@ -96,7 +96,7 @@ export async function generateSidebar(group: Group) {
 	const product = directory.find((p) => p.id === group.label);
 	if (product && product.data.entry.group === "Developer platform") {
 		const links = [
-			["llms.txt", "/llms.txt"],
+			["llms.txt", `/${product.id}/llms.txt`],
 			["prompt.txt", "/workers/prompt.txt"],
 			[`${product.data.name} llms-full.txt`, `/${product.id}/llms-full.txt`],
 			["Developer Platform llms-full.txt", "/developer-platform/llms-full.txt"],


### PR DESCRIPTION
### Summary

#### llms.txt
- Update root `llms.txt` to group products by category and link to product-specific `llms.txt` files
- Create `llms.txt` pages for each product at `/[product]/llms.txt`
- Add wildcard route pattern `**/llms.txt` to `astro.config.ts`
- Filter directory entries to only include products with actual documentation pages

#### Product side bars
- Update sidebar links to point to product-specific`llms.txt` instead of root

>**_Note:_** _The preview build `llms.txt` stuff all points torwards the prod domain `developers.cloudflare.com`, this is likely fixable by setting some env var for preview deploy builds, but it's out of scope for this ticket. Just manually update the baseUrl with the preview deploys domain manually._

### Screenshots (optional)

#### Product Side bars
<img width="640" height="933" alt="1" src="https://github.com/user-attachments/assets/25faa512-8ee8-4234-a98c-f2fdac6234eb" />
