### PR TITLE
Add Log Explorer and Trace usage guidance (SPM-2171)

### DIFF
--- a/src/content/docs/log-explorer/log-search.mdx
+++ b/src/content/docs/log-explorer/log-search.mdx
@@ -11,22 +11,11 @@ Log Explorer enables you to store and explore your Cloudflare logs directly with
 
 ## When to use Log Explorer
 
-Use **Log Explorer** when you need to investigate **what actually happened** with real production traffic:
+<Render file="log-explorer-use-cases" product="rules" />
 
-- Analyzing historical data and trends
-- Investigating security incidents after they occur
-- Searching for patterns across thousands of requests
-- Monitoring application performance over time
-- Providing forensic evidence to support teams
+<Render file="trace-use-cases" product="rules" params={{ addLink: true }} />
 
-Use **[Trace](/rules/trace-request/)** when you need to test **what would happen** with a simulated request:
-
-- Understanding why a rule did not trigger as expected
-- Testing how your rules handle different request scenarios
-- Seeing the evaluation order of your rules
-- Simulating requests from different geolocations or conditions
-
-**Key difference**: Log Explorer shows actual traffic; Trace shows simulated "what-if" scenarios.
+The key difference is that Log Explorer shows actual traffic, while Trace shows simulated "what-if" scenarios.
 
 ## Use Log Explorer
 
@@ -46,33 +35,32 @@ You can filter and view your logs via the Cloudflare dashboard or the API.
 For example, to find an HTTP request with a specific [Ray ID](/fundamentals/reference/cloudflare-ray-id/), go to **Custom SQL**, and enter the following SQL query:
 
 ```sql
-SELECT 
-	clientRequestScheme, 
-	clientRequestHost, 
-	clientRequestMethod, 
-	edgeResponseStatus, 
-	clientRequestUserAgent 
-FROM http_requests 
-WHERE RayID = '806c30a3cec56817' 
+SELECT
+	clientRequestScheme,
+	clientRequestHost,
+	clientRequestMethod,
+	edgeResponseStatus,
+	clientRequestUserAgent
+FROM http_requests
+WHERE RayID = '806c30a3cec56817'
 LIMIT 1
 ```
-
 
 As another example, to find Cloudflare Access requests with selected columns from a specific timeframe you could perform the following SQL query:
 
 ```sql
-SELECT 
-	CreatedAt, 
-	AppDomain, 
-	AppUUID, 
-	Action, 
-	Allowed, 
-	Country, 
-	RayID, 
-	Email, 
-	IPAddress, 
-	UserUID 
-FROM access_requests 
+SELECT
+	CreatedAt,
+	AppDomain,
+	AppUUID,
+	Action,
+	Allowed,
+	Country,
+	RayID,
+	Email,
+	IPAddress,
+	UserUID
+FROM access_requests
 WHERE Date >= '2025-02-06' AND Date <= '2025-02-06' AND CreatedAt >= '2025-02-06T12:28:39Z' AND CreatedAt <= '2025-02-06T12:58:39Z'
 ```
 
@@ -111,21 +99,21 @@ All the tables supported by Log Explorer contain a special column called `date`,
 
 ```sql
 SELECT
-	clientip, 
-	clientrequesthost, 
-	clientrequestmethod, 
-	clientrequesturi, 
-	edgeendtimestamp, 
-	edgeresponsestatus, 
-	originresponsestatus, 
-	edgestarttimestamp, 
-	rayid, 
-	clientcountry, 
-	clientrequestpath, 
+	clientip,
+	clientrequesthost,
+	clientrequestmethod,
+	clientrequesturi,
+	edgeendtimestamp,
+	edgeresponsestatus,
+	originresponsestatus,
+	edgestarttimestamp,
+	rayid,
+	clientcountry,
+	clientrequestpath,
 	date
-FROM 
+FROM
 	http_requests
-WHERE 
+WHERE
 	date = '2023-10-12' LIMIT 500
 ```
 

