### PR TITLE
Document default Workers AI model used by /json endpoint

### DIFF
--- a/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
@@ -281,7 +281,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/{account_id}/browser
 
 ### Product catalog extraction with AI
 
-Extract structured product data using the `json` format. This leverages [Workers AI](/workers-ai/) by default.
+Extract structured product data using the `json` format. This leverages [Workers AI](/workers-ai/) by default. Refer to the [`/json` endpoint](/browser-rendering/rest-api/json-endpoint/) to learn more.
 
 ```bash
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/{account_id}/browser-rendering/crawl' \

--- a/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
@@ -13,7 +13,7 @@ The `/json` endpoint extracts structured data from a webpage. You can specify th
 
 :::note[Note]
 
-By default, the `/json` endpoint leverages [Workers AI](/workers-ai/) for data extraction using [`@cf/meta/llama-3.3-70b-instruct-fp8-fast`](/workers-ai/models/llama-3.3-70b-instruct-fp8-fast/). Using this endpoint incurs usage on Workers AI, which you can monitor through the Workers AI dashboard. To use a different model, refer to [Using a custom model (BYO API Key)](/browser-rendering/rest-api/json-endpoint/#using-a-custom-model-byo-api-key).
+By default, the `/json` endpoint leverages [Workers AI](/workers-ai/) for data extraction using [`@cf/meta/llama-3.3-70b-instruct-fp8-fast`](/workers-ai/models/llama-3.3-70b-instruct-fp8-fast/). Using this endpoint incurs usage on Workers AI, which you can monitor in the [Workers AI Dashboard](https://dash.cloudflare.com/?to=/:account/ai/workers-ai). To use a different model, refer to [Using a custom model (BYO API Key)](/browser-rendering/rest-api/json-endpoint/#using-a-custom-model-byo-api-key).
 
 :::
 

--- a/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
@@ -9,11 +9,11 @@ sidebar:
 
 import { Tabs, TabItem, Render } from "~/components";
 
-The `/json` endpoint extracts structured data from a webpage. You can specify the expected output using either a `prompt` or a `response_format` parameter which accepts a JSON schema. The endpoint returns the extracted data in JSON format. By default, this endpoint leverages [Workers AI](/workers-ai/). If you would like to specify your own AI model for the extraction, you can use the `custom_ai` parameter.
+The `/json` endpoint extracts structured data from a webpage. You can specify the expected output using either a `prompt` or a `response_format` parameter which accepts a JSON schema. The endpoint returns the extracted data in JSON format.
 
 :::note[Note]
 
-By default, the `/json` endpoint leverages [Workers AI](/workers-ai/) for data extraction. Using this endpoint incurs usage on Workers AI, which you can monitor usage through the Workers AI Dashboard.
+By default, the `/json` endpoint leverages [Workers AI](/workers-ai/) for data extraction using [`@cf/meta/llama-3.3-70b-instruct-fp8-fast`](/workers-ai/models/llama-3.3-70b-instruct-fp8-fast/). Using this endpoint incurs usage on Workers AI, which you can monitor through the Workers AI dashboard. To use a different model, refer to [Using a custom model (BYO API Key)](/browser-rendering/rest-api/json-endpoint/#using-a-custom-model-byo-api-key).
 
 :::
 


### PR DESCRIPTION
- Add default model name (@cf/meta/llama-3.3-70b-instruct-fp8-fast) to the note block on the /json endpoint page with link to model docs
- Add link to Using a custom model (BYO API Key) section for users who want to change the model
- Simplify intro paragraph to avoid repetition with the note block
- Add cross-reference to /json endpoint docs in the crawl endpoint product catalog extraction section

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
