### PR TITLE
Browser Rendering: Increase REST API rate limit to 600/min (10/sec)

### DIFF
--- a/src/content/docs/browser-rendering/limits.mdx
+++ b/src/content/docs/browser-rendering/limits.mdx
@@ -39,7 +39,7 @@ If you are on a Workers Paid plan and you want to increase your limits beyond th
 | Concurrent browsers per account  (Workers Bindings only) [^1] | 30 per account ([See pricing](/browser-rendering/pricing/)) |
 | New browser instances per minute (Workers Bindings only) | 30 per minute   |
 | Browser timeout                                          | 60 seconds [^2] |
-| Total requests per min (REST API only) [^3]              | 180 per minute (3 per second)  |
+| Total requests per min (REST API only) [^3]              | 600 per minute (10 per second)  |
 
 [^1]: Browsers close upon task completion or sixty seconds of inactivity (if you do not [extend your browser timeout](#can-i-increase-the-browser-timeout)). Therefore, in practice, many workflows do not require a high number of concurrent browsers.
 

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,7 +3,7 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
-  - publish_date: "2026-03-XX"
+  - publish_date: "2026-03-03"
     title: "Increased REST API rate limits"
     description: |-
       * Increased [REST API rate limits](/browser-rendering/limits/#workers-paid) for Workers Paid plans from 180 requests per minute (3 per second) to **600 requests per minute (10 per second)**. No action is needed to benefit from the higher limits.

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -6,7 +6,7 @@ entries:
   - publish_date: "2026-03-03"
     title: "Increased REST API rate limits"
     description: |-
-      * Increased [REST API rate limits](/browser-rendering/limits/#workers-paid) for Workers Paid plans from 180 requests per minute (3 per second) to **600 requests per minute (10 per second)**. No action is needed to benefit from the higher limits.
+      * Increased [REST API rate limits](/browser-rendering/limits/#workers-paid) for Workers Paid plans from 180 requests per minute (3 per second) to 600 requests per minute (10 per second). No action is needed to benefit from the higher limits.
   - publish_date: "2026-02-26"
     title: "New tutorial: Generate OG images for Astro sites"
     description: |-

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,7 +3,7 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
-  - publish_date: "2026-03-03"
+  - publish_date: "2026-03-04"
     title: "Increased REST API rate limits"
     description: |-
       * Increased [REST API rate limits](/browser-rendering/limits/#workers-paid) for Workers Paid plans from 180 requests per minute (3 per second) to 600 requests per minute (10 per second). No action is needed to benefit from the higher limits.

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,6 +3,10 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
+  - publish_date: "2026-03-XX"
+    title: "Increased REST API rate limits"
+    description: |-
+      * Increased [REST API rate limits](/browser-rendering/limits/#workers-paid) for Workers Paid plans from 180 requests per minute (3 per second) to **600 requests per minute (10 per second)**. No action is needed to benefit from the higher limits.
   - publish_date: "2026-02-26"
     title: "New tutorial: Generate OG images for Astro sites"
     description: |-


### PR DESCRIPTION
Increases the REST API rate limit for Workers Paid plans from 180 requests per minute (3 per second) to 600 requests per minute (10 per second).

## Changes
- **limits.mdx**: Updated Workers Paid REST API limit from `180 per minute (3 per second)` to `600 per minute (10 per second)`
- **browser-rendering.yaml**: Added changelog entry for the limit increase

## Notes
- **Do not merge until the limit change is deployed by eng.** Update `publish_date` from `2026-03-XX` to the actual deploy date before merging.
- Workers Binding limits (concurrent browsers, new browsers/min) and the per-second wording change will come in a follow-up PR.