### PR TITLE
Add dismiss and filter matches feature in Brand Protection

### DIFF
--- a/src/content/changelog/security-center/2026-03-06-brand-protection-dismiss-match.mdx
+++ b/src/content/changelog/security-center/2026-03-06-brand-protection-dismiss-match.mdx
@@ -1,0 +1,21 @@
+---
+title: Dismiss and filter matches in Brand Protection
+description: Streamline your workflow by dismissing benign matches and toggling visibility of past reviews
+date: 2026-03-06
+---
+
+We have introduced new triage controls to help you manage your Brand Protection results more efficiently. You can now clear out the noise by dismissing matches while maintaining full visibility into your historical decisions.
+
+### What's new
+
+- **Dismiss matches**: Users can now mark specific results as dismissed if they are determined to be benign or false positives, removing them from the primary triage view.
+- **Show/Hide toggle**: A new visibility control allows you to instantly switch between viewing only active matches and including previously dismissed ones.
+- **Persistent review states**: Dismissed status is saved across sessions, ensuring that your workspace remains organized and focused on new or high-priority threats.
+
+### Key benefits of the dismiss match functionality:
+
+- Reduce alert fatigue by hiding known-safe results, allowing your team to focus exclusively on unreviewed or high-risk infringements.
+- Auditability and recovery through the visibility toggle, ensuring that no match is ever truly "lost" and can be re-evaluated if a site's content changes.
+- Improved collaboration as your team members can see which matches have already been vetted and dismissed by others.
+
+Ready to clean up your match queue? Learn more in our [Brand Protection documentation](/security-center/brand-protection/).


### PR DESCRIPTION
Added new triage controls for managing Brand Protection results, including dismissing benign matches and toggling visibility of past reviews.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
