### PR TITLE
[Canonicals] Add functionality + frontmatter to a few pages

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -233,6 +233,18 @@ head.push({
 	},
 });
 
+if (frontmatter.canonical) {
+	const canonicalHref = new URL(frontmatter.canonical, Astro.site).toString();
+	const canonicalIdx = head.findIndex(
+		({ tag, attrs }) => tag === "link" && attrs?.rel === "canonical",
+	);
+	if (canonicalIdx !== -1) {
+		head[canonicalIdx].attrs!.href = canonicalHref;
+	} else {
+		head.push({ tag: "link", attrs: { rel: "canonical", href: canonicalHref } });
+	}
+}
+
 metaTags.map((attrs) => {
 	head.push({
 		tag: "meta",

--- a/src/content/docs/waf/reference/legacy/index.mdx
+++ b/src/content/docs/waf/reference/legacy/index.mdx
@@ -6,7 +6,7 @@ sidebar:
   group:
     hideIndex: true
 description: Documentation for legacy WAF features.
-noindex: true
+canonical: /waf/
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/waf/reference/legacy/old-rate-limiting/index.mdx
+++ b/src/content/docs/waf/reference/legacy/old-rate-limiting/index.mdx
@@ -4,7 +4,7 @@ source: https://support.cloudflare.com/hc/en-us/articles/115001635128-Configurin
 title: Rate Limiting (previous version)
 sidebar:
   order: 3
-noindex: true
+canonical: /waf/rate-limiting-rules/
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/waf/reference/legacy/old-rate-limiting/troubleshooting.mdx
+++ b/src/content/docs/waf/reference/legacy/old-rate-limiting/troubleshooting.mdx
@@ -5,7 +5,7 @@ title: Troubleshoot Rate Limiting (previous version)
 sidebar:
   order: 2
   label: Troubleshooting
-noindex: true
+canonical: /waf/rate-limiting-rules/troubleshooting/
 ---
 
 A few common rate limiting configuration issues prevent proper request matches:

--- a/src/content/docs/waf/reference/legacy/old-waf-managed-rules/index.mdx
+++ b/src/content/docs/waf/reference/legacy/old-waf-managed-rules/index.mdx
@@ -4,7 +4,7 @@ source: https://support.cloudflare.com/hc/en-us/articles/200172016-Understanding
 title: WAF managed rules (previous version)
 sidebar:
   order: 2
-noindex: true
+canonical: /waf/managed-rules/
 ---
 
 Managed rules, a feature of Cloudflare WAF (Web Application Firewall), identifies and removes suspicious activity for HTTP `GET` and `POST` requests.

--- a/src/content/docs/waf/reference/legacy/old-waf-managed-rules/troubleshooting.mdx
+++ b/src/content/docs/waf/reference/legacy/old-waf-managed-rules/troubleshooting.mdx
@@ -5,7 +5,7 @@ title: Troubleshoot WAF managed rules (previous version)
 sidebar:
   order: 2
   label: Troubleshooting
-noindex: true
+canonical: /waf/managed-rules/troubleshooting/
 ---
 
 By default, WAF managed rules are fully managed via the Cloudflare dashboard and are compatible with most websites and web applications. However, false positives and false negatives may occur:

--- a/src/content/docs/workers/configuration/sites/configuration.mdx
+++ b/src/content/docs/workers/configuration/sites/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: configuration
 title: Workers Sites configuration
-noindex: true
+canonical: /workers/static-assets/
 sidebar:
   order: 4
 ---

--- a/src/content/docs/workers/configuration/sites/index.mdx
+++ b/src/content/docs/workers/configuration/sites/index.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Workers Sites
 head: []
 description: Use [Workers Static Assets](/workers/static-assets/) to host full-stack applications instead of Workers Sites. Do not use Workers Sites for new projects.
-canonical: /workers/fake/
+canonical: /workers/static-assets/
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/workers/configuration/sites/index.mdx
+++ b/src/content/docs/workers/configuration/sites/index.mdx
@@ -3,7 +3,7 @@ pcx_content_type: navigation
 title: Workers Sites
 head: []
 description: Use [Workers Static Assets](/workers/static-assets/) to host full-stack applications instead of Workers Sites. Do not use Workers Sites for new projects.
-noindex: true
+canonical: /workers/fake/
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/workers/configuration/sites/start-from-existing.mdx
+++ b/src/content/docs/workers/configuration/sites/start-from-existing.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Start from existing
-noindex: true
+canonical: /workers/static-assets/
 sidebar:
   order: 1
 ---

--- a/src/content/docs/workers/configuration/sites/start-from-scratch.mdx
+++ b/src/content/docs/workers/configuration/sites/start-from-scratch.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Start from scratch
-noindex: true
+canonical: /workers/static-assets/
 sidebar:
   order: 2
 ---

--- a/src/content/docs/workers/configuration/sites/start-from-worker.mdx
+++ b/src/content/docs/workers/configuration/sites/start-from-worker.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Start from Worker
-noindex: true
+canonical: /workers/static-assets/
 sidebar:
   order: 3
 ---

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/authentication.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/authentication.mdx
@@ -3,7 +3,7 @@ pcx_content_type: how-to
 title: Authentication
 sidebar:
   order: 2
-canonical: /workers/workers/wrangler/
+canonical: /workers/wrangler/
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/authentication.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/authentication.mdx
@@ -3,7 +3,7 @@ pcx_content_type: how-to
 title: Authentication
 sidebar:
   order: 2
-noindex: true
+canonical: /workers/workers/wrangler/
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/commands.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/commands.mdx
@@ -6,7 +6,7 @@ sidebar:
 head:
   - tag: title
     content: Commands - Wrangler v1 (deprecated)
-noindex: true
+canonical: /workers/workers/wrangler/commands/
 ---
 
 import { Render, Type, MetaInfo, WranglerConfig, DashButton } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/commands.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/commands.mdx
@@ -6,7 +6,7 @@ sidebar:
 head:
   - tag: title
     content: Commands - Wrangler v1 (deprecated)
-canonical: /workers/workers/wrangler/commands/
+canonical: /workers/wrangler/commands/
 ---
 
 import { Render, Type, MetaInfo, WranglerConfig, DashButton } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/configuration.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/configuration.mdx
@@ -7,7 +7,7 @@ head:
   - tag: title
     content: Configuration - Wrangler v1 (deprecated)
 description: Learn how to configure your Cloudflare Worker using Wrangler v1. This guide covers top-level and environment-specific settings, key types, and deployment options.
-canonical: /workers/workers/wrangler/configuration/
+canonical: /workers/wrangler/configuration/
 ---
 
 import { Render, WranglerConfig } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/configuration.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/configuration.mdx
@@ -7,7 +7,7 @@ head:
   - tag: title
     content: Configuration - Wrangler v1 (deprecated)
 description: Learn how to configure your Cloudflare Worker using Wrangler v1. This guide covers top-level and environment-specific settings, key types, and deployment options.
-noindex: true
+canonical: /workers/workers/wrangler/configuration/
 ---
 
 import { Render, WranglerConfig } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/index.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/index.mdx
@@ -4,7 +4,7 @@ pcx_content_type: navigation
 head:
   - tag: title
     content: Wrangler v1 (legacy)
-noindex: true
+canonical: /workers/workers/wrangler/
 ---
 
 import { DirectoryListing, Render } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/index.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/index.mdx
@@ -4,7 +4,7 @@ pcx_content_type: navigation
 head:
   - tag: title
     content: Wrangler v1 (legacy)
-canonical: /workers/workers/wrangler/
+canonical: /workers/wrangler/
 ---
 
 import { DirectoryListing, Render } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/install-update.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/install-update.mdx
@@ -4,7 +4,7 @@ title: Install / Update
 sidebar:
   order: 1
 
-noindex: true
+canonical: /workers/workers/wrangler/
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/install-update.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/install-update.mdx
@@ -4,7 +4,7 @@ title: Install / Update
 sidebar:
   order: 1
 
-canonical: /workers/workers/wrangler/
+canonical: /workers/wrangler/
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/webpack.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/webpack.mdx
@@ -4,7 +4,7 @@ title: Webpack
 description: Learn how to migrate from Wrangler v1 to v2 using webpack. This guide covers configuration, custom builds, and compatibility for Cloudflare Workers.
 sidebar:
   order: 5
-noindex: true
+canonical: /workers/workers/wrangler/
 ---
 
 import { Render, WranglerConfig } from "~/components";

--- a/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/webpack.mdx
+++ b/src/content/docs/workers/wrangler/migration/v1-to-v2/wrangler-legacy/webpack.mdx
@@ -4,7 +4,7 @@ title: Webpack
 description: Learn how to migrate from Wrangler v1 to v2 using webpack. This guide covers configuration, custom builds, and compatibility for Cloudflare Workers.
 sidebar:
   order: 5
-canonical: /workers/workers/wrangler/
+canonical: /workers/wrangler/
 ---
 
 import { Render, WranglerConfig } from "~/components";

--- a/src/schemas/base.ts
+++ b/src/schemas/base.ts
@@ -135,4 +135,10 @@ export const baseSchema = ({ image }: SchemaContext) =>
 			.describe(
 				"Whether to show the FeedbackPrompt on the page, defaults to true",
 			),
+		canonical: z
+			.string()
+			.optional()
+			.describe(
+				'A canonical URL or path to set as the `<link rel="canonical">` in the page `<head>`, overriding the default derived from the page URL.',
+			),
 	});


### PR DESCRIPTION
### Summary

Add new ability to specify a `canonical` URL by frontmatter property and then add to the `Head` of the current page.

### Testing

- [x] If canonical set, overwrite canonical link in head
- [x] If canonical not set, don't touch canonical link in head.

This first push doesn't evaluate whether the canonical is valid or not. If this becomes a common pattern across a lot of pages, we can circle back on that as a req.