### PR TITLE
[Gateway] Update proxy endpoints docs for authorization proxy open beta

### DIFF
--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -340,18 +340,7 @@ To test your configuration, create an [HTTP policy](/cloudflare-one/traffic-poli
 
 You can now use the Proxy Endpoint selector in [network](/cloudflare-one/traffic-policies/network-policies/#proxy-endpoint) and [HTTP](/cloudflare-one/traffic-policies/http-policies/#proxy-endpoint) policies to filter traffic proxied via PAC files.
 
-## 5. View logs and analytics
-
-Proxy endpoint traffic is logged in the following locations:
-
-- **Authentication logs**: When users authenticate through an authorization endpoint, login events appear in your [Access logs](/cloudflare-one/insights/logs/).
-- **Traffic logs**: HTTP and network traffic proxied through the endpoint appears in [Gateway logs](/cloudflare-one/insights/logs/gateway-logs/), with the specific proxy endpoint indicated.
-
-### Billing
-
-Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/team-and-resources/users/seat-management/), the same as a user connected through the WARP client.
-
-## 6. (Optional) Configure firewall
+## 5. (Optional) Configure firewall
 
 You may need to configure your organization's firewall to allow your users to connect to a proxy endpoint. Depending on your firewall, you will need to create a rule using either your proxy endpoint's domain or IP addresses.
 
@@ -485,6 +474,17 @@ You can modify proxy endpoint settings after creation.
 3. Select the three dots, then select **Configure**.
 4. Update the endpoint name or modify the allowed source IP addresses.
 5. Select **Save**.
+
+## Logs
+
+Proxy endpoint traffic is logged in the following locations:
+
+- **Authentication logs**: When users authenticate through an authorization endpoint, login events appear in your [Access logs](/cloudflare-one/insights/logs/).
+- **Traffic logs**: HTTP and network traffic proxied through the endpoint appears in [Gateway logs](/cloudflare-one/insights/logs/gateway-logs/), with the specific proxy endpoint indicated.
+
+## Billing
+
+Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/team-and-resources/users/seat-management/), the same as a user connected through the WARP client.
 
 ## Limitations
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -31,7 +31,6 @@ For the best experience and deepest visibility, Cloudflare recommends using the 
 Proxy endpoints are designed for environments where deploying the WARP client is not an option. Common use cases include:
 
 - **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
-- **Mergers and acquisitions**: Bring multiple organizations under one security umbrella quickly, with support for multiple identity providers simultaneously.
 - **BYOD programs**: Apply security policies to unmanaged personal devices without requiring software installation.
 - **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
 - **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
@@ -348,7 +347,6 @@ Proxy endpoint traffic is logged in the following locations:
 
 - **Authentication logs**: When users authenticate through an authorization endpoint, login events appear in your [Access logs](/cloudflare-one/insights/logs/).
 - **Traffic logs**: HTTP and network traffic proxied through the endpoint appears in [Gateway logs](/cloudflare-one/insights/logs/gateway-logs/), with the specific proxy endpoint indicated.
