### PR TITLE
Add containers-pid-namespace compatibility flag

### DIFF
--- a/src/content/compatibility-flags/containers-pid-namespace.md
+++ b/src/content/compatibility-flags/containers-pid-namespace.md
@@ -1,0 +1,16 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Use an isolated PID namespace for containers"
+sort_date: "2026-04-01"
+enable_date: "2026-04-01"
+enable_flag: "containers_pid_namespace"
+disable_flag: "no_containers_pid_namespace"
+---
+
+When `containers_pid_namespace` is set, containers will use an isolated PID namespace. The `ENTRYPOINT` of your container will have PID 1.
+
+When unset, the container shares the PID namespace with the virtual machine (VM) containing the container. The `ENTRYPOINT` of your container will _not_ have PID 1 and other processes running on the VM (that are not part of your container) will be visible.


### PR DESCRIPTION
### Summary

This flag was added in https://github.com/cloudflare/workerd/pull/6063 and the compatibility date added in https://github.com/cloudflare/workerd/pull/6264

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
