### PR TITLE
Add new beta protocols to Gateway protocol detection docs

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
@@ -45,13 +45,13 @@ Gateway supports detection and filtering of the following protocols:
 
 | Protocol | Notes                                                                                       |
 | -------- | ------------------------------------------------------------------------------------------- |
-| HTTP     |                                                                                             |
-| HTTP2    |                                                                                             |
-| SSH      |                                                                                             |
-| TLS      | Gateway detects TLS versions 1.1 through 1.3 with the _TLS_ value.                          |
-| DCERPC   |                                                                                             |
-| MQTT     |                                                                                             |
-| TPKT     | TPKT commonly initiates RDP sessions, so you can use it to identify and filter RDP traffic. |
+| HTTP     | Hypertext Transfer Protocol (HTTP/1.1).                                                     |
+| HTTP2    | Hypertext Transfer Protocol Version 2.                                                      |
+| SSH      | Secure Shell Protocol — remote login and command execution.                                  |
+| TLS      | Transport Layer Security. Gateway detects TLS versions 1.1 through 1.3 with the _TLS_ value. |
+| DCERPC   | Distributed Computing Environment / Remote Procedure Call.                                   |
+| MQTT     | Message Queuing Telemetry Transport — lightweight IoT messaging protocol.                    |
+| TPKT     | TPKT commonly initiates RDP sessions, so you can use it to identify and filter RDP traffic.  |
 | IMAP <Badge text="Beta" variant="caution" size="small" />         | Internet Message Access Protocol — email retrieval.  |
 | POP3 <Badge text="Beta" variant="caution" size="small" />         | Post Office Protocol v3 — email retrieval.           |
 | SMTP <Badge text="Beta" variant="caution" size="small" />         | Simple Mail Transfer Protocol — email sending.       |

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
@@ -45,13 +45,13 @@ Gateway supports detection and filtering of the following protocols:
 
 | Protocol | Notes                                                                                       |
 | -------- | ------------------------------------------------------------------------------------------- |
-| HTTP     | The policy builder includes separate values for HTTP/1.1 and HTTP/2.                        |
+| HTTP     |                                                                                             |
+| HTTP2    |                                                                                             |
 | SSH      |                                                                                             |
 | TLS      | Gateway detects TLS versions 1.1 through 1.3 with the _TLS_ value.                          |
-| DCE/RPC  |                                                                                             |
+| DCERPC   |                                                                                             |
 | MQTT     |                                                                                             |
 | TPKT     | TPKT commonly initiates RDP sessions, so you can use it to identify and filter RDP traffic. |
-| DNP3     |                                                                                             |
 | IMAP <Badge text="Beta" variant="caution" size="small" />         | Internet Message Access Protocol — email retrieval.  |
 | POP3 <Badge text="Beta" variant="caution" size="small" />         | Post Office Protocol v3 — email retrieval.           |
 | SMTP <Badge text="Beta" variant="caution" size="small" />         | Simple Mail Transfer Protocol — email sending.       |

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
@@ -52,6 +52,13 @@ Gateway supports detection and filtering of the following protocols:
 | MQTT     |                                                                                             |
 | TPKT     | TPKT commonly initiates RDP sessions, so you can use it to identify and filter RDP traffic. |
 | DNP3     |                                                                                             |
+| IMAP <Badge text="Beta" variant="caution" size="small" />         | Internet Message Access Protocol — email retrieval.  |
+| POP3 <Badge text="Beta" variant="caution" size="small" />         | Post Office Protocol v3 — email retrieval.           |
+| SMTP <Badge text="Beta" variant="caution" size="small" />         | Simple Mail Transfer Protocol — email sending.       |
+| MYSQL <Badge text="Beta" variant="caution" size="small" />        | MySQL database wire protocol.                        |
+| RSYNC-DAEMON <Badge text="Beta" variant="caution" size="small" /> | rsync daemon protocol.                               |
+| LDAP <Badge text="Beta" variant="caution" size="small" />         | Lightweight Directory Access Protocol.               |
+| NTP <Badge text="Beta" variant="caution" size="small" />          | Network Time Protocol.                               |
 
 ## Example network policy
 


### PR DESCRIPTION
## Summary

- Adds seven new protocols to the **Supported protocols** table on the [Protocol detection](https://developers.cloudflare.com/cloudflare-one/traffic-policies/network-policies/protocol-detection/) docs page, each with a `Beta` badge.
- Corrects the existing protocol list to match the policy builder:
  - Split the combined `HTTP` row into separate **HTTP** and **HTTP2** rows.
  - Renamed `DCE/RPC` to **DCERPC**.
  - Removed **DNP3** (not a supported protocol detection value).
- Added descriptive notes to all existing protocols that were previously missing them.

### New protocols added (Beta)

| Protocol | Notes |
| --- | --- |
| IMAP | Internet Message Access Protocol — email retrieval |
| POP3 | Post Office Protocol v3 — email retrieval |
| SMTP | Simple Mail Transfer Protocol — email sending |
| MYSQL | MySQL database wire protocol |
| RSYNC-DAEMON | rsync daemon protocol |
| LDAP | Lightweight Directory Access Protocol |
| NTP | Network Time Protocol |

## Files changed

- `src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx`