### PR TITLE
[Registrar] Improve domain transfer guide with missing steps and troubleshooting

### DIFF
--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -164,17 +164,17 @@ Registrants transferring a `.us` domain will always receive a FOA email.
 
 ## Transfer from website builders
 
-Some website builder platforms (such as Wix, Squarespace, and Shopify) act as both your hosting provider and domain registrar. These platforms typically do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer is not possible.
+Some website builder platforms (such as Block, Shopify, Squarespace, and Wix) act as both your hosting provider and domain registrar. These platforms typically do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer is not possible.
 
-The workaround is to transfer through an intermediate registrar:
+The workaround is to transfer your domain to another registrar first, wait 60 days, then transfer to Cloudflare:
 
 1. **Get your authorization code from the website builder.** Each platform has a different process. Refer to your platform documentation for instructions on transferring your domain away.
-2. **Transfer to an intermediate registrar** that allows nameserver changes. Enter the authorization code there and complete the transfer. This usually takes 3-5 days.
-3. **Update nameservers to Cloudflare.** Once the domain is at the intermediate registrar, update the nameservers to Cloudflare. You can use all of Cloudflare features (CDN, DNS, security) immediately after this step.
+2. **Transfer to another registrar** that allows nameserver changes. Enter the authorization code there and complete the transfer. This usually takes 3-5 days.
+3. **Update nameservers to Cloudflare.** Once the domain is at the new registrar, update the nameservers to Cloudflare. You can use all of Cloudflare features (CDN, DNS, security) immediately after this step.
 4. **Transfer to Cloudflare Registrar after 60 days.** ICANN requires a 60-day wait between transfers. After that period, initiate the transfer to Cloudflare from the [Transfer Domains](/registrar/get-started/transfer-domain-to-cloudflare/#7-initiate-your-transfer-to-cloudflare) page.
 
 :::note
-Each transfer adds one year to your domain registration. You will pay the intermediate registrar for the first transfer, and Cloudflare for the second. These are not redundant charges — each extends your registration.
+Each transfer adds one year to your domain registration. You will pay the other registrar for the first transfer, and Cloudflare for the second. These are not redundant charges — each extends your registration.
 
 If you do not need Cloudflare as your registrar and only want to use Cloudflare DNS, CDN, and security features, you can stop after step 3.
 :::

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -66,17 +66,7 @@ Refer to the [Disable DNSSEC](/registrar/get-started/transfer-domain-to-cloudfla
 
 Most domains can be transferred with WHOIS privacy enabled. If you experience issues with your transfer, check with your current registrar to confirm WHOIS privacy is not blocking it.
 
-### 5. Request an authorization code
-
-Your new registrar needs to confirm with your old registrar that the transfer flow is authorized. To do that, your old registrar will provide an authorization code to you.
-
-:::note
-This code is often referred to as an authorization code, auth code, authinfo code, or transfer code. You will need to input that code to complete your transfer to Cloudflare. Cloudflare will use it to confirm the transfer is authentic.
-:::
-
-You do not need the authorization code right away. Cloudflare requires your domain to be added and active on Cloudflare before you can enter the code (see step 6). You will not enter it until [step 8](/registrar/get-started/transfer-domain-to-cloudflare/#8-input-your-authorization-code). Some authorization codes expire within 5-14 days depending on the registrar, so you may want to wait until your zone is active before requesting one.
-
-### 6. Add your domain to Cloudflare and activate the zone
+### 5. Add your domain to Cloudflare and activate the zone
 
 Unlike most registrars, Cloudflare requires your domain to be added and active on Cloudflare **before** you can enter your authorization code and begin the transfer. This ensures your site is protected by Cloudflare performance and security features from the moment the transfer begins. You cannot skip this step.
 
@@ -91,7 +81,7 @@ You cannot enter your authorization code or proceed with the transfer until your
 
 If your zone has been pending for more than 24 hours, verify that you updated the nameservers correctly at your current registrar.
 
-### 7. Initiate your transfer to Cloudflare
+### 6. Initiate your transfer to Cloudflare
 
 From your Cloudflare Account Home, go to the **Transfer Domains** page.
 
@@ -134,7 +124,17 @@ Sites can be unavailable to transfer for a few reasons, including:
 
 <Render file="email-verification" product="registrar" />
 
-### 8. Input your authorization code
+### 7. Request an authorization code from your current registrar
+
+Go back to your current registrar and request an authorization code for your domain. This code is also referred to as an auth code, authinfo code, or transfer code. Cloudflare will use it to confirm the transfer is authentic.
+
+:::note
+Unlike other registrars, Cloudflare does not accept your authorization code upfront. You can only enter it after your domain is active on Cloudflare (step 5) and you have initiated the transfer (step 6). Request the code now so you have it ready for the next step.
+:::
+
+Some authorization codes expire within 5-14 days depending on the registrar. Some registrars issue a new code each time one is requested, which invalidates the previous code.
+
+### 8. Input your authorization code in the Cloudflare dashboard
 
 In the next page, input the authorization code for each domain you are transferring. You also need to unlock each domain so that Cloudflare can process your request. For more information, refer to the instructions provided by your [current registrar on how to transfer your domain](/registrar/get-started/transfer-domain-to-cloudflare/#set-up-a-domain-transfer).
 
@@ -171,7 +171,7 @@ The workaround is to transfer your domain to another registrar first, wait 60 da
 1. **Get your authorization code from the website builder.** Each platform has a different process. Refer to your platform documentation for instructions on transferring your domain away.
 2. **Transfer to another registrar** that allows nameserver changes. Enter the authorization code there and complete the transfer. This usually takes 3-5 days.
 3. **Update nameservers to Cloudflare.** Once the domain is at the new registrar, update the nameservers to Cloudflare. You can use all of Cloudflare features (CDN, DNS, security) immediately after this step.
-4. **Transfer to Cloudflare Registrar after 60 days.** ICANN requires a 60-day wait between transfers. After that period, initiate the transfer to Cloudflare from the [Transfer Domains](/registrar/get-started/transfer-domain-to-cloudflare/#7-initiate-your-transfer-to-cloudflare) page.
+4. **Transfer to Cloudflare Registrar after 60 days.** ICANN requires a 60-day wait between transfers. After that period, initiate the transfer to Cloudflare from the [Transfer Domains](/registrar/get-started/transfer-domain-to-cloudflare/#6-initiate-your-transfer-to-cloudflare) page.
 
 :::note
 Each transfer adds one year to your domain registration. You will pay the other registrar for the first transfer, and Cloudflare for the second. These are not redundant charges — each extends your registration.

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -4,10 +4,10 @@ title: Transfer your domain to Cloudflare
 sidebar:
   order: 2
 description: >-
-  This page contains generic instructions on how to transfer your domain to Cloudflare.
+  Transfer a domain to Cloudflare Registrar from another registrar.
 ---
 
-import { DashButton, Render } from "~/components";
+import { DashButton, Details, Render } from "~/components";
 
 Transferring your domain to Cloudflare tells your registry that a different registrar can now set those authoritative records for you. The relationship is based on trust. Registries only trust one registrar at any given time to make changes on your behalf.
 
@@ -52,21 +52,46 @@ Registrars include a lightweight safeguard to prevent unauthorized users from st
 
 Only the registrant can enable or disable this lock, typically through the administration interface of the registrar. To proceed with a transfer, remove this lock if it is enabled.
 
-### 3. Remove WHOIS privacy
+:::note
+Some registrars have multiple lock types that must each be disabled separately, such as "domain lock", "transfer lock", and "privacy lock". If you have unlocked the domain but it still shows as locked, check your registrar settings for all lock and protection toggles.
+:::
 
-In most cases, domains may be transferred even if WHOIS privacy services have been enabled. However, some registrars may prohibit the transfer if the WHOIS privacy service has been enabled.
+### 3. Disable DNSSEC
 
-### 4. Request an authorization code
+If DNSSEC is enabled at your current registrar, you must disable it before transferring. An active DNSSEC configuration will block the transfer from completing.
+
+Refer to the [Disable DNSSEC](/registrar/get-started/transfer-domain-to-cloudflare/#disable-dnssec) section above for detailed steps.
+
+### 4. WHOIS privacy
+
+Most domains can be transferred with WHOIS privacy enabled. If you experience issues with your transfer, check with your current registrar to confirm WHOIS privacy is not blocking it.
+
+### 5. Request an authorization code
 
 Your new registrar needs to confirm with your old registrar that the transfer flow is authorized. To do that, your old registrar will provide an authorization code to you.
 
 :::note
-
 This code is often referred to as an authorization code, auth code, authinfo code, or transfer code. You will need to input that code to complete your transfer to Cloudflare. Cloudflare will use it to confirm the transfer is authentic.
-
 :::
 
-### 5. Initiate your transfer to Cloudflare
+You do not need the authorization code right away. Cloudflare requires your domain to be added and active on Cloudflare before you can enter the code (see step 6). You will not enter it until [step 8](/registrar/get-started/transfer-domain-to-cloudflare/#8-input-your-authorization-code). Some authorization codes expire within 5-14 days depending on the registrar, so you may want to wait until your zone is active before requesting one.
+
+### 6. Add your domain to Cloudflare and activate the zone
+
+Unlike most registrars, Cloudflare requires your domain to be added and active on Cloudflare **before** you can enter your authorization code and begin the transfer. You cannot skip this step.
+
+1. [Add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account if you have not already.
+2. Cloudflare will assign you two nameservers (for example, `ada.ns.cloudflare.com` and `paul.ns.cloudflare.com`).
+3. Go to your current registrar and [update your domain nameservers](/dns/nameservers/update-nameservers/) to the ones Cloudflare provided.
+4. Wait for your domain status to change from **Pending** to **Active** in your Cloudflare dashboard. This usually takes a few minutes but can take up to 24 hours.
+
+:::caution
+You cannot enter your authorization code or proceed with the transfer until your domain shows **Active** status. If you try while the zone is still **Pending**, the transfer page will not let you proceed.
+:::
+
+If your zone has been pending for more than 24 hours, verify that you updated the nameservers correctly at your current registrar.
+
+### 7. Initiate your transfer to Cloudflare
 
 From your Cloudflare Account Home, go to the **Transfer Domains** page.
 
@@ -74,25 +99,32 @@ From your Cloudflare Account Home, go to the **Transfer Domains** page.
 
 Cloudflare Registrar will display the zones available for transfer.
 
-You will be presented with the price for each transfer. When you transfer a domain, you are required by ICANN to pay to extend its registration by one year from the expiration date. You can remove domains from your transfer by selecting **x**.
+You will be presented with the price for each transfer. When you transfer a domain, you are required by ICANN to pay to extend its registration by one year from the expiration date.
 
 If you do not have a payment method on file, add one at this step before proceeding.
 
-You will not be billed at this step. Cloudflare will only bill your card when you input the auth code and confirm the contact information at the conclusion of your transfer request.
+:::note
+Verify your payment method is valid before submitting. A payment failure after submitting the auth code can leave the transfer in a partially started state.
+:::
 
 In some cases, premium (non-standard priced) domains may not be detected immediately. Pricing will be confirmed with the registry before submission, and you will have the opportunity to review and approve any price adjustments.
 
-In most cases, transferring a domain adds one additional year to its registration term. However, the following exceptions apply:
+<Details header="Exceptions to the one-year registration extension">
 
 - Transferring a `.uk` domain does not extend its registration by an additional year.
-- If the transfer is completed within 45 days of the domain's expiration, the extra year may not be added. This is determined by the domain's Registry.
-- If the domain already has more than nine years remaining, a full year may not be added. This is also subject to Registry policy.
+- If the transfer is completed within 45 days of the domain expiration, the extra year may not be added. This is determined by the domain registry.
+- If the domain already has more than nine years remaining, a full year may not be added. This is also subject to registry policy.
+- `.co` domains have a maximum registration period of 5 years. If a transfer would exceed this limit, it may be rejected.
+- `.ai` domains require a minimum 2-year registration for transfers.
+- Most TLDs (such as `.com`, `.net`, `.org`) allow up to 10 years of registration. You cannot exceed these limits through transfers or renewals.
+
+</Details>
 
 :::note
 
 Sites can be unavailable to transfer for a few reasons, including:
 
-- You did not [add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare.
+- You did not [add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account.
 - The site was registered in the last 60 days.
 - Cloudflare does not yet support the TLD.
 - The domain has a status that does not allow for a transfer.
@@ -102,29 +134,52 @@ Sites can be unavailable to transfer for a few reasons, including:
 
 <Render file="email-verification" product="registrar" />
 
-### 6. Input your authorization code
+### 8. Input your authorization code
 
 In the next page, input the authorization code for each domain you are transferring. You also need to unlock each domain so that Cloudflare can process your request. For more information, refer to the instructions provided by your [current registrar on how to transfer your domain](/registrar/get-started/transfer-domain-to-cloudflare/#set-up-a-domain-transfer).
 
-### 7. Confirm or input your contact information
+### 9. Confirm or input your contact information
 
 In the final stage of the transfer process, input the contact information for your registration. Cloudflare Registrar redacts this information by default but is required to collect the authentic contact information for this registration. It is important that you provide accurate WHOIS contact information. You may be required to verify the contact information. Failure to provide accurate information and/or failure to verify the information may result in suspension or deletion of your domain.
 
 You can always [modify the contact information](/registrar/account-options/domain-contact-updates/) later, if needed.
 
+:::caution
+Some TLDs have additional registrant verification requirements. For `.ca`, `.mx`, and `.nz` domains, you may receive a separate email to verify your registrant contact information after the transfer completes. Failure to complete this verification within the required timeframe may result in domain suspension.
+:::
+
 After entering the contact information, agree to the domain registration terms of service by selecting **Confirm transfer**.
 
-### 8. Approve the transfer
+### 10. Approve the transfer
 
 Once you have requested your transfer, Cloudflare will begin processing it, and send a Form of Authorization (FOA) email to the registrant, if the information is available in the public WHOIS database. The FOA is what authorizes the domain transfer.
 
-After this step, your previous registrar will also email you to confirm your request to transfer. Most registrars will include a link to confirm the transfer request. If you select that link, you can accelerate the transfer operation. If you do not act on the email, the registrar can wait up to five days to process the transfer to Cloudflare. You may also be able to approve the transfer from within your current registrar dashboard.
+After this step, your previous registrar will also email you to confirm your request to transfer. Most registrars will include a link to confirm the transfer request. If you select that link, you can accelerate the transfer operation. If you do not act on the email, most registrars will wait up to 5 business days to process the transfer to Cloudflare. Some TLDs (such as `.mx`) can take up to 10 business days. You may also be able to approve the transfer from within your current registrar dashboard.
 
 :::note
-
 Registrants transferring a `.us` domain will always receive a FOA email.
-
 :::
+
+---
+
+## Transfer from website builders
+
+Some website builder platforms (such as Wix, Squarespace, and Shopify) act as both your hosting provider and domain registrar. These platforms typically do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer is not possible.
+
+The workaround is to transfer through an intermediate registrar:
+
+1. **Get your authorization code from the website builder.** Each platform has a different process. Refer to your platform documentation for instructions on transferring your domain away.
+2. **Transfer to an intermediate registrar** that allows nameserver changes. Enter the authorization code there and complete the transfer. This usually takes 3-5 days.
+3. **Update nameservers to Cloudflare.** Once the domain is at the intermediate registrar, update the nameservers to Cloudflare. You can use all of Cloudflare features (CDN, DNS, security) immediately after this step.
+4. **Transfer to Cloudflare Registrar after 60 days.** ICANN requires a 60-day wait between transfers. After that period, initiate the transfer to Cloudflare from the [Transfer Domains](/registrar/get-started/transfer-domain-to-cloudflare/#7-initiate-your-transfer-to-cloudflare) page.
+
+:::note
+Each transfer adds one year to your domain registration. You will pay the intermediate registrar for the first transfer, and Cloudflare for the second. These are not redundant charges — each extends your registration.
+
+If you do not need Cloudflare as your registrar and only want to use Cloudflare DNS, CDN, and security features, you can stop after step 3.
+:::
+
+---
 
 ## Bulk domain transfers
 
@@ -132,12 +187,52 @@ The process for transferring domains in bulk to Cloudflare is the same process a
 
 ## Transfer statuses
 
-You can check the status of your transfer in **Account Home** > **Overview** > **Domain Registration** for your domain. Below, you can find a list of the possible transfer statuses.
+You can check the status of your transfer on the **Transfer Domains** page in the dashboard. Below, you can find a list of the possible transfer statuses.
 
 - **Transfer in progress**: Your request has been submitted by Cloudflare to your previous registrar. Cloudflare is now waiting on them to confirm they have received the request. If this status persists for more than a day (24 hours), ensure that the domain has been unlocked at your current registrar and any WHOIS privacy services have been removed.
 
 - **Pending approval**: Your current registrar has received the transfer request. They can now wait up to five days to release the domain. If you want to move faster, you can manually approve the transfer for immediate release in the dashboard of most registrars.
 
 - **Transfer rejected**: your transfer has been rejected. This can occur if you canceled the request at your current registrar instead of approving it. If you still wish to transfer, you can select **Retry** and initiate a new transfer request.
+
+---
+
+## Troubleshoot transfer issues
+
+If your transfer is stuck, failing, or taking longer than expected, check the following common causes.
+
+### Domain is still locked
+
+If `clientTransferProhibited` appears in your domain WHOIS or RDAP output, the domain is still locked. Unlock it at your current registrar.
+
+If you already unlocked the domain but WHOIS still shows it as locked, allow up to 5 hours for the change to propagate. Some registrars may take up to 24 hours. Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your registrar dashboard shows unlocked but WHOIS disagrees, contact your current registrar directly.
+
+### DNSSEC is still active
+
+Active DNSSEC at your current registrar will block the transfer. Disable DNSSEC and wait for the DS record TTL to expire (usually 24 hours) before retrying. Refer to the [Disable DNSSEC](/registrar/get-started/transfer-domain-to-cloudflare/#disable-dnssec) section.
+
+### Authorization code is invalid or expired
+
+Authorization codes typically expire within 5-14 days depending on your registrar. If your code is rejected, request a fresh one from your current registrar. Check for trailing spaces or line breaks when copy-pasting the code. Some registrars issue a new code each time one is requested, which invalidates the previous code.
+
+### Zone is not active on Cloudflare
+
+You cannot enter an authorization code until your domain shows **Active** status in the Cloudflare dashboard. If the zone is still **Pending**, verify that you updated nameservers correctly at your current registrar and wait up to 24 hours.
+
+### Domain was recently registered or transferred
+
+ICANN rules prohibit transfers within 60 days of registration or a previous transfer. Check the domain creation date and last transfer date in WHOIS.
+
+### Domain is in a restricted status
+
+Domains with a status of `clientHold`, `serverHold`, `redemptionPeriod`, or `pendingDelete` cannot be transferred. Resolve the issue with your current registrar before retrying.
+
+### Payment failed during transfer
+
+If your payment method was declined after submitting the authorization code, the transfer may be in a partially started state. Update your payment method in your Cloudflare billing settings and check the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page for the current status.
+
+### Transfer is taking too long
+
+Domain transfers typically take 3-5 business days. Some TLDs (such as `.mx`) can take up to 10 days. You can speed up the process by approving the transfer at your current registrar when you receive the confirmation email. If the transfer has been stuck beyond these timeframes with no identifiable issue, contact your current registrar to confirm there are no holds or restrictions on their end.
 
 <Render file="next-steps" product="registrar" />

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -78,7 +78,7 @@ You do not need the authorization code right away. Cloudflare requires your doma
 
 ### 6. Add your domain to Cloudflare and activate the zone
 
-Unlike most registrars, Cloudflare requires your domain to be added and active on Cloudflare **before** you can enter your authorization code and begin the transfer. You cannot skip this step.
+Unlike most registrars, Cloudflare requires your domain to be added and active on Cloudflare **before** you can enter your authorization code and begin the transfer. This ensures your site is protected by Cloudflare performance and security features from the moment the transfer begins. You cannot skip this step.
 
 1. [Add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account if you have not already.
 2. Cloudflare will assign you two nameservers (for example, `ada.ns.cloudflare.com` and `paul.ns.cloudflare.com`).

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -197,42 +197,6 @@ You can check the status of your transfer on the **Transfer Domains** page in th
 
 ---
 
-## Troubleshoot transfer issues
-
-If your transfer is stuck, failing, or taking longer than expected, check the following common causes.
-
-### Domain is still locked
-
-If `clientTransferProhibited` appears in your domain WHOIS or RDAP output, the domain is still locked. Unlock it at your current registrar.
-
-If you already unlocked the domain but WHOIS still shows it as locked, allow up to 5 hours for the change to propagate. Some registrars may take up to 24 hours. Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your registrar dashboard shows unlocked but WHOIS disagrees, contact your current registrar directly.
-
-### DNSSEC is still active
-
-Active DNSSEC at your current registrar will block the transfer. Disable DNSSEC and wait for the DS record TTL to expire (usually 24 hours) before retrying. Refer to the [Disable DNSSEC](/registrar/get-started/transfer-domain-to-cloudflare/#disable-dnssec) section.
-
-### Authorization code is invalid or expired
-
-Authorization codes typically expire within 5-14 days depending on your registrar. If your code is rejected, request a fresh one from your current registrar. Check for trailing spaces or line breaks when copy-pasting the code. Some registrars issue a new code each time one is requested, which invalidates the previous code.
-
-### Zone is not active on Cloudflare
-
-You cannot enter an authorization code until your domain shows **Active** status in the Cloudflare dashboard. If the zone is still **Pending**, verify that you updated nameservers correctly at your current registrar and wait up to 24 hours.
-
-### Domain was recently registered or transferred
-
-ICANN rules prohibit transfers within 60 days of registration or a previous transfer. Check the domain creation date and last transfer date in WHOIS.
-
-### Domain is in a restricted status
-
-Domains with a status of `clientHold`, `serverHold`, `redemptionPeriod`, or `pendingDelete` cannot be transferred. Resolve the issue with your current registrar before retrying.
-
-### Payment failed during transfer
-
-If your payment method was declined after submitting the authorization code, the transfer may be in a partially started state. Update your payment method in your Cloudflare billing settings and check the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page for the current status.
-
-### Transfer is taking too long
-
-Domain transfers typically take 3-5 business days. Some TLDs (such as `.mx`) can take up to 10 days. You can speed up the process by approving the transfer at your current registrar when you receive the confirmation email. If the transfer has been stuck beyond these timeframes with no identifiable issue, contact your current registrar to confirm there are no holds or restrictions on their end.
+If your transfer is stuck or failing, refer to [Troubleshoot failed domain transfers](/registrar/troubleshooting/).
 
 <Render file="next-steps" product="registrar" />

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -29,13 +29,9 @@ Authorization codes typically expire within 5-14 days depending on your registra
 
 ## Cannot find where to enter your authorization code
 
-Unlike some registrars, Cloudflare does not allow you to submit an authorization code upfront. You must first [add your domain](/fundamentals/manage-domains/add-site/) to Cloudflare, [update your nameservers](/dns/nameservers/update-nameservers/), and wait for the zone to show **Active** status in the Cloudflare dashboard. Only then will the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page allow you to enter your code.
+Unlike some registrars, Cloudflare does not allow you to submit an authorization code upfront. Cloudflare requires your domain to be active on its network first so that your site benefits from Cloudflare performance and security features from the moment the transfer begins. You must first [add your domain](/fundamentals/manage-domains/add-site/) to Cloudflare, [update your nameservers](/dns/nameservers/update-nameservers/), and wait for the zone to show **Active** status in the Cloudflare dashboard. Only then will the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page allow you to enter your code.
 
-If you already have an authorization code, keep in mind that most codes expire within 5-14 days depending on the registrar. If your code expires while you wait for the zone to activate, request a new one from your current registrar before proceeding.
-
-## Zone is not active on Cloudflare
-
-You cannot enter an authorization code until your domain shows **Active** status in the Cloudflare dashboard. If the zone is still **Pending**, verify that you updated nameservers correctly at your current registrar and wait up to 24 hours.
+If your zone is still **Pending**, verify that you updated nameservers correctly at your current registrar and wait up to 24 hours. If you already have an authorization code, keep in mind that most codes expire within 5-14 days depending on the registrar. If your code expires while you wait for the zone to activate, request a new one from your current registrar before proceeding.
 
 ## Transfer rejected
 

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -13,33 +13,58 @@ After you start the transfer process to Cloudflare Registrar, your previous regi
 
 Most issues with a stalled transfer can be solved by checking the following details and [restarting the transfer](#restart-your-transfer).
 
-## Registrar lock reapplied
+## Domain is still locked
 
-You have reapplied the registrar lock at your current registrar since requesting the transfer. You will need to remove it again to restart the transfer process.
+If `clientTransferProhibited` appears in your domain WHOIS or RDAP output, the domain is still locked. Unlock it at your current registrar. If you reapplied the registrar lock after requesting the transfer, you will need to remove it again to restart the transfer process.
+
+If you already unlocked the domain but WHOIS still shows it as locked, allow up to 5 hours for the change to propagate. Some registrars may take up to 24 hours. Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your registrar dashboard shows unlocked but WHOIS disagrees, contact your current registrar directly.
+
+## DNSSEC is still active
+
+Active DNSSEC at your current registrar will block the transfer. Disable DNSSEC and wait for the DS record TTL to expire (usually 24 hours) before retrying. Refer to [Disable DNSSEC](/registrar/get-started/transfer-domain-to-cloudflare/#disable-dnssec) for detailed steps.
+
+## Authorization code is invalid or expired
+
+Authorization codes typically expire within 5-14 days depending on your registrar. If your code is rejected, request a fresh one from your current registrar. Check for trailing spaces or line breaks when copy-pasting the code. Some registrars issue a new code each time one is requested, which invalidates the previous code.
+
+## Zone is not active on Cloudflare
+
+You cannot enter an authorization code until your domain shows **Active** status in the Cloudflare dashboard. If the zone is still **Pending**, verify that you updated nameservers correctly at your current registrar and wait up to 24 hours.
 
 ## Transfer rejected
 
 Your transfer has been rejected by your previous registrar. There are several reasons for this to happen:
 
-* You actively rejected the transfer request in the email you received from your registrar or on your registrar's interface.
+* You actively rejected the transfer request in the email you received from your registrar or on your registrar interface.
 * Your registrar determined the domain is not eligible for transfer.
 * Some registrars allow customers to enable a setting to reject all transfer requests.
 * In some instances, registrars may reject the transfer if they suspect malicious behavior.
 
-You will need to restart the transfer and approve the request or contact your current registrar to solve this issue.
+You will need to restart the transfer and approve the request or contact your current registrar to resolve this issue.
 
-## Auth code invalid
+## Domain was recently registered or transferred
 
-Your auth code (also referred to as authentication code and authorization code) has since changed or been deprecated, and Cloudflare cannot complete the transfer. Confirm the code with your current registrar again. To avoid mistakes, copy and paste the auth code provided by your current registrar.
+ICANN rules prohibit transfers within 60 days of registration or a previous transfer. Check the domain creation date and last transfer date in WHOIS.
 
-## WHOIS Guard / privacy protection
+## Domain is in a restricted status
 
-Some registrars may prohibit transfer requests if you have WHOIS privacy services enabled. You need to first disable those services at your current registrar before you can proceed with the transfer process.
+Domains with a status of `clientHold`, `serverHold`, `redemptionPeriod`, or `pendingDelete` cannot be transferred. Resolve the issue with your current registrar before retrying.
+
+## WHOIS privacy is blocking the transfer
+
+Most domains can be transferred with WHOIS privacy enabled. However, some registrars may prohibit transfer requests if you have WHOIS privacy services enabled. If your transfer is failing, check with your current registrar to confirm WHOIS privacy is not blocking it.
+
+## Payment failed during transfer
+
+If your payment method was declined after submitting the authorization code, the transfer may be in a partially started state. Update your payment method in your Cloudflare billing settings and check the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page for the current status.
+
+## Transfer is taking too long
+
+Domain transfers typically take 3-5 business days. Some TLDs (such as `.mx`) can take up to 10 days. You can speed up the process by approving the transfer at your current registrar when you receive the confirmation email. If the transfer has been stuck beyond these timeframes with no identifiable issue, contact your current registrar to confirm there are no holds or restrictions on their end.
 
 ## Restart your transfer
 
 :::note
-
 This solution does not apply to `.uk` domains.
 :::
 

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -62,6 +62,10 @@ If your payment method was declined after submitting the authorization code, the
 
 Domain transfers typically take 3-5 business days. Some TLDs (such as `.mx`) can take up to 10 days. You can speed up the process by approving the transfer at your current registrar when you receive the confirmation email. If the transfer has been stuck beyond these timeframes with no identifiable issue, contact your current registrar to confirm there are no holds or restrictions on their end.
 
+## Cannot update nameservers at your current registrar
+
+Some website builder platforms (such as Block, Shopify, Squarespace, and Wix) do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer from these platforms is not possible. For the recommended workaround, refer to [Transfer from website builders](/registrar/get-started/transfer-domain-to-cloudflare/#transfer-from-website-builders).
+
 ## Restart your transfer
 
 :::note

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -27,6 +27,12 @@ Active DNSSEC at your current registrar will block the transfer. Disable DNSSEC 
 
 Authorization codes typically expire within 5-14 days depending on your registrar. If your code is rejected, request a fresh one from your current registrar. Check for trailing spaces or line breaks when copy-pasting the code. Some registrars issue a new code each time one is requested, which invalidates the previous code.
 
+## Authorization code expired before you could use it
+
+Cloudflare does not ask for your authorization code until your domain is added and active on Cloudflare. If you requested the code before updating your nameservers, it may expire while you wait for the zone to become active. Authorization codes typically expire within 5-14 days depending on the registrar.
+
+To avoid this, wait until your domain shows **Active** status in the Cloudflare dashboard before requesting an authorization code from your current registrar. If your code has already expired, request a new one.
+
 ## Zone is not active on Cloudflare
 
 You cannot enter an authorization code until your domain shows **Active** status in the Cloudflare dashboard. If the zone is still **Pending**, verify that you updated nameservers correctly at your current registrar and wait up to 24 hours.

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -27,11 +27,11 @@ Active DNSSEC at your current registrar will block the transfer. Disable DNSSEC 
 
 Authorization codes typically expire within 5-14 days depending on your registrar. If your code is rejected, request a fresh one from your current registrar. Check for trailing spaces or line breaks when copy-pasting the code. Some registrars issue a new code each time one is requested, which invalidates the previous code.
 
-## Authorization code expired before you could use it
+## Cannot find where to enter your authorization code
 
-Cloudflare does not ask for your authorization code until your domain is added and active on Cloudflare. If you requested the code before updating your nameservers, it may expire while you wait for the zone to become active. Authorization codes typically expire within 5-14 days depending on the registrar.
+Unlike some registrars, Cloudflare does not allow you to submit an authorization code upfront. You must first [add your domain](/fundamentals/manage-domains/add-site/) to Cloudflare, [update your nameservers](/dns/nameservers/update-nameservers/), and wait for the zone to show **Active** status in the Cloudflare dashboard. Only then will the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page allow you to enter your code.
 
-To avoid this, wait until your domain shows **Active** status in the Cloudflare dashboard before requesting an authorization code from your current registrar. If your code has already expired, request a new one.
+If you already have an authorization code, keep in mind that most codes expire within 5-14 days depending on the registrar. If your code expires while you wait for the zone to activate, request a new one from your current registrar before proceeding.
 
 ## Zone is not active on Cloudflare
 


### PR DESCRIPTION
Rewrites the "Transfer your domain to Cloudflare" page to address gaps identified by comparing it against the internal support knowledge base. Users were getting stuck because the page did not explain that zones must be active before entering an auth code, and common failure scenarios had no troubleshooting guidance.

- **New step 3 (Disable DNSSEC)**: Surfaced directly in the numbered flow instead of buried in a partial
- **New step 6 (Add domain and activate zone)**: Explains that Cloudflare requires an Active zone before you can enter an auth code — the biggest gap in the original page
- **Step 4 (WHOIS privacy)**: Simplified — most transfers work with privacy enabled, only check if issues arise
- **Step 5 (Auth code)**: Added note that code is not needed immediately, with link forward to step 8 and expiration warning
- **Step 7 (Initiate transfer)**: Added payment failure warning, moved registration year exceptions into collapsible `<Details>` with new entries (`.co` 5-year max, `.ai` 2-year minimum, 10-year general limit)
- **Step 9 (Contact info)**: Added caution about `.ca`, `.mx`, `.nz` registrant verification emails
- **Step 10 (Approve transfer)**: Clarified timing — most registrars wait up to 5 business days, some TLDs (`.mx`) up to 10
- **New section: Transfer from website builders** — Wix/Squarespace/Shopify intermediate registrar workaround (no competing registrar names)
- **New section: Troubleshoot transfer issues** — 8 common failure scenarios (locked domain, DNSSEC still active, invalid auth code, zone not active, 60-day lock, restricted status, payment failure, slow transfer)
- **Transfer statuses intro**: Updated stale dashboard navigation path
- Removed outdated lines ("select **x** to remove domains", "You will not be billed at this step")
- Steps renumbered from 1–8 → 1–10