### PR TITLE
Update docs for Sandbox exec timeout handling

### DIFF
--- a/src/content/docs/sandbox/api/commands.mdx
+++ b/src/content/docs/sandbox/api/commands.mdx
@@ -71,6 +71,12 @@ await sandbox.exec('python process_login.py', {
 ```
 </TypeScriptExample>
 
+:::note[Timeout behavior]
+When a command times out, the SDK raises an error on the caller side and closes the connection. The underlying process **continues running** inside the container. To stop a timed-out process, delete the session with [`deleteSession()`](/sandbox/api/sessions/#deletesession) or destroy the sandbox with [`destroy()`](/sandbox/api/lifecycle/#destroy).
+
+Timeout precedence: per-command `timeout` on `exec()` > session-level `commandTimeoutMs` on [`createSession()`](/sandbox/api/sessions/#createsession) > global [`COMMAND_TIMEOUT_MS`](/sandbox/configuration/environment-variables/#command_timeout_ms) environment variable. If none are set, commands run without a timeout.
+:::
+
 ### `execStream()`
 
 Execute a command and return a Server-Sent Events stream for real-time processing.

--- a/src/content/docs/sandbox/api/sessions.mdx
+++ b/src/content/docs/sandbox/api/sessions.mdx
@@ -29,6 +29,7 @@ const session = await sandbox.createSession(options?: SessionOptions): Promise<E
   - `id` - Custom session ID (auto-generated if not provided)
   - `env` - Environment variables for this session: `Record<string, string | undefined>`
   - `cwd` - Working directory (default: `"/workspace"`)
+  - `commandTimeoutMs` - Maximum time in milliseconds that any command in this session can run before timing out. Individual commands can override this with the `timeout` option on `exec()`.
 
 **Returns**: `Promise<ExecutionSession>` with all sandbox methods bound to this session
 
@@ -56,6 +57,16 @@ const [prodResult, testResult] = await Promise.all([
   prodSession.exec('npm run build'),
   testSession.exec('npm run build')
 ]);
+
+// Session with a default command timeout
+const session = await sandbox.createSession({
+  commandTimeoutMs: 5000 // 5s timeout for all commands
+});
+
+await session.exec('sleep 10'); // Times out after 5s
+
+// Per-command timeout overrides session-level timeout
+await session.exec('sleep 10', { timeout: 3000 }); // Times out after 3s
 ```
 </TypeScriptExample>
 

--- a/src/content/docs/sandbox/concepts/sessions.mdx
+++ b/src/content/docs/sandbox/concepts/sessions.mdx
@@ -80,6 +80,19 @@ await buildSession.exec("npm run build");
 await testSession.exec("npm test");
 ```
 
+You can also set a default command timeout for all commands in a session:
+
+```typescript
+const session = await sandbox.createSession({
+  id: "ci",
+  commandTimeoutMs: 30000 // 30s timeout for all commands
+});
+
+await session.exec("npm test"); // Times out after 30s if still running
+```
+
+Individual commands can override the session timeout with the `timeout` option on `exec()`. For more details, refer to the [Sessions API](/sandbox/api/sessions/) and the [execute commands guide](/sandbox/guides/execute-commands/#timeouts).
+
 ## What's isolated per session
 
 Each session has its own:

--- a/src/content/docs/sandbox/configuration/environment-variables.mdx
+++ b/src/content/docs/sandbox/configuration/environment-variables.mdx
@@ -34,6 +34,31 @@ Controls the transport protocol for SDK-to-container communication. WebSocket tr
 
 See [Transport modes](/sandbox/configuration/transport/) for a complete guide including when to use each transport, performance considerations, and migration instructions.
 
+### COMMAND_TIMEOUT_MS
+
+| | |
+|---|---|
+| **Type** | `number` (milliseconds) |
+| **Default** | None (no timeout) |
+
+Sets a global default timeout for every `exec()` call. When set, any command that exceeds this duration raises an error on the caller side and closes the connection.
+
+Per-command `timeout` on `exec()` and session-level `commandTimeoutMs` on [`createSession()`](/sandbox/api/sessions/#createsession) both override this value. For more details on timeout precedence, refer to [Execute commands - Timeouts](/sandbox/guides/execute-commands/#timeouts).
+
+<WranglerConfig>
+```jsonc
+{
+	"vars": {
+		"COMMAND_TIMEOUT_MS": "30000"
+	}
+}
+```
+</WranglerConfig>
+
+:::note
+A timeout does not kill the underlying process. It only terminates the connection to the caller. The process continues running until the session is deleted or the sandbox is destroyed.
+:::
+
 ## Three ways to set environment variables
 
 The Sandbox SDK provides three methods for setting environment variables, each suited for different use cases:
@@ -127,7 +152,7 @@ await sandbox.setEnvVars({
 	// Set new values
 	API_KEY: 'new-key',
 	DATABASE_URL: env.DATABASE_URL,
-	
+
 	// Unset variables (removes them from the environment)
 	OLD_API_KEY: undefined,
 	TEMP_TOKEN: null

--- a/src/content/docs/sandbox/guides/execute-commands.mdx
+++ b/src/content/docs/sandbox/guides/execute-commands.mdx
@@ -133,6 +133,60 @@ await sandbox.exec('python /workspace/analyze.py data.csv');
 ```
 </TypeScriptExample>
 
+## Timeouts
+
+Set a maximum execution time for commands to prevent long-running operations from blocking indefinitely.
+
+### Per-command timeout
+
+Pass `timeout` in the options to set a timeout for a single command:
+
+<TypeScriptExample>
+```
+const result = await sandbox.exec('npm run build', {
+  timeout: 30000 // 30 seconds
+});
+```
+</TypeScriptExample>
+
+### Session-level timeout
+
+Set a default timeout for all commands in a session with `commandTimeoutMs`:
+
+<TypeScriptExample>
+```
+const session = await sandbox.createSession({
+  commandTimeoutMs: 10000 // 10s default for all commands
+});
+
+await session.exec('npm install');    // Times out after 10s
+await session.exec('npm run build');  // Times out after 10s
+
+// Per-command timeout overrides the session default
+await session.exec('npm test', { timeout: 60000 }); // 60s for this command
+```
+</TypeScriptExample>
+
+### Global timeout
+
+Set the `COMMAND_TIMEOUT_MS` [environment variable](/sandbox/configuration/environment-variables/#command_timeout_ms) to define a global default timeout for every `exec()` call across all sessions.
+
+### Timeout precedence
+
+When multiple timeouts are configured, the most specific value wins:
+
+1. **Per-command** `timeout` on `exec()` (highest priority)
+2. **Session-level** `commandTimeoutMs` on `createSession()`
+3. **Global** `COMMAND_TIMEOUT_MS` environment variable (lowest priority)
+
+If none are set, commands run without a timeout.
+
+### Timeout does not kill the process
+
+:::caution
+When a command times out, the SDK raises an error and closes the connection. The underlying process **continues running** inside the container. To stop a timed-out process, delete the session with [`deleteSession()`](/sandbox/api/sessions/#deletesession) or destroy the sandbox with [`destroy()`](/sandbox/api/lifecycle/#destroy).
+:::
+
 ## Best practices
 
 - **Check exit codes** - Always verify `result.success` and `result.exitCode`


### PR DESCRIPTION
### Summary

This PR updates the documentation around `exec` timeouts in sandbox-sdk, fixed [here](https://github.com/cloudflare/sandbox-sdk/pull/450).
This fix is not new behaviour, we're just updating the docs to make it clear how timeouts work, the different layer precedence, etc.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).