### PR TITLE
[Cloudflare One] Document non-identity email for auth proxy endpoint background requests

### DIFF
--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -472,9 +472,15 @@ Authorization endpoints do not support plaintext HTTP traffic unless the traffic
 
 #### Referer header traffic
 
-Traffic with a referer HTTP header matching the domain of a recently logged in user from the same source IP will be allowed through and logged with a non-identity email address.
+Traffic with a referer HTTP header matching the domain of a recently logged in user from the same source IP will be allowed through and logged with the following non-identity email address:
 
-This issue occurs because browsers will not tag HTTP sub-requests with the identity cookie used to verify user authentication. If you would like to filter this traffic, you can set up an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) to block all traffic matching the non-identity email address.
+```txt
+auth-proxy-non-identity@<team-domain>.cloudflareaccess.com
+```
+
+Where `<team-domain>` is your [team domain](/cloudflare-one/faq/getting-started-faq/#what-is-a-team-domainteam-name).
+
+This occurs because browsers do not tag HTTP sub-requests with the identity cookie used to verify user authentication. If you would like to filter this traffic, you can set up an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) to block or allow all traffic matching the `auth-proxy-non-identity@<team-domain>.cloudflareaccess.com` email address.
 
 ### Traffic limitations
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -475,12 +475,12 @@ Authorization endpoints do not support plaintext HTTP traffic unless the traffic
 Traffic with a referer HTTP header matching the domain of a recently logged in user from the same source IP will be allowed through and logged with the following non-identity email address:
 
 ```txt
-auth-proxy-non-identity@<team-domain>.cloudflareaccess.com
+auth-proxy-non-identity@<your-team-name>.cloudflareaccess.com
 ```
 
-Where `<team-domain>` is your [team domain](/cloudflare-one/faq/getting-started-faq/#what-is-a-team-domainteam-name).
+Where `<your-team-name>` is your [team name](/cloudflare-one/faq/getting-started-faq/#what-is-a-team-domainteam-name).
 
-This occurs because browsers do not tag HTTP sub-requests with the identity cookie used to verify user authentication. If you would like to filter this traffic, you can set up an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) to block or allow all traffic matching the `auth-proxy-non-identity@<team-domain>.cloudflareaccess.com` email address.
+This occurs because browsers do not tag HTTP sub-requests with the identity cookie used to verify user authentication. If you would like to filter this traffic, you can set up an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) to block or allow all traffic matching the `auth-proxy-non-identity@<your-team-name>.cloudflareaccess.com` email address.
 
 ### Traffic limitations
 


### PR DESCRIPTION
## Summary

- Explicitly documents the non-identity email address (`auth-proxy-non-identity@<team-domain>.cloudflareaccess.com`) used for background/sub-requests through authorization proxy endpoints.
- Updates the "Referer header traffic" limitation section to call out the exact email format so admins know what to filter on when creating HTTP policies.

## Context

When using authorization proxy endpoints, browsers do not attach the identity cookie to HTTP sub-requests (background requests). These requests are logged with a fixed non-identity email address. The previous documentation mentioned a "non-identity email address" but did not specify the actual format, making it difficult for admins to set up filtering policies.

Related: https://jira.cfdata.org/browse/GIN-1506