### PR TITLE
Modify Shopify O2O instructions for clarity

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
@@ -39,20 +39,19 @@ To enable O2O on your account, [create](/dns/manage-dns-records/how-to/create-dn
 
 Once you save the new DNS record, the Cloudflare dashboard will show a Shopify icon next to the CNAME record value. For example:
 
-:::caution[Avoid Always Use HTTPS]
-Do not enable the **Always Use HTTPS** setting in your Cloudflare dashboard. 
+![Cloudflare dashboard showing a CNAME DNS entry for Shopify with a specific Shopify icon](~/assets/images/cloudflare-for-platforms/provider-guides/shopify-dns-entry.png)
+
+:::caution[Do not use Always Use HTTPS]
+
+Do not enable the [Always Use HTTPS](/ssl/edge-certificates/additional-options/always-use-https/) setting in an O2O scenario with Shopify.
 
 This setting forces a redirect on all requests, including the `/.well-known/acme-challenge/` path used for HTTP-01 domain validation. This prevents Shopify from automatically provisioning or renewing SSL certificates via Let's Encrypt for your domain.
 
-Instead, create a [Redirect Rule](rules/url-forwarding/single-redirects/create-dashboard/) to enforce HTTPS while excluding the validation path:
-
-![](~/assets/images/cloudflare-for-platforms/provider-guides/shopify-dns-entry.png)
-
-:::note
-
-For questions about Shopify setup, refer to their [support guide](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-manual).
+Instead, create a [redirect rule](/rules/url-forwarding/single-redirects/create-dashboard/) to enforce HTTPS while excluding the validation path mentioned above.
 
 :::
+
+For questions about Shopify setup, refer to their [support guide](https://help.shopify.com/en/manual/domains/add-a-domain/connecting-domains/connect-domain-manual).
 
 ## Product compatibility
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/provider-guides/shopify.mdx
@@ -39,6 +39,13 @@ To enable O2O on your account, [create](/dns/manage-dns-records/how-to/create-dn
 
 Once you save the new DNS record, the Cloudflare dashboard will show a Shopify icon next to the CNAME record value. For example:
 
+:::caution[Avoid Always Use HTTPS]
+Do not enable the **Always Use HTTPS** setting in your Cloudflare dashboard. 
+
+This setting forces a redirect on all requests, including the `/.well-known/acme-challenge/` path used for HTTP-01 domain validation. This prevents Shopify from automatically provisioning or renewing SSL certificates via Let's Encrypt for your domain.
+
+Instead, create a [Redirect Rule](rules/url-forwarding/single-redirects/create-dashboard/) to enforce HTTPS while excluding the validation path:
+
 ![](~/assets/images/cloudflare-for-platforms/provider-guides/shopify-dns-entry.png)
 
 :::note


### PR DESCRIPTION
### Summary

Shopify would like Cloudflare to update our Shopify O2O documentation to include a warning about conflicts caused by Always Use HTTPS. Instead, they prefer customers to deploy a redirect rule for http -> https which excludes /.well-known/acme-challenge/* paths.

### Screenshots (optional)

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
