### PR TITLE
docs(cache): add Cache Response Rules documentation

### DIFF
--- a/src/content/docs/cache/concepts/cdn-cache-control.mdx
+++ b/src/content/docs/cache/concepts/cdn-cache-control.mdx
@@ -10,7 +10,9 @@ pcx_content_type: concept
 
 You have several options available to determine how `CDN-Cache-Control` directives interact with `Cache-Control` directives.
 
-An origin can:
+If a [Cache Response Rule](/cache/how-to/cache-response-rules/) sets `Cache-Control` directives using the `set_cache_control` action, those directives take precedence over any origin-set `Cloudflare-CDN-Cache-Control` and `CDN-Cache-Control` headers.
+
+When no Cache Response Rule applies, an origin can:
 
 * Return the `CDN-Cache-Control` response header which Cloudflare evaluates to make caching decisions. `Cache-Control`, if also returned by the origin, is proxied as is and does not affect caching decisions made by Cloudflare. Additionally, `CDN-Cache-Control` is proxied downstream in case there are other CDNs between Cloudflare and the browser.
 

--- a/src/content/docs/cache/how-to/cache-response-rules/create-api.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/create-api.mdx
@@ -1,0 +1,240 @@
+---
+title: Create a rule via API
+pcx_content_type: how-to
+sidebar:
+  order: 4
+head:
+  - tag: title
+    content: Create a Cache Response Rule via API
+---
+
+import { Details, APIRequest } from "~/components";
+
+Use the [Rulesets API](/ruleset-engine/rulesets-api/) to create a Cache Response Rule via API. To configure the Cloudflare API, refer to the [API documentation](/fundamentals/api/get-started/).
+
+## Basic rule settings
+
+When creating a Cache Response Rule via API, make sure you:
+
+- Set the rule action to one of the [available actions](/cache/how-to/cache-response-rules/settings/#available-actions).
+- Define the parameters in the `action_parameters` field according to the [settings](/cache/how-to/cache-response-rules/settings/) you wish to configure for matching responses.
+- Deploy the rule to the `http_response_cache_settings` phase entry point ruleset.
+
+## Procedure
+
+1. Use the [List zone rulesets](/api/resources/rulesets/methods/list/) method to check if a ruleset already exists for the `http_response_cache_settings` phase.
+2. If the phase ruleset does not exist, create it using the [Create a zone ruleset](/api/resources/rulesets/methods/create/) operation. In the new ruleset properties, set the following values:
+   - kind: `zone`
+   - phase: `http_response_cache_settings`
+3. Use the [Update a zone ruleset](/api/resources/rulesets/methods/update/) operation to add rules to the ruleset. Alternatively, include the rules in the [Create a zone ruleset](/api/resources/rulesets/methods/create/) request mentioned in the previous step.
+
+## Example requests
+
+These examples demonstrate all the available actions in Cache Response Rules using request and response matching criteria. Using these examples directly will cause any existing rules in the phase to be replaced.
+
+<Details header="Example: Strip response headers from JS files before caching">
+
+<APIRequest
+  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  method="PUT"
+  json={{
+    rules: [
+      {
+        expression: 'http.request.uri.path.extension eq "js"',
+        description: "Strip caching headers from JS files",
+        action: "set_cache_settings",
+        action_parameters: {
+          strip_etags: true,
+          strip_set_cookie: true,
+          strip_last_modified: true
+        }
+      }
+    ]
+  }}
+  roles={false}
+/>
+
+</Details>
+
+<Details header="Example: Set static cache tags on API responses">
+
+<APIRequest
+  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  method="PUT"
+  json={{
+    rules: [
+      {
+        expression: 'http.request.uri.path starts_with "/api/"',
+        description: "Tag API responses for targeted purging",
+        action: "set_cache_tags",
+        action_parameters: {
+          operation: "set",
+          values: ["api-response", "dynamic-content"]
+        }
+      }
+    ]
+  }}
+  roles={false}
+/>
+
+</Details>
+
+<Details header="Example: Add cache tags from a response header using an expression">
+
+<APIRequest
+  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  method="PUT"
+  json={{
+    rules: [
+      {
+        expression: 'any(http.response.headers.names[*] == "Surrogate-Keys")',
+        description: "Extract cache tags from alternative CDN response header",
+        action: "set_cache_tags",
+        action_parameters: {
+          operation: "add",
+          expression: 'split(http.response.headers["Surrogate-Keys"][0], ",", 1)'
+        }
+      }
+    ]
+  }}
+  roles={false}
+/>
+
+</Details>
+
+<Details header="Example: Override cache-control with max-age ">
+
+<APIRequest
+  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  method="PUT"
+  json={{
+    rules: [
+      {
+        expression: "http.response.code eq 200",
+        description: "Override cache-control for successful responses",
+        action: "set_cache_control",
+        action_parameters: {
+          "max-age": {
+            operation: "set",
+            value: 3600,
+            cloudflare_only: true
+          },
+        }
+      }
+    ]
+  }}
+  roles={false}
+/>
+
+</Details>
+
+<Details header="Example: Set private directive with qualifiers">
+
+<APIRequest
+  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  method="PUT"
+  json={{
+    rules: [
+      {
+        expression: 'http.request.uri.path starts_with "/user/"',
+        description: "Mark user content as private",
+        action: "set_cache_control",
+        action_parameters: {
+          "private": {
+            operation: "set",
+            qualifiers: ["X-User-Id", "X-Session-Token"]
+          },
+          "no-cache": {
+            operation: "set"
+          }
+        }
+      }
+    ]
+  }}
+  roles={false}
+/>
+
+</Details>
+
+<Details header="Example: Set immutable for static font assets">
+
+<APIRequest
+  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  method="PUT"
+  json={{
+    rules: [
+      {
+        expression: 'http.request.uri.path.extension in {"woff2" "woff" "ttf"}',
+        description: "Mark fonts as immutable",
+        action: "set_cache_control",
+        action_parameters: {
+          "immutable": {
+            operation: "set"
+          },
+          "max-age": {
+            operation: "set",
+            value: 31536000
+          }
+        }
+      }
+    ]
+  }}
+  roles={false}
+/>
+
+</Details>
+
+<Details header="Example: Multiple rules — strip headers, tag responses, and set cache control">
+
+<APIRequest
+  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  method="PUT"
+  json={{
+    rules: [
+      {
+        expression: 'http.response.code eq 200 and http.request.uri.path.extension eq "html"',
+        description: "Strip tracking headers from HTML responses",
+        action: "set_cache_settings",
+        action_parameters: {
+          strip_etags: true,
+          strip_set_cookie: true
+        }
+      },
+      {
+        expression: 'http.request.uri.path starts_with "/products/"',
+        description: "Tag product pages for purging",
+        action: "set_cache_tags",
+        action_parameters: {
+          operation: "add",
+          values: ["product-catalog", "storefront"]
+        }
+      },
+      {
+        expression: "http.response.code eq 200",
+        description: "Set cache control for all 200 responses",
+        action: "set_cache_control",
+        action_parameters: {
+          "s-maxage": {
+            operation: "set",
+            value: 86400,
+            cloudflare_only: true
+          },
+          "must-revalidate": {
+            operation: "set"
+          }
+        }
+      }
+    ]
+  }}
+  roles={false}
+/>
+
+</Details>
+
+## Required API token permissions
+
+The API token used in API requests to manage Cache Response Rules must have the following permissions:
+
+- *Zone* > *Cache Rules* > *Edit*
+- *Account Rulesets* > *Edit*
+- *Account Filter Lists* > *Edit*

--- a/src/content/docs/cache/how-to/cache-response-rules/create-api.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/create-api.mdx
@@ -35,8 +35,9 @@ These examples demonstrate all the available actions in Cache Response Rules usi
 <Details header="Example: Strip response headers from JS files before caching">
 
 <APIRequest
-  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
   method="PUT"
+  parameters={{ ruleset_phase: "http_response_cache_settings" }}
   json={{
     rules: [
       {
@@ -59,8 +60,9 @@ These examples demonstrate all the available actions in Cache Response Rules usi
 <Details header="Example: Set static cache tags on API responses">
 
 <APIRequest
-  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
   method="PUT"
+  parameters={{ ruleset_phase: "http_response_cache_settings" }}
   json={{
     rules: [
       {
@@ -82,8 +84,9 @@ These examples demonstrate all the available actions in Cache Response Rules usi
 <Details header="Example: Add cache tags from a response header using an expression">
 
 <APIRequest
-  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
   method="PUT"
+  parameters={{ ruleset_phase: "http_response_cache_settings" }}
   json={{
     rules: [
       {
@@ -105,8 +108,9 @@ These examples demonstrate all the available actions in Cache Response Rules usi
 <Details header="Example: Override cache-control with max-age ">
 
 <APIRequest
-  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
   method="PUT"
+  parameters={{ ruleset_phase: "http_response_cache_settings" }}
   json={{
     rules: [
       {
@@ -131,8 +135,9 @@ These examples demonstrate all the available actions in Cache Response Rules usi
 <Details header="Example: Set private directive with qualifiers">
 
 <APIRequest
-  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
   method="PUT"
+  parameters={{ ruleset_phase: "http_response_cache_settings" }}
   json={{
     rules: [
       {
@@ -159,8 +164,9 @@ These examples demonstrate all the available actions in Cache Response Rules usi
 <Details header="Example: Set immutable for static font assets">
 
 <APIRequest
-  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
   method="PUT"
+  parameters={{ ruleset_phase: "http_response_cache_settings" }}
   json={{
     rules: [
       {
@@ -187,8 +193,9 @@ These examples demonstrate all the available actions in Cache Response Rules usi
 <Details header="Example: Multiple rules with strip headers, tag responses, and set cache control">
 
 <APIRequest
-  path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"
+  path="/zones/{zone_id}/rulesets/phases/{ruleset_phase}/entrypoint"
   method="PUT"
+  parameters={{ ruleset_phase: "http_response_cache_settings" }}
   json={{
     rules: [
       {

--- a/src/content/docs/cache/how-to/cache-response-rules/create-api.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/create-api.mdx
@@ -184,7 +184,7 @@ These examples demonstrate all the available actions in Cache Response Rules usi
 
 </Details>
 
-<Details header="Example: Multiple rules — strip headers, tag responses, and set cache control">
+<Details header="Example: Multiple rules with strip headers, tag responses, and set cache control">
 
 <APIRequest
   path="/zones/{zone_id}/rulesets/phases/http_response_cache_settings/entrypoint"

--- a/src/content/docs/cache/how-to/cache-response-rules/create-dashboard.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/create-dashboard.mdx
@@ -26,7 +26,20 @@ import { Render, DashButton } from "~/components";
    :::
 
 7. Following the selection of the field and operator, enter the corresponding value that will trigger the Cache Response Rule. For example, if the selected field is `Hostname` and the operator is `equals`, a value of `example.com` would mean the rule matches any request to that hostname.
-8. Under **Then**, select the action you want to apply. Refer to [Available settings](/cache/how-to/cache-response-rules/settings/#available-actions) for the list of available actions and their parameters.
+8. Under **Then**, select one of the following actions:
+
+   - **Modify cache-control directives**: Set or remove `Cache-Control` directives sent by your origin. For each directive, choose **Set directive** or **Remove directive**. For duration-based directives like `max-age` or `s-maxage`, enter a value in seconds. Turn on **Cloudflare only** to apply the directive only within Cloudflare's cache without changing what visitors receive. Refer to [Supported directives](/cache/how-to/cache-response-rules/settings/#supported-directives) for the full list.
+
+   - **Modify cache tags**: Add, override, or remove cache tags on the response for targeted [purging](/cache/how-to/purge-cache/purge-by-tags/). Select one of the following operations:
+     - **Add to existing tags**: Append new tags to the current set.
+     - **Override existing tags**: Replace all current tags with the specified tags.
+     - **Remove from existing tags**: Remove specific tags from the current set.
+
+     For the tag source, you can either specify tags manually or select **Parse from response header** to extract tags from a response header value. When parsing from a header, you can split the header value using a custom separator (for example, commas instead of spaces).
+
+   - **Strip headers**: Remove `Set-Cookie`, `ETag`, or `Last-Modified` headers from the origin response before Cloudflare evaluates the response for caching. Select which headers to strip.
+
+   For more details on each action, refer to [Available settings](/cache/how-to/cache-response-rules/settings/#available-actions).
 9. Under **Place at**, from the dropdown, you can select the order of your rule. From the main page, you can also change the order of the rules you have created.
 10. To save and deploy your rule, select **Deploy**. If you are not ready to deploy your rule, select **Save as Draft**.
 

--- a/src/content/docs/cache/how-to/cache-response-rules/create-dashboard.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/create-dashboard.mdx
@@ -1,0 +1,33 @@
+---
+pcx_content_type: how-to
+title: Create a rule in the dashboard
+sidebar:
+  order: 3
+head:
+  - tag: title
+    content: Create a Cache Response Rule in the dashboard
+---
+
+import { Render, DashButton } from "~/components";
+
+1. In the Cloudflare dashboard, go to **Cache** > **Cache Rules**.
+
+   <DashButton url="/?to=/:account/:zone/caching/cache-rules" />
+
+2. Select the **Cache Response Rules** tab.
+3. Select **Create rule**.
+
+4. Enter a descriptive name for the rule in **Rule name**.
+5. Under **When incoming requests match**, select **All incoming requests** if you want the rule to apply to all traffic or **Custom filter expression** if you want the rule to only apply to traffic matching the custom expression.
+6. If you selected **Custom filter expression**, define the [rule expression](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-builder). Use the **Field** drop-down list to choose an HTTP property and select an **Operator**. Both request fields (such as URI path or hostname) and response fields (such as response status code or response headers) are available for matching. Refer to [Available settings](/cache/how-to/cache-response-rules/settings/) for the full list of available fields and operators.
+
+   :::note
+   Rules can be further customized by using the **Edit expression** option. You can find more information in [Edit expressions in the dashboard](/ruleset-engine/rules-language/expressions/edit-expressions/).
+   :::
+
+7. Following the selection of the field and operator, enter the corresponding value that will trigger the Cache Response Rule. For example, if the selected field is `Hostname` and the operator is `equals`, a value of `example.com` would mean the rule matches any request to that hostname.
+8. Under **Then**, select the action you want to apply. Refer to [Available settings](/cache/how-to/cache-response-rules/settings/#available-actions) for the list of available actions and their parameters.
+9. Under **Place at**, from the dropdown, you can select the order of your rule. From the main page, you can also change the order of the rules you have created.
+10. To save and deploy your rule, select **Deploy**. If you are not ready to deploy your rule, select **Save as Draft**.
+
+   <Render file="rules-creation-dash-dns-popup" product="rules" />

--- a/src/content/docs/cache/how-to/cache-response-rules/index.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/index.mdx
@@ -1,0 +1,64 @@
+---
+title: Cache Response Rules
+pcx_content_type: concept
+sidebar:
+  order: 2
+---
+
+import { FeatureTable, InlineBadge, Render } from "~/components";
+
+Cache Response Rules allow you to configure cache settings based on request and response attributes. These rules execute prior to caching in the in the `http_response_cache_settings` phase, which runs after Cloudflare receives the origin response.
+
+With Cache Response Rules you can:
+
+- Strip specific headers (ETags, Set-Cookie, Last-Modified) from origin responses before caching.
+- Add, remove, or set cache tags on responses for targeted [cache purging](/cache/how-to/purge-cache/).
+- Modify Cache-Control header directives in the origin response.
+
+Cache Response Rules apply to both cached and non-cached (dynamic) responses from the origin. For example, you can strip Set-Cookie headers from responses that are not eligible for caching.
+
+Cache Response Rules can be created in the [dashboard](/cache/how-to/cache-response-rules/create-dashboard/), via [API](/cache/how-to/cache-response-rules/create-api/), or [Terraform](/cache/how-to/cache-response-rules/terraform-example/).
+
+:::note
+
+Cache Response Rules require that you [proxy the DNS records](/dns/proxy-status/) of your domain (or subdomain) through Cloudflare.
+
+:::
+
+## Availability
+
+The following table describes Cache Response Rules availability per plan.
+
+<FeatureTable id="cache.cache_rules" />
+
+<Render
+	file="troubleshoot-rules-with-trace"
+	product="rules"
+	params={{ rulesFeatureName: "Cache Response Rules" }}
+/>
+
+## Relationship with Cache Rules
+
+Cache Response Rules operate on the origin response, while [Cache Rules](/cache/how-to/cache-rules/) operate on the incoming request. When settings from both rule types conflict, Cache Response Rules take precedence.
+
+Key differences:
+
+- **Cache eligibility**: Cache Rules remain the only mechanism to decide whether content is eligible for caching. However, Cache Response Rules can make a cacheable asset non-cacheable by setting the `no-store` directive using the `set_cache_control` action.
+- **Origin Cache Control (OCC)**: If any rule in the `http_response_cache_settings` phase matches, Cloudflare defaults to Origin Cache Control behavior (`origin_cache_control = true`).
+- **CDN-Cache-Control precedence**: `Cache-Control` directives set by Cache Response Rules take precedence over origin-set `Cloudflare-CDN-Cache-Control` and `CDN-Cache-Control` headers. For more information, refer to [CDN-Cache-Control header precedence](/cache/concepts/cdn-cache-control/#header-precedence).
+- **Stacking**: Cache Response Rules stack the same way as Cache Rules. When multiple rules specify the same setting, the last matching rule wins.
+
+### Example: OCC precedence over Edge TTL
+
+Consider the following scenario:
+
+1. A Cache Rule sets **Edge TTL** to `override_origin` with a value of `7200` seconds (2 hours).
+2. A Cache Response Rule uses `set_cache_control` to set `s-maxage` to `3600` seconds (1 hour) with `cloudflare_only` enabled.
+3. The origin responds with `Cache-Control: s-maxage=600`.
+
+In this case, the Cache Response Rule takes precedence. Cloudflare caches the asset for `3600` seconds (1 hour) based on the `s-maxage` directive set by the Cache Response Rule, while visitors still receive the original `s-maxage=600` from the origin because `cloudflare_only` is enabled.
+
+## Notes
+
+- If you strip last modified then Smart Edge Revalidation will be turned off.
+- Cache Response Rules ignore HTTP Response 1xx as it is treated as informational responses.

--- a/src/content/docs/cache/how-to/cache-response-rules/index.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/index.mdx
@@ -11,9 +11,9 @@ Cache Response Rules allow you to configure cache settings based on request and 
 
 With Cache Response Rules you can:
 
-- Strip specific headers (ETags, Set-Cookie, Last-Modified) from origin responses before caching.
-- Add, remove, or set cache tags on responses for targeted [cache purging](/cache/how-to/purge-cache/).
-- Modify Cache-Control header directives in the origin response.
+- Modify `Cache-Control` directives sent by your origin.
+- Modify cache tags on responses for targeted [cache purging](/cache/how-to/purge-cache/).
+- Strip headers (`ETag`, `Set-Cookie`, `Last-Modified`) from origin responses before caching.
 
 Cache Response Rules apply to both cached and non-cached (dynamic) responses from the origin. For example, you can strip Set-Cookie headers from responses that are not eligible for caching.
 

--- a/src/content/docs/cache/how-to/cache-response-rules/settings.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/settings.mdx
@@ -69,6 +69,7 @@ The following functions are available in this phase:
 - starts_with
 - substring
 - to_string
+- upper
 - url_decode
 - wildcard_replace
 
@@ -162,7 +163,7 @@ Refer to [Create a rule via API](/cache/how-to/cache-response-rules/create-api/)
 
 Modifies Cache-Control header directives in the origin response.
 
-### Supported directives
+#### Supported directives
 
 **Directives with duration value (seconds):**
 
@@ -186,11 +187,11 @@ Modifies Cache-Control header directives in the origin response.
 - `public`
 - `immutable`
 
-### Directive configuration
+#### Directive configuration
 
 The available parameters depend on the directive type.
 
-#### Directives with duration value
+##### Directives with duration value
 
 Applies to `max-age`, `s-maxage`, `stale-if-error`, and `stale-while-revalidate`.
 
@@ -200,7 +201,7 @@ Applies to `max-age`, `s-maxage`, `stale-if-error`, and `stale-while-revalidate`
 | `cloudflare_only` | Boolean | When enabled, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive. |
 | `value` | Integer | Duration in seconds. **Required when operation is `set`.** |
 
-#### Directives with optional qualifiers
+##### Directives with optional qualifiers
 
 Applies to `private` and `no-cache`.
 
@@ -210,7 +211,7 @@ Applies to `private` and `no-cache`.
 | `cloudflare_only` | Boolean | When enabled, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive. |
 | `qualifiers` | Array | Optional list of header names to qualify the directive. |
 
-#### Boolean directives
+##### Boolean directives
 
 Applies to `no-store`, `no-transform`, `must-revalidate`, `proxy-revalidate`, `must-understand`, `public`, and `immutable`.
 

--- a/src/content/docs/cache/how-to/cache-response-rules/settings.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/settings.mdx
@@ -1,0 +1,241 @@
+---
+title: Available settings
+pcx_content_type: reference
+sidebar:
+  order: 6
+head:
+  - tag: title
+    content: Cache Response Rules settings
+---
+
+import { Details } from "~/components";
+
+These are the settings that you can configure when creating a Cache Response Rule. Because Cache Response Rules execute after Cloudflare receives the origin response, both request and response fields are available for rule matching.
+
+## Expression fields
+
+### Request fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `http.cookie` | String | Full cookie header value |
+| `http.host` | String | The HTTP Host header |
+| `http.referer` | String | The HTTP Referer header |
+| `http.user_agent` | String | The HTTP User-Agent header |
+| `http.request.method` | String | The HTTP request method |
+| `http.request.uri` | String | The request URI |
+| `http.request.uri.path` | String | The URI path |
+| `http.request.uri.path.basename` | String | The basename of the URI path |
+| `http.request.uri.path.extension` | String | The file extension from the URI path |
+| `http.request.uri.query` | String | The query string |
+| `http.request.uri.args` | Map | Query string arguments as key-value pairs |
+| `http.request.uri.args.names` | Array | Query string argument names |
+| `http.request.uri.args.values` | Array | Query string argument values |
+| `http.request.full_uri` | String | The full request URI including scheme and host |
+| `http.request.headers` | Map | Request headers as key-value pairs |
+| `http.request.headers.names` | Array | Request header names |
+| `http.request.headers.values` | Array | Request header values |
+| `http.request.cookies` | Map | Parsed cookies as key-value pairs |
+| `http.request.accepted_languages` | Array | Parsed Accept-Language header values |
+
+### Response fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `http.response.code` | Integer | The HTTP response status code from the origin |
+| `http.response.headers` | Map | Response headers as key-value pairs |
+| `http.response.headers.names` | Array | Response header names |
+| `http.response.headers.values` | Array | Response header values |
+
+If you select the [Edit expression](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-editor) option, you can enter any of the above response fields.
+
+## Functions
+
+The following functions are available in this phase:
+
+- all
+- any
+- concat
+- decode_base64
+- ends_with
+- len
+- lookup_json_integer
+- lookup_json_string
+- lower
+- regex_replace
+- remove_bytes
+- remove_query_args
+- split
+- starts_with
+- substring
+- to_string
+- url_decode
+- wildcard_replace
+
+For descriptions of each function, refer to [Functions](/ruleset-engine/rules-language/functions/).
+
+## Operators
+
+For the full list of operators, refer to [Operators](/ruleset-engine/rules-language/operators/).
+
+## Available actions
+
+Cache Response Rules support three actions:
+
+| Action | Description |
+| --- | --- |
+| `set_cache_settings` | Strip headers (ETags, Set-Cookie, Last-Modified) from the origin response before caching. |
+| `set_cache_tags` | Add, remove, or set cache tags on the response for targeted purging. |
+| `set_cache_control` | Modify Cache-Control header directives in the origin response. |
+
+---
+
+### Action: set_cache_settings
+
+Configures settings related to caching on the origin response. The following parameters are available:
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `strip_etags` | Boolean | Strip ETag headers from the origin response before caching. |
+| `strip_set_cookie` | Boolean | Strip Set-Cookie headers from the origin response before caching. |
+| `strip_last_modified` | Boolean | Strip Last-Modified headers from the origin response before caching. |
+
+:::note
+
+If `strip_etags` or `strip_last_modified` is `true` after all matching rules are applied, [Smart Edge Revalidation](https://blog.cloudflare.com/introducing-smart-edge-revalidation/) is disabled for the origin response.
+
+:::
+
+<Details header="API information">
+
+API action: `set_cache_settings`.
+
+```json title="API configuration example"
+"action_parameters": {
+  "strip_etags": true,
+  "strip_set_cookie": true,
+  "strip_last_modified": true
+}
+```
+
+Refer to [Create a rule via API](/cache/how-to/cache-response-rules/create-api/) for complete API examples.
+
+</Details>
+
+---
+
+### Action: set_cache_tags
+
+Modifies the cache tags associated with the response. Cache tags can be used for targeted [cache purging](/cache/how-to/purge-cache/purge-by-tags/).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `operation` | String | **Required.** One of: `add`, `remove`, `set`. |
+| `values` | Array | A list of cache tag strings. Mutually exclusive with `expression`. |
+| `expression` | String | An expression that evaluates to an array of cache tags. Mutually exclusive with `values`. |
+
+<Details header="API information">
+
+API action: `set_cache_tags`.
+
+```json title="API configuration example (static values)"
+"action_parameters": {
+  "operation": "set",
+  "values": ["api-response", "dynamic-content"]
+}
+```
+
+```json title="API configuration example (expression)"
+"action_parameters": {
+  "operation": "add",
+  "expression": "split(http.response.headers[\"Surrogate-Keys\"][0], \",\", 1)"
+}
+```
+
+Refer to [Create a rule via API](/cache/how-to/cache-response-rules/create-api/) for complete API examples.
+
+</Details>
+
+---
+
+### Action: set_cache_control
+
+Modifies Cache-Control header directives in the origin response.
+
+### Supported directives
+
+**Directives with duration value (seconds):**
+
+- `max-age`
+- `s-maxage`
+- `stale-if-error`
+- `stale-while-revalidate`
+
+**Directives with optional qualifiers (header names):**
+
+- `private`
+- `no-cache`
+
+**Boolean directives:**
+
+- `no-store`
+- `no-transform`
+- `must-revalidate`
+- `proxy-revalidate`
+- `must-understand`
+- `public`
+- `immutable`
+
+### Directive configuration
+
+The available parameters depend on the directive type.
+
+#### Directives with duration value
+
+Applies to `max-age`, `s-maxage`, `stale-if-error`, and `stale-while-revalidate`.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `operation` | String | **Required.** `set` or `remove`. |
+| `cloudflare_only` | Boolean | When enabled, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive. |
+| `value` | Integer | Duration in seconds. **Required when operation is `set`.** |
+
+#### Directives with optional qualifiers
+
+Applies to `private` and `no-cache`.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `operation` | String | **Required.** `set` or `remove`. |
+| `cloudflare_only` | Boolean | When enabled, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive. |
+| `qualifiers` | Array | Optional list of header names to qualify the directive. |
+
+#### Boolean directives
+
+Applies to `no-store`, `no-transform`, `must-revalidate`, `proxy-revalidate`, `must-understand`, `public`, and `immutable`.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `operation` | String | **Required.** `set` or `remove`. |
+| `cloudflare_only` | Boolean | When enabled, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive. |
+
+<Details header="API information">
+
+API action: `set_cache_control`.
+
+```json title="API configuration example"
+"action_parameters": {
+  "max-age": {
+    "operation": "set",
+    "value": 3600,
+    "cloudflare_only": true
+  },
+  "stale-if-error": {
+    "operation": "remove"
+  }
+}
+```
+
+Refer to [Create a rule via API](/cache/how-to/cache-response-rules/create-api/) for complete API examples.
+
+</Details>

--- a/src/content/docs/cache/how-to/cache-response-rules/terraform-example.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/terraform-example.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 head:
   - tag: title
-    content: Cache Response Rules — Terraform example
+    content: Cache Response Rules Terraform example
 ---
 
 import { Details, Render } from "~/components";

--- a/src/content/docs/cache/how-to/cache-response-rules/terraform-example.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/terraform-example.mdx
@@ -1,0 +1,75 @@
+---
+title: Terraform example
+pcx_content_type: configuration
+sidebar:
+  order: 5
+head:
+  - tag: title
+    content: Cache Response Rules — Terraform example
+---
+
+import { Details, Render } from "~/components";
+
+The following example defines a single Cache Response Rule for a zone using Terraform. The rule strips Set-Cookie and ETag headers from JavaScript file responses before caching.
+
+<Details header="Terraform `cloudflare_ruleset` resource">
+
+```tf
+# Cache Response Rule to strip headers from JS responses
+resource "cloudflare_ruleset" "cache_response_rules_example" {
+  zone_id     = "<ZONE_ID>"
+  name        = "Cache Response Rules"
+  description = "Configure cache settings for origin responses"
+  kind        = "zone"
+  phase       = "http_response_cache_settings"
+
+  rules {
+    ref         = "strip_js_headers"
+    description = "Strip caching headers from JS file responses"
+    expression  = "http.request.uri.path.extension eq \"js\""
+    action      = "set_cache_settings"
+    action_parameters {
+      strip_etags      = true
+      strip_set_cookie = true
+    }
+  }
+
+  rules {
+    ref         = "tag_api_responses"
+    description = "Tag API responses for targeted purging"
+    expression  = "starts_with(http.request.uri.path, \"/api/\")"
+    action      = "set_cache_tags"
+    action_parameters {
+      operation = "set"
+      values    = ["api-response", "dynamic-content"]
+    }
+  }
+
+  rules {
+    ref         = "cache_control_200"
+    description = "Set cache-control for successful responses"
+    expression  = "http.response.code eq 200"
+    action      = "set_cache_control"
+    action_parameters {
+      s_maxage {
+        operation      = "set"
+        value          = 86400
+        cloudflare_only = true
+      }
+      must_revalidate {
+        operation = "set"
+      }
+    }
+  }
+}
+```
+
+<Render
+	file="terraform-use-ref-field"
+	product="rules"
+	params={{ addDocsLocation: true }}
+/>
+
+</Details>
+
+For additional guidance on using Terraform with Cloudflare, refer to [Terraform](/terraform/).


### PR DESCRIPTION
### Summary

Add new Cache Response Rules how-to section covering the http_response_cache_settings phase, including:
- Overview and concept page with availability and troubleshooting
- Available settings reference (fields, operators, actions)
- API creation guide with examples for all three actions
- Dashboard creation guide
- Terraform example

Referenced changelog: https://github.com/cloudflare/cloudflare-docs/pull/28986

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.