### PR TITLE
[Cloudflare One] HTTP Policies ELI5

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/antivirus-scanning.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/antivirus-scanning.mdx
@@ -7,9 +7,9 @@ sidebar:
 
 import { Render, Details } from "~/components";
 
-Cloudflare Gateway protects users as they browse the Internet. When users download or upload a file to an origin on the Internet, that file could potentially contain malicious code that may cause their device to perform undesired behavior. To prevent this, Cloudflare Gateway allows admins to turn on anti-virus (AV) scanning of files that are uploaded or downloaded by users as the file passes through Gateway.
+Cloudflare Gateway can scan files for malware as users upload or download them. Anti-virus (AV) scanning runs inline — Gateway inspects files as they pass through the proxy and blocks any file that contains a known malicious payload.
 
-In addition to scanning files, Gateway can quarantine files as your users download them. Quarantining files helps protect organizations from zero-day vulnerabilities not yet available in anti-virus databases. For more information, refer to [File sandboxing](/cloudflare-one/traffic-policies/http-policies/file-sandboxing/).
+In addition to AV scanning, Gateway can quarantine previously unseen files into a sandbox to detect zero-day threats not yet in anti-virus databases. For more information, refer to [File sandboxing](/cloudflare-one/traffic-policies/http-policies/file-sandboxing/).
 
 ## Get started
 
@@ -32,18 +32,16 @@ When a request is blocked due to the presence of malware, Gateway will log the m
 
 ## File scan criteria
 
-If AV scanning is turned on, Gateway will use the following criteria to determine whether a file is present in a request or response, and whether to scan that file. The first match will result in the file being scanned.
+If AV scanning is turned on, Gateway uses the following criteria (in order) to detect and scan files. The first match triggers a scan:
 
-- If the `Content-Disposition` HTTP header is `Attachment`
-- If the byte signature of the body of the request matches a signature Gateway identifies as one of the following file type categories:
-  - **Executable** (for example, `.exe`, `.bat`, `.dll`, and `.wasm`)
-  - **Documents** (for example, `.doc`, `.docx`, `.pdf`, `.ppt`, and `.xls`)
-  - **Compressed** (for example, `.7z`, `.gz`, `.zip`, and `.rar`)
-- If the file name in the `Content-Disposition` header contains a file extension that indicates it is one of the file type categories above
+1. The `Content-Disposition` HTTP header is set to `Attachment`.
+2. The byte signature of the request or response body matches a known file type:
+   - **Executable** (for example, `.exe`, `.bat`, `.dll`, and `.wasm`)
+   - **Documents** (for example, `.doc`, `.docx`, `.pdf`, `.ppt`, and `.xls`)
+   - **Compressed** (for example, `.7z`, `.gz`, `.zip`, and `.rar`)
+3. The file name in the `Content-Disposition` header contains a file extension matching one of the above categories.
 
-If none of the above conditions trigger a file to be scanned, Gateway will use the origin's `Content-Type` header to determine whether or not to scan the file. Additionally, Gateway will not scan files it determines to be image, video, or audio files.
-
-If a file does not trigger a scan based on the three methods above but also does not match criteria to be exempted from scanning, Gateway will default to scanning the file for malware.
+If none of these conditions match, Gateway falls back to the origin's `Content-Type` header. Gateway will not scan files it determines to be image, video, or audio files. All other files default to being scanned.
 
 ## Opt content out from scanning
 
