### PR TITLE
[Cloudflare One] Network policies ELI5

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/common-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/common-policies.mdx
@@ -10,7 +10,7 @@ head:
 
 import { Render, Tabs, TabItem, APIRequest } from "~/components";
 
-The following policies are commonly used to secure network traffic.
+The following policies are commonly used to secure network traffic. Network policies are evaluated in order from top to bottom, and the first matching policy applies. Place more specific Allow policies above broader Block policies.
 
 For a baseline set of recommended policies, refer to [Secure your Internet traffic and SaaS apps](/learning-paths/secure-internet-traffic/build-network-policies/recommended-network-policies/).
 
@@ -29,6 +29,8 @@ Refer to the [network policies page](/cloudflare-one/traffic-policies/network-po
 </TabItem>
 
 <TabItem label="API">
+
+In the following API examples, `filters: ["l4"]` indicates that this is a network (Layer 4) policy.
 
 <APIRequest
 	path="/accounts/{account_id}/gateway/rules"
@@ -95,7 +97,7 @@ To require users to re-authenticate after a certain amount of time has elapsed, 
 
 ## Allow only approved traffic
 
-Restrict user access to only the specific sites or applications configured in your [HTTP policies](/cloudflare-one/traffic-policies/http-policies/).
+Restrict user access to only the specific sites or applications configured in your [HTTP policies](/cloudflare-one/traffic-policies/http-policies/). This pattern uses two policies: an Allow policy to permit HTTP/HTTPS traffic, followed by a Block policy to deny everything else. Place the Allow policy above the Block policy so that matching traffic is allowed before the catch-all block applies.
 
 ### 1. Allow HTTP and HTTPS traffic
 

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/index.mdx
@@ -13,9 +13,11 @@ import { Details, InlineBadge, Render, Badge } from "~/components";
 To enable this feature, download and deploy the [WARP client](/cloudflare-one/team-and-resources/devices/warp/deployment/) on your devices.
 :::
 
-With Cloudflare One, you can configure policies to control network-level traffic leaving your endpoints. Using network selectors like IP addresses and ports, your policies will control access to any network origin. Because Cloudflare One [integrates with your identity provider](/cloudflare-one/integrations/identity-providers/), it also gives you the ability to create identity-based network policies. This means you can now control access to non-HTTP resources on a per-user basis regardless of where they are or what device they access that resource from.
+Network policies control TCP and UDP traffic between your users and network destinations. Use them to allow or block non-HTTP traffic such as SSH, RDP, and database connections based on IP addresses, ports, and protocols.
 
-A network policy consists of an **Action** as well as a logical expression that determines the scope of the action. To build an expression, you need to choose a **Selector** and an **Operator**, and enter a value or range of values in the **Value** field. You can use **And** and **Or** logical operators to evaluate multiple conditions.
+Because Cloudflare One [integrates with your identity provider](/cloudflare-one/integrations/identity-providers/), you can also create identity-based network policies. This allows you to control access to non-HTTP resources on a per-user basis regardless of the user's location or device.
+
+A network policy consists of an **Action** and a logical expression that determines the scope of the action. To build an expression, choose a **Selector** and an **Operator**, then enter a value or range of values in the **Value** field. You can use **And** and **Or** logical operators to evaluate multiple conditions.
 
 - [Actions](#actions)
 - [Selectors](#selectors)
@@ -79,7 +81,7 @@ API value: `allow`
 
 </Details>
 
-Policies with Allow actions allow network traffic to reach certain IPs or ports. For example, the following configuration allows specific users to reach a given IP address:
+Policies with Allow actions allow network traffic to reach certain IPs or ports. In a default-block configuration, Allow policies define the exceptions — traffic that does not match an Allow policy will be blocked by a lower-priority catch-all Block policy. For example, the following configuration allows specific users to reach a given IP address:
 
 | Selector       | Operator | Value           | Logic | Action |
 | -------------- | -------- | --------------- | ----- | ------ |
@@ -237,7 +239,11 @@ Policies with Network Override actions override traffic directed to or coming fr
 | User Email     | in       | `*@example.com` | And   |                  |
 | Override IP    |          | `10.0.0.1`      |       |                  |
 
-Gateway will only log successful override connections in your [network logs](/cloudflare-one/insights/logs/gateway-logs/#network-logs). If the override destination IP does not exist, Gateway will override the destination IP but will not log the override action.
+:::caution
+If the override destination IP is unreachable, Gateway still rewrites the destination but does not log the connection. The traffic fails silently with no log entry. Verify that your override IP is reachable before deploying this policy.
+:::
+
+Gateway will only log successful override connections in your [network logs](/cloudflare-one/insights/logs/gateway-logs/#network-logs).
 
 ## Selectors
 
@@ -335,12 +341,9 @@ To enable Gateway filtering on TCP and UDP, go to **Traffic policies** > **Traff
 
 ### SNI
 
-The host whose Server Name Indication (SNI) header Gateway will filter traffic against. This will allow for an exact match.
+Server Name Indication (SNI) is the hostname a client sends during the TLS handshake, before encryption begins. Gateway reads the SNI to identify the destination of encrypted traffic. The SNI selector matches the exact hostname.
 
-<Render
-	file="gateway/selectors/sni-443"
-	product="cloudflare-one"
-/>
+<Render file="gateway/selectors/sni-443" product="cloudflare-one" />
 
 | UI name | API example                         |
 | ------- | ----------------------------------- |
@@ -350,10 +353,7 @@ The host whose Server Name Indication (SNI) header Gateway will filter traffic a
 
 The domain whose Server Name Indication (SNI) header Gateway will filter traffic against. For example, a rule for `example.com` will match `example.com`, `www.example.com`, and `my.test.example.com`.
 
-<Render
-	file="gateway/selectors/sni-443"
-	product="cloudflare-one"
-/>
+<Render file="gateway/selectors/sni-443" product="cloudflare-one" />
 
 | UI name    | API example                        |
 | ---------- | ---------------------------------- |
@@ -404,7 +404,7 @@ The country of the user making the request. <Render file="gateway/selectors/sour
 <Render file="gateway/comparison-operators" product="cloudflare-one" />
 
 :::note
-The _in_ operator allows you to specify IP addresses or networks using CIDR notation.
+The _in_ operator allows you to specify IP addresses or networks using CIDR notation (for example, `10.0.0.0/8` matches all IPs from `10.0.0.0` to `10.255.255.255`).
 :::
 
 ## Value
@@ -412,7 +412,13 @@ The _in_ operator allows you to specify IP addresses or networks using CIDR nota
 <Render
 	file="gateway/value"
 	product="cloudflare-one"
-	params={{ selector: "SNI", selectordescription: "SNI host", operator: "matches regex", valueOne: ".*whispersystems.org", valueTwo: ".*signal.org" }}
+	params={{
+		selector: "SNI",
+		selectordescription: "SNI host",
+		operator: "matches regex",
+		valueOne: ".*whispersystems.org",
+		valueTwo: ".*signal.org",
+	}}
 />
 
 ## Logical operators

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
@@ -35,7 +35,9 @@ You can now use _Detected Protocol_ as a selector in a [Network policy](/cloudfl
 
 **TLS interception on all ports**: When you turn on this setting, Gateway will attempt to intercept TLS traffic on every port, not just port `443`. This means all applications using TLS on non-standard ports will have their traffic intercepted by the Gateway proxy. If you only want to turn on SNI detection for Network policy filtering without full TLS interception, you will need to create [Do Not Inspect policies](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#do-not-inspect) for the specific applications or domains that use TLS on non-standard ports.
 
-**Filtering non-HTTPS protocols inside TLS**: Once a Network policy allows a TLS connection at the network level (Layer 4), the Gateway proxy will intercept and decrypt the TLS traffic. However, Gateway cannot filter based on non-HTTP protocols inside the TLS connection. All non-HTTPS traffic inside TLS (such as SSH over TLS, database protocols, or custom protocols) will be allowed by default, and no further filtering will be applied to it. This limitation means that if your organization uses a Network policy to block all traffic by default, the Gateway proxy will allow all non-HTTPS TLS traffic through, and you will not be able to filter this traffic with HTTP policies.
+:::caution[Non-HTTP protocols inside TLS bypass network policy filtering]
+Once a Network policy allows a TLS connection at Layer 4, Gateway decrypts the TLS traffic. However, Gateway cannot filter non-HTTP protocols inside the TLS connection. All non-HTTPS traffic inside TLS (such as SSH over TLS, database protocols, or custom protocols) is allowed by default with no further filtering applied. If your organization uses a default-block Network policy, Gateway will still allow all non-HTTPS TLS traffic through.
+:::
 
 To use HTTP policies to filter all HTTPS traffic on all ports when using a default Block Network policy, [create a Network policy to explicitly allow HTTP and TLS traffic](/cloudflare-one/traffic-policies/network-policies/common-policies/#filter-https-traffic-when-inspecting-on-all-ports).
 
@@ -43,22 +45,22 @@ To use HTTP policies to filter all HTTPS traffic on all ports when using a defau
 
 Gateway supports detection and filtering of the following protocols:
 
-| Protocol | Notes                                                                                       |
-| -------- | ------------------------------------------------------------------------------------------- |
-| HTTP     | Hypertext Transfer Protocol (HTTP/1.1).                                                     |
-| HTTP2    | Hypertext Transfer Protocol Version 2.                                                      |
-| SSH      | Secure Shell Protocol — remote login and command execution.                                  |
-| TLS      | Transport Layer Security. Gateway detects TLS versions 1.1 through 1.3 with the _TLS_ value. |
-| DCERPC   | Distributed Computing Environment / Remote Procedure Call.                                   |
-| MQTT     | Message Queuing Telemetry Transport — lightweight IoT messaging protocol.                    |
-| TPKT     | TPKT commonly initiates RDP sessions, so you can use it to identify and filter RDP traffic.  |
-| IMAP <Badge text="Beta" variant="caution" size="small" />         | Internet Message Access Protocol — email retrieval.  |
-| POP3 <Badge text="Beta" variant="caution" size="small" />         | Post Office Protocol v3 — email retrieval.           |
-| SMTP <Badge text="Beta" variant="caution" size="small" />         | Simple Mail Transfer Protocol — email sending.       |
-| MYSQL <Badge text="Beta" variant="caution" size="small" />        | MySQL database wire protocol.                        |
-| RSYNC-DAEMON <Badge text="Beta" variant="caution" size="small" /> | rsync daemon protocol.                               |
-| LDAP <Badge text="Beta" variant="caution" size="small" />         | Lightweight Directory Access Protocol.               |
-| NTP <Badge text="Beta" variant="caution" size="small" />          | Network Time Protocol.                               |
+| Protocol                                                          | Notes                                                                                        |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| HTTP                                                              | Hypertext Transfer Protocol (HTTP/1.1).                                                      |
+| HTTP2                                                             | Hypertext Transfer Protocol Version 2.                                                       |
+| SSH                                                               | Secure Shell Protocol — remote login and command execution.                                  |
+| TLS                                                               | Transport Layer Security. Gateway detects TLS versions 1.1 through 1.3 with the _TLS_ value. |
+| DCERPC                                                            | Distributed Computing Environment / Remote Procedure Call.                                   |
+| MQTT                                                              | Message Queuing Telemetry Transport — lightweight IoT messaging protocol.                    |
+| TPKT                                                              | TPKT commonly initiates RDP sessions, so you can use it to identify and filter RDP traffic.  |
+| IMAP <Badge text="Beta" variant="caution" size="small" />         | Internet Message Access Protocol — email retrieval.                                          |
+| POP3 <Badge text="Beta" variant="caution" size="small" />         | Post Office Protocol v3 — email retrieval.                                                   |
+| SMTP <Badge text="Beta" variant="caution" size="small" />         | Simple Mail Transfer Protocol — email sending.                                               |
+| MYSQL <Badge text="Beta" variant="caution" size="small" />        | MySQL database wire protocol.                                                                |
+| RSYNC-DAEMON <Badge text="Beta" variant="caution" size="small" /> | rsync daemon protocol.                                                                       |
+| LDAP <Badge text="Beta" variant="caution" size="small" />         | Lightweight Directory Access Protocol.                                                       |
+| NTP <Badge text="Beta" variant="caution" size="small" />          | Network Time Protocol.                                                                       |
 
 ## Example network policy
 

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/ssh-logging.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/ssh-logging.mdx
@@ -61,9 +61,9 @@ cat /etc/ssh/sshd_config
 
 ## 7. Create an Audit SSH policy
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Network**.
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Firewall policies**.
 
-2. In the **Network** tab, create a new network policy.
+2. In the **Network** tab, select **Add a network policy**.
 
 3. Name the policy and specify the [Destination IP](/cloudflare-one/traffic-policies/network-policies/#destination-ip) for your origin server.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/ssh-logging.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/ssh-logging.mdx
@@ -10,8 +10,8 @@ sidebar:
 
 import { Render } from "~/components";
 
-:::note
-Not recommended for new deployments. We recommend using [Access for Infrastructure](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/) to manage SSH sessions and log SSH commands.
+:::caution[Legacy feature — not recommended for new deployments]
+This SSH proxy and command logging method is deprecated. For new deployments, use [Access for Infrastructure](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/) to manage SSH sessions and log SSH commands.
 :::
 
 Cloudflare One supports SSH proxying and command logging using Secure Web Gateway and the WARP client.
@@ -61,7 +61,7 @@ cat /etc/ssh/sshd_config
 
 ## 7. Create an Audit SSH policy
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Network** > **Firewall policies**.
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Network**.
 
 2. In the **Network** tab, create a new network policy.
 


### PR DESCRIPTION
Improves readability and reduces jargon across all four network policies pages (`/cloudflare-one/traffic-policies/network-policies/`), based on an ELI5 clarity analysis.

- **Rewrite introduction** (`index.mdx`): Replace dense paragraph with concrete language — "Network policies control TCP and UDP traffic" with examples (SSH, RDP, database connections). Separates identity-based capability into its own paragraph. Fixes misleading "traffic leaving your endpoints" phrasing.
- **Add caution for Network Override silent failure** (`index.mdx`): The override destination rewrite happens even when the target IP is unreachable, with no log entry. This operational surprise is now a `:::caution` aside instead of buried prose.
- **Define SNI** (`index.mdx`): Replace "The host whose SNI header Gateway will filter traffic against" with a plain explanation of what SNI is and how Gateway uses it.
- **Add CIDR example** (`index.mdx`): Expand the CIDR notation note with a concrete example (`10.0.0.0/8` matches `10.0.0.0` to `10.255.255.255`).
- **Clarify Allow action** (`index.mdx`): Explain that Allow is meaningful in a default-block configuration where it defines exceptions.
- **Explain policy evaluation order** (`common-policies.mdx`): Add note that policies are evaluated top-to-bottom, first match wins. The two-policy patterns on this page depend on this but never stated it.
- **Explain `filters: ["l4"]`** (`common-policies.mdx`): Add note in the API tab explaining that `l4` means this is a network (Layer 4) policy.
- **Surface TLS pass-through security behavior** (`protocol-detection.mdx`): Non-HTTP protocols inside TLS bypass network policy filtering. Previously a dense paragraph — now a `:::caution` aside with a descriptive title.
- **Strengthen SSH logging deprecation** (`ssh-logging.mdx`): Upgrade from `:::note` to `:::caution` with explicit "Legacy feature" title and "deprecated" language.
- **Fix outdated UI navigation path** (`ssh-logging.mdx`): Remove "Firewall policies" from nav path — current UI uses "Network" directly.