### PR TITLE
[AI Gateway] Clarify Vertex AI authentication and BYOK usage

### DIFF
--- a/src/content/docs/ai-gateway/features/dlp/set-up-dlp.mdx
+++ b/src/content/docs/ai-gateway/features/dlp/set-up-dlp.mdx
@@ -183,6 +183,8 @@ try {
 
 ## Troubleshooting
 
+For general AI Gateway troubleshooting, refer to [Troubleshooting](/ai-gateway/reference/troubleshooting/).
+
 ### DLP not triggering
 
 - Verify DLP toggle is enabled for your gateway

--- a/src/content/docs/ai-gateway/reference/troubleshooting.mdx
+++ b/src/content/docs/ai-gateway/reference/troubleshooting.mdx
@@ -1,0 +1,61 @@
+---
+pcx_content_type: troubleshooting
+title: Troubleshooting
+sidebar:
+  order: 5
+---
+
+This page covers common issues when using AI Gateway. For provider-specific troubleshooting, refer to the relevant provider documentation.
+
+## Authentication errors
+
+### 401 or unauthenticated errors
+
+If you receive authentication errors from your AI provider, AI Gateway did not pass valid credentials upstream. Check the following:
+
+1. **Verify header placement**: Make sure your Cloudflare token is in `cf-aig-authorization`, not `Authorization`. The `Authorization` header is reserved for provider credentials.
+
+2. **Check your configuration based on endpoint type**:
+   - **Provider-specific endpoints**: Confirm your request URL includes the provider path (for example, `/google-vertex-ai/` or `/openai/`). AI Gateway uses this to identify the provider and apply the correct stored credentials.
+   - **Unified `/compat/chat/completions` endpoint**: Confirm your `model` name starts with the provider prefix (for example, `google-vertex-ai/google/gemini-2.5-flash` or `openai/gpt-4o`). AI Gateway uses this prefix to route the request and select the correct stored credentials.
+
+3. **Verify BYOK key selection**: If you have multiple keys configured for a provider, ensure either:
+   - You are using the key with alias `default`, or
+   - You include the `cf-aig-byok-alias` header with the correct alias name
+
+4. **Verify BYOK configuration**: If using BYOK, confirm in the dashboard that your credentials were saved correctly.
+
+For provider-specific authentication issues:
+
+- [Google Vertex AI troubleshooting](/ai-gateway/usage/providers/vertex/#troubleshooting)
+
+## DLP issues
+
+For troubleshooting Data Loss Prevention issues such as DLP not triggering or unexpected blocking, refer to [DLP troubleshooting](/ai-gateway/features/dlp/set-up-dlp/#troubleshooting).
+
+## Request failures
+
+### Requests timing out
+
+- Check if the upstream provider is experiencing issues
+- Consider implementing [dynamic routing](/ai-gateway/features/dynamic-routing/) with fallbacks for transient failures
+- Review your [rate limiting](/ai-gateway/features/rate-limiting/) configuration
+
+### Requests returning errors from the provider
+
+- Verify your API key or credentials are valid with the provider directly
+- Check the provider's status page for outages
+- Review [AI Gateway logs](/ai-gateway/observability/logging/) for detailed error information
+
+## Caching issues
+
+### Requests not being cached
+
+- Verify [caching is enabled](/ai-gateway/features/caching/) for your gateway
+- Check that the request method and content type are cacheable
+- Streaming responses are not cached by default
+
+### Unexpected cache hits or misses
+
+- Review your cache TTL settings
+- Check if [semantic caching](/ai-gateway/features/caching/#semantic-caching) is affecting cache behavior

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -48,6 +48,18 @@ Use a specific regional endpoint like `us-central1` or `us-east4` rather than `g
 
 Authenticating with Vertex AI normally requires generating short-term credentials using the [Google Cloud SDKs](https://cloud.google.com/vertex-ai/docs/authentication) with a complicated setup, but AI Gateway simplifies this for you with multiple options.
 
+### Authentication methods comparison
+
+| Method                             | `cf-aig-authorization` header | `Authorization` header                | Region handling              |
+| ---------------------------------- | ----------------------------- | ------------------------------------- | ---------------------------- |
+| **BYOK (Recommended)**             | `Bearer {CF_AIG_TOKEN}`       | Not needed                            | Select in dashboard dropdown |
+| **Service account JSON in header** | `Bearer {CF_AIG_TOKEN}`       | Base64-encoded JSON with `region` key | Include `region` key in JSON |
+| **Direct access token**            | `Bearer {CF_AIG_TOKEN}`       | `Bearer {gcloud_access_token}`        | Included in URL path         |
+
+:::caution[Do not confuse the headers]
+`cf-aig-authorization` authenticates your request to AI Gateway. `Authorization` passes credentials to the upstream provider (Google). When using BYOK, you only need `cf-aig-authorization` because AI Gateway injects the stored Google credentials for you.
+:::
+
 ### Option 1: BYOK (Recommended)
 
 The recommended approach is to store your Google service account credentials using AI Gateway's [Bring Your Own Keys (BYOK)](/ai-gateway/configuration/bring-your-own-keys/) feature. This keeps your credentials secure and out of your application code.
@@ -162,13 +174,21 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat
 
 ### Example with OpenAI SDK
 
-If not using BYOK, pass the service account JSON (with `region` key included) as the API key:
+If not using BYOK, pass the base64-encoded service account JSON (with `region` key included) as the API key:
 
 ```javascript
 import OpenAI from "openai";
 
+// Service account JSON must include "region" key when not using BYOK
+const serviceAccountJson = JSON.stringify({
+	type: "service_account",
+	project_id: "your-project-id",
+	// ... other fields from your downloaded JSON
+	region: "us-central1", // Required: add this to your service account JSON
+});
+
 const client = new OpenAI({
-	apiKey: "{service_account_json_with_region}",
+	apiKey: Buffer.from(serviceAccountJson).toString("base64"),
 	baseURL:
 		"https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat",
 	defaultHeaders: {
@@ -192,9 +212,12 @@ console.log(response.choices[0].message.content);
 ### Example with cURL
 
 ```bash
+# First, base64-encode your service account JSON (must include "region" key)
+SERVICE_ACCOUNT_BASE64=$(cat service-account.json | base64)
+
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions" \
     -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
-    -H "Authorization: Bearer {service_account_json_with_region}" \
+    -H "Authorization: Bearer $SERVICE_ACCOUNT_BASE64" \
     -H 'Content-Type: application/json' \
     -d '{
         "model": "google-vertex-ai/google/gemini-2.5-pro",
@@ -208,7 +231,7 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat
 ```
 
 :::note
-When not using BYOK, the service account JSON must include the `region` key. Refer to [Authenticating with Vertex AI](#authenticating-with-vertex-ai) for details.
+When not using BYOK, the service account JSON must include the `region` key and be base64-encoded. Refer to [Option 2: Service Account JSON in Header](#option-2-service-account-json-in-header) for the required JSON structure.
 :::
 
 ## Using Provider-Specific Endpoint
@@ -237,12 +260,15 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
 
 ### cURL with Service Account JSON
 
-If not using BYOK, pass the service account JSON (with `region` key included) in the Authorization header:
+If not using BYOK, pass the base64-encoded service account JSON (with `region` key included) in the Authorization header:
 
 ```bash
+# First, base64-encode your service account JSON (must include "region" key)
+SERVICE_ACCOUNT_BASE64=$(cat service-account.json | base64)
+
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent" \
     -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
-    -H "Authorization: Bearer {service_account_json_with_region}" \
+    -H "Authorization: Bearer $SERVICE_ACCOUNT_BASE64" \
     -H 'Content-Type: application/json' \
     -d '{
         "contents": {
@@ -260,9 +286,22 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
 
 ### 401 UNAUTHENTICATED errors
 
-If you receive a `CREDENTIALS_MISSING` or `UNAUTHENTICATED` error from Google:
+If you receive a `CREDENTIALS_MISSING` or `UNAUTHENTICATED` error from Google, AI Gateway did not pass valid Google credentials to Vertex AI. Check the following:
 
-1. **Check your region**: Make sure you are using a specific regional endpoint (like `us-central1`) in your URL, not `global`. The `global` endpoint has limited model support.
-2. **Verify BYOK configuration**: If using BYOK, confirm that your service account JSON was saved correctly and the region was selected in the dashboard.
-3. **Check service account permissions**: Ensure your service account has the `Vertex AI User` role or equivalent permissions.
-4. **Verify the region key**: If passing service account JSON directly in the header (not using BYOK), make sure the JSON includes the `region` key matching your endpoint URL.
+1. **Verify header placement**: Make sure your Cloudflare token is in `cf-aig-authorization`, not `Authorization`. The `Authorization` header is reserved for provider credentials.
+
+2. **Check your URL path**: Confirm your request URL includes `/google-vertex-ai/` in the path. AI Gateway uses this to identify the provider and apply the correct stored credentials.
+
+3. **Verify BYOK key selection**: If you have multiple keys configured for Google Vertex AI, ensure either:
+   - You are using the key with alias `default`, or
+   - You include the `cf-aig-byok-alias` header with the correct alias name
+
+4. **Check your region**: Use a specific regional endpoint (like `us-central1`) in your URL, not `global`. The `global` endpoint has limited model support.
+
+5. **Verify BYOK configuration**: If using BYOK, confirm in the dashboard that:
+   - Your service account JSON was saved correctly
+   - A region was selected from the dropdown
+
+6. **Check service account permissions**: Ensure your service account has the `Vertex AI User` role or equivalent permissions in Google Cloud.
+
+7. **Verify the region key** (non-BYOK only): If passing service account JSON directly in the `Authorization` header, make sure the JSON includes the `region` key.

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -273,14 +273,16 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
     -H "Authorization: Bearer $SERVICE_ACCOUNT_BASE64" \
     -H 'Content-Type: application/json' \
     -d '{
-        "contents": {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Tell me more about Cloudflare"
-            }
-          ]
-        }
+        "contents": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "text": "Tell me more about Cloudflare"
+              }
+            ]
+          }
+        ]
       }'
 ```
 

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -215,7 +215,7 @@ console.log(response.choices[0].message.content);
 
 ```bash
 # First, base64-encode your service account JSON (must include "region" key)
-SERVICE_ACCOUNT_BASE64=$(cat service-account.json | base64)
+SERVICE_ACCOUNT_BASE64=$(base64 < service-account.json | tr -d '\n')
 
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions" \
     -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -134,14 +134,16 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
     -H "Authorization: Bearer ya29.c.b0Aaekm1K..." \
     -H 'Content-Type: application/json' \
     -d '{
-        "contents": {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Tell me more about Cloudflare"
-            }
-          ]
-        }
+        "contents": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "text": "Tell me more about Cloudflare"
+              }
+            ]
+          }
+        ]
       }'
 ```
 
@@ -249,14 +251,16 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
     -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
     -H 'Content-Type: application/json' \
     -d '{
-        "contents": {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Tell me more about Cloudflare"
-            }
-          ]
-        }
+        "contents": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "text": "Tell me more about Cloudflare"
+              }
+            ]
+          }
+        ]
       }'
 ```
 

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -270,7 +270,7 @@ If not using BYOK, pass the base64-encoded service account JSON (with `region` k
 
 ```bash
 # First, base64-encode your service account JSON (must include "region" key) as a single line
-SERVICE_ACCOUNT_BASE64=$(cat service-account.json | base64 | tr -d '\n')
+SERVICE_ACCOUNT_BASE64=$(base64 < service-account.json | tr -d '\n')
 
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent" \
     -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -67,7 +67,7 @@ The recommended approach is to store your Google service account credentials usi
 1. [Create a service account key](https://cloud.google.com/iam/docs/keys-create-delete) in the Google Cloud Console. Ensure that the service account has the required permissions for the Vertex AI endpoints and models you plan to use.
 2. In the Cloudflare dashboard, go to **AI** > **AI Gateway** > your gateway > **Provider Keys**.
 3. Select **Add API Key** and choose **Google Vertex AI** as the provider.
-4. Paste your service account JSON and select your region from the dropdown.
+4. Paste your service account JSON and select your region from the dropdown. AI Gateway automatically applies this selected region to your stored credentials, so you do not need to manually add a `region` field to the JSON.
 5. Select **Save**.
 
 With BYOK configured, you only need to include the `cf-aig-authorization` header in your requests. AI Gateway handles the Vertex AI authentication automatically.

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -300,7 +300,7 @@ If you receive a `CREDENTIALS_MISSING` or `UNAUTHENTICATED` error from Google, A
 
 2. **Check your configuration based on endpoint type**:
    - **Provider-specific endpoints** (for example, `.../google-vertex-ai/v1/projects/...`): Confirm your request URL includes `/google-vertex-ai/` in the path. AI Gateway uses this to identify the provider and apply the correct stored credentials.
-   - **Unified `/compat/chat/completions` endpoint**: Confirm your `model` name starts with the `google-vertex-ai/` prefix (for example, `google-vertex-ai/gemini-2.5-flash`). AI Gateway uses this prefix to route the request to Vertex AI and select the correct stored credentials.
+   - **Unified `/compat/chat/completions` endpoint**: Confirm your `model` name starts with the `google-vertex-ai/` prefix (for example, `google-vertex-ai/google/gemini-2.5-flash`). AI Gateway uses this prefix to route the request to Vertex AI and select the correct stored credentials.
 
 3. **Verify BYOK key selection**: If you have multiple keys configured for Google Vertex AI, ensure either:
    - You are using the key with alias `default`, or

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -77,14 +77,16 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
     -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
     -H 'Content-Type: application/json' \
     -d '{
-        "contents": {
-          "role": "user",
-          "parts": [
-            {
-              "text": "Tell me more about Cloudflare"
-            }
-          ]
-        }
+        "contents": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "text": "Tell me more about Cloudflare"
+              }
+            ]
+          }
+        ]
       }'
 ```
 

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -292,26 +292,18 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
 
 ## Troubleshooting
 
-### 401 UNAUTHENTICATED errors
+For general AI Gateway troubleshooting, refer to [Troubleshooting](/ai-gateway/reference/troubleshooting/).
 
-If you receive a `CREDENTIALS_MISSING` or `UNAUTHENTICATED` error from Google, AI Gateway did not pass valid Google credentials to Vertex AI. Check the following:
+### 401 Unauthenticated errors
 
-1. **Verify header placement**: Make sure your Cloudflare token is in `cf-aig-authorization`, not `Authorization`. The `Authorization` header is reserved for provider credentials.
+If you receive a `CREDENTIALS_MISSING` or `UNAUTHENTICATED` error from Google, check the following Vertex AI-specific issues:
 
-2. **Check your configuration based on endpoint type**:
-   - **Provider-specific endpoints** (for example, `.../google-vertex-ai/v1/projects/...`): Confirm your request URL includes `/google-vertex-ai/` in the path. AI Gateway uses this to identify the provider and apply the correct stored credentials.
-   - **Unified `/compat/chat/completions` endpoint**: Confirm your `model` name starts with the `google-vertex-ai/` prefix (for example, `google-vertex-ai/google/gemini-2.5-flash`). AI Gateway uses this prefix to route the request to Vertex AI and select the correct stored credentials.
+1. **Check your region**: Use a specific regional endpoint (like `us-central1`) in your URL, not `global`. The `global` endpoint has limited model support.
 
-3. **Verify BYOK key selection**: If you have multiple keys configured for Google Vertex AI, ensure either:
-   - You are using the key with alias `default`, or
-   - You include the `cf-aig-byok-alias` header with the correct alias name
-
-4. **Check your region**: Use a specific regional endpoint (like `us-central1`) in your URL, not `global`. The `global` endpoint has limited model support.
-
-5. **Verify BYOK configuration**: If using BYOK, confirm in the dashboard that:
+2. **Verify BYOK configuration**: If using BYOK, confirm in the dashboard that:
    - Your service account JSON was saved correctly
    - A region was selected from the dropdown
 
-6. **Check service account permissions**: Ensure your service account has the `Vertex AI User` role or equivalent permissions in Google Cloud.
+3. **Check service account permissions**: Ensure your service account has the `Vertex AI User` role or equivalent permissions in Google Cloud.
 
-7. **Verify the region key** (non-BYOK only): If passing service account JSON directly in the `Authorization` header, make sure the JSON includes the `region` key.
+4. **Verify the region key** (non-BYOK only): If passing service account JSON directly in the `Authorization` header, make sure the JSON includes the `region` key.

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -11,7 +11,7 @@ Below is a quick guide on how to set your Google Cloud Account:
    - Sign up for a [GCP account](https://cloud.google.com/vertex-ai). New users may be eligible for credits (valid for 90 days).
 
 2. Enable the Vertex AI API
-   - Navigate to [Enable Vertex AI API](https://console.cloud.google.com/marketplace/product/google/aiplatform.googleapis.com) and activate the API for your project.
+   - Go to [Enable Vertex AI API](https://console.cloud.google.com/marketplace/product/google/aiplatform.googleapis.com) and activate the API for your project.
 
 3. Apply for access to desired models.
 
@@ -23,14 +23,14 @@ https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai
 
 ## Prerequisites
 
-When making requests to Google Vertex, you will need:
+When making requests to Google Vertex AI, you will need:
 
 - AI Gateway account tag
 - AI Gateway gateway name
-- Google Vertex API key
-- Google Vertex Project Name
-- Google Vertex Region (for example, us-east4)
-- Google Vertex model
+- Google Vertex AI credentials (service account JSON or access token)
+- Google Vertex AI Project Name
+- Google Vertex AI Region (for example, `us-central1`)
+- Google Vertex AI model
 
 ## URL structure
 
@@ -40,43 +40,73 @@ Then you can append the endpoint you want to hit, for example: `/publishers/goog
 
 So your final URL will come together as: `https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent`
 
