### PR TITLE
[Support Feedback] Improve account, auth, and domain docs (Fundamentals)

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/secure-a-compromised-account.mdx
+++ b/src/content/docs/fundamentals/account/account-security/secure-a-compromised-account.mdx
@@ -9,7 +9,14 @@ products:
 
 import { Render } from "~/components";
 
-If you observe suspicious activity within your Cloudflare account, secure your account with these steps.
+If you observe suspicious activity within your Cloudflare account, secure your account immediately. At a minimum, complete these actions as quickly as possible:
+
+1. **Change your password** — use a strong, unique password not used elsewhere.
+2. **Enable two-factor authentication (2FA)** — if not already enabled.
+3. **Rotate your Global API Key** — regenerate it to invalidate the old key.
+4. **Log out all sessions** — manually sign out of the dashboard to terminate all ongoing sessions.
+
+The sections below walk through each step in detail.
 
 ## Step 1 - Change your password
 

--- a/src/content/docs/fundamentals/account/account-security/secure-a-compromised-account.mdx
+++ b/src/content/docs/fundamentals/account/account-security/secure-a-compromised-account.mdx
@@ -9,14 +9,7 @@ products:
 
 import { Render } from "~/components";
 
-If you observe suspicious activity within your Cloudflare account, secure your account immediately. At a minimum, complete these actions as quickly as possible:
-
-1. **Change your password** — use a strong, unique password not used elsewhere.
-2. **Enable two-factor authentication (2FA)** — if not already enabled.
-3. **Rotate your Global API Key** — regenerate it to invalidate the old key.
-4. **Log out all sessions** — manually sign out of the dashboard to terminate all ongoing sessions.
-
-The sections below walk through each step in detail.
+If you observe suspicious activity within your Cloudflare account, secure your account immediately by completing the steps below.
 
 ## Step 1 - Change your password
 

--- a/src/content/docs/fundamentals/account/change-super-admin.mdx
+++ b/src/content/docs/fundamentals/account/change-super-admin.mdx
@@ -6,7 +6,7 @@ products:
   - fundamentals
 ---
 
-If you or someone in your organization leaves or loses access to email, you can add another Super Administrator using any other Super Administrator on your account with a [verified email](/fundamentals/account/verify-email-address/) address.
+If you or someone in your organization leaves or loses access to email, you can add another Super Administrator using any other Super Administrator on your account with a [verified email](/fundamentals/user-profiles/verify-email-address/) address.
 
 1. [Add a member](/fundamentals/manage-members/manage/) to your account and assign the **Super Administrator** role.
 2. If needed, remove the previous Super Administrator.

--- a/src/content/docs/fundamentals/account/change-super-admin.mdx
+++ b/src/content/docs/fundamentals/account/change-super-admin.mdx
@@ -6,14 +6,33 @@ products:
   - fundamentals
 ---
 
