### PR TITLE
[Cloudflare One] Add PAC file and proxy endpoint tiered limits to account limits

### DIFF
--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -41,7 +41,10 @@ This page lists the default account limits for rules, applications, fields, and 
 | DNS locations                             | 250   |
 | Source IP CIDRs per DNS location          | 1,500 |
 | Concurrent streams for HTTP/2 connections | 256   |
-| Proxy endpoints                           | 500   |
+| PAC files (Standard users)                | 50    |
+| PAC files (Enterprise users)              | 1,000 |
+| Proxy endpoints (Standard users)          | 50    |
+| Proxy endpoints (Enterprise users)        | 500   |
 | Source IP CIDRs per proxy endpoint        | 2,000 |
 | Lists                                     | 100   |
 | Entries per list (Standard users)         | 1,000 |

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -45,7 +45,6 @@ For the best experience and deepest visibility, Cloudflare recommends using the 
 Proxy endpoints are designed for environments where deploying the WARP client is not an option. Common use cases include:
 
 - **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
-- **Mergers and acquisitions**: Bring multiple organizations under one security umbrella quickly, with support for multiple identity providers simultaneously.
 - **BYOD programs**: Apply security policies to unmanaged personal devices without requiring software installation.
 - **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
 - **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
@@ -362,7 +361,6 @@ Proxy endpoint traffic is logged in the following locations:
 
 - **Authentication logs**: When users authenticate through an authorization endpoint, login events appear in your [Access logs](/cloudflare-one/insights/logs/).
 - **Traffic logs**: HTTP and network traffic proxied through the endpoint appears in [Gateway logs](/cloudflare-one/insights/logs/gateway-logs/), with the specific proxy endpoint indicated.
-- **Analytics**: You can filter by proxy endpoint in the Gateway analytics dashboard.
 
 ### Billing
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -36,6 +36,20 @@ Proxy endpoints are designed for environments where deploying the WARP client is
 
 ### What is a PAC file
 
