### PR TITLE
docs: Fix typos - `you` -> `your` and `be sure` -> `make sure` in Workers dashboard

### DIFF
--- a/src/content/docs/workers/get-started/dashboard.mdx
+++ b/src/content/docs/workers/get-started/dashboard.mdx
@@ -37,10 +37,10 @@ To get started with a new Workers application:
 Applications started in the dashboard are set up with Git to help kickstart your development workflow. To continue developing on your repository, you can run:
 
 ```bash
-# clone you repository locally
+# clone your repository locally
 git clone <git repo URL>
 
-# be sure you are in the root directory
+# make sure you are in the root directory
 cd <directory>
 ```
 


### PR DESCRIPTION
### Summary

Fix minor wording issues in the Workers dashboard guide.

### Changes
- `src/content/docs/workers/get-started/dashboard.mdx`
     - "clone you repository locally" -> "clone your repository locally"
     - "be sure you are in the root directory" -> "make sure you are in the root directory"

### Screenshots

![typo_screenshot](https://github.com/user-attachments/assets/2fd75e3e-2dc3-492d-ac05-3c724684a398)