### PR TITLE
fix(ci): Loosen required npm version to 10.x in package.json#engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
 		"wrangler": "4.58.0"
 	},
 	"engines": {
-		"npm": "10.9.4",
+		"npm": "10.x",
 		"node": "22.x"
 	},
 	"packageManager": "npm@10.9.4+sha512.3a7506f37e85c1ba1021baad79f0cd9724748131f321fc117c4dc3ba235ec01be7327584a41d15117c01945560aa9373220628fcc1e1dddd877a5fe9b336a900"


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Node v22.9.0 installs NPM v10.8.3

Because NPM isn't explicitly installed at the required version in Workers Builds, `engine-strict` throws an error: https://github.com/cloudflare/cloudflare-docs/blob/d9226fdc9569605eae696477c7f257ecefdea007/.npmrc#L3

This loosens the `npm` restriction that was introduced in https://github.com/cloudflare/cloudflare-docs/pull/27530


### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

#### Before


<img width="831" height="402" alt="Screenshot 2026-03-10 at 5 02 27 PM" src="https://github.com/user-attachments/assets/60492ab5-f98d-4794-b7a4-13db6a674604" />

#### After

<img width="1204" height="571" alt="Screenshot 2026-03-11 at 11 51 22 AM" src="https://github.com/user-attachments/assets/a7f6ff5e-47a3-4fe3-90dd-6f425c5d4873" />


### Documentation checklist

