### PR TITLE
Remove outdated link to email Queues team

### DIFF
--- a/src/content/docs/queues/configuration/javascript-apis.mdx
+++ b/src/content/docs/queues/configuration/javascript-apis.mdx
@@ -282,7 +282,7 @@ interface MessageBatch<Body = unknown> {
 
 * <code>messages</code> <Type text="Message[]" />
 
-  * An array of messages in the batch. Ordering of messages is best effort -- not guaranteed to be exactly the same as the order in which they were published. If you are interested in guaranteed FIFO ordering, please [email the Queues team](mailto:queues@cloudflare.com).
+  * An array of messages in the batch. Ordering of messages is best effort -- not guaranteed to be exactly the same as the order in which they were published.
 
 * <code>ackAll()</code> <Type text="void" />
 


### PR DESCRIPTION
### Summary

Remove outdated link to email Queues team

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).