### PR TITLE
fix sql insert syntax

### DIFF
--- a/src/content/docs/workers/databases/third-party-integrations/turso.mdx
+++ b/src/content/docs/workers/databases/third-party-integrations/turso.mdx
@@ -5,58 +5,39 @@ title: Turso
 
 import { Render, PackageManagers } from "~/components";
 
-[Turso](https://turso.tech/) is an edge-hosted, distributed database based on [libSQL](https://libsql.org/), an open-source fork of SQLite. Turso was designed to minimize query latency for applications where queries comes from anywhere in the world.
+[Turso](https://turso.tech/) is an in-process SQL database, compatible with SQLite. The [tursodatabase/turso](https://github.com/tursodatabase/turso) project provides a CLI (`tursodb`) for managing local database files and a client library for use in Workers.
 
 ## Set up an integration with Turso
 
 To set up an integration with Turso:
 
-1. You need to install Turso CLI to create and populate a database. Use one of the following two commands in your terminal to install the Turso CLI:
+1. You need to install the Turso CLI to create and populate a database. Use one of the following commands in your terminal:
 
    ```sh
-   # On macOS and linux with homebrew
-   brew install tursodatabase/tap/turso
+   # On macOS with Homebrew
+   brew install turso
 
-   # Manual scripted installation
-   curl -sSfL https://get.tur.so/install.sh | bash
+   # On macOS, Linux, or Windows (WSL) using the installer script
+   curl --proto '=https' --tlsv1.2 -LsSf \
+     https://github.com/tursodatabase/turso/releases/latest/download/turso_cli-installer.sh | sh
    ```
 
    Next, run the following command to make sure the Turso CLI is installed:
 
    ```sh
-   turso --version
+   tursodb --version
    ```
 
-2. Before you create your first Turso database, you have to authenticate with your GitHub account by running:
+2. Open the Turso interactive shell by running:
 
    ```sh
-   turso auth login
+   tursodb
    ```
 
-   ```sh output
-   Waiting for authentication...
-   ✔  Success! Logged in as <YOUR_GITHUB_USERNAME>
-   ```
-
-   After you have authenticated, you can create a database using the command `turso db create <DATABASE_NAME>`. Turso will create a database and automatically choose a location closest to you.
+   This starts an in-memory database session. To work with a persistent database file, pass a filename:
 
    ```sh
-   turso db create my-db
-   ```
-
-   ```sh output
-
-   # Example:
-   Creating database my-db in Amsterdam, Netherlands (ams)
-
-   # Once succeeded:
-   Created database my-db in Amsterdam, Netherlands (ams) in 13 seconds.
-   ```
-
-   With the first database created, you can now connect to it directly and execute SQL queries against it.
-
-   ```sh
-   turso db shell my-db
+   tursodb my-db.db
    ```
 
 3. Copy the following SQL query into the shell you just opened:
@@ -82,26 +63,16 @@ To set up an integration with Turso:
      (10, 'Neon', 10, 'Ne');
    ```
 
-4. Configure the Turso database credentials in your Worker:
+4. Configure the database connection in your Worker:
 
-   You need to add your Turso database URL and authentication token as secrets to your Worker. First, get your database URL and create an authentication token:
-
-   ```sh
-   # Get your database URL
-   turso db show my-db --url
-   
-   # Create an authentication token
-   turso db tokens create my-db
-   ```
-
-   Then add these as secrets to your Worker using Wrangler:
+   The `@libsql/client` library connects using a URL. For a local file, use a `file:` URL. If you are using [Turso Cloud](https://turso.tech/), get your remote database URL and authentication token from the Turso dashboard, then add them as secrets:
 
    ```sh
    # Add the database URL as a secret
    npx wrangler secret put TURSO_URL
-   # When prompted, paste your database URL
-   
-   # Add the authentication token as a secret  
+   # When prompted, paste your database URL (e.g. libsql://my-db-<username>.turso.io or file:my-db.db)
+
+   # Add the authentication token as a secret (required for Turso Cloud remote databases)
    npx wrangler secret put TURSO_AUTH_TOKEN
    # When prompted, paste your authentication token
    ```

--- a/src/content/docs/workers/databases/third-party-integrations/turso.mdx
+++ b/src/content/docs/workers/databases/third-party-integrations/turso.mdx
@@ -5,16 +5,20 @@ title: Turso
 
 import { Render, PackageManagers } from "~/components";
 
-[Turso](https://turso.tech/) is an edge-hosted, distributed database based on [libSQL](https://libsql.org/), an open-source fork of SQLite. Turso was designed to minimize query latency for applications where queries come from anywhere in the world.
+[Turso](https://turso.tech/) is an edge-hosted, distributed database based on [libSQL](https://libsql.org/), an open-source fork of SQLite. Turso was designed to minimize query latency for applications where queries comes from anywhere in the world.
 
 ## Set up an integration with Turso
 
 To set up an integration with Turso:
 
-1. You need to install the Turso CLI to create and populate a database. Use one of the following two commands in your terminal to install the Turso CLI:
+1. You need to install Turso CLI to create and populate a database. Use one of the following two commands in your terminal to install the Turso CLI:
 
    ```sh
+   # On macOS and linux with homebrew
    brew install tursodatabase/tap/turso
+
+   # Manual scripted installation
+   curl -sSfL https://get.tur.so/install.sh | bash
    ```
 
    Next, run the following command to make sure the Turso CLI is installed:
@@ -85,7 +89,7 @@ To set up an integration with Turso:
    ```sh
    # Get your database URL
    turso db show my-db --url
-
+   
    # Create an authentication token
    turso db tokens create my-db
    ```
@@ -96,8 +100,8 @@ To set up an integration with Turso:
    # Add the database URL as a secret
    npx wrangler secret put TURSO_URL
    # When prompted, paste your database URL
-
-   # Add the authentication token as a secret
+   
+   # Add the authentication token as a secret  
    npx wrangler secret put TURSO_AUTH_TOKEN
    # When prompted, paste your authentication token
    ```

--- a/src/content/docs/workers/databases/third-party-integrations/turso.mdx
+++ b/src/content/docs/workers/databases/third-party-integrations/turso.mdx
@@ -5,39 +5,54 @@ title: Turso
 
 import { Render, PackageManagers } from "~/components";
 
-[Turso](https://turso.tech/) is an in-process SQL database, compatible with SQLite. The [tursodatabase/turso](https://github.com/tursodatabase/turso) project provides a CLI (`tursodb`) for managing local database files and a client library for use in Workers.
+[Turso](https://turso.tech/) is an edge-hosted, distributed database based on [libSQL](https://libsql.org/), an open-source fork of SQLite. Turso was designed to minimize query latency for applications where queries come from anywhere in the world.
 
 ## Set up an integration with Turso
 
 To set up an integration with Turso:
 
-1. You need to install the Turso CLI to create and populate a database. Use one of the following commands in your terminal:
+1. You need to install the Turso CLI to create and populate a database. Use one of the following two commands in your terminal to install the Turso CLI:
 
    ```sh
-   # On macOS with Homebrew
-   brew install turso
-
-   # On macOS, Linux, or Windows (WSL) using the installer script
-   curl --proto '=https' --tlsv1.2 -LsSf \
-     https://github.com/tursodatabase/turso/releases/latest/download/turso_cli-installer.sh | sh
+   brew install tursodatabase/tap/turso
    ```
 
    Next, run the following command to make sure the Turso CLI is installed:
 
    ```sh
-   tursodb --version
+   turso --version
    ```
 
-2. Open the Turso interactive shell by running:
+2. Before you create your first Turso database, you have to authenticate with your GitHub account by running:
 
    ```sh
-   tursodb
+   turso auth login
    ```
 
-   This starts an in-memory database session. To work with a persistent database file, pass a filename:
+   ```sh output
+   Waiting for authentication...
+   ✔  Success! Logged in as <YOUR_GITHUB_USERNAME>
+   ```
+
+   After you have authenticated, you can create a database using the command `turso db create <DATABASE_NAME>`. Turso will create a database and automatically choose a location closest to you.
 
    ```sh
-   tursodb my-db.db
+   turso db create my-db
+   ```
+
+   ```sh output
+
+   # Example:
+   Creating database my-db in Amsterdam, Netherlands (ams)
+
+   # Once succeeded:
+   Created database my-db in Amsterdam, Netherlands (ams) in 13 seconds.
+   ```
+
+   With the first database created, you can now connect to it directly and execute SQL queries against it.
+
+   ```sh
+   turso db shell my-db
    ```
 
 3. Copy the following SQL query into the shell you just opened:
@@ -63,16 +78,26 @@ To set up an integration with Turso:
      (10, 'Neon', 10, 'Ne');
    ```
 
-4. Configure the database connection in your Worker:
+4. Configure the Turso database credentials in your Worker:
 
-   The `@libsql/client` library connects using a URL. For a local file, use a `file:` URL. If you are using [Turso Cloud](https://turso.tech/), get your remote database URL and authentication token from the Turso dashboard, then add them as secrets:
+   You need to add your Turso database URL and authentication token as secrets to your Worker. First, get your database URL and create an authentication token:
+
+   ```sh
+   # Get your database URL
+   turso db show my-db --url
+
+   # Create an authentication token
+   turso db tokens create my-db
+   ```
+
+   Then add these as secrets to your Worker using Wrangler:
 
    ```sh
    # Add the database URL as a secret
    npx wrangler secret put TURSO_URL
-   # When prompted, paste your database URL (e.g. libsql://my-db-<username>.turso.io or file:my-db.db)
+   # When prompted, paste your database URL
 
-   # Add the authentication token as a secret (required for Turso Cloud remote databases)
+   # Add the authentication token as a secret
    npx wrangler secret put TURSO_AUTH_TOKEN
    # When prompted, paste your authentication token
    ```

--- a/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
+++ b/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
@@ -94,7 +94,7 @@ In the shell you just opened, paste in the following SQL:
 
 ```sql
 create table example_users (email text);
-insert into example_users values ("foo@bar.com");
+insert into example_users values ('foo@bar.com');
 ```
 
 If the SQL statements succeeded, there will be no output. Note that the trailing semi-colons (`;`) are necessary to terminate each SQL statement.

--- a/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
+++ b/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
@@ -1,5 +1,5 @@
 ---
-reviewed: 2023-04-01
+reviewed: 2026-03-26
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Connect to and query your Turso database using Workers
@@ -7,7 +7,7 @@ tags:
   - TypeScript
   - SQL
 description: >-
-  This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and Turso, an edge-hosted distributed database based on libSQL.
+  This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and Turso, an in-process SQL database compatible with SQLite.
 ---
 
 import { Render, PackageManagers, WranglerConfig } from "~/components";

--- a/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
+++ b/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
@@ -7,12 +7,12 @@ tags:
   - TypeScript
   - SQL
 description: >-
-  This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and Turso, an in-process SQL database compatible with SQLite.
+  This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and Turso, an edge-hosted distributed database based on libSQL.
 ---
 
 import { Render, PackageManagers, WranglerConfig } from "~/components";
 
-This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and [Turso](https://turso.tech/), an in-process SQL database compatible with SQLite. By using Workers and Turso, you can create applications that are close to your end users without having to maintain or operate infrastructure in tens or hundreds of regions.
+This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and [Turso](https://turso.tech/), an edge-hosted distributed database based on libSQL. By using Workers and Turso, you can create applications that are close to your end users without having to maintain or operate infrastructure in tens or hundreds of regions.
 
 :::note
 
@@ -26,6 +26,7 @@ Before continuing with this tutorial, you should have:
 
 - Successfully [created your first Cloudflare Worker](/workers/get-started/guide/) and/or have deployed a Cloudflare Worker before.
 - Installed [Wrangler](/workers/wrangler/install-and-update/), a command-line tool for building Cloudflare Workers.
+- A [GitHub account](https://github.com/), required for authenticating to Turso.
 - A basic familiarity with installing and using command-line interface (CLI) applications.
 
 ## Install the Turso CLI
@@ -33,31 +34,57 @@ Before continuing with this tutorial, you should have:
 You will need the Turso CLI to create and populate a database. Run one of the following commands in your terminal to install the Turso CLI:
 
 ```sh
-# On macOS with Homebrew
-brew install turso
-
-# On macOS, Linux, or Windows (WSL) using the installer script
-curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/tursodatabase/turso/releases/latest/download/turso_cli-installer.sh | sh
+brew install tursodatabase/tap/turso
 ```
 
-After you have installed the Turso CLI, verify the installation:
+After you have installed the Turso CLI, verify that the CLI is in your shell path:
 
 ```sh
-tursodb --version
+turso --version
+```
+
+```sh output
+# This should output your current Turso CLI version (your installed version may be higher):
+turso version v0.51.0
 ```
 
 ## Create and populate a database
 
-Open the Turso interactive shell with a persistent database file:
+Before you create your first Turso database, you need to log in to the CLI using your GitHub account by running:
 
 ```sh
-tursodb my-db.db
+turso auth login
 ```
 
-This creates `my-db.db` if it does not already exist and opens an interactive SQL prompt.
+```sh output
 
-To get started, create a table and insert some data. In this example, you will create an `example_users` table with one column: `email` (of type `text`) and then populate it with one email address.
+Waiting for authentication...
+✔  Success! Logged in as <your GitHub username>
+```
+
+`turso auth login` will open a browser window and ask you to sign into your GitHub account, if you are not already logged in. The first time you do this, you will need to give the Turso application permission to use your account. Select **Approve** to grant Turso the permissions needed.
+
+After you have authenticated, you can create a database by running `turso db create <DATABASE_NAME>`. Turso will automatically choose a location closest to you.
+
+```sh
+turso db create my-db
+```
+
+```sh output
+# Example:
+[===>                ]
+Creating database my-db in Los Angeles, California (US) (lax)
+# Once succeeded:
+Created database my-db in Los Angeles, California (US) (lax) in 34 seconds.
+```
+
+With your first database created, you can now connect to it directly and execute SQL against it:
+
+```sh
+turso db shell my-db
+```
+
+To get started with your database, create and define a schema for your first table. In this example, you will create a `example_users` table with one column: `email` (of type `text`) and then populate it with one email address.
 
 In the shell you just opened, paste in the following SQL:
 
@@ -111,8 +138,18 @@ For this tutorial, only the [Wrangler configuration file](/workers/wrangler/conf
 
 The Turso client library requires two pieces of information to make a connection:
 
-1. `LIBSQL_DB_URL` - The connection string for your Turso database. For a local file, use `file:my-db.db`. If you are using [Turso Cloud](https://turso.tech/), this is the remote URL shown in the Turso dashboard (for example, `libsql://my-db-<username>.turso.io`).
-2. `LIBSQL_DB_AUTH_TOKEN` - The authentication token for your Turso database. Required for Turso Cloud remote databases. This should be kept secret and not committed to source code.
+1. `LIBSQL_DB_URL` - The connection string for your Turso database.
+2. `LIBSQL_DB_AUTH_TOKEN` - The authentication token for your Turso database. This should be kept a secret, and not committed to source code.
+
+To get the URL for your database, run the following Turso CLI command, and copy the result:
+
+```sh
+turso db show my-db --url
+```
+
+```sh output
+libsql://my-db-<your-github-username>.turso.io
+```
 
 Open the [Wrangler configuration file](/workers/wrangler/configuration/) in your editor and at the bottom of the file, create a new `[vars]` section representing the [environment variables](/workers/configuration/environment-variables/) for your project:
 
@@ -130,7 +167,12 @@ Open the [Wrangler configuration file](/workers/wrangler/configuration/) in your
 
 Save the changes to the [Wrangler configuration file](/workers/wrangler/configuration/).
 
-If you are using a Turso Cloud remote database, create an authentication token from the Turso dashboard and copy it to your clipboard.
+Next, create a long-lived authentication token for your Worker to use when connecting to your database. Run the following Turso CLI command, and copy the output to your clipboard:
+
+```sh
+turso db tokens create my-db -e none
+# Will output a long text string (an encoded JSON Web Token)
+```
 
 To keep this token secret:
 
@@ -354,11 +396,11 @@ You have now deployed a Worker that can connect to your Turso database, query it
 To clean up the resources you created as part of this tutorial:
 
 - If you do not want to keep this Worker, run `npx wrangler delete worker-turso-ts` to delete the deployed Worker.
-- You can delete your local Turso database file by removing `my-db.db` from your project directory.
+- You can also delete your Turso database via `turso db destroy my-db`.
 
 ## Related resources
 
 - Find the [complete project source code on GitHub](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-turso-ts/).
 - Understand how to [debug your Cloudflare Worker](/workers/observability/).
 - Join the [Cloudflare Developer Discord](https://discord.cloudflare.com).
-- Join the [Turso Discord](https://tur.so/discord).
+- Join the [ChiselStrike (Turso) Discord](https://discord.com/invite/4B5D7hYwub).

--- a/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
+++ b/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
@@ -12,7 +12,7 @@ description: >-
 
 import { Render, PackageManagers, WranglerConfig } from "~/components";
 
-This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and [Turso](https://chiselstrike.com/), an edge-hosted distributed database based on libSQL. By using Workers and Turso, you can create applications that are close to your end users without having to maintain or operate infrastructure in tens or hundreds of regions.
+This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and [Turso](https://turso.tech/), an in-process SQL database compatible with SQLite. By using Workers and Turso, you can create applications that are close to your end users without having to maintain or operate infrastructure in tens or hundreds of regions.
 
 :::note
 
@@ -24,71 +24,40 @@ For a more seamless experience, refer to the [Turso Database Integration guide](
 
 Before continuing with this tutorial, you should have:
 
-- Successfully [created up your first Cloudflare Worker](/workers/get-started/guide/) and/or have deployed a Cloudflare Worker before.
+- Successfully [created your first Cloudflare Worker](/workers/get-started/guide/) and/or have deployed a Cloudflare Worker before.
 - Installed [Wrangler](/workers/wrangler/install-and-update/), a command-line tool for building Cloudflare Workers.
-- A [GitHub account](https://github.com/), required for authenticating to Turso.
 - A basic familiarity with installing and using command-line interface (CLI) applications.
 
 ## Install the Turso CLI
 
-You will need the Turso CLI to create and populate a database. Run either of the following two commands in your terminal to install the Turso CLI:
+You will need the Turso CLI to create and populate a database. Run one of the following commands in your terminal to install the Turso CLI:
 
 ```sh
-# On macOS or Linux with Homebrew
-brew install chiselstrike/tap/turso
+# On macOS with Homebrew
+brew install turso
 
-# Manual scripted installation
-curl -sSfL <https://get.tur.so/install.sh> | bash
+# On macOS, Linux, or Windows (WSL) using the installer script
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/tursodatabase/turso/releases/latest/download/turso_cli-installer.sh | sh
 ```
 
-After you have installed the Turso CLI, verify that the CLI is in your shell path:
+After you have installed the Turso CLI, verify the installation:
 
 ```sh
-turso --version
-```
-
-```sh output
-# This should output your current Turso CLI version (your installed version may be higher):
-turso version v0.51.0
+tursodb --version
 ```
 
 ## Create and populate a database
 
-Before you create your first Turso database, you need to log in to the CLI using your GitHub account by running:
+Open the Turso interactive shell with a persistent database file:
 
 ```sh
-turso auth login
+tursodb my-db.db
 ```
 
-```sh output
+This creates `my-db.db` if it does not already exist and opens an interactive SQL prompt.
 
-Waiting for authentication...
-✔  Success! Logged in as <your GitHub username>
-```
-
-`turso auth login` will open a browser window and ask you to sign into your GitHub account, if you are not already logged in. The first time you do this, you will need to give the Turso application permission to use your account. Select **Approve** to grant Turso the permissions needed.
-
-After you have authenticated, you can create a database by running `turso db create <DATABASE_NAME>`. Turso will automatically choose a location closest to you.
-
-```sh
-turso db create my-db
-```
-
-```sh output
-# Example:
-[===>                ]
-Creating database my-db in Los Angeles, California (US) (lax)
-# Once succeeded:
-Created database my-db in Los Angeles, California (US) (lax) in 34 seconds.
-```
-
-With your first database created, you can now connect to it directly and execute SQL against it:
-
-```sh
-turso db shell my-db
-```
-
-To get started with your database, create and define a schema for your first table. In this example, you will create a `example_users` table with one column: `email` (of type `text`) and then populate it with one email address.
+To get started, create a table and insert some data. In this example, you will create an `example_users` table with one column: `email` (of type `text`) and then populate it with one email address.
 
 In the shell you just opened, paste in the following SQL:
 
@@ -142,18 +111,8 @@ For this tutorial, only the [Wrangler configuration file](/workers/wrangler/conf
 
 The Turso client library requires two pieces of information to make a connection:
 
-1. `LIBSQL_DB_URL` - The connection string for your Turso database.
-2. `LIBSQL_DB_AUTH_TOKEN` - The authentication token for your Turso database. This should be kept a secret, and not committed to source code.
-
-To get the URL for your database, run the following Turso CLI command, and copy the result:
-
-```sh
-turso db show my-db --url
-```
-
-```sh output
-libsql://my-db-<your-github-username>.turso.io
-```
+1. `LIBSQL_DB_URL` - The connection string for your Turso database. For a local file, use `file:my-db.db`. If you are using [Turso Cloud](https://turso.tech/), this is the remote URL shown in the Turso dashboard (for example, `libsql://my-db-<username>.turso.io`).
+2. `LIBSQL_DB_AUTH_TOKEN` - The authentication token for your Turso database. Required for Turso Cloud remote databases. This should be kept secret and not committed to source code.
 
 Open the [Wrangler configuration file](/workers/wrangler/configuration/) in your editor and at the bottom of the file, create a new `[vars]` section representing the [environment variables](/workers/configuration/environment-variables/) for your project:
 
@@ -162,8 +121,8 @@ Open the [Wrangler configuration file](/workers/wrangler/configuration/) in your
 ```jsonc
 {
 	"vars": {
-		"LIBSQL_DB_URL": "paste-your-url-here"
-	}
+		"LIBSQL_DB_URL": "paste-your-url-here",
+	},
 }
 ```
 
@@ -171,12 +130,7 @@ Open the [Wrangler configuration file](/workers/wrangler/configuration/) in your
 
 Save the changes to the [Wrangler configuration file](/workers/wrangler/configuration/).
 
-Next, create a long-lived authentication token for your Worker to use when connecting to your database. Run the following Turso CLI command, and copy the output to your clipboard:
-
-```sh
-turso db tokens create my-db -e none
-# Will output a long text string (an encoded JSON Web Token)
-```
+If you are using a Turso Cloud remote database, create an authentication token from the Turso dashboard and copy it to your clipboard.
 
 To keep this token secret:
 
@@ -400,11 +354,11 @@ You have now deployed a Worker that can connect to your Turso database, query it
 To clean up the resources you created as part of this tutorial:
 
 - If you do not want to keep this Worker, run `npx wrangler delete worker-turso-ts` to delete the deployed Worker.
-- You can also delete your Turso database via `turso db destroy my-db`.
+- You can delete your local Turso database file by removing `my-db.db` from your project directory.
 
 ## Related resources
 
 - Find the [complete project source code on GitHub](https://github.com/cloudflare/workers-sdk/tree/main/templates/worker-turso-ts/).
 - Understand how to [debug your Cloudflare Worker](/workers/observability/).
 - Join the [Cloudflare Developer Discord](https://discord.cloudflare.com).
-- Join the [ChiselStrike (Turso) Discord](https://discord.com/invite/4B5D7hYwub).
+- Join the [Turso Discord](https://tur.so/discord).

--- a/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
+++ b/src/content/docs/workers/tutorials/connect-to-turso-using-workers.mdx
@@ -1,5 +1,5 @@
 ---
-reviewed: 2026-03-26
+reviewed: 2023-04-01
 difficulty: Beginner
 pcx_content_type: tutorial
 title: Connect to and query your Turso database using Workers
@@ -12,7 +12,7 @@ description: >-
 
 import { Render, PackageManagers, WranglerConfig } from "~/components";
 
-This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and [Turso](https://turso.tech/), an edge-hosted distributed database based on libSQL. By using Workers and Turso, you can create applications that are close to your end users without having to maintain or operate infrastructure in tens or hundreds of regions.
+This tutorial will guide you on how to build globally distributed applications with Cloudflare Workers, and [Turso](https://chiselstrike.com/), an edge-hosted distributed database based on libSQL. By using Workers and Turso, you can create applications that are close to your end users without having to maintain or operate infrastructure in tens or hundreds of regions.
 
 :::note
 
@@ -24,17 +24,21 @@ For a more seamless experience, refer to the [Turso Database Integration guide](
 
 Before continuing with this tutorial, you should have:
 
-- Successfully [created your first Cloudflare Worker](/workers/get-started/guide/) and/or have deployed a Cloudflare Worker before.
+- Successfully [created up your first Cloudflare Worker](/workers/get-started/guide/) and/or have deployed a Cloudflare Worker before.
 - Installed [Wrangler](/workers/wrangler/install-and-update/), a command-line tool for building Cloudflare Workers.
 - A [GitHub account](https://github.com/), required for authenticating to Turso.
 - A basic familiarity with installing and using command-line interface (CLI) applications.
 
 ## Install the Turso CLI
 
-You will need the Turso CLI to create and populate a database. Run one of the following commands in your terminal to install the Turso CLI:
+You will need the Turso CLI to create and populate a database. Run either of the following two commands in your terminal to install the Turso CLI:
 
 ```sh
-brew install tursodatabase/tap/turso
+# On macOS or Linux with Homebrew
+brew install chiselstrike/tap/turso
+
+# Manual scripted installation
+curl -sSfL <https://get.tur.so/install.sh> | bash
 ```
 
 After you have installed the Turso CLI, verify that the CLI is in your shell path:
@@ -158,8 +162,8 @@ Open the [Wrangler configuration file](/workers/wrangler/configuration/) in your
 ```jsonc
 {
 	"vars": {
-		"LIBSQL_DB_URL": "paste-your-url-here",
-	},
+		"LIBSQL_DB_URL": "paste-your-url-here"
+	}
 }
 ```
 


### PR DESCRIPTION
### Summary

"foo@bar.com" is an identifier not a string.

```
→  insert into example_users values ("foo@bar.com");
Error: failed to execute SQL:
SQLite input error: no such column: foo@bar.com (at offset 34)
```

updated to single quotes.

Replaces #28698 which I closed accidentally :sweat_smile: 