### PR TITLE
[ProductChangelog] Add optional prop to limit # of entries

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -160,6 +160,7 @@ export default defineConfig({
 									"/markdown.zip",
 									"/style-guide/index.md",
 									"/style-guide/fixtures/markdown/index.md",
+									"/search/**",
 								],
 							}),
 						]

--- a/src/components/ProductChangelog.astro
+++ b/src/components/ProductChangelog.astro
@@ -23,6 +23,7 @@ const props = z
 		z.object({
 			hideEntry: z.string().optional(),
 			scheduled: z.boolean().default(false),
+			numberOfEntries: z.number().int().positive().optional(),
 		}),
 	);
 
@@ -54,7 +55,11 @@ if ("product" in input) {
 	};
 }
 
-const changelogs = await getChangelogs({ filter });
+const allChangelogs = await getChangelogs({ filter });
+const changelogs =
+	input.numberOfEntries !== undefined
+		? allChangelogs.slice(0, input.numberOfEntries)
+		: allChangelogs;
 ---
 
 <RSSButton href={rss} />

--- a/src/content/docs/waf/change-log/general-updates.mdx
+++ b/src/content/docs/waf/change-log/general-updates.mdx
@@ -9,6 +9,11 @@ head:
 tableOfContents: false
 ---
 
-import { ProductChangelog } from "~/components";
+import { LinkButton, ProductChangelog } from "~/components";
 
-<ProductChangelog product="waf" />
+<ProductChangelog product="waf" numberOfEntries={15} />
+
+<br />
+<LinkButton href="/search/?product=WAF&contentType=Changelog+entry">
+	<strong>View more entries ></strong>
+</LinkButton>


### PR DESCRIPTION
### Summary

Updates `ProductChangelog` component to have an optional `numberOfEntries` property to limit length of the rendered content.

CED-387

<img width="882" height="620" alt="image" src="https://github.com/user-attachments/assets/b3c2c94c-fa2b-405f-b8df-c338fd3618b9" />

