### PR TITLE
Clarify Zone Holds default setting for Enterprise zones

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/zone-holds.mdx
+++ b/src/content/docs/fundamentals/account/account-security/zone-holds.mdx
@@ -10,6 +10,10 @@ Zone holds prevent other teams in your organization from adding zones that are a
 
 For example, you might already have an active Cloudflare zone for `example.com`. If another team does not realize this, they could add and activate `example.com` in another Cloudflare account, which may cause downtimes or security issues until the original zone could be re-activated.
 
+<Aside type="note">
+Zone Holds are enabled by default for all Enterprise zones.
+</Aside>
+
 ## Availability
 
 <FeatureTable id="account.zone_holds" />


### PR DESCRIPTION
Added note about default enabling of Zone Holds for Enterprise zones.

Source: https://blog.cloudflare.com/protect-your-domain-with-zone-holds/#how-zone-holds-protect-customers
