### PR TITLE
Add changelog: New Gateway Protocol Detection protocols (Beta)

### DIFF
--- a/src/content/changelog/gateway/2026-02-27-new-protocol-detection-protocols.mdx
+++ b/src/content/changelog/gateway/2026-02-27-new-protocol-detection-protocols.mdx
@@ -1,0 +1,25 @@
+---
+title: New protocols added for Gateway Protocol Detection (Beta)
+description: Gateway protocol detection now supports IMAP, POP3, SMTP, MYSQL, RSYNC-DAEMON, LDAP, and NTP.
+products:
+  - gateway
+date: 2026-02-27
+---
+
+Gateway [Protocol Detection](/cloudflare-one/traffic-policies/network-policies/protocol-detection/) now supports seven additional protocols in beta:
+
+| Protocol     | Notes                                              |
+| ------------ | -------------------------------------------------- |
+| IMAP         | Internet Message Access Protocol — email retrieval  |
+| POP3         | Post Office Protocol v3 — email retrieval           |
+| SMTP         | Simple Mail Transfer Protocol — email sending       |
+| MYSQL        | MySQL database wire protocol                        |
+| RSYNC-DAEMON | rsync daemon protocol                               |
+| LDAP         | Lightweight Directory Access Protocol               |
+| NTP          | Network Time Protocol                               |
+
+These protocols join the existing set of detected protocols (HTTP, SSH, TLS, DCE/RPC, MQTT, TPKT, and DNP3) and can be used with the _Detected Protocol_ selector in [Network policies](/cloudflare-one/traffic-policies/network-policies/) to identify and filter traffic based on the application-layer protocol, without relying on port-based identification.
+
+If protocol detection is enabled on your account, these protocols will be logged when detected in your Gateway network traffic.
+
+For more information on using Protocol Detection, refer to the [Protocol detection documentation](/cloudflare-one/traffic-policies/network-policies/protocol-detection/).

--- a/src/content/changelog/gateway/2026-02-27-new-protocol-detection-protocols.mdx
+++ b/src/content/changelog/gateway/2026-02-27-new-protocol-detection-protocols.mdx
@@ -18,7 +18,7 @@ Gateway [Protocol Detection](/cloudflare-one/traffic-policies/network-policies/p
 | LDAP         | Lightweight Directory Access Protocol               |
 | NTP          | Network Time Protocol                               |
 
-These protocols join the existing set of detected protocols (HTTP, SSH, TLS, DCE/RPC, MQTT, TPKT, and DNP3) and can be used with the _Detected Protocol_ selector in [Network policies](/cloudflare-one/traffic-policies/network-policies/) to identify and filter traffic based on the application-layer protocol, without relying on port-based identification.
+These protocols join the existing set of detected protocols (HTTP, HTTP2, SSH, TLS, DCERPC, MQTT, and TPKT) and can be used with the _Detected Protocol_ selector in [Network policies](/cloudflare-one/traffic-policies/network-policies/) to identify and filter traffic based on the application-layer protocol, without relying on port-based identification.
 
 If protocol detection is enabled on your account, these protocols will automatically be logged when detected in your Gateway network traffic.
 

--- a/src/content/changelog/gateway/2026-02-27-new-protocol-detection-protocols.mdx
+++ b/src/content/changelog/gateway/2026-02-27-new-protocol-detection-protocols.mdx
@@ -20,6 +20,6 @@ Gateway [Protocol Detection](/cloudflare-one/traffic-policies/network-policies/p
 
 These protocols join the existing set of detected protocols (HTTP, SSH, TLS, DCE/RPC, MQTT, TPKT, and DNP3) and can be used with the _Detected Protocol_ selector in [Network policies](/cloudflare-one/traffic-policies/network-policies/) to identify and filter traffic based on the application-layer protocol, without relying on port-based identification.
 
-If protocol detection is enabled on your account, these protocols will be logged when detected in your Gateway network traffic.
+If protocol detection is enabled on your account, these protocols will automatically be logged when detected in your Gateway network traffic.
 
 For more information on using Protocol Detection, refer to the [Protocol detection documentation](/cloudflare-one/traffic-policies/network-policies/protocol-detection/).


### PR DESCRIPTION
## Summary

- Adds a changelog entry for seven new protocols added to Gateway Protocol Detection in beta: IMAP, POP3, SMTP, MYSQL, RSYNC-DAEMON, LDAP, and NTP.
- These protocols join the existing set (HTTP, HTTP2, SSH, TLS, DCERPC, MQTT, and TPKT) and can be used with the _Detected Protocol_ selector in Network policies.
- Notes that these protocols will be logged when protocol detection is enabled on the account.

## Files changed

- `src/content/changelog/gateway/2026-02-27-new-protocol-detection-protocols.mdx` (new file)