### PR TITLE
[Sidebar] Add sticky behavior sidebar title and search

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -321,7 +321,7 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 			top: 0;
 			z-index: 10;
 			background-color: var(--sl-color-bg-sidebar);
-			padding-top: 0.75rem;
+			padding-top: 0.25rem;
 			padding-bottom: 0.75rem;
 		}
 

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -43,9 +43,7 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	</div>
 </div>
 
-<div class="sidebar-nav-scroll">
-	<Default><slot /></Default>
-</div>
+<Default><slot /></Default>
 
 <script>
 	import { track } from "~/util/zaraz";
@@ -317,26 +315,31 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	}
 
 	:root {
-		/* .sidebar-content is the flex column containing both our header and the
-		   nav scroll wrapper. Stop it from scrolling; only .sidebar-nav-scroll scrolls. */
+		/* Sticky header: position: sticky works because .sidebar-pane (overflow-y: auto)
+		   is the scroll container, and we remove min-height: max-content from
+		   .sidebar-content so the containing block height is bounded by the viewport. */
 		.sidebar-header {
+			position: sticky;
+			top: 0;
+			z-index: 1;
 			display: flex;
 			flex-direction: column;
 			gap: 0.5rem;
 			background-color: var(--sl-color-black);
-			padding: 1rem 1.5rem;
+			padding-top: 1rem;
+			padding-bottom: 1rem;
 
 			@media (min-width: 50rem) {
 				background-color: var(--sl-color-bg-sidebar);
 			}
 		}
 
-		/* Stop .sidebar-content from scrolling — .sidebar-nav-scroll handles it */
+		/* Override Starlight's height: 100% / min-height: max-content.
+		   Let .sidebar-content size to its content so sticky has the full
+		   scroll range to work within, not just one viewport height. */
 		.sidebar-content {
-			overflow: hidden !important;
+			height: auto !important;
 			min-height: 0 !important;
-			padding-top: 0 !important;
-			padding-bottom: 0 !important;
 
 			--sl-color-hairline-light: #cacaca !important;
 

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -7,42 +7,57 @@ import { lookupProductTitle } from "~/util/sidebar";
 const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 ---
 
-<div class="sidebar-product-header">
-	<a
-		href={"/" + product + "/"}
-		class="flex items-center gap-2 px-1 no-underline"
+<div class="sidebar-sticky-header">
+	<div class="sidebar-product-header">
+		<a
+			href={"/" + product + "/"}
+			class="flex items-center gap-2 px-1 no-underline"
+		>
+			<AstroIcon name={product} size="32px" class="text-cl1-brand-orange" />
+			<span class="text-xl text-black">
+				<strong>
+					{lookupProductTitle(product, module)}
+				</strong>
+			</span>
+		</a>
+	</div>
+
+	<!-- Search Input -->
+	<div class="relative">
+		<input
+			type="text"
+			id="sidebar-search"
+			placeholder="Search sidebar..."
+			class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-10 text-sm text-gray-900 placeholder-gray-500 transition-colors duration-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:border-orange-500 dark:focus:ring-orange-500"
+		/>
+		<div class="sidebar-search-icon"></div>
+	</div>
+
+	<!-- No Results Message -->
+	<div
+		id="sidebar-no-results"
+		class="hidden p-4 text-center text-sm text-gray-500 dark:text-gray-400"
 	>
-		<AstroIcon name={product} size="32px" class="text-cl1-brand-orange" />
-		<span class="text-xl text-black">
-			<strong>
-				{lookupProductTitle(product, module)}
-			</strong>
-		</span>
-	</a>
+		No results found. Try a different search term, or use our <button
+			id="global-search-link"
+			class="font-inherit cursor-pointer border-none bg-transparent p-0 text-blue-500 underline hover:no-underline dark:text-orange-500"
+			>global search</button
+		>.
+	</div>
 </div>
 
-<!-- Search Input -->
-<div class="relative">
-	<input
-		type="text"
-		id="sidebar-search"
-		placeholder="Search sidebar..."
-		class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-10 text-sm text-gray-900 placeholder-gray-500 transition-colors duration-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:border-orange-500 dark:focus:ring-orange-500"
-	/>
-	<div class="sidebar-search-icon"></div>
-</div>
-
-<!-- No Results Message -->
-<div
-	id="sidebar-no-results"
-	class="hidden p-4 text-center text-sm text-gray-500 dark:text-gray-400"
->
-	No results found. Try a different search term, or use our <button
-		id="global-search-link"
-		class="font-inherit cursor-pointer border-none bg-transparent p-0 text-blue-500 underline hover:no-underline dark:text-orange-500"
-		>global search</button
-	>.
-</div>
+<!-- Hoist the sticky header out of .sidebar-content (the flex scroll container)
+     and prepend it directly into #starlight__sidebar (.sidebar-pane) so that
+     it is a sibling — not a child — of the scrolling element. -->
+<script is:inline>
+	(function () {
+		const header = document.querySelector(".sidebar-sticky-header");
+		const pane = document.getElementById("starlight__sidebar");
+		if (header && pane && header.parentElement !== pane) {
+			pane.insertBefore(header, pane.firstChild);
+		}
+	})();
+</script>
 
 <Default><slot /></Default>
 
@@ -50,7 +65,20 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	import { track } from "~/util/zaraz";
 	import { openGlobalSearch } from "~/util/search";
 
+	// Ensure the sticky header is a direct child of #starlight__sidebar
+	// (not inside .sidebar-content) so it is not part of the scroll container.
+	// The is:inline script above handles initial placement; this covers re-renders.
+	function hoistStickyHeader() {
+		const header = document.querySelector(".sidebar-sticky-header");
+		const pane = document.getElementById("starlight__sidebar");
+		if (header && pane && header.parentElement !== pane) {
+			pane.insertBefore(header, pane.firstChild);
+		}
+	}
+
 	function initSidebarSearch() {
+		hoistStickyHeader();
+
 		const searchInput = document.getElementById(
 			"sidebar-search",
 		) as HTMLInputElement;
@@ -316,16 +344,38 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	}
 
 	:root {
+		/* Hoist the sticky header out of the flex/scroll container:
+		   - #starlight__sidebar becomes a flex column (was just overflow-y:auto)
+		   - .sidebar-sticky-header is a static flex child at the top — never scrolls
+		   - .sidebar-content takes the remaining height and scrolls independently */
+		#starlight__sidebar {
+			display: flex !important;
+			flex-direction: column !important;
+			overflow: hidden !important;
+		}
+
+		.sidebar-sticky-header {
+			flex-shrink: 0;
+			/* Match .sidebar-pane: black on mobile, sidebar bg on desktop */
+			background-color: var(--sl-color-black);
+			padding: 1rem var(--sl-sidebar-pad-x) 0.75rem;
+
+			@media (min-width: 50rem) {
+				background-color: var(--sl-color-bg-sidebar);
+			}
+		}
+
 		.sidebar-product-header {
-			position: sticky;
-			top: 0;
-			z-index: 10;
-			background-color: var(--sl-color-bg-sidebar);
-			padding-top: 0.25rem;
 			padding-bottom: 0.75rem;
 		}
 
 		.sidebar-content {
+			flex: 1 !important;
+			overflow-y: auto !important;
+			/* Top padding is now provided by the header above */
+			padding-top: 0 !important;
+			min-height: 0 !important;
+
 			--sl-color-hairline-light: #cacaca !important;
 
 			& > * {

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -331,12 +331,6 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 			}
 		}
 
-		.sidebar-nav-scroll {
-			flex: 1;
-			overflow-y: auto;
-			min-height: 0;
-		}
-
 		/* Stop .sidebar-content from scrolling — .sidebar-nav-scroll handles it */
 		.sidebar-content {
 			overflow: hidden !important;

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -7,12 +7,9 @@ import { lookupProductTitle } from "~/util/sidebar";
 const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 ---
 
-<div class="sidebar-sticky-header">
-	<div class="sidebar-product-header">
-		<a
-			href={"/" + product + "/"}
-			class="flex items-center gap-2 px-1 no-underline"
-		>
+<div class="sidebar-header">
+	<div class="sidebar-product-title px-1">
+		<a href={"/" + product + "/"} class="flex items-center gap-2 no-underline">
 			<AstroIcon name={product} size="32px" class="text-cl1-brand-orange" />
 			<span class="text-xl text-black">
 				<strong>
@@ -46,39 +43,15 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	</div>
 </div>
 
-<!-- Hoist the sticky header out of .sidebar-content (the flex scroll container)
-     and prepend it directly into #starlight__sidebar (.sidebar-pane) so that
-     it is a sibling — not a child — of the scrolling element. -->
-<script is:inline>
-	(function () {
-		const header = document.querySelector(".sidebar-sticky-header");
-		const pane = document.getElementById("starlight__sidebar");
-		if (header && pane && header.parentElement !== pane) {
-			pane.insertBefore(header, pane.firstChild);
-		}
-	})();
-</script>
-
-<Default><slot /></Default>
+<div class="sidebar-nav-scroll">
+	<Default><slot /></Default>
+</div>
 
 <script>
 	import { track } from "~/util/zaraz";
 	import { openGlobalSearch } from "~/util/search";
 
-	// Ensure the sticky header is a direct child of #starlight__sidebar
-	// (not inside .sidebar-content) so it is not part of the scroll container.
-	// The is:inline script above handles initial placement; this covers re-renders.
-	function hoistStickyHeader() {
-		const header = document.querySelector(".sidebar-sticky-header");
-		const pane = document.getElementById("starlight__sidebar");
-		if (header && pane && header.parentElement !== pane) {
-			pane.insertBefore(header, pane.firstChild);
-		}
-	}
-
 	function initSidebarSearch() {
-		hoistStickyHeader();
-
 		const searchInput = document.getElementById(
 			"sidebar-search",
 		) as HTMLInputElement;
@@ -344,37 +317,32 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	}
 
 	:root {
-		/* Hoist the sticky header out of the flex/scroll container:
-		   - #starlight__sidebar becomes a flex column (was just overflow-y:auto)
-		   - .sidebar-sticky-header is a static flex child at the top — never scrolls
-		   - .sidebar-content takes the remaining height and scrolls independently */
-		#starlight__sidebar {
-			display: flex !important;
-			flex-direction: column !important;
-			overflow: hidden !important;
-		}
-
-		.sidebar-sticky-header {
-			flex-shrink: 0;
-			/* Match .sidebar-pane: black on mobile, sidebar bg on desktop */
+		/* .sidebar-content is the flex column containing both our header and the
+		   nav scroll wrapper. Stop it from scrolling; only .sidebar-nav-scroll scrolls. */
+		.sidebar-header {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
 			background-color: var(--sl-color-black);
-			padding: 1rem var(--sl-sidebar-pad-x) 0.75rem;
+			padding: 1rem 1.5rem;
 
 			@media (min-width: 50rem) {
 				background-color: var(--sl-color-bg-sidebar);
 			}
 		}
 
-		.sidebar-product-header {
-			padding-bottom: 0.75rem;
+		.sidebar-nav-scroll {
+			flex: 1;
+			overflow-y: auto;
+			min-height: 0;
 		}
 
+		/* Stop .sidebar-content from scrolling — .sidebar-nav-scroll handles it */
 		.sidebar-content {
-			flex: 1 !important;
-			overflow-y: auto !important;
-			/* Top padding is now provided by the header above */
-			padding-top: 0 !important;
+			overflow: hidden !important;
 			min-height: 0 !important;
+			padding-top: 0 !important;
+			padding-bottom: 0 !important;
 
 			--sl-color-hairline-light: #cacaca !important;
 

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -7,14 +7,19 @@ import { lookupProductTitle } from "~/util/sidebar";
 const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 ---
 
-<a href={"/" + product + "/"} class="flex items-center gap-2 px-1 no-underline">
-	<AstroIcon name={product} size="32px" class="text-cl1-brand-orange" />
-	<span class="text-xl text-black">
-		<strong>
-			{lookupProductTitle(product, module)}
-		</strong>
-	</span>
-</a>
+<div class="sidebar-product-header">
+	<a
+		href={"/" + product + "/"}
+		class="flex items-center gap-2 px-1 no-underline"
+	>
+		<AstroIcon name={product} size="32px" class="text-cl1-brand-orange" />
+		<span class="text-xl text-black">
+			<strong>
+				{lookupProductTitle(product, module)}
+			</strong>
+		</span>
+	</a>
+</div>
 
 <!-- Search Input -->
 <div class="relative">
@@ -22,7 +27,7 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 		type="text"
 		id="sidebar-search"
 		placeholder="Search sidebar..."
-		class="w-full px-3 py-2 pr-10 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-orange-500 dark:focus:border-orange-500 transition-colors duration-200"
+		class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-10 text-sm text-gray-900 placeholder-gray-500 transition-colors duration-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:border-orange-500 dark:focus:ring-orange-500"
 	/>
 	<div class="sidebar-search-icon"></div>
 </div>
@@ -30,9 +35,13 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 <!-- No Results Message -->
 <div
 	id="sidebar-no-results"
-	class="text-sm text-gray-500 dark:text-gray-400 text-center p-4 hidden"
+	class="hidden p-4 text-center text-sm text-gray-500 dark:text-gray-400"
 >
-	No results found. Try a different search term, or use our <button id="global-search-link" class="text-blue-500 dark:text-orange-500 underline hover:no-underline cursor-pointer bg-transparent border-none p-0 font-inherit">global search</button>.
+	No results found. Try a different search term, or use our <button
+		id="global-search-link"
+		class="font-inherit cursor-pointer border-none bg-transparent p-0 text-blue-500 underline hover:no-underline dark:text-orange-500"
+		>global search</button
+	>.
 </div>
 
 <Default><slot /></Default>
@@ -42,40 +51,51 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	import { openGlobalSearch } from "~/util/search";
 
 	function initSidebarSearch() {
-		const searchInput = document.getElementById('sidebar-search') as HTMLInputElement;
-		const noResultsMessage = document.getElementById('sidebar-no-results') as HTMLElement;
-		const globalSearchLink = document.getElementById('global-search-link') as HTMLButtonElement;
-		const sidebarContent = document.querySelector('.sidebar-content');
+		const searchInput = document.getElementById(
+			"sidebar-search",
+		) as HTMLInputElement;
+		const noResultsMessage = document.getElementById(
+			"sidebar-no-results",
+		) as HTMLElement;
+		const globalSearchLink = document.getElementById(
+			"global-search-link",
+		) as HTMLButtonElement;
+		const sidebarContent = document.querySelector(".sidebar-content");
 
-		if (!searchInput || !sidebarContent || !noResultsMessage || !globalSearchLink) return;
+		if (
+			!searchInput ||
+			!sidebarContent ||
+			!noResultsMessage ||
+			!globalSearchLink
+		)
+			return;
 
 		const originalState: Map<Element, boolean> = new Map();
 
 		// Store original state of details elements
 		function storeOriginalState() {
 			if (originalState.size === 0) {
-				const detailsElements = sidebarContent!.querySelectorAll('details');
-				detailsElements.forEach(details => {
+				const detailsElements = sidebarContent!.querySelectorAll("details");
+				detailsElements.forEach((details) => {
 					originalState.set(details, details.open);
 				});
 			}
 		}
 
-
 		// Check if text matches all search terms (for multi-word searches)
 		function matchesAllTerms(text: string, searchTerms: string[]): boolean {
 			const lowerText = text.toLowerCase();
-			return searchTerms.every(term => lowerText.includes(term));
+			return searchTerms.every((term) => lowerText.includes(term));
 		}
 
 		// Show only direct children of a folder (not recursive)
 		function showDirectChildren(details: HTMLDetailsElement) {
 			details.open = true;
-			const directList = details.querySelector(':scope > ul');
+			const directList = details.querySelector(":scope > ul");
 			if (directList) {
-				const directChildren = directList.querySelectorAll(':scope > li');
-				directChildren.forEach(child => {
-					(child as HTMLElement).style.display = '';
+				const directChildren = directList.querySelectorAll(":scope > li");
+				directChildren.forEach((child) => {
+					(child as HTMLElement).style.display = "";
 				});
 			}
 		}
@@ -84,10 +104,10 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 		function showParentChain(element: Element) {
 			let parent = element.parentElement;
 			while (parent && parent !== sidebarContent) {
-				if (parent.tagName === 'LI') {
-					(parent as HTMLElement).style.display = '';
+				if (parent.tagName === "LI") {
+					(parent as HTMLElement).style.display = "";
 				}
-				if (parent.tagName === 'DETAILS') {
+				if (parent.tagName === "DETAILS") {
 					(parent as HTMLDetailsElement).open = true;
 				}
 				parent = parent.parentElement;
@@ -96,18 +116,18 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 
 		// Filter sidebar items based on search query
 		function filterSidebarItems(query: string) {
-			const items = sidebarContent!.querySelectorAll('li');
-			const detailsElements = sidebarContent!.querySelectorAll('details');
+			const items = sidebarContent!.querySelectorAll("li");
+			const detailsElements = sidebarContent!.querySelectorAll("details");
 			track("use sidebar search", { query: query });
 
 			if (!query.trim()) {
 				// Reset to original state
-				items.forEach(item => {
-					(item as HTMLElement).style.display = '';
+				items.forEach((item) => {
+					(item as HTMLElement).style.display = "";
 				});
 
 				// Restore original details state
-				detailsElements.forEach(details => {
+				detailsElements.forEach((details) => {
 					const originalOpen = originalState.get(details);
 					if (originalOpen !== undefined) {
 						(details as HTMLDetailsElement).open = originalOpen;
@@ -115,19 +135,22 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 				});
 
 				// Hide no results message
-				noResultsMessage.classList.add('hidden');
+				noResultsMessage.classList.add("hidden");
 
 				return;
 			}
 
 			// Split search query into terms for more precise matching
-			const searchTerms = query.toLowerCase().split(/\s+/).filter(term => term.length > 0);
+			const searchTerms = query
+				.toLowerCase()
+				.split(/\s+/)
+				.filter((term) => term.length > 0);
 
 			// First, hide all items and close all details
-			items.forEach(item => {
-				(item as HTMLElement).style.display = 'none';
+			items.forEach((item) => {
+				(item as HTMLElement).style.display = "none";
 			});
-			detailsElements.forEach(details => {
+			detailsElements.forEach((details) => {
 				(details as HTMLDetailsElement).open = false;
 			});
 
@@ -135,16 +158,16 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 			const matchedItems = new Set<Element>();
 
 			// 1. Check for folder/subfolder matches first (highest priority)
-			detailsElements.forEach(details => {
-				const summary = details.querySelector('summary');
+			detailsElements.forEach((details) => {
+				const summary = details.querySelector("summary");
 				if (summary) {
-					const summaryText = summary.textContent || '';
+					const summaryText = summary.textContent || "";
 
 					if (matchesAllTerms(summaryText, searchTerms)) {
 						// This is a folder match - show the folder and its direct children
-						const parentLi = details.closest('li');
+						const parentLi = details.closest("li");
 						if (parentLi && !matchedItems.has(parentLi)) {
-							(parentLi as HTMLElement).style.display = '';
+							(parentLi as HTMLElement).style.display = "";
 							showDirectChildren(details);
 							showParentChain(parentLi);
 							matchedItems.add(parentLi);
@@ -154,21 +177,21 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 			});
 
 			// 2. Check for specific page matches (show page + parent chain)
-			items.forEach(item => {
+			items.forEach((item) => {
 				if (matchedItems.has(item)) return; // Skip if already matched as folder
 
-				const link = item.querySelector('a');
-				const summary = item.querySelector('summary');
+				const link = item.querySelector("a");
+				const summary = item.querySelector("summary");
 
 				// Skip if this is a folder (has summary) - those are handled above
 				if (summary) return;
 
 				if (link) {
-					const linkText = link.textContent || '';
+					const linkText = link.textContent || "";
 
 					if (matchesAllTerms(linkText, searchTerms)) {
 						// This is a specific page match - show page + parent chain
-						(item as HTMLElement).style.display = '';
+						(item as HTMLElement).style.display = "";
 						showParentChain(item);
 						matchedItems.add(item);
 					}
@@ -177,24 +200,27 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 
 			// 3. Fallback: if no exact matches, show partial matches (less specific)
 			if (matchedItems.size === 0) {
-				items.forEach(item => {
-					const textContent = item.textContent?.toLowerCase() || '';
-					const link = item.querySelector('a');
-					const linkText = link?.textContent?.toLowerCase() || '';
-					const summary = item.querySelector('summary');
-					const summaryText = summary?.textContent?.toLowerCase() || '';
+				items.forEach((item) => {
+					const textContent = item.textContent?.toLowerCase() || "";
+					const link = item.querySelector("a");
+					const linkText = link?.textContent?.toLowerCase() || "";
+					const summary = item.querySelector("summary");
+					const summaryText = summary?.textContent?.toLowerCase() || "";
 
 					// Check if any search term is found (partial matching)
-					const hasPartialMatch = searchTerms.some(term =>
-						textContent.includes(term) || linkText.includes(term) || summaryText.includes(term)
+					const hasPartialMatch = searchTerms.some(
+						(term) =>
+							textContent.includes(term) ||
+							linkText.includes(term) ||
+							summaryText.includes(term),
 					);
 
 					if (hasPartialMatch) {
-						(item as HTMLElement).style.display = '';
+						(item as HTMLElement).style.display = "";
 
 						// If it's a folder, show direct children only
 						if (summary) {
-							const details = item.querySelector('details');
+							const details = item.querySelector("details");
 							if (details) {
 								showDirectChildren(details);
 							}
@@ -208,29 +234,29 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 
 			// Show/hide no results message based on matches
 			if (matchedItems.size === 0) {
-				noResultsMessage.classList.remove('hidden');
+				noResultsMessage.classList.remove("hidden");
 			} else {
-				noResultsMessage.classList.add('hidden');
+				noResultsMessage.classList.add("hidden");
 			}
 		}
 
 		// Event listeners
-		searchInput.addEventListener('input', (e) => {
+		searchInput.addEventListener("input", (e) => {
 			storeOriginalState();
 			const query = (e.target as HTMLInputElement).value;
 			filterSidebarItems(query);
 		});
 
 		// Clear search on Escape key
-		searchInput.addEventListener('keydown', (e) => {
-			if (e.key === 'Escape') {
-				searchInput.value = '';
-				filterSidebarItems('');
+		searchInput.addEventListener("keydown", (e) => {
+			if (e.key === "Escape") {
+				searchInput.value = "";
+				filterSidebarItems("");
 			}
 		});
 
 		// Global search link click handler
-		globalSearchLink.addEventListener('click', () => {
+		globalSearchLink.addEventListener("click", () => {
 			const currentQuery = searchInput.value.trim();
 			if (currentQuery) {
 				openGlobalSearch(currentQuery);
@@ -263,8 +289,8 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	}
 
 	// Initialize when DOM is loaded
-	if (document.readyState === 'loading') {
-		document.addEventListener('DOMContentLoaded', initSidebarSearch);
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", initSidebarSearch);
 	} else {
 		initSidebarSearch();
 	}
@@ -290,6 +316,15 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	}
 
 	:root {
+		.sidebar-product-header {
+			position: sticky;
+			top: 0;
+			z-index: 10;
+			background-color: var(--sl-color-bg-sidebar);
+			padding-top: 0.75rem;
+			padding-bottom: 0.75rem;
+		}
+
 		.sidebar-content {
 			--sl-color-hairline-light: #cacaca !important;
 

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1,6 +1,7 @@
 .sidebar-content {
+	scrollbar-gutter: stable;
 	gap: 0.5rem;
-	padding: 1rem 1.5rem;
+	padding: 1rem 0.5rem 1rem 1.5rem;
 
 	.large {
 		font-weight: unset;
@@ -77,6 +78,7 @@
 }
 
 :root[data-theme="dark"] {
+	--sl-color-bg-nav: var(--color-cl1-gray-0);
 	--sl-color-bg-sidebar: var(--color-cl1-gray-0);
 	--sl-color-sidebar-active: var(--color-cl1-blue-7);
 	--sl-color-sidebar-hover: var(--color-cl1-gray-2);

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1,7 +1,11 @@
-.sidebar-content {
+.sidebar-nav-scroll {
 	scrollbar-gutter: stable;
-	gap: 0.5rem;
-	padding: 1rem 0.5rem 1rem 1.5rem;
+	padding: 0 0.5rem 1rem 1.5rem;
+}
+
+.sidebar-content {
+	gap: 0;
+	padding: 0;
 
 	.large {
 		font-weight: unset;
@@ -78,7 +82,6 @@
 }
 
 :root[data-theme="dark"] {
-	--sl-color-bg-nav: var(--color-cl1-gray-0);
 	--sl-color-bg-sidebar: var(--color-cl1-gray-0);
 	--sl-color-sidebar-active: var(--color-cl1-blue-7);
 	--sl-color-sidebar-hover: var(--color-cl1-gray-2);

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1,14 +1,10 @@
-.sidebar-nav-scroll {
-	flex: 1;
-	overflow-y: auto;
-	min-height: 0;
+.sidebar-pane {
 	scrollbar-gutter: stable;
-	padding: 0 0.5rem 1rem 1.5rem;
 }
 
 .sidebar-content {
 	gap: 0;
-	padding: 0;
+	padding: 0 1.5rem 1rem;
 
 	.large {
 		font-weight: unset;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -1,4 +1,7 @@
 .sidebar-nav-scroll {
+	flex: 1;
+	overflow-y: auto;
+	min-height: 0;
 	scrollbar-gutter: stable;
 	padding: 0 0.5rem 1rem 1.5rem;
 }


### PR DESCRIPTION
### Summary

Readers frequently lose context in long sidebars (and we can't adjust the breadcrumbs easily), so adding sticky header behavior to the left side title (and link) of the current product you're in.

In the video, `Style Guide` is pinned to the top of that container so always visible upon scroll.

https://github.com/user-attachments/assets/7eb88a70-1b35-4cd5-91c2-b66488accd84




