### PR TITLE
Clarify email provider example in test-email-routing.mdx

### DIFF
--- a/src/content/docs/email-routing/get-started/test-email-routing.mdx
+++ b/src/content/docs/email-routing/get-started/test-email-routing.mdx
@@ -8,6 +8,6 @@ sidebar:
 
 To test that your configuration is working properly, send an email to the custom address [you set up in the dashboard](/email-routing/get-started/enable-email-routing/). You should send your test email from a different address than the one you specified as the destination address.
 
-For example, if you set up `your-name@gmail.com` as the destination address, do not send your test email from that same Gmail account. Send a test email to that destination address from another email account (for example, `your-name@outlook.com`).
+For example, if you set up `your-name@gmail.com` as the destination address, do not send your test email from that same email account. Send a test email to that destination address from another email account (for example, `your-name@outlook.com`).
 
 The reason for this is that some email providers will discard what they interpret as an incoming duplicate email and will not show it in your inbox, making it seem like Email Routing is not working properly.


### PR DESCRIPTION
The documentation example currently uses **Gmail** specifically when explaining how to test email routing. This can unintentionally imply that Gmail must be used as the sending account.

The example has been updated to use a **generic email account reference** instead, making the guidance provider-agnostic and applicable to any email service.

### Summary

- Replaced the provider-specific reference (`Gmail account`) with a generic term (`email account`).
- Keeps the example accurate for users who may use Outlook, custom domains, or other providers.
- No functional change to the instructions — only improves clarity and inclusiveness of the example.

### Screenshots (optional)

Before:
> "do not send your test email from that same Gmail account"

After:
> "do not send your test email from that same email account"

### Documentation checklist

- [ ] Is there a changelog entry?
- [x] The change adheres to the documentation style guide.
- [ ] If a larger change - such as adding a new page - an issue has been opened.
- [ ] Files which have changed name or location have been allocated redirects.