### PR TITLE
docs(agents): updates for agents 0.7.0 release

### DIFF
--- a/src/content/docs/agents/api-reference/agents-api.mdx
+++ b/src/content/docs/agents/api-reference/agents-api.mdx
@@ -75,21 +75,21 @@ flowchart TD
 
 ## Server-side API reference
 
-| Feature               | Methods                                                               | Documentation                                                       |
-| --------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| **State**             | `setState()`, `onStateChanged()`, `initialState`                      | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
-| **Callable methods**  | `@callable()` decorator                                               | [Callable methods](/agents/api-reference/callable-methods/)         |
-| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getSchedules()`, `cancelSchedule()` | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
-| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                  | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
-| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`              | [WebSockets](/agents/api-reference/websockets/)                     |
-| **HTTP/SSE**          | `onRequest()`                                                         | [HTTP and SSE](/agents/api-reference/http-sse/)                     |
-| **Email**             | `onEmail()`, `replyToEmail()`                                         | [Email routing](/agents/api-reference/email/)                       |
-| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                  | [Run Workflows](/agents/api-reference/run-workflows/)               |
-| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`              | [MCP Client API](/agents/api-reference/mcp-client-api/)             |
-| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                | [Using AI models](/agents/api-reference/using-ai-models/)           |
-| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`       | [Protocol messages](/agents/api-reference/protocol-messages/)       |
-| **Context**           | `getCurrentAgent()`                                                   | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
-| **Observability**     | `observability.emit()`                                                | [Observability](/agents/api-reference/observability/)               |
+| Feature               | Methods                                                                              | Documentation                                                       |
+| --------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| **State**             | `setState()`, `onStateChanged()`, `initialState`                                     | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
+| **Callable methods**  | `@callable()` decorator                                                              | [Callable methods](/agents/api-reference/callable-methods/)         |
+| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getSchedules()`, `cancelSchedule()`, `keepAlive()` | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
+| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                                 | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
+| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                             | [WebSockets](/agents/api-reference/websockets/)                     |
+| **HTTP/SSE**          | `onRequest()`                                                                        | [HTTP and SSE](/agents/api-reference/http-sse/)                     |
+| **Email**             | `onEmail()`, `replyToEmail()`                                                        | [Email routing](/agents/api-reference/email/)                       |
+| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                                 | [Run Workflows](/agents/api-reference/run-workflows/)               |
+| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                             | [MCP Client API](/agents/api-reference/mcp-client-api/)             |
+| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                               | [Using AI models](/agents/api-reference/using-ai-models/)           |
+| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`                      | [Protocol messages](/agents/api-reference/protocol-messages/)       |
+| **Context**           | `getCurrentAgent()`                                                                  | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
+| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                    | [Observability](/agents/api-reference/observability/)               |
 
 ## SQL API
 

--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -213,13 +213,17 @@ export class ChatAgent extends AIChatAgent {
 }
 ```
 
-**Accessing custom body data**:
+**Accessing custom body data and request ID**:
 
 ```ts
 export class ChatAgent extends AIChatAgent {
 	async onChatMessage(_onFinish, options) {
 		const { timezone, userId } = options?.body ?? {};
 		// Use these values in your LLM call or business logic
+
+		// options.requestId — unique identifier for this chat request,
+		// useful for logging and correlating events
+		console.log("Request ID:", options?.requestId);
 	}
 }
 ```
@@ -268,6 +272,36 @@ export class ChatAgent extends AIChatAgent {
 ```
 
 </TypeScriptExample>
+
+### `waitForMcpConnections`
+
+Controls whether `AIChatAgent` waits for MCP server connections to settle before calling `onChatMessage`. This ensures `this.mcp.getAITools()` returns the full set of tools, especially after Durable Object hibernation when connections are being restored in the background.
+
+| Value                  | Behavior                                      |
+| ---------------------- | --------------------------------------------- |
+| `{ timeout: 10_000 }` | Wait up to 10 seconds (default)               |
+| `{ timeout: N }`      | Wait up to `N` milliseconds                   |
+| `true`                 | Wait indefinitely until all connections ready  |
+| `false`                | Do not wait (old behavior before 0.2.0)        |
+
+<TypeScriptExample>
+
+```ts
+export class ChatAgent extends AIChatAgent {
+	// Default — waits up to 10 seconds
+	// waitForMcpConnections = { timeout: 10_000 };
+
+	// Wait forever
+	waitForMcpConnections = true;
+
+	// Disable waiting
+	waitForMcpConnections = false;
+}
+```
+
+</TypeScriptExample>
+
+For lower-level control, call `this.mcp.waitForConnections()` directly inside your `onChatMessage` instead.
 
 ### `persistMessages` and `saveMessages`
 
