### PR TITLE
Document DCV bypass behavior in Trace and WAF FAQ (SPM-2962)

### DIFF
--- a/src/content/docs/rules/trace-request/limitations.mdx
+++ b/src/content/docs/rules/trace-request/limitations.mdx
@@ -6,6 +6,30 @@ sidebar:
   label: Limitations
 ---
 
+## Automatic rule bypasses
+
+Trace does not show when rules are automatically bypassed by Cloudflare for operational reasons. The following bypasses occur but will not appear in trace results:
+
+### Certificate validation (DCV)
+
+When SSL/TLS certificates managed by Cloudflare are in `pending_validation` status with valid DCV tokens, the following security features are automatically disabled on specific paths:
+
+**Affected paths:**
+- `/.well-known/pki-validation/`
+- `/.well-known/acme-challenge/`
+
+**Bypassed features:**
+- Custom rules (WAF custom rules)
+- Managed Rules
+
+This automatic bypass ensures certificate authorities can validate domain ownership without interference from security rules. If you are troubleshooting why a rule did not trigger, check if the request path matches these patterns.
+
+Refer to [Why are some rules bypassed?](/waf/troubleshooting/faq/#why-are-some-rules-bypassed-when-i-did-not-create-an-exception) for more details.
+
+---
+
+## Unsupported features
+
 Trace currently does not support:
 
 - Hostnames using [Data Localization Suite](/data-localization/)

--- a/src/content/docs/waf/troubleshooting/faq.mdx
+++ b/src/content/docs/waf/troubleshooting/faq.mdx
@@ -8,13 +8,11 @@ sidebar:
 ## General questions
 
 ### Why does a security event display a Cloudflare IP address even though other fields match the client details?
-
 This happens when a request goes through a Cloudflare Worker.
 
 In this case, Cloudflare considers the client details, including its IP address, for triggering security settings. However, the IP displayed in [Security Events](/waf/analytics/security-events/) will be a Cloudflare IP address.
 
 ### Do I need to escape certain characters in expressions?
-
 Yes, you may have to escape certain characters in expressions. The exact escaping will depend on the string syntax you use:
 
 - If you use the raw string syntax (for example, `r#"this is a string"#`), you will only need to escape characters that have a special meaning in regular expressions.
@@ -23,15 +21,27 @@ Yes, you may have to escape certain characters in expressions. The exact escapin
 For more information on string syntaxes and escaping, refer to [String values and regular expressions](/ruleset-engine/rules-language/values/#string-values-and-regular-expressions).
 
 ### Why is my regular expression pattern not working?
-
 If you are using a regular expression, it is recommended that you test it with a tool such as [Regular Expressions 101](https://regex101.com/?flavor=rust&regex=) or [Rustexp](https://rustexp.lpil.uk).
 
 ### Why are some rules bypassed when I did not create an exception?
 
+:::caution[Automatic DCV bypass]
+
+If you have SSL/TLS certificates managed by Cloudflare, security rules are automatically bypassed for domain control validation (DCV) paths when certificates require validation.
+
+**This bypass:**
+- Happens automatically when certificates are in `pending_validation` status
+- Affects [custom rules](/waf/custom-rules/) and [Managed Rules](/waf/managed-rules/)
+- Applies to paths: `/.well-known/pki-validation/` and `/.well-known/acme-challenge/`
+- **Does not appear in [Trace](/rules/trace-request/) or security analytics**
+
+:::
+
 If you have [SSL/TLS certificates](/ssl/) managed by Cloudflare, every time a certificate is issued or renewed, a [domain control validation (DCV)](/ssl/edge-certificates/changing-dcv-method/dcv-flow/) must happen. When a certificate is in `pending_validation` state and there are valid DCV tokens in place, some Cloudflare security features such as [custom rules](/waf/custom-rules/) and [Managed Rules](/waf/managed-rules/) will be automatically disabled on specific DCV paths (for example, `/.well-known/pki-validation/` and `/.well-known/acme-challenge/`).
 
-### Why have I been blocked?
+This ensures certificate authorities can complete validation without security rules blocking legitimate validation requests.
 
+### Why have I been blocked?
 Cloudflare may block requests when it detects activity that could be unsafe. Common reasons include:
 
 - Security protection against malicious traffic, DDoS attacks, or other threats.
@@ -58,22 +68,3 @@ ISP-level blocks are distinct from Cloudflare or site-owner security restriction
 ## Bots
 
 ### How does the WAF handle traffic from known bots?
-
-#### Caution about potentially blocking bots
-
-When you create a custom rule with a _Block_, _Non-Interactive Challenge_, _Managed Challenge_, or _Interactive Challenge_ action, you might unintentionally block traffic from known bots. Specifically, this might affect search engine optimization (SEO) and website monitoring when trying to enforce a mitigation action based on URI, path, host, ASN, or country.
-
-Refer to the [Challenges documentation](/cloudflare-challenges/troubleshooting/#allowlist-traffic-from-mitigation-actions) for more information.
-
-#### Bots currently detected
-
-[Cloudflare Radar](https://radar.cloudflare.com/verified-bots) lists a **sample** of known bots that the WAF currently detects. When traffic comes from these bots and others not listed, the `cf.client.bot` field is set to `true`.
-
-To submit a friendly bot to be verified, go to the [**Verified bots**](https://radar.cloudflare.com/traffic/verified-bots) page in Cloudflare Radar and select **Add a bot**.
-
-For more information on verified bots, refer to [Bots](/bots/concepts/bot/).
-
-:::note
-
-There is no functional difference between known and verified bots. However, the known bots field (`cf.client.bot`) is available for all customers, while the verified bots field (`cf.bot_management.verified_bot`) is available for Enterprise customers.
-:::


### PR DESCRIPTION
## Summary
Adds documentation about automatic DCV bypass behavior that isn't visible in Trace or security analytics.

## Related Issues
- Jira: SPM-2962
- Customer case: CUSTESC-56853

## Changes
1. **Trace Limitations page** ():
   - Added new 'Automatic rule bypasses' section before existing limitations
   - Documents that DCV bypasses don't appear in trace results
   - Lists affected paths and bypassed features

2. **WAF FAQ page** ():
   - Enhanced DCV bypass answer with prominent callout box
   - Explicitly states bypasses are invisible in Trace and security analytics
   - Improved scannability with structured bullet points

## Why This Matters
Customers troubleshooting security rules using Trace don't see any indication that rules are automatically bypassed for `.well-known` paths during certificate validation. This has led to confusion and support escalations. These changes make the behavior discoverable from multiple entry points.

## Testing
- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri- Veri-e
- - - - - - - - -  f- - - - - - - -t - - - - - - - - -  f- - - - -