### PR TITLE
Increase fontsize of sidenav search on mobile

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -25,7 +25,7 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 			type="text"
 			id="sidebar-search"
 			placeholder="Search sidebar..."
-			class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-10 text-sm text-gray-900 placeholder-gray-500 transition-colors duration-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:border-orange-500 dark:focus:ring-orange-500"
+			class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-10 text-base sm:text-sm text-gray-900 placeholder-gray-500 transition-colors duration-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:border-orange-500 dark:focus:ring-orange-500"
 		/>
 		<div class="sidebar-search-icon"></div>
 	</div>


### PR DESCRIPTION
### Summary

On iOS, browsers zoom into the sidenav search when a user clicks it. This is a pretty bad experience. Looking into this, seems like there is a 16px cutoff here. Anything less than gets zoomed on text input, anything greater doesn't. Thus, the fix is just to increase the font size.

### Videos

#### Before
https://github.com/user-attachments/assets/d9079be2-37f1-4370-bef4-c75abf5e0300

#### After
https://github.com/user-attachments/assets/60fa619e-39e3-4e69-b2fc-a2f92964efc7


