### PR TITLE
[CF1 Tunnel] Add FedRAMP High tunnel endpoints

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters.mdx
@@ -82,8 +82,8 @@ Specifies the verbosity of logging for the local `cloudflared` instance. Availab
 
 ## `metrics`
 
-| Syntax                                                      | Default                                                                                          | Environment Variable |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------- |
+| Syntax                                                      | Default                                                                                                   | Environment Variable |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------------- |
 | `cloudflared tunnel --metrics <IP:PORT> run <UUID or NAME>` | Refer to [Tunnel metrics](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/metrics/) | `TUNNEL_METRICS`     |
 
 Exposes a Prometheus endpoint on the specified IP address and port, which you can then query for [usage metrics](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/metrics/).
@@ -152,6 +152,10 @@ The `auto` value will automatically configure the `quic` protocol. If `cloudflar
 Allows you to choose the regions to which connections are established. Currently the only available value is `us`, which routes all connections through data centers in the United States. Omit or leave empty to connect to the global region.
 
 When the region is set to `us`, `cloudflared` uses different US-specific hostnames and IPs. Refer to [Tunnel with firewall](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#region-us) for details.
+
+:::note
+For [FedRAMP High](https://www.cloudflare.com/cloudflare-for-government/) environments, the tunnel token determines routing to FedRAMP data centers automatically — no `--region` flag is required. Refer to [Tunnel with firewall](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#region-fedramp-high) for the FedRAMP-specific endpoints your firewall must allow.
+:::
 
 ## `retries`
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/run-parameters.mdx
@@ -154,7 +154,7 @@ Allows you to choose the regions to which connections are established. Currently
 When the region is set to `us`, `cloudflared` uses different US-specific hostnames and IPs. Refer to [Tunnel with firewall](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#region-us) for details.
 
 :::note
-For [FedRAMP High](https://www.cloudflare.com/cloudflare-for-government/) environments, the tunnel token determines routing to FedRAMP data centers automatically — no `--region` flag is required. Refer to [Tunnel with firewall](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#region-fedramp-high) for the FedRAMP-specific endpoints your firewall must allow.
+For [FedRAMP High](https://www.cloudflare.com/cloudflare-for-government/) environments, the [tunnel token](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions/) determines routing to FedRAMP data centers automatically — no `--region` flag is required. Refer to [Tunnel with firewall](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#region-fedramp-high) for the FedRAMP-specific endpoints your firewall must allow.
 :::
 
 ## `retries`

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall.mdx
@@ -84,6 +84,22 @@ When using the [US region](/cloudflare-one/networks/connectors/cloudflare-tunnel
 | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---- | ------------------------ |
 | `198.41.219.1` `198.41.219.2` `198.41.219.3` `198.41.219.4` `198.41.219.5` `198.41.219.6` `198.41.219.7` `198.41.219.8` `198.41.219.9` `198.41.219.10` | `2606:4700:a9::1` `2606:4700:a9::2` `2606:4700:a9::3` `2606:4700:a9::4` `2606:4700:a9::5` `2606:4700:a9::6` `2606:4700:a9::7` `2606:4700:a9::8` `2606:4700:a9::9` `2606:4700:a9::10` | 7844 | TCP/UDP (`http2`/`quic`) |
 
+### Region FedRAMP High
+
+When deploying `cloudflared` in a [FedRAMP High](https://www.cloudflare.com/cloudflare-for-government/) environment, `cloudflared` automatically routes to FedRAMP data centers based on the tunnel token. Ensure your firewall allows outbound connections to these FedRAMP-specific destinations on port `7844` (TCP/UDP).
+
+#### `fed-region1.v2.argotunnel.com`
+
+| IPv4                                                                                                                                                             | IPv6                                                                                                                                                                                 | Port | Protocols                |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---- | ------------------------ |
+| `162.159.234.1` `162.159.234.2` `162.159.234.3` `162.159.234.4` `162.159.234.5` `162.159.234.6` `162.159.234.7` `162.159.234.8` `162.159.234.9` `162.159.234.10` | `2a06:98c1:4d::1` `2a06:98c1:4d::2` `2a06:98c1:4d::3` `2a06:98c1:4d::4` `2a06:98c1:4d::5` `2a06:98c1:4d::6` `2a06:98c1:4d::7` `2a06:98c1:4d::8` `2a06:98c1:4d::9` `2a06:98c1:4d::10` | 7844 | TCP/UDP (`http2`/`quic`) |
+
+#### `fed-region2.v2.argotunnel.com`
+
+| IPv4                                                                                                                                                   | IPv6                                                                                                                                                                                 | Port | Protocols                |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---- | ------------------------ |
+| `172.64.234.1` `172.64.234.2` `172.64.234.3` `172.64.234.4` `172.64.234.5` `172.64.234.6` `172.64.234.7` `172.64.234.8` `172.64.234.9` `172.64.234.10` | `2606:4700:f6::1` `2606:4700:f6::2` `2606:4700:f6::3` `2606:4700:f6::4` `2606:4700:f6::5` `2606:4700:f6::6` `2606:4700:f6::7` `2606:4700:f6::8` `2606:4700:f6::9` `2606:4700:f6::10` | 7844 | TCP/UDP (`http2`/`quic`) |
+
 ### Optional
 
 Opening port `443` enables some optional features. Failure to allow these connections may prompt a log error, but `cloudflared` will still run correctly.
@@ -130,8 +146,8 @@ Allows `cloudflared` to report [post-quantum key exchange](https://blog.cloudfla
 
 #### `cfd-features.argotunnel.com`
 
-| IPv4           | IPv6           | Port | Protocols    |
-| -------------- | -------------- | ---- | ------------ |
+| IPv4           | IPv6           | Port           | Protocols      |
+| -------------- | -------------- | -------------- | -------------- |
 | Not applicable | Not applicable | Not applicable | Not applicable |
 
 Performing a DNS query for a `TXT` record to this hostname allows `cloudflared` to determine which version of [UDP datagram](/changelog/2025-07-15-udp-improvements/) to use when connecting via the `quic` protocol. If your firewall filters egress DNS queries by FQDN, you may need to allow queries for this domain to ensure optimal `quic` performance.
@@ -190,10 +206,10 @@ Alternatively, you may use operating system (OS)-level firewall rules to block a
 
 8. By default, rules you add via the `iptables` command are stored only in memory and do not persist on reboot. There are many different ways to save and reload your firewall rules, depending on your Linux distribution. For example, on Debian you can use the [`iptables-persistent`](https://packages.debian.org/sid/iptables-persistent) package:
 
-	```sh
-	sudo apt install iptables-persistent
-	sudo netfilter-persistent save
-	```
+   ```sh
+   sudo apt install iptables-persistent
+   sudo netfilter-persistent save
+   ```
 
 ## Test connectivity
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall.mdx
@@ -86,7 +86,7 @@ When using the [US region](/cloudflare-one/networks/connectors/cloudflare-tunnel
 
 ### Region FedRAMP High
 
-When deploying `cloudflared` in a [FedRAMP High](https://www.cloudflare.com/cloudflare-for-government/) environment, `cloudflared` automatically routes to FedRAMP data centers based on the tunnel token. Ensure your firewall allows outbound connections to these FedRAMP-specific destinations on port `7844` (TCP/UDP).
+When deploying `cloudflared` in a [FedRAMP High](https://www.cloudflare.com/cloudflare-for-government/) environment, `cloudflared` automatically routes to FedRAMP data centers based on the [tunnel token](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions/). Ensure your firewall allows outbound connections to these FedRAMP-specific destinations on port `7844` (TCP/UDP).
 
 #### `fed-region1.v2.argotunnel.com`
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/tips.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/tips.mdx
@@ -17,12 +17,13 @@ For Google Cloud Project (GCP) deployments, [enable IP forwarding](https://cloud
 ### AWS
 
 For Amazon Web Services (AWS) deployments:
+
 - Stop [source/destination checking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html) on the EC2 instance where you installed WARP Connector.
 - In your [subnet route table](https://docs.aws.amazon.com/vpc/latest/userguide/subnet-route-tables.html), route all IPv4 traffic to the EC2 instance where you installed WARP Connector. For example:
 
-		| Destination | Target |
-		| ----------- | ------ |
-		| `0.0.0.0/0` | `eni-11223344556677889` |
+      | Destination | Target |
+      | ----------- | ------ |
+      | `0.0.0.0/0` | `eni-11223344556677889` |
 
 ## Source IPs for Cloudflare services
 
@@ -35,8 +36,13 @@ WARP Connector and [`cloudflared`](/cloudflare-one/networks/connectors/cloudflar
 By design, WARP Connector captures all outbound traffic and routes it through Cloudflare's network. This prevents `cloudflared` from making its own [required outbound connections](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#required-for-tunnel-operation) to Cloudflare, causing the tunnel to fail with connection timeouts.
 
 To allow `cloudflared` to connect, use [Split Tunnels](/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/split-tunnels/) to explicitly exclude the [Cloudflare Tunnel destinations](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/) from the WARP tunnel. For example, if you are using Split Tunnels in **Exclude** mode, add the following hostnames (or their corresponding IP ranges) to your Split Tunnel exclusion list:
-	- `region1.v2.argotunnel.com`
-	- `region2.v2.argotunnel.com`
+
+- `region1.v2.argotunnel.com`
+- `region2.v2.argotunnel.com`
+- `us-region1.v2.argotunnel.com` (US region only)
+- `us-region2.v2.argotunnel.com` (US region only)
+- `fed-region1.v2.argotunnel.com` (FedRAMP High only)
+- `fed-region2.v2.argotunnel.com` (FedRAMP High only)
 
 :::note
 Split Tunnels is the only supported method of running both connectors on one machine. Due to its low-level integration with the kernel networking stack, WARP Connector will override any routing configurations made by commands such as `ip route add` and `iptables`.
@@ -47,6 +53,7 @@ Split Tunnels is the only supported method of running both connectors on one mac
 To ensure reliable network performance, it is important to understand the requirements for [Maximum Transmission Unit (MTU)](https://www.cloudflare.com/learning/network-layer/what-is-mtu/) and [Maximum Segment Size (MSS)](https://www.cloudflare.com/learning/network-layer/what-is-mss/) when using WARP Connector. An incorrect configuration can lead to performance degradation or packet loss.
 
 WARP Connector uses encapsulation to route traffic, which adds extra headers and bytes to each [packet](https://www.cloudflare.com/learning/network-layer/what-is-a-packet/). This is especially critical for traffic from your private network (on-ramped via WARP Connector) to a remote WARP client. This traffic flow is encapsulated twice:
+
 1. By the WARP Connector on your Linux host.
 2. Again by Cloudflare before being delivered to the off-ramp.
 
@@ -61,7 +68,7 @@ Cloudflare then tries to encapsulate this 1,460-byte packet to send to the WARP 
 
 ### Recommendations
 
-To ensure reliable connectivity for all traffic types, especially legacy UDP applications, the most effective solution is to configure the MTU on your source devices (such as servers, cameras, or other devices on your private network) to 1,280 bytes. 
+To ensure reliable connectivity for all traffic types, especially legacy UDP applications, the most effective solution is to configure the MTU on your source devices (such as servers, cameras, or other devices on your private network) to 1,280 bytes.
 
 This ensures the original packet is small enough to be encapsulated and delivered without being fragmented or dropped.
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/connectivity-prechecks.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/connectivity-prechecks.mdx
@@ -25,7 +25,7 @@ This guide is structured as follows:
 
 You must have:
 
-- A host machine connected to the Internet where you plan to run `cloudflared`. The tests must run from the same environment where `cloudflared` will run (same network, same firewall path).  
+- A host machine connected to the Internet where you plan to run `cloudflared`. The tests must run from the same environment where `cloudflared` will run (same network, same firewall path).
 
 - A terminal session with permission to run `dig` and `nc` (netcat), or similar software.
 
@@ -45,7 +45,7 @@ Cloudflare Tunnel errors can originate from the environment (for example, DNS or
 
 ## 2. DNS test with dig
 
-Cloudflare Tunnel requires outbound connectivity to `region1.v2.argotunnel.com` and `region2.v2.argotunnel.com` (or to the equivalent `us-region1` and `us-region2` endpoints when using only the [US region](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#region-us)).  
+Cloudflare Tunnel requires outbound connectivity to `region1.v2.argotunnel.com` and `region2.v2.argotunnel.com` (or to the equivalent `us-region1` and `us-region2` endpoints when using the [US region](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#region-us), or `fed-region1` and `fed-region2` when using the [FedRAMP High region](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/#region-fedramp-high)).
 
 For a successful and healthy deployment, `cloudflared` should have [four active replicas](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-availability/) with connectivity to both regions (that is, both `region1.v2.argotunnel.com` and `region2.v2.argotunnel.com`, or both `us-region1` and `us-region2`).
 
@@ -214,6 +214,85 @@ us-region2.v2.argotunnel.com. 86400 IN	AAAA	2606:4700:a9::10
 ```
 
 </TabItem>