@@ -549,6 +583,29 @@ const { messages, addToolApprovalResponse } = useAgentChat({ agent });
 ```
 
 </TypeScriptExample>
+
+#### Custom denial messages with `addToolOutput`
+
+When a user rejects a tool, `addToolApprovalResponse({ id, approved: false })` sets the tool state to `output-denied` with a generic message. To give the LLM a more specific reason for the denial, use `addToolOutput` with `state: "output-error"` instead:
+
+<TypeScriptExample>
+
+```ts
+const { addToolOutput } = useAgentChat({ agent });
+
+// Reject with a custom error message
+addToolOutput({
+	toolCallId: part.toolCallId,
+	state: "output-error",
+	errorText: "User declined: insufficient budget for this quarter",
+});
+```
+
+</TypeScriptExample>
+
+This sends a `tool_result` to the LLM with your custom error text, so it can respond appropriately (for example, suggest an alternative or ask clarifying questions).
+
+`addToolApprovalResponse` (with `approved: false`) auto-continues the conversation when `autoContinueAfterToolResult` is enabled (the default). `addToolOutput` with `state: "output-error"` does **not** auto-continue — call `sendMessage()` afterward if you want the LLM to respond to the error.
 
 For more patterns, refer to [Human-in-the-loop](/agents/concepts/human-in-the-loop/).
 

--- a/src/content/docs/agents/api-reference/get-current-agent.mdx
+++ b/src/content/docs/agents/api-reference/get-current-agent.mdx
@@ -82,7 +82,7 @@ export class MyAgent extends AIChatAgent {
 
 ### Built-in vs custom methods
 
-- **Built-in methods** (`onRequest`, `onEmail`, `onStateUpdate`): Already have context.
+- **Built-in methods** (`onRequest`, `onEmail`, `onStateChanged`): Already have context.
 - **Custom methods** (your methods): Automatically wrapped during initialization.
 - **External functions**: Access context through `getCurrentAgent()`.
 

--- a/src/content/docs/agents/api-reference/mcp-client-api.mdx
+++ b/src/content/docs/agents/api-reference/mcp-client-api.mdx
@@ -61,15 +61,15 @@ Connections persist in the agent's [SQL storage](/agents/api-reference/store-and
 
 ## Adding MCP servers
 
-Use `addMcpServer()` to connect to an MCP server:
+Use `addMcpServer()` to connect to an MCP server. For non-OAuth servers, no options are needed:
 
 <TypeScriptExample>
 
 ```ts
-// Simple connection
+// Non-OAuth server — no options required
 await this.addMcpServer("notion", "https://mcp.notion.so/mcp");
 
-// With explicit callback host
+// OAuth server — provide callbackHost for the OAuth redirect flow
 await this.addMcpServer("github", "https://mcp.github.com/mcp", {
 	callbackHost: "https://my-worker.workers.dev",
 });
