### PR TITLE
Browser Rendering: Increase REST API rate limit to 600/min (10/sec)

### DIFF
--- a/src/content/docs/browser-rendering/limits.mdx
+++ b/src/content/docs/browser-rendering/limits.mdx
@@ -39,7 +39,7 @@ If you are on a Workers Paid plan and you want to increase your limits beyond th
 | Concurrent browsers per account  (Workers Bindings only) [^1] | 30 per account ([See pricing](/browser-rendering/pricing/)) |
 | New browser instances per minute (Workers Bindings only) | 30 per minute   |
 | Browser timeout                                          | 60 seconds [^2] |
-| Total requests per min (REST API only) [^3]              | 180 per minute (3 per second)  |
+| Total requests per min (REST API only) [^3]              | 600 per minute (10 per second)  |
 
 [^1]: Browsers close upon task completion or sixty seconds of inactivity (if you do not [extend your browser timeout](#can-i-increase-the-browser-timeout)). Therefore, in practice, many workflows do not require a high number of concurrent browsers.
 

--- a/src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx
+++ b/src/content/docs/queues/tutorials/web-crawler-with-browser-rendering/index.mdx
@@ -174,7 +174,7 @@ Then, in your Wrangler file, add the following:
 
 </WranglerConfig>
 
-Adding the `max_batch_timeout` of 60 seconds to the consumer queue is important because Browser Rendering has a limit of two new browsers per minute per account. This timeout waits up to a minute before collecting queue messages into a batch. The Worker will then remain under this browser invocation limit.
+Adding the `max_batch_timeout` of 60 seconds to the consumer queue is important because it allows the Queue to collect messages into a batch over a longer period. This helps manage Browser Rendering rate limits and can improve efficiency by processing multiple URLs in a single batch with one browser instance.
 
 Your final Wrangler file should look similar to the one below.
 

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,6 +3,10 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
+  - publish_date: "2026-03-XX"
+    title: "Increased REST API rate limits"
+    description: |-
+      * Increased [REST API rate limits](/browser-rendering/limits/#workers-paid) for Workers Paid plans from 180 requests per minute (3 per second) to **600 requests per minute (10 per second)**. No action is needed to benefit from the higher limits.
   - publish_date: "2026-02-26"
     title: "New tutorial: Generate OG images for Astro sites"
     description: |-


### PR DESCRIPTION
Increases the REST API rate limit for Workers Paid plans from 180 requests per minute (3 per second) to 600 requests per minute (10 per second).

## Changes
- **limits.mdx**: Updated Workers Paid REST API limit from 180/min to 600/min
- **browser-rendering.yaml**: Added changelog entry for the limit increase

## Context
This is the first phase of a broader limit increase. Workers Binding limits (concurrent browsers, new browsers/min) and the per-second wording change will come in a follow-up PR.

Do not merge until the limit change is deployed.