### PR TITLE
Document that /crawl endpoint User-Agent is not customizable

### DIFF
--- a/src/content/docs/browser-rendering/reference/automatic-request-headers.mdx
+++ b/src/content/docs/browser-rendering/reference/automatic-request-headers.mdx
@@ -21,7 +21,7 @@ The default User-Agent depends on how you access Browser Rendering:
 The Chrome version in the REST API and Workers Bindings User-Agent strings may change as Browser Rendering updates its underlying browser engine. Do not rely on a specific version number.
 :::
 
-Unlike the headers listed below, the User-Agent can be customized using the `userAgent` parameter in your [REST API](/browser-rendering/rest-api/) request or in your [Workers Bindings](/browser-rendering/workers-bindings/) configuration. Because the User-Agent is configurable, destination servers should use the headers below to identify Browser Rendering requests rather than relying on the User-Agent string.
+Unlike the headers listed below, the User-Agent can be customized for the [REST API](/browser-rendering/rest-api/) (using the `userAgent` parameter) and [Workers Bindings](/browser-rendering/workers-bindings/) configuration. The [crawl endpoint](/browser-rendering/rest-api/crawl-endpoint/) is the exception. Its User-Agent is always `CloudflareBrowserRenderingCrawler/1.0` and cannot be changed. Because the User-Agent is configurable for most methods, destination servers should use the headers below to identify Browser Rendering requests rather than relying on the User-Agent string.
 
 ## Non-configurable headers
 

--- a/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
@@ -433,12 +433,11 @@ Browser Rendering does not bypass CAPTCHAs, Turnstile challenges, or any other b
 If you are crawling your own site and want Browser Rendering to access it freely, you can create a WAF skip rule to allowlist Browser Rendering. Refer to [How do I allowlist Browser Rendering?](/browser-rendering/faq/#can-i-allowlist-browser-rendering-on-my-own-website) for instructions.
 :::
 
-<Render
-  file="setting-custom-user-agent"
-  product="browser-rendering"
-/>
+### User-Agent
 
-The `/crawl` endpoint uses `CloudflareBrowserRenderingCrawler/1.0` as its default User-Agent, which is different from the other [REST API](/browser-rendering/rest-api/) endpoints. For a full list of default User-Agent strings, refer to [Automatic request headers](/browser-rendering/reference/automatic-request-headers/#user-agent).
+The `/crawl` endpoint uses `CloudflareBrowserRenderingCrawler/1.0` as its User-Agent, which is different from the other [REST API](/browser-rendering/rest-api/) endpoints. This User-Agent is not customizable. Unlike the other REST API endpoints and [Workers Bindings](/browser-rendering/workers-bindings/), the `userAgent` parameter is not supported on the `/crawl` endpoint.
+
+For a full list of default User-Agent strings, refer to [Automatic request headers](/browser-rendering/reference/automatic-request-headers/#user-agent).
 
 ## Troubleshooting
 


### PR DESCRIPTION
- Remove setting-custom-user-agent partial from crawl-endpoint.mdx since the crawl UA cannot be changed
- Add User-Agent subsection to crawl endpoint explaining the fixed UA
- Update automatic-request-headers.mdx to clarify that /crawl is the exception to UA customization

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
