### PR TITLE
CC-4634: Add containers ssh docs

### DIFF
--- a/src/content/changelog/containers/2026-03-12-ssh-support.mdx
+++ b/src/content/changelog/containers/2026-03-12-ssh-support.mdx
@@ -6,9 +6,13 @@ products:
 date: 2026-03-12
 ---
 
+import { WranglerConfig } from "~/components";
+
 You can now SSH into running Container instances using Wrangler. This is useful for debugging, inspecting running processes, or executing one-off commands inside a Container.
 
 To connect, enable `wrangler_ssh` in your Container configuration and add your `ssh-ed25519` public key to `authorized_keys`:
+
+<WranglerConfig>
 
 ```jsonc
 {
@@ -27,6 +31,8 @@ To connect, enable `wrangler_ssh` in your Container configuration and add your `
 	]
 }
 ```
+
+</WranglerConfig>
 
 Then connect with:
 

--- a/src/content/changelog/containers/2026-03-12-ssh-support.mdx
+++ b/src/content/changelog/containers/2026-03-12-ssh-support.mdx
@@ -1,0 +1,45 @@
+---
+title: SSH into running Container instances
+description: Connect to running Container instances with SSH through Wrangler.
+products:
+  - containers
+date: 2026-03-12
+---
+
+You can now SSH into running Container instances using Wrangler. This is useful for debugging, inspecting running processes, or executing one-off commands inside a Container.
+
+To connect, enable `wrangler_ssh` in your Container configuration and add your `ssh-ed25519` public key to `authorized_keys`:
+
+```jsonc
+{
+	"containers": [
+		{
+			"wrangler_ssh": {
+				"enabled": true
+			},
+			"authorized_keys": [
+				{
+					"name": "<NAME>",
+					"public_key": "<YOUR_PUBLIC_KEY_HERE>"
+				}
+			]
+		}
+	]
+}
+```
+
+Then connect with:
+
+```sh
+wrangler containers ssh <INSTANCE_ID>
+```
+
+You can also run a single command without opening an interactive shell:
+
+```sh
+wrangler containers ssh <INSTANCE_ID> -- ls -al
+```
+
+Use `wrangler containers instances <APPLICATION>` to find the instance ID for a running Container.
+
+For more information, refer to the [SSH documentation](/containers/ssh/).

--- a/src/content/docs/containers/index.mdx
+++ b/src/content/docs/containers/index.mdx
@@ -162,6 +162,14 @@ regional placement, Workflow and Queue integrations, AI-generated code execution
 </LinkTitleCard>
 
 <LinkTitleCard
+	title="SSH"
+	href="/containers/ssh/"
+	icon="seti:shell"
+>
+	Connect to running Container instances with SSH through Wrangler.
+</LinkTitleCard>
+
+<LinkTitleCard
 	title="Containers Discord"
 	href="https://discord.cloudflare.com"
 	icon="discord"

--- a/src/content/docs/containers/ssh.mdx
+++ b/src/content/docs/containers/ssh.mdx
@@ -47,7 +47,7 @@ The following example shows a basic configuration:
 
 For more information on configuring SSH, refer to [Wrangler SSH configuration](/workers/wrangler/configuration/#wrangler-ssh).
 
-Find the instance ID for your Container by running [`wrangler containers instances`](/workers/wrangler/commands/#containers-instances) or in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/containers).
+Find the instance ID for your Container by running [`wrangler containers instances`](/workers/wrangler/commands/containers/#containers-instances) or in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/containers).
 The instance you want to SSH into must be running.
 SSH will not start a stopped Container, and an active SSH connection alone will not keep a Container alive.
 
@@ -59,4 +59,4 @@ wrangler containers ssh <INSTANCE_ID>
 
 ## Process visibility
 
-Without the [`containers_pid_namespace`](/workers/configuration/compatibility-flags/#use-an-isolated-pid-namespace-for-containers) compatibility flag, all processes inside the VM are visible when you connect to your Container through SSH. This flag is enabled by default for Workers with a [compatibility date](/workers/configuration/compatibility-dates/) of `2026-04-01` or later.
+Without the [`containers_pid_namespace`](/workers/configuration/compatibility-flags/#use-an-isolated-pid-namespace-for-containers) compatibility flag, all processes inside the VM are visible when you connect to your Container through SSH. This flag is turned on by default for Workers with a [compatibility date](/workers/configuration/compatibility-dates/) of `2026-04-01` or later.

--- a/src/content/docs/containers/ssh.mdx
+++ b/src/content/docs/containers/ssh.mdx
@@ -1,0 +1,62 @@
+---
+pcx_content_type: reference
+title: SSH
+description: Connect to running container instances with SSH.
+sidebar:
+  order: 10
+---
+
+import { WranglerConfig } from "~/components";
+
+Anyone with write access to a Container can SSH into it with Wrangler as long as SSH is enabled.
+
+## Configure SSH
+
+SSH can be configured in your [Container's configuration](/workers/wrangler/configuration/#containers) with the `wrangler_ssh` and `authorized_keys` properties. Only the `ssh-ed25519` key type is supported.
+
+The `wrangler_ssh.enabled` property only controls whether you can SSH into a Container through Wrangler.
+If `wrangler_ssh.enabled` is false but keys are still present in `authorized_keys`, the SSH service will still be started on the Container.
+
+## Connect with Wrangler
+
+To SSH into a Container with Wrangler, you must first enable Wrangler SSH.
+The following example shows a basic configuration:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"containers": [
+		{
+			// other options here...
+			"wrangler_ssh": {
+				"enabled": true
+			},
+			"authorized_keys": [
+				{
+					"name": "<NAME>",
+					"public_key": "<YOUR_PUBLIC_KEY_HERE>"
+				}
+			]
+		}
+	]
+}
+```
+
+</WranglerConfig>
+
+For more information on configuring SSH, refer to [Wrangler SSH configuration](/workers/wrangler/configuration/#wrangler-ssh).
+
+Find the instance ID for your Container by running [`wrangler containers instances`](/workers/wrangler/commands/#containers-instances) or in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers/containers).
+The instance you want to SSH into must be running.
+SSH will not start a stopped Container, and an active SSH connection alone will not keep a Container alive.
+
+Once SSH is configured and the Container is running, open the SSH connection with:
+
+```bash
+wrangler containers ssh <INSTANCE_ID>
+```
+
+## Process visibility
+
+Without the [`containers_pid_namespace`](/workers/configuration/compatibility-flags/#use-an-isolated-pid-namespace-for-containers) compatibility flag, all processes inside the VM are visible when you connect to your Container through SSH. This flag is enabled by default for Workers with a [compatibility date](/workers/configuration/compatibility-dates/) of `2026-04-01` or later.

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1255,6 +1255,12 @@ The following options are available:
   - Defaults to `[10, 100]`.
   - This can be overridden ad hoc by deploying with the `--containers-rollout=immediate` flag, which will roll out to 100% of instances in one step. Note that flag will not override `rollout_active_grace_period`, if configured.
 
+- `wrangler_ssh` <Type text="object" /> <MetaInfo text="optional" />
+  - Configuration for SSH through Wrangler. Refer to [Wrangler SSH](#wrangler-ssh).
+
+- `authorized_keys` <Type text="object[]" /> <MetaInfo text="optional" />
+  - Public keys that should be added to the Container's `authorized_keys` file.
+
 <WranglerConfig>
 
 ```jsonc
@@ -1323,6 +1329,31 @@ The following options are available:
 ```
 
 </WranglerConfig>
+
+### Wrangler SSH
+
+Configuration for SSH access to a Container instance through Wrangler. For a guide on connecting to Containers via SSH, refer to [SSH](/containers/ssh/).
+
+The following options are available:
+
+- `enabled` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Whether SSH through Wrangler is enabled. Defaults to `false`.
+
+- `port` <Type text="number" /> <MetaInfo text="optional" />
+  - The port for the SSH service to run on. Defaults to `22`.
+
+### Authorized keys
+
+An authorized key is a public key that can be used to SSH into a Container.
+
+The following are properties of a key:
+
+- `name` <Type text="string" /> <MetaInfo text="required" />
+  - The display name of the key.
+
+- `public_key` <Type text="string" /> <MetaInfo text="required" />
+  - The public key itself.
+  - Currently only the `ssh-ed25519` key type is supported.
 
 ## Bundling
 

--- a/src/content/partials/workers/wrangler-commands/containers.mdx
+++ b/src/content/partials/workers/wrangler-commands/containers.mdx
@@ -212,3 +212,20 @@ wrangler containers push [TAG] [OPTIONS]
 - `--path-to-docker` <Type text="string" /> <MetaInfo text="optional" />
   - Path to your docker binary if it's not on `$PATH`.
   - Default: "docker"
+
+<AnchorHeading title="`ssh`" slug="containers-ssh" depth={3} />
+
+Connect to a running Container instance using SSH. Refer to [SSH](/containers/ssh/) for configuration details.
+
+```txt
+wrangler containers ssh <INSTANCE_ID>
+```
+
+You can also specify a command to run, instead of the default shell. For example:
+
+```txt
+wrangler containers ssh <INSTANCE_ID> -- ls -al
+```
+
+- `INSTANCE_ID` <Type text="string" /> <MetaInfo text="required" />
+  - The ID of the Container instance to SSH into.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Continuation of https://github.com/cloudflare/cloudflare-docs/pull/25076

Document the new(-ish) `wrangler containers ssh` command.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
