### PR TITLE
Add Sandbox request proxying guide

### DIFF
--- a/src/content/docs/sandbox/concepts/security.mdx
+++ b/src/content/docs/sandbox/concepts/security.mdx
@@ -135,6 +135,20 @@ try {
 }
 ```
 
+## Proxying external API requests
+
+Passing credentials directly to a sandbox — via environment variables or files — means the sandbox process holds a live credential that any code running inside it can read. A Worker proxy removes that exposure by keeping credentials exclusively in the Worker and giving the sandbox a short-lived JWT instead.
+
+The flow works as follows:
+
+```
+Sandbox (short-lived JWT) → Worker proxy (validates JWT, injects real credentials) → External API
+```
+
+The sandbox never sees the real credential. If the JWT is compromised, it expires after a short window and cannot be reused.
+
+This pattern is useful when accessing GitHub for private repository operations, AI services, or object storage where you want to keep credentials out of the container entirely. Refer to [Proxy requests to external APIs](/sandbox/guides/proxy-requests/) for a complete implementation.
+
 ## What the SDK protects against
 
 - Sandbox-to-sandbox access (VM isolation)

--- a/src/content/docs/sandbox/configuration/environment-variables.mdx
+++ b/src/content/docs/sandbox/configuration/environment-variables.mdx
@@ -375,3 +375,4 @@ await sandbox.exec("node app.js", {
 - [Secrets](/workers/configuration/secrets/) - Managing sensitive data
 - [Sessions API](/sandbox/api/sessions/) - Session-level environment variables
 - [Security model](/sandbox/concepts/security/) - Understanding data isolation
+- [Proxy requests to external APIs](/sandbox/guides/proxy-requests/) - Keep credentials out of the sandbox entirely using a Worker proxy

--- a/src/content/docs/sandbox/guides/git-workflows.mdx
+++ b/src/content/docs/sandbox/guides/git-workflows.mdx
@@ -51,6 +51,10 @@ await sandbox.gitCheckout(repoUrl);
 ```
 </TypeScriptExample>
 