--- a/src/content/docs/log-explorer/log-search.mdx
+++ b/src/content/docs/log-explorer/log-search.mdx
@@ -22,7 +22,7 @@ Use **Log Explorer** when you need to investigate **what actually happened** wit
 Use **[Trace](/rules/trace-request/)** when you need to test **what would happen** with a simulated request:
 
 - Understanding why a rule did not trigger as expected
-- Testing configuration changes before deployment
+- Testing how your rules handle different request scenarios
 - Seeing the evaluation order of your rules
 - Simulating requests from different geolocations or conditions
 

--- a/src/content/docs/log-explorer/log-search.mdx
+++ b/src/content/docs/log-explorer/log-search.mdx
@@ -9,6 +9,25 @@ import { TabItem, Tabs, Render, DashButton } from "~/components";
 
 Log Explorer enables you to store and explore your Cloudflare logs directly within the Cloudflare dashboard or API, giving you visibility into your logs without the need to forward them to third-party services. Logs are stored on Cloudflare's global network using the R2 object storage platform and can be queried via the dashboard or SQL API.
 
+## When to use Log Explorer
+
+Use **Log Explorer** when you need to investigate **what actually happened** with real production traffic:
+
+- Analyzing historical data and trends
+- Investigating security incidents after they occur
+- Searching for patterns across thousands of requests
+- Monitoring application performance over time
+- Providing forensic evidence to support teams
+
+Use **[Trace](/rules/trace-request/)** when you need to test **what would happen** with a simulated request:
+
+- Understanding why a rule did not trigger as expected
+- Testing configuration changes before deployment
+- Seeing the evaluation order of your rules
+- Simulating requests from different geolocations or conditions
+
+**Key difference**: Log Explorer shows actual traffic; Trace shows simulated "what-if" scenarios.
+
 ## Use Log Explorer
 
 You can filter and view your logs via the Cloudflare dashboard or the API.

--- a/src/content/docs/rules/trace-request/how-to.mdx
+++ b/src/content/docs/rules/trace-request/how-to.mdx
@@ -11,6 +11,25 @@ description: Learn how to use Cloudflare Trace in the dashboard and with the API
 
 import { GlossaryTooltip, DashButton, Steps } from "~/components";
 
+## When to use Trace
+
+Use **Trace** when you need to test **what would happen** with a simulated request:
+
+- Testing configuration changes before deploying to production
+- Understanding why a rule did not trigger as expected
+- Seeing the exact evaluation order of your Cloudflare rules
+- Simulating requests from different geolocations, User-Agents, or bot scores
+- Debugging rule logic without sending real traffic
+
+Use **[Log Explorer](/log-explorer/)** when you need to investigate **what actually happened** with real production traffic:
+
+- Analyzing historical production traffic
+- Investigating security incidents after they occur
+- Searching for patterns across thousands of requests
+- Monitoring trends over time with dashboards
+
+**Key difference**: Trace simulates "what-if" scenarios; Log Explorer shows actual historical traffic.
+
 ## Use Trace in the dashboard
 
 ### 1. Configure one or more Cloudflare products

--- a/src/content/docs/rules/trace-request/how-to.mdx
+++ b/src/content/docs/rules/trace-request/how-to.mdx
@@ -11,25 +11,6 @@ description: Learn how to use Cloudflare Trace in the dashboard and with the API
 
 import { GlossaryTooltip, DashButton, Steps } from "~/components";
 
-## When to use Trace
-
-Use **Trace** when you need to test **what would happen** with a simulated request:
-
-- Testing how your rules handle different request scenarios
-- Understanding why a rule did not trigger as expected
-- Seeing the exact evaluation order of your Cloudflare rules
-- Simulating requests from different geolocations, User-Agents, or bot scores
-- Debugging rule logic without sending real traffic
-
-Use **[Log Explorer](/log-explorer/)** when you need to investigate **what actually happened** with real production traffic:
-
-- Analyzing historical production traffic
-- Investigating security incidents after they occur
-- Searching for patterns across thousands of requests
-- Monitoring trends over time with dashboards
-
-**Key difference**: Trace simulates "what-if" scenarios; Log Explorer shows actual historical traffic.
-
 ## Use Trace in the dashboard
 
 ### 1. Configure one or more Cloudflare products