+<TabItem label="FedRAMP High region">
+
+```sh
+dig A fed-region1.v2.argotunnel.com
+```
+
+```sh output
+;; ANSWER SECTION:
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.1
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.2
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.3
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.4
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.5
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.6
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.7
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.8
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.9
+fed-region1.v2.argotunnel.com. 300 IN	A	162.159.234.10
+...
+```
+
+```sh
+dig AAAA fed-region1.v2.argotunnel.com
+```
+
+```sh output
+;; ANSWER SECTION:
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::1
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::2
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::3
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::4
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::5
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::6
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::7
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::8
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::9
+fed-region1.v2.argotunnel.com. 300 IN	AAAA	2a06:98c1:4d::10
+...
+```
+
+```sh
+dig A fed-region2.v2.argotunnel.com
+```
+
+```sh output
+;; ANSWER SECTION:
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.1
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.2
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.3
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.4
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.5
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.6
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.7
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.8
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.9
+fed-region2.v2.argotunnel.com. 300 IN	A	172.64.234.10
+...
+```
+
+```sh
+dig AAAA fed-region2.v2.argotunnel.com
+```
+
+```sh output
+;; ANSWER SECTION:
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::1
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::2
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::3
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::4
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::5
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::6
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::7
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::8
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::9
+fed-region2.v2.argotunnel.com. 300 IN	AAAA	2606:4700:f6::10
+...
+```
+
+</TabItem>
 </Tabs>
 
 The `ANSWER SECTION` should include the expected IP addresses for Cloudflare Tunnel endpoints.
