### PR TITLE
Changelog: Correct async SWR behavior and rewrite benefits

### DIFF
--- a/src/content/changelog/cache/2026-02-26-async-stale-while-revalidate.mdx
+++ b/src/content/changelog/cache/2026-02-26-async-stale-while-revalidate.mdx
@@ -1,21 +1,20 @@
 ---
 title: Asynchronous stale-while-revalidate
-description: Stale-while-revalidate now returns stale content immediately while revalidation happens in the background, eliminating wait time for the first request that triggers revalidation.
+description: The first request after cache expiry now receives stale content immediately with an UPDATING status while revalidation happens asynchronously, instead of blocking until the origin responds.
 products:
   - cache
 date: 2026-02-26
 ---
 
-Cloudflare's [`stale-while-revalidate`](/cache/concepts/cache-control/#revalidation) support is now fully asynchronous. Revalidation begins at expiry rather than waiting for the next visitor request. Stale content is served immediately while Cloudflare refreshes the asset in the background, and no visitor has to wait for an origin round-trip.
+Cloudflare's [`stale-while-revalidate`](/cache/concepts/cache-control/#revalidation) support is now fully asynchronous. Previously, the first request for a stale (expired) asset in cache had to wait for an origin response, after which that visitor received a REVALIDATED or EXPIRED status. Now, the first request after the asset expires triggers revalidation in the background and immediately receives stale content with an UPDATING status. All following requests also receive stale content with an `UPDATING` status until the origin responds, after which subsequent requests receive fresh content with a `HIT` status.
 
-`stale-while-revalidate` is a Cache-Control directive that allows Cloudflare to serve an expired cached asset while a fresh copy is fetched from the origin.
+`stale-while-revalidate` is a `Cache-Control` directive set by your origin server that allows Cloudflare to serve an expired cached asset while a fresh copy is fetched from the origin.
 
 Asynchronous revalidation brings:
 
-- **Lower latency**: The first visitor is no longer blocked while the asset is updated from the origin, providing a faster experience.
-- **Fresher content**: Assets are revalidated sooner, and visitors are more likely to receive up-to-date content.
-
-Note that your origin may see an increase in traffic due to revalidation on expiry. In addition, all revalidation cache statuses are now `UPDATING` or `HIT` instead of `MISS` or `REVALIDATED`.
+- **Lower latency**: No visitor is waiting for the origin when the asset is already in cache. Every request is served from cache during revalidation.
+- **Consistent experience**: All visitors receive the same cached response during revalidation.
+- **Reduced error exposure**: The first request is no longer vulnerable to origin timeouts or errors. All visitors receive a cached response while revalidation happens in the background.
 
 ## Availability
 


### PR DESCRIPTION
### Summary

Corrected cache changelog for Async stale while revalidate 

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).