### PR TITLE
Add changelog entry for OG images Astro tutorial

### DIFF
--- a/src/content/docs/browser-rendering/examples.mdx
+++ b/src/content/docs/browser-rendering/examples.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Examples
 sidebar:
-  order: 3
+  order: 2
 ---
 
 import { CardGrid, LinkCard } from "~/components"

--- a/src/content/docs/browser-rendering/get-started.mdx
+++ b/src/content/docs/browser-rendering/get-started.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Get started
 sidebar:
-  order: 2
+  order: 1
 ---
 import { Render } from "~/components";
 

--- a/src/content/docs/browser-rendering/rest-api/index.mdx
+++ b/src/content/docs/browser-rendering/rest-api/index.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: REST API
 sidebar:
-  order: 1
+  order: 3
 ---
 import { DashButton } from "~/components";
 

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,6 +3,10 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
+  - publish_date: "2026-02-26"
+    title: "New tutorial: Generate OG images for Astro sites"
+    description: |-
+      * Added a new tutorial on how to [generate OG images for Astro sites](/browser-rendering/how-to/og-images-astro/) using Browser Rendering. The tutorial walks through creating an Astro template, using Browser Rendering to screenshot it as a PNG, and serving the generated images.
   - publish_date: "2026-02-24"
     title: "Documentation updates for robots.txt and sitemaps"
     description: |-


### PR DESCRIPTION
Adds a changelog entry for the new [Generate OG images for Astro sites](https://developers.cloudflare.com/browser-rendering/how-to/og-images-astro/) tutorial in Browser Rendering.