### PR TITLE
feat: add changelog for copy resources as JSON or POST requests

### DIFF
--- a/src/content/changelog/cloudflare-one/2026-03-copy-resources-as-json-or-post-requests.mdx
+++ b/src/content/changelog/cloudflare-one/2026-03-copy-resources-as-json-or-post-requests.mdx
@@ -1,0 +1,22 @@
+---
+title: Copy Cloudflare One resources as JSON or POST requests
+description: Cloudflare One resources can be easily copied from the dashboard as schema to help users more quickly adopt API and infrastructure-as-code tools.
+date: 2026-03-02
+products:
+  - cloudflare-one
+---
+
+You can now copy Cloudflare One resources as JSON or as a ready-to-use API POST request directly from the dashboard. This makes it simple to transition workflows into API calls, automation scripts, or infrastructure-as-code pipelines.
+
+To use this feature, click the overflow menu (⋮) on any supported resource and select **Copy as JSON** or **Copy as POST request**. The copied output includes only the fields present on your resource, giving you a clean and minimal starting point for your own API calls.
+
+Initially supported resources:
+
+- Access applications
+- Access policies
+- Gateway policies
+- Resolver policies
+- Service tokens
+- Identity providers
+
+We will continue to add support for more resources throughout 2026.


### PR DESCRIPTION
Adds a changelog entry for the new **Copy as JSON** and **Copy as POST request** actions available from the overflow menu on supported Cloudflare One resources.

Initially supported resources:
- Access applications
- Access policies
- Gateway policies
- Resolver policies
- Service tokens
- Identity providers

Related: [SHIP-13724](https://jira.cfdata.org/browse/SHIP-13724)