### PR TITLE
docs: add changelog for JSON and RFC 9457 support on 1xxx errors

### DIFF
--- a/src/content/changelog/fundamentals/2026-03-11-json-rfc9457-responses-for-1xxx-errors.mdx
+++ b/src/content/changelog/fundamentals/2026-03-11-json-rfc9457-responses-for-1xxx-errors.mdx
@@ -1,6 +1,6 @@
 ---
 title: JSON responses and RFC 9457 support for Cloudflare 1xxx errors
-description: "Cloudflare-generated 1xxx errors now return structured JSON when requested with Accept: application/json or Accept: application/problem+json, following RFC 9457 (Problem Details for HTTP APIs)."
+description: "Cloudflare-generated 1xxx errors now return structured JSON when requested with 'Accept: application/json' or 'Accept: application/problem+json', following RFC 9457 (Problem Details for HTTP APIs)."
 products:
   - fundamentals
 date: 2026-03-11
@@ -33,12 +33,14 @@ The Markdown frontmatter field `http_status` has been renamed to `status`. Agent
 
 ## Negotiation behavior
 
-- `Accept: application/json` -> JSON (`application/json` content type)
-- `Accept: application/problem+json` -> JSON (`application/problem+json` content type)
-- `Accept: application/json, text/markdown;q=0.9` -> JSON
-- `Accept: text/markdown` -> Markdown
-- `Accept: text/markdown, application/json` -> Markdown (equal `q`, first-listed wins)
-- `Accept: */*` -> HTML (default)
+| Request header sent                             | Response format                                |
+| ----------------------------------------------- | ---------------------------------------------- |
+| `Accept: application/json`                      | JSON (`application/json` content type)         |
+| `Accept: application/problem+json`              | JSON (`application/problem+json` content type) |
+| `Accept: application/json, text/markdown;q=0.9` | JSON                                           |
+| `Accept: text/markdown`                         | Markdown                                       |
+| `Accept: text/markdown, application/json`       | Markdown (equal `q`, first-listed wins)        |
+| `Accept: */*`                                   | HTML (default)                                 |
 
 ## Availability
 

--- a/src/content/changelog/fundamentals/2026-03-11-json-rfc9457-responses-for-1xxx-errors.mdx
+++ b/src/content/changelog/fundamentals/2026-03-11-json-rfc9457-responses-for-1xxx-errors.mdx
@@ -1,0 +1,59 @@
+---
+title: JSON responses and RFC 9457 support for Cloudflare 1xxx errors
+description: "Cloudflare-generated 1xxx errors now return structured JSON when requested with Accept: application/json or Accept: application/problem+json, following RFC 9457 (Problem Details for HTTP APIs)."
+products:
+  - fundamentals
+date: 2026-03-11
+---
+
+Cloudflare-generated 1xxx errors now return structured JSON when clients send `Accept: application/json` or `Accept: application/problem+json`. JSON responses follow [RFC 9457 (Problem Details for HTTP APIs)](https://www.rfc-editor.org/rfc/rfc9457), so any HTTP client that understands Problem Details can parse the base members without Cloudflare-specific code.
+
+## Breaking change
+
+The Markdown frontmatter field `http_status` has been renamed to `status`. Agents consuming Markdown frontmatter should update parsers accordingly.
+
+## Changes
+
+**JSON format.** Clients sending `Accept: application/json` or `Accept: application/problem+json` now receive a structured JSON object with the same operational fields as Markdown frontmatter, plus RFC 9457 standard members.
+
+**RFC 9457 standard members (JSON only):**
+
+- `type` — URI pointing to Cloudflare documentation for the specific error code
+- `status` — HTTP status code (matching the response status)
+- `title` — short, human-readable summary
+- `detail` — human-readable explanation specific to this occurrence
+- `instance` — Ray ID identifying this specific error occurrence
+
+**Field renames:**
+
+- `http_status` -> `status` (JSON and Markdown)
+- `what_happened` -> `detail` (JSON only — Markdown prose sections are unchanged)
+
+**Content-Type mirroring.** Clients sending `Accept: application/problem+json` receive `Content-Type: application/problem+json; charset=utf-8` back; `Accept: application/json` receives `application/json; charset=utf-8`. Same body in both cases.
+
+## Negotiation behavior
+
+- `Accept: application/json` -> JSON (`application/json` content type)
+- `Accept: application/problem+json` -> JSON (`application/problem+json` content type)
+- `Accept: application/json, text/markdown;q=0.9` -> JSON
+- `Accept: text/markdown` -> Markdown
+- `Accept: text/markdown, application/json` -> Markdown (equal `q`, first-listed wins)
+- `Accept: */*` -> HTML (default)
+
+## Availability
+
+Available now for Cloudflare-generated 1xxx errors.
+
+## Get started
+
+```bash
+curl -s --compressed -H "Accept: application/json" -A "TestAgent/1.0" -H "Accept-Encoding: gzip, deflate" "<YOUR_DOMAIN>/cdn-cgi/error/1015" | jq .
+```
+
+```bash
+curl -s --compressed -H "Accept: application/problem+json" -A "TestAgent/1.0" -H "Accept-Encoding: gzip, deflate" "<YOUR_DOMAIN>/cdn-cgi/error/1015" | jq .
+```
+
+References:
+- [RFC 9457 — Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457)
+- [Cloudflare 1xxx error documentation](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/)


### PR DESCRIPTION
## Summary

- Add a Fundamentals changelog entry for JSON responses and RFC 9457 compliance on Cloudflare-generated 1xxx errors
- Document breaking change: Markdown frontmatter field `http_status` renamed to `status`
- Document new RFC 9457 standard members (`type`, `status`, `title`, `detail`, `instance`)
- Document `application/problem+json` content-type mirroring
- Document updated Accept negotiation behavior including JSON and problem+json
- Include concrete test commands and reference links