### PR TITLE
docs: add scheduler.wait() API documentation and examples

### DIFF
--- a/src/content/docs/workers/runtime-apis/scheduler.mdx
+++ b/src/content/docs/workers/runtime-apis/scheduler.mdx
@@ -1,0 +1,179 @@
+---
+pcx_content_type: configuration
+title: Scheduler
+head: []
+description: Use the scheduler.wait() API to pause execution for a specified duration without blocking other work in Cloudflare Workers.
+---
+
+import { TypeScriptExample } from "~/components";
+
+The global `scheduler` object provides scheduling APIs for use within Cloudflare Workers. Its primary method, `scheduler.wait()`, offers a Promise-based alternative to `setTimeout()` for delaying execution.
+
+`scheduler.wait()` is part of the [WICG Scheduling APIs proposal](https://github.com/nicolo-ribaudo/tc39-proposal-await-dictionary#schedulerwait).
+
+## scheduler.wait()
+
+`scheduler.wait()` returns a `Promise` that resolves after the specified number of milliseconds. It is the `await`-able equivalent of `setTimeout()`.
+
+```ts
+await scheduler.wait(delay);
+await scheduler.wait(delay, options);
+```
+
+### Parameters
+
+- `delay` number
+  - The number of milliseconds to wait before the returned Promise resolves.
+
+- `options` object optional
+  - Optional configuration.
+  - `signal` AbortSignal
+    - An [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). If the signal is aborted before the delay elapses, the returned Promise rejects with an `AbortError`.
+
+### Return type
+
+- `Promise<void>` — Resolves after `delay` milliseconds.
+
+## Behavior
+
+`scheduler.wait()` does **not** block the main thread. It yields control and allows other asynchronous work to proceed while waiting. Internally, it is equivalent to:
+
+```ts
+await new Promise((resolve) => setTimeout(resolve, delay));
+```
+
+The key difference is ergonomic — `scheduler.wait()` is cleaner, directly `await`-able, and supports cancellation through an `AbortSignal`.
+
+Like all timers in Workers, `scheduler.wait()` is only available inside the [request context](/workers/runtime-apis/request/#the-request-context).
+
+## Examples
+
+### Basic delay
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+export default {
+	async fetch(request, env, ctx): Promise<Response> {
+		// Wait for 1 second before responding
+		await scheduler.wait(1000);
+		return new Response("Delayed response");
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+### Retry with exponential backoff
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+export default {
+	async fetch(request, env, ctx): Promise<Response> {
+		const maxAttempts = 3;
+		const baseBackoffMs = 100;
+		const maxBackoffMs = 5000;
+
+		for (let attempt = 0; attempt < maxAttempts; attempt++) {
+			try {
+				const response = await fetch("https://example.com/api");
+				if (response.ok) {
+					return response;
+				}
+			} catch (e) {
+				// Transient error, will retry
+			}
+
+			const backoffMs = Math.min(
+				maxBackoffMs,
+				baseBackoffMs * Math.random() * Math.pow(2, attempt),
+			);
+			await scheduler.wait(backoffMs);
+		}
+
+		return new Response("Service unavailable", { status: 503 });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+### Cancellable wait with AbortSignal
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+export default {
+	async fetch(request, env, ctx): Promise<Response> {
+		const controller = new AbortController();
+
+		// Cancel the wait after 2 seconds
+		setTimeout(() => controller.abort(), 2000);
+
+		try {
+			// Attempt to wait for 10 seconds, but abort after 2
+			await scheduler.wait(10000, { signal: controller.signal });
+			return new Response("Waited the full 10 seconds");
+		} catch (e) {
+			if (e instanceof DOMException && e.name === "AbortError") {
+				return new Response("Wait was cancelled early");
+			}
+			throw e;
+		}
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+### Use with the incoming request signal
+
+<TypeScriptExample filename="index.ts">
+
+```ts
+export default {
+	async fetch(request, env, ctx): Promise<Response> {
+		const { readable, writable } = new IdentityTransformStream();
+		ctx.waitUntil(sendPing(writable, request.signal));
+		return new Response(readable, {
+			headers: { "Content-Type": "text/plain" },
+		});
+	},
+} satisfies ExportedHandler<Env>;
+
+async function sendPing(
+	writable: WritableStream,
+	signal: AbortSignal,
+): Promise<void> {
+	const writer = writable.getWriter();
+	const encoder = new TextEncoder();
+
+	try {
+		while (!signal.aborted) {
+			await writer.write(encoder.encode("ping\r\n"));
+			await scheduler.wait(1000, { signal });
+		}
+	} catch {
+		// Client disconnected
+	} finally {
+		await writer.close();
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Comparison with setTimeout
+
+| Feature                | `scheduler.wait()` | `setTimeout()`         |
+| ---------------------- | ------------------ | ---------------------- |
+| Returns a Promise      | Yes                | No                     |
+| Directly `await`-able  | Yes                | No (requires wrapping) |
+| Supports `AbortSignal` | Yes                | No                     |
+| Blocks the main thread | No                 | No                     |
+
+## Related resources
+
+- [Timers (Node.js compatibility)](/workers/runtime-apis/nodejs/timers/) — Node.js-compatible timer APIs.
+- [Web standards — Timers](/workers/runtime-apis/web-standards/) — `setTimeout()`, `setInterval()`, and related timer APIs.

--- a/src/content/docs/workers/runtime-apis/web-standards.mdx
+++ b/src/content/docs/workers/runtime-apis/web-standards.mdx
@@ -50,6 +50,9 @@ The following methods are available per the [Worker Global Scope](https://develo
 - clearTimeout()
   - Cancels the delayed execution set using [`setTimeout()`](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout).
 
+- [scheduler.wait()](/workers/runtime-apis/scheduler/)
+  - Returns a `Promise` that resolves after a given number of milliseconds — an `await`-able alternative to `setTimeout()`.
+
 :::note
 
 Timers are only available inside of [the Request Context](/workers/runtime-apis/request/#the-request-context).


### PR DESCRIPTION
Closes: #28595 
### Summary

Adds a dedicated API reference page for `scheduler.wait()` at `/workers/runtime-apis/scheduler/`.

This API is available in the Workers runtime and part of the auto-generated types, but was previously undocumented outside of a brief mention in the [historical changelog](https://developers.cloudflare.com/workers/platform/changelog/historical-changelog/).

Changes:
- New page `src/content/docs/workers/runtime-apis/scheduler.mdx` covering:
  - Full API signature with parameters and return type
  - Behavior clarification (non-blocking, equivalent to `await new Promise(r => setTimeout(r, ms))`)
  - `AbortSignal` cancellation support
  - Four usage examples (basic delay, retry backoff, cancellable wait, streaming with request signal)
  - Comparison table vs `setTimeout()`
- Updated `src/content/docs/workers/runtime-apis/web-standards.mdx` to reference `scheduler.wait()` in the Timers section

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).