### PR TITLE
[Cloudflare One] Revert Implementation guides redirect + device-to-network QoL fixes

### DIFF
--- a/src/content/docs/cloudflare-one/implementation-guides/index.mdx
+++ b/src/content/docs/cloudflare-one/implementation-guides/index.mdx
@@ -24,11 +24,10 @@ Implementation guides cover deployment steps and best practices for specific Clo
 
 <LinkTitleCard
 	title="Replace your VPN"
-	href="/cloudflare-one/setup/replace-vpn/"
+	href="/learning-paths/replace-vpn/concepts/"
 	icon="seti:db"
 >
-	Connect remote users to internal applications and services through a secure
-	connection. Best for remote access to private networks.
+	Give users secure, auditable network and application access.
 </LinkTitleCard>
 
 <LinkTitleCard

--- a/src/content/docs/cloudflare-one/setup/replace-vpn/device-to-network.mdx
+++ b/src/content/docs/cloudflare-one/setup/replace-vpn/device-to-network.mdx
@@ -48,7 +48,7 @@ Add the IP range of your private network to the tunnel. This defines which inter
 2. Select **Continue**.
 
 :::note
-If you are not sure of your IP range, check your router or network settings. Common private network ranges include `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`.
+If you are not sure of your IP range, check your router or network settings.
 :::
 
 ## Step 3: Deploy your Tunnel
@@ -108,7 +108,7 @@ To verify connectivity, try reaching a resource on your private network (for exa
 
 After verifying your connection, consider securing your private network with policies and access controls:
 
-- **Set up Gateway policies**: By default, all enrolled devices can reach your entire private network. Gateway policies let you inspect traffic and control access based on user identity and network attributes. For more information, refer to [DNS policies](/cloudflare-one/traffic-policies/dns-policies/) and [Network policies](/cloudflare-one/traffic-policies/network-policies/).
+- **Set up Gateway policies**: By default, all enrolled devices can reach your entire private network. Gateway policies let you scan, filter, and log traffic between your devices and your private network. For more information, refer to [DNS policies](/cloudflare-one/traffic-policies/dns-policies/), [Network policies](/cloudflare-one/traffic-policies/network-policies/), and [HTTP policies](/cloudflare-one/traffic-policies/http-policies/).
 - **Create an Access application**: Restrict access to specific applications or hostnames on your private network with identity-based rules. For more information, refer to [Secure a private IP or hostname](/cloudflare-one/access-controls/applications/non-http/self-hosted-private-app/).
 - **Explore more with Zero Trust**: Review your tunnel, policies, and connected devices in the [Cloudflare One dashboard](https://one.dash.cloudflare.com).
 


### PR DESCRIPTION
Reverts the Replace your VPN card in Implementation guides back to the learning path URL (`/learning-paths/replace-vpn/concepts/`). The redirect to the new Get Started page needs broader team alignment before shipping. Will discuss in team sync.

Also includes three QoL fixes for the device-to-network page to align it with the device-to-device and network-to-network sibling pages and improve clarity:

- Remove unvalidated common IP range recommendations from the note in Step 2.
- Align Gateway policies description with sibling pages: "scan, filter, and log traffic" instead of "inspect traffic and control access based on user identity and network attributes."
- Add missing HTTP policies link alongside DNS and Network policies (already present on both sibling pages).

Related: PCX-20931