+:::note[Use a specific region]
+Use a specific regional endpoint like `us-central1` or `us-east4` rather than `global`. The `global` endpoint has limited model support and may not work with all Vertex AI operations.
+:::
+
 ## Authenticating with Vertex AI
 
-Authenticating with Vertex AI normally requires generating short-term credentials using the [Google Cloud SDKs](https://cloud.google.com/vertex-ai/docs/authentication) with a complicated setup, but AI Gateway simplifies this for you with multiple options:
+Authenticating with Vertex AI normally requires generating short-term credentials using the [Google Cloud SDKs](https://cloud.google.com/vertex-ai/docs/authentication) with a complicated setup, but AI Gateway simplifies this for you with multiple options.
 
-### Option 1: Service Account JSON
+### Option 1: BYOK (Recommended)
 
-AI Gateway supports passing a Google service account JSON directly in the `Authorization` header on requests or through AI Gateway's [Bring Your Own Keys](/ai-gateway/configuration/bring-your-own-keys/) feature.
+The recommended approach is to store your Google service account credentials using AI Gateway's [Bring Your Own Keys (BYOK)](/ai-gateway/configuration/bring-your-own-keys/) feature. This keeps your credentials secure and out of your application code.
 
-You can [create a service account key](https://cloud.google.com/iam/docs/keys-create-delete) in the Google Cloud Console. Ensure that the service account has the required permissions for the Vertex AI endpoints and models you plan to use.
+1. [Create a service account key](https://cloud.google.com/iam/docs/keys-create-delete) in the Google Cloud Console. Ensure that the service account has the required permissions for the Vertex AI endpoints and models you plan to use.
+2. In the Cloudflare dashboard, go to **AI** > **AI Gateway** > your gateway > **Provider Keys**.
+3. Select **Add API Key** and choose **Google Vertex AI** as the provider.
+4. Paste your service account JSON and select your region from the dropdown.
+5. Select **Save**.
+
+With BYOK configured, you only need to include the `cf-aig-authorization` header in your requests. AI Gateway handles the Vertex AI authentication automatically.
+
+```bash
+curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent" \
+    -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "contents": {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Tell me more about Cloudflare"
+            }
+          ]
+        }
+      }'
+```
+
+### Option 2: Service Account JSON in Header
+
+You can pass a Google service account JSON directly in the `Authorization` header on each request with a base64-encoded version of the JSON. This option is useful for testing or when you cannot use BYOK.
+
+[Create a service account key](https://cloud.google.com/iam/docs/keys-create-delete) in the Google Cloud Console. Ensure that the service account has the required permissions for the Vertex AI endpoints and models you plan to use.
 
 AI Gateway uses your service account JSON to generate short-term access tokens which are cached and used for consecutive requests, and are automatically refreshed when they expire.
 
 :::note
-The service account JSON must include an additional key called `region` with the GCP region code (for example, `us-east1`) you intend to use for your [Vertex AI endpoint](https://cloud.google.com/vertex-ai/docs/reference/rest#service-endpoint). You can also pass the region code `global` to use the global endpoint.
+When passing the service account JSON directly in the header (not using BYOK), you must include an additional key called `region` in the JSON with the GCP region code (for example, `us-central1`) you intend to use for your [Vertex AI endpoint](https://cloud.google.com/vertex-ai/docs/reference/rest#service-endpoint).
 :::
 
 #### Example service account JSON structure
 
 ```json
 {
-  "type": "service_account",
-  "project_id": "your-project-id",
-  "private_key_id": "your-private-key-id",
-  "private_key": "-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----\n",
-  "client_email": "your-service-account@your-project.iam.gserviceaccount.com",
-  "client_id": "your-client-id",
-  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-  "token_uri": "https://oauth2.googleapis.com/token",
-  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/your-service-account%40your-project.iam.gserviceaccount.com",
-  "region": "us-east1"
+	"type": "service_account",
+	"project_id": "your-project-id",
+	"private_key_id": "your-private-key-id",
+	"private_key": "-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----\n",
+	"client_email": "your-service-account@your-project.iam.gserviceaccount.com",
+	"client_id": "your-client-id",
+	"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+	"token_uri": "https://oauth2.googleapis.com/token",
+	"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+	"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/your-service-account%40your-project.iam.gserviceaccount.com",
+	"region": "us-central1"
 }
 ```
 
-You can pass this JSON in the `Authorization` header or configure it in [Bring Your Own Keys](/ai-gateway/configuration/bring-your-own-keys/).
-
-### Option 2: Direct Access Token
+### Option 3: Direct Access Token
 
 If you are already using the Google Cloud SDKs and generating a short-term access token (for example, with `gcloud auth print-access-token`), you can directly pass this as a Bearer token in the `Authorization` header of the request.
 
@@ -86,6 +116,7 @@ This option is only supported for the provider-specific endpoint, not for the un
 
 ```bash
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent" \
+    -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
     -H "Authorization: Bearer ya29.c.b0Aaekm1K..." \
     -H 'Content-Type: application/json' \
     -d '{
@@ -110,24 +141,49 @@ AI Gateway provides a [Unified API](/ai-gateway/usage/chat-completion/) that wor
 https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions
 ```
 
+### Example with BYOK
+
+With BYOK configured, you only need to include the `cf-aig-authorization` header:
+
+```bash
+curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions" \
+    -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "model": "google-vertex-ai/google/gemini-2.5-pro",
+        "messages": [
+          {
+            "role": "user",
+            "content": "What is Cloudflare?"
+          }
+        ]
+      }'
+```
+
 ### Example with OpenAI SDK
 
+If not using BYOK, pass the service account JSON (with `region` key included) as the API key:
+
 ```javascript
-import OpenAI from 'openai';
+import OpenAI from "openai";
 
 const client = new OpenAI({
-  apiKey: '{service_account_json}',
-  baseURL: 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat'
+	apiKey: "{service_account_json_with_region}",
+	baseURL:
+		"https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat",
+	defaultHeaders: {
+		"cf-aig-authorization": "Bearer {CF_AIG_TOKEN}",
+	},
 });
 
 const response = await client.chat.completions.create({
-  model: 'google-vertex-ai/google/gemini-2.5-pro',
-  messages: [
-    {
-      role: 'user',
-      content: 'What is Cloudflare?'
-    }
-  ]
+	model: "google-vertex-ai/google/gemini-2.5-pro",
+	messages: [
+		{
+			role: "user",
+			content: "What is Cloudflare?",
+		},
+	],
 });
 
 console.log(response.choices[0].message.content);
@@ -137,7 +193,8 @@ console.log(response.choices[0].message.content);
 
 ```bash
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions" \
-    -H "Authorization: Bearer {service_account_json}" \
+    -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
+    -H "Authorization: Bearer {service_account_json_with_region}" \
     -H 'Content-Type: application/json' \
     -d '{
         "model": "google-vertex-ai/google/gemini-2.5-pro",
@@ -151,18 +208,20 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat
 ```
 
 :::note
-See the [Authenticating with Vertex AI](#authenticating-with-vertex-ai) section below for details on the service account JSON structure and authentication options.
+When not using BYOK, the service account JSON must include the `region` key. Refer to [Authenticating with Vertex AI](#authenticating-with-vertex-ai) for details.
 :::
 
 ## Using Provider-Specific Endpoint
 
 You can also use the provider-specific endpoint to access the full Vertex AI API.
 
-### cURL
+### cURL with BYOK
 
-```bash title="Example fetch request"
+With BYOK configured, you only need the `cf-aig-authorization` header:
+
+```bash
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent" \
-    -H "Authorization: Bearer {vertex_api_key}" \
+    -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
     -H 'Content-Type: application/json' \
     -d '{
         "contents": {
@@ -172,7 +231,38 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
               "text": "Tell me more about Cloudflare"
             }
           ]
-        }'
-
+        }
+      }'
 ```
 
+### cURL with Service Account JSON
+
+If not using BYOK, pass the service account JSON (with `region` key included) in the Authorization header:
+
+```bash
+curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent" \
+    -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \
+    -H "Authorization: Bearer {service_account_json_with_region}" \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "contents": {
+          "role": "user",
+          "parts": [
+            {
+              "text": "Tell me more about Cloudflare"
+            }
+          ]
+        }
+      }'
+```
+
+## Troubleshooting
+
+### 401 UNAUTHENTICATED errors
+
+If you receive a `CREDENTIALS_MISSING` or `UNAUTHENTICATED` error from Google:
+
+1. **Check your region**: Make sure you are using a specific regional endpoint (like `us-central1`) in your URL, not `global`. The `global` endpoint has limited model support.
+2. **Verify BYOK configuration**: If using BYOK, confirm that your service account JSON was saved correctly and the region was selected in the dashboard.
+3. **Check service account permissions**: Ensure your service account has the `Vertex AI User` role or equivalent permissions.
+4. **Verify the region key**: If passing service account JSON directly in the header (not using BYOK), make sure the JSON includes the `region` key matching your endpoint URL.

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -294,7 +294,9 @@ If you receive a `CREDENTIALS_MISSING` or `UNAUTHENTICATED` error from Google, A
 
 1. **Verify header placement**: Make sure your Cloudflare token is in `cf-aig-authorization`, not `Authorization`. The `Authorization` header is reserved for provider credentials.
 
-2. **Check your URL path**: Confirm your request URL includes `/google-vertex-ai/` in the path. AI Gateway uses this to identify the provider and apply the correct stored credentials.
+2. **Check your configuration based on endpoint type**:
+   - **Provider-specific endpoints** (for example, `.../google-vertex-ai/v1/projects/...`): Confirm your request URL includes `/google-vertex-ai/` in the path. AI Gateway uses this to identify the provider and apply the correct stored credentials.
+   - **Unified `/compat/chat/completions` endpoint**: Confirm your `model` name starts with the `google-vertex-ai/` prefix (for example, `google-vertex-ai/gemini-2.5-flash`). AI Gateway uses this prefix to route the request to Vertex AI and select the correct stored credentials.
 
 3. **Verify BYOK key selection**: If you have multiple keys configured for Google Vertex AI, ensure either:
    - You are using the key with alias `default`, or

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -192,7 +192,7 @@ const client = new OpenAI({
 	baseURL:
 		"https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat",
 	defaultHeaders: {
-		"cf-aig-authorization": "Bearer {CF_AIG_TOKEN}",
+		"cf-aig-authorization": `Bearer {cf_aig_token}`,
 	},
 });
 

--- a/src/content/docs/ai-gateway/usage/providers/vertex.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/vertex.mdx
@@ -265,8 +265,8 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vert
 If not using BYOK, pass the base64-encoded service account JSON (with `region` key included) in the Authorization header:
 
 ```bash
-# First, base64-encode your service account JSON (must include "region" key)
-SERVICE_ACCOUNT_BASE64=$(cat service-account.json | base64)
+# First, base64-encode your service account JSON (must include "region" key) as a single line
+SERVICE_ACCOUNT_BASE64=$(cat service-account.json | base64 | tr -d '\n')
 
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/google-vertex-ai/v1/projects/{project_name}/locations/{region}/publishers/google/models/gemini-2.5-flash:generateContent" \
     -H 'cf-aig-authorization: Bearer {CF_AIG_TOKEN}' \


### PR DESCRIPTION
## Summary

Addresses customer feedback from Ploy.ai about confusion when setting up AI Gateway with Google Vertex AI.

## Changes

- **BYOK as recommended option**: Added clear step-by-step instructions for storing service account credentials via the dashboard, including the region dropdown
- **Region configuration clarity**: Clarified that when using BYOK, the region is selected in the UI dropdown (no need to manually edit the JSON). The `region` key in JSON is only needed when passing credentials directly in the Authorization header
- **Authentication headers**: Added `cf-aig-authorization` header to all examples for consistency with other provider docs
- **Global endpoint warning**: Added a note recommending specific regional endpoints (like `us-central1`) instead of `global`, which has limited model support
- **Troubleshooting section**: Added guidance for resolving 401 UNAUTHENTICATED errors

## Customer Feedback Summary

1. Docs said to manually add `region` key to service account JSON, but UI now has a region dropdown - unclear which to use
2. Using `locations/global` endpoint resulted in 401 errors
3. BYOK + Vertex AI flow wasn't clearly documented
4. Examples were missing `cf-aig-authorization` header

## Testing

- [x] `npm run check` passes (pre-existing unrelated error)
- [x] No MDX syntax issues
- [x] All code blocks have valid language identifiers