### PR TITLE
Folder Highlighting within the Sidebar Navigation

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -356,6 +356,20 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 					}
 				}
 
+				/* Style parent navigation items that contain the current page */
+				details:has(a[aria-current="page"]) > summary,
+				details:has(a[aria-current="page"]) > summary * {
+					color: var(--sl-color-accent-high) !important;
+					font-weight: 600 !important;
+				}
+
+				/* Override to keep caret default color */
+				details:has(a[aria-current="page"]) > summary svg,
+				details:has(a[aria-current="page"]) > summary .caret,
+				details:has(a[aria-current="page"]) > summary [class*="caret"] {
+					fill: var(--sl-color-gray-3) !important;
+				}
+
 				summary {
 					padding: 0.1375em var(--sl-sidebar-item-padding-inline) !important;
 				}

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -49,20 +49,7 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	import { track } from "~/util/zaraz";
 	import { openGlobalSearch } from "~/util/search";
 
-	// Ensure the sticky header is a direct child of #starlight__sidebar
-	// (not inside .sidebar-content) so it is not part of the scroll container.
-	// The is:inline script above handles initial placement; this covers re-renders.
-	function hoistStickyHeader() {
-		const header = document.querySelector(".sidebar-sticky-header");
-		const pane = document.getElementById("starlight__sidebar");
-		if (header && pane && header.parentElement !== pane) {
-			pane.insertBefore(header, pane.firstChild);
-		}
-	}
-
 	function initSidebarSearch() {
-		hoistStickyHeader();
-
 		const searchInput = document.getElementById(
 			"sidebar-search",
 		) as HTMLInputElement;

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -49,7 +49,20 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	import { track } from "~/util/zaraz";
 	import { openGlobalSearch } from "~/util/search";
 
+	// Ensure the sticky header is a direct child of #starlight__sidebar
+	// (not inside .sidebar-content) so it is not part of the scroll container.
+	// The is:inline script above handles initial placement; this covers re-renders.
+	function hoistStickyHeader() {
+		const header = document.querySelector(".sidebar-sticky-header");
+		const pane = document.getElementById("starlight__sidebar");
+		if (header && pane && header.parentElement !== pane) {
+			pane.insertBefore(header, pane.firstChild);
+		}
+	}
+
 	function initSidebarSearch() {
+		hoistStickyHeader();
+
 		const searchInput = document.getElementById(
 			"sidebar-search",
 		) as HTMLInputElement;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -81,6 +81,7 @@
 }
 
 :root[data-theme="dark"] {
+	--sl-color-bg-nav: var(--color-cl1-gray-0);
 	--sl-color-bg-sidebar: var(--color-cl1-gray-0);
 	--sl-color-sidebar-active: var(--color-cl1-blue-7);
 	--sl-color-sidebar-hover: var(--color-cl1-gray-2);

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -81,7 +81,6 @@
 }
 
 :root[data-theme="dark"] {
-	--sl-color-bg-nav: var(--color-cl1-gray-0);
 	--sl-color-bg-sidebar: var(--color-cl1-gray-0);
 	--sl-color-sidebar-active: var(--color-cl1-blue-7);
 	--sl-color-sidebar-hover: var(--color-cl1-gray-2);


### PR DESCRIPTION
### Summary
This changes the color of the parent folder within the sidebar navigation, making it easier for the user to keep track of where they are.

### Screenshots (optional)

Before:
<img width="590" height="776" alt="CleanShot 2026-03-06 at 16 52 00@2x" src="https://github.com/user-attachments/assets/96c1bb40-5caa-4884-b205-eed9e24fae46" />

After:
<img width="590" height="776" alt="CleanShot 2026-03-06 at 16 52 32@2x" src="https://github.com/user-attachments/assets/ae4f38ee-7aca-4332-aaa6-efb199722fea" />


