### PR TITLE
[Registrar] Rewrite transfer page and add registration limits troubleshooting

### DIFF
--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -18,7 +18,7 @@ Transferring a domain moves your registration from your current registrar to Clo
 Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare).
 
 :::note
-If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
 :::
 
 ---

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -9,9 +9,13 @@ description: >-
 
 import { DashButton, Details, Render } from "~/components";
 
-Transferring a domain moves your registration from your current registrar to Cloudflare. The process takes about 30 minutes of active work, but the full transfer usually takes 3-5 business days to complete because your current registrar has up to 5 days to release the domain, and changes to your domain settings take time to take effect across the internet. Each transfer adds one year to your domain registration at Cloudflare's at-cost price.
+Transferring a domain moves your registration from your current registrar to Cloudflare.
 
-**Cloudflare works differently from most registrars.** You cannot enter an authorization code right away. Instead, Cloudflare requires you to add your domain and point your nameservers to Cloudflare first, so your site benefits from Cloudflare performance and security features from the moment the transfer begins. This is covered in [step 1](#1-add-your-domain-to-cloudflare) below.
+- **Active work:** About 30 minutes.
+- **Total time:** Usually 3-5 business days, because your current registrar has up to 5 days to release the domain and changes to your domain settings take time to take effect across the internet.
+- **Cost:** One year of registration at Cloudflare's at-cost price, added to your current expiration date.
+
+Before you can transfer, you must [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare) and update your nameservers. Only then can you enter an authorization code and start the transfer. This is because Cloudflare applies performance and security features to your site before the transfer begins.
 
 :::note
 If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
@@ -28,7 +32,7 @@ Confirm the following before you start:
 - Your domain was registered at least 60 days ago and has not been transferred in the last 60 days (ICANN requirement).
 - You have not changed your registrant name, organization, or email address in the last 60 days. Under ICANN rules, changes to these fields trigger a 60-day transfer lock. Some registrars let you opt out of this lock during the change, but not all do.
 - Your account at your current registrar is active. If your domain has expired, renew it at your current registrar first.
-- Your domain is not an internationalized domain name (IDN). Cloudflare does not currently support IDNs.
+- Your domain uses only standard characters (letters, numbers, hyphens). Cloudflare does not support domains with non-Latin characters (for example, `例え.jp`).
 - If you are transferring a `.us` domain, refer to [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).
 - If you are transferring multiple domains, notify your bank to prevent fraud alerts on multiple charges.
 
@@ -38,9 +42,9 @@ Cloudflare Registrar requires your domain to use Cloudflare for [authoritative D
 
 <Details header="Restrictions" id="restrictions">
 
-Domains with any of the following statuses cannot be transferred: `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod`. Domains that are locked (`clientTransferProhibited`) will not appear as available for transfer until you unlock them at your current registrar.
-
 If your domain appears as available for transfer in the Cloudflare dashboard, these restrictions have already been checked.
+
+For reference, domains with any of the following statuses cannot be transferred: `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod`. Domains that are locked (`clientTransferProhibited`) will not appear as available for transfer until you unlock them at your current registrar.
 
 :::caution
 If you renew an expired domain and then transfer it within 45 days of the original expiration date, the registry may not add the extra year. Refer to [Registration limits and the one-year extension](#enter-your-authorization-code-and-confirm-payment) for details.
@@ -52,7 +56,7 @@ If you renew an expired domain and then transfer it within 45 days of the origin
 
 ## 1. Add your domain to Cloudflare
 
-Before you can transfer your registration, your domain must be active on Cloudflare. This is what allows Cloudflare to protect your site with performance and security features during and after the transfer. You will not be able to enter an authorization code or proceed with the transfer until this step is complete.
+Before you can transfer your registration, your domain must be [active on Cloudflare](/dns/zone-setups/full-setup/). This is what allows Cloudflare to protect your site with performance and security features during and after the transfer. You will not be able to enter an authorization code or proceed with the transfer until this step is complete.
 
 ### Disable DNSSEC
 
@@ -60,43 +64,17 @@ If DNSSEC is enabled at your current registrar, disable it before you change nam
 
 **At your current registrar:**
 
-1. Check your domain settings for DNSSEC or DS records. If there are none, DNSSEC is not active and you can skip to [Add your domain](#add-your-domain).
+1. Check your domain settings for DNSSEC or DS records. If there are none, DNSSEC is not active and you can skip to [Add your domain](#add-your-domain-and-update-your-nameservers).
 2. Remove or disable DNSSEC (sometimes labeled "DS records").
 3. Wait at least 24 hours for the change to propagate before changing nameservers.
 
-<Details header="DNSSEC instructions for specific registrars">
-
-This is not an exhaustive list, but the following links may be helpful:
-
-- [DNSimple](https://support.dnsimple.com/articles/cloudflare-ds-record/)
-- [DreamHost](https://help.dreamhost.com/hc/en-us/articles/219539467)
-- [Dynadot](https://www.dynadot.com/help/question/set-DNSSEC)
-- [Enom](https://support.enom.com/support/solutions/articles/201000065386)
-- [Gandi](https://docs.gandi.net/en/domain_names/advanced_users/dnssec.html)
-- [GoDaddy](https://www.godaddy.com/help/add-a-ds-record-23865)
-- [Hover](https://support.hover.com/support/solutions/articles/201000064716)
-- [Name.com](https://www.name.com/support/articles/205439058-managing-dnssec)
-- [Namecheap](https://www.namecheap.com/support/knowledgebase/article.aspx/9722/2232/managing-dnssec-for-domains-pointed-to-custom-dns/)
-- [Squarespace](https://support.squarespace.com/hc/articles/4404183898125-Nameservers-and-DNSSEC-for-Squarespace-managed-domains#toc-dnssec)
-- [Porkbun](https://kb.porkbun.com/article/93-how-to-install-dnssec) (do not fill out **keyData**)
-
-</Details>
+<Render file="dnssec-providers" product="dns" />
 
 After your transfer completes, you can re-enable DNSSEC through Cloudflare with one click. Refer to [Enable DNSSEC](/dns/dnssec/#1-activate-dnssec-in-cloudflare).
 
-### Add your domain
+### Add your domain and update your nameservers
 
-**In the Cloudflare dashboard:**
-
-1. [Add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account.
-2. [Review your DNS records](/dns/zone-setups/full-setup/setup/#review-dns-records). Cloudflare scans for common records automatically, but the scan is not guaranteed to find all existing records. Compare the results against your current DNS configuration to avoid downtime.
-3. Cloudflare will assign you two nameservers (for example, `ada.ns.cloudflare.com` and `paul.ns.cloudflare.com`).
-
-### Update your nameservers
-
-**At your current registrar:**
-
-[Update your domain nameservers](/dns/nameservers/update-nameservers/) to the Cloudflare nameservers assigned in the previous step.
+Follow the steps in [Set up Cloudflare DNS](/dns/zone-setups/full-setup/setup/) to add your domain, review your DNS records, and get your assigned nameservers. Then [update the nameservers](/dns/nameservers/update-nameservers/) at your current registrar to the ones Cloudflare assigned.
 
 <Details header="Nameserver instructions for popular registrars">
 
@@ -133,7 +111,7 @@ Once your domain is active on Cloudflare, you can transfer the registration. Thi
 
 **At your current registrar:**
 
-Registrars apply a lock (sometimes called registrar lock, domain lock, or transfer lock) to prevent unauthorized transfers. In WHOIS, this appears as `clientTransferProhibited`. Remove this lock so Cloudflare can process the transfer.
+Remove the lock on your domain so Cloudflare can process the transfer. Most registrars apply a lock by default (sometimes called registrar lock, domain lock, or transfer lock) to prevent unauthorized transfers. In WHOIS, this appears as `clientTransferProhibited`.
 
 :::note
 Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your domain still shows as locked after you have disabled one, check for additional lock settings.
@@ -175,7 +153,7 @@ Every domain transfer adds one year to your registration. However, domain regist
 **When a transfer may be rejected:**
 
 - Your domain already has 9 or more years of registration remaining, and adding one year would exceed the 10-year limit (or the 5-year limit for `.co`).
-- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year.
+- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year. For example, if `example.com` expires on December 10, you renew it on December 20 (extending it to December 20 of the following year), and then transfer to Cloudflare on December 30 — the transfer is within 45 days of the original expiration, so the registry may not add an additional year. Your expiration date would remain December 20 of the following year, meaning you effectively paid twice for the same year. If this happens, you are entitled to request a refund from your previous registrar under ICANN rules.
 
 **TLD-specific requirements:**
 

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -1,5 +1,5 @@
 ---
-pcx_content_type: tutorial
+pcx_content_type: how-to
 title: Transfer your domain to Cloudflare
 sidebar:
   order: 2
@@ -9,31 +9,98 @@ description: >-
 
 import { DashButton, Details, Render } from "~/components";
 
-Transferring your domain to Cloudflare tells your registry that a different registrar can now set those authoritative records for you. The relationship is based on trust. Registries only trust one registrar at any given time to make changes on your behalf.
+Transferring a domain moves your registration from your current registrar to Cloudflare. The process takes about 30 minutes of active work, but the full transfer completes over 3-5 business days. Each transfer adds one year to your domain registration at Cloudflare's at-cost price.
 
-Transferring a domain to a new registrar informs the registry that they should instead trust that new registrar to modify information. The process requires some action steps at your new and previous registrar. Each registrar handles transfers a bit differently, but in general, they follow a pattern based on rules set by ICANN, the organization responsible for regulating domain registration.
+**Cloudflare works differently from most registrars.** You cannot enter an authorization code right away. Instead, Cloudflare requires you to add your domain and point your nameservers to Cloudflare first, so your site benefits from Cloudflare performance and security features from the moment the transfer begins. This is covered in [step 1](#1-add-your-domain-to-cloudflare) below.
 
-Most domain transfers add one additional year to your current registration term. After the transfer, your domain registration will be set to auto-renew by default.
-
-This page contains generic instructions on how to transfer your domain to Cloudflare from most registrars.
-
----
-
-<Render file="requirements" product="registrar" />
+:::note
+If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+:::
 
 ---
 
-<Render file="before-you-begin" product="registrar" />
+<Details header="Before you begin">
+
+Confirm the following before you start:
+
+- You have a [Cloudflare account](/fundamentals/account/create-account/) with a [verified email address](/fundamentals/user-profiles/verify-email-address/).
+- Your Cloudflare account has a valid payment method on file.
+- Your domain was registered at least 60 days ago and has not been transferred in the last 60 days (ICANN requirement).
+- You have not changed your registrant name, organization, or email address in the last 60 days. Under ICANN rules, changes to these fields trigger a 60-day transfer lock. Some registrars let you opt out of this lock during the change, but not all do.
+- Your account at your current registrar is active. If your domain has expired, renew it at your current registrar first.
+- Your domain is not an internationalized domain name (IDN). Cloudflare does not currently support IDNs.
+- If you are transferring a `.us` domain, refer to [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).
+- If you are transferring multiple domains, notify your bank to prevent fraud alerts on multiple charges.
+
+Cloudflare Registrar requires your domain to use Cloudflare for [authoritative DNS](/dns/zone-setups/full-setup/) (full setup). You cannot use another DNS provider while registered with Cloudflare.
+
+</Details>
+
+<Details header="Restrictions" id="restrictions">
+
+Domains with any of the following statuses cannot be transferred: `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod`. Domains that are locked (`clientTransferProhibited`) will not appear as available for transfer until you unlock them at your current registrar.
+
+If your domain appears as available for transfer in the Cloudflare dashboard, these restrictions have already been checked.
+
+:::caution
+If you renew an expired domain and then transfer it within 45 days of the original expiration date, the registry may not add the extra year. Refer to [Registration limits and the one-year extension](#enter-your-authorization-code-and-confirm-payment) for details.
+:::
+
+</Details>
 
 ---
 
-<Render file="restrictions" product="registrar" />
+## 1. Add your domain to Cloudflare
 
----
+Before you can transfer your registration, your domain must be active on Cloudflare. This is what allows Cloudflare to protect your site with performance and security features during and after the transfer. You will not be able to enter an authorization code or proceed with the transfer until this step is complete.
 
-## Set up a domain transfer
+### Disable DNSSEC
 
-To begin, complete the following steps in your current registrar to transfer your domain to Cloudflare. Below, you will find links for detailed transfer instructions from some of the most popular registrars:
+If DNSSEC is enabled at your current registrar, disable it before you change nameservers. DNSSEC validates DNS responses using cryptographic signatures tied to your current provider. When you point nameservers to Cloudflare, those signatures will no longer match, which causes DNS resolution failures and can prevent your domain from becoming active.
+
+**At your current registrar:**
+
+1. Check your domain settings for DNSSEC or DS records. If there are none, DNSSEC is not active and you can skip to [Add your domain](#add-your-domain).
+2. Remove or disable DNSSEC (sometimes labeled "DS records").
+3. Wait at least 24 hours for the change to propagate before changing nameservers.
+
+<Details header="DNSSEC instructions for specific registrars">
+
+This is not an exhaustive list, but the following links may be helpful:
+
+- [DNSimple](https://support.dnsimple.com/articles/cloudflare-ds-record/)
+- [DreamHost](https://help.dreamhost.com/hc/en-us/articles/219539467)
+- [Dynadot](https://www.dynadot.com/help/question/set-DNSSEC)
+- [Enom](https://support.enom.com/support/solutions/articles/201000065386)
+- [Gandi](https://docs.gandi.net/en/domain_names/advanced_users/dnssec.html)
+- [GoDaddy](https://www.godaddy.com/help/add-a-ds-record-23865)
+- [Hover](https://support.hover.com/support/solutions/articles/201000064716)
+- [Name.com](https://www.name.com/support/articles/205439058-managing-dnssec)
+- [Namecheap](https://www.namecheap.com/support/knowledgebase/article.aspx/9722/2232/managing-dnssec-for-domains-pointed-to-custom-dns/)
+- [Squarespace](https://support.squarespace.com/hc/articles/4404183898125-Nameservers-and-DNSSEC-for-Squarespace-managed-domains#toc-dnssec)
+- [Porkbun](https://kb.porkbun.com/article/93-how-to-install-dnssec) (do not fill out **keyData**)
+
+</Details>
+
+After your transfer completes, you can re-enable DNSSEC through Cloudflare with one click. Refer to [Enable DNSSEC](/dns/dnssec/#1-activate-dnssec-in-cloudflare).
+
+### Add your domain
+
+**In the Cloudflare dashboard:**
+
+1. [Add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account.
+2. [Review your DNS records](/dns/zone-setups/full-setup/setup/#review-dns-records). Cloudflare scans for common records automatically, but the scan is not guaranteed to find all existing records. Compare the results against your current DNS configuration to avoid downtime.
+3. Cloudflare will assign you two nameservers (for example, `ada.ns.cloudflare.com` and `paul.ns.cloudflare.com`).
+
+### Update your nameservers
+
+**At your current registrar:**
+
+[Update your domain nameservers](/dns/nameservers/update-nameservers/) to the Cloudflare nameservers assigned in the previous step.
+
+<Details header="Nameserver instructions for popular registrars">
+
+Each registrar has a different interface for updating nameservers. These links explain the process at popular registrars:
 
 - [Enom](https://support.enom.com/support/solutions/articles/201000065324-preparing-your-domain-for-transfer)
 - [GoDaddy](https://www.godaddy.com/help/transfer-my-domain-away-from-godaddy-3560)
@@ -42,107 +109,106 @@ To begin, complete the following steps in your current registrar to transfer you
 - [Network Solutions](https://www.networksolutions.com/help/article/transfer-out-of-network-solutions)
 - [Squarespace](https://support.squarespace.com/hc/articles/205812338-Transferring-a-domain-away-from-Squarespace)
 
-### 1. Log in to your registrar account
+</Details>
 
-Log in to the registrar account where the domain is currently registered.
+### Wait for your domain to become active
 
-### 2. Unlock the domain
+**In the Cloudflare dashboard:**
 
-Registrars include a lightweight safeguard to prevent unauthorized users from starting domain transfers. This is known as registrar lock, but you might also see it referred to as domain lock. In WHOIS, it may appear as `clientTransferProhibited`. When enabled, the lock prevents any other registrar from attempting to initiate a transfer.
-
-Only the registrant can enable or disable this lock, typically through the administration interface of the registrar. To proceed with a transfer, remove this lock if it is enabled.
-
-:::note
-Some registrars have multiple lock types that must each be disabled separately, such as "domain lock", "transfer lock", and "privacy lock". If you have unlocked the domain but it still shows as locked, check your registrar settings for all lock and protection toggles.
-:::
-
-### 3. Disable DNSSEC
-
-If DNSSEC is enabled at your current registrar, you must disable it before transferring. An active DNSSEC configuration will block the transfer from completing.
-
-Refer to the [Disable DNSSEC](/registrar/get-started/transfer-domain-to-cloudflare/#disable-dnssec) section above for detailed steps.
-
-### 4. WHOIS privacy
-
-Most domains can be transferred with WHOIS privacy enabled. If you experience issues with your transfer, check with your current registrar to confirm WHOIS privacy is not blocking it.
-
-### 5. Add your domain to Cloudflare and activate the zone
-
-Unlike most registrars, Cloudflare requires your domain to be added and active on Cloudflare **before** you can enter your authorization code and begin the transfer. This ensures your site is protected by Cloudflare performance and security features from the moment the transfer begins. You cannot skip this step.
-
-1. [Add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account if you have not already.
-2. Cloudflare will assign you two nameservers (for example, `ada.ns.cloudflare.com` and `paul.ns.cloudflare.com`).
-3. Go to your current registrar and [update your domain nameservers](/dns/nameservers/update-nameservers/) to the ones Cloudflare provided.
-4. Wait for your domain status to change from **Pending** to **Active** in your Cloudflare dashboard. This usually takes a few minutes but can take up to 24 hours.
+Wait for your domain status to change from **Pending** to **Active**. This usually takes a few minutes but can take up to 24 hours.
 
 :::caution
-You cannot enter your authorization code or proceed with the transfer until your domain shows **Active** status. If you try while the zone is still **Pending**, the transfer page will not let you proceed.
+You cannot proceed with the transfer until your domain shows **Active** status. The Transfer Domains page will not let you enter an authorization code while the zone is still **Pending**.
 :::
 
-If your zone has been pending for more than 24 hours, verify that you updated the nameservers correctly at your current registrar.
+If your zone has been pending for more than 24 hours, verify that you updated the nameservers correctly at your current registrar and that DNSSEC is disabled.
 
-### 6. Initiate your transfer to Cloudflare
+---
 
-From your Cloudflare Account Home, go to the **Transfer Domains** page.
+## 2. Transfer your registration
+
+Once your domain is active on Cloudflare, you can transfer the registration. This moves your domain record from your current registrar to Cloudflare. You will go back and forth between your current registrar and Cloudflare during this process.
+
+### Unlock your domain
+
+**At your current registrar:**
+
+Registrars apply a lock (sometimes called registrar lock, domain lock, or transfer lock) to prevent unauthorized transfers. In WHOIS, this appears as `clientTransferProhibited`. Remove this lock so Cloudflare can process the transfer.
+
+:::note
+Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your domain still shows as locked after you have disabled one, check for additional lock settings.
+:::
+
+### Request an authorization code
+
+**At your current registrar:**
+
+Request an authorization code for your domain. This is also called an auth code, EPP code, authinfo code, or transfer code. Cloudflare uses this code to verify that the transfer is authorized by the domain owner.
+
+Authorization codes expire within 5-14 days depending on the registrar. Some registrars invalidate the previous code each time you request a new one. Request the code when you are ready to enter it in the next step.
+
+### Enter your authorization code and confirm payment
+
+**In the Cloudflare dashboard:**
+
+Go to the **Transfer Domains** page.
 
 <DashButton url="/?to=/:account/registrar/transfer" />
 
-Cloudflare Registrar will display the zones available for transfer.
+Select your domain and enter the authorization code. The page will show the transfer price, which includes a one-year registration extension from your current expiration date. This is an ICANN requirement — every transfer extends your registration by one year.
 
-You will be presented with the price for each transfer. When you transfer a domain, you are required by ICANN to pay to extend its registration by one year from the expiration date.
-
-If you do not have a payment method on file, add one at this step before proceeding.
+If you do not have a payment method on file, add one before proceeding.
 
 :::note
-Verify your payment method is valid before submitting. A payment failure after submitting the auth code can leave the transfer in a partially started state.
+Verify your payment method is valid before submitting. A payment failure after submitting the authorization code can leave the transfer in a partially started state.
 :::
 
-In some cases, premium (non-standard priced) domains may not be detected immediately. Pricing will be confirmed with the registry before submission, and you will have the opportunity to review and approve any price adjustments.
+<Details header="Registration limits and the one-year extension">
 
-<Details header="Exceptions to the one-year registration extension">
+Every domain transfer adds one year to your registration. However, domain registries enforce maximum registration periods, which can cause a transfer to be rejected or the extra year to not be added.
 
-- Transferring a `.uk` domain does not extend its registration by an additional year.
-- If the transfer is completed within 45 days of the domain expiration, the extra year may not be added. This is determined by the domain registry.
-- If the domain already has more than nine years remaining, a full year may not be added. This is also subject to registry policy.
-- `.co` domains have a maximum registration period of 5 years. If a transfer would exceed this limit, it may be rejected.
+**Maximum registration periods:**
+
+- Most TLDs (such as `.com`, `.net`, `.org`) allow up to 10 years of registration.
+- `.co` domains have a maximum registration period of 5 years.
+
+**When a transfer may be rejected:**
+
+- Your domain already has 9 or more years of registration remaining, and adding one year would exceed the 10-year limit (or the 5-year limit for `.co`).
+- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year.
+
+**TLD-specific requirements:**
+
 - `.ai` domains require a minimum 2-year registration for transfers.
-- Most TLDs (such as `.com`, `.net`, `.org`) allow up to 10 years of registration. You cannot exceed these limits through transfers or renewals.
+- `.uk` domains do not receive an additional year when transferred.
+
+**What you can do if your transfer is rejected:**
+
+- If your domain has too many years remaining, wait until the total registration period (current time remaining plus one year) would not exceed the maximum — 10 years for most TLDs, or 5 years for `.co`. For example, a `.com` domain with 9 years and 6 months remaining cannot be transferred until at least 6 months have passed.
+- If your domain is near expiration, renew it at your current registrar first, then transfer after the renewal is confirmed.
+
+For more details, refer to [Transfer rejected due to registration limits](/registrar/troubleshooting/#transfer-rejected-due-to-registration-limits).
 
 </Details>
 
-:::note
+<Details header="Why is my domain not available for transfer?">
 
-Sites can be unavailable to transfer for a few reasons, including:
+Your domain may not appear on the Transfer Domains page if:
 
-- You did not [add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account.
-- The site was registered in the last 60 days.
-- Cloudflare does not yet support the TLD.
-- The domain has a status that does not allow for a transfer.
-- You failed to follow the steps highlighted above in [creating an account with your domain](/fundamentals/account/create-account/) and [changing your DNS nameservers to Cloudflare](/dns/zone-setups/full-setup/).
+- You have not [added your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account, or it is still in **Pending** status.
+- The domain was registered or previously transferred in the last 60 days.
+- Cloudflare does not support the TLD.
+- The domain has a status that does not allow transfers (such as `serverHold` or `pendingDelete`).
 
-:::
+</Details>
 
-<Render file="email-verification" product="registrar" />
+### Confirm your contact information
 
-### 7. Request an authorization code from your current registrar
+**In the Cloudflare dashboard:**
 
-Go back to your current registrar and request an authorization code for your domain. This code is also referred to as an auth code, authinfo code, or transfer code. Cloudflare will use it to confirm the transfer is authentic.
+Enter the contact information for your registration. Cloudflare Registrar redacts this information from public WHOIS by default, but ICANN requires Cloudflare to collect accurate contact details. Providing inaccurate information may result in domain suspension.
 
-:::note
-Unlike other registrars, Cloudflare does not accept your authorization code upfront. You can only enter it after your domain is active on Cloudflare (step 5) and you have initiated the transfer (step 6). Request the code now so you have it ready for the next step.
-:::
-
-Some authorization codes expire within 5-14 days depending on the registrar. Some registrars issue a new code each time one is requested, which invalidates the previous code.
-
-### 8. Input your authorization code in the Cloudflare dashboard
-
-In the next page, input the authorization code for each domain you are transferring. You also need to unlock each domain so that Cloudflare can process your request. For more information, refer to the instructions provided by your [current registrar on how to transfer your domain](/registrar/get-started/transfer-domain-to-cloudflare/#set-up-a-domain-transfer).
-
-### 9. Confirm or input your contact information
-
-In the final stage of the transfer process, input the contact information for your registration. Cloudflare Registrar redacts this information by default but is required to collect the authentic contact information for this registration. It is important that you provide accurate WHOIS contact information. You may be required to verify the contact information. Failure to provide accurate information and/or failure to verify the information may result in suspension or deletion of your domain.
-
-You can always [modify the contact information](/registrar/account-options/domain-contact-updates/) later, if needed.
+You can [modify your contact information](/registrar/account-options/domain-contact-updates/) later.
 
 :::caution
 Some TLDs have additional registrant verification requirements. For `.ca`, `.mx`, and `.nz` domains, you may receive a separate email to verify your registrant contact information after the transfer completes. Failure to complete this verification within the required timeframe may result in domain suspension.
@@ -150,11 +216,11 @@ Some TLDs have additional registrant verification requirements. For `.ca`, `.mx`
 
 After entering the contact information, agree to the domain registration terms of service by selecting **Confirm transfer**.
 
-### 10. Approve the transfer
+### Approve the transfer at your current registrar
 
-Once you have requested your transfer, Cloudflare will begin processing it, and send a Form of Authorization (FOA) email to the registrant, if the information is available in the public WHOIS database. The FOA is what authorizes the domain transfer.
+After you submit the transfer, Cloudflare will begin processing it and send a Form of Authorization (FOA) email to the registrant if the information is available in the public WHOIS database.
 
-After this step, your previous registrar will also email you to confirm your request to transfer. Most registrars will include a link to confirm the transfer request. If you select that link, you can accelerate the transfer operation. If you do not act on the email, most registrars will wait up to 5 business days to process the transfer to Cloudflare. Some TLDs (such as `.mx`) can take up to 10 business days. You may also be able to approve the transfer from within your current registrar dashboard.
+Your current registrar will also email you to confirm the transfer request. Most registrars include a link to approve the transfer. Selecting that link speeds up the process. If you do not act on the email, most registrars will release the domain after 5 business days. Some TLDs (such as `.mx`) can take up to 10 business days. You can also approve the transfer from within your current registrar dashboard.
 
 :::note
 Registrants transferring a `.us` domain will always receive a FOA email.
@@ -170,8 +236,8 @@ The workaround is to transfer your domain to another registrar first, wait 60 da
 
 1. **Get your authorization code from the website builder.** Each platform has a different process. Refer to your platform documentation for instructions on transferring your domain away.
 2. **Transfer to another registrar** that allows nameserver changes. Enter the authorization code there and complete the transfer. This usually takes 3-5 days.
-3. **Update nameservers to Cloudflare.** Once the domain is at the new registrar, update the nameservers to Cloudflare. You can use all of Cloudflare features (CDN, DNS, security) immediately after this step.
-4. **Transfer to Cloudflare Registrar after 60 days.** ICANN requires a 60-day wait between transfers. After that period, initiate the transfer to Cloudflare from the [Transfer Domains](/registrar/get-started/transfer-domain-to-cloudflare/#6-initiate-your-transfer-to-cloudflare) page.
+3. **Update nameservers to Cloudflare.** Once the domain is at the new registrar, update the nameservers to Cloudflare. You can use all Cloudflare features (CDN, DNS, security) immediately after this step.
+4. **Transfer to Cloudflare Registrar after 60 days.** ICANN requires a 60-day wait between transfers. After that period, initiate the transfer to Cloudflare from the [Transfer Domains](#enter-your-authorization-code-and-confirm-payment) page.
 
 :::note
 Each transfer adds one year to your domain registration. You will pay the other registrar for the first transfer, and Cloudflare for the second. These are not redundant charges — each extends your registration.
@@ -181,19 +247,21 @@ If you do not need Cloudflare as your registrar and only want to use Cloudflare 
 
 ---
 
-## Bulk domain transfers
-
-The process for transferring domains in bulk to Cloudflare is the same process as transferring a single domain. Even if you transfer multiple domains in bulk, you will be charged for each domain as bulk billing is not yet available.
-
 ## Transfer statuses
 
-You can check the status of your transfer on the **Transfer Domains** page in the dashboard. Below, you can find a list of the possible transfer statuses.
+You can check the status of your transfer on the **Transfer Domains** page in the dashboard.
 
-- **Transfer in progress**: Your request has been submitted by Cloudflare to your previous registrar. Cloudflare is now waiting on them to confirm they have received the request. If this status persists for more than a day (24 hours), ensure that the domain has been unlocked at your current registrar and any WHOIS privacy services have been removed.
+- **Transfer in progress**: Cloudflare has submitted the request to your current registrar. If this status persists for more than 24 hours, verify that you have unlocked the domain at your current registrar.
 
-- **Pending approval**: Your current registrar has received the transfer request. They can now wait up to five days to release the domain. If you want to move faster, you can manually approve the transfer for immediate release in the dashboard of most registrars.
+- **Pending approval**: Your current registrar has received the transfer request and can take up to five days to release the domain. To speed this up, approve the transfer through the email or dashboard of your current registrar.
 
-- **Transfer rejected**: your transfer has been rejected. This can occur if you canceled the request at your current registrar instead of approving it. If you still wish to transfer, you can select **Retry** and initiate a new transfer request.
+- **Transfer rejected**: The transfer was rejected by your current registrar. This can happen if you declined the transfer request, or if the registrar determined the domain is not eligible. Select **Retry** to start a new transfer request.
+
+---
+
+## Bulk domain transfers
+
+The process for transferring domains in bulk is the same as transferring a single domain. Each domain is charged individually.
 
 ---
 

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -9,7 +9,7 @@ description: >-
 
 import { DashButton, Details, Render } from "~/components";
 
-Transferring a domain moves your registration from your current registrar to Cloudflare. The process takes about 30 minutes of active work, but the full transfer completes over 3-5 business days. Each transfer adds one year to your domain registration at Cloudflare's at-cost price.
+Transferring a domain moves your registration from your current registrar to Cloudflare. The process takes about 30 minutes of active work, but the full transfer usually takes 3-5 business days to complete because your current registrar has up to 5 days to release the domain, and changes to your domain settings take time to take effect across the internet. Each transfer adds one year to your domain registration at Cloudflare's at-cost price.
 
 **Cloudflare works differently from most registrars.** You cannot enter an authorization code right away. Instead, Cloudflare requires you to add your domain and point your nameservers to Cloudflare first, so your site benefits from Cloudflare performance and security features from the moment the transfer begins. This is covered in [step 1](#1-add-your-domain-to-cloudflare) below.
 

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -12,10 +12,10 @@ import { DashButton, Details, Render } from "~/components";
 Transferring a domain moves your registration from your current registrar to Cloudflare.
 
 - **Active work:** About 30 minutes.
-- **Total time:** Usually 3-5 business days, because your current registrar has up to 5 days to release the domain and changes to your domain settings take time to take effect across the internet.
+- **Total time:** Around 5 business days. Your current registrar has up to 5 days to release the domain and DNS changes take time to propagate.
 - **Cost:** One year of registration at Cloudflare's at-cost price, added to your current expiration date.
 
-Before you can transfer, you must [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare) and update your nameservers. Only then can you enter an authorization code and start the transfer. This is because Cloudflare applies performance and security features to your site before the transfer begins.
+Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare).
 
 :::note
 If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
@@ -32,23 +32,15 @@ Confirm the following before you start:
 - Your domain was registered at least 60 days ago and has not been transferred in the last 60 days (ICANN requirement).
 - You have not changed your registrant name, organization, or email address in the last 60 days. Under ICANN rules, changes to these fields trigger a 60-day transfer lock. Some registrars let you opt out of this lock during the change, but not all do.
 - Your account at your current registrar is active. If your domain has expired, renew it at your current registrar first.
+
+:::note
+If your domain recently expired and you renewed it, wait at least 45 days after the original expiration date before transferring. Otherwise, the registry may not add the extra year. For details, refer to [Why did my domain's expiration date change?](/registrar/faq/#my-domains-registration-was-not-extended-by-one-year-after-transferring-to-cloudflare).
+:::
+
 - Your domain uses only standard characters (letters, numbers, hyphens). Cloudflare does not support domains with non-Latin characters (for example, `例え.jp`).
 - If you are transferring a `.us` domain, refer to [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).
 - If you are transferring multiple domains, notify your bank to prevent fraud alerts on multiple charges.
-
-Cloudflare Registrar requires your domain to use Cloudflare for [authoritative DNS](/dns/zone-setups/full-setup/) (full setup). You cannot use another DNS provider while registered with Cloudflare.
-
-</Details>
-
-<Details header="Restrictions" id="restrictions">
-
-If your domain appears as available for transfer in the Cloudflare dashboard, these restrictions have already been checked.
-
-For reference, domains with any of the following statuses cannot be transferred: `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod`. Domains that are locked (`clientTransferProhibited`) will not appear as available for transfer until you unlock them at your current registrar.
-
-:::caution
-If you renew an expired domain and then transfer it within 45 days of the original expiration date, the registry may not add the extra year. Refer to [Registration limits and the one-year extension](#enter-your-authorization-code-and-confirm-payment) for details.
-:::
+- Cloudflare Registrar requires your domain to use Cloudflare for [authoritative DNS](/dns/zone-setups/full-setup/) (full setup). You cannot use another DNS provider while registered with Cloudflare.
 
 </Details>
 
@@ -95,7 +87,7 @@ Each registrar has a different interface for updating nameservers. These links e
 
 Wait for your domain status to change from **Pending** to **Active**. This usually takes a few minutes but can take up to 24 hours.
 
-:::caution
+:::note
 You cannot proceed with the transfer until your domain shows **Active** status. The Transfer Domains page will not let you enter an authorization code while the zone is still **Pending**.
 :::
 
@@ -129,8 +121,6 @@ Authorization codes expire within 5-14 days depending on the registrar. Some reg
 
 **In the Cloudflare dashboard:**
 
-Go to the **Transfer Domains** page.
-
 <DashButton url="/?to=/:account/registrar/transfer" />
 
 Select your domain and enter the authorization code. The page will show the transfer price, which includes a one-year registration extension from your current expiration date. This is an ICANN requirement — every transfer extends your registration by one year.
@@ -141,44 +131,7 @@ If you do not have a payment method on file, add one before proceeding.
 Verify your payment method is valid before submitting. A payment failure after submitting the authorization code can leave the transfer in a partially started state.
 :::
 
-<Details header="Registration limits and the one-year extension">
-
-Every domain transfer adds one year to your registration. However, domain registries enforce maximum registration periods, which can cause a transfer to be rejected or the extra year to not be added.
-
-**Maximum registration periods:**
-
-- Most TLDs (such as `.com`, `.net`, `.org`) allow up to 10 years of registration.
-- `.co` domains have a maximum registration period of 5 years.
-
-**When a transfer may be rejected:**
-
-- Your domain already has 9 or more years of registration remaining, and adding one year would exceed the 10-year limit (or the 5-year limit for `.co`).
-- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year. For example, if `example.com` expires on December 10, you renew it on December 20 (extending it to December 20 of the following year), and then transfer to Cloudflare on December 30 — the transfer is within 45 days of the original expiration, so the registry may not add an additional year. Your expiration date would remain December 20 of the following year, meaning you effectively paid twice for the same year. If this happens, you are entitled to request a refund from your previous registrar under ICANN rules.
-
-**TLD-specific requirements:**
-
-- `.ai` domains require a minimum 2-year registration for transfers.
-- `.uk` domains do not receive an additional year when transferred.
-
-**What you can do if your transfer is rejected:**
-
-- If your domain has too many years remaining, wait until the total registration period (current time remaining plus one year) would not exceed the maximum — 10 years for most TLDs, or 5 years for `.co`. For example, a `.com` domain with 9 years and 6 months remaining cannot be transferred until at least 6 months have passed.
-- If your domain is near expiration, renew it at your current registrar first, then transfer after the renewal is confirmed.
-
-For more details, refer to [Transfer rejected due to registration limits](/registrar/troubleshooting/#transfer-rejected-due-to-registration-limits).
-
-</Details>
-
-<Details header="Why is my domain not available for transfer?">
-
-Your domain may not appear on the Transfer Domains page if:
-
-- You have not [added your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account, or it is still in **Pending** status.
-- The domain was registered or previously transferred in the last 60 days.
-- Cloudflare does not support the TLD.
-- The domain has a status that does not allow transfers (such as `serverHold` or `pendingDelete`).
-
-</Details>
+For information about registration limits and the one-year extension, refer to [Transfer rejected due to registration limits](/registrar/troubleshooting/#transfer-rejected-due-to-registration-limits).
 
 ### Confirm your contact information
 
@@ -198,7 +151,7 @@ After entering the contact information, agree to the domain registration terms o
 
 After you submit the transfer, Cloudflare will begin processing it and send a Form of Authorization (FOA) email to the registrant if the information is available in the public WHOIS database.
 
-Your current registrar will also email you to confirm the transfer request. Most registrars include a link to approve the transfer. Selecting that link speeds up the process. If you do not act on the email, most registrars will release the domain after 5 business days. Some TLDs (such as `.mx`) can take up to 10 business days. You can also approve the transfer from within your current registrar dashboard.
+Your current registrar will email you confirming the transfer or asking for your approval. Afterwards, most registrars process it within 5 business days (but some TLDs, such as `.mx`, can take up to 10 business days).
 
 :::note
 Registrants transferring a `.us` domain will always receive a FOA email.

--- a/src/content/docs/registrar/top-level-domains/index.mdx
+++ b/src/content/docs/registrar/top-level-domains/index.mdx
@@ -6,14 +6,13 @@ learning_center:
   link: https://www.cloudflare.com/learning/dns/top-level-domain/
 sidebar:
   order: 5
-
 ---
 
 Cloudflare supports over 400 [top-level domains (TLDs)](https://www.cloudflare.com/learning/dns/top-level-domain/) and is always evaluating adding new TLDs. We have no specific timeframes for TLDs not yet listed. You can find the full list of supported and coming soon TLDs on the [TLD policies page](https://www.cloudflare.com/tld-policies/).
 
 :::note
 
-If you want to register a `.us` domain refer to  [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).
+If you want to register a `.us` domain refer to [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).
 :::
 
 ## Domain availability
@@ -22,9 +21,9 @@ During your [TLD registration process](/registrar/get-started/register-domain/#h
 
 Possible causes for the domain not being available include:
 
-* Someone else owns that domain.
-* It is an Internationalized Domain Name (IDN) which Cloudflare Registrar does not support. These domains include international characters (such as `á`, `ü`, among others).
+- Someone else owns that domain.
+- It is an Internationalized Domain Name (IDN) which Cloudflare Registrar does not support. These domains include international characters (such as `á`, `ü`, among others).
 
 ## Transfer a domain
 
-When transferring a domain to Cloudflare Registrar, refer to [Restrictions](/registrar/get-started/transfer-domain-to-cloudflare/#restrictions) for a full list of aspects to consider before starting the transfer.
+When transferring a domain to Cloudflare Registrar, refer to [Domain is in a restricted status](/registrar/troubleshooting/#domain-is-in-a-restricted-status) for statuses that can block a transfer.

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -55,8 +55,9 @@ Domain registries enforce maximum registration periods. Because every transfer a
 **Common reasons for rejection:**
 
 - Your domain already has 9 or more years of registration remaining. Adding one year would exceed the 10-year limit (or 5-year limit for `.co`).
-- Your domain was transferred or renewed within 45 days of its expiration date. In this case, the registry may not add the extra year, even if the transfer itself succeeds.
+- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year. For example, if `example.com` expires on December 10, you renew it on December 20 (extending it to December 20 of the following year), and then transfer to Cloudflare on December 30 — the transfer is within 45 days of the original expiration, so the registry may not add an additional year. Your expiration date would remain December 20 of the following year, meaning you effectively paid twice for the same year. If this happens, you are entitled to request a refund from your previous registrar under ICANN rules.
 - Your domain does not meet a TLD-specific minimum. For example, `.ai` domains require a minimum 2-year registration for transfers.
+- `.uk` domains do not receive an additional year when transferred.
 
 **What you can do:**
 
@@ -87,6 +88,15 @@ If your payment method was declined after submitting the authorization code, the
 ## Transfer is taking too long
 
 Domain transfers typically take 3-5 business days. Some TLDs (such as `.mx`) can take up to 10 days. You can speed up the process by approving the transfer at your current registrar when you receive the confirmation email. If the transfer has been stuck beyond these timeframes with no identifiable issue, contact your current registrar to confirm there are no holds or restrictions on their end.
+
+## Domain not available for transfer
+
+Your domain may not appear on the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page if:
+
+- You have not [added your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account, or it is still in **Pending** status. Your domain must be **Active** before you can transfer it.
+- The domain was registered or previously transferred in the last 60 days (ICANN requirement).
+- Cloudflare does not support the TLD.
+- The domain has a status that blocks transfers (such as `serverHold` or `pendingDelete`). Refer to [Domain is in a restricted status](#domain-is-in-a-restricted-status) for details.
 
 ## Cannot update nameservers at your current registrar
 

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -4,7 +4,6 @@ source: https://support.cloudflare.com/hc/en-us/articles/4424747060109-Registrar
 title: Troubleshoot failed domain transfers
 sidebar:
   order: 8
-
 ---
 
 import { DashButton } from "~/components";
@@ -37,12 +36,33 @@ If your zone is still **Pending**, verify that you updated nameservers correctly
 
 Your transfer has been rejected by your previous registrar. There are several reasons for this to happen:
 
-* You actively rejected the transfer request in the email you received from your registrar or on your registrar interface.
-* Your registrar determined the domain is not eligible for transfer.
-* Some registrars allow customers to enable a setting to reject all transfer requests.
-* In some instances, registrars may reject the transfer if they suspect malicious behavior.
+- You actively rejected the transfer request in the email you received from your registrar or on your registrar interface.
+- Your registrar determined the domain is not eligible for transfer.
+- Some registrars allow customers to enable a setting to reject all transfer requests.
+- In some instances, registrars may reject the transfer if they suspect malicious behavior.
 
 You will need to restart the transfer and approve the request or contact your current registrar to resolve this issue.
+
+## Transfer rejected due to registration limits
+
+Domain registries enforce maximum registration periods. Because every transfer adds one year to your registration, a transfer can be rejected if the extra year would exceed the limit.
+
+**Maximum registration periods:**
+
+- Most TLDs (such as `.com`, `.net`, `.org`) allow up to **10 years** of registration.
+- `.co` domains have a maximum of **5 years**.
+
+**Common reasons for rejection:**
+
+- Your domain already has 9 or more years of registration remaining. Adding one year would exceed the 10-year limit (or 5-year limit for `.co`).
+- Your domain was transferred or renewed within 45 days of its expiration date. In this case, the registry may not add the extra year, even if the transfer itself succeeds.
+- Your domain does not meet a TLD-specific minimum. For example, `.ai` domains require a minimum 2-year registration for transfers.
+
+**What you can do:**
+
+- If your domain has too many years remaining, wait until the total registration period (current time remaining plus the one year added by the transfer) would not exceed the maximum — 10 years for most TLDs, or 5 years for `.co`. For example, a `.com` domain with 9 years and 6 months remaining cannot be transferred until at least 6 months have passed.
+- If your domain is close to expiration, renew it at your current registrar first. Once the renewal is confirmed, initiate the transfer.
+- If your domain is a TLD with special requirements (such as `.ai`), verify that you meet the minimum registration period before transferring.
 
 ## Domain was recently registered or transferred
 
@@ -50,7 +70,11 @@ ICANN rules prohibit transfers within 60 days of registration or a previous tran
 
 ## Domain is in a restricted status
 
-Domains with a status of `clientHold`, `serverHold`, `redemptionPeriod`, or `pendingDelete` cannot be transferred. Resolve the issue with your current registrar before retrying.
+Domains with certain WHOIS statuses cannot be transferred:
+
+- `clientHold` or `serverHold` — the domain is suspended, usually due to non-payment, failed verification, or a dispute. Contact your current registrar to find out why the hold was applied and how to remove it.
+- `redemptionPeriod` — the domain has expired and passed the grace period. You must restore and renew it at your current registrar before it can be transferred.
+- `pendingDelete` — the domain is scheduled for deletion by the registry and cannot be transferred or recovered. After deletion, the domain becomes available for anyone to register.
 
 ## WHOIS privacy is blocking the transfer
 
@@ -76,7 +100,7 @@ This solution does not apply to `.uk` domains.
 
 1. In the Cloudflare dashboard, go to the **Manage Domains** page.
 
-    <DashButton url="/?to=/:account/registrar/domains" />
+   <DashButton url="/?to=/:account/registrar/domains" />
 
 2. Find the correct domain and select **Manage**.
 3. Select **Cancel Transfer and Retry**. After you initiate the retry, you must re-enter your auth code and confirm your WHOIS information.


### PR DESCRIPTION
Rewrites the "Transfer your domain to Cloudflare" page for clarity and adds registration limits content to the troubleshooting page. Follows up on #28723 (merged).

**Transfer page (`transfer-domain-to-cloudflare.mdx`):**
- Restructured from a flat 10-step list into two clear phases: (1) Add your domain to Cloudflare, (2) Transfer your registration — so users understand they cannot just paste an auth code like other registrars
- Inlined content from three partials (`requirements`, `before-you-begin`, `restrictions`) that were only used on this page
- Added DNSSEC provider links and nameserver change links in collapsible Details blocks
- Explained *why* each step is needed (DNSSEC causes resolution failures, zone must be Active before auth code entry, etc.)
- Added "Registration limits and the one-year extension" Details block with max periods (10 years for most TLDs, 5 for `.co`), rejection reasons, TLD-specific requirements (`.ai` 2-year minimum, `.uk` no extra year), and concrete actionable guidance with examples
- Replaced vague language throughout: specific ICANN contact-change lock fields (name, organization, email), concrete 45-day expiration rule instead of "may result", specific WHOIS status explanations
- Added website builder callout near the top linking to the workaround section
- Changed `pcx_content_type` from `tutorial` to `how-to`

**Troubleshooting page (`troubleshooting.mdx`):**
- Added new "Transfer rejected due to registration limits" section with max registration periods, common rejection reasons, and what users can do (with concrete example: `.com` with 9.5 years must wait 6 months)
- Expanded "Domain is in a restricted status" from a single vague sentence to per-status explanations (`clientHold`/`serverHold` = suspended, `redemptionPeriod` = expired past grace, `pendingDelete` = scheduled for deletion)

Preserves all existing anchors referenced by external pages: `#disable-dnssec`, `#transfer-from-website-builders`, `#restrictions`.