### PR TITLE
Match sidenav ui state after search navigation

### DIFF
--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -262,6 +262,22 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 			}
 		});
 
+		// On link click during search, clear persisted open[] so the next page
+		// uses its server-rendered state instead of the search-modified state.
+		sidebarContent.addEventListener("click", (e) => {
+			if (!searchInput.value) return;
+			if (!(e.target instanceof Element)) return;
+			if (!e.target.closest("a")) return;
+			try {
+				// try/catch guards against sessionStorage being blocked (e.g. private browsing)
+				const storageKey = "sl-sidebar-state";
+				const raw = sessionStorage.getItem(storageKey);
+				const state = JSON.parse(raw || "{}");
+				state.open = [];
+				sessionStorage.setItem(storageKey, JSON.stringify(state));
+			} catch (_) {} // eslint-disable-line no-empty
+		});
+
 		document.addEventListener(
 			"keydown",
 			(keyboardEvent) => {


### PR DESCRIPTION
### Summary

When using the search functionality in the sidenav to navigate between pages, the state of sidenav wouldn't update to match to the newly navigated page. Specifically, the sidenav folders would still be open to the previous page, not the new page.

The fix here involves clearing starlight's persisted `sl-sidebar-state` session storage on search navigation to stop starlight from overriding it with the most recently persisted state (the _filtered_ state during the search).

### Screenshots

#### Before
https://github.com/user-attachments/assets/e80f443c-a2ee-40a3-b971-8aae185d4bfd

#### After
https://github.com/user-attachments/assets/1256e4b7-54b7-4b05-ad2b-d76a762f7f80




