### PR TITLE
Fix typo: 'a each server' -> 'each server'

### DIFF
--- a/src/content/docs/learning-paths/load-balancing/concepts/health-checks.mdx
+++ b/src/content/docs/learning-paths/load-balancing/concepts/health-checks.mdx
@@ -18,7 +18,7 @@ That's where another part of the load balancing equation comes in: monitors and 
 
 ## How it works
 
-A monitor issues health checks periodically to evaluate the health of a each server within a pool.
+A monitor issues health checks periodically to evaluate the health of each server within a pool.
 
 <GlossaryDefinition term="health check" />
 

--- a/src/content/docs/learning-paths/load-balancing/planning/server-pool-health.mdx
+++ b/src/content/docs/learning-paths/load-balancing/planning/server-pool-health.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { Details, GlossaryDefinition, Render } from "~/components"
 
-As discussed before, a monitor issues health checks periodically to evaluate the health of a each server within a pool.
+As discussed before, a monitor issues health checks periodically to evaluate the health of each server within a pool.
 
 <Render file="health-check-diagram" product="load-balancing" /> <br/>
 


### PR DESCRIPTION
## Summary
- Fixed typo "a each server" → "each server" in two load balancing docs pages

## Files changed
- `src/content/docs/learning-paths/load-balancing/planning/server-pool-health.mdx`
- `src/content/docs/learning-paths/load-balancing/concepts/health-checks.mdx`