### PR TITLE
[Cloudflare One] Egress Policies ELI5

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -11,7 +11,9 @@ import { Details, Render } from "~/components";
 Only available as an add-on to Zero Trust Enterprise plans.
 :::
 
-Dedicated egress IPs are static IP addresses that can be used to allowlist traffic from your organization. These IPs are unique to your account and are not used by any other customers routing traffic through Cloudflare's network. Each dedicated egress IP consists of an IPv4 address and an IPv6 range that are assigned to a specific Cloudflare data center. At minimum, Cloudflare will provision your account with two dedicated egress IPs corresponding to data centers in two different cities.
+Dedicated egress IPs are static IP addresses that can be used to allowlist traffic from your organization. Third-party services that restrict access by source IP can trust that traffic from your dedicated egress IPs belongs to your organization.
+
+These IPs are unique to your account and are not used by any other customers routing traffic through Cloudflare's network. Each dedicated egress IP consists of an IPv4 address and an IPv6 range that are assigned to a specific Cloudflare data center. At minimum, Cloudflare will provision your account with two dedicated egress IPs corresponding to data centers in two different cities for geographic redundancy.
 
 An account can have any number of additional dedicated egress IPs. To request additional dedicated egress IPs, contact your account team to schedule a service window.
 
@@ -75,7 +77,7 @@ Dedicated egress IPs do not apply to:
 - Traffic destined for private networks connected to Zero Trust via [Cloudflare WAN](/cloudflare-wan/)
 - ICMP traffic (such as `ping`)
 
-These origins will see the default shared IPs instead of the dedicated egress IPs. This is because Cloudflare can filter traffic to these origins by identifiers other than source IP.
+These origins will see the default shared IPs instead of the dedicated egress IPs. Dedicated egress IPs are designed for traffic where the destination identifies your organization by source IP. For the traffic types listed above, Cloudflare uses other identifiers (such as tunnel authentication or account configuration) to attribute the traffic, so a dedicated IP is not required.
 
 ### Traffic resilience
 
@@ -90,10 +92,10 @@ If the location for your primary egress IPs goes down and there is no secondary 
 ### IP geolocation
 
 :::note
-IP geolocation will take at least six weeks to update across databases.
+IP geolocation will take at least six weeks to update across databases. Third-party geolocation databases (such as MaxMind and Google) update their records on their own schedules, which typically takes several weeks.
 :::
 
