### PR TITLE
[Sandbox] Add proxyToSandbox() to Ports API reference

### DIFF
--- a/src/content/docs/sandbox/api/ports.mdx
+++ b/src/content/docs/sandbox/api/ports.mdx
@@ -13,6 +13,50 @@ Preview URLs require a custom domain with wildcard DNS routing in production. Se
 
 Expose services running in your sandbox via public preview URLs. See [Preview URLs concept](/sandbox/concepts/preview-urls/) for details.
 
+## Module functions
+
+### `proxyToSandbox()`
+
+Route incoming HTTP and WebSocket requests to the correct sandboxed container. Call this at the top of your Worker's `fetch` handler, before any application logic, so that preview URL requests are intercepted and forwarded automatically.
+
+```ts
+const response = await proxyToSandbox(request: Request, env: Env): Promise<Response | null>
+```
+
+**Parameters**:
+
+- `request` - The incoming `Request` object from the `fetch` handler
+- `env` - The `Env` object containing your Sandbox binding
+
+**Returns**: `Promise<Response | null>` — a `Response` if the request matched a preview URL and was routed to the sandbox, or `null` if the request did not match and should be handled by your application logic.
+
+The function inspects the request hostname to determine whether it matches the subdomain pattern of an exposed port (for example, `8080-sandbox-id-token.yourdomain.com`). If it matches, the request is proxied to the correct Durable Object and the sandbox service handles it. HTTP and WebSocket upgrade requests are both supported.
+
+<TypeScriptExample>
+```ts
+import { proxyToSandbox, getSandbox } from "@cloudflare/sandbox";
+
+export { Sandbox } from "@cloudflare/sandbox";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Always call proxyToSandbox first to handle preview URL requests
+    const proxyResponse = await proxyToSandbox(request, env);
+    if (proxyResponse) return proxyResponse;
+
+    // Your application routes
+    const sandbox = getSandbox(env.Sandbox, 'my-sandbox');
+    // ...
+    return new Response('Not found', { status: 404 });
+  }
+};
+```
+</TypeScriptExample>
+
+:::note
+`proxyToSandbox` is a module-level function imported directly from `@cloudflare/sandbox`, not a method on a `Sandbox` instance. It requires the Sandbox Durable Object binding (`env.Sandbox`) to look up and route requests to the correct container.
+:::
+
 ## Methods
 
 ### `exposePort()`
@@ -235,4 +279,6 @@ export default {
 ## Related resources
 
 - [Preview URLs concept](/sandbox/concepts/preview-urls/) - How preview URLs work
+- [Expose Services guide](/sandbox/guides/expose-services/) - Full workflow for starting services, exposing ports, and routing requests
+- [WebSocket Connections guide](/sandbox/guides/websocket-connections/) - WebSocket routing via preview URLs
 - [Commands API](/sandbox/api/commands/) - Start background processes

--- a/src/content/docs/sandbox/api/ports.mdx
+++ b/src/content/docs/sandbox/api/ports.mdx
@@ -17,7 +17,7 @@ Expose services running in your sandbox via public preview URLs. See [Preview UR
 
 ### `proxyToSandbox()`
 
-Route incoming HTTP and WebSocket requests to the correct sandboxed container. Call this at the top of your Worker's `fetch` handler, before any application logic, so that preview URL requests are intercepted and forwarded automatically.
+Route incoming HTTP and WebSocket requests to the correct sandbox container. Call this at the top of your Worker's `fetch` handler, before any application logic, so that it intercepts and forwards preview URL requests automatically.
 
 ```ts
 const response = await proxyToSandbox(request: Request, env: Env): Promise<Response | null>
@@ -25,12 +25,12 @@ const response = await proxyToSandbox(request: Request, env: Env): Promise<Respo
 
 **Parameters**:
 
-- `request` - The incoming `Request` object from the `fetch` handler
-- `env` - The `Env` object containing your Sandbox binding
+- `request` - The incoming `Request` object from the `fetch` handler.
+- `env` - The `Env` object containing your Sandbox binding.
 
 **Returns**: `Promise<Response | null>` — a `Response` if the request matched a preview URL and was routed to the sandbox, or `null` if the request did not match and should be handled by your application logic.
 
-The function inspects the request hostname to determine whether it matches the subdomain pattern of an exposed port (for example, `8080-sandbox-id-token.yourdomain.com`). If it matches, the request is proxied to the correct Durable Object and the sandbox service handles it. HTTP and WebSocket upgrade requests are both supported.
+The function inspects the request hostname to determine whether it matches the subdomain pattern of an exposed port (for example, `8080-sandbox-id-token.yourdomain.com`). If it matches, `proxyToSandbox()` proxies the request to the correct Durable Object, and the sandbox service handles it. Both HTTP and WebSocket upgrade requests are supported.
 
 <TypeScriptExample>
 ```ts
@@ -54,7 +54,7 @@ export default {
 </TypeScriptExample>
 
 :::note
-`proxyToSandbox` is a module-level function imported directly from `@cloudflare/sandbox`, not a method on a `Sandbox` instance. It requires the Sandbox Durable Object binding (`env.Sandbox`) to look up and route requests to the correct container.
+`proxyToSandbox` is a module-level function imported directly from `@cloudflare/sandbox` — it is not a method on a `Sandbox` instance. It requires the Sandbox Durable Object binding (`env.Sandbox`) to look up and route requests to the correct container.
 :::
 
 ## Methods

--- a/src/content/docs/sandbox/api/ports.mdx
+++ b/src/content/docs/sandbox/api/ports.mdx
@@ -20,7 +20,7 @@ Expose services running in your sandbox via public preview URLs. See [Preview UR
 Route incoming HTTP and WebSocket requests to the correct sandbox container. Call this at the top of your Worker's `fetch` handler, before any application logic, so that it intercepts and forwards preview URL requests automatically.
 
 ```ts
-const response = await proxyToSandbox(request: Request, env: Env): Promise<Response | null>
+proxyToSandbox(request: Request, env: Env): Promise<Response | null>
 ```
 
 **Parameters**:


### PR DESCRIPTION
## Summary

- Adds a dedicated `proxyToSandbox()` reference entry to the Ports API page (`/sandbox/api/ports/`) under a new `## Module functions` section
- Documents the function signature, parameters, return value, behavior, and includes a `TypeScriptExample` code example
- Adds a note clarifying it is a module-level import (not a `Sandbox` instance method)
- Extends the Related resources section with links to the Expose Services and WebSocket Connections guides

## Context

`proxyToSandbox()` is used in nearly every Sandbox Worker fetch handler but previously had no API reference entry — it only appeared in passing in how-to guides and concept pages. This PR makes it a first-class documented API.