### PR TITLE
[Registrar] Address review feedback on transfer docs

### DIFF
--- a/src/content/docs/registrar/faq.mdx
+++ b/src/content/docs/registrar/faq.mdx
@@ -4,21 +4,20 @@ title: FAQ
 structured_data: true
 sidebar:
   order: 7
-
 ---
 
 import { DashButton } from "~/components";
 
 Below you will find answers to our most commonly asked questions. If you cannot find the answer you are looking for, refer to the [community page](https://community.cloudflare.com/) to explore more resources.
 
-* [Domain management](#domain-management)
-* [Domain transfers](#domain-transfers)
-* [Domain registrations](#domain-registrations)
-* [Domain restoration](#domain-restoration)
-* [Domain deletions](#domain-deletions)
-* [Billing](#billing)
+- [Domain management](#domain-management)
+- [Domain transfers](#domain-transfers)
+- [Domain registrations](#domain-registrations)
+- [Domain restoration](#domain-restoration)
+- [Domain deletions](#domain-deletions)
+- [Billing](#billing)
 
-***
+---
 
 ## Domain management
 
@@ -34,7 +33,7 @@ If you still need to use different nameservers, you will have to [move your doma
 
 You can update both your default contact information and any individual Registrant, Administrator, Technical or Billing contact for your domain registrations by following [Registrant contact updates](/registrar/account-options/domain-contact-updates/). Details that may be updated include name, email, address, organization and telephone number.
 
-***
+---
 
 ## Domain transfers
 
@@ -56,7 +55,6 @@ Whenever a domain is first registered, the registrant purchases control of that 
 
 Transferring a domain adds time to the current expiration date, unless your domain already has [10 years on the term](#if-i-registered-my-domain-for-10-years-at-another-registrar-will-i-gain-another-year-if-i-transfer-it-to-cloudflare).
 
-
 ### How can I see the status of my domain transfer?
 
 Once you initiate a domain transfer, your previous registrar has five days to release the domain. In most cases, they will send you an email to confirm you want to transfer. If you actively acknowledge that email (through a link or the registrar's dashboard), they can process it immediately.
@@ -68,7 +66,6 @@ To see the progress of your transfer, go to the **Transfer domains** page in the
 To accelerate the process, be sure to check with your old registrar how you can approve the transfer out.
 
 Once successful, you will receive an email from Cloudflare and be able to manage the domain in the dashboard under **Overview** of that site.
-
 
 ### Why am I not allowed to transfer my domain?
 
@@ -88,36 +85,33 @@ If you have an [unverified email address](/fundamentals/user-profiles/verify-ema
 
 If you enter an incorrect auth code (also referred to as authentication code or authorization code), return to the **Domain Registration** page or the **Overview** for your site. You can use the available input field to reenter your authentication code.
 
-
 ### If I registered my domain for 10 years at another registrar, will I gain another year if I transfer it to Cloudflare?
-
 
 No. A domain cannot have more than 10 years on the term. If you registered your domain for 10 years, you will get 10 years upon transferring it to Cloudflare.
 
-***
+---
 
 ## Domain registrations
 
 ### My domain's registration was not extended by one year after transferring to Cloudflare
 
-When you transfer your domain to Cloudflare, the registry will extend your registration by one year. However, in one specific circumstance your transfer could result in you keeping your original expiration date.
+Most transfers add one year to your registration. However, if your domain expired, you renewed it to keep it, and then transferred within 45 days of renewal, you will be charged for the transfer but no additional year will actually be added. This is a registry restriction that applies to all registrars, not just Cloudflare.
 
-When a domain expires, the registration enters the auto-renew grace period. During that time, you can renew the domain at your registrar to avoid losing it. If your domain expires at your current registrar, you renew it and then transfer to Cloudflare within 45 days, the registry can restrict the addition of an extra year.
+For example, say `example.com` expires on March 1. You renew it on March 10, extending the registration to March 10 of the following year. You then transfer to Cloudflare on March 20. Because the transfer is within 45 days of renewal, the registry does not add an additional year. Your expiration date remains March 10 of the following year.
 
-Say you have `example.com` registered and it expires on December 10, 2021. You decide to renew it during the auto-renew grace period on December 20, 2021. That renewal extends the registration to December 20, 2022. You then transfer to Cloudflare on December 30, 2021. Since that transfer is within 45 days of the expiration, the registry may not add the year to your registration. When you transfer to Cloudflare or any registrar in this circumstance, your expiration can still remain December 20th, 2022.
+To avoid this, wait at least 45 days after renewal before transferring.
 
-If a year is not added to your registration, you have effectively paid twice for the same added year. Per ICANN rules, you are entitled to request a refund at your previous registrar.
-
+If this already happened, you have effectively paid twice for the same year. Per ICANN rules, you are entitled to request a refund from your previous registrar.
 
 ### What Happens When a Domain Expires?
 
 In summary, here is what will happen after a domain expires:
 
-* **Day 0**: Expiration Date.
-* **Day 1 - 30**: Grace Period (domain resolves normally).
-* **Day 31 - 40**: Suspension Period (domains resolves to suspension page).
-* **Day 41 - 70**: Redemption Period.
-* **Day 71 - 75**: Pending Delete Period.
+- **Day 0**: Expiration Date.
+- **Day 1 - 30**: Grace Period (domain resolves normally).
+- **Day 31 - 40**: Suspension Period (domains resolves to suspension page).
+- **Day 41 - 70**: Redemption Period.
+- **Day 71 - 75**: Pending Delete Period.
 
 Cloudflare currently offers a 40-day grace period for most top-level domains (TLDs).
 
@@ -129,7 +123,7 @@ If the domain is in a state where it can be restored, the Manage Domain page in 
 
 Cloudflare does not guarantee against domain loss in the sense of fully indemnifying you for business losses if you lose your domain. However, mechanisms are in place to alert you of domain expiration and redemption grace periods should your domain expire. You can also elect to set up your domain registration to renew automatically. For an additional layer of control over your domains, refer to [Domain Protection Service](https://www.cloudflare.com/products/registrar/custom-domain-protection/).
 
-***
+---
 
 ## Domain restoration
 
@@ -169,36 +163,29 @@ No. Once a restore has been completed it can not be reversed. It may be possible
 
 :::note[Note]
 
-
 Domain names should be released after a period of 75 days, although the exact deletion timeline is ultimately determined by the domain's registry. You should monitor the domain status to ascertain when it will become available for registration once again.
-
 
 :::
 
-
-
-***
+---
 
 ## Domain deletions
-
 
 ### Why am I unable to delete my Registrar domain?
 
 A domain can only be deleted if all the following conditions are met:
 
-* The user initiating the action is a Super Admin or Read/Write Administrator.
-* The domain is not delete locked at the registry with either `clientDeleteProhibited` or `serverDeleteProhibited`.
-* The domain is not already in `pendingDelete`, `redemptionPeriod`, or in `pendingTransfer`.
-* The domain has not been administratively locked by Cloudflare.  This typically occurs for legal reasons such as a UDRP filing or court order, but may also be the result of an abuse or payment investigation.
-* The domain is NOT a .UK domain. .UK domains currently cannot be deleted at the registry.
+- The user initiating the action is a Super Admin or Read/Write Administrator.
+- The domain is not delete locked at the registry with either `clientDeleteProhibited` or `serverDeleteProhibited`.
+- The domain is not already in `pendingDelete`, `redemptionPeriod`, or in `pendingTransfer`.
+- The domain has not been administratively locked by Cloudflare. This typically occurs for legal reasons such as a UDRP filing or court order, but may also be the result of an abuse or payment investigation.
+- The domain is NOT a .UK domain. .UK domains currently cannot be deleted at the registry.
 
 If any of the above conditions are not met, the domain cannot be deleted.
 
 ### Who has permission to delete a domain registration?
 
-
-Only Super Admins and Administrators with Read/Write access can initiate the deletion of a domain.  Note that only Super Admins will receive the email with the delete token.
-
+Only Super Admins and Administrators with Read/Write access can initiate the deletion of a domain. Note that only Super Admins will receive the email with the delete token.
 
 ### Will I receive a refund for my deleted domain registration?
 
@@ -218,7 +205,7 @@ If the domain is within 5 days of the initial registration, the domain will be i
 
 If the domain is more than 5 days old, it will enter the redemption period and will remain in account until the redemption period expires and the registry releases the domain.
 
-***
+---
 
 ## Billing
 
@@ -226,14 +213,10 @@ If the domain is more than 5 days old, it will enter the redemption period and w
 
 Refer to [What is Cloudflare Registrar](https://www.cloudflare.com/learning/dns/what-is-cloudflare-registrar/) for more information on pricing.
 
-
 ### When will I be billed?
 
 You will be billed when you input your authorization code and initiate the transfer of your domain to Cloudflare. Currently, Cloudflare Registrar only uses the primary payment method for any associated transaction. Make sure to copy and paste the code to avoid mistakes. The transfer will not initiate if the code is incorrect.
 
-
 ### Is there a fee to transfer a .UK domain?
 
 No, there is no fee to transfer a `.uk` domain. Also, an additional year is NOT added during the transfer process. However, if the domain is nearing the expiration date and is set to auto-renew, it may be automatically renewed shortly after the completion of the transfer.
-
-

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -109,8 +109,6 @@ Remove the lock on your domain so Cloudflare can process the transfer. Most regi
 Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your domain still shows as locked after you have disabled one, check for additional lock settings.
 :::
 
-If you are transferring from GoDaddy, also disable domain forwarding. GoDaddy will reject the transfer if it is still active.
-
 ### Request an authorization code
 
 **At your current registrar:**

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -34,7 +34,7 @@ Confirm the following before you start:
 - Your account at your current registrar is active. If your domain has expired, renew it at your current registrar first.
 
 :::note
-If your domain recently expired and you renewed it, wait at least 45 days after the original expiration date before transferring. Otherwise, the registry may not add the extra year. For details, refer to [Why did my domain's expiration date change?](/registrar/faq/#my-domains-registration-was-not-extended-by-one-year-after-transferring-to-cloudflare).
+Most transfers add one year to your registration. [Learn when this does not apply](/registrar/faq/#my-domains-registration-was-not-extended-by-one-year-after-transferring-to-cloudflare).
 :::
 
 - Your domain uses only standard characters (letters, numbers, hyphens). Cloudflare does not support domains with non-Latin characters (for example, `例え.jp`).

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -12,8 +12,8 @@ import { DashButton, Details, Render } from "~/components";
 Transferring a domain moves your registration from your current registrar to Cloudflare.
 
 - **Active work:** About 30 minutes.
-- **Total time:** Around 5 business days. Your current registrar has up to 5 days to release the domain and DNS changes take time to propagate.
-- **Cost:** One year of registration at Cloudflare's at-cost price, added to your current expiration date.
+- **Total time:** Up to 10 days, depending on your registrar.
+- **Cost:** Cloudflare domains are at-cost with no markup fees. Most transfers include a one-year extension from your current expiration date. Some country-code domains (such as `.uk`) have no transfer fee.
 
 Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare).
 
@@ -109,13 +109,15 @@ Remove the lock on your domain so Cloudflare can process the transfer. Most regi
 Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your domain still shows as locked after you have disabled one, check for additional lock settings.
 :::
 
+If you are transferring from GoDaddy, also disable domain forwarding. GoDaddy will reject the transfer if it is still active.
+
 ### Request an authorization code
 
 **At your current registrar:**
 
 Request an authorization code for your domain. This is also called an auth code, EPP code, authinfo code, or transfer code. Cloudflare uses this code to verify that the transfer is authorized by the domain owner.
 
-Authorization codes expire within 5-14 days depending on the registrar. Some registrars invalidate the previous code each time you request a new one. Request the code when you are ready to enter it in the next step.
+Authorization codes are usually only valid for a limited period. Request the code when you are ready to enter it in the next step.
 
 ### Enter your authorization code and confirm payment
 
@@ -123,7 +125,7 @@ Authorization codes expire within 5-14 days depending on the registrar. Some reg
 
 <DashButton url="/?to=/:account/registrar/transfer" />
 
-Select your domain and enter the authorization code. The page will show the transfer price, which includes a one-year registration extension from your current expiration date. This is an ICANN requirement — every transfer extends your registration by one year.
+Select your domain and enter the authorization code. For most generic TLDs (such as `.com`, `.net`, and `.org`), the transfer price includes a one-year registration extension from your current expiration date. This is an ICANN requirement for gTLD transfers. Country-code domains follow their own registry policies — for example, `.uk` transfers do not add an extra year or charge a transfer fee.
 
 If you do not have a payment method on file, add one before proceeding.
 

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -18,7 +18,7 @@ Transferring a domain moves your registration from your current registrar to Clo
 Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare).
 
 :::note
-If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
 :::
 
 ---

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -9,9 +9,13 @@ description: >-
 
 import { DashButton, Details, Render } from "~/components";
 
-Transferring a domain moves your registration from your current registrar to Cloudflare. The process takes about 30 minutes of active work, but the full transfer usually takes 3-5 business days to complete because your current registrar has up to 5 days to release the domain, and changes to your domain settings take time to take effect across the internet. Each transfer adds one year to your domain registration at Cloudflare's at-cost price.
+Transferring a domain moves your registration from your current registrar to Cloudflare.
 
-**Cloudflare works differently from most registrars.** You cannot enter an authorization code right away. Instead, Cloudflare requires you to add your domain and point your nameservers to Cloudflare first, so your site benefits from Cloudflare performance and security features from the moment the transfer begins. This is covered in [step 1](#1-add-your-domain-to-cloudflare) below.
+- **Active work:** About 30 minutes.
+- **Total time:** Usually 3-5 business days, because your current registrar has up to 5 days to release the domain and changes to your domain settings take time to take effect across the internet.
+- **Cost:** One year of registration at Cloudflare's at-cost price, added to your current expiration date.
+
+Before you can transfer, you must [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare) and update your nameservers. Only then can you enter an authorization code and start the transfer. This is because Cloudflare applies performance and security features to your site before the transfer begins.
 
 :::note
 If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
@@ -28,7 +32,7 @@ Confirm the following before you start:
 - Your domain was registered at least 60 days ago and has not been transferred in the last 60 days (ICANN requirement).
 - You have not changed your registrant name, organization, or email address in the last 60 days. Under ICANN rules, changes to these fields trigger a 60-day transfer lock. Some registrars let you opt out of this lock during the change, but not all do.
 - Your account at your current registrar is active. If your domain has expired, renew it at your current registrar first.
-- Your domain is not an internationalized domain name (IDN). Cloudflare does not currently support IDNs.
+- Your domain uses only standard characters (letters, numbers, hyphens). Cloudflare does not support domains with non-Latin characters (for example, `例え.jp`).
 - If you are transferring a `.us` domain, refer to [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).
 - If you are transferring multiple domains, notify your bank to prevent fraud alerts on multiple charges.
 
@@ -38,9 +42,9 @@ Cloudflare Registrar requires your domain to use Cloudflare for [authoritative D
 
 <Details header="Restrictions" id="restrictions">
 
-Domains with any of the following statuses cannot be transferred: `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod`. Domains that are locked (`clientTransferProhibited`) will not appear as available for transfer until you unlock them at your current registrar.
-
 If your domain appears as available for transfer in the Cloudflare dashboard, these restrictions have already been checked.
+
+For reference, domains with any of the following statuses cannot be transferred: `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod`. Domains that are locked (`clientTransferProhibited`) will not appear as available for transfer until you unlock them at your current registrar.
 
 :::caution
 If you renew an expired domain and then transfer it within 45 days of the original expiration date, the registry may not add the extra year. Refer to [Registration limits and the one-year extension](#enter-your-authorization-code-and-confirm-payment) for details.
@@ -52,7 +56,7 @@ If you renew an expired domain and then transfer it within 45 days of the origin
 
 ## 1. Add your domain to Cloudflare
 
-Before you can transfer your registration, your domain must be active on Cloudflare. This is what allows Cloudflare to protect your site with performance and security features during and after the transfer. You will not be able to enter an authorization code or proceed with the transfer until this step is complete.
+Before you can transfer your registration, your domain must be [active on Cloudflare](/dns/zone-setups/full-setup/). This is what allows Cloudflare to protect your site with performance and security features during and after the transfer. You will not be able to enter an authorization code or proceed with the transfer until this step is complete.
 
 ### Disable DNSSEC
 
@@ -60,43 +64,17 @@ If DNSSEC is enabled at your current registrar, disable it before you change nam
 
 **At your current registrar:**
 
-1. Check your domain settings for DNSSEC or DS records. If there are none, DNSSEC is not active and you can skip to [Add your domain](#add-your-domain).
+1. Check your domain settings for DNSSEC or DS records. If there are none, DNSSEC is not active and you can skip to [Add your domain](#add-your-domain-and-update-your-nameservers).
 2. Remove or disable DNSSEC (sometimes labeled "DS records").
 3. Wait at least 24 hours for the change to propagate before changing nameservers.
 
-<Details header="DNSSEC instructions for specific registrars">
-
-This is not an exhaustive list, but the following links may be helpful:
-
-- [DNSimple](https://support.dnsimple.com/articles/cloudflare-ds-record/)
-- [DreamHost](https://help.dreamhost.com/hc/en-us/articles/219539467)
-- [Dynadot](https://www.dynadot.com/help/question/set-DNSSEC)
-- [Enom](https://support.enom.com/support/solutions/articles/201000065386)
-- [Gandi](https://docs.gandi.net/en/domain_names/advanced_users/dnssec.html)
-- [GoDaddy](https://www.godaddy.com/help/add-a-ds-record-23865)
-- [Hover](https://support.hover.com/support/solutions/articles/201000064716)
-- [Name.com](https://www.name.com/support/articles/205439058-managing-dnssec)
-- [Namecheap](https://www.namecheap.com/support/knowledgebase/article.aspx/9722/2232/managing-dnssec-for-domains-pointed-to-custom-dns/)
-- [Squarespace](https://support.squarespace.com/hc/articles/4404183898125-Nameservers-and-DNSSEC-for-Squarespace-managed-domains#toc-dnssec)
-- [Porkbun](https://kb.porkbun.com/article/93-how-to-install-dnssec) (do not fill out **keyData**)
-
-</Details>
+<Render file="dnssec-providers" product="dns" />
 
 After your transfer completes, you can re-enable DNSSEC through Cloudflare with one click. Refer to [Enable DNSSEC](/dns/dnssec/#1-activate-dnssec-in-cloudflare).
 
-### Add your domain
+### Add your domain and update your nameservers
 
-**In the Cloudflare dashboard:**
-
-1. [Add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account.
-2. [Review your DNS records](/dns/zone-setups/full-setup/setup/#review-dns-records). Cloudflare scans for common records automatically, but the scan is not guaranteed to find all existing records. Compare the results against your current DNS configuration to avoid downtime.
-3. Cloudflare will assign you two nameservers (for example, `ada.ns.cloudflare.com` and `paul.ns.cloudflare.com`).
-
-### Update your nameservers
-
-**At your current registrar:**
-
-[Update your domain nameservers](/dns/nameservers/update-nameservers/) to the Cloudflare nameservers assigned in the previous step.
+Follow the steps in [Set up Cloudflare DNS](/dns/zone-setups/full-setup/setup/) to add your domain, review your DNS records, and get your assigned nameservers. Then [update the nameservers](/dns/nameservers/update-nameservers/) at your current registrar to the ones Cloudflare assigned.
 
 <Details header="Nameserver instructions for popular registrars">
 
@@ -133,7 +111,7 @@ Once your domain is active on Cloudflare, you can transfer the registration. Thi
 
 **At your current registrar:**
 
-Registrars apply a lock (sometimes called registrar lock, domain lock, or transfer lock) to prevent unauthorized transfers. In WHOIS, this appears as `clientTransferProhibited`. Remove this lock so Cloudflare can process the transfer.
+Remove the lock on your domain so Cloudflare can process the transfer. Most registrars apply a lock by default (sometimes called registrar lock, domain lock, or transfer lock) to prevent unauthorized transfers. In WHOIS, this appears as `clientTransferProhibited`.
 
 :::note
 Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your domain still shows as locked after you have disabled one, check for additional lock settings.
@@ -175,7 +153,7 @@ Every domain transfer adds one year to your registration. However, domain regist
 **When a transfer may be rejected:**
 
 - Your domain already has 9 or more years of registration remaining, and adding one year would exceed the 10-year limit (or the 5-year limit for `.co`).
-- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year.
+- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year. For example, if `example.com` expires on December 10, you renew it on December 20 (extending it to December 20 of the following year), and then transfer to Cloudflare on December 30 — the transfer is within 45 days of the original expiration, so the registry may not add an additional year. Your expiration date would remain December 20 of the following year, meaning you effectively paid twice for the same year. If this happens, you are entitled to request a refund from your previous registrar under ICANN rules.
 
 **TLD-specific requirements:**
 

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -9,17 +9,15 @@ description: >-
 
 import { DashButton, Details, Render } from "~/components";
 
-Transferring a domain moves your registration from your current registrar to Cloudflare.
+Transferring a domain moves your registration from your current registrar to Cloudflare. The process takes about 30 minutes of active work, but the full transfer completes over 3-5 business days. Each transfer adds one year to your domain registration at Cloudflare's at-cost price.
 
-- **Active work:** About 30 minutes.
-- **Total time:** Around 5 business days. Your current registrar has up to 5 days to release the domain and DNS changes take time to propagate.
-- **Cost:** One year of registration at Cloudflare's at-cost price, added to your current expiration date.
-
-Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare).
+**Cloudflare works differently from most registrars.** You cannot enter an authorization code right away. Instead, Cloudflare requires you to add your domain and point your nameservers to Cloudflare first, so your site benefits from Cloudflare performance and security features from the moment the transfer begins. This is covered in [step 1](#1-add-your-domain-to-cloudflare) below.
 
 :::note
-You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
 :::
+
+---
 
 <Details header="Before you begin">
 
@@ -30,15 +28,23 @@ Confirm the following before you start:
 - Your domain was registered at least 60 days ago and has not been transferred in the last 60 days (ICANN requirement).
 - You have not changed your registrant name, organization, or email address in the last 60 days. Under ICANN rules, changes to these fields trigger a 60-day transfer lock. Some registrars let you opt out of this lock during the change, but not all do.
 - Your account at your current registrar is active. If your domain has expired, renew it at your current registrar first.
-
-:::note
-If your domain recently expired and you renewed it, wait at least 45 days after the original expiration date before transferring. Otherwise, the registry may not add the extra year. For details, refer to [Why did my domain's expiration date change?](/registrar/faq/#my-domains-registration-was-not-extended-by-one-year-after-transferring-to-cloudflare).
-:::
-
-- Your domain uses only standard characters (letters, numbers, hyphens). Cloudflare does not support domains with non-Latin characters (for example, `例え.jp`).
+- Your domain is not an internationalized domain name (IDN). Cloudflare does not currently support IDNs.
 - If you are transferring a `.us` domain, refer to [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).
 - If you are transferring multiple domains, notify your bank to prevent fraud alerts on multiple charges.
-- Cloudflare Registrar requires your domain to use Cloudflare for [authoritative DNS](/dns/zone-setups/full-setup/) (full setup). You cannot use another DNS provider while registered with Cloudflare.
+
+Cloudflare Registrar requires your domain to use Cloudflare for [authoritative DNS](/dns/zone-setups/full-setup/) (full setup). You cannot use another DNS provider while registered with Cloudflare.
+
+</Details>
+
+<Details header="Restrictions" id="restrictions">
+
+Domains with any of the following statuses cannot be transferred: `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod`. Domains that are locked (`clientTransferProhibited`) will not appear as available for transfer until you unlock them at your current registrar.
+
+If your domain appears as available for transfer in the Cloudflare dashboard, these restrictions have already been checked.
+
+:::caution
+If you renew an expired domain and then transfer it within 45 days of the original expiration date, the registry may not add the extra year. Refer to [Registration limits and the one-year extension](#enter-your-authorization-code-and-confirm-payment) for details.
+:::
 
 </Details>
 
@@ -46,7 +52,7 @@ If your domain recently expired and you renewed it, wait at least 45 days after 
 
 ## 1. Add your domain to Cloudflare
 
-Before you can transfer your registration, your domain must be [active on Cloudflare](/dns/zone-setups/full-setup/). This is what allows Cloudflare to protect your site with performance and security features during and after the transfer. You will not be able to enter an authorization code or proceed with the transfer until this step is complete.
+Before you can transfer your registration, your domain must be active on Cloudflare. This is what allows Cloudflare to protect your site with performance and security features during and after the transfer. You will not be able to enter an authorization code or proceed with the transfer until this step is complete.
 
 ### Disable DNSSEC
 
@@ -54,17 +60,43 @@ If DNSSEC is enabled at your current registrar, disable it before you change nam
 
 **At your current registrar:**
 
-1. Check your domain settings for DNSSEC or DS records. If there are none, DNSSEC is not active and you can skip to [Add your domain](#add-your-domain-and-update-your-nameservers).
+1. Check your domain settings for DNSSEC or DS records. If there are none, DNSSEC is not active and you can skip to [Add your domain](#add-your-domain).
 2. Remove or disable DNSSEC (sometimes labeled "DS records").
 3. Wait at least 24 hours for the change to propagate before changing nameservers.
 
-<Render file="dnssec-providers" product="dns" />
+<Details header="DNSSEC instructions for specific registrars">
+
+This is not an exhaustive list, but the following links may be helpful:
+
+- [DNSimple](https://support.dnsimple.com/articles/cloudflare-ds-record/)
+- [DreamHost](https://help.dreamhost.com/hc/en-us/articles/219539467)
+- [Dynadot](https://www.dynadot.com/help/question/set-DNSSEC)
+- [Enom](https://support.enom.com/support/solutions/articles/201000065386)
+- [Gandi](https://docs.gandi.net/en/domain_names/advanced_users/dnssec.html)
+- [GoDaddy](https://www.godaddy.com/help/add-a-ds-record-23865)
+- [Hover](https://support.hover.com/support/solutions/articles/201000064716)
+- [Name.com](https://www.name.com/support/articles/205439058-managing-dnssec)
+- [Namecheap](https://www.namecheap.com/support/knowledgebase/article.aspx/9722/2232/managing-dnssec-for-domains-pointed-to-custom-dns/)
+- [Squarespace](https://support.squarespace.com/hc/articles/4404183898125-Nameservers-and-DNSSEC-for-Squarespace-managed-domains#toc-dnssec)
+- [Porkbun](https://kb.porkbun.com/article/93-how-to-install-dnssec) (do not fill out **keyData**)
+
+</Details>
 
 After your transfer completes, you can re-enable DNSSEC through Cloudflare with one click. Refer to [Enable DNSSEC](/dns/dnssec/#1-activate-dnssec-in-cloudflare).
 
-### Add your domain and update your nameservers
+### Add your domain
 
-Follow the steps in [Set up Cloudflare DNS](/dns/zone-setups/full-setup/setup/) to add your domain, review your DNS records, and get your assigned nameservers. Then [update the nameservers](/dns/nameservers/update-nameservers/) at your current registrar to the ones Cloudflare assigned.
+**In the Cloudflare dashboard:**
+
+1. [Add your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account.
+2. [Review your DNS records](/dns/zone-setups/full-setup/setup/#review-dns-records). Cloudflare scans for common records automatically, but the scan is not guaranteed to find all existing records. Compare the results against your current DNS configuration to avoid downtime.
+3. Cloudflare will assign you two nameservers (for example, `ada.ns.cloudflare.com` and `paul.ns.cloudflare.com`).
+
+### Update your nameservers
+
+**At your current registrar:**
+
+[Update your domain nameservers](/dns/nameservers/update-nameservers/) to the Cloudflare nameservers assigned in the previous step.
 
 <Details header="Nameserver instructions for popular registrars">
 
@@ -85,7 +117,7 @@ Each registrar has a different interface for updating nameservers. These links e
 
 Wait for your domain status to change from **Pending** to **Active**. This usually takes a few minutes but can take up to 24 hours.
 
-:::note
+:::caution
 You cannot proceed with the transfer until your domain shows **Active** status. The Transfer Domains page will not let you enter an authorization code while the zone is still **Pending**.
 :::
 
@@ -101,7 +133,7 @@ Once your domain is active on Cloudflare, you can transfer the registration. Thi
 
 **At your current registrar:**
 
-Remove the lock on your domain so Cloudflare can process the transfer. Most registrars apply a lock by default (sometimes called registrar lock, domain lock, or transfer lock) to prevent unauthorized transfers. In WHOIS, this appears as `clientTransferProhibited`.
+Registrars apply a lock (sometimes called registrar lock, domain lock, or transfer lock) to prevent unauthorized transfers. In WHOIS, this appears as `clientTransferProhibited`. Remove this lock so Cloudflare can process the transfer.
 
 :::note
 Some registrars have multiple lock types (domain lock, transfer lock, privacy lock) that must each be disabled separately. If your domain still shows as locked after you have disabled one, check for additional lock settings.
@@ -119,6 +151,8 @@ Authorization codes expire within 5-14 days depending on the registrar. Some reg
 
 **In the Cloudflare dashboard:**
 
+Go to the **Transfer Domains** page.
+
 <DashButton url="/?to=/:account/registrar/transfer" />
 
 Select your domain and enter the authorization code. The page will show the transfer price, which includes a one-year registration extension from your current expiration date. This is an ICANN requirement — every transfer extends your registration by one year.
@@ -129,7 +163,44 @@ If you do not have a payment method on file, add one before proceeding.
 Verify your payment method is valid before submitting. A payment failure after submitting the authorization code can leave the transfer in a partially started state.
 :::
 
-For information about registration limits and the one-year extension, refer to [Transfer rejected due to registration limits](/registrar/troubleshooting/#transfer-rejected-due-to-registration-limits).
+<Details header="Registration limits and the one-year extension">
+
+Every domain transfer adds one year to your registration. However, domain registries enforce maximum registration periods, which can cause a transfer to be rejected or the extra year to not be added.
+
+**Maximum registration periods:**
+
+- Most TLDs (such as `.com`, `.net`, `.org`) allow up to 10 years of registration.
+- `.co` domains have a maximum registration period of 5 years.
+
+**When a transfer may be rejected:**
+
+- Your domain already has 9 or more years of registration remaining, and adding one year would exceed the 10-year limit (or the 5-year limit for `.co`).
+- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year.
+
+**TLD-specific requirements:**
+
+- `.ai` domains require a minimum 2-year registration for transfers.
+- `.uk` domains do not receive an additional year when transferred.
+
+**What you can do if your transfer is rejected:**
+
+- If your domain has too many years remaining, wait until the total registration period (current time remaining plus one year) would not exceed the maximum — 10 years for most TLDs, or 5 years for `.co`. For example, a `.com` domain with 9 years and 6 months remaining cannot be transferred until at least 6 months have passed.
+- If your domain is near expiration, renew it at your current registrar first, then transfer after the renewal is confirmed.
+
+For more details, refer to [Transfer rejected due to registration limits](/registrar/troubleshooting/#transfer-rejected-due-to-registration-limits).
+
+</Details>
+
+<Details header="Why is my domain not available for transfer?">
+
+Your domain may not appear on the Transfer Domains page if:
+
+- You have not [added your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account, or it is still in **Pending** status.
+- The domain was registered or previously transferred in the last 60 days.
+- Cloudflare does not support the TLD.
+- The domain has a status that does not allow transfers (such as `serverHold` or `pendingDelete`).
+
+</Details>
 
 ### Confirm your contact information
 
@@ -149,7 +220,7 @@ After entering the contact information, agree to the domain registration terms o
 
 After you submit the transfer, Cloudflare will begin processing it and send a Form of Authorization (FOA) email to the registrant if the information is available in the public WHOIS database.
 
-Your current registrar will email you confirming the transfer or asking for your approval. Afterwards, most registrars process it within 5 business days (but some TLDs, such as `.mx`, can take up to 10 business days).
+Your current registrar will also email you to confirm the transfer request. Most registrars include a link to approve the transfer. Selecting that link speeds up the process. If you do not act on the email, most registrars will release the domain after 5 business days. Some TLDs (such as `.mx`) can take up to 10 business days. You can also approve the transfer from within your current registrar dashboard.
 
 :::note
 Registrants transferring a `.us` domain will always receive a FOA email.

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -9,7 +9,7 @@ description: >-
 
 import { DashButton, Details, Render } from "~/components";
 
-Transferring a domain moves your registration from your current registrar to Cloudflare. The process takes about 30 minutes of active work, but the full transfer completes over 3-5 business days. Each transfer adds one year to your domain registration at Cloudflare's at-cost price.
+Transferring a domain moves your registration from your current registrar to Cloudflare. The process takes about 30 minutes of active work, but the full transfer usually takes 3-5 business days to complete because your current registrar has up to 5 days to release the domain, and changes to your domain settings take time to take effect across the internet. Each transfer adds one year to your domain registration at Cloudflare's at-cost price.
 
 **Cloudflare works differently from most registrars.** You cannot enter an authorization code right away. Instead, Cloudflare requires you to add your domain and point your nameservers to Cloudflare first, so your site benefits from Cloudflare performance and security features from the moment the transfer begins. This is covered in [step 1](#1-add-your-domain-to-cloudflare) below.
 

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -12,10 +12,10 @@ import { DashButton, Details, Render } from "~/components";
 Transferring a domain moves your registration from your current registrar to Cloudflare.
 
 - **Active work:** About 30 minutes.
-- **Total time:** Usually 3-5 business days, because your current registrar has up to 5 days to release the domain and changes to your domain settings take time to take effect across the internet.
+- **Total time:** Around 5 business days. Your current registrar has up to 5 days to release the domain and DNS changes take time to propagate.
 - **Cost:** One year of registration at Cloudflare's at-cost price, added to your current expiration date.
 
-Before you can transfer, you must [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare) and update your nameservers. Only then can you enter an authorization code and start the transfer. This is because Cloudflare applies performance and security features to your site before the transfer begins.
+Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare).
 
 :::note
 If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
@@ -32,23 +32,15 @@ Confirm the following before you start:
 - Your domain was registered at least 60 days ago and has not been transferred in the last 60 days (ICANN requirement).
 - You have not changed your registrant name, organization, or email address in the last 60 days. Under ICANN rules, changes to these fields trigger a 60-day transfer lock. Some registrars let you opt out of this lock during the change, but not all do.
 - Your account at your current registrar is active. If your domain has expired, renew it at your current registrar first.
+
+:::note
+If your domain recently expired and you renewed it, wait at least 45 days after the original expiration date before transferring. Otherwise, the registry may not add the extra year. For details, refer to [Why did my domain's expiration date change?](/registrar/faq/#my-domains-registration-was-not-extended-by-one-year-after-transferring-to-cloudflare).
+:::
+
 - Your domain uses only standard characters (letters, numbers, hyphens). Cloudflare does not support domains with non-Latin characters (for example, `例え.jp`).
 - If you are transferring a `.us` domain, refer to [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).
 - If you are transferring multiple domains, notify your bank to prevent fraud alerts on multiple charges.
-
-Cloudflare Registrar requires your domain to use Cloudflare for [authoritative DNS](/dns/zone-setups/full-setup/) (full setup). You cannot use another DNS provider while registered with Cloudflare.
-
-</Details>
-
-<Details header="Restrictions" id="restrictions">
-
-If your domain appears as available for transfer in the Cloudflare dashboard, these restrictions have already been checked.
-
-For reference, domains with any of the following statuses cannot be transferred: `serverHold`, `serverTransferProhibited`, `pendingDelete`, `pendingTransfer`, or `RedemptionPeriod`. Domains that are locked (`clientTransferProhibited`) will not appear as available for transfer until you unlock them at your current registrar.
-
-:::caution
-If you renew an expired domain and then transfer it within 45 days of the original expiration date, the registry may not add the extra year. Refer to [Registration limits and the one-year extension](#enter-your-authorization-code-and-confirm-payment) for details.
-:::
+- Cloudflare Registrar requires your domain to use Cloudflare for [authoritative DNS](/dns/zone-setups/full-setup/) (full setup). You cannot use another DNS provider while registered with Cloudflare.
 
 </Details>
 
@@ -95,7 +87,7 @@ Each registrar has a different interface for updating nameservers. These links e
 
 Wait for your domain status to change from **Pending** to **Active**. This usually takes a few minutes but can take up to 24 hours.
 
-:::caution
+:::note
 You cannot proceed with the transfer until your domain shows **Active** status. The Transfer Domains page will not let you enter an authorization code while the zone is still **Pending**.
 :::
 
@@ -129,8 +121,6 @@ Authorization codes expire within 5-14 days depending on the registrar. Some reg
 
 **In the Cloudflare dashboard:**
 
-Go to the **Transfer Domains** page.
-
 <DashButton url="/?to=/:account/registrar/transfer" />
 
 Select your domain and enter the authorization code. The page will show the transfer price, which includes a one-year registration extension from your current expiration date. This is an ICANN requirement — every transfer extends your registration by one year.
@@ -141,44 +131,7 @@ If you do not have a payment method on file, add one before proceeding.
 Verify your payment method is valid before submitting. A payment failure after submitting the authorization code can leave the transfer in a partially started state.
 :::
 
-<Details header="Registration limits and the one-year extension">
-
-Every domain transfer adds one year to your registration. However, domain registries enforce maximum registration periods, which can cause a transfer to be rejected or the extra year to not be added.
-
-**Maximum registration periods:**
-
-- Most TLDs (such as `.com`, `.net`, `.org`) allow up to 10 years of registration.
-- `.co` domains have a maximum registration period of 5 years.
-
-**When a transfer may be rejected:**
-
-- Your domain already has 9 or more years of registration remaining, and adding one year would exceed the 10-year limit (or the 5-year limit for `.co`).
-- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year. For example, if `example.com` expires on December 10, you renew it on December 20 (extending it to December 20 of the following year), and then transfer to Cloudflare on December 30 — the transfer is within 45 days of the original expiration, so the registry may not add an additional year. Your expiration date would remain December 20 of the following year, meaning you effectively paid twice for the same year. If this happens, you are entitled to request a refund from your previous registrar under ICANN rules.
-
-**TLD-specific requirements:**
-
-- `.ai` domains require a minimum 2-year registration for transfers.
-- `.uk` domains do not receive an additional year when transferred.
-
-**What you can do if your transfer is rejected:**
-
-- If your domain has too many years remaining, wait until the total registration period (current time remaining plus one year) would not exceed the maximum — 10 years for most TLDs, or 5 years for `.co`. For example, a `.com` domain with 9 years and 6 months remaining cannot be transferred until at least 6 months have passed.
-- If your domain is near expiration, renew it at your current registrar first, then transfer after the renewal is confirmed.
-
-For more details, refer to [Transfer rejected due to registration limits](/registrar/troubleshooting/#transfer-rejected-due-to-registration-limits).
-
-</Details>
-
-<Details header="Why is my domain not available for transfer?">
-
-Your domain may not appear on the Transfer Domains page if:
-
-- You have not [added your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account, or it is still in **Pending** status.
-- The domain was registered or previously transferred in the last 60 days.
-- Cloudflare does not support the TLD.
-- The domain has a status that does not allow transfers (such as `serverHold` or `pendingDelete`).
-
-</Details>
+For information about registration limits and the one-year extension, refer to [Transfer rejected due to registration limits](/registrar/troubleshooting/#transfer-rejected-due-to-registration-limits).
 
 ### Confirm your contact information
 
@@ -198,7 +151,7 @@ After entering the contact information, agree to the domain registration terms o
 
 After you submit the transfer, Cloudflare will begin processing it and send a Form of Authorization (FOA) email to the registrant if the information is available in the public WHOIS database.
 
-Your current registrar will also email you to confirm the transfer request. Most registrars include a link to approve the transfer. Selecting that link speeds up the process. If you do not act on the email, most registrars will release the domain after 5 business days. Some TLDs (such as `.mx`) can take up to 10 business days. You can also approve the transfer from within your current registrar dashboard.
+Your current registrar will email you confirming the transfer or asking for your approval. Afterwards, most registrars process it within 5 business days (but some TLDs, such as `.mx`, can take up to 10 business days).
 
 :::note
 Registrants transferring a `.us` domain will always receive a FOA email.

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -15,11 +15,15 @@ Transferring a domain moves your registration from your current registrar to Clo
 - **Total time:** Up to 10 days, depending on your registrar.
 - **Cost:** Cloudflare domains are at-cost with no markup fees. Most transfers include a one-year extension from your current expiration date. Some country-code domains (such as `.uk`) have no transfer fee.
 
-Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare).
+:::note
+Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare). You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+:::
 
 :::note
-You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+If your domain recently expired and you renewed it, wait at least 45 days after the original expiration date before transferring. Otherwise, the registry may not add the extra year. For details, refer to [Why did my domain's expiration date change?](/registrar/faq/#my-domains-registration-was-not-extended-by-one-year-after-transferring-to-cloudflare).
 :::
+
+<Render file="icann-unverified-email" product="registrar" />
 
 ---
 
@@ -32,10 +36,6 @@ Confirm the following before you start:
 - Your domain was registered at least 60 days ago and has not been transferred in the last 60 days (ICANN requirement).
 - You have not changed your registrant name, organization, or email address in the last 60 days. Under ICANN rules, changes to these fields trigger a 60-day transfer lock. Some registrars let you opt out of this lock during the change, but not all do.
 - Your account at your current registrar is active. If your domain has expired, renew it at your current registrar first.
-
-:::note
-Most transfers add one year to your registration. [Learn when this does not apply](/registrar/faq/#my-domains-registration-was-not-extended-by-one-year-after-transferring-to-cloudflare).
-:::
 
 - Your domain uses only standard characters (letters, numbers, hyphens). Cloudflare does not support domains with non-Latin characters (for example, `例え.jp`).
 - If you are transferring a `.us` domain, refer to [Additional requirements for .US domains](/registrar/top-level-domains/us-domains/).

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -24,13 +24,13 @@ Active DNSSEC at your current registrar will block the transfer. Disable DNSSEC 
 
 ## Authorization code is invalid or expired
 
-Authorization codes typically expire within 5-14 days depending on your registrar. If your code is rejected, request a fresh one from your current registrar. Check for trailing spaces or line breaks when copy-pasting the code. Some registrars issue a new code each time one is requested, which invalidates the previous code.
+Authorization codes are usually only valid for a limited period. If your code is rejected, request a fresh one from your current registrar. Check for trailing spaces or line breaks when copy-pasting the code.
 
 ## Cannot find where to enter your authorization code
 
 Unlike some registrars, Cloudflare does not allow you to submit an authorization code upfront. Cloudflare requires your domain to be active on its network first so that your site benefits from Cloudflare performance and security features from the moment the transfer begins. You must first [add your domain](/fundamentals/manage-domains/add-site/) to Cloudflare, [update your nameservers](/dns/nameservers/update-nameservers/), and wait for the zone to show **Active** status in the Cloudflare dashboard. Only then will the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page allow you to enter your code.
 
-If your zone is still **Pending**, verify that you updated nameservers correctly at your current registrar and wait up to 24 hours. If you already have an authorization code, keep in mind that most codes expire within 5-14 days depending on the registrar. If your code expires while you wait for the zone to activate, request a new one from your current registrar before proceeding.
+If your zone is still **Pending**, verify that you updated nameservers correctly at your current registrar and wait up to 24 hours. If you already have an authorization code, keep in mind that most codes are only valid for a limited period. If your code expires while you wait for the zone to activate, request a new one from your current registrar before proceeding.
 
 ## Transfer rejected
 
@@ -39,6 +39,7 @@ Your transfer has been rejected by your previous registrar. There are several re
 - You actively rejected the transfer request in the email you received from your registrar or on your registrar interface.
 - Your registrar determined the domain is not eligible for transfer.
 - Some registrars allow customers to enable a setting to reject all transfer requests.
+- If you are transferring from GoDaddy, domain forwarding may still be active. GoDaddy will reject the transfer until it is disabled.
 - In some instances, registrars may reject the transfer if they suspect malicious behavior.
 
 You will need to restart the transfer and approve the request or contact your current registrar to resolve this issue.

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -103,6 +103,14 @@ Your domain may not appear on the [Transfer Domains](https://dash.cloudflare.com
 
 Some website builder platforms (such as Block, Shopify, Squarespace, and Wix) do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer from these platforms is not possible. For the recommended workaround, refer to [Transfer from website builders](/registrar/get-started/transfer-domain-to-cloudflare/#transfer-from-website-builders).
 
+## Email verification required
+
+Cloudflare may send a verification email to your registrant contact email address when you register or transfer a domain, or when you update your registrant email. Per ICANN requirements, if the registrant email is not verified within 15 days, a hold is placed on the domain and nameservers are replaced with a parking server until verification is complete. After successful verification, nameservers are automatically restored.
+
+Verification is triggered when your registrant contact email differs from your verified Cloudflare account email.
+
+Some TLDs — including `.mx`, `.nz`, and `.ca` — may send verification through a third-party service. In these cases, the verification email will come from `noreply@emailverification.info` rather than Cloudflare. Check your spam folder if you do not receive it.
+
 ## Restart your transfer
 
 :::note

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -55,8 +55,9 @@ Domain registries enforce maximum registration periods. Because every transfer a
 **Common reasons for rejection:**
 
 - Your domain already has 9 or more years of registration remaining. Adding one year would exceed the 10-year limit (or 5-year limit for `.co`).
-- Your domain was transferred or renewed within 45 days of its expiration date. In this case, the registry may not add the extra year, even if the transfer itself succeeds.
+- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year. For example, if `example.com` expires on December 10, you renew it on December 20 (extending it to December 20 of the following year), and then transfer to Cloudflare on December 30 — the transfer is within 45 days of the original expiration, so the registry may not add an additional year. Your expiration date would remain December 20 of the following year, meaning you effectively paid twice for the same year. If this happens, you are entitled to request a refund from your previous registrar under ICANN rules.
 - Your domain does not meet a TLD-specific minimum. For example, `.ai` domains require a minimum 2-year registration for transfers.
+- `.uk` domains do not receive an additional year when transferred.
 
 **What you can do:**
 
@@ -87,6 +88,15 @@ If your payment method was declined after submitting the authorization code, the
 ## Transfer is taking too long
 
 Domain transfers typically take 3-5 business days. Some TLDs (such as `.mx`) can take up to 10 days. You can speed up the process by approving the transfer at your current registrar when you receive the confirmation email. If the transfer has been stuck beyond these timeframes with no identifiable issue, contact your current registrar to confirm there are no holds or restrictions on their end.
+
+## Domain not available for transfer
+
+Your domain may not appear on the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page if:
+
+- You have not [added your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account, or it is still in **Pending** status. Your domain must be **Active** before you can transfer it.
+- The domain was registered or previously transferred in the last 60 days (ICANN requirement).
+- Cloudflare does not support the TLD.
+- The domain has a status that blocks transfers (such as `serverHold` or `pendingDelete`). Refer to [Domain is in a restricted status](#domain-is-in-a-restricted-status) for details.
 
 ## Cannot update nameservers at your current registrar
 

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -55,9 +55,8 @@ Domain registries enforce maximum registration periods. Because every transfer a
 **Common reasons for rejection:**
 
 - Your domain already has 9 or more years of registration remaining. Adding one year would exceed the 10-year limit (or 5-year limit for `.co`).
-- Your domain was renewed after expiring and then transferred within 45 days of the original expiration date. In this case, the registry may not add the extra year. For example, if `example.com` expires on December 10, you renew it on December 20 (extending it to December 20 of the following year), and then transfer to Cloudflare on December 30 — the transfer is within 45 days of the original expiration, so the registry may not add an additional year. Your expiration date would remain December 20 of the following year, meaning you effectively paid twice for the same year. If this happens, you are entitled to request a refund from your previous registrar under ICANN rules.
+- Your domain was transferred or renewed within 45 days of its expiration date. In this case, the registry may not add the extra year, even if the transfer itself succeeds.
 - Your domain does not meet a TLD-specific minimum. For example, `.ai` domains require a minimum 2-year registration for transfers.
-- `.uk` domains do not receive an additional year when transferred.
 
 **What you can do:**
 
@@ -89,15 +88,6 @@ If your payment method was declined after submitting the authorization code, the
 
 Domain transfers typically take 3-5 business days. Some TLDs (such as `.mx`) can take up to 10 days. You can speed up the process by approving the transfer at your current registrar when you receive the confirmation email. If the transfer has been stuck beyond these timeframes with no identifiable issue, contact your current registrar to confirm there are no holds or restrictions on their end.
 
-## Domain not available for transfer
-
-Your domain may not appear on the [Transfer Domains](https://dash.cloudflare.com/?to=/:account/registrar/transfer) page if:
-
-- You have not [added your domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account, or it is still in **Pending** status. Your domain must be **Active** before you can transfer it.
-- The domain was registered or previously transferred in the last 60 days (ICANN requirement).
-- Cloudflare does not support the TLD.
-- The domain has a status that blocks transfers (such as `serverHold` or `pendingDelete`). Refer to [Domain is in a restricted status](#domain-is-in-a-restricted-status) for details.
-
 ## Cannot update nameservers at your current registrar
 
 Some website builder platforms (such as Block, Shopify, Squarespace, and Wix) do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer from these platforms is not possible. For the recommended workaround, refer to [Transfer from website builders](/registrar/get-started/transfer-domain-to-cloudflare/#transfer-from-website-builders).
@@ -114,7 +104,3 @@ This solution does not apply to `.uk` domains.
 
 2. Find the correct domain and select **Manage**.
 3. Select **Cancel Transfer and Retry**. After you initiate the retry, you must re-enter your auth code and confirm your WHOIS information.
-
-## Account recovery
-
-If you are locked out of the Cloudflare account you used to register your domain, refer to [Account recovery](/fundamentals/user-profiles/account-recovery/).

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -39,7 +39,7 @@ Your transfer has been rejected by your previous registrar. There are several re
 - You actively rejected the transfer request in the email you received from your registrar or on your registrar interface.
 - Your registrar determined the domain is not eligible for transfer.
 - Some registrars allow customers to enable a setting to reject all transfer requests.
-- If you are transferring from GoDaddy, domain forwarding may still be active. GoDaddy will reject the transfer until it is disabled.
+- If you are transferring from GoDaddy, make sure Domain Privacy and Domain Protection are fully disabled. GoDaddy may reject the transfer if either is still active.
 - In some instances, registrars may reject the transfer if they suspect malicious behavior.
 
 You will need to restart the transfer and approve the request or contact your current registrar to resolve this issue.


### PR DESCRIPTION
## Summary

Addresses Jared Weeks' review feedback on the recently rewritten domain transfer guide. Four issues fixed:

1. **Auth code expiration** — Removed unverifiable "5-14 days" claim. Replaced with "usually only valid for a limited period." Trimmed redundant sentences about code invalidation.
2. **GoDaddy domain forwarding** — Added note to disable domain forwarding before transferring from GoDaddy (causes transfer rejection). Added to both the transfer guide and troubleshooting page.
3. **ICANN one-year extension** — Qualified the blanket "ICANN requirement" language to clarify it applies to gTLD transfers only. Country-code domains (like `.uk`) follow their own registry policies.
4. **Cost bullet** — Rewrote to highlight Cloudflare's at-cost pricing with no markup. Noted that some country-code domains have no transfer fee.

Also updated the "Total time" estimate from "Around 5 business days" to "Up to 10 days, depending on your registrar."

## Files changed

- `src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx` — 5 edits
- `src/content/docs/registrar/troubleshooting.mdx` — 3 edits