### PR TITLE
Update Cache API subrequest limit for Workers Paid plan

### DIFF
--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -322,10 +322,10 @@ If you require more than 1,000 routes or 1,000 routed zones per Worker, consider
 
 ## Cache API limits
 
-| Feature             | Workers Free | Workers Paid |
-| ------------------- | ------------ | ------------ |
-| Maximum object size | 512 MB       | 512 MB       |
-| Calls per request   | 50           | 1,000        |
+| Feature             | Workers Free | Workers Paid       |
+| ------------------- | ------------ | ------------------ |
+| Maximum object size | 512 MB       | 512 MB             |
+| Calls per request   | 50           | 10,000 (up to 10M) |
 
 Calls per request is the number of `put()`, `match()`, or `delete()` Cache API calls per request. This shares the same quota as subrequests (`fetch()`).
 


### PR DESCRIPTION
### Summary

Workers recently raised the subrequest limits to 10k (configurable to 10M on paid plans), as can be seen [here](https://developers.cloudflare.com/workers/platform/limits/#subrequests).

This was updated in the docs but [the table](https://developers.cloudflare.com/workers/platform/limits/#cache-api-limits) for Cache API limits (listed as sharing the same limit) was not updated. This PR updates that table.

Alternatively, it might be better to just remove it from the table and refer people to the normal subrequest limit table to avoid duplication and accidental missing of updates like what happened here.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
