### PR TITLE
Revert https://github.com/cloudflare/cloudflare-docs/pull/28425

### DIFF
--- a/src/content/docs/fundamentals/api/get-started/account-owned-tokens.mdx
+++ b/src/content/docs/fundamentals/api/get-started/account-owned-tokens.mdx
@@ -12,7 +12,7 @@ While user tokens act on behalf of a particular user and inherit a subset of tha
 ## Create an account owned token
 
 :::note
-Creating an account owned token requires Super Administrator or Administrator permission on the account.
+Creating an account owned token requires Super Administrator permission on the account
 :::
 
 1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com).


### PR DESCRIPTION
### Summary

This change saying users with the admin role can create account tokens was incorrect and needs to be reverted.

PR with commit being reverted: https://github.com/cloudflare/cloudflare-docs/pull/28425


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