@@ -231,6 +310,7 @@ If your original `dig` response is empty or does not match the documented IPs, t
 ```sh
 dig A region1.v2.argotunnel.com @1.1.1.1
 ```
+
 #### If only `1.1.1.1` works
 
 If `1.1.1.1` returns the correct IPs, but your original resolver does not, your local DNS resolver is misconfigured or blocked.
@@ -326,4 +406,8 @@ To resolve: Allow all traffic over port `7844` on the local network firewall. If
 
 If either DNS or network test failed, it will likely be a problem in your local environment. You will need to debug with your administrator, ISP or cloud provider. If you believe the issue is with Cloudflare, please provide detailed information when contacting support.
 
-<Render file="warp/support-ticket-best-practices" product="cloudflare-one" params={{ tunnelMode: true }} />
+<Render
+	file="warp/support-ticket-best-practices"
+	product="cloudflare-one"
+	params={{ tunnelMode: true }}
+/>


### PR DESCRIPTION
## Summary

- Add FedRAMP High tunnel endpoints (`fed-region1.v2.argotunnel.com` and `fed-region2.v2.argotunnel.com`) to Cloudflare One tunnel documentation
- Document that FedRAMP routing is determined by the **tunnel token**, not by a `--region` flag
- Add FedRAMP-specific firewall rules (IPv4 + IPv6), connectivity pre-check tabs, and Split Tunnel exclusions

