### PR TITLE
[WAF] Clean up 2024 changelog entries

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -1748,6 +1748,12 @@
 /waf/reference/migration-guides/waf-managed-rules-migration/ /waf/reference/legacy/old-waf-managed-rules/upgrade/ 301
 /waf/reference/migration-guides/firewall-rules-to-custom-rules/ /waf/reference/legacy/firewall-rules-upgrade/ 301
 /waf/managed-rules/handle-false-positives/ /waf/managed-rules/troubleshooting/ 301
+/changelog/post/2024-12-18-improved-vpn-managed-list/ /waf/change-log/historical-2024/#2024-12-18 301
+/changelog/post/2024-12-10-change-order-of-list-items-in-ip-lists/ /waf/change-log/historical-2024/#2024-12-10 301
+/changelog/post/2024-11-14-security-events-pagination/ /waf/change-log/historical-2024/#2024-11-14
+/changelog/post/2024-11-04-new-table-in-security-analytics-and-security-events/ /waf/change-log/historical-2024/#2024-11-04 301
+/changelog/post/2024-08-29-fixed-occasional-attack-score-mismatches/ /waf/change-log/historical-2024/#2024-08-29 301
+/changelog/post/2024-05-23-improved-detection-capabilities/ /waf/change-log/historical-2024/#2024-05-23 301
 
 # waiting-room
 /waiting-room/how-to/mobile-traffic/ /waiting-room/how-to/json-response/ 301

--- a/public/__redirects
+++ b/public/__redirects
@@ -1750,7 +1750,7 @@
 /waf/managed-rules/handle-false-positives/ /waf/managed-rules/troubleshooting/ 301
 /changelog/post/2024-12-18-improved-vpn-managed-list/ /waf/change-log/historical-2024/#2024-12-18 301
 /changelog/post/2024-12-10-change-order-of-list-items-in-ip-lists/ /waf/change-log/historical-2024/#2024-12-10 301
-/changelog/post/2024-11-14-security-events-pagination/ /waf/change-log/historical-2024/#2024-11-14
+/changelog/post/2024-11-14-security-events-pagination/ /waf/change-log/historical-2024/#2024-11-14 301
 /changelog/post/2024-11-04-new-table-in-security-analytics-and-security-events/ /waf/change-log/historical-2024/#2024-11-04 301
 /changelog/post/2024-08-29-fixed-occasional-attack-score-mismatches/ /waf/change-log/historical-2024/#2024-08-29 301
 /changelog/post/2024-05-23-improved-detection-capabilities/ /waf/change-log/historical-2024/#2024-05-23 301

--- a/public/__redirects
+++ b/public/__redirects
@@ -765,7 +765,7 @@
 /fundamentals/subscriptions-and-billing/troubleshooting-failed-payments/ /billing/troubleshoot-failed-payments/ 301
 /fundamentals/subscriptions-and-billing/understand-invoices/ /billing/invoices/ 301
 /fundamentals/subscriptions-and-billing/update-billing-info/ /billing/update-billing-info/ 301
-/fundamentals/changelog/ /changelog/?product=fundamentals 301
+/fundamentals/changelog/ /changelog/product/fundamentals/ 301
 /fundamentals/reference-architecture/ /reference-architecture/ 301
 /fundamentals/subscriptions-and-billing/cancel-subscription/ /billing/cancel-subscription/ 301
 /fundamentals/subscriptions-and-billing/change-plan/ /billing/change-plan/ 301

