### PR TITLE
Replace AI Playground link with AI Agents

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,11 +76,7 @@ const topCards = [
 			{ text: "Workers AI", href: "/workers-ai/" },
 			{ text: "Vectorize", href: "/vectorize/" },
 			{ text: "AI Gateway", href: "/ai-gateway/" },
-			{
-				text: "AI Playground",
-				href: "https://playground.ai.cloudflare.com/",
-				target: "_blank",
-			},
+			{ text: "AI Agents", href: "/agents/" },
 		],
 		cta: {
 			text: "View all AI products",
@@ -219,7 +215,6 @@ const recommendedSection = {
 							<li>
 								<a
 									href={link.href}
-									target={link.target}
 									class="hover:text-accent! dark:text-accent-high! text-black! dark:hover:text-black!"
 								>
 									{link.text}


### PR DESCRIPTION
Update src/pages/index.astro: replace the topCards entry for the external "AI Playground" link with an internal "AI Agents" (/agents/) link, and remove the anchor's target attribute usage in the recommended section. This makes the navigation consistent for internal pages and avoids relying on a link.target property for rendering.

The AI Playground isn't a top level target for our users, let's get them using AI Agents instead. 