-If you or someone in your organization leaves or loses access to email, you can add another Super Administrator using any other Super Administrator on your Account with a [verified email](https://developers.cloudflare.com/fundamentals/account/verify-email-address/) address.
+If you or someone in your organization leaves or loses access to email, you can add another Super Administrator using any other Super Administrator on your account with a [verified email](/fundamentals/account/verify-email-address/) address.
 
-First, [add a member](/fundamentals/manage-members/manage/) to your account and assign the **Super Administrator** role.
-
-Then, if needed, remove the previous Super Administrator.
+1. [Add a member](/fundamentals/manage-members/manage/) to your account and assign the **Super Administrator** role.
+2. If needed, remove the previous Super Administrator.
 
 :::note
 
 Cloudflare recommends having more than one user as Super Administrators for your accounts, so that if you are unable to login with your credentials for any reason, there is another one you can use to manage your domains.
 
 :::
+
+## Swap Super Administrator email addresses
+
+If you need to reassign the Super Administrator role between two existing members, the system will not allow you to assign an email address that is already in use on the account. Use a temporary placeholder:
+
+1. Change the new Super Administrator's email (for example, `newsuperadmin@example.com`) to a temporary placeholder (for example, `temp@example.com`).
+2. Change the old Super Administrator's email (for example, `oldsuperadmin@example.com`) to `newsuperadmin@example.com`.
+3. Change the temporary placeholder (`temp@example.com`) to `oldsuperadmin@example.com`, or remove the temporary member.
+
+:::note
+This process applies to self-serve accounts only. Enterprise accounts should contact their account team.
+:::
+
+## Regain access when the Super Administrator email is lost
+
+If you cannot access the email address associated with the Super Administrator role:
+
+1. **Recover the email account** — contact your email provider to regain access to the mailbox, or set up email forwarding from the old address to one you control.
+2. **Reset your Cloudflare password** — once you can receive email at the Super Administrator address, go to [`https://dash.cloudflare.com/forgot-password`](https://dash.cloudflare.com/forgot-password) to reset your password.
+3. **Add a new Super Administrator** — after logging in, [add a new member](/fundamentals/manage-members/manage/#add-account-members) with the Super Administrator role using an email address you control, then remove the old Super Administrator if needed.

--- a/src/content/docs/fundamentals/account/change-super-admin.mdx
+++ b/src/content/docs/fundamentals/account/change-super-admin.mdx
@@ -17,7 +17,7 @@ Cloudflare recommends having more than one user as Super Administrators for your
 
 :::
 
-## Swap Super Administrator email addresses
+## Reassign Super Administrator email addresses
 
 If you need to reassign the Super Administrator role between two existing members, the system will not allow you to assign an email address that is already in use on the account. Use a temporary placeholder:
 
@@ -33,6 +33,6 @@ This process applies to self-serve accounts only. Enterprise accounts should con
 
 If you cannot access the email address associated with the Super Administrator role:
 
-1. **Recover the email account** — contact your email provider to regain access to the mailbox, or set up email forwarding from the old address to one you control.
-2. **Reset your Cloudflare password** — once you can receive email at the Super Administrator address, go to [`https://dash.cloudflare.com/forgot-password`](https://dash.cloudflare.com/forgot-password) to reset your password.
-3. **Add a new Super Administrator** — after logging in, [add a new member](/fundamentals/manage-members/manage/#add-account-members) with the Super Administrator role using an email address you control, then remove the old Super Administrator if needed.
+1. **Recover the email account** — Contact your email provider to regain access to the mailbox, or set up email forwarding from the old address to one you control.
+2. **Reset your Cloudflare password** — Once you can receive email at the Super Administrator address, go to [`https://dash.cloudflare.com/forgot-password`](https://dash.cloudflare.com/forgot-password) to reset your password.
+3. **Add a new Super Administrator** — After logging in, [add a new member](/fundamentals/manage-members/manage/#add-account-members) with the Super Administrator role using an email address you control, then remove the old Super Administrator if needed.

--- a/src/content/docs/fundamentals/manage-domains/move-domain.mdx
+++ b/src/content/docs/fundamentals/manage-domains/move-domain.mdx
@@ -26,17 +26,17 @@ To transfer a domain from one Cloudflare account to another, you will need:
 - Access to your domain registrar. If your domain is using Cloudflare Registrar, refer to [Transfer a Cloudflare Registrar domain registration between accounts](/registrar/account-options/inter-account-transfer/).
 - At least one Cloudflare account associated with the domain.
 
+## Domain transfer checklist
+
+Before transferring an active Cloudflare domain to another Cloudflare account, complete the following steps:
+
+1. **Remove DNSSEC configurations** — [Disable DNSSEC](/dns/dnssec/) on the domain before moving it. DNSSEC records at the registrar will prevent the domain from activating in the new account.
+2. **Cancel add-ons and subscriptions** — [Remove all add-on subscriptions](/billing/cancel-subscription/) associated with the domain.
+3. **Remove custom certificates** — Delete any [custom SSL/TLS certificates](/ssl/edge-certificates/custom-certificates/) from the domain. You will need to re-upload them to the new account.
+4. **Export DNS records** — [Export your DNS records](/dns/manage-dns-records/how-to/import-and-export/#export-records) while the domain is still in the previous account. Then [import](/dns/manage-dns-records/how-to/import-and-export/#import-records) them into the new account. If you miss this step, Cloudflare will import your proxied DNS records, which might cause your domain to experience a [1000 error](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/).
+5. **Back up configuration** — Consider using [Terraform](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs) to export and back up your zone configuration before moving. Settings from the original account (Page Rules, Firewall Rules, cache settings, and so on) do not transfer to the new account and must be recreated manually.
+
 ## Transfer your domain
-
-:::caution
-Before transferring an active Cloudflare domain to another Cloudflare account, complete this pre-transfer checklist:
-
-1. **Remove DNSSEC configurations** — [disable DNSSEC](/dns/dnssec/) on the domain before moving it. DNSSEC records at the registrar will prevent the domain from activating in the new account.
-2. **Cancel add-ons and subscriptions** — [remove all add-on subscriptions](/billing/cancel-subscription/) associated with the domain.
-3. **Remove custom certificates** — delete any [custom SSL/TLS certificates](/ssl/edge-certificates/custom-certificates/) from the domain. You will need to re-upload them to the new account.
-4. **Export DNS records** — [export your DNS records](/dns/manage-dns-records/how-to/import-and-export/#export-records) while the domain is still in the previous account. Then [import](/dns/manage-dns-records/how-to/import-and-export/#import-records) them into the new account. If you miss this step, Cloudflare will import your proxied DNS records, which might cause your domain to experience a [1000 error](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/).
-5. **Back up configuration** — consider using [Terraform](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs) to export and back up your zone configuration before moving. Settings from the original account (page rules, firewall rules, cache settings, and so on) do not transfer to the new account and must be recreated manually.
-:::
 
 If you still have access to your previous Cloudflare account, you can copy over the Cloudflare account settings manually. You must reissue [SSL/TLS certificates](#issue-new-certificates) and [recreate and validate DNS records](/dns/manage-dns-records/how-to/create-dns-records/) when transferring domains between Cloudflare accounts.
 

--- a/src/content/docs/fundamentals/manage-domains/move-domain.mdx
+++ b/src/content/docs/fundamentals/manage-domains/move-domain.mdx
@@ -29,14 +29,13 @@ To transfer a domain from one Cloudflare account to another, you will need:
 ## Transfer your domain
 
 :::caution
+Before transferring an active Cloudflare domain to another Cloudflare account, complete this pre-transfer checklist:
 
-
-Before transferring an active Cloudflare domain to another Cloudflare account, you must remove any [DNSSEC configurations](/dns/dnssec/) and [add-ons or subscriptions](/billing/manage/cancel-subscription/).
-
-We also recommend [exporting](/dns/manage-dns-records/how-to/import-and-export/#export-records) the DNS records of your zone while it is in the previous account. Then, you can [import](/dns/manage-dns-records/how-to/import-and-export/#import-records) the correct DNS records into the new account.
-If you miss this step, Cloudflare will import your proxied DNS records, which might cause your domain to experience a [1000 error](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/).
-
-
+1. **Remove DNSSEC configurations** — [disable DNSSEC](/dns/dnssec/) on the domain before moving it. DNSSEC records at the registrar will prevent the domain from activating in the new account.
+2. **Cancel add-ons and subscriptions** — [remove all add-on subscriptions](/billing/cancel-subscription/) associated with the domain.
+3. **Remove custom certificates** — delete any [custom SSL/TLS certificates](/ssl/edge-certificates/custom-certificates/) from the domain. You will need to re-upload them to the new account.
+4. **Export DNS records** — [export your DNS records](/dns/manage-dns-records/how-to/import-and-export/#export-records) while the domain is still in the previous account. Then [import](/dns/manage-dns-records/how-to/import-and-export/#import-records) them into the new account. If you miss this step, Cloudflare will import your proxied DNS records, which might cause your domain to experience a [1000 error](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/).
+5. **Back up configuration** — consider using [Terraform](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs) to export and back up your zone configuration before moving. Settings from the original account (page rules, firewall rules, cache settings, and so on) do not transfer to the new account and must be recreated manually.
 :::
 
 If you still have access to your previous Cloudflare account, you can copy over the Cloudflare account settings manually. You must reissue [SSL/TLS certificates](#issue-new-certificates) and [recreate and validate DNS records](/dns/manage-dns-records/how-to/create-dns-records/) when transferring domains between Cloudflare accounts.

--- a/src/content/docs/fundamentals/manage-domains/remove-domain.mdx
+++ b/src/content/docs/fundamentals/manage-domains/remove-domain.mdx
@@ -62,3 +62,22 @@ Please also note that domains in the `Initializing (Finish setup)` or `Pending` 
    :::
 
 3. Select **Confirm**.
+
+## Automatic domain removal
+
+Cloudflare periodically checks whether your domain's nameservers still point to Cloudflare. If the nameservers are changed away from Cloudflare:
+
+1. **After 7 days** — the domain is marked as **Moved** and Cloudflare sends an email notification to the account owner.
+2. **After 7 more days in Moved status** — the domain is permanently deleted from the account.
+
+This process ensures that new domain owners can add domains to their own Cloudflare accounts without conflicts.
+
+### Restore an automatically removed domain
+
+To restore a domain that was automatically removed:
+
+1. [Re-add the domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account.
+2. Update the nameservers at your domain registrar to the Cloudflare nameservers assigned to your zone.
+3. Wait for the domain to become **Active** in the Cloudflare dashboard.
+
+You will need to reconfigure any settings (DNS records, page rules, firewall rules, and so on) that were previously associated with the domain, as they are not preserved after deletion.

--- a/src/content/docs/fundamentals/manage-domains/remove-domain.mdx
+++ b/src/content/docs/fundamentals/manage-domains/remove-domain.mdx
@@ -69,7 +69,7 @@ Cloudflare periodically checks whether your domain's nameservers still point to 
 
 1. **Moved** — Cloudflare detects that nameservers no longer point to Cloudflare and marks the domain as **Moved**. An email notification is sent to the account owner.
 2. **Deleted** — For Free zones, Cloudflare automatically transitions the domain from Moved to Deleted after 7 days. At this stage, the domain can still be re-added.
-3. **Purged** — 7 days after being marked Deleted, the zone is permanently purged. Zone settings are not preserved.
+3. **Purged** — Seven days after being marked Deleted, the zone is permanently purged. Zone settings are not preserved.
 
 For more details on each status, refer to [Domain status](/dns/zone-setups/reference/domain-status/).
 
@@ -85,4 +85,4 @@ To restore a domain that was automatically removed:
 2. Update the nameservers at your domain registrar to the new Cloudflare nameservers assigned to your zone.
 3. Wait for the domain to become **Active** in the Cloudflare dashboard.
 
-You will need to reconfigure any settings (DNS records, page rules, firewall rules, and so on) that were previously associated with the domain, as they are not preserved after removal.
+You will need to reconfigure any settings (DNS records, Page Rules, Firewall Rules, and so on) that were previously associated with the domain, as they are not preserved after removal.

--- a/src/content/docs/fundamentals/manage-domains/remove-domain.mdx
+++ b/src/content/docs/fundamentals/manage-domains/remove-domain.mdx
@@ -65,19 +65,24 @@ Please also note that domains in the `Initializing (Finish setup)` or `Pending` 
 
 ## Automatic domain removal
 
-Cloudflare periodically checks whether your domain's nameservers still point to Cloudflare. If the nameservers are changed away from Cloudflare:
+Cloudflare periodically checks whether your domain's nameservers still point to Cloudflare. If the nameservers are changed away from Cloudflare, the domain transitions through the following statuses:
 
-1. **After 7 days** — the domain is marked as **Moved** and Cloudflare sends an email notification to the account owner.
-2. **After 7 more days in Moved status** — the domain is permanently deleted from the account.
+1. **Moved** — Cloudflare detects that nameservers no longer point to Cloudflare and marks the domain as **Moved**. An email notification is sent to the account owner.
+2. **Deleted** — For Free zones, Cloudflare automatically transitions the domain from Moved to Deleted after 7 days. At this stage, the domain can still be re-added.
+3. **Purged** — 7 days after being marked Deleted, the zone is permanently purged. Zone settings are not preserved.
 
-This process ensures that new domain owners can add domains to their own Cloudflare accounts without conflicts.
+For more details on each status, refer to [Domain status](/dns/zone-setups/reference/domain-status/).
+
+:::note
+If you re-add a domain after it has been removed, Cloudflare assigns a new nameserver pair. You will need to update your registrar with the new nameservers.
+:::
 
 ### Restore an automatically removed domain
 
 To restore a domain that was automatically removed:
 
 1. [Re-add the domain](/fundamentals/manage-domains/add-site/) to your Cloudflare account.
-2. Update the nameservers at your domain registrar to the Cloudflare nameservers assigned to your zone.
+2. Update the nameservers at your domain registrar to the new Cloudflare nameservers assigned to your zone.
 3. Wait for the domain to become **Active** in the Cloudflare dashboard.
 
-You will need to reconfigure any settings (DNS records, page rules, firewall rules, and so on) that were previously associated with the domain, as they are not preserved after deletion.
+You will need to reconfigure any settings (DNS records, page rules, firewall rules, and so on) that were previously associated with the domain, as they are not preserved after removal.

--- a/src/content/docs/fundamentals/manage-members/dashboard-sso.mdx
+++ b/src/content/docs/fundamentals/manage-members/dashboard-sso.mdx
@@ -263,7 +263,7 @@ If there is an issue with your SSO IdP provider, you can add an alternate IdP us
      | jq '.result[] | select(.type == "dash_sso")'
    ```
 
-```txt
+   ```json output
    {
    	"id": "3537a672-e4d8-4d89-aab9-26cb622918a1",
    	"uid": "3537a672-e4d8-4d89-aab9-26cb622918a1",
@@ -325,7 +325,7 @@ The following API calls will disable SSO enforcement for an account. This action
      --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
    ```
 
-```txt
+   ```json output {2}
    {
    	"result": [
    		{
@@ -352,7 +352,7 @@ The following API calls will disable SSO enforcement for an account. This action
      }'
    ```
 
-```txt
+   ```json output
    {
    	"result": [
    		{

--- a/src/content/docs/fundamentals/manage-members/dashboard-sso.mdx
+++ b/src/content/docs/fundamentals/manage-members/dashboard-sso.mdx
@@ -182,7 +182,7 @@ Before enabling SSO for your domain, verify that your identity provider is confi
 
 If the test fails, review your IdP configuration against the [identity provider setup instructions](/cloudflare-one/integrations/identity-providers/) before enabling the SSO connector.
 
-### Troubleshoot IdP errors
+## Troubleshoot IdP errors
 
 If you encounter errors during IdP setup or testing, provide the following when [contacting support](/support/contacting-cloudflare-support/):
 

--- a/src/content/docs/fundamentals/manage-members/manage.mdx
+++ b/src/content/docs/fundamentals/manage-members/manage.mdx
@@ -76,4 +76,4 @@ You can delete your user as a Super Administrator, but you cannot delete your ac
 
 ### Reassign or recover Super Administrator access
 
-If you need to swap Super Administrator email addresses or regain access when the current Super Administrator email is unavailable, refer to [Change Super Administrator](/fundamentals/account/change-super-admin/). That page covers the temporary placeholder process for self-serve accounts and the recovery steps to take when the current mailbox is unavailable.
+If you need to reassign Super Administrator email addresses or regain access when the current Super Administrator email is unavailable, refer to [Change Super Administrator](/fundamentals/account/change-super-admin/) for the temporary placeholder process for self-serve accounts and the recovery steps to take when the current mailbox is unavailable.

--- a/src/content/docs/fundamentals/manage-members/manage.mdx
+++ b/src/content/docs/fundamentals/manage-members/manage.mdx
@@ -73,3 +73,7 @@ If you have been invited to an account and want to remove yourself from the acco
 If you are a Super Administrator for an account that has existing domains and you decide to leave the account, you can invite a new Super Administrator who will have access to the same account privileges.
 
 You can delete your user as a Super Administrator, but you cannot delete your account. Other Super Administrators will continue to have access to the appropriate privileges to manage the account, including billing information.
+
+### Reassign or recover Super Administrator access
+
+If you need to swap Super Administrator email addresses or regain access when the current Super Administrator email is unavailable, refer to [Change Super Administrator](/fundamentals/account/change-super-admin/). That page covers the temporary placeholder process for self-serve accounts and the recovery steps to take when the current mailbox is unavailable.

--- a/src/content/docs/fundamentals/reference/policies-compliances/compliance-docs.mdx
+++ b/src/content/docs/fundamentals/reference/policies-compliances/compliance-docs.mdx
@@ -6,7 +6,7 @@ products:
   - fundamentals
 ---
 
-Super Administrators can access common compliance documentation, such as PCI, SOC 2, ISO, and more, through the Cloudflare dashboard. Compliance documents are available to customers on Pro, Business, and Enterprise plans.
+Super Administrators can access common compliance documentation, such as PCI, SOC 2, ISO, and more, through the Cloudflare dashboard.
 
 Public compliance information is also available at [cloudflare.com/trust-hub/compliance-resources/](https://www.cloudflare.com/trust-hub/compliance-resources/).
 

--- a/src/content/docs/fundamentals/reference/policies-compliances/compliance-docs.mdx
+++ b/src/content/docs/fundamentals/reference/policies-compliances/compliance-docs.mdx
@@ -6,12 +6,12 @@ products:
   - fundamentals
 ---
 
-Super Administrators can access common compliance documentation, such as PCI, SOC 2, ISO, and more, through the Cloudflare dashboard.
+Super Administrators can access common compliance documentation, such as PCI, SOC 2, ISO, and more, directly from the Cloudflare dashboard.
 
-Public compliance information is also available at [cloudflare.com/trust-hub/compliance-resources/](https://www.cloudflare.com/trust-hub/compliance-resources/).
+Public compliance information is also available at the [Cloudflare Trust Hub - Compliance Resources](https://www.cloudflare.com/trust-hub/compliance-resources/).
 
 :::note
-For confidentiality purposes, only **Super Administrators** for an account can access compliance documentation through the dashboard.
+For confidentiality purposes, only **Super Administrators** for an account can access compliance documentation from the dashboard.
 :::
 
 To access compliance documentation:

--- a/src/content/docs/fundamentals/reference/policies-compliances/compliance-docs.mdx
+++ b/src/content/docs/fundamentals/reference/policies-compliances/compliance-docs.mdx
@@ -6,18 +6,22 @@ products:
   - fundamentals
 ---
 
-Super Administrators can access common compliance documentation, such as PCI, SOC 2, ISO, and more, through the Cloudflare dashboard.
+Super Administrators can access common compliance documentation, such as PCI, SOC 2, ISO, and more, through the Cloudflare dashboard. Compliance documents are available to customers on Pro, Business, and Enterprise plans.
+
+Public compliance information is also available at [cloudflare.com/trust-hub/compliance-resources/](https://www.cloudflare.com/trust-hub/compliance-resources/).
+
+:::note
+For confidentiality purposes, only **Super Administrators** for an account can access compliance documentation through the dashboard.
+:::
 
 To access compliance documentation:
 
-1. Visit [Compliance Documents](https://dash.cloudflare.com/?to=/:account/compliance-docs) and select your account where you are a **Super Administrator**.
-2. If you have not accessed this page before, read the confidentiality statement and select **I Agree**.
-3. Choose the document you need and select **Download**.
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
+2. Go to **Support** > **Compliance Documents**.
+3. If you have not accessed this page before, read the confidentiality statement and select **I Agree**.
+4. Choose the document you need and select **Download**.
 
-:::note
-
-For confidentiality purposes, only **Super Administrators** for an account can access compliance documentation.
-:::
+You can also access the page directly at [Compliance Documents](https://dash.cloudflare.com/?to=/:account/compliance-docs).
 
 ## Public data protection and compliance documentation
 

--- a/src/content/docs/fundamentals/user-profiles/2fa.mdx
+++ b/src/content/docs/fundamentals/user-profiles/2fa.mdx
@@ -175,7 +175,7 @@ If you do not have access to your 2FA account or backup codes and cannot current
 
 2. On the **Two-Factor Authentication** page, select **Try recovery** on **Lost all 2FA devices and backup codes?**.
 3. Select **Begin recovery**.
-4. A 6-digit access code will be sent to the email address associated with your Cloudflare account.
+4. An access code will be sent to the email address associated with your Cloudflare account.
 5. Enter the temporary access code into the Cloudflare Dashboard and select **Verify email**.
 6. Select **Verify device**. This checks whether you are using a device that has previously logged into your account.
 
@@ -185,7 +185,7 @@ If you see **Device verification failed**, you may be able to try again consider
 
    * If you clear your cookies often or are logging in from a different IP address, you have wiped Cloudflare's memory of your device and will need to use a different device to verify.
    * Your browser may be set to clear cookies on exit or after browser or OS upgrades. This interferes with the device verification process.
-   * You may be using anti-malware or other software that automatically clears your browser cookies and makes your device unregognizable by Cloudflare's Dashboard.
+   * You may be using anti-malware or other software that automatically clears your browser cookies and makes your device unrecognizable by Cloudflare's Dashboard.
 
 If you are still unable to verify your device, follow the instructions to *Request manual verification* on the **Device verification failed** page.
 
@@ -209,10 +209,7 @@ If device verification fails, your browser may have cleared cookies since your l
 
 ### Contact support for manual recovery
 
-If both backup codes and device recovery are unavailable, [contact Cloudflare Support](/support/contacting-cloudflare-support/) with billing verification details to prove account ownership:
-
-- Date and amount of the last charge on the account
-- Last four digits and expiry date of the payment card on file (or the PayPal email address used for billing)
+If both backup codes and device recovery are unavailable, [contact Cloudflare Support](/support/contacting-cloudflare-support/) and follow the account verification steps provided by Support to prove account ownership.
 
 :::caution
 As a last resort, Cloudflare can delete the account so you can re-register with the same email address. This permanently removes all account configuration, domains, and data. This action cannot be undone.

--- a/src/content/docs/fundamentals/user-profiles/2fa.mdx
+++ b/src/content/docs/fundamentals/user-profiles/2fa.mdx
@@ -165,6 +165,61 @@ When setting up 2FA, you should have saved your backup codes in a secure locatio
 Once you use a backup code, it becomes invalid.
 :::
 
+## Recover your account
+
+If you do not have access to your 2FA account or backup codes and cannot currently generate a 2FA code, use a verified device that you have logged in from before to request a temporary access code.
+
+1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/login).
+
+      <DashButton url="/?to=/:account/home" />
+
+2. On the **Two-Factor Authentication** page, select **Try recovery** on **Lost all 2FA devices and backup codes?**.
+3. Select **Begin recovery**.
+4. A 6-digit access code will be sent to the email address associated with your Cloudflare account.
+5. Enter the temporary access code into the Cloudflare Dashboard and select **Verify email**.
+6. Select **Verify device**. This checks whether you are using a device that has previously logged into your account.
+
+If you see **Device verified**, you will receive an email within 3-5 days with instructions to regain access to your account. It is important to note this process cannot be expedited, so you will need to wait until that email arrives before you can proceed.
+
+If you see **Device verification failed**, you may be able to try again considering the following:
+
+   * If you clear your cookies often or are logging in from a different IP address, you have wiped Cloudflare's memory of your device and will need to use a different device to verify.
+   * Your browser may be set to clear cookies on exit or after browser or OS upgrades. This interferes with the device verification process.
+   * You may be using anti-malware or other software that automatically clears your browser cookies and makes your device unregognizable by Cloudflare's Dashboard.
+
+If you are still unable to verify your device, follow the instructions to *Request manual verification* on the **Device verification failed** page.
+
+## Troubleshooting and recovery
+
+### Find your backup codes
+
+When you first set up 2FA, your backup codes were saved in a file named `cloudflare-<YOUR_EMAIL>-<DATE>.txt`. Search your computer's downloads folder for a file starting with `cloudflare-` to locate it.
+
+### Self-service recovery from a recognized device
+
+If you have lost your backup codes, you can attempt recovery from a device where you have recently logged in:
+
+1. Go to the [Cloudflare login page](https://dash.cloudflare.com/login) and enter your credentials.
+2. At the 2FA challenge, select **Try recovery** under **Lost all 2FA devices and backup codes?**.
+3. Follow the on-screen steps to verify your device. The device must have an existing Cloudflare login cookie.
+
+:::note
+If device verification fails, your browser may have cleared cookies since your last login. Try from a different device or browser where you previously logged in.
+:::
+
+### Contact support for manual recovery
+
+If both backup codes and device recovery are unavailable, [contact Cloudflare Support](/support/contacting-cloudflare-support/) with billing verification details to prove account ownership:
+
+- Date and amount of the last charge on the account
+- Last four digits and expiry date of the payment card on file (or the PayPal email address used for billing)
+
+:::caution
+As a last resort, Cloudflare can delete the account so you can re-register with the same email address. This permanently removes all account configuration, domains, and data. This action cannot be undone.
+:::
+
+***
+
 ## Related resources
 
 * [Google Authentication documentation](https://support.google.com/accounts/answer/1066447?hl=en\&ref_topic=2954345\&co=GENIE.Platform%3DiOS\&oco=0)

--- a/src/content/docs/fundamentals/user-profiles/2fa.mdx
+++ b/src/content/docs/fundamentals/user-profiles/2fa.mdx
@@ -167,27 +167,7 @@ Once you use a backup code, it becomes invalid.
 
 ## Recover your account
 
-If you do not have access to your 2FA account or backup codes and cannot currently generate a 2FA code, use a verified device that you have logged in from before to request a temporary access code.
-
-1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/login).
-
-      <DashButton url="/?to=/:account/home" />
-
-2. On the **Two-Factor Authentication** page, select **Try recovery** on **Lost all 2FA devices and backup codes?**.
-3. Select **Begin recovery**.
-4. An access code will be sent to the email address associated with your Cloudflare account.
-5. Enter the temporary access code into the Cloudflare Dashboard and select **Verify email**.
-6. Select **Verify device**. This checks whether you are using a device that has previously logged into your account.
-
-If you see **Device verified**, you will receive an email within 3-5 days with instructions to regain access to your account. It is important to note this process cannot be expedited, so you will need to wait until that email arrives before you can proceed.
-
-If you see **Device verification failed**, you may be able to try again considering the following:
-
-   * If you clear your cookies often or are logging in from a different IP address, you have wiped Cloudflare's memory of your device and will need to use a different device to verify.
-   * Your browser may be set to clear cookies on exit or after browser or OS upgrades. This interferes with the device verification process.
-   * You may be using anti-malware or other software that automatically clears your browser cookies and makes your device unrecognizable by Cloudflare's Dashboard.
-
-If you are still unable to verify your device, follow the instructions to *Request manual verification* on the **Device verification failed** page.
+If you do not have access to your 2FA account or backup codes, refer to [Account recovery](/fundamentals/user-profiles/account-recovery/) for the full recovery process using a verified device.
 
 ## Troubleshooting and recovery
 

--- a/src/content/docs/fundamentals/user-profiles/change-password-or-email.mdx
+++ b/src/content/docs/fundamentals/user-profiles/change-password-or-email.mdx
@@ -62,17 +62,20 @@ If you forget the email address associated with your application:
 
 ## Forgot your password
 
-You must be logged out of the Cloudflare dashboard to view the **Forgot your password?** option. 
+You must be logged out of the Cloudflare dashboard to view the **Forgot your password?** option.
 
 If you forget the password associated with your email address:
 
-1. Go to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select **Forgot your password?**.
-2. Enter your email address.
+1. Go to [`https://dash.cloudflare.com/forgot-password`](https://dash.cloudflare.com/forgot-password).
+2. Enter your email address and at least one domain on the account. If no domains are on the account, your email address alone is sufficient.
 3. Cloudflare will send an email with instructions to reset your password. If you do not receive an email within 20 minutes, check your spam folder. The message will be sent from `no-reply@cloudflare.com` or `noreply@notify.cloudflare.com`.
 
 :::note
+The password reset code expires after 2 hours. If the code has expired, submit a new reset request.
+:::
 
-This process does not affect your account or share your email address with anyone.
+:::caution
+Cloudflare employees cannot view or change your password. Support can only send a password reset email to the address on file for the account.
 :::
 
 If you still cannot access the email address associated with your Cloudflare account, you may need to [move your domain to another account](/fundamentals/manage-domains/move-domain/).

--- a/src/content/docs/fundamentals/user-profiles/delete-account.mdx
+++ b/src/content/docs/fundamentals/user-profiles/delete-account.mdx
@@ -60,9 +60,11 @@ All domains, subscriptions, and billing information on your account will be remo
 
 ## After deletion
 
-- **Re-register with the same email** — you can sign up for a new Cloudflare account using the same email address. In most cases, the email is available for reuse immediately.
-- **Re-invitation to other accounts** — if you were a member of other Cloudflare accounts or organizations, the account owner will need to re-invite you after you create a new account.
-- **Prevent future lockouts** — when setting up your new account, store your 2FA backup codes in a secure location (such as a password manager) and consider adding multiple 2FA methods (security key, TOTP app, and email) so you are not dependent on a single device.
+After your account is deleted, all domains, subscriptions, and billing information are permanently removed from Cloudflare. If you need to use Cloudflare again:
+
+- **Create a new account** — You can sign up for a new Cloudflare account using the same email address. In most cases, the email is available for reuse immediately. Note that your previous account settings and configurations will not be restored.
+- **Rejoin other accounts** — If you were a member of other Cloudflare accounts or organizations, the account owner will need to re-invite you after you create a new account.
+- **Prevent future lockouts** — When setting up your new account, store your 2FA backup codes in a secure location (such as a password manager) and consider adding multiple 2FA methods (security key, TOTP app, and email) so you are not dependent on a single device.
 
 :::note
 

--- a/src/content/docs/fundamentals/user-profiles/delete-account.mdx
+++ b/src/content/docs/fundamentals/user-profiles/delete-account.mdx
@@ -20,15 +20,17 @@ If your account does not use SSO, you can delete your account on your own.
 
 ## Prerequisites
 
-Before Cloudflare can cancel your account and delete your personal information, you will need to follow the process below for each domain associated with your Cloudflare account:
+Before Cloudflare can cancel your account and delete your personal information, complete the following steps for each domain associated with your Cloudflare account:
 
-- [Cancel your subscriptions or add-on services](/billing/manage/cancel-subscription/)
-- [Remove your domain from Cloudflare](/fundamentals/manage-domains/remove-domain/)
-- [Remove Cloudflare nameservers at your domain registrar](/dns/zone-setups/full-setup/setup/)
-- [Disable auto-renew for your Registrar domain(s)](/registrar/account-options/renew-domains#set-up-automatic-renewals)
-- If you are using a Cloudflare [CNAME setup](/dns/zone-setups/partial-setup/), [update your DNS records](/dns/manage-dns-records/how-to/create-dns-records/#edit-dns-records) at your DNS provider to point to your website IPs or hostnames instead of Cloudflare.
-- [Delete payment information](/billing/get-started/update-billing-info/#delete-a-payment-method)
-- (*Optional*) [Download a copy of your invoices](/billing/manage/invoices/#download-invoice). Once deleted, the invoices will no longer be accessible and cannot be re-sent to you.
+1. [Cancel all subscriptions and add-on services](/billing/manage/cancel-subscription/).
+2. [Remove all domains from Cloudflare](/fundamentals/manage-domains/remove-domain/).
+3. Update DNS at your registrar:
+   - If using a [full setup](/dns/zone-setups/full-setup/setup/), remove Cloudflare nameservers at your domain registrar and replace them with your previous DNS provider's nameservers.
+   - If using a [CNAME setup](/dns/zone-setups/partial-setup/), [update your DNS records](/dns/manage-dns-records/how-to/create-dns-records/#edit-dns-records) at your DNS provider to point to your website IPs or hostnames instead of Cloudflare.
+4. [Disable auto-renew for your Registrar domain(s)](/registrar/account-options/renew-domains#set-up-automatic-renewals).
+5. [Download a copy of your invoices](/billing/manage/invoices/#download-invoice) from the billing section. Once the account is deleted, invoices will no longer be accessible and cannot be re-sent.
+6. [Delete payment information](/billing/get-started/update-billing-info/#delete-a-payment-method).
+7. Delete your account and personal information from the dashboard (steps below).
 
 ## Delete your Cloudflare account
 
@@ -55,6 +57,12 @@ All domains, subscriptions, and billing information on your account will be remo
 3. Select **Delete this user**.
 4. Select **Delete user**.
 5. Follow the prompts to finish deleting your account.
+
+## After deletion
+
+- **Re-register with the same email** — you can sign up for a new Cloudflare account using the same email address. In most cases, the email is available for reuse immediately.
+- **Re-invitation to other accounts** — if you were a member of other Cloudflare accounts or organizations, the account owner will need to re-invite you after you create a new account.
+- **Prevent future lockouts** — when setting up your new account, store your 2FA backup codes in a secure location (such as a password manager) and consider adding multiple 2FA methods (security key, TOTP app, and email) so you are not dependent on a single device.
 
 :::note
 

--- a/src/content/docs/fundamentals/user-profiles/login.mdx
+++ b/src/content/docs/fundamentals/user-profiles/login.mdx
@@ -50,13 +50,17 @@ You will receive an email with instructions to set your password. Once created, 
 
 * **Different Cloudflare account email as Apple ID**: This option creates a new Cloudflare account. If you want to log in to an existing account, [change your email address](/fundamentals/user-profiles/change-password-or-email/) to match the one used for your Apple ID.
 
-If you chose to share your email when creating a Cloudflare account with Apple ID and want to set a password and obtain an API key, go to the [Cloudflare dashboard](https://dash.cloudflare.com/login) login page and select **Forgot your password?** to trigger a password reset email.
+##### Shared email (not hidden)
 
-If you have chosen to hide your email when creating a Cloudflare account with Apple ID, resetting your password will not work. You can use the suggested workaround below:
+If you chose to share your email when creating a Cloudflare account with Apple ID and want to set a password and obtain an API key, trigger a password reset from [`https://dash.cloudflare.com/forgot-password`](https://dash.cloudflare.com/forgot-password). The reset email will be sent to the email address you shared with Cloudflare during sign-up.
 
-1. [Add a new member to your account](/fundamentals/manage-members/manage/#add-account-members) using your secondary email address.
-2. [Register a new Cloudflare account](/fundamentals/account/create-account/) with your secondary email address and set a password.
-3. Access the Cloudflare dashboard with the new user and password to obtain an API key.
+##### Hidden email (Apple Private Relay)
+
+If you chose to hide your email when creating a Cloudflare account with Apple ID, password reset will not work because the relay address does not accept inbound email from arbitrary senders. Use the following workaround:
+
+1. [Add a new member to your account](/fundamentals/manage-members/manage/#add-account-members) using a secondary email address you control.
+2. [Register a new Cloudflare account](/fundamentals/account/create-account/) with that secondary email address and set a password.
+3. Log in to the Cloudflare dashboard with the new account to obtain an API key.
 
 Changing your Cloudflare account email address will unlink the login credentials with the Apple ID from your Cloudflare account. If you attempt to log in using the same Apple ID after the email is changed, you will create a new Cloudflare account.
 

--- a/src/content/docs/fundamentals/user-profiles/login.mdx
+++ b/src/content/docs/fundamentals/user-profiles/login.mdx
@@ -50,11 +50,11 @@ You will receive an email with instructions to set your password. Once created, 
 
 * **Different Cloudflare account email as Apple ID**: This option creates a new Cloudflare account. If you want to log in to an existing account, [change your email address](/fundamentals/user-profiles/change-password-or-email/) to match the one used for your Apple ID.
 
-##### Shared email (not hidden)
+#### Shared email (not hidden)
 
 If you chose to share your email when creating a Cloudflare account with Apple ID and want to set a password and obtain an API key, trigger a password reset from [`https://dash.cloudflare.com/forgot-password`](https://dash.cloudflare.com/forgot-password). The reset email will be sent to the email address you shared with Cloudflare during sign-up.
 
-##### Hidden email (Apple Private Relay)
+#### Hidden email (Apple Private Relay)
 
 If you chose to hide your email when creating a Cloudflare account with Apple ID, password reset will not work because the relay address does not accept inbound email from arbitrary senders. Use the following workaround:
 

--- a/src/content/docs/fundamentals/user-profiles/multi-factor-email-authentication.mdx
+++ b/src/content/docs/fundamentals/user-profiles/multi-factor-email-authentication.mdx
@@ -25,11 +25,18 @@ Email MFA can only be disabled by enabling [two-factor authentication](/fundamen
 
 ## Troubleshoot MFA
 
-Cloudflare emails are sometimes flagged as spam by the recipient's email service. If you are expecting an authentication token, you should check the spam folder for any Cloudflare emails and configure a filter to allow Cloudflare emails from *[no-reply@notify.cloudflare.com](mailto:no-reply@notify.cloudflare.com)*\_**.**\_
+### When does email MFA trigger?
 
-Other times, emails are rejected by the recipient email service. Cloudflare will try again it will flag your email address after several attempts and no further emails will be sent.
+Email MFA challenges a login when the client IP address is not recognized for that account. This means you may be prompted for a code when logging in from a new network, device, or location.
 
-If you still do not receive an email after ensuring your email service is not flagging Cloudflare, contact [Cloudflare Support](/support/contacting-cloudflare-support/).
+### Not receiving the one-time code email
+
+1. **Check your spam or junk folder** for an email from `no-reply@notify.cloudflare.com`.
+2. **Allowlist the sender** — add `no-reply@notify.cloudflare.com` to your email provider's allowlist or safe senders list to prevent future emails from being flagged as spam.
+3. **Request a new code** if the token has expired. Each one-time code has a limited validity period (30 minutes). If it has expired, return to the login page and attempt to log in again to receive a fresh code.
+4. **Check for email suppression** — if previous emails to your address bounced or were marked as spam, Cloudflare may have added it to a suppression list and will stop sending further emails. [Contact Cloudflare Support](/support/contacting-cloudflare-support/) to have your email address cleared from the suppression list.
+
+If you still do not receive an email after completing these steps, [contact Cloudflare Support](/support/contacting-cloudflare-support/).
 
 ***
 

--- a/src/content/docs/fundamentals/user-profiles/multi-factor-email-authentication.mdx
+++ b/src/content/docs/fundamentals/user-profiles/multi-factor-email-authentication.mdx
@@ -25,9 +25,9 @@ Email MFA can only be disabled by enabling [two-factor authentication](/fundamen
 
 ## Troubleshoot MFA
 
-### When does email MFA trigger?
+### MFA trigger conditions
 
-Email MFA challenges a login when the client IP address is not recognized for that account. This means you may be prompted for a code when logging in from a new network, device, or location.
+Email MFA challenges a login when the client IP address is not recognized for that account. You may be prompted for a code when logging in from a new network, device, or location.
 
 ### Not receiving the one-time code email
 

--- a/src/content/docs/radar/glossary.mdx
+++ b/src/content/docs/radar/glossary.mdx
@@ -136,7 +136,7 @@ Cloudflare uses a variety of data sources to categorize domains. Using Cloudflar
 
 ### Review domain categories
 
-To check the categories assigned to a domain, go to `https://radar.cloudflare.com/domains/lookup/<DOMAIN>` and replace `<DOMAIN>` with the domain you want to look up.
+To check the categories assigned to a domain, go to `https://radar.cloudflare.com/domain/<DOMAIN>` and replace `<DOMAIN>` with the domain you want to look up.
 
 ### Request recategorization
 

--- a/src/content/docs/radar/glossary.mdx
+++ b/src/content/docs/radar/glossary.mdx
@@ -134,7 +134,17 @@ Cloudflare Speed Test measures latency multiple times over the course of the tes
 
 Cloudflare uses a variety of data sources to categorize domains. Using Cloudflare Radar, you can view the content categories associated with a given domain. Cloudflare customers using [Cloudflare Gateway](/cloudflare-one/traffic-policies/domain-categories/) or [1.1.1.1 for Families](/1.1.1.1/setup/#1111-for-families) can decide to block certain categories, like "Adult Content", in addition to security threats like malware and phishing.
 
-In some cases, a domain may be miscategorized. For example, a social media site might be categorized as "Shopping & Auctions". If you believe a domain is miscategorized, or a domain has not yet been categorized, please provide your suggested category using [this form](https://radar.cloudflare.com/domains/feedback) to bring it to our attention.
+### Review domain categories
+
+To check the categories assigned to a domain, go to `https://radar.cloudflare.com/domains/lookup/<DOMAIN>` and replace `<DOMAIN>` with the domain you want to look up.
+
+### Request recategorization
+
+In some cases, a domain may be miscategorized. For example, a social media site might be categorized as "Shopping & Auctions". If you believe a domain is miscategorized, or a domain has not yet been categorized, you can request a change through any of the following methods:
+
+- **Radar**: Select **Domain Categorization Feedback** on the [Radar domain feedback page](https://radar.cloudflare.com/domains/feedback).
+- **Security Center**: In the Cloudflare dashboard, go to **Security Center** > **Investigate**, search for the domain, then select **Request to change categorization**. For detailed steps, refer to [Change categorization](/security-center/investigate/change-categorization/).
+- **API**: Create an API token with Intel Edit permissions and use the [miscategorization endpoint](/api/resources/intel/subresources/miscategorizations/methods/create/). For detailed steps, refer to [Change categorization via the API](/security-center/investigate/change-categorization/#via-the-api).
 
 ## DNS
 

--- a/src/content/docs/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips.mdx
+++ b/src/content/docs/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips.mdx
@@ -493,6 +493,24 @@ https://example.com {
 ```
 ---
 
+## Cloudflare IPs in your server logs
+
+When your site is proxied through Cloudflare, your origin server logs will show Cloudflare edge IP addresses instead of original visitor IPs by default. This is expected behavior and does not mean Cloudflare is originating traffic to your site. Cloudflare does not generate or originate attack traffic to customer origins.
+
+### Scenario 1: Cloudflare IPs in origin HTTP logs (expected when proxied)
+
+If your site is proxied through Cloudflare and your origin logs show Cloudflare IP addresses, this is normal. Your origin sees Cloudflare edge server IPs because Cloudflare acts as a reverse proxy between visitors and your origin.
+
+To log the original visitor IP instead, follow the [web server instructions](#web-server-instructions) on this page to extract the IP from the [`CF-Connecting-IP` header](/fundamentals/reference/http-headers/#cf-connecting-ip).
+
+### Scenario 2: Cloudflare IPs on non-HTTP protocols (likely IP spoofing)
+
+Cloudflare's reverse proxy only forwards HTTP and HTTPS traffic. If you observe UDP traffic, ICMP traffic, or other non-HTTP traffic that appears to originate from [Cloudflare IP addresses](https://www.cloudflare.com/ips/), this is consistent with IP spoofing or amplification attacks, not Cloudflare-originated traffic.
+
+In IP spoofing attacks, the attacker forges the source IP address of packets to make them appear to come from a different source. Cloudflare IP addresses, like any other public IP ranges, can be used as spoofed source addresses by attackers. This does not indicate that Cloudflare systems sent the traffic.
+
+---
+
 ## Related Resources
 
 - [Cloudflare HTTP headers](/fundamentals/reference/http-headers/)


### PR DESCRIPTION
## Summary

Improves documentation for high-volume support topics in Fundamentals, based on an audit of active support macros. These are the responses agents send most frequently — gaps here mean customers cannot self-serve.

### Changes

- **2FA recovery**: Add self-service recovery steps, backup code location hints, and verification options
- **Email MFA**: Document email-based MFA enrollment and troubleshooting
- **Password reset & login**: Clarify Apple ID/social login limitations and recovery paths
- **Account security**: Add compromised-account response checklist
- **Account deletion**: Document prerequisites and data retention
- **Super Admin transfer**: Add step-by-step swap procedure
- **Domain management**: Expand move-domain checklist and auto-removal triggers
- **Compliance docs**: Clarify how to request compliance documentation
- **Member management**: Improve role and access documentation
- **Dashboard SSO**: Add SSO testing guidance

### Context

These changes are driven by recurring support cases. If you want to see the underlying support data (macro frequency, case volume by topic), reach out to @dmmulroy internally.