### PR TITLE
Add Warp SSL error documentation

### DIFF
--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -49,10 +49,6 @@ The build and push usually take the longest on the first deploy. Subsequent depl
 are faster, because they [reuse cached image layers](https://docs.docker.com/build/cache/).
 
 :::note
-If you are running Cloudflare WARP or a VPN that performs TLS inspection, HTTPS requests during the Docker build may fail with SSL or certificate errors. You can resolve this by disabling WARP or your VPN while deploying, or by adding the certificate to your build context. Refer to [SSL errors with Cloudflare WARP or a VPN](/containers/local-dev/#ssl-errors-with-cloudflare-warp-or-a-vpn) for details.
-:::
-
-:::note
 After you deploy your Worker for the first time, you will need to wait several minutes until
 it is ready to receive requests. Unlike Workers, Containers take a few minutes to be provisioned.
 During this time, requests are sent to the Worker, but calls to the Container will error.

--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -49,6 +49,10 @@ The build and push usually take the longest on the first deploy. Subsequent depl
 are faster, because they [reuse cached image layers](https://docs.docker.com/build/cache/).
 
 :::note
+If you are running Cloudflare WARP or a VPN that performs TLS inspection, HTTPS requests during the Docker build may fail with SSL or certificate errors. You can resolve this by disabling WARP or your VPN while deploying, or by adding the certificate to your build context. Refer to [SSL errors with Cloudflare WARP or a VPN](/containers/local-dev/#ssl-errors-with-cloudflare-warp-or-a-vpn) for details.
+:::
+
+:::note
 After you deploy your Worker for the first time, you will need to wait several minutes until
 it is ready to receive requests. Unlike Workers, Containers take a few minutes to be provisioned.
 During this time, requests are sent to the Worker, but calls to the Container will error.

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -83,13 +83,17 @@ If you are running Cloudflare WARP or a VPN that performs TLS inspection, HTTPS 
 To resolve this, you can either:
 
 - Disable WARP or your VPN while running `wrangler dev` or `wrangler deploy`, then re-enable it afterwards.
-- Add the certificate to your Docker build context. Cloudflare WARP exposes its certificate via the `NODE_EXTRA_CA_CERTS` and `SSL_CERT_FILE` environment variables on your host machine. You can pass the certificate into your Docker build as an environment variable, so that it is available during the build without being baked into the final image:
+- Add the certificate to your Docker build context. Cloudflare WARP exposes its certificate via the `NODE_EXTRA_CA_CERTS` and `SSL_CERT_FILE` environment variables on your host machine. You can pass the certificate into your Docker build as an environment variable, so that it is available during the build without being baked into the final image.
 
   ```dockerfile
-RUN if [ -n "$SSL_CERT_FILE" ]; then \
-    cp "$SSL_CERT_FILE" /usr/local/share/ca-certificates/Custom_CA.crt && \
-    update-ca-certificates; \
-    fi
+  RUN if [ -n "$SSL_CERT_FILE" ]; then \
+      cp "$SSL_CERT_FILE" /usr/local/share/ca-certificates/Custom_CA.crt && \
+      update-ca-certificates; \
+      fi
   ```
+
+  :::note
+  The above Dockerfile snippet is an example. Depending on your base image, the commands to install certificates may differ (for example, Alpine uses `apk add ca-certificates` and a different certificate path).
+  :::
 
   Wrangler invokes Docker automatically when you run `wrangler dev` or `wrangler deploy`, so if you need to pass build secrets, you will need to build and push the image manually using `wrangler containers images push`.

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -94,6 +94,8 @@ To resolve this, you can either:
 
   :::note
   The above Dockerfile snippet is an example. Depending on your base image, the commands to install certificates may differ (for example, Alpine uses `apk add ca-certificates` and a different certificate path).
+
+  This snippet will store the certificate into the image. This is only recommended for local development, do not share your certificate or any images that contain it.
   :::
 
   Wrangler invokes Docker automatically when you run `wrangler dev` or `wrangler deploy`, so if you need to pass build secrets, you will need to build and push the image manually using `wrangler containers images push`.

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -95,7 +95,7 @@ To resolve this, you can either:
   :::note
   The above Dockerfile snippet is an example. Depending on your base image, the commands to install certificates may differ (for example, Alpine uses `apk add ca-certificates` and a different certificate path).
 
-  This snippet will store the certificate into the image. This is only recommended for local development, do not share your certificate or any images that contain it.
+  This snippet will store the certificate into the image. Depending on whether your production environment needs the certificate, you may choose to do this only during development or use it in production too.
   :::
 
   Wrangler invokes Docker automatically when you run `wrangler dev` or `wrangler deploy`, so if you need to pass build secrets, you will need to build and push the image manually using `wrangler containers images push`.

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -75,3 +75,21 @@ This retry logic should be handled for you if you are using the [containers pack
 ### Socket configuration - `internal error`
 
 If you see an opaque `internal error` when attempting to connect to your container, you may need to set the `DOCKER_HOST` environment variable to the socket path your container engine is listening on. Wrangler or Vite will attempt to automatically find the correct socket to use to communicate with your container engine, but if that does not work, you may have to set this environment variable to the appropriate socket path.
+
+### SSL errors with Cloudflare WARP or a VPN
+
+If you are running Cloudflare WARP or a VPN that performs TLS inspection, HTTPS requests made during the Docker build process may fail with SSL or certificate errors. This happens because the VPN intercepts HTTPS traffic and re-signs it with its own certificate authority, which Docker does not trust by default.
+
+To resolve this, you can either:
+
+- Disable WARP or your VPN while running `wrangler dev` or `wrangler deploy`, then re-enable it afterwards.
+- Add the certificate to your Docker build context. Cloudflare WARP exposes its certificate via the `NODE_EXTRA_CA_CERTS` and `SSL_CERT_FILE` environment variables on your host machine. You can pass the certificate into your Docker build as an environment variable, so that it is available during the build without being baked into the final image:
+
+  ```dockerfile
+RUN if [ -n "$SSL_CERT_FILE" ]; then \
+    cp "$SSL_CERT_FILE" /usr/local/share/ca-certificates/Custom_CA.crt && \
+    update-ca-certificates; \
+    fi
+  ```
+
+  Wrangler invokes Docker automatically when you run `wrangler dev` or `wrangler deploy`, so if you need to pass build secrets, you will need to build and push the image manually using `wrangler containers images push`.


### PR DESCRIPTION
### Summary

Adds information & resolutions for SSL errors during Docker builds with wrangler when using Warp/VPN. We advise to either disable Warp/VPN during build time, or add a small script to your Dockerfile to use the host CA certificate.