### PR TITLE
docs(agents): sync API reference with Agents SDK 0.5.0+ changes

### DIFF
--- a/src/content/docs/agents/api-reference/mcp-client-api.mdx
+++ b/src/content/docs/agents/api-reference/mcp-client-api.mdx
@@ -445,9 +445,10 @@ function Dashboard() {
 
 ### `addMcpServer()`
 
-Add a connection to an MCP server and make its tools available to your agent.
+Add a connection to an MCP server and make its tools available to your agent. If `addMcpServer` is called with a `serverName` that already has an active connection, the existing connection is returned instead of creating a duplicate. This makes it safe to call in `onStart()` without worrying about duplicate connections on restart.
 
 ```ts
+// HTTP transport (Streamable HTTP, SSE)
 async addMcpServer(
   serverName: string,
   url: string,
@@ -460,24 +461,31 @@ async addMcpServer(
       headers?: HeadersInit;
       type?: "sse" | "streamable-http" | "auto";
     };
-    retry?: {
-      maxAttempts?: number;
-      baseDelayMs?: number;
-      maxDelayMs?: number;
-    };
+    retry?: RetryOptions;
   }
 ): Promise<
   | { id: string; state: "authenticating"; authUrl: string }
   | { id: string; state: "ready" }
 >
+
+// RPC transport (Durable Object binding — no HTTP overhead)
+async addMcpServer(
+  serverName: string,
+  binding: DurableObjectNamespace,
+  options?: {
+    props?: Record<string, unknown>;
+    client?: ClientOptions;
+    retry?: RetryOptions;
+  }
+): Promise<{ id: string; state: "ready" }>
 ```
 
-#### Parameters
+#### Parameters (HTTP transport)
 
 - `serverName` (string, required) — Display name for the MCP server
 - `url` (string, required) — URL of the MCP server endpoint
 - `options` (object, optional) — Connection configuration:
-  - `callbackHost` — Host for OAuth callback URL. If omitted, automatically derived from the incoming request
+  - `callbackHost` — Host for OAuth callback URL. Only needed for OAuth-authenticated servers. If omitted, automatically derived from the incoming request
   - `callbackPath` — Custom callback URL path that bypasses the default `/agents/{class}/{name}/callback` construction. **Required when `sendIdentityOnConnect` is `false`** to prevent leaking the instance name. When set, the callback URL becomes `{callbackHost}/{callbackPath}`. You must route this path to the agent instance via `getAgentByName`
   - `agentsPrefix` — URL prefix for OAuth callback path. Default: `"agents"`. Ignored when `callbackPath` is provided
   - `client` — MCP client configuration options (passed to `@modelcontextprotocol/sdk` Client constructor). By default, includes `CfWorkerJsonSchemaValidator` for validating tool parameters against JSON schemas
@@ -485,6 +493,17 @@ async addMcpServer(
     - `headers` — Custom HTTP headers for authentication
     - `type` — Transport type: `"auto"` (default), `"streamable-http"`, or `"sse"`
   - `retry` — Retry options for connection and reconnection attempts. Persisted and used when restoring connections after hibernation or after OAuth completion. Default: 3 attempts, 500ms base delay, 5s max delay. Refer to [Retries](/agents/api-reference/retries/) for details on `RetryOptions`.
+
+#### Parameters (RPC transport)
+
+- `serverName` (string, required) — Display name for the MCP server
+- `binding` (`DurableObjectNamespace`, required) — The Durable Object binding for the `McpAgent` class
+- `options` (object, optional) — Connection configuration:
+  - `props` — Initialization data passed to the `McpAgent`'s `onStart(props)`. Use this to pass user context, configuration, or other data to the MCP server instance
+  - `client` — MCP client configuration options
+  - `retry` — Retry options for the connection
+
+RPC transport connects your Agent directly to an `McpAgent` via Durable Object bindings without HTTP overhead. Refer to [MCP Transport](/agents/model-context-protocol/transport/) for details on configuring RPC transport.
 
 #### Returns
 

--- a/src/content/docs/agents/api-reference/queue-tasks.mdx
+++ b/src/content/docs/agents/api-reference/queue-tasks.mdx
@@ -84,7 +84,7 @@ dequeue(id: string): void
 
 ```ts
 // Remove a specific task
-await agent.dequeue("abc123def");
+agent.dequeue("abc123def");
 ```
 
 </TypeScriptExample>
@@ -103,7 +103,7 @@ dequeueAll(): void
 
 ```ts
 // Clear the entire queue
-await agent.dequeueAll();
+agent.dequeueAll();
 ```
 
 </TypeScriptExample>
@@ -126,7 +126,7 @@ dequeueAllByCallback(callback: string): void
 
 ```ts
 // Remove all email processing tasks
-await agent.dequeueAllByCallback("processEmail");
+agent.dequeueAllByCallback("processEmail");
 ```
 
 </TypeScriptExample>
@@ -152,7 +152,7 @@ The payload is automatically parsed from JSON before being returned.
 <TypeScriptExample>
 
 ```ts
-const task = await agent.getQueue("abc123def");
+const task = agent.getQueue("abc123def");
 if (task) {
 	console.log(`Task callback: ${task.callback}`);
 	console.log(`Task payload:`, task.payload);
@@ -184,7 +184,7 @@ This method fetches all queue items and filters them in memory by parsing each p
 
 ```ts
 // Find all tasks for a specific user
-const userTasks = await agent.getQueues("userId", "12345");
+const userTasks = agent.getQueues("userId", "12345");
 ```
 
 </TypeScriptExample>

--- a/src/content/docs/agents/api-reference/schedule-tasks.mdx
+++ b/src/content/docs/agents/api-reference/schedule-tasks.mdx
@@ -277,7 +277,7 @@ Retrieve a scheduled task by its ID:
 <TypeScriptExample>
 
 ```ts
-const schedule = await this.getSchedule(scheduleId);
+const schedule = this.getSchedule(scheduleId);
 
 if (schedule) {
 	console.log(
@@ -668,7 +668,8 @@ Use Workflows when:
 async schedule<T>(
   when: Date | string | number,
   callback: keyof this,
-  payload?: T
+  payload?: T,
+  options?: { retry?: RetryOptions }
 ): Promise<Schedule<T>>
 ```
 
@@ -679,6 +680,7 @@ Schedule a task for future execution.
 - `when` - When to execute: `number` (seconds delay), `Date` (specific time), or `string` (cron expression)
 - `callback` - Name of the method to call
 - `payload` - Data to pass to the callback (must be JSON-serializable)
+- `options.retry` - Optional retry configuration. Refer to [Retries](/agents/api-reference/retries/) for details.
 
 **Returns:** A `Schedule` object with the task details
 
@@ -694,7 +696,8 @@ Tasks that set a callback for a method that does not exist will throw an excepti
 async scheduleEvery<T>(
   intervalSeconds: number,
   callback: keyof this,
-  payload?: T
+  payload?: T,
+  options?: { retry?: RetryOptions }
 ): Promise<Schedule<T>>
 ```
 
@@ -705,6 +708,7 @@ Schedule a task to run repeatedly at a fixed interval.
 - `intervalSeconds` - Number of seconds between executions (must be greater than 0)
 - `callback` - Name of the method to call
 - `payload` - Data to pass to the callback (must be JSON-serializable)
+- `options.retry` - Optional retry configuration. Refer to [Retries](/agents/api-reference/retries/) for details.
 
 **Returns:** A `Schedule` object with `type: "interval"`
 

--- a/src/content/docs/agents/concepts/agent-class.mdx
+++ b/src/content/docs/agents/concepts/agent-class.mdx
@@ -329,14 +329,14 @@ Schedules are stored in the `cf_agents_schedules` SQL table. Cron schedules auto
 
 ```ts
 class MyAgent extends Agent {
-	async onConnect() {
-		// Add an MCP server
-		await this.addMcpServer(
-			"GitHub",
-			"https://mcp.example.com/mcp",
-			"https://my-worker.example.workers.dev", // callback host for OAuth
-			"agents", // routing prefix
-		);
+	async onStart() {
+		// Add an HTTP MCP server (callbackHost only needed for OAuth servers)
+		await this.addMcpServer("GitHub", "https://mcp.github.com/mcp", {
+			callbackHost: "https://my-worker.example.workers.dev",
+		});
+
+		// Add an MCP server via RPC (Durable Object binding, no HTTP overhead)
+		await this.addMcpServer("internal-tools", this.env.MyMCP);
 	}
 }
 ```

--- a/src/content/docs/agents/model-context-protocol/transport.mdx
+++ b/src/content/docs/agents/model-context-protocol/transport.mdx
@@ -102,6 +102,225 @@ If your MCP server needs to maintain state across requests, use `createMcpHandle
 
 See [Stateful MCP Servers](/agents/api-reference/mcp-handler-api#stateful-mcp-servers) for implementation details.
 
+## RPC transport
+
+The **RPC transport** is designed for internal applications where your MCP server and agent are both running on Cloudflare — they can even run in the same Worker. It sends JSON-RPC messages directly over Cloudflare's [RPC bindings](/workers/runtime-apis/bindings/service-bindings/rpc/) without going over the public internet.
+
+- **Faster** — no network overhead, direct function calls between Durable Objects
+- **Simpler** — no HTTP endpoints, no connection management
+- **Internal only** — perfect for agents calling MCP servers within the same Worker
+
+RPC transport does not support authentication. Use Streamable HTTP for external connections that require OAuth.
+
+### Connecting an Agent to an McpAgent via RPC
+
+#### 1. Define your MCP server
+
+Create your `McpAgent` with the tools you want to expose:
+
+<TypeScriptExample>
+
+```ts
+import { McpAgent } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+type State = { counter: number };
+
+export class MyMCP extends McpAgent<Env, State> {
+	server = new McpServer({ name: "MyMCP", version: "1.0.0" });
+	initialState: State = { counter: 0 };
+
+	async init() {
+		this.server.tool(
+			"add",
+			"Add to the counter",
+			{ amount: z.number() },
+			async ({ amount }) => {
+				this.setState({ counter: this.state.counter + amount });
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Added ${amount}, total is now ${this.state.counter}`,
+						},
+					],
+				};
+			},
+		);
+	}
+}
+```
+
+</TypeScriptExample>
+
+#### 2. Connect your Agent to the MCP server
+
+In your `Agent`, call `addMcpServer()` with the Durable Object binding in `onStart()`:
+
+<TypeScriptExample>
+
+```ts
+import { AIChatAgent } from "@cloudflare/ai-chat";
+
+export class Chat extends AIChatAgent<Env> {
+	async onStart(): Promise<void> {
+		// Pass the DO namespace binding directly
+		await this.addMcpServer("my-mcp", this.env.MyMCP);
+	}
+
+	async onChatMessage(onFinish) {
+		const allTools = this.mcp.getAITools();
+
+		const result = streamText({
+			model,
+			tools: allTools,
+			// ...
+		});
+
+		return createUIMessageStreamResponse({ stream: result });
+	}
+}
+```
+
+</TypeScriptExample>
+
+RPC connections are automatically restored after Durable Object hibernation, just like HTTP connections. The binding name and props are persisted to storage so the connection can be re-established without any extra code.
+
+If `addMcpServer` is called with a name that already has an active connection, the existing connection is returned instead of creating a duplicate. This makes it safe to call in `onStart()`.
+
+#### 3. Configure Durable Object bindings
+
+In your `wrangler.jsonc`, define bindings for both Durable Objects:
+
+```jsonc
+{
+	"durable_objects": {
+		"bindings": [
+			{ "name": "Chat", "class_name": "Chat" },
+			{ "name": "MyMCP", "class_name": "MyMCP" }
+		]
+	},
+	"migrations": [
+		{
+			"new_sqlite_classes": ["MyMCP", "Chat"],
+			"tag": "v1"
+		}
+	]
+}
+```
+
+#### 4. Set up your Worker fetch handler
+
+Route requests to your Chat agent:
+
+<TypeScriptExample>
+
+```ts
+import { routeAgentRequest } from "agents";
+
+export default {
+	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+		const url = new URL(request.url);
+
+		// Optionally expose the MCP server via HTTP as well
+		if (url.pathname.startsWith("/mcp")) {
+			return MyMCP.serve("/mcp").fetch(request, env, ctx);
+		}
+
+		const response = await routeAgentRequest(request, env);
+		if (response) return response;
+
+		return new Response("Not found", { status: 404 });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+### Passing props to the MCP server
+
+Since RPC transport does not have an OAuth flow, you can pass user context directly as props:
+
+<TypeScriptExample>
+
+```ts
+await this.addMcpServer("my-mcp", this.env.MyMCP, {
+	props: { userId: "user-123", role: "admin" },
+});
+```
+
+</TypeScriptExample>
+
+Your `McpAgent` can then access these props:
+
+<TypeScriptExample>
+
+```ts
+export class MyMCP extends McpAgent<
+	Env,
+	State,
+	{ userId?: string; role?: string }
+> {
+	async init() {
+		this.server.tool("whoami", "Get current user info", {}, async () => {
+			const userId = this.props?.userId || "anonymous";
+			const role = this.props?.role || "guest";
+
+			return {
+				content: [
+					{ type: "text", text: `User ID: ${userId}, Role: ${role}` },
+				],
+			};
+		});
+	}
+}
+```
+
+</TypeScriptExample>
+
+Props are type-safe (TypeScript extracts the Props type from your `McpAgent` generic), persistent (stored in Durable Object storage), and available immediately before any tool calls are made.
+
+### Configuring RPC transport server timeout
+
+The RPC transport has a configurable timeout for waiting for tool responses. By default, the server waits **60 seconds** for a tool handler to respond. You can customize this by overriding `getRpcTransportOptions()` in your `McpAgent`:
+
+<TypeScriptExample>
+
+```ts
+export class MyMCP extends McpAgent<Env, State> {
+	server = new McpServer({ name: "MyMCP", version: "1.0.0" });
+
+	protected getRpcTransportOptions() {
+		return { timeout: 120000 }; // 2 minutes
+	}
+
+	async init() {
+		this.server.tool(
+			"long-running-task",
+			"A tool that takes a while",
+			{ input: z.string() },
+			async ({ input }) => {
+				await longRunningOperation(input);
+				return {
+					content: [{ type: "text", text: "Task completed" }],
+				};
+			},
+		);
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Choosing a transport
+
+| Transport           | Use when                              | Pros                                     | Cons                            |
+| ------------------- | ------------------------------------- | ---------------------------------------- | ------------------------------- |
+| **Streamable HTTP** | External MCP servers, production apps | Standard protocol, secure, supports auth | Slight network overhead         |
+| **RPC**             | Internal agents on Cloudflare         | Fastest, simplest setup                  | No auth, Durable Object bindings only |
+| **SSE**             | Legacy compatibility                  | Backwards compatible                     | Deprecated, use Streamable HTTP |
+
 ### Migrating from McpAgent
 
 If you have an existing MCP server using the `McpAgent` class:


### PR DESCRIPTION
## Summary

Syncs Cloudflare Agents docs with changes introduced since the Agents SDK 0.5.0 release.

### Changes

**queue-tasks.mdx**
- Remove `await` from 5 examples calling synchronous methods (`dequeue`, `dequeueAll`, `dequeueAllByCallback`, `getQueue`, `getQueues`) — these were made synchronous in 0.5.0

**schedule-tasks.mdx**
- Remove `await` from `getSchedule()` example (synchronous since 0.5.0)
- Add `options?: { retry?: RetryOptions }` parameter to `schedule()` and `scheduleEvery()` API signatures

**mcp-client-api.mdx**
- Add RPC transport overload to `addMcpServer()` API reference (`DurableObjectNamespace` binding)
- Add deduplication behavior note (safe to call in `onStart()`)
- Clarify `callbackHost` is only needed for OAuth-authenticated servers

**agent-class.mdx (concepts)**
- Update `this.mcp` example from legacy positional `addMcpServer` signature to options-based
- Add RPC transport example

**transport.mdx**
- Add full RPC transport section: step-by-step setup guide, props passing, timeout configuration
- Add "Choosing a transport" comparison table (Streamable HTTP vs RPC vs SSE)