### PR TITLE
[Pages] Update v1 build image deprecation date

### DIFF
--- a/src/content/docs/pages/configuration/build-image.mdx
+++ b/src/content/docs/pages/configuration/build-image.mdx
@@ -113,7 +113,7 @@ Cloudflare Pages builds are run in a [gVisor](https://gvisor.dev/docs/) containe
 
 If you are currently using the v1 or v2 build image, your project will be automatically moved to v3:
 
-- **v1 build image**: If you are using the Pages v1 build image, your project will be automatically moved to v3 on August 25, 2026.
+- **v1 build image**: If you are using the Pages v1 build image, your project will be automatically moved to v3 on September 15, 2026.
 - **v2 build image**: If you are using the Pages v2 build image, your project will be automatically moved to v3 on February 23, 2027.
 
 You will receive 6 months’ notice before the deprecation date via the [Cloudflare Changelog](https://developers.cloudflare.com/changelog/), dashboard notifications, and email.


### PR DESCRIPTION
## Summary
- Updates the Pages v1 build image deprecation date from August 25, 2026 to September 15, 2026.