### PR TITLE
Remove references to `r2 object list` commands

### DIFF
--- a/skills/cloudflare/references/r2/api.md
+++ b/skills/cloudflare/references/r2/api.md
@@ -196,5 +196,4 @@ interface R2UploadedPart {
 wrangler r2 object put my-bucket/file.txt --file=./local.txt
 wrangler r2 object get my-bucket/file.txt --file=./download.txt
 wrangler r2 object delete my-bucket/file.txt
-wrangler r2 object list my-bucket --prefix=photos/
 ```

--- a/src/content/docs/r2/get-started/cli.mdx
+++ b/src/content/docs/r2/get-started/cli.mdx
@@ -117,9 +117,6 @@ wrangler r2 object put my-bucket/myfile.txt --file ./myfile.txt
 
 # Download myfile.txt and save it as downloaded.txt
 wrangler r2 object get my-bucket/myfile.txt --file ./downloaded.txt
-
-# List all objects in my-bucket
-wrangler r2 object list my-bucket
 ```
 
 Refer to the [Wrangler R2 commands](/r2/reference/wrangler-commands/) for all available operations.


### PR DESCRIPTION
These do not exist in the current version of wrangler.