-Your egress traffic will geolocate to the city selected in your [egress policies](/cloudflare-one/traffic-policies/egress-policies/). If the traffic does not match an egress policy, IP geolocation defaults to the closest dedicated egress location to the user. We recommend you create a [catch-all egress policy](/cloudflare-one/traffic-policies/egress-policies/#catch-all-policy) before dedicated egress IPs are assigned to your account. This will prevent incorrect geolocation for your users' traffic while geolocation databases update.
+Your egress traffic will geolocate to the city selected in your [egress policies](/cloudflare-one/traffic-policies/egress-policies/). If the traffic does not match an egress policy, IP geolocation defaults to the closest dedicated egress location to the user. We recommend you create a [catch-all egress policy](/cloudflare-one/traffic-policies/egress-policies/#catch-all-policy) before dedicated egress IPs are assigned to your account. Without a catch-all policy, traffic that does not match any egress policy may use a dedicated egress IP in an unexpected city. Geolocation databases will then associate your users with that city until the databases update — a process that takes at least six weeks to reverse.
 
 When you turn on dedicated egress IPs, Gateway will update third-party IP geolocation databases. Other websites, such as Google Search, will check these databases to geolocate a user's source IP. For example, if your users are in India, Google will direct them to the United States Google landing page instead of the India landing page until Google recognizes the updated IP geolocation.
 
@@ -123,6 +125,8 @@ To verify that the IP geolocation has updated, check your dedicated egress IP in
 
 Your users' physical egress location will vary depending on whether their connection is over IPv4 or IPv6.
 
+IPv4 addresses are limited, so Cloudflare must physically route traffic to the data center where your dedicated IPv4 address is provisioned. IPv6 has virtually unlimited address space, so Cloudflare can assign IPv6 ranges from all geolocations to every data center. This means IPv6 traffic can egress locally while still appearing to originate from your configured geolocation.
+
 | Protocol | Destination proxied by Cloudflare | Physical egress location             | IP geolocation                       |
 | -------- | --------------------------------- | ------------------------------------ | ------------------------------------ |
 | IPv4     | No                                | Data center with dedicated egress IP | Matches dedicated egress IP location |
@@ -134,13 +138,9 @@ Your users' physical egress location will vary depending on whether their connec
 
 To physically egress from a specific location, traffic must be proxied to Cloudflare via IPv4. The end user connects to the nearest Cloudflare data center, but Cloudflare will internally route their traffic to egress from the dedicated location configured in your [egress policies](/cloudflare-one/traffic-policies/egress-policies/). Therefore, the connected data center shown in the user's WARP client preferences may not match their actual egress location.
 
-We are able to offer better IPv4 performance when users visit domains proxied by Cloudflare (also known as an [orange-clouded](/dns/proxy-status/) domain). In this scenario, IPv4 traffic will physically egress from the most performant data center in our network while still appearing to egress from your dedicated location.
+Cloudflare offers better IPv4 performance when users visit domains [proxied by Cloudflare](/dns/proxy-status/) (orange-clouded). In this scenario, IPv4 traffic will physically egress from the most performant data center in our network while still appearing to egress from your dedicated location.
 
-For example, assume you have a primary dedicated egress IP in Los Angeles and a secondary dedicated egress IP in New York. A user in Las Vegas would see Las Vegas as their connected data center. If they go to a site not proxied by Cloudflare ([gray-clouded](/dns/proxy-status/#dns-only-records)), such as `espn.com`, they will egress from Los Angeles (or whichever city is in the matching egress policy). If they go to an orange-clouded site such as `cloudflare.com`, they will physically egress from Las Vegas but use Los Angeles as their IP geolocation.
-
-:::note[IPv4 and IPv6 behavior]
-IPv4 addresses are limited, so Cloudflare must physically route traffic to the data center where your dedicated IPv4 address is provisioned. IPv6 has virtually unlimited address space, so Cloudflare can assign IPv6 ranges from all geolocations to every data center. This means IPv6 traffic can egress locally while still appearing to originate from your configured geolocation.
-:::
+For example, assume you have a primary dedicated egress IP in Los Angeles and a secondary dedicated egress IP in New York. A user in Las Vegas would see Las Vegas as their connected data center. If they go to a site [not proxied by Cloudflare](/dns/proxy-status/#dns-only-records) (gray-clouded), such as `espn.com`, they will egress from Los Angeles (or whichever city is in the matching egress policy). If they go to an orange-clouded site such as `cloudflare.com`, they will physically egress from Las Vegas but use Los Angeles as their IP geolocation.
 
 #### IPv6
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -13,7 +13,7 @@ Only available as an add-on to Zero Trust Enterprise plans.
 
 Dedicated egress IPs are static IP addresses that can be used to allowlist traffic from your organization. Third-party services that restrict access by source IP can trust that traffic from your dedicated egress IPs belongs to your organization.
 
-These IPs are unique to your account and are not used by any other customers routing traffic through Cloudflare's network. Each dedicated egress IP consists of an IPv4 address and an IPv6 range that are assigned to a specific Cloudflare data center. At minimum, Cloudflare will provision your account with two dedicated egress IPs corresponding to data centers in two different cities for geographic redundancy.
+These IPs are unique to your account and are not used by any other customers routing traffic through Cloudflare's network. Each dedicated egress IP consists of an IPv4 address and an IPv6 range that are assigned to a specific Cloudflare data center. At minimum, Cloudflare will provision your account with two dedicated egress IPs corresponding to data centers in two different cities.
 
 An account can have any number of additional dedicated egress IPs. To request additional dedicated egress IPs, contact your account team to schedule a service window.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/egress-cloudflared.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/egress-cloudflared.mdx
@@ -9,12 +9,9 @@ sidebar:
 
 import { Render, Details, GlossaryTooltip } from "~/components";
 
-<Render
-	file="gateway/egress-selector-warp-version"
-	product="cloudflare-one"
-/>
+<Render file="gateway/egress-selector-warp-version" product="cloudflare-one" />
 
-A Cloudflare Tunnel can be used for source IP anchoring when you want to use existing egress IPs instead of purchasing [Cloudflare dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/). Some third-party websites may have an Access Control List (ACL) that only allows connections from certain source IPs. If you already have a non-Cloudflare IP on their allowlist (such as an egress IP provided by an ISP or a cloud provider like AWS), you can configure `cloudflared` to anchor user traffic to the same IPs that you use today.
+A Cloudflare Tunnel can be used for source IP anchoring — routing outgoing traffic through a location you control so it exits the Internet with a specific source IP — when you want to use existing egress IPs instead of purchasing [Cloudflare dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/). Some third-party websites may have an Access Control List (ACL) that only allows connections from certain source IPs. If you already have a non-Cloudflare IP on their allowlist (such as an egress IP provided by an ISP or a cloud provider like AWS), you can configure `cloudflared` to anchor user traffic to the same IPs that you use today.
 
 For example, assume that your organization's banking service, `app.bank.com`, expects user traffic to come from an AWS IP. You can install `cloudflared` in your AWS environment and add a public hostname route pointing to `app.bank.com`. When users connect to `app.bank.com` using the WARP client, Gateway will apply your network policies and route the filtered traffic down the corresponding Cloudflare Tunnel to AWS. The traffic can then egress to the public Internet using your AWS egress IP.
 
@@ -42,10 +39,7 @@ To learn more about how Gateway applies hostname-based egress policies, refer to
 
 User traffic is on-ramped to Gateway using one of the following methods:
 
-<Render
-	file="gateway/egress-selector-onramps"
-	product="cloudflare-one"
-/>
+<Render file="gateway/egress-selector-onramps" product="cloudflare-one" />
 
 ## 1. Connect your private network
 
@@ -77,14 +71,11 @@ In your WARP [Split Tunnels](/cloudflare-one/team-and-resources/devices/warp/con
 
 When users connect to a public hostname route, Gateway will assign an <GlossaryTooltip term="initial resolved IP">initial resolved IP</GlossaryTooltip> to the DNS query from the following range:
 
-The initial resolved IP is required because Gateway's network engine operates at L3/L4 and can only see IPs (not hostnames) when processing the connection. If a packet's destination IP falls within the initial resolved IP CGNAT range, Gateway knows that the IP maps to a public hostname route and sends the traffic down the corresponding Cloudflare Tunnel.
+The initial resolved IP is required because Gateway's network engine operates at layer 3/layer 4 (the network and transport layers) and can only see IP addresses — not hostnames — when processing the connection. If a packet's destination IP falls within the initial resolved IP range (`100.80.0.0/16` or `2606:4700:0cf1:4000::/64`), Gateway knows that the IP maps to a public hostname route and sends the traffic down the corresponding Cloudflare Tunnel.
 
 To route initial resolved IPs through WARP:
 
-<Render
-	file="gateway/egress-selector-split-tunnels"
-	product="cloudflare-one"
-/>
+<Render file="gateway/egress-selector-split-tunnels" product="cloudflare-one" />
 
 ### Private network IPs
 
@@ -95,13 +86,18 @@ Your private network's CIDR block should also route through the WARP tunnel. For
 You can build [Gateway network policies](/cloudflare-one/traffic-policies/network-policies/) to filter HTTPS traffic to your public hostname on port `443`. For example, suppose that you want to block all WARP users from accessing `app.bank.com` except for a specific set of users or groups. Additionally, those authorized users should only access `app.bank.com` using your AWS egress IP. You can accomplish this using two policies: the first allows specific users to reach `app.bank.com`, and the second blocks all other port `443` traffic to `app.bank.com`.
 
 1. Allow company employees:
-	<Render file="gateway/policies/restrict-access-to-private-networks-allow" product="cloudflare-one" params={{ selector: "SNI", value: "app.bank.com" }} />
+
+   <Render
+   	file="gateway/policies/restrict-access-to-private-networks-allow"
+   	product="cloudflare-one"
+   	params={{ selector: "SNI", value: "app.bank.com" }}
+   />
 
 2. Block everyone else on port `443`:
 
-	| Selector       | Operator | Value        | Action |
-	| -------------- | -------- | ------------ | ------ |
-	| SNI            | in       | `app.bank.com` | Block  |
+   | Selector | Operator | Value          | Action |
+   | -------- | -------- | -------------- | ------ |
+   | SNI      | in       | `app.bank.com` | Block  |
 
 Gateway does not currently support hostname-based filtering for traffic on non-`443` ports. To block traffic to `app.bank.com` on all ports, you will need to use the [Destination IP](/cloudflare-one/traffic-policies/network-policies/#destination-ip) selector and specify the public IP space of `app.bank.com`.
 
@@ -115,4 +111,4 @@ You can search for `app.bank.com` in your [Gateway DNS logs](/cloudflare-one/ins
 
 ### Google Chrome restricts local network access
 
-<Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one"/>
+<Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
@@ -11,7 +11,7 @@ import { Tabs, TabItem, Details, APIRequest, Render } from "~/components";
 
 | [WARP modes](/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/) | [Zero Trust plans](https://www.cloudflare.com/teams-pricing/) |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| Traffic and DNS mode                                                                        | Enterprise                                                    |
+| Traffic and DNS mode                                                                     | Enterprise                                                    |
 
 | System   | Availability | Minimum WARP version |
 | -------- | ------------ | -------------------- |
@@ -24,7 +24,9 @@ import { Tabs, TabItem, Details, APIRequest, Render } from "~/components";
 
 </Details>
 
-When Gateway receives a DNS query for hostname covered by the [Application](/cloudflare-one/traffic-policies/egress-policies/#application), [Content Categories](/cloudflare-one/traffic-policies/egress-policies/#content-categories), [Domain](/cloudflare-one/traffic-policies/egress-policies/#domain), and [Host](/cloudflare-one/traffic-policies/egress-policies/#host) selectors in an Egress policy, Gateway initially resolves DNS to an IP in the `100.80.0.0/16` or `2606:4700:0cf1:4000::/64` range. This process allows Gateway to map a destination IP with a hostname at [layer 4](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/) (where Gateway evaluates Egress policies). The destination IP for a hostname is not usually known at layer 4. Prior to evaluating Egress policies, the initially resolved IP is overwritten with the correct destination IP.
+Egress policies evaluate traffic at [layer 4](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/) (the transport layer), where only IP addresses are visible — not hostnames. To allow hostname-based selectors to work at this layer, Gateway uses a temporary IP mapping.
+
+When Gateway receives a DNS query for a hostname covered by the [Application](/cloudflare-one/traffic-policies/egress-policies/#application), [Content Categories](/cloudflare-one/traffic-policies/egress-policies/#content-categories), [Domain](/cloudflare-one/traffic-policies/egress-policies/#domain), and [Host](/cloudflare-one/traffic-policies/egress-policies/#host) selectors in an egress policy, Gateway initially resolves the DNS query to a temporary IP in the `100.80.0.0/16` or `2606:4700:0cf1:4000::/64` range. These reserved IP ranges do not route to real destinations. Instead, the temporary IP acts as a tag that allows Gateway to associate the network-layer connection with the original hostname. Prior to forwarding the traffic to the real destination, Gateway overwrites the temporary IP with the correct destination IP.
 
 ![Example egress policy flow](~/assets/images/cloudflare-one/policies/host-selector-diagram.png)
 
@@ -67,7 +69,7 @@ Traffic must be on-ramped to Gateway with the following methods:
 | [PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/)                        | ✅            |
 | [Browser Isolation](/cloudflare-one/remote-browser-isolation/)                                      | ✅            |
 | [WARP Connector](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/) | ❌            |
-| [Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/)                                              | ✅            |
+| [Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/)                                    | ✅            |
 
 Unsupported traffic will be resolved with your default Gateway settings. If you use DNS locations to send a DNS query to Gateway with IPv4, IPv6, DoT, or DoH, Gateway will not return the initial resolved IP for supported traffic nor resolve unsupported traffic.
 
@@ -76,9 +78,9 @@ Unsupported traffic will be resolved with your default Gateway settings. If you 
 To configure your Zero Trust organization to use Host selectors with Egress policies:
 
 1.  Make sure you deploy the following version of WARP on your users' devices:
-    - **Desktop**: [WARP version 2025.4.929.0](/cloudflare-one/team-and-resources/devices/warp/download-warp/) or later 
+    - **Desktop**: [WARP version 2025.4.929.0](/cloudflare-one/team-and-resources/devices/warp/download-warp/) or later
     - **iOS**: [WARP version 1.11](/cloudflare-one/team-and-resources/devices/warp/download-warp/#ios) or later
-    - **Android and Chrome OS**: [WARP version 2.4.2](/cloudflare-one/team-and-resources/devices/warp/download-warp/#android) or later. 
+    - **Android and Chrome OS**: [WARP version 2.4.2](/cloudflare-one/team-and-resources/devices/warp/download-warp/#android) or later.
 
     If you need to support devices running prior versions of WARP, add and deploy the following key-value pair to your devices' [WARP configuration file](/cloudflare-one/team-and-resources/devices/warp/deployment/mdm-deployment/) (`mdm.xml` on Windows and Linux or `com.cloudflare.warp.plist` on macOS):
 
@@ -95,7 +97,7 @@ To configure your Zero Trust organization to use Host selectors with Egress poli
 
 2. <Render file="gateway/egress-selector-split-tunnels" product="cloudflare-one"/>
 
-The WARP client must be set to _Traffic and DNS mode_ mode for traffic affected by these selectors to route correctly.
+The WARP client must be set to _Traffic and DNS mode_ for traffic affected by these selectors to route correctly.
 
 {/* prettier-ignore-end */}
 
@@ -103,4 +105,4 @@ The WARP client must be set to _Traffic and DNS mode_ mode for traffic affected 
 
 ### Google Chrome restricts local network access
 
-<Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one"/>
+<Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/index.mdx
@@ -19,7 +19,9 @@ import {
 Only available on Enterprise plans.
 :::
 
-When your users connect to the Internet through Cloudflare Gateway, by default their traffic is assigned a source IP address that is shared across all Cloudflare WARP users. Enterprise users can purchase [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) to ensure that egress traffic from your organization is assigned a unique, static IP. These source IPs are dedicated to your account and can be used within allowlists on upstream services.
+Many third-party services restrict access by source IP address — the IP that the destination sees on incoming traffic. When your users connect to the Internet through Cloudflare Gateway, by default their traffic is assigned a source IP address that is shared across all Cloudflare WARP users. Because this IP is shared, external services cannot use it to identify your organization.
+
+Enterprise users can purchase [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) to ensure that egress traffic (traffic leaving Cloudflare's network toward a destination) from your organization is assigned a unique, static IP. These source IPs are dedicated to your account and can be used within allowlists on upstream services.
 
 Egress policies allow you to control which dedicated egress IP is used and when, based on attributes such as identity, IP address, and geolocation. Traffic that does not match an egress policy will default to using the most performant dedicated egress IP.
 
@@ -29,7 +31,9 @@ Cloudflare does not publish WARP egress IP ranges. WARP egress IPs are not docum
 
 ## Load balancing
 
-When using either the default Cloudflare egress IPs or any dedicated egress IPs, Gateway traffic that does not match an egress policy will egress from the closest Cloudflare data center with a default Gateway egress IP. If there are two data centers of equal distance from the user, Gateway will split the traffic between the two data centers, and the load balancer will retain the same user selection and egress IP regardless of data center.
+Traffic that does not match an egress policy will egress from the closest Cloudflare data center using a default Gateway egress IP. This applies whether you are using the default Cloudflare egress IPs or dedicated egress IPs.
+
+If two data centers are equidistant from the user, Gateway splits traffic between them. The load balancer maintains user affinity, so each user keeps the same egress IP regardless of which data center handles the request.
 
 ## Force IP version
 
@@ -66,7 +70,7 @@ When you configure your egress policy, you can choose whether to egress traffic 
 
 **Use dedicated egress IPs (Cloudflare or BYOIP)** uses the primary IPv4 address and IPv6 range selected in the dropdown menus. <Render file="gateway/secondary-ipv4-requirement" product="cloudflare-one" />
 
-If the data center associated with your primary dedicated egress IPv4 goes down, Gateway will egress from the secondary data center to avoid traffic drops during reroutes. There is no need for a secondary IPv6 because IPv6 traffic can egress from any Cloudflare data center. Dedicated egress IPs can be provided by either Cloudflare or [BYOIP](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/#bring-your-own-ip-address-byoip).
+If the data center associated with your primary dedicated egress IPv4 goes down, Gateway will egress from the secondary data center to avoid traffic drops during reroutes. There is no need for a secondary IPv6 because IPv6 address space is large enough for Cloudflare to assign ranges from every geolocation to every data center, so IPv6 traffic can egress from any Cloudflare data center. Dedicated egress IPs can be provided by either Cloudflare or [Bring Your Own IP (BYOIP)](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/#bring-your-own-ip-address-byoip).
 
 To learn more about IPv4 and IPv6 egress behavior, refer to [Egress locations](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/#egress-location).
 
@@ -228,4 +232,4 @@ Gateway uses Rust to evaluate regular expressions. The Rust implementation is sl
 
 ### Selector prerequisites
 
-The [Application](#application), [Content Categories](#content-categories), [Domain](#domain), and [Host](#host) selectors require configuration changes in order to be operational. Before deploying policies with these selectors, refer to [Host selectors](/cloudflare-one/traffic-policies/egress-policies/host-selectors).
+The [Application](#application), [Content Categories](#content-categories), [Domain](#domain), and [Host](#host) selectors require additional configuration because egress policies evaluate traffic at the network layer, where only IP addresses are visible — not hostnames. Gateway uses a temporary IP mapping to bridge this gap. Before deploying policies with these selectors, refer to [Host selectors](/cloudflare-one/traffic-policies/egress-policies/host-selectors).


### PR DESCRIPTION
Improves clarity and accessibility across all four egress policy pages (`index.mdx`, `host-selectors.mdx`, `dedicated-egress-ips.mdx`, `egress-cloudflared.mdx`) by adding missing context, defining jargon, and restructuring dense sections.

- **Add problem framing to `index.mdx`**: opens with *why* shared source IPs are a problem before introducing dedicated egress IPs as the solution, so readers understand the motivation before the mechanism
- **Break load-balancing paragraph**: splits a compound sentence into two clear statements — closest-DC routing and equidistant-DC splitting with user affinity
- **Expand BYOIP on first mention** in `index.mdx`: readers encounter the acronym here before the dedicated-egress-ips page defines it
- **Add L4 context to selector limitation** in `index.mdx`: explains *why* host selectors need extra configuration (network layer cannot see hostnames)
- **Rewrite host-selectors opening** in `host-selectors.mdx`: leads with the *why* (L4 visibility gap) before describing the temporary-IP mechanism, and clarifies that the reserved IP ranges do not route to real destinations
- **Fix "Traffic and DNS mode mode" typo** in `host-selectors.mdx`
- **Add geographic redundancy rationale** in `dedicated-egress-ips.mdx`: explains *why* the minimum is two IPs in two cities
- **Clarify unsupported traffic reasoning** in `dedicated-egress-ips.mdx`: explains that dedicated IPs are for external identification by source IP, and traffic types that use other identifiers do not need them
- **Move IPv4/IPv6 explanation before table** in `dedicated-egress-ips.mdx`: readers now understand *why* the protocols differ before encountering the behavior matrix
- **Add inline glosses for orange-clouded/gray-clouded** in `dedicated-egress-ips.mdx`: brief parenthetical definitions alongside existing links
- **Expand geolocation note** in `dedicated-egress-ips.mdx`: explains *why* it takes six weeks (third-party database update cycles) and spells out the consequence of a missing catch-all policy
- **Define "source IP anchoring"** in `egress-cloudflared.mdx`: inline definition on first use
- **Expand L3/L4 and replace CGNAT acronym** in `egress-cloudflared.mdx`: uses full terms ("layer 3/layer 4") and explicit IP ranges instead of unexpanded acronym