### PR TITLE
[Stream] Migrate technical specifications from FAQ to relevant documentation pages

### DIFF
--- a/src/content/docs/stream/faq.mdx
+++ b/src/content/docs/stream/faq.mdx
@@ -12,10 +12,6 @@ import { GlossaryTooltip, DashButton } from "~/components";
 
 ## Stream
 
-### What formats and quality levels are delivered through Cloudflare Stream?
-
-Cloudflare decides on which bitrate, resolution, and codec is best for you. We deliver all videos to industry standard H264 codec. We use a few different adaptive streaming levels from 360p to 1080p to ensure smooth streaming for your audience watching on different devices and bandwidth constraints.
-
 ### Can I download original video files from Stream?
 
 You cannot download the _exact_ input file that you uploaded. However, depending on your use case, you can use the [Downloadable Videos](/stream/viewing-videos/download-videos/) feature to get encoded MP4s for use cases like offline viewing.
@@ -42,54 +38,9 @@ Uploads over these limits will receive a [429 (Too Many Requests)](/support/trou
 
 Yes. Stream videos can be embedded on any domain, even domains not on Cloudflare.
 
-### What input file formats are supported?
-
-Users can upload video in the following file formats:
-
-MP4, MKV, MOV, AVI, FLV, MPEG-2 TS, MPEG-2 PS, MXF, LXF, GXF, 3GP, WebM, MPG, QuickTime
-
 ### Does Stream support High Dynamic Range (HDR) video content?
 
 When HDR videos are uploaded to Stream, they are re-encoded and delivered in SDR format, to ensure compatibility with the widest range of viewing devices.
-
-### What frame rates (FPS) are supported?
-
-Cloudflare Stream supports video file uploads for any FPS, however videos will be re-encoded for 70 FPS playback. If the original video file has a frame rate lower than 70 FPS, Stream will re-encode at the original frame rate.
-
-If the frame rate is variable we will drop frames (for example if there are more than 1 frames within 1/30 seconds, we will drop the extra frames within that period).
-
-### What browsers does Stream work on?
-
-You can embed the Stream player on the following platforms:
-
-<table-wrap>
-
-| Browser | Version                             |
-| ------- | ----------------------------------- |
-| Chrome  | Supported since Chrome version 88+  |
-| Firefox | Supported since Firefox version 87+ |
-| Edge    | Supported since Edge 89+            |
-| Safari  | Supported since Safari version 14+  |
-| Opera   | Supported since Opera version 75+   |
-
-</table-wrap>
-
-:::note[Note]
-
-Cloudflare Stream is not available on Chromium, as Chromium does not support H.264 videos.
-
-:::
-
-<table-wrap>
-
-| Mobile Platform       | Version                                                                  |
-| --------------------- | ------------------------------------------------------------------------ |
-| Chrome on Android     | Supported on Chrome 90                                                   |
-| UC Browser on Android | Supported on version 12.12+                                              |
-| Samsung Internet      | Supported on 13+                                                         |
-| Safari on iOS         | Supported on iOS 13.4+. Speed selector supported when not in fullscreen. |
-
-</table-wrap>
 
 ### What are the recommended upload settings for video uploads?
 

--- a/src/content/docs/stream/get-started.mdx
+++ b/src/content/docs/stream/get-started.mdx
@@ -24,6 +24,8 @@ You can upload videos using the API or directly on the **Stream** page of the Cl
 
 <DashButton url="/?to=/:account/stream/videos" />
 
+For a list of accepted file types, refer to [Supported video formats](/stream/uploading-videos/#supported-video-formats).
+
 To use the API, replace the `API_TOKEN` and `ACCOUNT_ID` values with your credentials in the example below.
 
 ```bash title="Upload a video using the API"

--- a/src/content/docs/stream/index.mdx
+++ b/src/content/docs/stream/index.mdx
@@ -22,6 +22,8 @@ Cloudflare Stream lets you or your end users upload, store, encode, and deliver 
 
 You can use Stream to build your own video features in websites and native apps, from simple playback to an entire video platform.
 
+Stream automatically encodes and delivers videos using the H.264 codec with adaptive bitrate streaming, supporting resolutions from 360p to 1080p. This ensures smooth playback across different devices and network conditions without additional configuration.
+
 Cloudflare Stream runs on [Cloudflare’s global cloud network](https://www.cloudflare.com/network/) in hundreds of cities worldwide.
 
  <LinkButton variant="primary" href="/stream/get-started/">Get started</LinkButton> <LinkButton variant="secondary" href="https://dash.cloudflare.com/?to=/:account/stream">Stream dashboard</LinkButton>

--- a/src/content/docs/stream/index.mdx
+++ b/src/content/docs/stream/index.mdx
@@ -22,7 +22,7 @@ Cloudflare Stream lets you or your end users upload, store, encode, and deliver 
 
 You can use Stream to build your own video features in websites and native apps, from simple playback to an entire video platform.
 
-Stream automatically encodes and delivers videos using the H.264 codec with adaptive bitrate streaming, supporting resolutions from 360p to 1080p. This ensures smooth playback across different devices and network conditions without additional configuration.
+Stream automatically encodes and delivers videos using the H.264 codec with adaptive bitrate streaming, supporting resolutions from 360p to 1080p. This ensures smooth playback across different devices and network conditions.
 
 Cloudflare Stream runs on [Cloudflare’s global cloud network](https://www.cloudflare.com/network/) in hundreds of cities worldwide.
 

--- a/src/content/docs/stream/uploading-videos/index.mdx
+++ b/src/content/docs/stream/uploading-videos/index.mdx
@@ -53,4 +53,4 @@ Files must be less than 30 GB, and content should be encoded and uploaded in the
 
 Stream accepts video uploads at any frame rate. During encoding, Stream re-encodes videos for a maximum of 70 FPS playback. If the original video has a frame rate lower than 70 FPS, Stream re-encodes at the original frame rate.
 
-For variable frame rate content, Stream drops extra frames to maintain consistency. For example, if there is more than one frame within a 1/30 second window, Stream drops the extra frames within that period.
+For variable frame rate content, Stream drops extra frames. For example, if there is more than one frame within a 1/30 second window, Stream drops the extra frames within that period.

--- a/src/content/docs/stream/uploading-videos/index.mdx
+++ b/src/content/docs/stream/uploading-videos/index.mdx
@@ -48,3 +48,9 @@ Files must be less than 30 GB, and content should be encoded and uploaded in the
   - 60 or fewer frames per second
 - Closed GOP (_Only required for live streaming._)
 - Mono or Stereo audio. Stream will mix audio tracks with more than two channels down to stereo.
+
+## Frame rates
+
+Stream accepts video uploads at any frame rate. During encoding, Stream re-encodes videos for a maximum of 70 FPS playback. If the original video has a frame rate lower than 70 FPS, Stream re-encodes at the original frame rate.
+
+For variable frame rate content, Stream drops extra frames to maintain consistency. For example, if there is more than one frame within a 1/30 second window, Stream drops the extra frames within that period.

--- a/src/content/docs/stream/viewing-videos/using-the-stream-player/index.mdx
+++ b/src/content/docs/stream/viewing-videos/using-the-stream-player/index.mdx
@@ -61,7 +61,7 @@ Cloudflare Stream is not available on Chromium, as Chromium does not support H.2
 
 ### Mobile
 
-- Chrome on Android: version 90 or higher
+- Chrome on Android: version 90
 - UC Browser on Android: version 12.12 or higher
 - Samsung Internet: version 13 or higher
 - Safari on iOS: version 13.4 or higher (speed selector supported when not in fullscreen)

--- a/src/content/docs/stream/viewing-videos/using-the-stream-player/index.mdx
+++ b/src/content/docs/stream/viewing-videos/using-the-stream-player/index.mdx
@@ -43,6 +43,29 @@ To add the Stream Player to a web page, you can either:
 
 Stream player is also available as a [React](https://www.npmjs.com/package/@cloudflare/stream-react) or [Angular](https://www.npmjs.com/package/@cloudflare/stream-angular) component.
 
+## Browser compatibility
+
+### Desktop
+
+- Chrome: version 88 or higher
+- Firefox: version 87 or higher
+- Edge: version 89 or higher
+- Safari: version 14 or higher
+- Opera: version 75 or higher
+
+:::note
+
+Cloudflare Stream is not available on Chromium, as Chromium does not support H.264 videos.
+
+:::
+
+### Mobile
+
+- Chrome on Android: version 90 or higher
+- UC Browser on Android: version 12.12 or higher
+- Samsung Internet: version 13 or higher
+- Safari on iOS: version 13.4 or higher (speed selector supported when not in fullscreen)
+
 ## Player Size
 
 ### Fixed Dimensions


### PR DESCRIPTION
Migrates four technical specification FAQs from /stream/faq/ into relevant docs pages. Added delivery format details to the overview, a supported formats link to get-started, a frame rates section to upload videos, and browser compatibility to the Stream player page. Removed the corresponding FAQ entries. 