### PR TITLE
docs: add --secrets-file documentation for wrangler deploy and versions upload

### DIFF
--- a/src/content/docs/workers/configuration/secrets.mdx
+++ b/src/content/docs/workers/configuration/secrets.mdx
@@ -113,6 +113,20 @@ To add a secret via the dashboard:
 5. (Optional) To add more secrets, select **Add variable**.
 6. Select **Deploy** to implement your changes.
 
+#### Upload secrets alongside code
+
+You can upload secrets at the same time as your Worker code using the `--secrets-file` flag on [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) or [`wrangler versions upload`](/workers/wrangler/commands/workers/#versions-upload). This accepts a path to a JSON or `.env` file — the same formats accepted by [`wrangler secret bulk`](/workers/wrangler/commands/workers/#secret-bulk).
+
+```sh
+npx wrangler deploy --secrets-file .env.production
+```
+
+```sh
+npx wrangler versions upload --secrets-file secrets.json
+```
+
+Secrets not included in the file are preserved from the previous version. This is useful in CI/CD pipelines where you want to deploy code and update secrets in a single operation.
+
 ### Delete secrets from your project
 
 #### Via Wrangler

--- a/src/content/docs/workers/wrangler/commands/workers.mdx
+++ b/src/content/docs/workers/wrangler/commands/workers.mdx
@@ -218,6 +218,8 @@ None of the options for this command are required. Also, many can be set in your
   - It is recommended best practice to treat your Wrangler developer environment as a source of truth for your Worker configuration, and avoid making changes via the Cloudflare dashboard.
   - If you change your environment variables in the Cloudflare dashboard, Wrangler will override them the next time you deploy. If you want to disable this behaviour set `keep-vars` to `true`.
   - Secrets are never deleted by a deployment whether this flag is true or false.
+- `--secrets-file` <Type text="string" /> <MetaInfo text="optional" />
+  - Path to a file containing secrets to upload alongside the deployment. Accepts JSON or `.env` format — the same formats used by [`wrangler secret bulk`](#secret-bulk). Existing secrets not included in the file are preserved from the previous version. Refer to [Secrets — Upload secrets alongside code](/workers/configuration/secrets/#upload-secrets-alongside-code) for more details.
 - `--dispatch-namespace` <Type text="string" /> <MetaInfo text="optional" />
   - Specify the [Workers for Platforms dispatch namespace](/cloudflare-for-platforms/workers-for-platforms/how-workers-for-platforms-works/#dispatch-namespace) to upload this Worker to.
 - `--metafile` <Type text="string" /> <MetaInfo text="optional" />


### PR DESCRIPTION
Companion docs PR for https://github.com/cloudflare/workers-sdk/pull/10896.

## Summary

- Adds `--secrets-file` option to the `wrangler deploy` command reference in `general.mdx`
- Adds a new "Upload secrets alongside code" subsection to the secrets configuration guide in `secrets.mdx`

The `--secrets-file` flag for `wrangler versions upload` is auto-generated by the `<WranglerCommand>` component and will appear once the docs repo bumps its wrangler dependency to include the release.

---

- Tests
  - [ ] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [x] Additional testing not necessary because: documentation-only change
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because: this is the documentation PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/28976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
