### PR TITLE
[Cloudflare One] Add TCP SYN filtering guidance to order of enforcement

### DIFF
--- a/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
+++ b/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
@@ -84,6 +84,23 @@ If the TCP connection to the destination server is successful, Gateway will appl
 
 Connections to Zero Trust will always appear in your [Zero Trust network session logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/) regardless of connection success. Because Gateway does not inspect failed connections, they will not appear in your [Gateway activity logs](/cloudflare-one/insights/logs/gateway-logs/).
 
+### Filter TCP SYN packets with Cloudflare Network Firewall
+
+Because Gateway sends a TCP SYN to the destination server before evaluating policies, Gateway Network or HTTP Block policies do not prevent the initial TCP SYN from reaching the origin. If you need to prevent TCP SYN packets from being sent to specific destination IP addresses, you can create a [Cloudflare Network Firewall](/cloudflare-one/traffic-policies/packet-filtering/) rule to block traffic at the packet level. As shown in the [enforcement flowchart](#order-of-enforcement), Cloudflare Network Firewall evaluates traffic before Gateway checks for origin availability.
+
+To block TCP SYN packets to a specific destination:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Firewall policies** > **Custom policies**.
+2. Select **Add a policy**.
+3. Create a rule with the destination IP address or CIDR range you want to block. For example, to block all traffic to `10.0.0.0/8`, use the expression `ip.dst in {10.0.0.0/8}` with a **Block** action.
+4. Select **Add new policy**.
+
+For more information on creating packet filtering rules, refer to [Add policies](/cloudflare-one/traffic-policies/packet-filtering/add-policies/).
+
+:::note
+Cloudflare Network Firewall is available to Enterprise users only.
+:::
+
 ## Priority between policy builders
 
 Gateway applies your policies in the following order:

--- a/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
+++ b/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
@@ -86,7 +86,11 @@ Connections to Zero Trust will always appear in your [Zero Trust network session
 
 ### Filter TCP SYN packets with Cloudflare Network Firewall
 
-Because Gateway sends a TCP SYN to the destination server before evaluating policies, Gateway Network or HTTP Block policies do not prevent the initial TCP SYN from reaching the origin. If you need to prevent TCP SYN packets from being sent to specific destination IP addresses, you can create a [Cloudflare Network Firewall](/cloudflare-one/traffic-policies/packet-filtering/) rule to block traffic at the packet level. As shown in the [enforcement flowchart](#order-of-enforcement), Cloudflare Network Firewall evaluates traffic before Gateway checks for origin availability.
+Because Gateway sends a TCP SYN to the destination server before evaluating policies, Gateway Network or HTTP Block policies do not prevent the initial TCP SYN from reaching the destination server. If you need to prevent TCP SYN packets from being sent to specific destination IP addresses, you can create a [Cloudflare Network Firewall](/cloudflare-one/traffic-policies/packet-filtering/) rule to block traffic at the packet level. As shown in the [enforcement flowchart](#order-of-enforcement), Cloudflare Network Firewall evaluates traffic before Gateway checks for origin availability.
+
+:::note
+Cloudflare Network Firewall is available to Enterprise users only.
+:::
 
 To block TCP SYN packets to a specific destination:
 
@@ -96,10 +100,6 @@ To block TCP SYN packets to a specific destination:
 4. Select **Add new policy**.
 
 For more information on creating packet filtering rules, refer to [Add policies](/cloudflare-one/traffic-policies/packet-filtering/add-policies/).
-
-:::note
-Cloudflare Network Firewall is available to Enterprise users only.
-:::
 
 ## Priority between policy builders
 


### PR DESCRIPTION
## Summary

- Adds a new subsection "Filter TCP SYN packets with Cloudflare Network Firewall" below the "Connection establishment" section on the [order of enforcement](https://developers.cloudflare.com/cloudflare-one/traffic-policies/order-of-enforcement/#connection-establishment) page
- Documents that Gateway sends TCP SYN packets to the origin server before evaluating policies, so Network/HTTP Block policies do not prevent the initial TCP SYN from reaching the destination
- Explains how Enterprise customers can use Cloudflare Network Firewall rules (packet filtering) to block traffic at the packet level before Gateway's connection establishment step
- Includes step-by-step instructions and a link to the packet filtering docs

## Related tickets

- Resolves [PCX-20932](https://jira.cfdata.org/browse/PCX-20932)
- Reference: [ESCALATION-203](https://jira.cfdata.org/browse/ESCALATION-203)