### PR TITLE
Add Kimi K2.5 via AI Gateway and lilbonk workflow

### DIFF
--- a/.github/workflows/lilbonk.yml
+++ b/.github/workflows/lilbonk.yml
@@ -9,7 +9,7 @@ on:
     types: [submitted]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  group: bonk-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/lilbonk.yml
+++ b/.github/workflows/lilbonk.yml
@@ -1,4 +1,4 @@
-name: Bonk
+name: Lil Bonk
 
 on:
   issue_comment:

--- a/.github/workflows/lilbonk.yml
+++ b/.github/workflows/lilbonk.yml
@@ -9,6 +9,7 @@ on:
     types: [submitted]
 
 concurrency:
+  # intentionally hardcoded so that all Bonk workflows coexist peacefully
   group: bonk-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: false
 

--- a/.github/workflows/lilbonk.yml
+++ b/.github/workflows/lilbonk.yml
@@ -1,0 +1,50 @@
+name: Bonk
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  lilbonk:
+    if: github.event.sender.type != 'Bot' && contains(github.event.comment.body, '/lilbonk')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Lil Bonk
+        uses: ask-bonk/ask-bonk/github@main
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
+          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+        with:
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.5"
+          agent: docs
+          mentions: "/lilbonk"
+          permissions: CODEOWNERS

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -28,7 +28,7 @@
 						"temperature": 1.0,
 						"top_p": 0.95,
 						"max_tokens": 64000,
-						"parallel_tool_calls": false,
+						"parallel_tool_calls": true,
 					},
 				},
 			},

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -4,4 +4,34 @@
 	"experimental": {
 		"continue_loop_on_deny": true,
 	},
+	"provider": {
+		"cloudflare-ai-gateway": {
+			"models": {
+				"workers-ai/@cf/moonshotai/kimi-k2.5": {
+					"name": "Kimi K2.5",
+					"attachment": true,
+					"reasoning": true,
+					"tool_call": true,
+					"temperature": true,
+					"interleaved": {
+						"field": "reasoning_content",
+					},
+					"modalities": {
+						"input": ["text", "image"],
+						"output": ["text"],
+					},
+					"limit": {
+						"context": 256000,
+						"output": 64000,
+					},
+					"options": {
+						"temperature": 1.0,
+						"top_p": 0.95,
+						"max_tokens": 64000,
+						"parallel_tool_calls": false,
+					},
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
## Summary

Adds Kimi K2.5 (Workers AI) as a model option via Cloudflare AI Gateway, and a new `/lilbonk` workflow that uses it.

- Add `workers-ai/@cf/moonshotai/kimi-k2.5` to `opencode.jsonc` with model capabilities (256K context, reasoning, vision, tool calling)
- Add `lilbonk.yml` workflow triggered by `/lilbonk` comments, using the same AI Gateway secrets as bonk
- Both bonk and lilbonk share the `Bonk` workflow name so they use the same concurrency group per-PR

cc @mchenco