### PR TITLE
ZTIA-1370: Updates limitations for browser-based RDP

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/rdp/rdp-browser.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/rdp/rdp-browser.mdx
@@ -172,6 +172,11 @@ To connect to a Windows machine over RDP:
 
 4. Select the port that you want to connect to. The port selection screen only appears if the Access application allows RDP traffic on multiple ports (for example, port `3389` and port `65321`).
 5. (Optional) In your browser settings, allow the Access application to access the clipboard. Clipboard access is subject to [policy restrictions](#configure-clipboard-controls) configured by your administrator.
+
+   :::note
+   Automatic clipboard sharing between local and remote machine requires a Chromium-based browser (Chrome, Edge, Opera, Brave). Firefox has this functionality disabled by default and can be enabled. See [Known limitations](#known-limitations) for details.
+   :::
+
 6. Enter your Windows username and password. For more information on how to format your username, refer to [User identifier formats](#user-identifier-formats).
 
 You now have access to the remote Windows desktop.
@@ -363,3 +368,9 @@ The login flow differs slightly when using an Microsoft Entra ID-bound username:
 - **File transfers**: Users cannot transfer files from their local machine to the remote machine and vice versa.
 - **Print to local printer**: Users cannot print information from their browser-based RDP session to a printer in their local network.
 - **Network Level Authentication for Entra-joined accounts**: Browser-based RDP does not support PKU2U authentication which is required for [Network Level Authentication (NLA)](https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/remotepc/remote-desktop-allow-access#why-allow-connections-only-with-network-level-authentication) with Entra-joined accounts. Connecting to Entra-joined accounts requires disabling enforcement of NLA on the remote Windows machine. You can disable NLA from **Settings** > **System** > **Remote Desktop**, or use the Local Group Policy Editor to disable **Require user authentication for remote connections by using Network Level Authentication**.
+- **Clipboard browser compatibility**: Automatic clipboard sharing between local and remote machine is only available in Chromium-based browsers by default (Google Chrome, Microsoft Edge, Opera, Brave). This functionality can also be enabled in Firefox by:
+    1. Type `about:config` into the browser address bar and press Enter
+    2. Accept the warning prompt if displayed
+    3. Search for `dom.events.testing.asyncClipboard` and set it to `true`
+    4. Search for `dom.events.asyncClipboard.clipboardItem` and set it to `true`
+    5. Search for `dom.events.asyncClipboard.readText` and set it to `true`

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/rdp/rdp-browser.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/rdp/rdp-browser.mdx
@@ -174,7 +174,7 @@ To connect to a Windows machine over RDP:
 5. (Optional) In your browser settings, allow the Access application to access the clipboard. Clipboard access is subject to [policy restrictions](#configure-clipboard-controls) configured by your administrator.
 
    :::note
-   Automatic clipboard sharing between local and remote machine requires a Chromium-based browser (Chrome, Edge, Opera, Brave). Firefox has this functionality disabled by default and can be enabled. See [Known limitations](#known-limitations) for details.
+   Automatic clipboard sharing only works by default in Chromium-based browsers; Firefox requires additional configuration. Refer to [Known limitations](#known-limitations) for details.
    :::
 
 6. Enter your Windows username and password. For more information on how to format your username, refer to [User identifier formats](#user-identifier-formats).
@@ -368,9 +368,9 @@ The login flow differs slightly when using an Microsoft Entra ID-bound username:
 - **File transfers**: Users cannot transfer files from their local machine to the remote machine and vice versa.
 - **Print to local printer**: Users cannot print information from their browser-based RDP session to a printer in their local network.
 - **Network Level Authentication for Entra-joined accounts**: Browser-based RDP does not support PKU2U authentication which is required for [Network Level Authentication (NLA)](https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/remotepc/remote-desktop-allow-access#why-allow-connections-only-with-network-level-authentication) with Entra-joined accounts. Connecting to Entra-joined accounts requires disabling enforcement of NLA on the remote Windows machine. You can disable NLA from **Settings** > **System** > **Remote Desktop**, or use the Local Group Policy Editor to disable **Require user authentication for remote connections by using Network Level Authentication**.
-- **Clipboard browser compatibility**: Automatic clipboard sharing between local and remote machine is only available in Chromium-based browsers by default (Google Chrome, Microsoft Edge, Opera, Brave). This functionality can also be enabled in Firefox by:
-    1. Type `about:config` into the browser address bar and press Enter
-    2. Accept the warning prompt if displayed
-    3. Search for `dom.events.testing.asyncClipboard` and set it to `true`
-    4. Search for `dom.events.asyncClipboard.clipboardItem` and set it to `true`
-    5. Search for `dom.events.asyncClipboard.readText` and set it to `true`
+- **Clipboard browser compatibility**: Automatic clipboard sharing between the local and remote machine is only available in Chromium-based browsers by default (Google Chrome, Microsoft Edge, Opera, Brave). To enable this functionality in Firefox:
+    1. Type `about:config` into the browser address bar and press **Enter**.
+    2. Accept the warning prompt if displayed.
+    3. Search for `dom.events.testing.asyncClipboard` and set it to `true`.
+    4. Search for `dom.events.asyncClipboard.clipboardItem` and set it to `true`.
+    5. Search for `dom.events.asyncClipboard.readText` and set it to `true`.


### PR DESCRIPTION
### Summary

Adds clipboard limitations for Browser-based RDP 


- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
