### PR TITLE
Remove Punycode domain support limitation for Google Trust Services

### DIFF
--- a/src/content/docs/ssl/reference/certificate-authorities.mdx
+++ b/src/content/docs/ssl/reference/certificate-authorities.mdx
@@ -68,7 +68,7 @@ You can find the full list of supported clients in the [Let's Encrypt documentat
 
 #### Limitations
 
-- Punycode domains are not yet supported.
+- None
 
 #### Browser compatibility (most compatible)
 


### PR DESCRIPTION
Google Trust Services now offers the ability to request TLS certificates for domain names with Punycode labels. (i.e. Internationalized Domain Names or IDNs) This enables customers with IDNs to use Google Trust Services for their TLS certificates. See: https://pki.goog/updates/february2026-idn-update.html

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