+:::note[More secure alternative]
+Embedding a token in the URL passes the credential directly into the sandbox. For better access control, use a Worker proxy that validates a short-lived JWT and injects the real token at request time — the sandbox never holds the credential. Refer to [Proxy requests to external APIs](/sandbox/guides/proxy-requests/).
+:::
+
 ## Clone and build
 
 Clone a repository and run build steps:

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -389,3 +389,4 @@ await sandbox.exec('cp', { args: ['/workspace/results.json', '/data/results/outp
 - [Storage API reference](/sandbox/api/storage/) - Full method documentation
 - [Environment variables](/sandbox/configuration/environment-variables/) - Credential configuration
 - [R2 documentation](/r2/) - Learn about Cloudflare R2
+- [Proxy requests to external APIs](/sandbox/guides/proxy-requests/) - Keep R2 credentials out of the sandbox by proxying requests through a Worker

--- a/src/content/docs/sandbox/guides/proxy-requests.mdx
+++ b/src/content/docs/sandbox/guides/proxy-requests.mdx
@@ -189,6 +189,19 @@ response = requests.post(
 
 The real `MY_API_KEY` is never present in the sandbox. The Worker substitutes it transparently.
 
+:::note[Pointing SDKs at the proxy URL]
+Many API clients and SDKs default to the official API base URL. After setting up the proxy, you need to tell the library to send requests to your Worker instead. Most SDKs support an environment variable or constructor option to override the base URL.
+
+For example, the Anthropic SDK reads `ANTHROPIC_BASE_URL`. Pass your proxy URL as that value and the JWT token as the API key:
+
+```bash
+export ANTHROPIC_BASE_URL="$PROXY_BASE/proxy/anthropic"
+export ANTHROPIC_API_KEY="$PROXY_TOKEN"
+```
+
+The SDK then sends all requests to your Worker proxy, which validates the token and forwards them to `api.anthropic.com` with the real key injected. Check the documentation for your API client to find the equivalent base URL setting.
+:::
+
 ## Adding more services
 
 To proxy additional APIs, define another `ServiceConfig` and add it to `createProxyHandler`:

--- a/src/content/docs/sandbox/guides/proxy-requests.mdx
+++ b/src/content/docs/sandbox/guides/proxy-requests.mdx
@@ -1,0 +1,264 @@
+---
+title: Proxy requests to external APIs
+pcx_content_type: how-to
+sidebar:
+  order: 7
+description: Keep credentials secure by routing sandbox requests through a Worker proxy that injects authentication at request time.
+---
+
+import { PackageManagers, TypeScriptExample } from "~/components";
+
+When a sandbox needs to call an external API, you might pass credentials directly into the sandbox process. That approach works, but it means the sandbox holds a live credential that any code running inside it can read, copy, or misuse.
+
+The proxy pattern removes that risk. Your Worker issues a short-lived JWT token to the sandbox. The sandbox uses that token for all API requests, which go to your Worker first. The Worker validates the JWT and injects the real credential before forwarding the request. Real credentials never enter the sandbox.
+
+For a complete multi-service implementation covering GitHub, Anthropic, and R2, refer to the [authentication example](https://github.com/cloudflare/sandbox-sdk/tree/main/examples/authentication).
+
+## How it works
+
+```
+Sandbox (short-lived JWT) → Worker proxy (validates JWT, injects real credential) → External API
+```
+
+The proxy framework routes requests to named services. Each service is a `ServiceConfig` object with three fields:
+
+- **`target`** — Base URL of the external API to proxy to
+- **`validate`** — Extracts the JWT from the incoming request (returns `null` to reject)
+- **`transform`** — Injects the real credential into the forwarded request (or returns a `Response` to short-circuit)
+
+You define only the service-specific logic. The framework handles JWT verification, routing, and error responses.
+
+## When to use this pattern
+
+Use the proxy pattern when you need to:
+
+- Call external APIs from sandboxes without exposing credentials
+- Rotate credentials without reconfiguring sandboxes
+- Restrict what a sandbox can do (for example, limit to specific paths or methods)
+- Share one credential across many sandboxes without each holding a copy
+
+For short-lived or low-risk credentials, [environment variables](/sandbox/configuration/environment-variables/) may be simpler.
+
+## Prerequisites
+
+- A Worker with a Sandbox binding (refer to [Get started](/sandbox/get-started/))
+- The [`jose`](https://github.com/panva/jose) package installed in your Worker project for JWT signing
+
+## 1. Set up secrets
+
+Store the API credential and a secret for signing JWT tokens in your Worker:
+
+```bash
+wrangler secret put MY_API_KEY
+wrangler secret put PROXY_JWT_SECRET
+```
+
+Generate a strong random value for `PROXY_JWT_SECRET`:
+
+```bash
+openssl rand -hex 32
+```
+
+## 2. Install dependencies
+
+<PackageManagers pkg="jose" />
+
+## 3. Copy the proxy framework
+
+The proxy framework is a self-contained module you copy into your project. Download the [`src/proxy/`](https://github.com/cloudflare/sandbox-sdk/tree/main/examples/authentication/src/proxy) directory from the authentication example and place it at `src/proxy/` in your Worker project.
+
+The framework exports:
+
+- **`createProxyHandler`** — Creates the Worker request handler that routes and validates proxy requests
+- **`createProxyToken`** — Issues a signed JWT for a sandbox
+- **`ServiceConfig`** — The interface your service definitions implement
+
+## 4. Define a service
+
+Create a `ServiceConfig` for each external API you want to proxy. This example proxies a generic HTTP API that expects a Bearer token:
+
+<TypeScriptExample>
+```
+import type { ServiceConfig } from '../proxy';
+
+interface Env {
+  MY_API_KEY: string;
+  PROXY_JWT_SECRET: string;
+}
+
+export const myApi: ServiceConfig<Env> = {
+  // All requests to /proxy/myapi/* are forwarded to this base URL
+  target: 'https://api.example.com',
+
+  // Extract the JWT from the Authorization header
+  validate: (req) =>
+    req.headers.get('Authorization')?.replace('Bearer ', '') ?? null,
+
+  // Replace the JWT with the real API key before forwarding
+  transform: async (req, ctx) => {
+    req.headers.set('Authorization', `Bearer ${ctx.env.MY_API_KEY}`);
+    return req;
+  }
+};
+```
+</TypeScriptExample>
+
+The `transform` function receives the outgoing request and a context object containing `ctx.env` (your Worker environment) and `ctx.jwt` (the verified token payload, including `sandboxId`). Return the modified request to forward it, or return a `Response` to short-circuit with an error.
+
+## 5. Wire up the Worker
+
+Register your services with `createProxyHandler` and issue tokens to sandboxes using `createProxyToken`:
+
+<TypeScriptExample>
+```
+import { getSandbox } from '@cloudflare/sandbox';
+import { createProxyHandler, createProxyToken } from './proxy';
+import { myApi } from './services/myapi';
+
+export { Sandbox } from '@cloudflare/sandbox';
+
+interface Env {
+  Sandbox: DurableObjectNamespace;
+  MY_API_KEY: string;
+  PROXY_JWT_SECRET: string;
+}
+
+const proxyHandler = createProxyHandler<Env>({
+  mountPath: '/proxy',
+  jwtSecret: (env) => env.PROXY_JWT_SECRET,
+  services: { myapi: myApi }
+});
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // Route all /proxy/* requests through the proxy handler
+    if (url.pathname.startsWith('/proxy/')) {
+      return proxyHandler(request, env);
+    }
+
+    // Create a sandbox and issue it a short-lived token
+    const sandboxId = 'my-sandbox';
+    const sandbox = getSandbox(env.Sandbox, sandboxId);
+    const token = await createProxyToken({
+      secret: env.PROXY_JWT_SECRET,
+      sandboxId,
+      expiresIn: '15m'
+    });
+
+    const proxyBase = `https://${url.hostname}`;
+
+    // Pass the token and proxy base URL to the sandbox
+    await sandbox.setEnvVars({
+      PROXY_TOKEN: token,
+      PROXY_BASE: proxyBase
+    });
+
+    return Response.json({ message: 'Sandbox ready' });
+  }
+};
+```
+</TypeScriptExample>
+
+The `mountPath` (`/proxy`) and service name (`myapi`) together form the proxy route. A request to `/proxy/myapi/some/path` is validated and forwarded to `https://api.example.com/some/path`.
+
+## 6. Call the proxy from the sandbox
+
+Inside the sandbox, use the `PROXY_TOKEN` and `PROXY_BASE` environment variables to call the proxy. The JWT takes the place of the real credential:
+
+```bash
+curl "$PROXY_BASE/proxy/myapi/v1/endpoint" \
+  -H "Authorization: Bearer $PROXY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"input": "hello"}'
+```
+
+Or from Python running inside the sandbox:
+
+```python
+import os
+import requests
+
+response = requests.post(
+    f"{os.environ['PROXY_BASE']}/proxy/myapi/v1/endpoint",
+    headers={"Authorization": f"Bearer {os.environ['PROXY_TOKEN']}"},
+    json={"input": "hello"}
+)
+```
+
+The real `MY_API_KEY` is never present in the sandbox. The Worker substitutes it transparently.
+
+## Adding more services
+
+To proxy additional APIs, define another `ServiceConfig` and add it to `createProxyHandler`:
+
+<TypeScriptExample>
+```
+export const anotherApi: ServiceConfig<Env> = {
+  target: 'https://api.another-service.com',
+  validate: (req) => req.headers.get('Authorization')?.replace('Bearer ', '') ?? null,
+  transform: async (req, ctx) => {
+    req.headers.set('Authorization', `Bearer ${ctx.env.ANOTHER_API_KEY}`);
+    return req;
+  }
+};
+
+// In your Worker:
+const proxyHandler = createProxyHandler<Env>({
+  mountPath: '/proxy',
+  jwtSecret: (env) => env.PROXY_JWT_SECRET,
+  services: { myapi: myApi, another: anotherApi }
+});
+```
+</TypeScriptExample>
+
+Each service is reachable at `/proxy/<service-name>/*`. The sandbox uses the same JWT token for all of them.
+
+## Troubleshooting
+
+### Proxy returns 401
+
+The JWT is missing, expired, or signed with the wrong secret. Verify that:
+
+- The sandbox is using the token returned by `createProxyToken`, not a hardcoded value
+- The same `PROXY_JWT_SECRET` value is used to create and verify tokens
+- The token has not expired — the default is 15 minutes
+
+To issue a fresh token and pass it to the sandbox:
+
+<TypeScriptExample>
+```
+const freshToken = await createProxyToken({
+  secret: env.PROXY_JWT_SECRET,
+  sandboxId,
+  expiresIn: '15m'
+});
+await sandbox.setEnvVars({ PROXY_TOKEN: freshToken });
+```
+</TypeScriptExample>
+
+### Proxy returns 404 for the service
+
+The service name in the URL must match the key in the `services` object. A request to `/proxy/myapi/...` requires `services: { myapi: ... }`.
+
+### transform returns unexpected results
+
+Log the request URL in `transform` to confirm the path is being rewritten correctly:
+
+<TypeScriptExample>
+```
+transform: async (req, ctx) => {
+  console.log('Proxying to:', req.url);
+  req.headers.set('Authorization', `Bearer ${ctx.env.MY_API_KEY}`);
+  return req;
+}
+```
+</TypeScriptExample>
+
+## Related resources
+
+- [Authentication example](https://github.com/cloudflare/sandbox-sdk/tree/main/examples/authentication) — complete multi-service implementation with GitHub, Anthropic, and R2
+- [Security model](/sandbox/concepts/security/) — how the Sandbox SDK approaches security
+- [Work with Git](/sandbox/guides/git-workflows/) — Git operations in sandboxes
+- [Environment variables](/sandbox/configuration/environment-variables/) — simpler alternative for lower-risk credentials

--- a/src/content/docs/sandbox/index.mdx
+++ b/src/content/docs/sandbox/index.mdx
@@ -254,6 +254,12 @@ Monitor files and directories for changes using native filesystem events. Perfec
 
 </Feature>
 
+<Feature header="Proxy external API requests securely" href="/sandbox/guides/proxy-requests/" cta="Learn about request proxying">
+
+Keep credentials in your Worker while allowing sandboxes to access external APIs. A Worker proxy validates short-lived JWT tokens from the sandbox and injects real credentials at request time.
+
+</Feature>
+
 ---
 
 ## Use Cases


### PR DESCRIPTION
### Summary

We already have an example of how we would go about proxying requests from Sandbox -> Worker to protect credentials [here](https://github.com/cloudflare/sandbox-sdk/tree/main/examples/authentication). We're adding a specific guide for this functionality to make it more discoverable & help explain the concept & usage.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.


Closes: https://github.com/cloudflare/sandbox-sdk/issues/368
