### PR TITLE
[GHA] chore: update stale issue CI message

### DIFF
--- a/.github/workflows/close-stale-issues-prs.yml
+++ b/.github/workflows/close-stale-issues-prs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: "Hey there, we've marked this pull request as stale because there's no recent activity on it. This label helps us identify long-standing issues in our repo (and not used to auto-close issues)."
+          stale-issue-message: "Hey there, we've marked this issue as stale because there's no recent activity on it. This label helps us identify long-standing issues in our repo (and not used to auto-close issues)."
           stale-pr-message: "Hey there, we've marked this pull request as stale because there's no recent activity on it. This label is helps us identify PRs that might need updates (or to be closed out by our team if no longer relevant)."
           days-before-stale: 14
           # setting to a negative number means they'll never be autoclosed


### PR DESCRIPTION
### Summary

This fixes a small typo in the stale issue message configuration from `pull request` to `issue`, to fix the text seen in places like this: https://github.com/cloudflare/cloudflare-docs/issues/25147#issuecomment-3995084999

cc @kodster28 