+:::note
+For the best experience and deepest visibility, Cloudflare recommends using the [WARP client](/cloudflare-one/team-and-resources/devices/warp/). Use proxy endpoints when installing a device client is not feasible for your environment.
+:::
+
+### When to use proxy endpoints
+
+Proxy endpoints are designed for environments where deploying the WARP client is not an option. Common use cases include:
+
+- **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
+- **Mergers and acquisitions**: Bring multiple organizations under one security umbrella quickly, with support for multiple identity providers simultaneously.
+- **BYOD programs**: Apply security policies to unmanaged personal devices without requiring software installation.
+- **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
+- **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
+
 <GlossaryDefinition term="PAC file" prepend="A PAC file is " />
 
 When end users visit a website, their browser sends the request to a Cloudflare proxy server associated with your account to be filtered by Gateway. PAC files are evaluated by the browser for every request, determining whether traffic should go through the proxy or connect directly. Note that Gateway [cannot filter every type of HTTP traffic](#traffic-limitations) proxied using PAC files.
@@ -342,7 +356,19 @@ To test your configuration, create an [HTTP policy](/cloudflare-one/traffic-poli
 
 You can now use the Proxy Endpoint selector in [network](/cloudflare-one/traffic-policies/network-policies/#proxy-endpoint) and [HTTP](/cloudflare-one/traffic-policies/http-policies/#proxy-endpoint) policies to filter traffic proxied via PAC files.
 
-## 5. (Optional) Configure firewall
+## 5. View logs and analytics
+
+Proxy endpoint traffic is logged in the following locations:
+
+- **Authentication logs**: When users authenticate through an authorization endpoint, login events appear in your [Access logs](/cloudflare-one/insights/logs/).
+- **Traffic logs**: HTTP and network traffic proxied through the endpoint appears in [Gateway logs](/cloudflare-one/insights/logs/gateway-logs/), with the specific proxy endpoint indicated.
+- **Analytics**: You can filter by proxy endpoint in the Gateway analytics dashboard.
+
+### Billing
+
+Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/insights/analytics/gateway/#seats), the same as a user connected through the WARP client.
+
+## 6. (Optional) Configure firewall
 
 You may need to configure your organization's firewall to allow your users to connect to a proxy endpoint. Depending on your firewall, you will need to create a rule using either your proxy endpoint's domain or IP addresses.
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -354,18 +354,7 @@ To test your configuration, create an [HTTP policy](/cloudflare-one/traffic-poli
 
 You can now use the Proxy Endpoint selector in [network](/cloudflare-one/traffic-policies/network-policies/#proxy-endpoint) and [HTTP](/cloudflare-one/traffic-policies/http-policies/#proxy-endpoint) policies to filter traffic proxied via PAC files.
 
-## 5. View logs and analytics
-
-Proxy endpoint traffic is logged in the following locations:
-
-- **Authentication logs**: When users authenticate through an authorization endpoint, login events appear in your [Access logs](/cloudflare-one/insights/logs/).
-- **Traffic logs**: HTTP and network traffic proxied through the endpoint appears in [Gateway logs](/cloudflare-one/insights/logs/gateway-logs/), with the specific proxy endpoint indicated.
-
-### Billing
-
-Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/team-and-resources/users/seat-management/), the same as a user connected through the WARP client.
-
-## 6. (Optional) Configure firewall
+## 5. (Optional) Configure firewall
 
 You may need to configure your organization's firewall to allow your users to connect to a proxy endpoint. Depending on your firewall, you will need to create a rule using either your proxy endpoint's domain or IP addresses.
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -363,7 +363,7 @@ Proxy endpoint traffic is logged in the following locations:
 
 ### Billing
 
-Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/insights/analytics/gateway/#seats), the same as a user connected through the WARP client.
+Each user who authenticates through an authorization proxy endpoint occupies a [Gateway seat](/cloudflare-one/team-and-resources/users/seat-management/), the same as a user connected through the WARP client.
 
 ## 6. (Optional) Configure firewall
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -22,20 +22,9 @@ import {
 
 Proxy endpoints allow you to apply Gateway policies without installing a client on your devices. By configuring a [Proxy Auto-Configuration (PAC) file](#what-is-a-pac-file) at the browser level, you can route traffic through Gateway for filtering and policy enforcement. Cloudflare supports configuring two types of proxy endpoints: identity-based [authorization endpoints](#authorization-endpoint) and [source IP proxy endpoints](#source-ip-endpoint).
 
-
 :::note
 For the best experience and deepest visibility, Cloudflare recommends using the [WARP client](/cloudflare-one/team-and-resources/devices/warp/). Use proxy endpoints when installing a device client is not feasible for your environment.
 :::
-
-### When to use proxy endpoints
-
-Proxy endpoints are designed for environments where deploying the WARP client is not an option. Common use cases include:
-
-- **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
-- **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
-- **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
-
-### What is a PAC file
 
 ### When to use proxy endpoints
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -22,6 +22,7 @@ import {
 
 Proxy endpoints allow you to apply Gateway policies without installing a client on your devices. By configuring a [Proxy Auto-Configuration (PAC) file](#what-is-a-pac-file) at the browser level, you can route traffic through Gateway for filtering and policy enforcement. Cloudflare supports configuring two types of proxy endpoints: identity-based [authorization endpoints](#authorization-endpoint) and [source IP proxy endpoints](#source-ip-endpoint).
 
+
 :::note
 For the best experience and deepest visibility, Cloudflare recommends using the [WARP client](/cloudflare-one/team-and-resources/devices/warp/). Use proxy endpoints when installing a device client is not feasible for your environment.
 :::
@@ -36,10 +37,6 @@ Proxy endpoints are designed for environments where deploying the WARP client is
 
 ### What is a PAC file
 
-:::note
-For the best experience and deepest visibility, Cloudflare recommends using the [WARP client](/cloudflare-one/team-and-resources/devices/warp/). Use proxy endpoints when installing a device client is not feasible for your environment.
-:::
-
 ### When to use proxy endpoints
 
 Proxy endpoints are designed for environments where deploying the WARP client is not an option. Common use cases include:
@@ -47,6 +44,8 @@ Proxy endpoints are designed for environments where deploying the WARP client is
 - **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
 - **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
 - **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
+
+### What is a PAC file
 
 <GlossaryDefinition term="PAC file" prepend="A PAC file is " />
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -45,7 +45,6 @@ For the best experience and deepest visibility, Cloudflare recommends using the 
 Proxy endpoints are designed for environments where deploying the WARP client is not an option. Common use cases include:
 
 - **Virtual desktops (VDI)**: Users log into a virtual machine and use a browser to reach the Internet.
-- **BYOD programs**: Apply security policies to unmanaged personal devices without requiring software installation.
 - **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
 - **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
 


### PR DESCRIPTION
## Summary

- Adds Standard vs Enterprise user limits for **PAC files** (50 / 1,000) and **proxy endpoints** (50 / 500) to the Gateway section of the [account limits page](/cloudflare-one/account-limits/).
- Replaces the previous single proxy endpoints limit of 500 with tiered rows that distinguish between Standard and Enterprise users.
- Adds PAC file hosting limits that were previously only documented on the proxy endpoints page.

## Changes

In `src/content/docs/cloudflare-one/account-limits.mdx`, the Gateway table now includes:

| Feature                          | Limit |
| -------------------------------- | ----- |
| PAC files (Standard users)       | 50    |
| PAC files (Enterprise users)     | 1,000 |
| Proxy endpoints (Standard users) | 50    |
| Proxy endpoints (Enterprise users) | 500 |

This follows the same convention used by `Entries per list (Standard users)` / `Entries per list (Enterprise users)` already in the table.