### PR TITLE
Fix docs regarding custom Docker setup for sandboxes

### DIFF
--- a/src/content/docs/sandbox/configuration/dockerfile.mdx
+++ b/src/content/docs/sandbox/configuration/dockerfile.mdx
@@ -137,9 +137,10 @@ COPY my-app.js /workspace/my-app.js
 COPY startup.sh /workspace/startup.sh
 RUN chmod +x /workspace/startup.sh
 
-ENTRYPOINT ["/sandbox"]
 CMD ["/workspace/startup.sh"]
 ```
+
+The base image already sets the correct `ENTRYPOINT`, so you only need to provide a `CMD`. The sandbox binary starts the HTTP API server, then spawns your `CMD` as a child process with proper signal forwarding.
 
 ```bash title="startup.sh"
 #!/bin/bash
@@ -156,7 +157,7 @@ wait
 ```
 
 :::note[Legacy startup scripts]
-If you have existing startup scripts that end with `exec bun /container-server/dist/index.js`, they will continue to work for backwards compatibility. However, we recommend migrating to the new approach using `ENTRYPOINT ["/sandbox"]` with `CMD` for your startup script.
+If you have existing startup scripts that end with `exec bun /container-server/dist/index.js`, they will continue to work for backwards compatibility. However, we recommend migrating to the new approach using `CMD` for your startup script. Do not override `ENTRYPOINT` when extending the base image.
 :::
 
 ## Related resources


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Fixes https://github.com/cloudflare/sandbox-sdk/issues/371

The "Custom startup scripts" section recommends `ENTRYPOINT ["/sandbox"]` when extending the base sandbox image. But `/sandbox` does not exist in the base images — the binary is at `/container-server/sandbox`. This causes containers to fail on startup with `exec /sandbox: no such file or directory`.

The fix: don't override `ENTRYPOINT` at all when extending the base image. It already sets `ENTRYPOINT ["/container-server/sandbox"]`. Just use `CMD`.

#### Changes
- Removed `ENTRYPOINT ["/sandbox"]` from the "Custom startup scripts" Dockerfile example
- Added a paragraph explaining the base image already sets the correct ENTRYPOINT
- Updated the legacy startup scripts note to recommend `CMD` instead of `ENTRYPOINT ["/sandbox"]`

#### Not changed

The "Using arbitrary base images" section correctly uses `ENTRYPOINT ["/sandbox"]` — in that pattern the binary is explicitly copied to `/sandbox` via `COPY --from=... /container-server/sandbox /sandbox`.

---
*Generated with [OpenCode](https://opencode.ai)*

### Documentation checklist
