### PR TITLE
Close json-codeblock

### DIFF
--- a/src/content/docs/workers/framework-guides/web-apps/microfrontends.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/microfrontends.mdx
@@ -194,6 +194,7 @@ For Chromium-based browsers, the router uses the **Speculation Rules API** - a m
 		}
 	]
 }
+```
 
 ## Smooth transitions
 


### PR DESCRIPTION
The codeblock wasn't properly closed making the page look bad

### Summary

The codeblock wasn't properly closed making the page look bad

### Screenshots (optional)

<img width="785" height="637" alt="image" src="https://github.com/user-attachments/assets/69269d9a-6ea7-4183-a462-01e245b4758b" />

### Documentation checklist


