### PR TITLE
Remove Punycode domain support limitation for Google Trust Services

### DIFF
--- a/src/content/docs/ssl/reference/certificate-authorities.mdx
+++ b/src/content/docs/ssl/reference/certificate-authorities.mdx
@@ -80,6 +80,10 @@ You can find the full list of supported clients in the [Let's Encrypt documentat
 
 * Punycode domains are not yet supported.
 
+#### Limitations
+
+None at this time.
+
 #### Browser compatibility (most compatible)
 
 :::caution[Warning]

--- a/src/content/docs/workers/get-started/guide.mdx
+++ b/src/content/docs/workers/get-started/guide.mdx
@@ -75,10 +75,10 @@ npm create cloudflare@latest -- --template <SOURCE>
 - `bitbucket:user/repo` (Bitbucket)
 - `gitlab:user/repo` (GitLab)
 
-At a minimum, template folders must contain the following:
+It's likely that you have an existing project that isn't configured as a Cloudflare template. Before your project can qualify as a valid template, the folder must contain the following files at least:
 
 - `package.json`
-- `wrangler.toml`
+- `wrangler.toml` [See this](/workers/wrangler/configuration/#sample-wranglertoml-configuration) for an example of a Wrangler configuration file
 - `src/` containing a worker script referenced from `wrangler.toml`
 
 </Details>

--- a/src/content/docs/workers/get-started/guide.mdx
+++ b/src/content/docs/workers/get-started/guide.mdx
@@ -58,7 +58,7 @@ In your project directory, C3 will have generated the following:
 
 <Details header="What if I already have a project in a git repository?">
 
-In addition to creating new projects from C3 templates, C3 also supports creating new projects from Git repositories. To create a new project from a Git repository, open your terminal and run:
+In addition to creating new projects from C3 templates, C3 also supports creating new projects from existing Git repositories. To create a new project from an existing Git repository, open your terminal and run:
 
 ```sh
 npm create cloudflare@latest -- --template <SOURCE>
@@ -75,10 +75,10 @@ npm create cloudflare@latest -- --template <SOURCE>
 - `bitbucket:user/repo` (Bitbucket)
 - `gitlab:user/repo` (GitLab)
 
-It's likely that you have an existing project that isn't configured as a Cloudflare template. Before your project can qualify as a valid template, the folder must contain the following files at least:
+Your existing template folder must contain the following files, at a minimum, to meet the requirements for Cloudflare Workers:
 
 - `package.json`
-- `wrangler.toml` [See this](/workers/wrangler/configuration/#sample-wranglertoml-configuration) for an example of a Wrangler configuration file
+- `wrangler.toml` [See sample Wrangler configuration](/workers/wrangler/configuration/#sample-wranglertoml-configuration)
 - `src/` containing a worker script referenced from `wrangler.toml`
 
 </Details>


### PR DESCRIPTION
Google Trust Services now offers the ability to request TLS certificates for domain names with Punycode labels. (i.e. Internationalized Domain Names or IDNs) This enables customers with IDNs to use Google Trust Services for their TLS certificates. See: https://pki.goog/updates/february2026-idn-update.html

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
