### PR TITLE
Fix link in changelog for auto configuration

### DIFF
--- a/src/content/changelog/workers/2026-02-25-wrangler-autoconfig-ga.mdx
+++ b/src/content/changelog/workers/2026-02-25-wrangler-autoconfig-ga.mdx
@@ -38,6 +38,6 @@ A pull request is only generated when your deploy command is `npx wrangler deplo
 
 ## Background
 
-In December 2025, we [introduced automatic configuration](/changelog/2025-12-16-wrangler-autoconfig/) as an experimental feature. It is now generally available and the default behavior.
+In December 2025, we [introduced automatic configuration](/changelog/post/2025-12-16-wrangler-autoconfig/) as an experimental feature. It is now generally available and the default behavior.
 
 If you have questions or run into issues, join the [GitHub discussion](https://github.com/cloudflare/workers-sdk/discussions/11667).


### PR DESCRIPTION
Fixes a broken link in the autoconfig ga changelog: https://developers.cloudflare.com/changelog/post/2026-02-25-wrangler-autoconfig-ga/