### PR TITLE
fix sql insert syntax

### DIFF
--- a/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
+++ b/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
@@ -94,7 +94,7 @@ In the shell you just opened, paste in the following SQL:
 
 ```sql
 create table example_users (email text);
-insert into example_users values ("foo@bar.com");
+insert into example_users values ('foo@bar.com');
 ```
 
 If the SQL statements succeeded, there will be no output. Note that the trailing semi-colons (`;`) are necessary to terminate each SQL statement.


### PR DESCRIPTION
### Summary

"foo@bar.com" is an identifier not a string.

```
→  insert into example_users values ("foo@bar.com");
Error: failed to execute SQL:
SQLite input error: no such column: foo@bar.com (at offset 34)
```

updated to single quotes.