### PR TITLE
[wrangler] Add tunnel commands documentation

### DIFF
--- a/src/content/docs/workers/wrangler/commands/tunnel.mdx
+++ b/src/content/docs/workers/wrangler/commands/tunnel.mdx
@@ -1,0 +1,11 @@
+---
+pcx_content_type: reference
+title: Tunnel
+description: Wrangler commands for managing Cloudflare Tunnels.
+---
+
+import { Render } from "~/components";
+
+Manage [Cloudflare Tunnels](/tunnel/) directly from Wrangler. Create, run, and manage tunnels that securely connect your local services to Cloudflare's network — no public IPs required.
+
+<Render file="wrangler-commands/tunnel" product="workers" />

--- a/src/content/partials/workers/wrangler-commands/tunnel.mdx
+++ b/src/content/partials/workers/wrangler-commands/tunnel.mdx
@@ -1,0 +1,210 @@
+---
+{}
+---
+
+import { Render, AnchorHeading, Type, MetaInfo } from "~/components";
+
+:::note
+
+All `wrangler tunnel` commands are **experimental** and may change without notice.
+
+:::
+
+Wrangler manages the [cloudflared](/tunnel/downloads/) binary automatically. On first use, Wrangler will prompt you to download `cloudflared` to a local cache directory. You can skip this by installing `cloudflared` yourself and adding it to your `PATH`, or by setting the `CLOUDFLARED_PATH` environment variable to point to an existing binary.
+
+<AnchorHeading title="`tunnel create`" slug="tunnel-create" depth={3} />
+
+Create a new remotely managed [Cloudflare Tunnel](/tunnel/).
+
+```txt
+wrangler tunnel create <NAME>
+```
+
+- `NAME` <Type text="string" /> <MetaInfo text="required" />
+  - A name for your tunnel. Must be unique within your account.
+
+Tunnels created via Wrangler are always **remotely managed** — configure them in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/tunnels) or via the API.
+
+After creation, use `wrangler tunnel run` with the tunnel ID to start the tunnel.
+
+```sh
+npx wrangler tunnel create my-app
+```
+
+```sh output
+Creating tunnel "my-app"
+Created tunnel.
+ID: f70ff985-a4ef-4643-bbbc-4a0ed4fc8415
+Name: my-app
+
+To run this tunnel, configure its ingress rules in the Cloudflare dashboard, then run:
+   wrangler tunnel run f70ff985-a4ef-4643-bbbc-4a0ed4fc8415
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading title="`tunnel delete`" slug="tunnel-delete" depth={3} />
+
+Delete a Cloudflare Tunnel from your account.
+
+```txt
+wrangler tunnel delete <TUNNEL> [OPTIONS]
+```
+
+- `TUNNEL` <Type text="string" /> <MetaInfo text="required" />
+  - The name or UUID of the tunnel to delete.
+- `--force` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Skip the confirmation prompt.
+
+:::caution
+
+Deleting a tunnel is permanent and cannot be undone. Any active connections through the tunnel will be terminated.
+
+:::
+
+```sh
+npx wrangler tunnel delete f70ff985-a4ef-4643-bbbc-4a0ed4fc8415
+```
+
+```sh output
+Are you sure you want to delete tunnel "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415"? This action cannot be undone. (y/n)
+Deleting tunnel f70ff985-a4ef-4643-bbbc-4a0ed4fc8415
+Tunnel deleted.
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading title="`tunnel info`" slug="tunnel-info" depth={3} />
+
+Display details about a Cloudflare Tunnel, including its ID, name, status, and creation time.
+
+```txt
+wrangler tunnel info <TUNNEL>
+```
+
+- `TUNNEL` <Type text="string" /> <MetaInfo text="required" />
+  - The name or UUID of the tunnel to inspect.
+
+```sh
+npx wrangler tunnel info f70ff985-a4ef-4643-bbbc-4a0ed4fc8415
+```
+
+```sh output
+Getting tunnel details
+ID: f70ff985-a4ef-4643-bbbc-4a0ed4fc8415
+Name: my-app
+Status: healthy
+Created: 2025-01-15T10:30:00Z
+Type: cfd_tunnel
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading title="`tunnel list`" slug="tunnel-list" depth={3} />
+
+List all Cloudflare Tunnels in your account.
+
+```txt
+wrangler tunnel list
+```
+
+The output includes the tunnel ID, name, status, and creation date for each tunnel. Only non-deleted tunnels are shown.
+
+```sh
+npx wrangler tunnel list
+```
+
+```sh output
+Listing Cloudflare Tunnels
+
+ID                                   Name       Status    Created
+f70ff985-a4ef-4643-bbbc-4a0ed4fc8415 my-app     healthy   2025-01-15T10:30:00Z
+550e8400-e29b-41d4-a716-446655440000 api-tunnel inactive  2025-01-10T15:45:00Z
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading title="`tunnel run`" slug="tunnel-run" depth={3} />
+
+Run a Cloudflare Tunnel using the [cloudflared](/tunnel/downloads/) daemon. This starts a persistent connection between your local machine and Cloudflare's network.
+
+```txt
+wrangler tunnel run [TUNNEL] [OPTIONS]
+```
+
+- `TUNNEL` <Type text="string" /> <MetaInfo text="optional" />
+  - The name or UUID of the tunnel to run. Required unless `--token` is provided.
+- `--token` <Type text="string" /> <MetaInfo text="optional" />
+  - A tunnel token to use directly. Skips API authentication.
+- `--log-level` <Type text="string" /> <MetaInfo text="(default: info) optional" />
+  - Log level for `cloudflared`. Does not affect Wrangler logs (controlled by `WRANGLER_LOG`). One of: `debug`, `info`, `warn`, `error`, `fatal`.
+
+Named tunnels are **remotely managed** — configure ingress rules (which local services to expose) in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/tunnels) or via the API before running the tunnel.
+
+There are two ways to run a tunnel:
+
+**By tunnel name or ID** (fetches the token via the API):
+
+```sh
+npx wrangler tunnel run my-app
+```
+
+**By token** (no API authentication needed — useful for CI/CD or remote servers):
+
+```sh
+npx wrangler tunnel run --token eyJhIjoiNGE2MjY...
+```
+
+:::note
+
+The tunnel token is passed to `cloudflared` via the `TUNNEL_TOKEN` environment variable rather than CLI arguments, preventing it from appearing in process listings.
+
+:::
+
+Press `Ctrl+C` to stop the tunnel. Wrangler will send a graceful shutdown signal to `cloudflared` before exiting.
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading
+	title="`tunnel quick-start`"
+	slug="tunnel-quick-start"
+	depth={3}
+/>
+
+Start a free, temporary tunnel without a Cloudflare account using [Quick Tunnels](/tunnel/setup/#quick-tunnels-development). This is useful for quick demos, testing webhooks, or sharing local development servers.
+
+```txt
+wrangler tunnel quick-start <URL>
+```
+
+- `URL` <Type text="string" /> <MetaInfo text="required" />
+  - The local URL to expose (for example, `http://localhost:8080`).
+
+The tunnel is assigned a random `*.trycloudflare.com` subdomain and lasts for the duration of the process.
+
+```sh
+npx wrangler tunnel quick-start http://localhost:8080
+```
+
+```sh output
+Starting quick tunnel to http://localhost:8080...
+Your tunnel URL: https://random-words-here.trycloudflare.com
+```
+
+:::note
+
+Quick tunnels are anonymous and temporary — they do not appear in your account's tunnel list and cannot be configured. For production use, create a named tunnel with `wrangler tunnel create`.
+
+:::
+
+<Render file="wrangler-commands/global-flags" product="workers" />


### PR DESCRIPTION
## Summary

Adds documentation for the new `wrangler tunnel` commands (experimental) to the Wrangler commands reference page.

- Adds a new partial at `src/content/partials/workers/wrangler-commands/tunnel.mdx` documenting all 6 tunnel subcommands: `create`, `delete`, `info`, `list`, `run`, and `quick-start`
- Adds the `tunnel` section to `commands.mdx` TOC and body, grouped with other product/feature commands (after `queues`, before `login`)

Companion to https://github.com/cloudflare/workers-sdk/pull/12492

## Notes

- All commands are marked as **experimental**
- Authentication info is in a `:::note` block (not a heading) to avoid polluting the sidebar nav
- Follows the same manual docs pattern as `containers` (using `AnchorHeading` components)
- The wrangler PR has not merged yet, so no minimum version is specified in the experimental note