### PR TITLE
Update id.name docs

### DIFF
--- a/src/content/docs/durable-objects/api/id.mdx
+++ b/src/content/docs/durable-objects/api/id.mdx
@@ -75,7 +75,13 @@ assert not id1.equals(id2), "Different unique ids should never be equal."
 
 ### `name`
 
-`name` is an optional property of a `DurableObjectId`, which returns the name that was used to create the `DurableObjectId` via [`DurableObjectNamespace::idFromName`](/durable-objects/api/namespace/#idfromname). This value is undefined if the `DurableObjectId` was constructed using [`DurableObjectNamespace::newUniqueId`](/durable-objects/api/namespace/#newuniqueid). This value is also undefined within the `ctx.id` passed into the Durable Object constructor (refer to [GitHub issue](https://github.com/cloudflare/workerd/issues/2240) for discussion).
+`name` is an optional property of a `DurableObjectId`, which returns the name that was used to create the `DurableObjectId` via [`DurableObjectNamespace::idFromName`](/durable-objects/api/namespace/#idfromname). This value is undefined if the `DurableObjectId` was constructed using [`DurableObjectNamespace::newUniqueId`](/durable-objects/api/namespace/#newuniqueid).
+
+The `name` property is available on `ctx.id` inside the Durable Object. Names longer than 1,024 bytes are not passed through and will be `undefined` on `ctx.id`.
+
+:::note
+Alarms created before 2026-03-15 do not have `name` stored. When such an alarm fires, `ctx.id.name` will be `undefined`, and any new alarm scheduled from that handler will also lack a `name`. To fix this, reschedule the alarm from a `fetch()` or RPC handler where `name` is available.
+:::
 
 <Tabs>
 


### PR DESCRIPTION
### Summary

Update the DO ctx.id docs to indicate the the id.name will now be available in the running DO. Also document the length limit and the alarms limitation. 