@@ -112,7 +110,7 @@ Gateway cannot scan [certain archive files](#non-scannable-files) regardless of 
 
 ### Non-scannable files
 
-Gateway cannot scan all files for malware. When Gateway encounters a non-scannable file, you can configure AV scanning whether to fail open (allow the file to pass through unscanned) or to fail closed (deny the file transfer).
+Gateway cannot scan all files for malware. When Gateway encounters a non-scannable file, you can configure AV scanning to either fail open (allow the file to pass through unscanned) or fail closed (deny the file transfer).
 
 Gateway cannot scan requests containing the following files:
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/common-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/common-policies.mdx
@@ -10,7 +10,7 @@ head:
 
 import { Render, Tabs, TabItem, APIRequest } from "~/components";
 
-The following policies are commonly used to secure HTTP traffic.
+The following policies are commonly used to secure HTTP traffic. HTTP policies are evaluated in order from top to bottom, and the first matching policy applies — except for [Do Not Inspect](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) policies, which are always evaluated first.
 
 For a baseline set of recommended policies, refer to [Secure your Internet traffic and SaaS apps](/learning-paths/secure-internet-traffic/build-http-policies/recommended-http-policies/).
 
@@ -33,6 +33,8 @@ Block all subdomains that use a host.
 </TabItem>
 
 <TabItem label="API">
+
+In the following API examples, `filters: ["http"]` indicates that this is an HTTP (Layer 7) policy.
 
 <APIRequest
 	path="/accounts/{account_id}/gateway/rules"
@@ -135,9 +137,9 @@ Block content categories which go against your organization's acceptable use pol
 
 ## Skip inspection for groups of applications
 
-Certain client applications, such as Zoom or Apple services, rely on certificate pinning. The [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) performed by Cloudflare Gateway will cause errors when users visit those applications. To avoid this behavior, you must add a Do Not Inspect HTTP policy.
+Certain client applications, such as Zoom or Apple services, rely on certificate pinning. These applications verify they are connecting directly to their own servers and will reject Gateway's TLS inspection certificate. To avoid connection errors, you must add a Do Not Inspect HTTP policy for these applications.
 
-Gateway [evaluates Do Not Inspect policies first](/cloudflare-one/traffic-policies/order-of-enforcement/#http-policies). We recommend moving your Do Not Inspect policies to the top of the list to reduce confusion.
+Gateway [evaluates Do Not Inspect policies first](/cloudflare-one/traffic-policies/order-of-enforcement/#http-policies), regardless of their position in the policy list. Cloudflare recommends moving your Do Not Inspect policies to the top of the list to reduce confusion.
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/file-sandboxing.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/file-sandboxing.mdx
@@ -13,7 +13,7 @@ Available as an add-on to Zero Trust Enterprise plans. For more information, con
 
 In addition to [anti-virus (AV) scanning](/cloudflare-one/traffic-policies/http-policies/antivirus-scanning/), Gateway can quarantine previously unseen files downloaded by your users into a sandbox and scan them for malware.
 
-If AV scanning does not detect malware in a file download, Gateway will quarantine the file in the [sandbox](#sandbox-environment). If the file has not been downloaded before, Gateway will monitor any actions taken by the file and compare them to known malware patterns. During this process, Gateway will display an interstitial page in the user's browser. If the sandbox does not detect malicious activity, Gateway will release the file from quarantine and download it to your user's device. If the sandbox detects malicious activity, Gateway will block the download. For any subsequent downloads of the file, Gateway will remember and apply its allow/block decision.
+When a file download passes AV scanning without a malware detection, Gateway quarantines the file in the [sandbox](#sandbox-environment). If the file has not been downloaded before, Gateway monitors the file's behavior and compares it to known malware patterns. During this process, Gateway displays an interstitial page in the user's browser. If the sandbox does not detect malicious activity, Gateway releases the file and downloads it to the user's device. If the sandbox detects malicious activity, Gateway blocks the download. For any subsequent downloads of the same file, Gateway remembers and applies its previous allow/block decision.
 
 Gateway will log any file sandbox decisions in your [HTTP logs](/cloudflare-one/insights/logs/gateway-logs/#http-logs).
 
@@ -59,7 +59,7 @@ You can now create [Quarantine HTTP policies](/cloudflare-one/traffic-policies/h
 
 To test if file sandboxing is working, you can create a Quarantine policy that matches the [Cloudflare Sandbox Test](https://sandbox.cloudflaredemos.com/):
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**, then select **HTTP**.
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Add the following expression:
 
@@ -75,7 +75,7 @@ Gateway will quarantine and scan the file, display an interstitial status page i
 
 ## Sandbox environment
 
-Gateway executes quarantined files in a sandboxed Windows operating system environment. Using machine learning, the sandbox compares how files of a certain type behave compared to how these files should behave. The sandbox detects file actions down to the kernel level and compare these a real-time malware database. In addition, Gateway checks the sandbox's network activity for malicious behavior and data exfiltration.
+Gateway executes quarantined files in a sandboxed Windows operating system environment. Using machine learning, the sandbox compares how files of a certain type behave compared to how these files should behave. The sandbox detects file actions down to the kernel level and compares them against a real-time malware database. In addition, Gateway checks the sandbox's network activity for malicious behavior and data exfiltration.
 
 ## Compatibility
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/file-sandboxing.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/file-sandboxing.mdx
@@ -59,7 +59,7 @@ You can now create [Quarantine HTTP policies](/cloudflare-one/traffic-policies/h
 
 To test if file sandboxing is working, you can create a Quarantine policy that matches the [Cloudflare Sandbox Test](https://sandbox.cloudflaredemos.com/):
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **HTTP**.
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Add the following expression:
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/granular-controls.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/granular-controls.mdx
@@ -32,7 +32,7 @@ To create a Gateway HTTP policy with Application Granular Controls:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **HTTP**.
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Name the policy.
 4. Under **Traffic**, build a logical expression that defines the traffic you want to allow or block. Because granular controls are specific to each application, you must use the _Application_ selector with the _is_ operator.
@@ -77,7 +77,7 @@ Gateway defines Application Granular Controls at different levels of granularity
 
 ### Application Controls
 
-Application Controls are pre-defined groups that represent common user actions, such as uploads or downloads. Cloudflare maps each Application Control to one or more underlying API operations for a given application. Use Application Controls when a pre-defined grouping matches your intent.
+Application Controls are pre-defined controls that represent user intent, such as uploads or downloads. Cloudflare organizes sets of related operations into Application Controls for each supported application. Use Application Controls when a pre-defined grouping matches your intent.
 
 ### Operations
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/granular-controls.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/granular-controls.mdx
@@ -32,7 +32,7 @@ To create a Gateway HTTP policy with Application Granular Controls:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**. Select **HTTP**.
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Name the policy.
 4. Under **Traffic**, build a logical expression that defines the traffic you want to allow or block. Because granular controls are specific to each application, you must use the _Application_ selector with the _is_ operator.
@@ -77,11 +77,11 @@ Gateway defines Application Granular Controls at different levels of granularity
 
 ### Application Controls
 
-Application Controls are pre-defined controls which represent user intent, such as uploads or downloads. Cloudflare defines and organizes sets of operations deemed related to specific intents in an application. Application Controls represent the most commonly used controls.
+Application Controls are pre-defined groups that represent common user actions, such as uploads or downloads. Cloudflare maps each Application Control to one or more underlying API operations for a given application. Use Application Controls when a pre-defined grouping matches your intent.
 
 ### Operations
 
-Operations are the individual API-level actions that an application uses. Defining controls at operation level allows for more fine-grained policies to support use cases such as blocking only certain types of downloads. You can also define controls where there is not an existing application control that covers the required intent, such as blocking comments. However, because each SaaS application uses a unique set of operations with its own scope and behaviors, the use of operation level controls often requires analysis for each desired use case. You can also use operation-level controls in cases where you need variations to the Cloudflare-defined application controls, such as including or excluding certain operations.
+Operations are the individual API-level actions that an application uses. Use Operations for more fine-grained control than Application Controls provide — for example, blocking only certain types of downloads or blocking comments where no Application Control exists. Because each SaaS application uses a unique set of operations with its own scope and behaviors, operation-level controls may require analysis for each use case.
 
 Cloudflare provides Operations based on the [available APIs for an application](#application-apis). For more information on how Operations map to [Application Controls](#application-controls), refer to [Compatible applications](#compatible-applications).
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/http3.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/http3.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Details } from "~/components";
 
-HTTP/3 uses the QUIC protocol over UDP instead of TCP. Because Gateway's default proxy only handles TCP traffic, HTTP/3 inspection requires turning on the UDP proxy. Without it, HTTP/3 traffic bypasses Gateway inspection entirely.
+HTTP/3 uses the QUIC protocol over UDP instead of TCP. Because Gateway's default proxy only handles TCP traffic, HTTP/3 inspection requires turning on the UDP proxy. Without it, HTTP/3 traffic bypasses HTTP inspection. [Network policies](/cloudflare-one/traffic-policies/network-policies/) still apply to the underlying UDP traffic.
 
 Gateway applies HTTP policies to HTTP/3 traffic last. For more information, refer to the [order of enforcement](/cloudflare-one/traffic-policies/order-of-enforcement/#http3-traffic).
 
@@ -29,7 +29,7 @@ Gateway can inspect HTTP/3 traffic from Mozilla Firefox and Microsoft Edge by es
 If both the UDP proxy and TLS decryption are turned on, Google Chrome will automatically cancel HTTP/3 connections and retry them over HTTP/2, which Gateway can inspect. If either the UDP proxy or TLS decryption is turned off, HTTP/3 traffic from Chrome bypasses inspection entirely.
 
 :::caution
-If you do not turn on the UDP proxy, HTTP/3 traffic from browsers other than Chrome will bypass all HTTP policy enforcement.
+If you do not turn on the UDP proxy, HTTP/3 traffic from browsers other than Chrome will bypass HTTP policy enforcement. Network policies still apply.
 :::
 
 ## Exempt HTTP/3 traffic from inspection

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/http3.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/http3.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Details } from "~/components";
 
-Gateway supports inspection of HTTP/3 traffic, which uses the QUIC protocol over UDP.
+HTTP/3 uses the QUIC protocol over UDP instead of TCP. Because Gateway's default proxy only handles TCP traffic, HTTP/3 inspection requires turning on the UDP proxy. Without it, HTTP/3 traffic bypasses Gateway inspection entirely.
 
 Gateway applies HTTP policies to HTTP/3 traffic last. For more information, refer to the [order of enforcement](/cloudflare-one/traffic-policies/order-of-enforcement/#http3-traffic).
 
@@ -26,7 +26,11 @@ To turn on the Gateway proxy for UDP and TLS decryption:
 
 Gateway can inspect HTTP/3 traffic from Mozilla Firefox and Microsoft Edge by establishing an HTTP/3 proxy connection. Gateway will then terminate the HTTP/3 connection, decrypt and inspect the traffic, and connect to the destination server over HTTP/2. Gateway can also inspect other HTTP applications, such as cURL.
 
-If both the UDP proxy and TLS decryption are turned on in Cloudflare One, Google Chrome will cancel all HTTP/3 connections and retry them with HTTP/2, allowing you to enforce your HTTP policies. If either the UDP proxy or TLS decryption is turned off, HTTP/3 traffic from Chrome will bypass inspection.
+If both the UDP proxy and TLS decryption are turned on, Google Chrome will automatically cancel HTTP/3 connections and retry them over HTTP/2, which Gateway can inspect. If either the UDP proxy or TLS decryption is turned off, HTTP/3 traffic from Chrome bypasses inspection entirely.
+
+:::caution
+If you do not turn on the UDP proxy, HTTP/3 traffic from browsers other than Chrome will bypass all HTTP policy enforcement.
+:::
 
 ## Exempt HTTP/3 traffic from inspection
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/index.mdx
@@ -11,9 +11,11 @@ import { Details, InlineBadge, Render } from "~/components";
 To use HTTP policies, install a [Cloudflare root certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/) or a [custom certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate/).
 :::
 
-HTTP policies allow you to intercept all HTTP and HTTPS requests and either block, allow, or override specific elements such as websites, IP addresses, and file types. HTTP policies operate on Layer 7 for all TCP (and [optionally UDP](/cloudflare-one/traffic-policies/get-started/http/#1-connect-to-gateway)) traffic. By default, Gateway inspects HTTP traffic on port `80` and, with [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) turned on, HTTPS traffic on port `443`. You can also configure Gateway to [inspect HTTP/HTTPS traffic on all ports](/cloudflare-one/traffic-policies/network-policies/protocol-detection/#inspect-on-all-ports).
+HTTP policies allow you to filter all HTTP and HTTPS requests based on URLs, hostnames, HTTP methods, file types, and other request attributes. Unlike [network policies](/cloudflare-one/traffic-policies/network-policies/) which operate at Layer 4 (TCP/UDP), HTTP policies operate at Layer 7 and can inspect the full content of web traffic.
 
-An HTTP policy consists of an **Action** as well as a logical expression that determines the scope of the policy. To build an expression, you need to choose a **Selector** and an **Operator**, and enter a value or range of values in the **Value** field. You can use **And** and **Or** logical operators to evaluate multiple conditions.
+By default, Gateway inspects HTTP traffic on port `80` and, with [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) turned on, HTTPS traffic on port `443`. You can also configure Gateway to [inspect HTTP/HTTPS traffic on all ports](/cloudflare-one/traffic-policies/network-policies/protocol-detection/#inspect-on-all-ports). Gateway supports HTTP/3 inspection with the [UDP proxy](/cloudflare-one/traffic-policies/http-policies/http3/) turned on.
+
+An HTTP policy consists of an **Action** and a logical expression that determines the scope of the policy. To build an expression, choose a **Selector** and an **Operator**, then enter a value or range of values in the **Value** field. You can use **And** and **Or** logical operators to evaluate multiple conditions.
 
 - [Actions](#actions)
 - [Selectors](#selectors)
@@ -234,9 +236,11 @@ Information contained within HTTPS encryption, such as the full requested URL, w
 
 :::
 
-Do Not Inspect lets you bypass certain elements from inspection. To prevent Gateway from decrypting and inspecting HTTPS traffic, your policy must match against the Server Name Indicator (SNI) in the TLS header. When accessing a Do Not Inspect site in the browser, your browser may display a **Your connection is not private** warning, which you can proceed through to connect. For more information about applications which may require a Do Not Inspect policy, refer to [TLS decryption limitations](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#inspection-limitations).
+Do Not Inspect lets you bypass certain elements from inspection. To prevent Gateway from decrypting and inspecting HTTPS traffic, your policy must match against the Server Name Indication (SNI) in the TLS header. When accessing a Do Not Inspect site in the browser, your browser may display a **Your connection is not private** warning, which you can proceed through to connect. For more information about applications which may require a Do Not Inspect policy, refer to [TLS decryption limitations](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#inspection-limitations).
 
-All Do Not Inspect rules are evaluated first, before any Allow or Block rules, to determine if inspection should occur. For more information, refer to [Order of enforcement](/cloudflare-one/traffic-policies/order-of-enforcement/#http-policies).
+:::note
+All Do Not Inspect policies are evaluated before any Allow or Block policies, regardless of their position in the policy list. For more information, refer to [Order of enforcement](/cloudflare-one/traffic-policies/order-of-enforcement/#http-policies).
+:::
 
 ### Do Not Isolate
 
@@ -441,7 +445,7 @@ The phase of an HTTP request. You can use this selector to specify whether to sc
 | Body Phase | `http.body_phase == \"download\"` |
 
 :::caution[Body phase mismatch]
-When combining this selector with the [Download and Upload File Types selectors](#download-and-upload-file-types), ensure you use the matching phase togethers. If body phase and file type selector logic do not match, the policy may not filter traffic as intended.
+When combining this selector with the [Download and Upload File Types selectors](#download-and-upload-file-types), ensure you use the matching phase together. For example, use the `download` body phase with the Download File Types selector. If body phase and file type selector logic do not match, the policy may not filter traffic as intended.
 :::
 
 ### Content Categories
@@ -601,15 +605,15 @@ Gateway supports the following file types for use with the _Download File Types_
 
 ### Download and Upload Mime Type
 
-These selectors depend on the `Content-Type` header being present in the request (for uploads) or response (for downloads).
+These selectors depend on the `Content-Type` header being present in the request (for uploads) or response (for downloads). The MIME type value must match the format used in the `Content-Type` header (for example, `image/png`, `application/pdf`).
 
-| UI name            | API example                          |
-| ------------------ | ------------------------------------ |
-| Download Mime Type | `http.download.mime == "image/png\"` |
+| UI name            | API example                         |
+| ------------------ | ----------------------------------- |
+| Download Mime Type | `http.download.mime == "image/png"` |
 
-| UI name          | API example                        |
-| ---------------- | ---------------------------------- |
-| Upload Mime Type | `http.upload.mime == "image/png\"` |
+| UI name          | API example                       |
+| ---------------- | --------------------------------- |
+| Upload Mime Type | `http.upload.mime == "image/png"` |
 
 ### DLP Profile
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/tenant-control.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/tenant-control.mdx
@@ -13,7 +13,7 @@ Gateway implements tenant control by injecting custom HTTP headers into matching
 
 To create an HTTP policy with custom headers:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **HTTP**.
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Firewall policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Build an expression to match the SaaS traffic you want to control.
 4. In **Action**, select _Allow_. In **Untrusted certificate action**, select _Block_.

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/tenant-control.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/tenant-control.mdx
@@ -5,15 +5,15 @@ sidebar:
   order: 7
 ---
 
-With Gateway tenant control, you can allow your users access to corporate SaaS applications while blocking access to personal applications. This helps prevent the loss of sensitive or confidential data from a corporate network.
+Tenant control allows your users to access corporate SaaS applications while blocking access to personal accounts on the same service. For example, you can allow access to your company's Google Workspace while blocking personal Gmail logins.
 
-When creating an HTTP policy with an Allow action, you will have the option to configure custom headers. Gateway can use custom headers to control SaaS application access. If a user's HTTP request is headed to your organization's account for the SaaS application, Gateway will approve the request. If the request does not match the information in the header, Gateway will block the request.
+Gateway implements tenant control by injecting custom HTTP headers into matching requests. These headers tell the SaaS application which tenant (organization) is authorized. If the user attempts to authenticate with a personal account, the SaaS application reads the header and rejects the request.
 
 ## Add custom headers for a SaaS application
 
 To create an HTTP policy with custom headers:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Firewall policies**. Select **HTTP**.
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Build an expression to match the SaaS traffic you want to control.
 4. In **Action**, select _Allow_. In **Untrusted certificate action**, select _Block_.

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/tls-decryption.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/tls-decryption.mdx
@@ -16,11 +16,11 @@ import {
 	Badge,
 } from "~/components";
 
-Cloudflare Gateway can perform [SSL/TLS decryption](https://www.cloudflare.com/learning/security/what-is-https-inspection/) to inspect HTTPS traffic for malware and other security risks. TLS decryption is required for HTTP policies to inspect encrypted traffic — without it, Gateway can only see the hostname (via SNI) but not the full URL, headers, or request body.
+Cloudflare Gateway can perform [SSL/TLS decryption](https://www.cloudflare.com/learning/security/what-is-https-inspection/) to inspect HTTPS traffic for malware and other security risks. TLS decryption is required for HTTP policies to inspect HTTPS traffic. Without it, information contained within HTTPS encryption, such as the full URL, headers, and request body, [will not be visible to Gateway](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect).
 
 When you turn on TLS decryption, Gateway will decrypt all traffic sent over HTTPS, apply your HTTP policies, and then re-encrypt the request with a [user-side certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/).
 
-Gateway decrypts, inspects, and re-encrypts HTTPS requests in memory only within Cloudflare data centers. Gateway only stores eligible cache content at rest, and all cache disks are encrypted at rest. You can configure where TLS decryption takes place with [Regional Services](/data-localization/regional-services/) in the [Cloudflare Data Localization Suite (DLS)](/data-localization/). To further control what data centers traffic egresses from, you can use [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/).
+Cloudflare prevents traffic interference by decrypting, inspecting, and re-encrypting HTTPS requests in its data centers in memory only. Gateway only stores eligible cache content at rest. All cache disks are encrypted at rest. You can configure where TLS decryption takes place with [Regional Services](/data-localization/regional-services/) in the [Cloudflare Data Localization Suite (DLS)](/data-localization/). To further control what data centers traffic egresses from, you can use [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/).
 
 Cloudflare supports connections from users to Gateway over TLS 1.1, 1.2, and 1.3.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/tls-decryption.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/tls-decryption.mdx
@@ -16,11 +16,11 @@ import {
 	Badge,
 } from "~/components";
 
-Cloudflare Gateway can perform [SSL/TLS decryption](https://www.cloudflare.com/learning/security/what-is-https-inspection/) in order to inspect HTTPS traffic for malware and other security risks.
+Cloudflare Gateway can perform [SSL/TLS decryption](https://www.cloudflare.com/learning/security/what-is-https-inspection/) to inspect HTTPS traffic for malware and other security risks. TLS decryption is required for HTTP policies to inspect encrypted traffic — without it, Gateway can only see the hostname (via SNI) but not the full URL, headers, or request body.
 
 When you turn on TLS decryption, Gateway will decrypt all traffic sent over HTTPS, apply your HTTP policies, and then re-encrypt the request with a [user-side certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/).
 
-Cloudflare prevents traffic interference by decrypting, inspecting, and re-encrypting HTTPS requests in its data centers in memory only. Gateway only stores eligible cache content at rest. All cache disks are encrypted at rest. You can configure where TLS decryption takes place with [Regional Services](/data-localization/regional-services/) in the [Cloudflare Data Localization Suite (DLS)](/data-localization/). To further control what data centers traffic egresses from, you can use [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/).
+Gateway decrypts, inspects, and re-encrypts HTTPS requests in memory only within Cloudflare data centers. Gateway only stores eligible cache content at rest, and all cache disks are encrypted at rest. You can configure where TLS decryption takes place with [Regional Services](/data-localization/regional-services/) in the [Cloudflare Data Localization Suite (DLS)](/data-localization/). To further control what data centers traffic egresses from, you can use [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/).
 
 Cloudflare supports connections from users to Gateway over TLS 1.1, 1.2, and 1.3.
 
@@ -103,11 +103,11 @@ Chrome Enterprise users can turn off automatic HTTPS upgrades for all URLs with 
 
 ### Mutual TLS (mTLS)
 
-When decrypting TLS to inspect traffic, connections that use mutual TLS (mTLS) will fail because Gateway cannot return the necessary client certificate. To prevent connection failures, create a [Do Not Inspect policy](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) for this traffic.
+In mutual TLS (mTLS), both the client and server present certificates to verify each other's identity. When Gateway decrypts TLS traffic, it terminates the connection from the client and creates a new connection to the origin server. Because Gateway cannot forward the client's certificate to the origin, the mTLS handshake fails. To prevent connection failures, create a [Do Not Inspect policy](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) for this traffic.
 
 ### ESNI and ECH
 
-Websites that adhere to [ESNI or Encrypted Client Hello (ECH) standards](https://blog.cloudflare.com/encrypted-client-hello/) encrypt the Server Name Indicator (SNI) during the TLS handshake and are therefore incompatible with HTTP inspection. This is because Gateway relies on the SNI to match an HTTP request to a policy. If the ECH fails, browsers will retry the TLS handshake using the unencrypted SNI from the initial request. To avoid this behavior, you can disable ECH in your users' browsers.
+Websites that adhere to [ESNI or Encrypted Client Hello (ECH) standards](https://blog.cloudflare.com/encrypted-client-hello/) encrypt the Server Name Indication (SNI) during the TLS handshake and are therefore incompatible with HTTP inspection. Gateway relies on the SNI to match an HTTP request to a policy — if the SNI is encrypted, Gateway cannot determine which policy to apply. If the ECH fails, browsers will retry the TLS handshake using the unencrypted SNI from the initial request. To avoid this behavior, you can disable ECH in your users' browsers.
 
 You can still apply all [network policy filters](/cloudflare-one/traffic-policies/network-policies/#selectors) except for SNI and SNI Domain. To restrict ESNI and ECH traffic, an option is to filter out all port `80` and `443` traffic that does not include an SNI header.
 


### PR DESCRIPTION
Improves readability and reduces jargon across all 8 HTTP policies pages (`/cloudflare-one/traffic-policies/http-policies/`), based on an ELI5 clarity analysis.

- **Rewrite introduction** (`index.mdx`): Explain what HTTP policies do vs. network policies (Layer 7 vs. Layer 4), mention HTTP/3 support.
- **Fix "Server Name Indicator" typo** (`index.mdx`): Correct to "Server Name Indication" in Do Not Inspect section.
- **Highlight Do Not Inspect evaluation order** (`index.mdx`): Wrap in `:::note` — these policies always evaluate first regardless of list position.
- **Fix Body Phase typo** (`index.mdx`): "togethers" → "together", add clarifying example.
- **Fix MIME type API examples** (`index.mdx`): Remove mismatched trailing backslash-quote in Download/Upload Mime Type examples. Add clarifying sentence about MIME format.
- **Explain policy evaluation order** (`common-policies.mdx`): Top-to-bottom first-match, except Do Not Inspect policies.
- **Explain `filters: ["http"]`** (`common-policies.mdx`): Note in API tab explaining Layer 7.
- **Clarify certificate pinning context** (`common-policies.mdx`): Explain *why* certificate-pinned apps reject Gateway's certificate.
- **Clarify TLS decryption value** (`tls-decryption.mdx`): Explain that without TLS decryption, Gateway can only see hostname (SNI), not full URL/headers/body.
- **Explain mTLS failure mechanism** (`tls-decryption.mdx`): Describe why Gateway cannot forward client certificates.
- **Fix SNI typo in ESNI/ECH section** (`tls-decryption.mdx`): "Server Name Indicator" → "Server Name Indication". Explain why encrypted SNI breaks policy matching.
- **Simplify AV scan criteria** (`antivirus-scanning.mdx`): Convert dense paragraph to numbered list. Fix grammar in non-scannable files section.
- **Fix grammar and sandbox flow** (`file-sandboxing.mdx`): Fix "compare these a" → "compares them against". Clarify active voice in sandbox flow description.
- **Fix UI nav paths** (`file-sandboxing.mdx`, `granular-controls.mdx`, `tenant-control.mdx`): Remove outdated "Firewall policies" from navigation instructions.
- **Simplify control definitions** (`granular-controls.mdx`): Rewrite Application Controls and Operations definitions for clarity.
- **Add HTTP/3 bypass context** (`http3.mdx`): Explain *why* HTTP/3 needs special handling (QUIC/UDP vs. TCP proxy). Add `:::caution` for non-Chrome HTTP/3 bypass.
- **Clarify tenant control intro** (`tenant-control.mdx`): Explain the mechanism (header injection → SaaS reads header → rejects personal accounts) with a concrete example.