### PR TITLE
[Workers] Add Error 501 Not Implemented documentation

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501.mdx
@@ -1,0 +1,18 @@
+---
+pcx_content_type: troubleshooting
+title: Error 501
+source: null
+---
+
+## Error 501: not implemented
+
+Cloudflare returns a `501` error when a request uses an HTTP method that is not supported by the Cloudflare Workers Runtime.
+
+### Common causes
+
+- A client sent a request to a Worker route using a custom or non-standard HTTP method (methods outside of `GET`, `POST`, `PUT`, etc.).
+- A typo in the HTTP method (e.g., `POT` instead of `POST`).
+
+### Resolution
+
+- Update the client to use a valid, standard [HTTP request method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501.mdx
@@ -6,11 +6,11 @@ source: null
 
 ## Error 501: not implemented
 
-Cloudflare returns a `501` error when a request uses an HTTP method that is not supported by the Cloudflare Workers Runtime.
+Cloudflare Workers returns a `501` error when a request uses an HTTP method that is not supported by the Workers Runtime.
 
 ### Common causes
 
-- A client sent a request to a Worker route using a custom or non-standard HTTP method (a method not defined in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-9)).
+- A client sent a request to a Workers script using a custom or non-standard HTTP method (methods outside of `GET`, `POST`, `PUT`, etc.).
 - A typo in the HTTP method (for example, `POT` instead of `POST`).
 
 ### Resolution

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501.mdx
@@ -11,7 +11,7 @@ Cloudflare returns a `501` error when a request uses an HTTP method that is not 
 ### Common causes
 
 - A client sent a request to a Worker route using a custom or non-standard HTTP method (methods outside of `GET`, `POST`, `PUT`, etc.).
-- A typo in the HTTP method (e.g., `POT` instead of `POST`).
+- A typo in the HTTP method (for example, `POT` instead of `POST`).
 
 ### Resolution
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501.mdx
@@ -10,7 +10,7 @@ Cloudflare returns a `501` error when a request uses an HTTP method that is not 
 
 ### Common causes
 
-- A client sent a request to a Worker route using a custom or non-standard HTTP method (methods outside of `GET`, `POST`, `PUT`, etc.).
+- A client sent a request to a Worker route using a custom or non-standard HTTP method (a method not defined in [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-9)).
 - A typo in the HTTP method (for example, `POT` instead of `POST`).
 
 ### Resolution

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/index.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/index.mdx
@@ -53,6 +53,10 @@ Log explorer [allows to build queries](/log-explorer/log-search/) filtering for 
 
 For a complete description of this error refer to the [Error 500](/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-500/) page.
 
+## Error 501: not implemented
+
+For a complete description of this error refer to the [Error 501](/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-501/) page.
+
 ## Error 502 bad gateway or error 504 gateway timeout
 
 For a complete description of this error refer to the [Error 502/504](/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-502-504/) page.


### PR DESCRIPTION
### Summary

[SPM-3086] Add documentation for HTTP Error 501 (Not Implemented) to the Cloudflare 5xx errors section.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