--- a/src/content/docs/rules/trace-request/how-to.mdx
+++ b/src/content/docs/rules/trace-request/how-to.mdx
@@ -15,7 +15,7 @@ import { GlossaryTooltip, DashButton, Steps } from "~/components";
 
 Use **Trace** when you need to test **what would happen** with a simulated request:
 
-- Testing configuration changes before deploying to production
+- Testing how your rules handle different request scenarios
 - Understanding why a rule did not trigger as expected
 - Seeing the exact evaluation order of your Cloudflare rules
 - Simulating requests from different geolocations, User-Agents, or bot scores

--- a/src/content/docs/rules/trace-request/index.mdx
+++ b/src/content/docs/rules/trace-request/index.mdx
@@ -8,7 +8,12 @@ head:
     content: Trace a request with Cloudflare Trace
 ---
 
-import { DirectoryListing, Plan, ProductAvailabilityText } from "~/components";
+import {
+	DirectoryListing,
+	Plan,
+	ProductAvailabilityText,
+	Render,
+} from "~/components";
 
 <Plan type="all" />
 
@@ -17,6 +22,18 @@ Cloudflare Trace <ProductAvailabilityText product="trace-request" /> follows an 
 You can define specific request properties to simulate different conditions for an HTTP/S request. Inactive rules configured in Cloudflare products will not be evaluated.
 
 Cloudflare Trace is available to users with an Administrator or Super Administrator role.
+
+## When to use Trace
+
+<Render file="trace-use-cases" product="rules" />
+
+<Render
+	file="log-explorer-use-cases"
+	product="rules"
+	params={{ addLink: true }}
+/>
+
+The key difference is that Trace simulates "what-if" scenarios, while Log Explorer shows actual historical traffic.
 
 ## Resources
 

--- a/src/content/partials/rules/log-explorer-use-cases.mdx
+++ b/src/content/partials/rules/log-explorer-use-cases.mdx
@@ -1,0 +1,12 @@
+---
+params:
+  - addLink?
+---
+
+Use { props.addLink ? <a href="/log-explorer/">Log Explorer</a> : "Log Explorer" } when you need to investigate what actually happened with real production traffic:
+
+- Analyzing historical data and trends
+- Investigating security incidents after they occur
+- Searching for patterns across thousands of requests
+- Monitoring application performance over time
+- Providing forensic evidence to support teams

--- a/src/content/partials/rules/trace-use-cases.mdx
+++ b/src/content/partials/rules/trace-use-cases.mdx
@@ -1,0 +1,11 @@
+---
+params:
+  - addLink?
+---
+
+Use { props.addLink ? <a href="/rules/trace-request/">Trace</a> : "Trace" } when you need to test what would happen with a simulated request:
+
+- Understanding why a rule did not trigger as expected
+- Testing how your rules handle different request scenarios
+- Seeing the evaluation order of your rules
+- Simulating requests from different geolocations or conditions


### PR DESCRIPTION
## Summary
Adds "When to use" guidance to help customers choose between Log Explorer and Trace for troubleshooting.

Addresses: SPM-2171

## Changes
- **Updated**: `/rules/trace-request/how-to.mdx` - Added "When to use Trace" section
- **Updated**: `/log-explorer/log-search.mdx` - Added "When to use Log Explorer" section

## What's Added
✅ Clear decision guidance for when to use each tool
✅ Cross-references between Log Explorer and Trace
✅ Key differences highlighted
✅ Practical use cases for each tool

## Related
- Jira: SPM-2171 - Integrate Log Explorer and Trace into customer experience
- Improves customer self-service for troubleshooting
- Reduces support volume by clarifying tool selection