### PR TITLE
[Functions] Add simple EventContext example in functions api_reference.mdx

### DIFF
--- a/src/content/docs/pages/functions/api-reference.mdx
+++ b/src/content/docs/pages/functions/api-reference.mdx
@@ -112,4 +112,4 @@ The following are the properties on the `context` object which are passed throug
 
 ### `EnvWithFetch`
 
-Holds the environment variables, secrets, and bindings for a Function. This also holds the `ASSETS` binding which is how you can fallback to the asset-serving behavior.
+Holds the environment variables, secrets, and [bindings](/pages/functions/bindings/) for a Function. This also holds the `ASSETS` binding which is how you can fallback to the asset-serving behavior.

--- a/src/content/docs/pages/functions/api-reference.mdx
+++ b/src/content/docs/pages/functions/api-reference.mdx
@@ -68,6 +68,15 @@ The following are the properties on the `context` object which are passed throug
 
   This is the incoming [Request](/workers/runtime-apis/request/).
 
+  You can use this to access request parameters such as the url:
+
+  ```js
+  export function onRequest(context) {
+  	const url = context.request.url;
+  	const pathname = new URL(url).pathname;
+  }
+  ```
+
 - `functionPath` string
 
   This is the path of the request.


### PR DESCRIPTION
### Summary
Added a code example of getting the request `url/pathname`. The `url` parameter is quite far down the Workers `Request` api reference, so it can be easily missed IMO.
Also add an in-text link to `bindings`.
(Old PR was closed due to being stale).

### Screenshots (optional)

![image](https://github.com/user-attachments/assets/e4309d7d-7568-4341-bd41-bc602f03a572)


### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
