### PR TITLE
Fix JsonSchemaViewer hydration error in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"astro-icon": "1.1.5",
 				"astro-live-code": "0.0.6",
 				"astro-skills": "0.0.5",
-				"cf-json-schema-viz": "0.1.0",
+				"cf-json-schema-viz": "0.3.0",
 				"cidr-tools": "11.0.3",
 				"codeowners-utils": "1.0.2",
 				"date-fns": "4.1.0",
@@ -8132,9 +8132,9 @@
 			}
 		},
 		"node_modules/cf-json-schema-viz": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/cf-json-schema-viz/-/cf-json-schema-viz-0.1.0.tgz",
-			"integrity": "sha512-Y6jxFTWSSJp/1S00KnIikHNKi9GL6rn151d24UiA+1AEJ8roOmaUjz0dYBwenmSFMg2EXmOQINUwRNKFart6ZQ==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/cf-json-schema-viz/-/cf-json-schema-viz-0.3.0.tgz",
+			"integrity": "sha512-abWFhQ/5m08sSqO5XFwF9vh49An2cxrfr1/MnF88Qdo7AXFOWEB3dFJ7MN74ASIKegwK7AemxNPGVkQjzNCujQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"astro-icon": "1.1.5",
 		"astro-live-code": "0.0.6",
 		"astro-skills": "0.0.5",
-		"cf-json-schema-viz": "0.1.0",
+		"cf-json-schema-viz": "0.3.0",
 		"cidr-tools": "11.0.3",
 		"codeowners-utils": "1.0.2",
 		"date-fns": "4.1.0",

--- a/src/pages/workers-ai/models/[name].astro
+++ b/src/pages/workers-ai/models/[name].astro
@@ -294,7 +294,7 @@ const starlightPageProps = {
 	<h2 id="Parameters">Parameters</h2>
 	<p><span class="text-red-500">*</span> indicates a required field</p>
 	<h3 id="Input">Input</h3>
-	<JsonSchemaViewer schema={model.schema.input} client:visible />
+	<JsonSchemaViewer schema={model.schema.input} client:only="react" />
 
 	<h3 id="Output">Output</h3>
 	{
@@ -309,7 +309,7 @@ const starlightPageProps = {
 				</p>
 			</>
 		) : (
-			<JsonSchemaViewer schema={model.schema.output} client:visible />
+			<JsonSchemaViewer schema={model.schema.output} client:only="react" />
 		)
 	}
 


### PR DESCRIPTION
## Summary
- Fixes `require is not defined` error when hydrating the JsonSchemaViewer component in production builds
- Changes client directive from `client:visible` to `client:only="react"` to skip SSR entirely

## Problem
The `@stoplight/json-schema-tree` and `@stoplight/json` packages use CommonJS as their main entry point. In development, Vite handles this seamlessly, but in production builds the CJS `require()` calls weren't being transformed, causing hydration failures.