### PR TITLE
Document DCV bypass visibility in Trace (SPM-2962)

### DIFF
--- a/src/content/docs/rules/trace-request/limitations.mdx
+++ b/src/content/docs/rules/trace-request/limitations.mdx
@@ -12,7 +12,7 @@ Trace does not display rules that are automatically bypassed for operational rea
 
 For example, when SSL/TLS certificates are in `pending_validation` status, security rules are automatically disabled for domain control validation (DCV) paths like `/.well-known/pki-validation/` and `/.well-known/acme-challenge/`. These bypasses will not appear in trace results.
 
-For more information, refer to [Why are some rules bypassed?](/waf/troubleshooting/faq/#why-are-some-rules-bypassed-when-i-did-not-create-an-exception)
+For more information, refer to [Why are some rules bypassed?](/waf/troubleshooting/faq/#why-are-some-rules-bypassed-when-i-did-not-create-an-exception) in the WAF documentation.
 
 ---
 

--- a/src/content/docs/rules/trace-request/limitations.mdx
+++ b/src/content/docs/rules/trace-request/limitations.mdx
@@ -6,6 +6,18 @@ sidebar:
   label: Limitations
 ---
 
+## Automatic rule bypasses
+
+Trace does not display rules that are automatically bypassed for operational reasons. 
+
+For example, when SSL/TLS certificates are in `pending_validation` status, security rules are automatically disabled for domain control validation (DCV) paths like `/.well-known/pki-validation/` and `/.well-known/acme-challenge/`. These bypasses will not appear in trace results.
+
+For more information, refer to [Why are some rules bypassed?](/waf/troubleshooting/faq/#why-are-some-rules-bypassed-when-i-did-not-create-an-exception)
+
+---
+
+## Unsupported features
+
 Trace currently does not support:
 
 - Hostnames using [Data Localization Suite](/data-localization/)

--- a/src/content/docs/waf/troubleshooting/faq.mdx
+++ b/src/content/docs/waf/troubleshooting/faq.mdx
@@ -30,12 +30,7 @@ If you are using a regular expression, it is recommended that you test it with a
 
 If you have [SSL/TLS certificates](/ssl/) managed by Cloudflare, every time a certificate is issued or renewed, a [domain control validation (DCV)](/ssl/edge-certificates/changing-dcv-method/dcv-flow/) must happen. When a certificate is in `pending_validation` state and there are valid DCV tokens in place, some Cloudflare security features such as [custom rules](/waf/custom-rules/) and [Managed Rules](/waf/managed-rules/) will be automatically disabled on specific DCV paths (for example, `/.well-known/pki-validation/` and `/.well-known/acme-challenge/`).
 
-:::note
-
-These automatic bypasses do not appear in [Trace](/rules/trace-request/).
-
-:::
-
+These automatic bypasses do not appear in [Trace](/rules/trace-request/) results.
 ### Why have I been blocked?
 
 Cloudflare may block requests when it detects activity that could be unsafe. Common reasons include:

--- a/src/content/docs/waf/troubleshooting/faq.mdx
+++ b/src/content/docs/waf/troubleshooting/faq.mdx
@@ -30,6 +30,12 @@ If you are using a regular expression, it is recommended that you test it with a
 
 If you have [SSL/TLS certificates](/ssl/) managed by Cloudflare, every time a certificate is issued or renewed, a [domain control validation (DCV)](/ssl/edge-certificates/changing-dcv-method/dcv-flow/) must happen. When a certificate is in `pending_validation` state and there are valid DCV tokens in place, some Cloudflare security features such as [custom rules](/waf/custom-rules/) and [Managed Rules](/waf/managed-rules/) will be automatically disabled on specific DCV paths (for example, `/.well-known/pki-validation/` and `/.well-known/acme-challenge/`).
 
+:::note
+
+These automatic bypasses do not appear in [Trace](/rules/trace-request/).
+
+:::
+
 ### Why have I been blocked?
 
 Cloudflare may block requests when it detects activity that could be unsafe. Common reasons include:


### PR DESCRIPTION
## Summary
Documents that automatic DCV bypasses don't appear in Trace or security analytics.

## Related Issues
- Jira: SPM-2962

## Changes
1. **Trace Limitations** - Added brief section about automatic rule bypasses
2. **WAF FAQ** - Added note that DCV bypasses don't appear in Trace

## Why
Customers troubleshooting security rules using Trace don't see any indication that rules are bypassed for .well-known paths during certificate validation, leading to confusion and support cases.

These minimal, focused changes make the limitation discoverable without extensive modifications.