### PR TITLE
Browser Rendering: address crawl endpoint feedback

### DIFF
--- a/src/content/docs/browser-rendering/faq.mdx
+++ b/src/content/docs/browser-rendering/faq.mdx
@@ -130,7 +130,7 @@ For complete working examples of all three methods, refer to [Capture a screensh
 
 Yes, Browser Rendering requests are always identified as bot traffic by Cloudflare. Cloudflare does not enforce bot protection by default — that is the customer's choice.
 
-If you are attempting to scan your own zone and want Browser Rendering to access your website freely without your bot protection configuration interfering, you can create a WAF skip rule to [allowlist Browser Rendering](/browser-rendering/faq/#how-do-i-allowlist-browser-rendering).
+If you are attempting to scan your own zone and want Browser Rendering to access your website freely without your bot protection configuration interfering, you can create a WAF skip rule to [allowlist Browser Rendering](/browser-rendering/faq/#can-i-allowlist-browser-rendering-on-my-own-website).
 
 ### Can I allowlist Browser Rendering on my own website?
 

--- a/src/content/docs/browser-rendering/rest-api/content-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/content-endpoint.mdx
@@ -9,6 +9,8 @@ import { Tabs, TabItem, Render } from "~/components";
 
 The `/content` endpoint instructs the browser to navigate to a website and capture the fully rendered HTML of a page, including the `head` section, after JavaScript execution. This is ideal for capturing content from JavaScript-heavy or interactive websites.
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt

--- a/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
@@ -428,7 +428,7 @@ Use the `source` parameter to customize which sources the crawler uses. The avai
 The `/crawl` endpoint respects the directives of `robots.txt` files, including `crawl-delay`. All URLs that `/crawl` is directed not to crawl are listed in the response with `"status": "disallowed"`. For guidance on configuring `robots.txt` and sitemaps for sites you plan to crawl, refer to [robots.txt and sitemaps](/browser-rendering/reference/robots-txt/).
 
 :::caution[Bot protection may block crawling]
-Browser Rendering does not bypass CAPTCHAs, Turnstile challenges, or any other bot protection mechanisms. If a target site uses Cloudflare products that control or restrict bot traffic — such as [Bot Management](/bots/), [Web Application Firewall (WAF)](/waf/), or [Turnstile](/turnstile/) — the same rules will apply to the Browser Rendering crawler.
+Browser Rendering does not bypass CAPTCHAs, Turnstile challenges, or any other bot protection mechanisms. If a target site uses Cloudflare products that control or restrict bot traffic such as [Bot Management](/bots/), [Web Application Firewall (WAF)](/waf/), or [Turnstile](/turnstile/), the same rules will apply to the Browser Rendering crawler.
 
 If you are crawling your own site and want Browser Rendering to access it freely, you can create a WAF skip rule to allowlist Browser Rendering. Refer to [How do I allowlist Browser Rendering?](/browser-rendering/faq/#can-i-allowlist-browser-rendering-on-my-own-website) for instructions.
 :::

--- a/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
@@ -10,6 +10,8 @@ import { Render } from "~/components";
 
 The `/crawl` endpoint scrapes content from a starting URL and follows links across the site, up to a configurable depth or page limit. Responses can be returned as HTML, Markdown, or JSON.
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt
@@ -426,7 +428,9 @@ Use the `source` parameter to customize which sources the crawler uses. The avai
 The `/crawl` endpoint respects the directives of `robots.txt` files, including `crawl-delay`. All URLs that `/crawl` is directed not to crawl are listed in the response with `"status": "disallowed"`. For guidance on configuring `robots.txt` and sitemaps for sites you plan to crawl, refer to [robots.txt and sitemaps](/browser-rendering/reference/robots-txt/).
 
 :::caution[Bot protection may block crawling]
-If you use Cloudflare products that control or restrict bot traffic such as [Bot Management](/bots/), [Web Application Firewall (WAF)](/waf/), or [Turnstile](/turnstile/), the same rules will apply to the Browser Rendering crawler. Refer to [Will Browser Rendering bypass Cloudflare's Bot Protection?](/browser-rendering/faq/#will-browser-rendering-bypass-cloudflares-bot-protection) for instructions on creating a WAF skip rule.
+Browser Rendering does not bypass CAPTCHAs, Turnstile challenges, or any other bot protection mechanisms. If a target site uses Cloudflare products that control or restrict bot traffic — such as [Bot Management](/bots/), [Web Application Firewall (WAF)](/waf/), or [Turnstile](/turnstile/) — the same rules will apply to the Browser Rendering crawler.
+
+If you are crawling your own site and want Browser Rendering to access it freely, you can create a WAF skip rule to allowlist Browser Rendering. Refer to [How do I allowlist Browser Rendering?](/browser-rendering/faq/#can-i-allowlist-browser-rendering-on-my-own-website) for instructions.
 :::
 
 <Render

--- a/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
@@ -17,6 +17,8 @@ By default, the `/json` endpoint leverages [Workers AI](/workers-ai/) for data e
 
 :::
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt

--- a/src/content/docs/browser-rendering/rest-api/links-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/links-endpoint.mdx
@@ -9,6 +9,8 @@ import { Tabs, TabItem, Render } from "~/components";
 
 The `/links` endpoint retrieves all links from a webpage. It can be used to extract all links from a page, including those that are hidden.
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt

--- a/src/content/docs/browser-rendering/rest-api/markdown-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/markdown-endpoint.mdx
@@ -9,6 +9,8 @@ import { Tabs, TabItem, Render } from "~/components";
 
 The `/markdown` endpoint retrieves a webpage's content and converts it into Markdown format. You can specify a URL and optional parameters to refine the extraction process.
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt

--- a/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
@@ -9,6 +9,8 @@ import { Tabs, TabItem, Render } from "~/components";
 
 The `/pdf` endpoint instructs the browser to generate a PDF of a webpage or custom HTML using Cloudflare's headless browser rendering service.
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt

--- a/src/content/docs/browser-rendering/rest-api/scrape-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/scrape-endpoint.mdx
@@ -9,6 +9,8 @@ import { Tabs, TabItem, Render } from "~/components";
 
 The `/scrape` endpoint extracts structured data from specific elements on a webpage, returning details such as element dimensions and inner HTML.
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt

--- a/src/content/docs/browser-rendering/rest-api/screenshot-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/screenshot-endpoint.mdx
@@ -9,6 +9,8 @@ import { Tabs, TabItem, Render } from "~/components";
 
 The `/screenshot` endpoint renders the webpage by processing its HTML and JavaScript, then captures a screenshot of the fully rendered page.
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt

--- a/src/content/docs/browser-rendering/rest-api/snapshot.mdx
+++ b/src/content/docs/browser-rendering/rest-api/snapshot.mdx
@@ -9,6 +9,8 @@ import { Tabs, TabItem, Render } from "~/components";
 
 The `/snapshot` endpoint captures both the HTML content and a screenshot of the webpage in one request. It returns the HTML as a text string and the screenshot as a Base64-encoded image.
 
+<Render file="rest-api-token-permissions" product="browser-rendering" />
+
 ## Endpoint
 
 ```txt

--- a/src/content/partials/browser-rendering/rest-api-token-permissions.mdx
+++ b/src/content/partials/browser-rendering/rest-api-token-permissions.mdx
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+Before you begin, make sure you [create a custom API Token](/fundamentals/api/get-started/create-token/) with the `Browser Rendering - Edit` permission. For more information, refer to [REST API — Before you begin](/browser-rendering/rest-api/#before-you-begin).


### PR DESCRIPTION
- Add API token permission requirements (Browser Rendering - Edit) to all REST API endpoint pages via a new reusable partial, so users do not need to find the REST API overview page first
- Clarify on the crawl endpoint page that Browser Rendering does not bypass CAPTCHAs, Turnstile challenges, or other bot protection mechanisms
- Fix broken FAQ link: the 'Will Browser Rendering be detected by Bot Management?' section was linking to a non-existent anchor (#how-do-i-allowlist-browser-rendering) instead of the correct one (#can-i-allowlist-browser-rendering-on-my-own-website)

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
