### PR TITLE
[Fundamentals] Added redirect for Fundmentals

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -596,6 +596,7 @@
 /fundamentals/account-and-billing/account-setup/manage-account-members/ /fundamentals/manage-members/ 301
 /fundamentals/account-and-billing/members/roles/ /fundamentals/manage-members/roles/ 301
 /fundamentals/basic-tasks/basic-features/ /fundamentals/concepts/ 301
+/fundamentals/basic-tasks/ /fundamentals/performance/ 301
 /fundamentals/get-started/cdn/ /fundamentals/concepts/how-cloudflare-works/ 301
 /fundamentals/get-started/how-cloudflare-works/ /fundamentals/concepts/how-cloudflare-works/ 301
 /fundamentals/get-started/cloudflare-cookies/ /fundamentals/reference/policies-compliances/cloudflare-cookies/ 301


### PR DESCRIPTION
Added redirect for older `basic-tasks` folder in Fundamentals that's since been removed.

Addresses https://github.com/cloudflare/cloudflare-docs/issues/28675