### PR TITLE
[Workers AI] Add NVIDIA Nemotron 3 Super model

### DIFF
--- a/src/content/changelog/workers-ai/2026-03-11-nemotron-3-super-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-03-11-nemotron-3-super-workers-ai.mdx
@@ -1,0 +1,22 @@
+---
+title: "NVIDIA Nemotron 3 Super now available on Workers AI"
+description: A hybrid MoE model with 120B total parameters and 12B active, optimized for multi-agent and agentic AI workloads.
+products:
+  - workers-ai
+date: 2026-03-11
+---
+
+We're excited to partner with NVIDIA to bring [`@cf/nvidia/nemotron-3-120b-a12b`](/workers-ai/models/nemotron-3-120b-a12b/) to Workers AI. NVIDIA Nemotron 3 Super is a Mixture-of-Experts (MoE) model with a hybrid Mamba-transformer architecture, 120B total parameters, and 12B active parameters per forward pass.
+
+The model is optimized for running many collaborating agents per application. It delivers high accuracy for reasoning, tool calling, and instruction following across complex multi-step tasks.
+
+**Key capabilities:**
+
+- **Hybrid Mamba-transformer architecture** delivers over 50% higher token generation throughput compared to leading open models, reducing latency for real-world applications
+- **Tool calling** support for building AI agents that invoke tools across multiple conversation turns
+- **Multi-Token Prediction (MTP)** accelerates long-form text generation by predicting several future tokens simultaneously in a single forward pass
+- **32,000 token context window** for retaining conversation history and plan states across multi-step agent workflows
+
+Use Nemotron 3 Super through the [Workers AI binding](/workers-ai/configuration/bindings/) (`env.AI.run()`), the REST API, or the [OpenAI-compatible endpoint](/workers-ai/configuration/open-ai-compatibility/).
+
+For more information, refer to the [Nemotron 3 Super model page](/workers-ai/models/nemotron-3-120b-a12b/).

--- a/src/content/docs/workers-ai/platform/pricing.mdx
+++ b/src/content/docs/workers-ai/platform/pricing.mdx
@@ -60,6 +60,7 @@ The Price in Tokens column is equivalent to the Price in Neurons column - the di
 | @cf/aisingapore/gemma-sea-lion-v4-27b-it     | $0.351 per M input tokens <br/> $0.555 per M output tokens | 31876 neurons per M input tokens <br/> 50488 neurons per M output tokens  |
 | @cf/ibm-granite/granite-4.0-h-micro          | $0.017 per M input tokens <br/> $0.112 per M output tokens | 1542 neurons per M input tokens <br/> 10158 neurons per M output tokens   |
 | @cf/zai-org/glm-4.7-flash                    | $0.060 per M input tokens <br/> $0.400 per M output tokens | 5500 neurons per M input tokens <br/> 36400 neurons per M output tokens   |
+| @cf/nvidia/nemotron-3-120b-a12b              | $0.500 per M input tokens <br/> $1.500 per M output tokens | 45455 neurons per M input tokens <br/> 136364 neurons per M output tokens |
 
 ## Embeddings model pricing
 

--- a/src/content/release-notes/workers-ai.yaml
+++ b/src/content/release-notes/workers-ai.yaml
@@ -3,6 +3,10 @@ link: "/workers-ai/changelog/"
 productName: Workers AI
 productLink: "/workers-ai/"
 entries:
+  - publish_date: "2026-03-11"
+    title: NVIDIA Nemotron 3 Super now available on Workers AI
+    description: |-
+      - [`@cf/nvidia/nemotron-3-120b-a12b`](/workers-ai/models/nemotron-3-120b-a12b/) now available on Workers AI! A hybrid MoE model with 120B total parameters and 12B active, optimized for multi-agent and agentic AI workloads. Read [changelog](/changelog/post/2026-03-11-nemotron-3-super-workers-ai/) to get started.
   - publish_date: "2026-03-06"
     title: Deepgram Nova-3 now supports 10 languages with regional variants
     description: |-

