### PR TITLE
Add non-configurable headers guidance to custom user agent section

### DIFF
--- a/src/content/partials/browser-rendering/setting-custom-user-agent.mdx
+++ b/src/content/partials/browser-rendering/setting-custom-user-agent.mdx
@@ -3,5 +3,5 @@
 You can change the user agent at the page level by passing `userAgent` as a top-level parameter in the JSON body. This is useful if the target website serves different content based on the user agent.
 
 :::note
-The `userAgent` parameter does not bypass bot protection. Requests from Browser Rendering will always be identified as a bot. 
+The `userAgent` parameter does not bypass bot protection. Requests from Browser Rendering will always be identified as a bot. Because the User-Agent is configurable, destination servers looking to identify or block Browser Rendering requests should use the [non-configurable headers](/browser-rendering/reference/automatic-request-headers/#non-configurable-headers) rather than relying on the User-Agent string.
 :::


### PR DESCRIPTION
- Updated the setting-custom-user-agent partial to advise destination servers to use non-configurable headers for identifying/blocking Browser Rendering requests
- Links to the non-configurable headers section of the automatic request headers reference
- Propagates to all REST API endpoint pages (content, screenshot, pdf, markdown, scrape, links, snapshot, json, crawl)

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
