### PR TITLE
Docs: Correct async SWR behavior in revalidation and cache-control

### DIFF
--- a/src/content/docs/cache/concepts/cache-control.mdx
+++ b/src/content/docs/cache/concepts/cache-control.mdx
@@ -79,7 +79,7 @@ Revalidation determines how the cache should behave when a resource expires, and
 * `stale-while-revalidate=<seconds>` — When present in an HTTP response, indicates caches may serve the response in which it appears after it becomes stale, up to the indicated number of seconds since the resource expired. If [Always Online](/cache/how-to/always-online/) is enabled, then the `stale-while-revalidate` and `stale-if-error` directives are ignored. This directive is not supported when using the Cache API methods `cache.match` or `cache.put`. For more information, refer to the [Workers documentation for Cache API](/workers/runtime-apis/cache/#methods).
 
 :::note
-`stale-while-revalidate` is fully asynchronous. Revalidation begins at expiry rather than on the next visitor request. All requests during revalidation are served from cache with an UPDATING or HIT status. No request is blocked waiting for the origin.
+`stale-while-revalidate` is now fully asynchronous. The first request after expiry triggers revalidation in the background and immediately receives stale content with an UPDATING status instead of blocking. All requests during revalidation are served stale with an UPDATING status until the origin responds, after which they receive a HIT.
 
 For more details, refer to [Revalidation](/cache/concepts/revalidation/#asynchronous-revalidation).
 :::

--- a/src/content/docs/cache/concepts/revalidation.mdx
+++ b/src/content/docs/cache/concepts/revalidation.mdx
@@ -14,11 +14,9 @@ Asynchronous `stale-while-revalidate` is live for all Free, Pro, and Business zo
 
 ## Asynchronous revalidation
 
-Revalidation is fully asynchronous. When a cached asset reaches its TTL expiry and `stale-while-revalidate` is set, Cloudflare begins revalidating the asset with the origin immediately at expiry rather than waiting for the next visitor request. All visitor requests that arrive during revalidation are served from cache with a [HIT](/cache/concepts/cache-responses/#hit) or [UPDATING](/cache/concepts/cache-responses/#updating) status. No request is blocked waiting for the origin to respond.
+Revalidation is fully asynchronous. When a cached asset expires and `stale-while-revalidate` is set, the first request that arrives after expiry triggers revalidation in the background. That request immediately receives stale content with an [UPDATING](/cache/concepts/cache-responses/#updating) status instead of blocking until the origin responds. All following requests also receive stale content with an `UPDATING` status until the origin responds. Once revalidation completes, subsequent requests receive fresh content with a [HIT](/cache/concepts/cache-responses/#hit) status.
 
 If the stale content is still valid, Cloudflare sets a new TTL. If the content has changed, the origin provides fresh content to replace the old.
-
-Note that your origin may see an increase in revalidation traffic because revalidation now starts at expiry rather than on the next request.
 
 ## Synchronous revalidation (legacy)
 


### PR DESCRIPTION
### Summary

Correct async SWR behavior in revalidation and cache-control in Cache docs

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).