-- **Analytics**: You can filter by proxy endpoint in the Gateway analytics dashboard.
 
 ### Billing
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -20,7 +20,7 @@ import {
 [Source IP proxy endpoints](#source-ip-endpoint) are only available on Enterprise plans.
 :::
 
-Proxy endpoints allow you to apply Gateway policies without installing a client on your devices. By configuring a Proxy Auto-Configuration (PAC) file at the browser level, you can route traffic through Gateway for filtering and policy enforcement. Cloudflare supports configuring two types of proxy endpoints: identity-based [authorization endpoints](#authorization-endpoint) and [source IP proxy endpoints](#source-ip-endpoint).
+Proxy endpoints allow you to apply Gateway policies without installing a client on your devices. By configuring a [Proxy Auto-Configuration (PAC) file](#what-is-a-pac-file) at the browser level, you can route traffic through Gateway for filtering and policy enforcement. Cloudflare supports configuring two types of proxy endpoints: identity-based [authorization endpoints](#authorization-endpoint) and [source IP proxy endpoints](#source-ip-endpoint).
 
 :::note
 For the best experience and deepest visibility, Cloudflare recommends using the [WARP client](/cloudflare-one/team-and-resources/devices/warp/). Use proxy endpoints when installing a device client is not feasible for your environment.
@@ -33,6 +33,8 @@ Proxy endpoints are designed for environments where deploying the WARP client is
 - **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
 - **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
 - **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
+
+### What is a PAC file
 
 <GlossaryDefinition term="PAC file" prepend="A PAC file is " />
 
@@ -48,13 +50,13 @@ PAC files offer several advantages:
 PAC files require user interaction. Authorization endpoints require users to log in through [Cloudflare Access](/cloudflare-one/access-controls/policies/). PAC files do not currently support username/password, mTLS, or Kerberos authorization. Support for additional authentication methods is planned for future releases.
 :::
 
-## Types of proxy endpoints
+### Types of proxy endpoints
 
 Cloudflare One offers two types of proxy endpoints, each with different authorization methods.
 
 Once you create a proxy endpoint, you cannot change its type. If you need a different authorization method, you must create a new proxy endpoint.
 
-### Authorization endpoint <Badge text="Beta" variant="caution" />
+#### Authorization endpoint <Badge text="Beta" variant="caution" />
 
 Authorization endpoints use [Cloudflare Access](/cloudflare-one/access-controls/policies/) to provide Zero Trust authorization. Users must authenticate through an identity provider and pass Access policies before they can use the proxy endpoint.
 
@@ -65,7 +67,7 @@ Use authorization endpoints when:
 - Your organization requires login through identity providers (such as Okta, Microsoft Entra ID, or Google Workspace)
 - You need granular control over who can access the proxy
 
-### Source IP endpoint
+#### Source IP endpoint
 
 Source IP endpoints authorize traffic based on the originating IP address. Only traffic from pre-configured IP addresses can use the proxy endpoint.
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -31,7 +31,6 @@ For the best experience and deepest visibility, Cloudflare recommends using the 
 Proxy endpoints are designed for environments where deploying the WARP client is not an option. Common use cases include:
 
 - **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
-- **BYOD programs**: Apply security policies to unmanaged personal devices without requiring software installation.
 - **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
 - **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -349,7 +349,7 @@ Proxy endpoint traffic is logged in the following locations:
 
 ### Billing
 
-Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/insights/analytics/gateway/#seats), the same as a user connected through the WARP client.
+Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/team-and-resources/users/seat-management/), the same as a user connected through the WARP client.
 
 ## 6. (Optional) Configure firewall
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -22,6 +22,20 @@ import {
 
 Proxy endpoints allow you to apply Gateway policies without installing a client on your devices. By configuring a Proxy Auto-Configuration (PAC) file at the browser level, you can route traffic through Gateway for filtering and policy enforcement. Cloudflare supports configuring two types of proxy endpoints: identity-based [authorization endpoints](#authorization-endpoint) and [source IP proxy endpoints](#source-ip-endpoint).
 
+:::note
+For the best experience and deepest visibility, Cloudflare recommends using the [WARP client](/cloudflare-one/team-and-resources/devices/warp/). Use proxy endpoints when installing a device client is not feasible for your environment.
+:::
+
+### When to use proxy endpoints
+
+Proxy endpoints are designed for environments where deploying the WARP client is not an option. Common use cases include:
+
+- **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
+- **Mergers and acquisitions**: Bring multiple organizations under one security umbrella quickly, with support for multiple identity providers simultaneously.
+- **BYOD programs**: Apply security policies to unmanaged personal devices without requiring software installation.
+- **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
+- **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
+
 <GlossaryDefinition term="PAC file" prepend="A PAC file is " />
 
 When end users visit a website, their browser sends the request to a Cloudflare proxy server associated with your account to be filtered by Gateway. PAC files are evaluated by the browser for every request, determining whether traffic should go through the proxy or connect directly. Note that Gateway [cannot filter every type of HTTP traffic](#traffic-limitations) proxied using PAC files.
@@ -33,7 +47,7 @@ PAC files offer several advantages:
 - **Load balancing**: Distribute traffic across multiple proxy servers with automatic failover
 
 :::note
-PAC files require user interaction. Authorization endpoints require users to log in through [Cloudflare Access](/cloudflare-one/access-controls/policies/). PAC files do not support username/password or mTLS authorization.
+PAC files require user interaction. Authorization endpoints require users to log in through [Cloudflare Access](/cloudflare-one/access-controls/policies/). PAC files do not currently support username/password, mTLS, or Kerberos authorization. Support for additional authentication methods is planned for future releases.
 :::
 
 ## Types of proxy endpoints
@@ -268,7 +282,7 @@ Where:
 Cloudflare-hosted PAC files have the following limits:
 
 - **Maximum file size**: 256 KB per PAC file
-- **Maximum PAC files per account**: 100
+- **Maximum PAC files per account**: 50 (non-Enterprise plans) or 1,000 (Enterprise plans)
 - **Update propagation**: Changes to PAC files propagate within seconds to minutes across the global network
 
 #### Caching behavior
@@ -282,6 +296,13 @@ Hosted PAC files are cached globally for performance and reliability:
 ### Self-hosting PAC files
 
 You can also host PAC files on your own infrastructure, such as an internal web server or [Cloudflare Workers](/workers/). Self-hosting gives you complete control over the hosting environment but requires you to manage availability and distribution.
+
+### Proxy endpoint limits
+
+Each account has a maximum number of proxy endpoints:
+
+- **Non-Enterprise plans**: 50 proxy endpoints
+- **Enterprise plans**: 500 proxy endpoints
 
 ## 3. Configure your devices
 
@@ -321,7 +342,19 @@ To test your configuration, create an [HTTP policy](/cloudflare-one/traffic-poli
 
 You can now use the Proxy Endpoint selector in [network](/cloudflare-one/traffic-policies/network-policies/#proxy-endpoint) and [HTTP](/cloudflare-one/traffic-policies/http-policies/#proxy-endpoint) policies to filter traffic proxied via PAC files.
 
-## 5. (Optional) Configure firewall
+## 5. View logs and analytics
+
+Proxy endpoint traffic is logged in the following locations:
+
+- **Authentication logs**: When users authenticate through an authorization endpoint, login events appear in your [Access logs](/cloudflare-one/insights/logs/).
+- **Traffic logs**: HTTP and network traffic proxied through the endpoint appears in [Gateway logs](/cloudflare-one/insights/logs/gateway-logs/), with the specific proxy endpoint indicated.
+- **Analytics**: You can filter by proxy endpoint in the Gateway analytics dashboard.
+
+### Billing
+
+Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/insights/analytics/gateway/#seats), the same as a user connected through the WARP client.
+
+## 6. (Optional) Configure firewall
 
 You may need to configure your organization's firewall to allow your users to connect to a proxy endpoint. Depending on your firewall, you will need to create a rule using either your proxy endpoint's domain or IP addresses.
 
@@ -470,6 +503,10 @@ You must bypass domains you do not intend to inspect with your PAC file. Gateway
 
 Authorization endpoints do not support plaintext HTTP traffic unless the traffic is configured through an [Access application](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) or bypassed with the PAC file.
 
+#### Browser Isolation
+
+Gateway [HTTP Isolate policies](/cloudflare-one/traffic-policies/http-policies/#isolate) are not currently supported with authorization endpoints during the beta period.
+
 #### Referer header traffic
 
 Traffic with a referer HTTP header matching the domain of a recently logged in user from the same source IP will be allowed through and logged with the following non-identity email address:
@@ -480,7 +517,12 @@ auth-proxy-non-identity@<your-team-name>.cloudflareaccess.com
 
 Where `<your-team-name>` is your [team name](/cloudflare-one/faq/getting-started-faq/#what-is-a-team-domainteam-name).
 
-This occurs because browsers do not tag HTTP sub-requests with the identity cookie used to verify user authentication. If you would like to filter this traffic, you can set up an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) to block or allow all traffic matching the `auth-proxy-non-identity@<your-team-name>.cloudflareaccess.com` email address.
+This occurs because browsers do not tag HTTP sub-requests with the identity cookie used to verify user authentication. This is an industry-standard behavior for proxy-based Secure Web Gateways.
+
+To filter this traffic, you have two options:
+
+- Set up an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) to block or allow all traffic matching the `auth-proxy-non-identity@<your-team-name>.cloudflareaccess.com` email address.
+- To restrict non-identity traffic to specific source IPs, create a [network policy](/cloudflare-one/traffic-policies/network-policies/) that matches both the source IP and the proxy endpoint.
 
 ### Traffic limitations
 


### PR DESCRIPTION
## Summary

Updates the proxy endpoints documentation with additional information sourced from the internal release notes and announcement blog post for the authorization proxy open beta.

## Changes

- **Browser Isolation limitation**: Documents that Gateway HTTP Isolate policies are not supported with authorization endpoints during the beta period.
- **Per-plan account limits**: Updates PAC file limits (50 non-Enterprise / 1,000 Enterprise) and adds proxy endpoint limits (50 non-Enterprise / 500 Enterprise).
- **Use-case guidance**: Adds a "When to use proxy endpoints" section covering VDI, M&A, BYOD, compliance-restricted endpoints, and legacy SWG migration.
- **WARP client recommendation**: Adds a note recommending the WARP client as the preferred approach when feasible.
- **Logging and analytics**: New "View logs and analytics" section documenting where authentication logs, traffic logs, and analytics live.
- **Billing**: Documents that each authenticated user occupies a Gateway seat.
- **Referer header workaround**: Expands the referer header traffic section with industry context and a network policy workaround for restricting non-identity traffic by source IP.
- **Future auth methods**: Updates the auth note to mention Kerberos, mTLS, and username/password support is planned.

## References

- Internal release notes: https://wiki.cfdata.org/spaces/RH/pages/1258008564
- Blog post: https://blog.cloudflare.com/gateway-authorization-proxy-identity-aware-policies/
- Dev docs: https://developers.cloudflare.com/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/