## Files changed

| File | Change |
|------|--------|
| `tunnel-with-firewall.mdx` | New "Region FedRAMP High" section with IPv4 and IPv6 tables for both endpoints (port 7844, TCP/UDP) |
| `run-parameters.mdx` | Add note that FedRAMP routing is token-based (no `--region fed` flag) |
| `connectivity-prechecks.mdx` | New "FedRAMP High region" tab with `dig` A and AAAA examples for both fed-region endpoints |
| `warp-connector/tips.mdx` | Add `fed-region1` and `fed-region2` endpoints to Split Tunnel exclusion list |

## FedRAMP endpoints

| Hostname | IPv4 | IPv6 | Port | Protocol |
|----------|------|------|------|----------|
| `fed-region1.v2.argotunnel.com` | `162.159.234.1` – `162.159.234.10` | `2a06:98c1:4d::1` – `2a06:98c1:4d::10` | 7844 | TCP/UDP |
| `fed-region2.v2.argotunnel.com` | `172.64.234.1` – `172.64.234.10` | `2606:4700:f6::1` – `2606:4700:f6::10` | 7844 | TCP/UDP |

## Important note

FedRAMP tunnel routing is determined automatically by the tunnel token — there is no `--region fed` flag. The `--region` parameter only supports `us` (and empty for global).