--- a/src/content/workers-ai-models/nemotron-3-120b-a12b.json
+++ b/src/content/workers-ai-models/nemotron-3-120b-a12b.json
@@ -1,0 +1,477 @@
+{
+    "id": "43dbadb4-2b0a-47e9-8479-34a49b971f1e",
+    "source": 1,
+    "name": "@cf/nvidia/nemotron-3-120b-a12b",
+    "description": "NVIDIA Nemotron 3 Super is a hybrid MoE model with leading accuracy for multi-agent applications and specialized agentic AI systems.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "created_at": "2026-02-24 23:22:47.215",
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "context_window",
+            "value": "32000"
+        },
+        {
+            "property_id": "price",
+            "value": [
+                {
+                    "unit": "per M input tokens",
+                    "price": 0.5,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M output tokens",
+                    "price": 1.5,
+                    "currency": "USD"
+                }
+            ]
+        },
+        {
+            "property_id": "function_calling",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-nemotron-open-model-license/"
+        }
+    ],
+    "schema": {
+        "input": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Prompt",
+                    "properties": {
+                        "prompt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The input text prompt for the model to generate a response."
+                        },
+                        "lora": {
+                            "type": "string",
+                            "description": "Name of the LoRA (Low-Rank Adaptation) model to fine-tune the base model."
+                        },
+                        "response_format": {
+                            "title": "JSON Mode",
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "json_object",
+                                        "json_schema"
+                                    ]
+                                },
+                                "json_schema": {}
+                            }
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0.001,
+                            "maximum": 1,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": -2,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": -2,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "prompt"
+                    ]
+                },
+                {
+                    "title": "Messages",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "description": "An array of message objects representing the conversation history.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": "The role of the message sender (e.g., 'user', 'assistant', 'system', 'tool')."
+                                    },
+                                    "content": {
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "description": "The content of the message as a string."
+                                            },
+                                            {
+                                                "type": "array",
+                                                "description": "Array of text content parts.",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Type of the content (text)"
+                                                        },
+                                                        "text": {
+                                                            "type": "string",
+                                                            "description": "Text content"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "role",
+                                    "content"
+                                ]
+                            }
+                        },
+                        "functions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "code"
+                                ]
+                            }
+                        },
+                        "tools": {
+                            "type": "array",
+                            "description": "A list of tools available for the assistant to use.",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the tool. More descriptive the better."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A brief description of what the tool does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "Schema defining the parameters accepted by the tool.",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "description": "The type of the parameters object (usually 'object')."
+                                                    },
+                                                    "required": {
+                                                        "type": "array",
+                                                        "description": "List of required parameter names.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "properties": {
+                                                        "type": "object",
+                                                        "description": "Definitions of each parameter.",
+                                                        "additionalProperties": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "description": "The data type of the parameter."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of the expected parameter."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "description"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "properties"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "description",
+                                            "parameters"
+                                        ]
+                                    },
+                                    {
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "description": "Specifies the type of tool (e.g., 'function')."
+                                            },
+                                            "function": {
+                                                "type": "object",
+                                                "description": "Details of the function tool.",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "description": "The name of the function."
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "description": "A brief description of what the function does."
+                                                    },
+                                                    "parameters": {
+                                                        "type": "object",
+                                                        "description": "Schema defining the parameters accepted by the function.",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "description": "The type of the parameters object (usually 'object')."
+                                                            },
+                                                            "required": {
+                                                                "type": "array",
+                                                                "description": "List of required parameter names.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "properties": {
+                                                                "type": "object",
+                                                                "description": "Definitions of each parameter.",
+                                                                "additionalProperties": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "description": "The data type of the parameter."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of the expected parameter."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "description"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "properties"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "description",
+                                                    "parameters"
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "type",
+                                            "function"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "response_format": {
+                            "title": "JSON Mode",
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "json_object",
+                                        "json_schema"
+                                    ]
+                                },
+                                "json_schema": {}
+                            }
+                        },
+                        "raw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, a chat template is not applied and you must adhere to the specific model's expected formatting."
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "If true, the response will be streamed back incrementally using SSE, Server Sent Events."
+                        },
+                        "max_tokens": {
+                            "type": "integer",
+                            "default": 256,
+                            "description": "The maximum number of tokens to generate in the response."
+                        },
+                        "temperature": {
+                            "type": "number",
+                            "default": 0.6,
+                            "minimum": 0,
+                            "maximum": 5,
+                            "description": "Controls the randomness of the output; higher values produce more random results."
+                        },
+                        "top_p": {
+                            "type": "number",
+                            "minimum": 0.001,
+                            "maximum": 1,
+                            "description": "Adjusts the creativity of the AI's responses by controlling how many possible words it considers. Lower values make outputs more predictable; higher values allow for more varied and creative responses."
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50,
+                            "description": "Limits the AI to choose from the top 'k' most probable words. Lower values make responses more focused; higher values introduce more variety and potential surprises."
+                        },
+                        "seed": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 9999999999,
+                            "description": "Random seed for reproducibility of the generation."
+                        },
+                        "repetition_penalty": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2,
+                            "description": "Penalty for repeated tokens; higher values discourage repetition."
+                        },
+                        "frequency_penalty": {
+                            "type": "number",
+                            "minimum": -2,
+                            "maximum": 2,
+                            "description": "Decreases the likelihood of the model repeating the same lines verbatim."
+                        },
+                        "presence_penalty": {
+                            "type": "number",
+                            "minimum": -2,
+                            "maximum": 2,
+                            "description": "Increases the likelihood of the model introducing new topics."
+                        }
+                    },
+                    "required": [
+                        "messages"
+                    ]
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "response": {
+                            "type": "string",
+                            "description": "The generated text response from the model"
+                        },
+                        "usage": {
+                            "type": "object",
+                            "description": "Usage statistics for the inference request",
+                            "properties": {
+                                "prompt_tokens": {
+                                    "type": "number",
+                                    "description": "Total number of tokens in input",
+                                    "default": 0
+                                },
+                                "completion_tokens": {
+                                    "type": "number",
+                                    "description": "Total number of tokens in output",
+                                    "default": 0
+                                },
+                                "total_tokens": {
+                                    "type": "number",
+                                    "description": "Total number of input and output tokens",
+                                    "default": 0
+                                }
+                            }
+                        },
+                        "tool_calls": {
+                            "type": "array",
+                            "description": "An array of tool calls requests made during the response generation",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "arguments": {
+                                        "type": "object",
+                                        "description": "The arguments passed to be passed to the tool call request"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the tool to be called"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "response"
+                    ]
+                },
+                {
+                    "type": "string",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `@cf/nvidia/nemotron-3-120b-a12b` (NVIDIA Nemotron 3 Super) model JSON fetched from the Workers AI API
- Add changelog entry at `/changelog/post/2026-03-11-nemotron-3-super-workers-ai/`
- Add release notes entry to `workers-ai.yaml`
- Add pricing row: $0.50/M input tokens, $1.50/M output tokens (45455 / 136364 neurons)

## Files changed

- `src/content/workers-ai-models/nemotron-3-120b-a12b.json` — new model definition (fetched via `node bin/fetch-ai-models.js`)
- `src/content/changelog/workers-ai/2026-03-11-nemotron-3-super-workers-ai.mdx` — changelog entry
- `src/content/release-notes/workers-ai.yaml` — release notes entry
- `src/content/docs/workers-ai/platform/pricing.mdx` — pricing table row