### PR TITLE
Remove wid in pages themselves, update ProductAvailabilityText and si…

### DIFF
--- a/src/components/ProductAvailabilityText.astro
+++ b/src/components/ProductAvailabilityText.astro
@@ -3,32 +3,41 @@ import { getEntry } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 
 interface Props {
-	product: CollectionEntry<"product-availability">["id"];
+	product: CollectionEntry<"directory">["id"];
 	parentheses?: string;
 }
 
 const { product, parentheses = "true" } = Astro.props;
 
-let entry = await getEntry("product-availability", product);
+const directoryEntry = await getEntry("directory", product);
 let output = "";
 
-if (!entry || !entry.data.availability) {
+if (!directoryEntry) {
 	console.warn(
-		`Product availability value not found for product="${product}" in ${Astro.url.pathname}. Returning empty.`,
+		`Directory entry not found for product="${product}" in ${Astro.url.pathname}. Returning empty.`,
 	);
-}
-// don't show anything for GA products
-else if (entry.data.availability.toUpperCase() === "GA") {
-	console.info(
-		`Product availability entry is GA for product="${product}" in ${Astro.url.pathname}. Returning empty.`,
-	);
-}
-// show an availability value
-else {
-	if (parentheses === "false") {
-		output = entry.data.availability;
-	} else {
-		output = `(${entry.data.availability})`;
+} else {
+	const availabilityId = directoryEntry.data.id;
+	const entry = await getEntry("product-availability", availabilityId);
+
+	if (!entry || !entry.data.availability) {
+		console.warn(
+			`Product availability value not found for product="${product}" (id="${availabilityId}") in ${Astro.url.pathname}. Returning empty.`,
+		);
+	}
+	// don't show anything for GA products
+	else if (entry.data.availability.toUpperCase() === "GA") {
+		console.info(
+			`Product availability entry is GA for product="${product}" (id="${availabilityId}") in ${Astro.url.pathname}. Returning empty.`,
+		);
+	}
+	// show an availability value
+	else {
+		if (parentheses === "false") {
+			output = entry.data.availability;
+		} else {
+			output = `(${entry.data.availability})`;
+		}
 	}
 }
 ---

--- a/src/content/collections/product-availability.ts
+++ b/src/content/collections/product-availability.ts
@@ -12,18 +12,21 @@ type ProductAvailability = z.infer<typeof productAvailabilitySchema>;
 const productAvailabilityCollectionConfig: CollectionConfig<
 	typeof productAvailabilitySchema
 > = {
-	loader: middlecacheLoader("v1/products/availability_certification.json", {
-		parser: (fileContent: string) => {
-			const data = JSON.parse(fileContent);
-			const lookup: Record<string, ProductAvailability> = {};
+	loader: middlecacheLoader(
+		"v1/products/reconciled-availability-certification.json",
+		{
+			parser: (fileContent: string) => {
+				const data = JSON.parse(fileContent);
+				const lookup: Record<string, ProductAvailability> = {};
 
-			for (const item of data) {
-				lookup[item.name] = { availability: item.availability };
-			}
+				for (const item of data) {
+					lookup[item.id] = { availability: item.availability };
+				}
 
-			return lookup;
+				return lookup;
+			},
 		},
-	}),
+	),
 	schema: productAvailabilitySchema,
 };
 

--- a/src/content/directory/warp-connector.yaml
+++ b/src/content/directory/warp-connector.yaml
@@ -3,7 +3,7 @@ name: warp-connector
 
 entry:
   title: WARP Connector
-  url: /cloudflare-one/connections/connect-networks/private-net/warp-connector/
+  url: /cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/
   show: false
 
 meta:

--- a/src/content/directory/workers-smart-placement.yaml
+++ b/src/content/directory/workers-smart-placement.yaml
@@ -3,7 +3,7 @@ name: workers-smart-placement
 
 entry:
   title: Placement
-  url: /workers/configuration/smart-placement/
+  url: /workers/configuration/placement/
   show: false
 
 meta:

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/index.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Pay Per Crawl
 pcx_content_type: navigation
-wid: pay-per-crawl
 sidebar:
   group:
     hideIndex: true

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/index.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: concept
 title: WARP Connector
-wid: warp-connector
 sidebar:
   label: Overview
   order: 5
@@ -10,13 +9,13 @@ sidebar:
 tableOfContents: false
 ---
 
-import { Render, Details} from "~/components";
+import { Render, Details } from "~/components";
 
 <Details header="Feature availability">
 
 | [WARP modes](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/) | [Zero Trust plans](https://www.cloudflare.com/teams-pricing/) |
-| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| Traffic and DNS mode                                                                         | All plans                                                     |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Traffic and DNS mode                                                                     | All plans                                                     |
 
 | System   | Availability |
 | -------- | ------------ |

--- a/src/content/docs/containers/index.mdx
+++ b/src/content/docs/containers/index.mdx
@@ -3,7 +3,6 @@ title: Containers (Beta)
 order: 0
 
 pcx_content_type: overview
-wid: cloudchamber
 sidebar:
   order: 1
   badge:

--- a/src/content/docs/dmarc-management/index.mdx
+++ b/src/content/docs/dmarc-management/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloudflare DMARC Management
 pcx_content_type: overview
-wid: dmarc-management
 head:
   - tag: title
     content: Overview

--- a/src/content/docs/dns/internal-dns/index.mdx
+++ b/src/content/docs/dns/internal-dns/index.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: overview
 title: Internal DNS (beta)
-wid: internal-dns
 sidebar:
   order: 14
   label: Overview

--- a/src/content/docs/multi-cloud-networking/index.mdx
+++ b/src/content/docs/multi-cloud-networking/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloudflare One Multi-Cloud Networking (beta)
 pcx_content_type: overview
-wid: magic-cloud
 sidebar:
   order: 1
   badge:
@@ -10,13 +9,13 @@ sidebar:
 head:
   - tag: title
     content: Multi-Cloud Networking
-
 ---
 
-import { Description, Feature, Plan, RelatedProduct } from "~/components"
+import { Description, Feature, Plan, RelatedProduct } from "~/components";
 
 <Description>
-Automate resource discovery and simplify connectivity when connecting to your public cloud.
+	Automate resource discovery and simplify connectivity when connecting to your
+	public cloud.
 </Description>
 
 <Plan type="enterprise" />
@@ -33,18 +32,33 @@ Learn how to [get started](/multi-cloud-networking/get-started/).
 
 ## Features
 
-<Feature header="Discover your cloud resources automatically" href="/multi-cloud-networking/get-started/" cta="Use cloud resource discovery">
-Discover your cloud resources like virtual private clouds (VPCs), subnets, virtual machines (VMs), route tables, and routes automatically, and easily set up your integrations.
+<Feature
+	header="Discover your cloud resources automatically"
+	href="/multi-cloud-networking/get-started/"
+	cta="Use cloud resource discovery"
+>
+	Discover your cloud resources like virtual private clouds (VPCs), subnets,
+	virtual machines (VMs), route tables, and routes automatically, and easily set
+	up your integrations.
 </Feature>
 
-<Feature header="Automatically connect a cloud network" href="/multi-cloud-networking/cloud-on-ramps/" cta="Create cloud on-ramps">
-Automatically build VPN tunnels between cloud networks and Cloudflare WAN.
+<Feature
+	header="Automatically connect a cloud network"
+	href="/multi-cloud-networking/cloud-on-ramps/"
+	cta="Create cloud on-ramps"
+>
+	Automatically build VPN tunnels between cloud networks and Cloudflare WAN.
 </Feature>
 
 ---
 
 ## Related products
 
-<RelatedProduct header="Cloudflare WAN" href="/cloudflare-wan/" product="cloudflare-wan">
-Connect and secure your network infrastructure with Cloudflare's global network.
+<RelatedProduct
+	header="Cloudflare WAN"
+	href="/cloudflare-wan/"
+	product="cloudflare-wan"
+>
+	Connect and secure your network infrastructure with Cloudflare's global
+	network.
 </RelatedProduct>

--- a/src/content/docs/pipelines/index.mdx
+++ b/src/content/docs/pipelines/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloudflare Pipelines
 pcx_content_type: overview
-wid: cloudflare-pipelines
 head:
   - tag: title
     content: Pipelines

--- a/src/content/docs/privacy-gateway/index.mdx
+++ b/src/content/docs/privacy-gateway/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloudflare Privacy Gateway
 pcx_content_type: overview
-wid: privacy-gateway
 head:
   - tag: title
     content: Overview

--- a/src/content/docs/r2-sql/index.mdx
+++ b/src/content/docs/r2-sql/index.mdx
@@ -2,7 +2,6 @@
 title: R2 SQL
 
 pcx_content_type: overview
-wid: r2sql
 sidebar:
   order: 1
   badge:

--- a/src/content/docs/r2/data-catalog/index.mdx
+++ b/src/content/docs/r2/data-catalog/index.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: navigation
 title: R2 Data Catalog
-wid: r2-data-catalog
 sidebar:
   order: 7
   group:

--- a/src/content/docs/rules/cloud-connector/index.mdx
+++ b/src/content/docs/rules/cloud-connector/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloud Connector
 pcx_content_type: concept
-wid: cloud-connector
 sidebar:
   order: 9
 head:

--- a/src/content/docs/rules/trace-request/index.mdx
+++ b/src/content/docs/rules/trace-request/index.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: concept
 title: Trace a request
-wid: cloudflare-trace
 sidebar:
   order: 14
 head:
@@ -13,7 +12,7 @@ import { DirectoryListing, Plan, ProductAvailabilityText } from "~/components";
 
 <Plan type="all" />
 
-Cloudflare Trace <ProductAvailabilityText product="cloudflare-trace" /> follows an HTTP/S request through Cloudflare's reverse proxy to your origin. Use this tool to understand how different Cloudflare configurations interact with an HTTP/S request for one of your hostnames. If the hostname you are testing is not [proxied by Cloudflare](/dns/proxy-status/), Cloudflare Trace will still return all the configurations that Cloudflare would have applied to the request.
+Cloudflare Trace <ProductAvailabilityText product="trace-request" /> follows an HTTP/S request through Cloudflare's reverse proxy to your origin. Use this tool to understand how different Cloudflare configurations interact with an HTTP/S request for one of your hostnames. If the hostname you are testing is not [proxied by Cloudflare](/dns/proxy-status/), Cloudflare Trace will still return all the configurations that Cloudflare would have applied to the request.
 
 You can define specific request properties to simulate different conditions for an HTTP/S request. Inactive rules configured in Cloudflare products will not be evaluated.
 

--- a/src/content/docs/speed/observatory/index.mdx
+++ b/src/content/docs/speed/observatory/index.mdx
@@ -1,16 +1,14 @@
 ---
 pcx_content_type: overview
 title: Observatory (beta)
-wid: observatory
 sidebar:
   order: 1
   sidebar:
   badge:
     text: Beta
-
 ---
 
-import { LinkButton } from "~/components"
+import { LinkButton } from "~/components";
 
 Observatory uses synthetic tests and real user data from browsers to assess the performance of your website. These data sources produce metrics that provide different types of insights into your website’s performance. Cloudflare then uses the analysis run by Observatory to recommend optimizations with the tools that best suit your performance issues.
 
@@ -26,7 +24,7 @@ The browser test loads the requested page in a headless browser and runs Google 
 
 ### Network test
 
-The network test is focused on giving a detailed breakdown of the network and back-end performance of an endpoint. For more information on metrics collected, refer to [Network monitoring metrics](/speed/observatory/test-results/#network-monitoring-metrics). 
+The network test is focused on giving a detailed breakdown of the network and back-end performance of an endpoint. For more information on metrics collected, refer to [Network monitoring metrics](/speed/observatory/test-results/#network-monitoring-metrics).
 
 ### Network comparison test
 
@@ -38,4 +36,6 @@ Real user monitoring (also known as RUM), on the other hand, captures real metri
 
 Free customers have RUM enabled automatically, with EU traffic excluded, and can switch it off if they prefer. Customers on other plans may enable RUM as needed.
 
- <LinkButton variant="primary" href="/speed/observatory/run-speed-test/">Run test</LinkButton>
+<LinkButton variant="primary" href="/speed/observatory/run-speed-test/">
+	Run test
+</LinkButton>

--- a/src/content/docs/speed/optimization/content/fonts/index.mdx
+++ b/src/content/docs/speed/optimization/content/fonts/index.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: overview
 title: Cloudflare Fonts
-wid: fonts
 sidebar:
   order: 4
 ---

--- a/src/content/docs/ssl/edge-certificates/additional-options/certificate-transparency-monitoring.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/certificate-transparency-monitoring.mdx
@@ -1,17 +1,15 @@
 ---
 pcx_content_type: concept
 title: Certificate Transparency Monitoring
-wid: certificate-transparency-monitoring
 sidebar:
   order: 3
 head: []
 description: Certificate Transparency (CT) Monitoring is an opt-in feature in
   public beta that aims at improving security by allowing you to double-check
   any SSL/TLS certificates issued for your domain.
-
 ---
 
-import { FeatureTable, GlossaryTooltip } from "~/components"
+import { FeatureTable, GlossaryTooltip } from "~/components";
 
 Certificate Transparency (CT) Monitoring is an [opt-in](#opt-in-and-out) feature in public beta that aims at improving security by allowing you to double-check any SSL/TLS certificates issued for your domain.
 
@@ -19,21 +17,19 @@ CT Monitoring alerts are triggered not only by Cloudflare processes - including 
 
 :::caution[Aspects to consider]
 
-
-* If you use Cloudflare or other services that automatically issue certificates for your domain or subdomains, this may trigger CT Monitoring emails as well.
-* If your domain is included in a shared certificate, you may receive notifications for domains or subdomains that do not belong to you but are included as <GlossaryTooltip term="Subject Alternative Names (SANs)">subject alternative names (SANs)</GlossaryTooltip> together with your domain. You can use a tool like [Certificate Search](https://crt.sh/) to gather more information in such cases.
-* CT Monitoring does not detect phishing attempts. For example, for `cloudflare.com`, an alert would not trigger if a certificate was issued for `cloudf1are.com` or `cloud-flare.com`.
-
+- If you use Cloudflare or other services that automatically issue certificates for your domain or subdomains, this may trigger CT Monitoring emails as well.
+- If your domain is included in a shared certificate, you may receive notifications for domains or subdomains that do not belong to you but are included as <GlossaryTooltip term="Subject Alternative Names (SANs)">subject alternative names (SANs)</GlossaryTooltip> together with your domain. You can use a tool like [Certificate Search](https://crt.sh/) to gather more information in such cases.
+- CT Monitoring does not detect phishing attempts. For example, for `cloudflare.com`, an alert would not trigger if a certificate was issued for `cloudf1are.com` or `cloud-flare.com`.
 
 :::
 
-***
+---
 
 ## Availability
 
 <FeatureTable id="ssl.cert_transparency" />
 
-***
+---
 
 ## Opt in and out
 
@@ -41,7 +37,7 @@ Alerts are turned off by default. If you want to receive alerts, go to the [**Ed
 
 To stop receiving alerts, disable **Certificate Transparency Monitoring** or remove your email from the feature card.
 
-***
+---
 
 ## Emails to be concerned about
 
@@ -50,16 +46,17 @@ Most certificate alerts are routine. Cloudflare sends alerts whenever a certific
 Additionally, you should check whether the certificate was issued through Cloudflare. Cloudflare partners with [multiple CAs](/ssl/reference/certificate-authorities/) to provide certificates.
 To view all Cloudflare-issued certificates and backup certificates - which require no additional actions - visit the [Edge Certificates page](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates) in the dashboard.
 
-You *should* take action when something is clearly wrong, such as if you:
+You _should_ take action when something is clearly wrong, such as if you:
 
-* Do not recognize the certificate issuer.
+- Do not recognize the certificate issuer.
   :::note
 
   Cloudflare provisions backup certificates, so you may see a certificate listed that is not in active use for your site. The [Edge Certificates page](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates) will show all certificates requested for your site.
   :::
-* Have recently noticed problems with your website.
 
-***
+- Have recently noticed problems with your website.
+
+---
 
 ## How to take action
 
@@ -67,19 +64,19 @@ You *should* take action when something is clearly wrong, such as if you:
 
 Only Certificate Authorities can revoke malicious certificates. If you believe an illegitimate certificate was issued for your domain, contact the Certificate Authority listed as the **Issuer** in the email.
 
-* [GlobalSign support](https://support.globalsign.com/)
+- [GlobalSign support](https://support.globalsign.com/)
 
-* [GoDaddy support](https://www.godaddy.com/contact-us?sp_hp=B)
+- [GoDaddy support](https://www.godaddy.com/contact-us?sp_hp=B)
 
-* [Google Trust Services support](https://pki.goog/faq/)
+- [Google Trust Services support](https://pki.goog/faq/)
 
-* [IdenTrust support](https://www.identrust.com/support/support-team)
+- [IdenTrust support](https://www.identrust.com/support/support-team)
 
-* [Let's Encrypt support](https://letsencrypt.org/contact/)
+- [Let's Encrypt support](https://letsencrypt.org/contact/)
 
-* [Sectigo support](https://sectigo.com/support)
+- [Sectigo support](https://sectigo.com/support)
 
-* [SSL.com support](https://www.ssl.com/submit-a-ticket/)
+- [SSL.com support](https://www.ssl.com/submit-a-ticket/)
 
 ### Option 2: Contact domain registrars
 
@@ -91,7 +88,7 @@ There are other ways to combat malicious certificates. You can warn your visitor
 
 If someone is attempting to impersonate you online, you should absolutely take action. This is usually difficult to recognize, so exercise caution. **Remember: the vast majority of certificates are not malicious. Only take action if you believe something is wrong.**
 
-***
+---
 
 ## HTTP Public Key Pinning
 

--- a/src/content/docs/stream/webrtc-beta.mdx
+++ b/src/content/docs/stream/webrtc-beta.mdx
@@ -1,22 +1,21 @@
 ---
 pcx_content_type: navigation
 title: WebRTC
-wid: webrtc
 sidebar:
   badge:
     text: Beta
   order: 9
 ---
 
-import { Badge, InlineBadge, DashButton } from '~/components';
+import { Badge, InlineBadge, DashButton } from "~/components";
 
 Sub-second latency live streaming (using WHIP) and playback (using WHEP) to unlimited concurrent viewers.
 
 WebRTC is ideal for when you need live video to playback in near real-time, such as:
 
-* When the outcome of a live event is time-sensitive (live sports, financial news)
-* When viewers interact with the live stream (live Q\&A, auctions, etc.)
-* When you want your end users to be able to easily go live or create their own video content, from a web browser or native app
+- When the outcome of a live event is time-sensitive (live sports, financial news)
+- When viewers interact with the live stream (live Q\&A, auctions, etc.)
+- When you want your end users to be able to easily go live or create their own video content, from a web browser or native app
 
 :::note
 
@@ -30,7 +29,7 @@ Create a live input using one of the two options:
 
 - Use the **Live inputs** page of the Cloudflare dashboard.
 
-   <DashButton url="/?to=/:account/stream/inputs" />
+  <DashButton url="/?to=/:account/stream/inputs" />
 
 - Make a POST request to the [`/live_inputs` API endpoint](/api/resources/stream/subresources/live_inputs/methods/create/)
 
@@ -50,11 +49,13 @@ Create a live input using one of the two options:
 
 ## Step 2: Go live using WHIP
 
-Every live input has a unique URL that one creator can be stream to. This URL should *only* be shared with the creator — anyone with this URL has the ability to stream live video to this live input.
+Every live input has a unique URL that one creator can be stream to. This URL should _only_ be shared with the creator — anyone with this URL has the ability to stream live video to this live input.
 
 Copy the URL from either:
+
 - The **Live inputs** page of the Cloudflare dashboard.
-   <DashButton url="/?to=/:account/stream/inputs" />
+
+  <DashButton url="/?to=/:account/stream/inputs" />
 
 - The `webRTC` key in the API response (see above).
 
@@ -78,8 +79,10 @@ You can also use this URL with any client that supports the [WebRTC-HTTP ingesti
 ## Step 3: Play live video using WHEP
 
 Copy the URL from either:
+
 - The **Live inputs** page of the Cloudflare dashboard.
-   <DashButton url="/?to=/:account/stream/inputs" />
+
+  <DashButton url="/?to=/:account/stream/inputs" />
 
 - The `webRTCPlayback` key in the API response (see above)
 
@@ -108,9 +111,9 @@ If you are building a native app, the example code above can run within a [WkWeb
 
 ## Debugging WebRTC
 
-* **Chrome**: Navigate to `chrome://webrtc-internals` to view detailed logs and graphs.
-* **Firefox**: Navigate to `about:webrtc` to view information about WebRTC sessions, similar to Chrome.
-* **Safari**: To enable WebRTC logs, from the inspector, open the settings tab (cogwheel icon), and set WebRTC logging to "Verbose" in the dropdown menu.
+- **Chrome**: Navigate to `chrome://webrtc-internals` to view detailed logs and graphs.
+- **Firefox**: Navigate to `about:webrtc` to view information about WebRTC sessions, similar to Chrome.
+- **Safari**: To enable WebRTC logs, from the inspector, open the settings tab (cogwheel icon), and set WebRTC logging to "Verbose" in the dropdown menu.
 
 ## Supported WHIP and WHEP clients
 
@@ -118,40 +121,40 @@ Beyond the example WHIP client and example WHEP client used in the examples abov
 
 ### WHIP
 
-* [OBS (Open Broadcaster Software)](https://obsproject.com)
-* [@eyevinn/whip-web-client](https://www.npmjs.com/package/@eyevinn/whip-web-client) (TypeScript)
-* [whip-go](https://github.com/ggarber/whip-go) (Go)
-* [gst-plugins-rs](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs) (Gstreamer plugins, written in Rust)
-* [Larix Broadcaster](https://softvelum.com/larix/) (free apps for iOS and Android with WebRTC based on Pion, SDK available)
+- [OBS (Open Broadcaster Software)](https://obsproject.com)
+- [@eyevinn/whip-web-client](https://www.npmjs.com/package/@eyevinn/whip-web-client) (TypeScript)
+- [whip-go](https://github.com/ggarber/whip-go) (Go)
+- [gst-plugins-rs](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs) (Gstreamer plugins, written in Rust)
+- [Larix Broadcaster](https://softvelum.com/larix/) (free apps for iOS and Android with WebRTC based on Pion, SDK available)
 
 ### WHEP
 
-* [@eyevinn/webrtc-player](https://www.npmjs.com/package/@eyevinn/webrtc-player) (TypeScript)
-* [@eyevinn/wrtc-egress](https://www.npmjs.com/package/@eyevinn/wrtc-egress) (TypeScript)
-* [gst-plugins-rs](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs) (Gstreamer plugins, written in Rust)
+- [@eyevinn/webrtc-player](https://www.npmjs.com/package/@eyevinn/webrtc-player) (TypeScript)
+- [@eyevinn/wrtc-egress](https://www.npmjs.com/package/@eyevinn/wrtc-egress) (TypeScript)
+- [gst-plugins-rs](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs) (Gstreamer plugins, written in Rust)
 
 As more WHIP and WHEP clients are published, we are committed to supporting them and being fully compliant with the both protocols.
 
 ## Supported codecs
 
-* [VP9](https://developers.google.com/media/vp9) (recommended for highest quality)
-* [VP8](https://en.wikipedia.org/wiki/VP8)
-* [h264](https://en.wikipedia.org/wiki/Advanced_Video_Coding) (Constrained Baseline Profile Level 3.1, referred to as `42e01f` in the SDP offer's `profile-level-id` parameter.)
+- [VP9](https://developers.google.com/media/vp9) (recommended for highest quality)
+- [VP8](https://en.wikipedia.org/wiki/VP8)
+- [h264](https://en.wikipedia.org/wiki/Advanced_Video_Coding) (Constrained Baseline Profile Level 3.1, referred to as `42e01f` in the SDP offer's `profile-level-id` parameter.)
 
 ## Conformance with WHIP and WHEP specifications
 
 Cloudflare Stream fully supports all aspects of the [WHIP](https://www.ietf.org/archive/id/draft-ietf-wish-whip-16.html) and [WHEP](https://www.ietf.org/archive/id/draft-murillo-whep-01.html) specifications, including:
 
-* [Trickle ICE](https://datatracker.ietf.org/doc/rfc8838/)
-* [Server and client offer modes](https://www.ietf.org/archive/id/draft-murillo-whep-01.html#section-3) for WHEP
+- [Trickle ICE](https://datatracker.ietf.org/doc/rfc8838/)
+- [Server and client offer modes](https://www.ietf.org/archive/id/draft-murillo-whep-01.html#section-3) for WHEP
 
 You can find the specific version of WHIP and WHEP being used in the `protocol-version` header in WHIP and WHEP API responses. The value of this header references the IETF draft slug for each protocol. Currently, Stream uses `draft-ietf-wish-whip-06` (expected to be the final WHIP draft revision) and `draft-murillo-whep-01` (the most current WHEP draft).
 
 ## Limitations while in beta
 
-* [Recording](/stream/stream-live/watch-live-stream/#live-stream-recording-playback) is not yet supported (coming soon)
-* [Simulcasting](/stream/stream-live/simulcasting) (restreaming) is not yet supported (coming soon)
-* [Live viewer counts](/stream/getting-analytics/live-viewer-count/) are not yet supported (coming soon)
-* [Analytics](/stream/getting-analytics/fetching-bulk-analytics/) are not yet supported (coming soon)
-* WHIP and WHEP must be used together — we do not yet support streaming using RTMP/SRT and playing using WHEP, or streaming using WHIP and playing using HLS or DASH. (coming soon)
-* Once generally available, WebRTC streaming will be priced just like the rest of Cloudflare Stream, based on minutes stored and minutes of video delivered.
+- [Recording](/stream/stream-live/watch-live-stream/#live-stream-recording-playback) is not yet supported (coming soon)
+- [Simulcasting](/stream/stream-live/simulcasting) (restreaming) is not yet supported (coming soon)
+- [Live viewer counts](/stream/getting-analytics/live-viewer-count/) are not yet supported (coming soon)
+- [Analytics](/stream/getting-analytics/fetching-bulk-analytics/) are not yet supported (coming soon)
+- WHIP and WHEP must be used together — we do not yet support streaming using RTMP/SRT and playing using WHEP, or streaming using WHIP and playing using HLS or DASH. (coming soon)
+- Once generally available, WebRTC streaming will be priced just like the rest of Cloudflare Stream, based on minutes stored and minutes of video delivered.

--- a/src/content/docs/waf/detections/firewall-for-ai/index.mdx
+++ b/src/content/docs/waf/detections/firewall-for-ai/index.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: concept
 title: Firewall for AI (beta)
-wid: firewall-for-ai
 tags:
   - AI
 sidebar:

--- a/src/content/docs/workers-vpc/index.mdx
+++ b/src/content/docs/workers-vpc/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloudflare Workers VPC
 pcx_content_type: overview
-wid: workers-vpc
 sidebar:
   order: 1
   badge: Beta
@@ -58,7 +57,7 @@ export default {
 
 };
 
-```
+````
 
     </TabItem>
     <TabItem label="wrangler.jsonc">
@@ -76,7 +75,7 @@ export default {
 			}
 		]
 	}
-```
+````
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/workers-vpc/index.mdx
+++ b/src/content/docs/workers-vpc/index.mdx
@@ -57,7 +57,7 @@ export default {
 
 };
 
-````
+```
 
     </TabItem>
     <TabItem label="wrangler.jsonc">
@@ -75,7 +75,7 @@ export default {
 			}
 		]
 	}
-````
+```
 
 </TabItem>
 </Tabs>

--- a/src/content/docs/workers/configuration/placement.mdx
+++ b/src/content/docs/workers/configuration/placement.mdx
@@ -1,7 +1,6 @@
 ---
 pcx_content_type: concept
 title: Placement
-wid: smart-placement
 head: []
 description: Control where your Worker runs to reduce latency.
 sidebar:

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -135,10 +135,4 @@ export const baseSchema = ({ image }: SchemaContext) =>
 			.describe(
 				"Whether to show the FeedbackPrompt on the page, defaults to true",
 			),
-		wid: z
-			.string()
-			.optional()
-			.describe(
-				"What Id? Used as a generic identifier for external data sources",
-			),
 	});

--- a/src/util/sidebar.ts
+++ b/src/util/sidebar.ts
@@ -17,7 +17,21 @@ export type SidebarEntry = Link | Group;
 type Badge = Link["badge"];
 
 const directory = await getCollection("directory");
+const productAvailability = await getCollection("product-availability");
 const sidebars = new Map<string, Group>();
+
+// Build URL → beta badge map from directory entries + product availability
+const betaBadgeUrls = new Map<string, Badge>();
+for (const dirEntry of directory) {
+	const availabilityId = dirEntry.data.id;
+	const availEntry = productAvailability.find((e) => e.id === availabilityId);
+	if (availEntry?.data.availability?.toLowerCase() === "beta") {
+		betaBadgeUrls.set(dirEntry.data.entry.url, {
+			text: "Beta",
+			variant: "caution",
+		});
+	}
+}
 
 export async function getSidebar(context: AstroGlobal) {
 	const pathname = context.url.pathname;
@@ -136,7 +150,11 @@ function setSidebarCurrentEntry(
 			const href = entry.href;
 
 			// Compare with and without trailing slash
-			if (href === pathname || href.slice(0, -1) === href) {
+			const normalizedHref = href.endsWith("/") ? href.slice(0, -1) : href;
+			const normalizedPathname = pathname.endsWith("/")
+				? pathname.slice(0, -1)
+				: pathname;
+			if (normalizedHref === normalizedPathname) {
 				entry.isCurrent = true;
 				return true;
 			}
@@ -214,8 +232,8 @@ async function handleGroup(group: Group): Promise<SidebarEntry> {
 
 	if (frontmatter.sidebar.group?.badge) {
 		group.badge = inferBadgeVariant(frontmatter.sidebar.group?.badge);
-	} else if (frontmatter.wid) {
-		const availabilityBadge = await productAvailabilityBadge(frontmatter.wid);
+	} else {
+		const availabilityBadge = betaBadgeUrls.get(index.href);
 		if (availabilityBadge) {
 			group.badge = availabilityBadge;
 		}
@@ -295,8 +313,8 @@ async function handleLink(link: Link): Promise<Link> {
 
 	if (link.badge) {
 		link.badge = inferBadgeVariant(link.badge);
-	} else if (frontmatter.wid) {
-		const availabilityBadge = await productAvailabilityBadge(frontmatter.wid);
+	} else {
+		const availabilityBadge = betaBadgeUrls.get(link.href);
 		if (availabilityBadge) {
 			link.badge = availabilityBadge;
 		}
@@ -317,23 +335,6 @@ async function handleLink(link: Link): Promise<Link> {
 	}
 
 	return link;
-}
-
-async function productAvailabilityBadge(
-	wid: string,
-): Promise<Badge | undefined> {
-	try {
-		const availabilityEntry = await getEntry("product-availability", wid);
-		if (
-			availabilityEntry &&
-			availabilityEntry.data.availability?.toLowerCase() === "beta"
-		) {
-			return { text: "Beta", variant: "caution" };
-		}
-	} catch (_error) {
-		// If the entry doesn't exist in the collection, return undefined
-	}
-	return undefined;
 }
 
 function inferBadgeVariant(badge: Badge) {


### PR DESCRIPTION
Until this PR the beta badges were coming from explicit mention in the frontmatter of an individual page or from matches between ProductAvailabilityText and the wid on a page. This PR removes these wids and instead matches beta badges (still allowing the explicit frontmatter ones) in sidebar and gets the values for ProductAvailabilityText via the ids in src/content/directory matching with the values in the middlecache file https://middlecache.ced.cloudflare.com/v1/products/reconciled-availability-certification.json.

- removal of wids
- update middlecache data source for content collection
- update of sidebar and ProductAvailabilityText component to use this method