@@ -118,6 +118,17 @@ await this.addMcpServer("internal", "https://internal-mcp.example.com/mcp", {
 ```
 
 </TypeScriptExample>
+
+### URL security
+
+MCP server URLs are validated before connection to prevent Server-Side Request Forgery (SSRF). The following URL targets are blocked:
+
+- Private/internal IP ranges (RFC 1918: `10.x`, `172.16-31.x`, `192.168.x`)
+- Loopback addresses (`127.x`, `::1`)
+- Link-local addresses (`169.254.x`, `fe80::`)
+- Cloud metadata endpoints (`169.254.169.254`)
+
+If you need to connect to an internal MCP server, use the [RPC transport](/agents/model-context-protocol/transport/) with a Durable Object binding instead of HTTP.
 
 ### Return value
 
@@ -445,7 +456,13 @@ function Dashboard() {
 
 ### `addMcpServer()`
 
-Add a connection to an MCP server and make its tools available to your agent. If `addMcpServer` is called with a `serverName` that already has an active connection, the existing connection is returned instead of creating a duplicate. This makes it safe to call in `onStart()` without worrying about duplicate connections on restart.
+Add a connection to an MCP server and make its tools available to your agent.
+
+Calling `addMcpServer` is idempotent when both the server name **and** URL match an existing active connection — the existing connection is returned without creating a duplicate. This makes it safe to call in `onStart()` without worrying about duplicate connections on restart.
+
+If you call `addMcpServer` with the same name but a **different** URL, a new connection is created. Both connections remain active and their tools are merged in `getAITools()`. To replace a server, call `removeMcpServer(oldId)` first.
+
+URLs are normalized before comparison (trailing slashes, default ports, and hostname case are handled), so `https://MCP.Example.com` and `https://mcp.example.com/` are treated as the same URL.
 
 ```ts
 // HTTP transport (Streamable HTTP, SSE)
@@ -811,6 +828,22 @@ type MCPDiscoverResult = {
   error?: string;
 }
 ```
+
+#### `this.mcp.waitForConnections()`
+
+Wait for all in-flight MCP connection and discovery operations to settle. This is useful when you need `this.mcp.getAITools()` to return the full set of tools immediately after the agent wakes from hibernation.
+
+```ts
+// Wait indefinitely
+await this.mcp.waitForConnections();
+
+// Wait with a timeout (milliseconds)
+await this.mcp.waitForConnections({ timeout: 10_000 });
+```
+
+:::note
+`AIChatAgent` calls this automatically via its [`waitForMcpConnections`](/agents/api-reference/chat-agents/#waitformcpconnections) property (defaults to `{ timeout: 10_000 }`). You only need `waitForConnections()` directly when using `Agent` with MCP, or when you want finer control inside `onChatMessage`.
+:::
 
 #### `this.mcp.closeConnection()`
 

--- a/src/content/docs/agents/api-reference/observability.mdx
+++ b/src/content/docs/agents/api-reference/observability.mdx
@@ -83,7 +83,7 @@ subscribe("agents:schedule", (event) => {
 
 ## Tail Workers (production)
 
-In production, all diagnostics channel messages are automatically forwarded to [Tail Workers](/workers/observability/tail-workers/). No subscription code is needed in the agent itself — attach a Tail Worker and access events via `event.diagnosticsChannelEvents`:
+In production, all diagnostics channel messages are automatically forwarded to [Tail Workers](/workers/observability/logs/tail-workers/). No subscription code is needed in the agent itself — attach a Tail Worker and access events via `event.diagnosticsChannelEvents`:
 
 <TypeScriptExample>
 
@@ -225,7 +225,7 @@ These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track
 
 <LinkCard
 	title="Tail Workers"
-	href="/workers/observability/tail-workers/"
+	href="/workers/observability/logs/tail-workers/"
 	description="Forward diagnostics channel events to a Tail Worker for production monitoring."
 />
 

--- a/src/content/docs/agents/api-reference/observability.mdx
+++ b/src/content/docs/agents/api-reference/observability.mdx
@@ -7,50 +7,131 @@ sidebar:
 
 import { TypeScriptExample, LinkCard } from "~/components";
 
-`Agent` instances use the `observability` property to emit various internal events that can be used for logging and monitoring.
+Agents emit structured events for every significant operation — RPC calls, state changes, schedule execution, workflow transitions, MCP connections, and more. These events are published to [diagnostics channels](/workers/runtime-apis/nodejs/diagnostics-channel/) and are silent by default (zero overhead when nobody is listening).
 
-## Default behavior
+## Event structure
 
-The default behavior is to `console.log()` the event value:
+Every event has three fields:
 
-```json
+```ts
 {
-	"displayMessage": "State updated",
-	"id": "EnOzrS_tEo_8dHy5oyl8q",
-	"payload": {},
-	"timestamp": 1758005142787,
-	"type": "state:update"
+  type: "rpc",                        // what happened
+  payload: { method: "getWeather" },  // details
+  timestamp: 1758005142787            // when (ms since epoch)
 }
 ```
 
+## Channels
+
+Events are routed to seven named channels based on their type:
+
+| Channel            | Event types                                                                                                                                                      | Description                         |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `agents:state`     | `state:update`                                                                                                                                                   | State sync events                   |
+| `agents:rpc`       | `rpc`, `rpc:error`                                                                                                                                               | RPC method calls and failures       |
+| `agents:message`   | `message:request`, `message:response`, `message:clear`, `message:cancel`, `message:error`, `tool:result`, `tool:approval`                                        | Chat message and tool lifecycle     |
+| `agents:schedule`  | `schedule:create`, `schedule:execute`, `schedule:cancel`, `schedule:retry`, `schedule:error`, `queue:retry`, `queue:error`                                       | Scheduled and queued task lifecycle |
+| `agents:lifecycle` | `connect`, `destroy`                                                                                                                                             | Agent connection and teardown       |
+| `agents:workflow`  | `workflow:start`, `workflow:event`, `workflow:approved`, `workflow:rejected`, `workflow:terminated`, `workflow:paused`, `workflow:resumed`, `workflow:restarted` | Workflow state transitions          |
+| `agents:mcp`       | `mcp:client:preconnect`, `mcp:client:connect`, `mcp:client:authorize`, `mcp:client:discover`                                                                     | MCP client operations               |
+
+## Subscribing to events
+
+### Typed subscribe helper
+
+The `subscribe()` function from `agents/observability` provides type-safe access to events on a specific channel:
+
+<TypeScriptExample>
+
+```ts
+import { subscribe } from "agents/observability";
+
+const unsub = subscribe("rpc", (event) => {
+	if (event.type === "rpc") {
+		console.log(`RPC call: ${event.payload.method}`);
+	}
+	if (event.type === "rpc:error") {
+		console.error(
+			`RPC failed: ${event.payload.method} — ${event.payload.error}`,
+		);
+	}
+});
+
+// Clean up when done
+unsub();
+```
+
+</TypeScriptExample>
+
+The callback is fully typed — `event` is narrowed to only the event types that flow through that channel.
+
+### Raw diagnostics_channel
+
+You can also subscribe directly using the Node.js API:
+
+<TypeScriptExample>
+
+```ts
+import { subscribe } from "node:diagnostics_channel";
+
+subscribe("agents:schedule", (event) => {
+	console.log(event);
+});
+```
+
+</TypeScriptExample>
+
+## Tail Workers (production)
+
+In production, all diagnostics channel messages are automatically forwarded to [Tail Workers](/workers/observability/tail-workers/). No subscription code is needed in the agent itself — attach a Tail Worker and access events via `event.diagnosticsChannelEvents`:
+
+<TypeScriptExample>
+
+```ts
+export default {
+	async tail(events) {
+		for (const event of events) {
+			for (const msg of event.diagnosticsChannelEvents) {
+				// msg.channel is "agents:rpc", "agents:workflow", etc.
+				// msg.message is the typed event payload
+				console.log(msg.timestamp, msg.channel, msg.message);
+			}
+		}
+	},
+};
+```
+
+</TypeScriptExample>
+
+This gives you structured, filterable observability in production with zero overhead in the agent hot path.
+
 ## Custom observability
 
-You can configure observability by overriding the property with an implementation of the `Observability` interface. This interface has a single `emit()` method that takes an `ObservabilityEvent`.
+You can override the default implementation by providing your own `Observability` interface:
 
 <TypeScriptExample>
 
 ```ts
 import { Agent } from "agents";
-import { type Observability } from "agents/observability";
+import type { Observability } from "agents/observability";
 
-const observability: Observability = {
+const myObservability: Observability = {
 	emit(event) {
-		if (event.type === "connect") {
-			console.log(event.timestamp, event.payload.connectionId);
+		// Send to your logging service, filter events, etc.
+		if (event.type === "rpc:error") {
+			console.error(event.payload.method, event.payload.error);
 		}
 	},
 };
 
 class MyAgent extends Agent {
-	override observability = observability;
+	override observability = myObservability;
 }
 ```
 
 </TypeScriptExample>
 
-## Disabling observability
-
-Alternatively, you can set the property to `undefined` to ignore all events:
+Set `observability` to `undefined` to disable all event emission:
 
 <TypeScriptExample>
 
@@ -64,93 +145,75 @@ class MyAgent extends Agent {
 
 </TypeScriptExample>
 
-## Event types
+## Event reference
 
-The observability system emits events for various agent activities:
+### RPC events
 
-| Event Type         | Description                      |
-| ------------------ | -------------------------------- |
-| `connect`          | WebSocket connection established |
-| `disconnect`       | WebSocket connection closed      |
-| `state:update`     | Agent state was updated          |
-| `message`          | Message received from client     |
-| `error`            | Error occurred during processing |
-| `schedule:execute` | Scheduled task executed          |
-| `queue:process`    | Queue task processed             |
+| Type        | Payload                  | When                            |
+| ----------- | ------------------------ | ------------------------------- |
+| `rpc`       | `{ method, streaming? }` | A `@callable` method is invoked |
+| `rpc:error` | `{ method, error }`      | A `@callable` method throws     |
 
-## ObservabilityEvent structure
+### State events
 
-Each event has the following structure:
+| Type           | Payload | When                   |
+| -------------- | ------- | ---------------------- |
+| `state:update` | `{}`    | `setState()` is called |
 
-```ts
-type ObservabilityEvent = {
-	id: string; // Unique event identifier
-	type: string; // Event type (e.g., "connect", "state:update")
-	displayMessage: string; // Human-readable description
-	timestamp: number; // Unix timestamp in milliseconds
-	payload: Record<string, unknown>; // Event-specific data
-};
-```
+### Message and tool events (AIChatAgent)
 
-## Integration with external services
+These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track the chat message lifecycle, including client-side tool interactions.
 
-You can integrate observability with external logging and monitoring services:
+| Type               | Payload                    | When                                |
+| ------------------ | -------------------------- | ----------------------------------- |
+| `message:request`  | `{}`                       | A chat message is received          |
+| `message:response` | `{}`                       | A chat response stream completes    |
+| `message:clear`    | `{}`                       | Chat history is cleared             |
+| `message:cancel`   | `{ requestId }`            | A streaming request is cancelled    |
+| `message:error`    | `{ error }`                | A chat stream fails                 |
+| `tool:result`      | `{ toolCallId, toolName }` | A client tool result is received    |
+| `tool:approval`    | `{ toolCallId, approved }` | A tool call is approved or rejected |
 
-<TypeScriptExample>
+### Schedule and queue events
 
-```ts
-import { Agent } from "agents";
-import {
-	type Observability,
-	type ObservabilityEvent,
-} from "agents/observability";
+| Type               | Payload                                  | When                                         |
+| ------------------ | ---------------------------------------- | -------------------------------------------- |
+| `schedule:create`  | `{ callback, id }`                       | A schedule is created                        |
+| `schedule:execute` | `{ callback, id }`                       | A scheduled callback starts                  |
+| `schedule:cancel`  | `{ callback, id }`                       | A schedule is cancelled                      |
+| `schedule:retry`   | `{ callback, id, attempt, maxAttempts }` | A scheduled callback is retried              |
+| `schedule:error`   | `{ callback, id, error, attempts }`      | A scheduled callback fails after all retries |
+| `queue:retry`      | `{ callback, id, attempt, maxAttempts }` | A queued callback is retried                 |
+| `queue:error`      | `{ callback, id, error, attempts }`      | A queued callback fails after all retries    |
 
-const observability: Observability = {
-	emit(event: ObservabilityEvent) {
-		// Send to external logging service
-		fetch("https://logging.example.com/ingest", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				service: "my-agent",
-				level: event.type === "error" ? "error" : "info",
-				message: event.displayMessage,
-				metadata: {
-					eventId: event.id,
-					eventType: event.type,
-					timestamp: event.timestamp,
-					...event.payload,
-				},
-			}),
-		}).catch(console.error);
-	},
-};
+### Lifecycle events
 
-class MyAgent extends Agent {
-	override observability = observability;
-}
-```
+| Type      | Payload            | When                                  |
+| --------- | ------------------ | ------------------------------------- |
+| `connect` | `{ connectionId }` | A WebSocket connection is established |
+| `destroy` | `{}`               | The agent is destroyed                |
 
-</TypeScriptExample>
+### Workflow events
 
-## Filtering events
+| Type                  | Payload                         | When                           |
+| --------------------- | ------------------------------- | ------------------------------ |
+| `workflow:start`      | `{ workflowId, workflowName? }` | A workflow instance is started |
+| `workflow:event`      | `{ workflowId, eventType? }`    | An event is sent to a workflow |
+| `workflow:approved`   | `{ workflowId, reason? }`       | A workflow is approved         |
+| `workflow:rejected`   | `{ workflowId, reason? }`       | A workflow is rejected         |
+| `workflow:terminated` | `{ workflowId, workflowName? }` | A workflow is terminated       |
+| `workflow:paused`     | `{ workflowId, workflowName? }` | A workflow is paused           |
+| `workflow:resumed`    | `{ workflowId, workflowName? }` | A workflow is resumed          |
+| `workflow:restarted`  | `{ workflowId, workflowName? }` | A workflow is restarted        |
 
-You can filter which events to process:
+### MCP events
 
-<TypeScriptExample>
-
-```ts
-const observability: Observability = {
-	emit(event) {
-		// Only log errors and state updates
-		if (event.type === "error" || event.type === "state:update") {
-			console.log(JSON.stringify(event));
-		}
-	},
-};
-```
-
-</TypeScriptExample>
+| Type                    | Payload                                 | When                                         |
+| ----------------------- | --------------------------------------- | -------------------------------------------- |
+| `mcp:client:preconnect` | `{ serverId }`                          | Before connecting to an MCP server           |
+| `mcp:client:connect`    | `{ url, transport, state, error? }`     | An MCP connection attempt completes or fails |
+| `mcp:client:authorize`  | `{ serverId, authUrl, clientId? }`      | An MCP OAuth flow begins                     |
+| `mcp:client:discover`   | `{ url?, state?, error?, capability? }` | MCP capability discovery succeeds or fails   |
 
 ## Next steps
 
@@ -161,9 +224,9 @@ const observability: Observability = {
 />
 
 <LinkCard
-	title="Dashboard setup"
-	href="/agents/api-reference/configuration/#dashboard-setup"
-	description="View logs in the Cloudflare dashboard."
+	title="Tail Workers"
+	href="/workers/observability/tail-workers/"
+	description="Forward diagnostics channel events to a Tail Worker for production monitoring."
 />
 
 <LinkCard

--- a/src/content/docs/agents/api-reference/schedule-tasks.mdx
+++ b/src/content/docs/agents/api-reference/schedule-tasks.mdx
@@ -747,6 +747,102 @@ async cancelSchedule(id: string): Promise<boolean>
 
 Cancel a scheduled task. Returns `true` if cancelled, `false` if not found.
 
+### `keepAlive()`
+
+```ts
+async keepAlive(): Promise<() => void>
+```
+
+Prevent the Durable Object from being evicted due to inactivity by creating a 30-second heartbeat schedule. Returns a disposer function that cancels the heartbeat when called. The disposer is idempotent — calling it multiple times is safe.
+
+Always call the disposer when the work is done — otherwise the heartbeat continues indefinitely.
+
+<TypeScriptExample>
+
+```ts
+const dispose = await this.keepAlive();
+try {
+	// Long-running work that must not be interrupted
+	const result = await longRunningComputation();
+	await sendResults(result);
+} finally {
+	dispose();
+}
+```
+
+</TypeScriptExample>
+
+### `keepAliveWhile()`
+
+```ts
+async keepAliveWhile<T>(fn: () => Promise<T>): Promise<T>
+```
+
+Run an async function while keeping the Durable Object alive. The heartbeat is automatically started before the function runs and stopped when it completes (whether it succeeds or throws). Returns the value returned by the function.
+
+This is the recommended way to use `keepAlive` — it guarantees cleanup.
+
+<TypeScriptExample>
+
+```ts
+const result = await this.keepAliveWhile(async () => {
+	const data = await longRunningComputation();
+	return data;
+});
+```
+
+</TypeScriptExample>
+
+## Keeping the agent alive
+
+Durable Objects are evicted after a period of inactivity (typically 70-140 seconds with no incoming requests, WebSocket messages, or alarms). During long-running operations — streaming LLM responses, waiting on external APIs, running multi-step computations — the agent can be evicted mid-flight.
+
+`keepAlive()` prevents this by creating a 30-second heartbeat schedule. The internal heartbeat callback is a no-op — the alarm firing itself is what resets the inactivity timer. Because it uses the scheduling system:
+
+- The heartbeat does not conflict with your own schedules (the scheduling system multiplexes through a single alarm slot)
+- The heartbeat shows up in `getSchedules()` if you need to inspect it
+- Multiple concurrent `keepAlive()` calls each get their own schedule, so they do not interfere with each other
+
+### Multiple concurrent callers
+
+Each `keepAlive()` call returns an independent disposer:
+
+<TypeScriptExample>
+
+```ts
+const dispose1 = await this.keepAlive();
+const dispose2 = await this.keepAlive();
+
+// Both heartbeats are active
+dispose1(); // Only cancels the first heartbeat
+// Agent is still alive via dispose2's heartbeat
+
+dispose2(); // Now the agent can go idle
+```
+
+</TypeScriptExample>
+
+### AIChatAgent
+
+`AIChatAgent` automatically calls `keepAlive()` during streaming responses. You do not need to add it yourself when using `AIChatAgent` — every LLM stream is protected from idle eviction by default.
+
+### When to use keepAlive
+
+| Scenario                                    | Use keepAlive?                         |
+| ------------------------------------------- | -------------------------------------- |
+| Streaming LLM responses via `AIChatAgent`   | No — already built in                  |
+| Long-running computation in a custom Agent  | Yes                                    |
+| Waiting on a slow external API call         | Yes                                    |
+| Multi-step tool execution                   | Yes                                    |
+| Short request-response handlers             | No — not needed                        |
+| Background work via scheduling or workflows | No — alarms already keep the DO active |
+
+:::note
+
+`keepAlive()` is marked `@experimental` and may change between releases.
+
+:::
+
 ## Limits
 
 - **Maximum tasks:** Limited by SQLite storage (each task is a row). Practical limit is tens of thousands per agent.

--- a/src/content/docs/agents/api-reference/store-and-sync-state.mdx
+++ b/src/content/docs/agents/api-reference/store-and-sync-state.mdx
@@ -365,7 +365,7 @@ function GameUI() {
   const agent = useAgent({
     agent: "game-agent",
     name: "room-123",
-    onStateChanged: (state, source) => {
+    onStateUpdate: (state, source) => {
       console.log("State updated:", state);
     }
   });
@@ -394,7 +394,7 @@ import { AgentClient } from "agents/client";
 const client = new AgentClient({
 	agent: "game-agent",
 	name: "room-123",
-	onStateChanged: (state) => {
+	onStateUpdate: (state) => {
 		document.getElementById("score").textContent = state.score;
 	},
 });

--- a/src/content/docs/agents/model-context-protocol/transport.mdx
+++ b/src/content/docs/agents/model-context-protocol/transport.mdx
@@ -187,7 +187,7 @@ export class Chat extends AIChatAgent<Env> {
 
 RPC connections are automatically restored after Durable Object hibernation, just like HTTP connections. The binding name and props are persisted to storage so the connection can be re-established without any extra code.
 
-If `addMcpServer` is called with a name that already has an active connection, the existing connection is returned instead of creating a duplicate. This makes it safe to call in `onStart()`.
+For RPC transport, if `addMcpServer` is called with a name that already has an active connection, the existing connection is returned instead of creating a duplicate. For HTTP transport, deduplication matches on both server name and URL (refer to [MCP Client API](/agents/api-reference/mcp-client-api/) for details). This makes it safe to call in `onStart()`.
 
 #### 3. Configure Durable Object bindings
 


### PR DESCRIPTION
## Summary

Documentation updates for the upcoming `agents@0.7.0` release. Covers new features, API changes, and stale content that has drifted from the SDK since `0.5.0`.

> **Note:** `agents@0.7.0` has not been published yet. This PR should be merged when the release ships.

## Changes

### 1. `keepAlive()` / `keepAliveWhile()` — new API docs (`schedule-tasks.mdx`)

Added full documentation for the new idle-eviction prevention API ([cloudflare/agents#1029](https://github.com/cloudflare/agents/pull/1029), [#1033](https://github.com/cloudflare/agents/pull/1033)):

- **API reference** — `keepAlive()` and `keepAliveWhile()` signatures, parameters, return types
- **"Keeping the agent alive" guide section** — explains the problem (DO eviction during long-running work), how the heartbeat mechanism works under the hood, multiple concurrent callers, and that `AIChatAgent` uses it automatically
- **When-to-use table** — helps users decide whether they need `keepAlive()` for their use case
- Marked as `@experimental`

### 2. Observability page rewrite (`observability.mdx`)

The entire observability page was stale — it described an old `console.log`-based `Observability.emit()` interface with incorrect event types (`disconnect`, `message`, `error`, `queue:process`). Rewrote from scratch to match the current `diagnostics_channel`-based implementation ([cloudflare/agents#1024](https://github.com/cloudflare/agents/pull/1024)):

- **diagnostics channels** — explains the 7 named channels (`agents:state`, `agents:rpc`, `agents:message`, `agents:schedule`, `agents:lifecycle`, `agents:workflow`, `agents:mcp`)
- **Typed `subscribe()` helper** — from `agents/observability`, with type-narrowed callbacks
- **Raw `node:diagnostics_channel`** — for direct access
- **Tail Workers** — production observability via `event.diagnosticsChannelEvents`
- **Custom `Observability` override** — retained but updated with correct event types
- **Complete event reference** — 30+ event types across all 7 categories with payload shapes and descriptions

### 3. `callbackHost` optional for non-OAuth servers (`mcp-client-api.mdx`)

Updated prose and code examples to clarify that `callbackHost` is not needed when connecting to MCP servers that do not use OAuth ([cloudflare/agents#963](https://github.com/cloudflare/agents/pull/963)). Previously the examples always showed `callbackHost`, which could mislead users into thinking it was required.

### 4. MCP dedup behavior (`mcp-client-api.mdx`, `transport.mdx`)

Documented the updated `addMcpServer` deduplication logic:
- HTTP transport now deduplicates on both server name **and** URL (previously name-only)
- RPC transport continues to deduplicate by name only
- URLs are normalized before comparison (hostname case, trailing slashes, default ports)
- Documented storage accumulation behavior when same name is used with different URLs

### 5. `agents-api.mdx` quick reference table

- Added `keepAlive()` to the Scheduling row
- Updated Observability row from `observability.emit()` to `subscribe()`, diagnostics channels, Tail Workers

### 6. `addToolOutput` with custom denial messages (`chat-agents.mdx`)

Documented the `output-error` type and `errorText` field for `addToolOutput`, allowing custom denial messages in human-in-the-loop tool approval flows ([cloudflare/agents#967](https://github.com/cloudflare/agents/pull/967)).

## Files changed

| File | What changed |
|------|-------------|
| `agents/api-reference/schedule-tasks.mdx` | Added `keepAlive()`, `keepAliveWhile()` API ref + guide section |
| `agents/api-reference/observability.mdx` | Full page rewrite (diagnostics_channel, channels, subscribe, Tail Workers, event ref) |
| `agents/api-reference/mcp-client-api.mdx` | callbackHost clarification, dedup behavior docs |
| `agents/model-context-protocol/transport.mdx` | Updated dedup description for RPC vs HTTP |
| `agents/api-reference/agents-api.mdx` | keepAlive + observability in quick ref table |
| `agents/api-reference/chat-agents.mdx` | addToolOutput output-error/errorText docs |
| `agents/api-reference/store-and-sync-state.mdx` | Minor fix |
| `agents/api-reference/get-current-agent.mdx` | Minor fix |

## Related PRs (agents repo)

- [#1029](https://github.com/cloudflare/agents/pull/1029) — `Agent.keepAlive()`
- [#1033](https://github.com/cloudflare/agents/pull/1033) — `Agent.keepAliveWhile()`
- [#1024](https://github.com/cloudflare/agents/pull/1024) — Observability → diagnostics_channel
- [#963](https://github.com/cloudflare/agents/pull/963) — callbackHost optional
- [#967](https://github.com/cloudflare/agents/pull/967) — addToolOutput approval states
- [#565](https://github.com/cloudflare/agents/pull/565) — RPC transport (0.6.0, dedup docs updated)
- MCP dedup name+URL change (on main, not yet released)