### PR TITLE
[Astro] Reduce logging errors

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -32,8 +32,12 @@ const shouldChatbotDeprioritize =
 
 // if not a top-level page, add metadata values from src/content/directory/ entries
 if (currentSection) {
-	// if entry for directory, grab and proceed
-	let product = await getEntry("directory", currentSection);
+	// For changelog pages there is no directory entry for "changelog" itself; skip
+	// the lookup to avoid spurious "Entry directory → changelog was not found" warnings.
+	// The actual product is resolved below from frontmatter.products[0].
+	let product = currentSection !== "changelog"
+		? await getEntry("directory", currentSection)
+		: undefined;
 	// if entry for changelog, grab the first product value (which corresponds to the folder the entry is in) and use as the primary "product"
 	if (currentSection === "changelog") {
 		const products = frontmatter.products;

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -20,6 +20,11 @@ const component = frontmatter.styleGuide?.component;
 
 const slug = Astro.locals.starlightRoute.entry.slug;
 
+// Currently the officially sanctioned way to alter behaviour on specific routes
+// https://starlight.astro.build/guides/overriding-components/#only-override-on-specific-pages
+const hideTitle = Astro.locals.starlightRoute.hideTitle;
+const hideBreadcrumbs = Astro.locals.starlightRoute.hideBreadcrumbs;
+
 const breadcrumbProps: Record<string, any> = {
 	crumbs: [
 		{
@@ -31,46 +36,43 @@ const breadcrumbProps: Record<string, any> = {
 	id: "breadcrumbs",
 };
 
-const segments = slug.split("/");
+if (!hideBreadcrumbs) {
+	const segments = slug.split("/");
 
-for (let i = 0; i < segments.length; i++) {
-	if (i === 0) {
-		const entry = await getEntry("directory", segments[0]);
+	for (let i = 0; i < segments.length; i++) {
+		if (i === 0) {
+			const entry = await getEntry("directory", segments[0]);
 
-		let title = segments[0];
+			let title = segments[0];
+			if (entry) {
+				title = entry.data.entry.title;
+			}
+
+			breadcrumbProps.crumbs.push({
+				text: title,
+				href: `/${segments[0]}/`,
+			});
+
+			continue;
+		}
+
+		let path = segments.slice(0, i + 1).join("/");
+
+		const entry = await getEntry("docs", path);
+
+		let title = segments[i];
 		if (entry) {
-			title = entry.data.entry.title;
+			title = entry.data.title;
+		} else {
+			continue;
 		}
 
 		breadcrumbProps.crumbs.push({
 			text: title,
-			href: `/${segments[0]}/`,
+			href: `/${path}/`,
 		});
-
-		continue;
 	}
-
-	let path = segments.slice(0, i + 1).join("/");
-
-	const entry = await getEntry("docs", path);
-
-	let title = segments[i];
-	if (entry) {
-		title = entry.data.title;
-	} else {
-		continue;
-	}
-
-	breadcrumbProps.crumbs.push({
-		text: title,
-		href: `/${path}/`,
-	});
 }
-
-// Currently the officially sanctioned way to alter behaviour on specific routes
-// https://starlight.astro.build/guides/overriding-components/#only-override-on-specific-pages
-const hideTitle = Astro.locals.starlightRoute.hideTitle;
-const hideBreadcrumbs = Astro.locals.starlightRoute.hideBreadcrumbs;
 ---
 
 <div class="flex items-center justify-between">


### PR DESCRIPTION
### Summary

Refactors our Head + Breadcrumb logic to avoid noisy warnings on builds.

Things to verify in review:

- [x] Breadcrumbs still work as expected (correct nav / links / scrunch in mobile)
- [x] `<meta name="pcx_product" content="$PRODUCT">` still renders and produces correct values on regular pages and changelog pages
- [ ] Breadcrumbs continue to work as expected for learning paths