--- a/src/content/changelog/ai-search/2025-09-25-ai-search-more-models.mdx
+++ b/src/content/changelog/ai-search/2025-09-25-ai-search-more-models.mdx
@@ -39,6 +39,4 @@ export default {
 };
 ```
 
-In the coming weeks we will also roll out updates to align the APIs with the new name. The existing APIs will continue to be supported for the time being. Stay tuned to the [AI Search Changelog](/changelog/?product=ai-search) and [Discord](https://discord.cloudflare.com/) for more updates!
-
-
+In the coming weeks we will also roll out updates to align the APIs with the new name. The existing APIs will continue to be supported for the time being. Stay tuned to the [AI Search Changelog](/changelog/product/ai-search/) and [Discord](https://discord.cloudflare.com/) for more updates!

--- a/src/content/changelog/audit-logs/2025-07-29-audit-logs-v2-ui-beta.mdx
+++ b/src/content/changelog/audit-logs/2025-07-29-audit-logs-v2-ui-beta.mdx
@@ -4,7 +4,7 @@ description: New version of audit logs UI
 date: 2025-07-29
 ---
 
-The Audit Logs v2 UI is now available to all Cloudflare customers in Beta. This release builds on the public [Beta of the Audit Logs v2 API](https://developers.cloudflare.com/changelog/?product=audit-logs) and introduces a redesigned user interface with powerful new capabilities to make it easier to investigate account activity.
+The Audit Logs v2 UI is now available to all Cloudflare customers in Beta. This release builds on the public [Beta of the Audit Logs v2 API](/changelog/product/audit-logs/) and introduces a redesigned user interface with powerful new capabilities to make it easier to investigate account activity.
 
 **Enabling the new UI**
 

--- a/src/content/changelog/waf/2024-05-23-improved-detection-capabilities.mdx
+++ b/src/content/changelog/waf/2024-05-23-improved-detection-capabilities.mdx
@@ -1,7 +1,0 @@
----
-title: Improved detection capabilities
-description: WAF attack score now detects Base64 and Unicode escapes.
-date: 2024-05-23
----
-
-[WAF attack score](/waf/detections/attack-score/) now automatically detects and decodes Base64 and JavaScript (Unicode escape sequences) in HTTP requests. This update is available for all customers with access to WAF attack score (Business customers with access to a single field and Enterprise customers).

--- a/src/content/changelog/waf/2024-08-29-fixed-occasional-attack-score-mismatches.mdx
+++ b/src/content/changelog/waf/2024-08-29-fixed-occasional-attack-score-mismatches.mdx
@@ -1,7 +1,0 @@
----
-title: Fixed occasional attack score mismatches
-description: Fixed mismatches between WAF attack score and subscores.
-date: 2024-08-29
----
-
-Fixed an issue causing score mismatches between the global [WAF attack score](/waf/detections/attack-score/) and subscores. In certain cases, subscores were higher (not an attack) than expected while the global attack score was lower than expected (attack), leading to false positives.

--- a/src/content/changelog/waf/2024-11-04-new-table-in-security-analytics-and-security-events.mdx
+++ b/src/content/changelog/waf/2024-11-04-new-table-in-security-analytics-and-security-events.mdx
@@ -1,7 +1,0 @@
----
-title: New table in Security Analytics and Security Events
-description: New responsive table in Security Analytics and Events.
-date: 2024-11-04
----
-
-Switched to a new, more responsive table in Security Analytics and Security Events.

--- a/src/content/changelog/waf/2024-11-14-security-events-pagination.mdx
+++ b/src/content/changelog/waf/2024-11-14-security-events-pagination.mdx
@@ -1,7 +1,0 @@
----
-title: Security Events pagination
-description: Fixed pagination and log count issues in Security Events.
-date: 2024-11-14
----
-
-Fixed an issue with pagination in Security Events' sampled logs where some pages were missing data. Also removed the total count from the events log as these are only sampled logs.

--- a/src/content/changelog/waf/2024-12-10-change-order-of-list-items-in-ip-lists.mdx
+++ b/src/content/changelog/waf/2024-12-10-change-order-of-list-items-in-ip-lists.mdx
@@ -1,7 +1,0 @@
----
-title: Change the order of list items in IP Lists (for API and Terraform users)
-description: API and Terraform users may see changes in IP list item order.
-date: 2024-12-10
----
-
-Due to changes in the API implementation, the order of list items in an IP list obtained via API or Terraform may change, which may cause Terraform to detect a change in Terraform state. To fix this issue, resync the Terraform state or upgrade the version of your Terraform Cloudflare provider to [version 4.44.0](https://github.com/cloudflare/terraform-provider-cloudflare/releases/tag/v4.44.0) or later.

--- a/src/content/changelog/waf/2024-12-18-improved-vpn-managed-list.mdx
+++ b/src/content/changelog/waf/2024-12-18-improved-vpn-managed-list.mdx
@@ -1,7 +1,0 @@
----
-title: Improved VPN Managed List
-description: Improved management of VPN IP traffic.
-date: 2024-12-18
----
-
-Customers can now effectively manage incoming traffic identified as originating from VPN IPs. Customers with compliance restrictions can now ensure compliance with local laws and regulations. Customers with CDN restrictions can use the improved VPN Managed List to prevent unauthorized access from users attempting to bypass geographical restrictions. With the new VPN Managed List enhancements, customers can improve their overall security posture to reduce exposure to unwanted or malicious traffic.

--- a/src/content/docs/learning-paths/holistic-ai-security/secure-approved-ai-models-tools/index.mdx
+++ b/src/content/docs/learning-paths/holistic-ai-security/secure-approved-ai-models-tools/index.mdx
@@ -30,7 +30,7 @@ By combining this with DLP profiles, you can report on data exposure within an A
 
 The Model Context Protocol (MCP) is an emerging standard that allows AI agents to communicate with both public and private APIs. An MCP server acts as a translation layer, which enables these AI agents to understand datasets, perform actions, and develop context beyond their original training.
 
-Cloudflare has been an early supporter of the MCP standard. Many of our customers are already building custom MCP servers and use cases, and our engineering teams have worked to deliver MCP functionality for our public API. You can review our [changelog](/changelog/?product=ai) to see some of the MCP servers we have already released.
+Cloudflare has been an early supporter of the MCP standard. Many of our customers are already building custom MCP servers and use cases, and our engineering teams have worked to deliver MCP functionality for our public API. You can review our [changelog](/changelog/product-group/ai/) to see some of the MCP servers we have already released.
 
 Just like an API, an MCP server is a primary entry point for AI agents to interact with and manipulate your structured data. Since anyone can build and host an MCP server, it is crucial to have a comprehensive secure access strategy as your business starts to adopt these new agentic workflows.
 

--- a/src/content/docs/waf/change-log/general-updates.mdx
+++ b/src/content/docs/waf/change-log/general-updates.mdx
@@ -14,6 +14,7 @@ import { LinkButton, ProductChangelog } from "~/components";
 <ProductChangelog product="waf" numberOfEntries={15} />
 
 <br />
+
 <LinkButton href="/search/?product=WAF&contentType=Changelog+entry">
 	<strong>View more entries ></strong>
 </LinkButton>

--- a/src/content/docs/waf/change-log/historical-2024.mdx
+++ b/src/content/docs/waf/change-log/historical-2024.mdx
@@ -9,6 +9,11 @@ tableOfContents: false
 
 import { RuleID } from "~/components";
 
+- [Managed ruleset updates](#managed-ruleset-updates)
+- [General updates](#general-updates)
+
+## Managed ruleset updates
+
 <table style="width: 100%">
 	<thead>
 		<tr>
@@ -1397,3 +1402,41 @@ import { RuleID } from "~/components";
 		</tr>
 	</tbody>
 </table>
+
+## General updates
+
+### 2024-12-18
+
+**Improved VPN Managed List**
+
+Customers can now effectively manage incoming traffic identified as originating from VPN IPs. Customers with compliance restrictions can now ensure compliance with local laws and regulations. Customers with CDN restrictions can use the improved VPN Managed List to prevent unauthorized access from users attempting to bypass geographical restrictions. With the new VPN Managed List enhancements, customers can improve their overall security posture to reduce exposure to unwanted or malicious traffic.
+
+### 2024-12-10
+
+**Change the order of list items in IP Lists (for API and Terraform users)**
+
+Due to changes in the API implementation, the order of list items in an IP list obtained via API or Terraform may change, which may cause Terraform to detect a change in Terraform state. To fix this issue, resync the Terraform state or upgrade the version of your Terraform Cloudflare provider to [version 4.44.0](https://github.com/cloudflare/terraform-provider-cloudflare/releases/tag/v4.44.0) or later.
+
+### 2024-11-14
+
+**Security Events pagination**
+
+Fixed an issue with pagination in Security Events' sampled logs where some pages were missing data. Also removed the total count from the events log as these are only sampled logs.
+
+### 2024-11-04
+
+**New table in Security Analytics and Security Events**
+
+Switched to a new, more responsive table in Security Analytics and Security Events.
+
+### 2024-08-29
+
+**Fixed occasional attack score mismatches**
+
+Fixed an issue causing score mismatches between the global [WAF attack score](/waf/detections/attack-score/) and subscores. In certain cases, subscores were higher (not an attack) than expected while the global attack score was lower than expected (attack), leading to false positives.
+
+### 2024-05-23
+
+**Improved detection capabilities**
+
+[WAF attack score](/waf/detections/attack-score/) now automatically detects and decodes Base64 and JavaScript (Unicode escape sequences) in HTTP requests. This update is available for all customers with access to WAF attack score (Business customers with access to a single field and Enterprise customers).

--- a/src/content/docs/waf/change-log/scheduled-changes.mdx
+++ b/src/content/docs/waf/change-log/scheduled-changes.mdx
@@ -9,4 +9,4 @@ import { ProductChangelog } from "~/components";
 
 <ProductChangelog product="waf" scheduled />
 
-For other WAF updates, refer to the [changelog](/changelog/?product=waf).
+For other WAF updates, refer to the [changelog](/changelog/product/waf/).


### PR DESCRIPTION
### Summary

All 2024 changelog entries for the WAF (including general updates) are now only present in the historical page for 2024, so that these older entries (managed ruleset updates + general updates) are in a single location.

We won't create a historical page for 2025, since all the entries are still available through the changelog.

This PR also fixes some URLs related to the changelog, since the URL format changed recently.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
