### PR TITLE
Code Quality fix within the Sidebar

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -293,9 +293,6 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	} else {
 		initSidebarSearch();
 	}
-
-	// Re-initialize on navigation (for SPA-like behavior)
-	initSidebarSearch();
 </script>
 
 <style is:global>

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -49,20 +49,7 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	import { track } from "~/util/zaraz";
 	import { openGlobalSearch } from "~/util/search";
 
-	// Ensure the sticky header is a direct child of #starlight__sidebar
-	// (not inside .sidebar-content) so it is not part of the scroll container.
-	// The is:inline script above handles initial placement; this covers re-renders.
-	function hoistStickyHeader() {
-		const header = document.querySelector(".sidebar-sticky-header");
-		const pane = document.getElementById("starlight__sidebar");
-		if (header && pane && header.parentElement !== pane) {
-			pane.insertBefore(header, pane.firstChild);
-		}
-	}
-
 	function initSidebarSearch() {
-		hoistStickyHeader();
-
 		const searchInput = document.getElementById(
 			"sidebar-search",
 		) as HTMLInputElement;

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -49,7 +49,20 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 	import { track } from "~/util/zaraz";
 	import { openGlobalSearch } from "~/util/search";
 
+	// Ensure the sticky header is a direct child of #starlight__sidebar
+	// (not inside .sidebar-content) so it is not part of the scroll container.
+	// The is:inline script above handles initial placement; this covers re-renders.
+	function hoistStickyHeader() {
+		const header = document.querySelector(".sidebar-sticky-header");
+		const pane = document.getElementById("starlight__sidebar");
+		if (header && pane && header.parentElement !== pane) {
+			pane.insertBefore(header, pane.firstChild);
+		}
+	}
+
 	function initSidebarSearch() {
+		hoistStickyHeader();
+
 		const searchInput = document.getElementById(
 			"sidebar-search",
 		) as HTMLInputElement;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -81,6 +81,7 @@
 }
 
 :root[data-theme="dark"] {
+	--sl-color-bg-nav: var(--color-cl1-gray-0);
 	--sl-color-bg-sidebar: var(--color-cl1-gray-0);
 	--sl-color-sidebar-active: var(--color-cl1-blue-7);
 	--sl-color-sidebar-hover: var(--color-cl1-gray-2);

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -81,7 +81,6 @@
 }
 
 :root[data-theme="dark"] {
-	--sl-color-bg-nav: var(--color-cl1-gray-0);
 	--sl-color-bg-sidebar: var(--color-cl1-gray-0);
 	--sl-color-sidebar-active: var(--color-cl1-blue-7);
 	--sl-color-sidebar-hover: var(--color-cl1-gray-2);


### PR DESCRIPTION
### Summary
#### Problem
The sidebar search initialization function was being called twice on page load when `document.readyState !== "loading"`:

1. Once in the conditional else block (line 294)
2. Once unconditionally immediately after (line 298)

This caused duplicate event listeners to be attached for:

- Search input events
- Keyboard shortcuts (Escape and "/" focus)
- Global search link clicks


#### Solution
Removed the unconditional `initSidebarSearch()` call at line 298. The conditional block already handles both scenarios correctly:

- If DOM is still loading → waits for DOMContentLoaded event
- If DOM is already loaded → initializes immediately

#### Impact
- Prevents duplicate event listener registration
- Eliminates potential for multiple tracking events per user action
- Reduces unnecessary function calls on page load