### PR TITLE
[Support Feedback] Add false positive remediation guide and domain categorization (WAF)

### DIFF
--- a/src/content/docs/radar/glossary.mdx
+++ b/src/content/docs/radar/glossary.mdx
@@ -134,7 +134,17 @@ Cloudflare Speed Test measures latency multiple times over the course of the tes
 
 Cloudflare uses a variety of data sources to categorize domains. Using Cloudflare Radar, you can view the content categories associated with a given domain. Cloudflare customers using [Cloudflare Gateway](/cloudflare-one/traffic-policies/domain-categories/) or [1.1.1.1 for Families](/1.1.1.1/setup/#1111-for-families) can decide to block certain categories, like "Adult Content", in addition to security threats like malware and phishing.
 
-In some cases, a domain may be miscategorized. For example, a social media site might be categorized as "Shopping & Auctions". If you believe a domain is miscategorized, or a domain has not yet been categorized, please provide your suggested category using [this form](https://radar.cloudflare.com/domains/feedback) to bring it to our attention.
+### Review domain categories
+
+To check the categories assigned to a domain, go to `https://radar.cloudflare.com/domains/lookup/<DOMAIN>` and replace `<DOMAIN>` with the domain you want to look up.
+
+### Request recategorization
+
+In some cases, a domain may be miscategorized. For example, a social media site might be categorized as "Shopping & Auctions". If you believe a domain is miscategorized, or a domain has not yet been categorized, you can request a change through any of the following methods:
+
+- **Radar**: Select **Domain Categorization Feedback** on the [Radar domain feedback page](https://radar.cloudflare.com/domains/feedback).
+- **Security Center**: In the Cloudflare dashboard, go to **Security Center** > **Investigate**, search for the domain, then select **Request to change categorization**. For detailed steps, refer to [Change categorization](/security-center/investigate/change-categorization/).
+- **API**: Create an API token with Intel Edit permissions and use the [miscategorization endpoint](/api/resources/intel/subresources/miscategorizations/methods/create/). For detailed steps, refer to [Change categorization via the API](/security-center/investigate/change-categorization/#via-the-api).
 
 ## DNS
 

--- a/src/content/docs/radar/glossary.mdx
+++ b/src/content/docs/radar/glossary.mdx
@@ -143,7 +143,7 @@ To check the categories assigned to a domain, go to `https://radar.cloudflare.co
 In some cases, a domain may be miscategorized. For example, a social media site might be categorized as "Shopping & Auctions". If you believe a domain is miscategorized, or a domain has not yet been categorized, you can request a change through any of the following methods:
 
 - **Radar**: Select **Domain Categorization Feedback** on the [Radar domain feedback page](https://radar.cloudflare.com/domains/feedback).
-- **Security Center**: In the Cloudflare dashboard, go to **Security Center** > **Investigate**, search for the domain, then select **Request to change categorization**. For detailed steps, refer to [Change categorization](/security-center/investigate/change-categorization/).
+- **Application Security**: In the Cloudflare dashboard, go to **Application Security** > **Investigate**, search for the domain, then select **Request to change categorization**. For detailed steps, refer to [Change categorization](/security-center/investigate/change-categorization/).
 - **API**: Create an API token with Intel Edit permissions and use the [miscategorization endpoint](/api/resources/intel/subresources/miscategorizations/methods/create/). For detailed steps, refer to [Change categorization via the API](/security-center/investigate/change-categorization/#via-the-api).
 
 ## DNS

--- a/src/content/docs/radar/glossary.mdx
+++ b/src/content/docs/radar/glossary.mdx
@@ -134,17 +134,9 @@ Cloudflare Speed Test measures latency multiple times over the course of the tes
 
 Cloudflare uses a variety of data sources to categorize domains. Using Cloudflare Radar, you can view the content categories associated with a given domain. Cloudflare customers using [Cloudflare Gateway](/cloudflare-one/traffic-policies/domain-categories/) or [1.1.1.1 for Families](/1.1.1.1/setup/#1111-for-families) can decide to block certain categories, like "Adult Content", in addition to security threats like malware and phishing.
 
-### Review domain categories
-
 To check the categories assigned to a domain, go to `https://radar.cloudflare.com/domains/lookup/<DOMAIN>` and replace `<DOMAIN>` with the domain you want to look up.
 
-### Request recategorization
-
-In some cases, a domain may be miscategorized. For example, a social media site might be categorized as "Shopping & Auctions". If you believe a domain is miscategorized, or a domain has not yet been categorized, you can request a change through any of the following methods:
-
-- **Radar**: Select **Domain Categorization Feedback** on the [Radar domain feedback page](https://radar.cloudflare.com/domains/feedback).
-- **Application Security**: In the Cloudflare dashboard, go to **Application Security** > **Investigate**, search for the domain, then select **Request to change categorization**. For detailed steps, refer to [Change categorization](/security-center/investigate/change-categorization/).
-- **API**: Create an API token with Intel Edit permissions and use the [miscategorization endpoint](/api/resources/intel/subresources/miscategorizations/methods/create/). For detailed steps, refer to [Change categorization via the API](/security-center/investigate/change-categorization/#via-the-api).
+If you believe a domain is miscategorized — for example, a social media site might be categorized as "Shopping & Auctions" — or a domain has not yet been categorized, you can request a change through Cloudflare Radar, the Cloudflare dashboard, or via API. For more information, refer to [Change categorization](/security-center/investigate/change-categorization/).
 
 ## DNS
 

--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/configure-api.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/configure-api.mdx
@@ -3,9 +3,10 @@ pcx_content_type: configuration
 description: Configure the OWASP Core Ruleset using the API.
 products:
   - waf
-title: Configure via API
+title: Configure the OWASP managed ruleset via API
 sidebar:
   order: 5
+  label: Configure via API
 ---
 
 import { Details, RuleID, APIRequest } from "~/components";

--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/configure-dashboard.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/configure-dashboard.mdx
@@ -3,12 +3,10 @@ pcx_content_type: configuration
 description: Configure the OWASP Core Ruleset in the dashboard.
 products:
   - waf
-title: Configure in the dashboard
+title: Configure the OWASP managed ruleset in the dashboard
 sidebar:
   order: 4
-head:
-  - tag: title
-    content: Configure the OWASP ruleset in the dashboard
+  label: Configure in the dashboard
 ---
 
 import { Render, Markdown, Tabs, TabItem } from "~/components";

--- a/src/content/docs/waf/managed-rules/troubleshooting.mdx
+++ b/src/content/docs/waf/managed-rules/troubleshooting.mdx
@@ -27,8 +27,8 @@ Cloudflare WAF includes multiple [managed rulesets](/waf/managed-rules/#availabl
 
 Before taking action, identify which rule blocked the request:
 
-1. Go to **Security** > **Events** in the Cloudflare dashboard.
-2. Filter by the request details (IP address, URI path, timestamp) to find the blocked event.
+1. Go to **Security** > **Analytics** > **Events** in the Cloudflare dashboard.
+2. Filter by the request details (IP address, URI path, timestamp, or Ray ID) to find the blocked event.
 3. Note the **Rule ID** and **Rule message** — these determine which remediation step to follow.
 
 ### Recommended remediation steps
@@ -40,6 +40,8 @@ Follow this decision tree based on the rule that triggered the false positive:
 [WAF exceptions](/waf/managed-rules/waf-exceptions/) let you skip specific rules or entire managed rulesets for requests that match certain conditions. This is the recommended approach because it preserves protection for all other traffic.
 
 Define exceptions in the [Cloudflare dashboard](/waf/managed-rules/waf-exceptions/define-dashboard/) or via the [Rulesets API](/waf/managed-rules/waf-exceptions/define-api/).
+
+To inspect the request payload and confirm whether traffic is a genuine false positive, you can [configure payload logging](/waf/managed-rules/payload-logging/configure/).
 
 #### 2. Adjust OWASP settings (if rule 949110 is triggering)
 

--- a/src/content/docs/waf/managed-rules/troubleshooting.mdx
+++ b/src/content/docs/waf/managed-rules/troubleshooting.mdx
@@ -9,7 +9,7 @@ sidebar:
   label: Troubleshooting
 ---
 
-import { RuleID } from "~/components";
+import { Tabs, TabItem, DashButton, RuleID } from "~/components";
 
 By default, WAF's managed rulesets are compatible with most websites and web applications. However, false positives and false negatives may occur:
 
@@ -27,9 +27,21 @@ Cloudflare WAF includes multiple [managed rulesets](/waf/managed-rules/#availabl
 
 Before taking action, identify which rule blocked the request:
 
-1. Go to **Security** > **Analytics** > **Events** in the Cloudflare dashboard.
+<Tabs syncKey="dashNewNav"> <TabItem label="New dashboard" icon="rocket">
+
+1. In the Cloudflare dashboard, go to the **Analytics** page.
+
+   <DashButton url="/?to=/:account/:zone/security/analytics" />
+
+2. Select the **Events** tab.
+3. Filter by the request details (IP address, URI path, timestamp, or Ray ID) to find the blocked event.
+
+</TabItem> <TabItem label="Old dashboard">
+
+1. In the Cloudflare dashboard, go to **Security** > **Events**.
 2. Filter by the request details (IP address, URI path, timestamp, or Ray ID) to find the blocked event.
-3. Note the **Rule ID** and **Rule message** — these determine which remediation step to follow.
+
+</TabItem> </Tabs>
 
 ### Recommended remediation steps
 

--- a/src/content/docs/waf/managed-rules/troubleshooting.mdx
+++ b/src/content/docs/waf/managed-rules/troubleshooting.mdx
@@ -18,19 +18,64 @@ By default, WAF's managed rulesets are compatible with most websites and web app
 
 ## Troubleshoot false positives
 
-You can use [Security Events](/waf/analytics/security-events/) to help you identify what caused legitimate requests to get blocked. Add filters and adjust the report duration as needed.
+Cloudflare WAF uses two main rule packages:
 
-If you encounter a false positive caused by a managed rule, do one of the following:
+- **Cloudflare Managed Ruleset**: Maintained by Cloudflare WAF engineers. Rule patterns are not publicly shared for security reasons.
+- **OWASP ModSecurity Core Rule Set**: Cloudflare's implementation of the open-source [OWASP CRS](https://owasp.org/www-project-modsecurity-core-rule-set/), which is not maintained by Cloudflare.
 
-- **Add an exception**: [Exceptions](/waf/managed-rules/waf-exceptions/) allow you to skip the execution of WAF managed rulesets or some of their rules for certain requests.
+### Identify the blocking rule
 
-- **Adjust the OWASP managed ruleset**: A request blocked by the rule with ID <RuleID id="6179ae15870a4bb7b2d480d4843b323c" /> and description `949110: Inbound Anomaly Score Exceeded` refers to the [Cloudflare OWASP Core Ruleset](/waf/managed-rules/reference/owasp-core-ruleset/). To resolve the issue, [configure the OWASP managed ruleset](/waf/managed-rules/reference/owasp-core-ruleset/configure-dashboard/).
+Before taking action, identify which rule blocked the request:
 
-- **Disable the corresponding managed rule(s)**: Create an override to disable specific rules. This may avoid false positives, but you will also reduce the overall site security. Refer to the [dashboard instructions](/waf/managed-rules/deploy-zone-dashboard/#configure-a-managed-ruleset) on configuring a managed ruleset, or to the [API instructions](/ruleset-engine/managed-rulesets/override-managed-ruleset/) on creating an override.
+1. Go to **Security** > **Events** in the Cloudflare dashboard.
+2. Filter by the request details (IP address, URI path, timestamp) to find the blocked event.
+3. Note the **Rule ID** and **Rule message** — these determine which remediation step to follow.
+
+### Recommended remediation steps
+
+Follow this decision tree based on the rule that triggered the false positive:
+
+#### 1. Add a WAF exception (recommended first step)
+
+[WAF exceptions](/waf/managed-rules/waf-exceptions/) let you skip specific rules or entire managed rulesets for requests that match certain conditions. This is the recommended approach because it preserves protection for all other traffic.
+
+Define exceptions in the [Cloudflare dashboard](/waf/managed-rules/waf-exceptions/define-dashboard/) or via the [Rulesets API](/waf/managed-rules/waf-exceptions/define-api/).
+
+#### 2. Adjust OWASP settings (if rule 949110 is triggering)
+
+A request blocked by the rule with ID <RuleID id="6179ae15870a4bb7b2d480d4843b323c" /> and description `949110: Inbound Anomaly Score Exceeded` was blocked by the [Cloudflare OWASP Core Ruleset](/waf/managed-rules/reference/owasp-core-ruleset/). The OWASP ruleset calculates a cumulative [threat score](/waf/managed-rules/reference/owasp-core-ruleset/concepts/#request-threat-score) — when the score exceeds the configured threshold, the request is blocked.
+
+To resolve OWASP false positives:
+
+- **Increase the anomaly score threshold**: Increase the [score threshold](/waf/managed-rules/reference/owasp-core-ruleset/concepts/#score-threshold) so that more rule matches are required before blocking.
+- **Lower the paranoia level**: Reduce the [paranoia level](/waf/managed-rules/reference/owasp-core-ruleset/concepts/#paranoia-level) to disable more aggressive rules that are more likely to produce false positives.
+
+For configuration steps, refer to [Configure the OWASP managed ruleset](/waf/managed-rules/reference/owasp-core-ruleset/configure-dashboard/).
+
+#### 3. Disable specific managed rules
+
+Create an override to disable the individual rule causing the false positive. This reduces overall security, so only disable the minimum number of rules necessary.
+
+Refer to the [dashboard instructions](/waf/managed-rules/deploy-zone-dashboard/#configure-a-managed-ruleset) or the [API instructions](/ruleset-engine/managed-rulesets/override-managed-ruleset/) on creating an override.
 
 :::note
 If you contact Cloudflare Support to verify whether a WAF managed rule triggers as expected, [provide a HAR file](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/#generate-a-har-file) captured while sending the specific request of concern.
 :::
+
+### Legacy WAF remediation options
+
+:::note
+The legacy WAF has been replaced by the current WAF managed rulesets. If you are still using the legacy WAF, consider migrating to the current WAF. The following options apply only to the legacy WAF.
+:::
+
+If you are on the legacy WAF, the following remediation options are available (ordered from least to most impact on security):
+
+1. **Add the requesting IP to the allowlist**: Use [IP Access Rules](/waf/tools/ip-access-rules/) to allowlist the IP. This is the best option if the affected users always connect from the same IP address and does not reduce site security for other visitors.
+2. **Disable the specific WAF rule**: Turn off only the rule causing the false positive. This reduces security slightly but stops the incorrect block or challenge.
+3. **Create a bypass rule**: Create a [custom rule](/waf/custom-rules/skip/) with a bypass action targeting a specific URL combined with IP address or user-agent conditions.
+4. **Lower OWASP sensitivity**: If the blocking rule is `981176` (legacy OWASP) or `949110` (current OWASP), decrease the OWASP sensitivity level.
+5. **Disable WAF for a specific endpoint via Page Rule** (not recommended): This disables the WAF entirely for that URL pattern, removing all WAF protection for matching requests.
+6. **WAF overrides via API** (Enterprise only): Use the [WAF Overrides API](/api/resources/waf/subresources/overrides/methods/list/) to disable a specific WAF rule for a particular URI without affecting other traffic.
 
 ### Additional recommendations
 

--- a/src/content/docs/waf/managed-rules/troubleshooting.mdx
+++ b/src/content/docs/waf/managed-rules/troubleshooting.mdx
@@ -18,10 +18,10 @@ By default, WAF's managed rulesets are compatible with most websites and web app
 
 ## Troubleshoot false positives
 
-Cloudflare WAF uses two main rule packages:
+Cloudflare WAF includes multiple [managed rulesets](/waf/managed-rules/#available-managed-rulesets). The two most commonly involved in false positives are:
 
 - **Cloudflare Managed Ruleset**: Maintained by Cloudflare WAF engineers. Rule patterns are not publicly shared for security reasons.
-- **OWASP ModSecurity Core Rule Set**: Cloudflare's implementation of the open-source [OWASP CRS](https://owasp.org/www-project-modsecurity-core-rule-set/), which is not maintained by Cloudflare.
+- **Cloudflare OWASP Core Ruleset**: Cloudflare's implementation of the open-source [OWASP CRS](https://owasp.org/www-project-modsecurity-core-rule-set/).
 
 ### Identify the blocking rule
 
@@ -73,9 +73,9 @@ If you are on the legacy WAF, the following remediation options are available (o
 1. **Add the requesting IP to the allowlist**: Use [IP Access Rules](/waf/tools/ip-access-rules/) to allowlist the IP. This is the best option if the affected users always connect from the same IP address and does not reduce site security for other visitors.
 2. **Disable the specific WAF rule**: Turn off only the rule causing the false positive. This reduces security slightly but stops the incorrect block or challenge.
 3. **Create a bypass rule**: Create a [custom rule](/waf/custom-rules/skip/) with a bypass action targeting a specific URL combined with IP address or user-agent conditions.
-4. **Lower OWASP sensitivity**: If the blocking rule is `981176` (legacy OWASP) or `949110` (current OWASP), decrease the OWASP sensitivity level.
+4. **Adjust OWASP settings**: If the blocking rule is `981176` (legacy OWASP) or `949110` (current OWASP), increase the OWASP score threshold and/or lower the OWASP paranoia level.
 5. **Disable WAF for a specific endpoint via Page Rule** (not recommended): This disables the WAF entirely for that URL pattern, removing all WAF protection for matching requests.
-6. **WAF overrides via API** (Enterprise only): Use the [WAF Overrides API](/api/resources/waf/subresources/overrides/methods/list/) to disable a specific WAF rule for a particular URI without affecting other traffic.
+6. **WAF overrides via API** (legacy WAF only): Use the [WAF Overrides API](/api/resources/firewall/subresources/waf/subresources/overrides/methods/list/) to disable a specific legacy WAF rule for a particular URI without affecting other traffic. These overrides apply only to the previous version of the WAF.
 
 ### Additional recommendations
 

--- a/src/content/docs/waf/managed-rules/troubleshooting.mdx
+++ b/src/content/docs/waf/managed-rules/troubleshooting.mdx
@@ -43,53 +43,46 @@ Before taking action, identify which rule blocked the request:
 
 </TabItem> </Tabs>
 
-### Recommended remediation steps
+Note the **Rule ID** and **Rule message** — these determine which remediation step to follow.
 
-Follow this decision tree based on the rule that triggered the false positive:
+:::tip
+If you have configured [payload logging](/waf/managed-rules/payload-logging/configure/), you can inspect the request payload in the event details and confirm whether traffic is a genuine false positive. For more information, refer to [View the payload content in the dashboard](/waf/managed-rules/payload-logging/view/).
+:::
 
-#### 1. Add a WAF exception (recommended first step)
+### Apply remediation measures
 
-[WAF exceptions](/waf/managed-rules/waf-exceptions/) let you skip specific rules or entire managed rulesets for requests that match certain conditions. This is the recommended approach because it preserves protection for all other traffic.
+Do the following based on the rule that triggered the false positive:
 
-Define exceptions in the [Cloudflare dashboard](/waf/managed-rules/waf-exceptions/define-dashboard/) or via the [Rulesets API](/waf/managed-rules/waf-exceptions/define-api/).
+#### 1. Add a WAF exception
 
-To inspect the request payload and confirm whether traffic is a genuine false positive, you can [configure payload logging](/waf/managed-rules/payload-logging/configure/).
+[WAF exceptions](/waf/managed-rules/waf-exceptions/) let you skip specific rules or entire managed rulesets for requests that match certain conditions. This is the recommended approach because it preserves protection for all other traffic. You can define exceptions in the [dashboard](/waf/managed-rules/waf-exceptions/define-dashboard/) or [via API](/waf/managed-rules/waf-exceptions/define-api/).
 
-#### 2. Adjust OWASP settings (if rule 949110 is triggering)
+#### 2. Adjust OWASP settings (if applicable)
 
-A request blocked by the rule with ID <RuleID id="6179ae15870a4bb7b2d480d4843b323c" /> and description `949110: Inbound Anomaly Score Exceeded` was blocked by the [Cloudflare OWASP Core Ruleset](/waf/managed-rules/reference/owasp-core-ruleset/). The OWASP ruleset calculates a cumulative [threat score](/waf/managed-rules/reference/owasp-core-ruleset/concepts/#request-threat-score) — when the score exceeds the configured threshold, the request is blocked.
+A request blocked by the rule with ID <RuleID id="6179ae15870a4bb7b2d480d4843b323c" /> and description `949110: Inbound Anomaly Score Exceeded` was blocked by the [Cloudflare OWASP Core Ruleset](/waf/managed-rules/reference/owasp-core-ruleset/). The OWASP ruleset calculates a cumulative [threat score](/waf/managed-rules/reference/owasp-core-ruleset/concepts/#request-threat-score). When the score exceeds the configured threshold, the request is blocked.
 
 To resolve OWASP false positives:
 
 - **Increase the anomaly score threshold**: Increase the [score threshold](/waf/managed-rules/reference/owasp-core-ruleset/concepts/#score-threshold) so that more rule matches are required before blocking.
 - **Lower the paranoia level**: Reduce the [paranoia level](/waf/managed-rules/reference/owasp-core-ruleset/concepts/#paranoia-level) to disable more aggressive rules that are more likely to produce false positives.
 
-For configuration steps, refer to [Configure the OWASP managed ruleset](/waf/managed-rules/reference/owasp-core-ruleset/configure-dashboard/).
+Refer to the following pages for step-by-step instructions:
+
+- [Configure the OWASP managed ruleset in the dashboard](/waf/managed-rules/reference/owasp-core-ruleset/configure-dashboard/)
+- [Configure the OWASP managed ruleset via API](/waf/managed-rules/reference/owasp-core-ruleset/configure-api/)
 
 #### 3. Disable specific managed rules
 
-Create an override to disable the individual rule causing the false positive. This reduces overall security, so only disable the minimum number of rules necessary.
+Create an override to disable the individual managed rule causing the false positive. This reduces overall security, so only disable the minimum number of rules necessary.
 
-Refer to the [dashboard instructions](/waf/managed-rules/deploy-zone-dashboard/#configure-a-managed-ruleset) or the [API instructions](/ruleset-engine/managed-rulesets/override-managed-ruleset/) on creating an override.
+Refer to the following pages for step-by-step instructions:
+
+- [Configure a managed ruleset](/waf/managed-rules/deploy-zone-dashboard/#configure-a-managed-ruleset) (dashboard)
+- [Override a managed ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset/) (API)
 
 :::note
 If you contact Cloudflare Support to verify whether a WAF managed rule triggers as expected, [provide a HAR file](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/#generate-a-har-file) captured while sending the specific request of concern.
 :::
-
-### Legacy WAF remediation options
-
-:::note
-The legacy WAF has been replaced by the current WAF managed rulesets. If you are still using the legacy WAF, consider migrating to the current WAF. The following options apply only to the legacy WAF.
-:::
-
-If you are on the legacy WAF, the following remediation options are available (ordered from least to most impact on security):
-
-1. **Add the requesting IP to the allowlist**: Use [IP Access Rules](/waf/tools/ip-access-rules/) to allowlist the IP. This is the best option if the affected users always connect from the same IP address and does not reduce site security for other visitors.
-2. **Disable the specific WAF rule**: Turn off only the rule causing the false positive. This reduces security slightly but stops the incorrect block or challenge.
-3. **Create a bypass rule**: Create a [custom rule](/waf/custom-rules/skip/) with a bypass action targeting a specific URL combined with IP address or user-agent conditions.
-4. **Adjust OWASP settings**: If the blocking rule is `981176` (legacy OWASP) or `949110` (current OWASP), increase the OWASP score threshold and/or lower the OWASP paranoia level.
-5. **Disable WAF for a specific endpoint via Page Rule** (not recommended): This disables the WAF entirely for that URL pattern, removing all WAF protection for matching requests.
-6. **WAF overrides via API** (legacy WAF only): Use the [WAF Overrides API](/api/resources/firewall/subresources/waf/subresources/overrides/methods/list/) to disable a specific legacy WAF rule for a particular URI without affecting other traffic. These overrides apply only to the previous version of the WAF.
 
 ### Additional recommendations
 
@@ -137,3 +130,9 @@ If WAF's managed rulesets do not detect a specific attack pattern after verifyin
 - Use [WAF attack score](/waf/detections/attack-score/) to complement signature-based managed rules with machine-learning detection. Attack score classifies each request with a score indicating the likelihood it is malicious, even when no managed rule matches.
 
 - Create a [custom rule](/waf/custom-rules/) to block the specific attack pattern. Use fields such as URI path, query string, or HTTP request headers to match the malicious requests.
+
+## More resources
+
+If you are still using the previous version of WAF managed rules, refer to [Troubleshoot WAF managed rules (previous version)](/waf/reference/legacy/old-waf-managed-rules/troubleshooting/).
+
+To learn more about upgrading to the new version of WAF Managed Rules, refer to [WAF managed rules upgrade](/waf/reference/legacy/old-waf-managed-rules/upgrade/).

--- a/src/content/docs/waf/reference/legacy/old-waf-managed-rules/troubleshooting.mdx
+++ b/src/content/docs/waf/reference/legacy/old-waf-managed-rules/troubleshooting.mdx
@@ -11,6 +11,10 @@ sidebar:
 canonical: /waf/managed-rules/troubleshooting/
 ---
 
+:::note
+This page applies only to the previous version of WAF managed rules. If you are troubleshooting the new implementation of WAF Managed Rules, refer to [Troubleshoot managed rules](/waf/managed-rules/troubleshooting/) instead.
+:::
+
 By default, WAF managed rules are fully managed via the Cloudflare dashboard and are compatible with most websites and web applications. However, false positives and false negatives may occur:
 
 - **False positives**: Legitimate requests detected and filtered as malicious.
@@ -22,17 +26,13 @@ The definition of suspicious content is subjective for each website. For example
 
 To test for false positives, set WAF managed rules to _Simulate_ mode. This mode allows you to record the response to possible attacks without challenging or blocking incoming requests. Also, review the Security Events' [sampled logs](/waf/analytics/security-events/#sampled-logs) to determine which managed rules caused false positives.
 
-If you find a false positive, there are several potential resolutions:
+If you find a false positive, consider the following remediation options (ordered from least to most impact on security):
 
-- **Add the client’s IP addresses to the [IP Access Rules](/waf/tools/ip-access-rules/) allowlist:** If the browser or client visits from the same IP addresses, allowing is recommended.
-- **Disable the corresponding managed rule(s)**: Stops blocking or challenging false positives, but reduces overall site security. A request blocked by Rule ID `981176` refers to OWASP rules. Decrease OWASP sensitivity to resolve the issue.
-- **Bypass WAF managed rules with a firewall rule (deprecated):** [Create a firewall rule](/firewall/cf-dashboard/create-edit-delete-rules/#create-a-firewall-rule) with the _Bypass_ action to deactivate WAF managed rules for a specific combination of parameters. For example, [bypass managed rules](/firewall/cf-firewall-rules/actions/) for a specific URL and a specific IP address or user agent.
-- **(Not recommended) Disable WAF managed rules for traffic to a URL:** Lowers security on the particular URL endpoint. Configured via [Page Rules](/rules/page-rules/).
-
-Additional guidelines are as follows:
-
-- If one specific rule causes false positives, set rule’s **Mode** to _Disable_ rather than turning _Off_ the entire rule **Group**.
-- For false positives with the administrator section of your website, create a [page rule](/rules/page-rules/) to **Disable Security** for the admin section of your site resources — for example, `example.com/admin`.
+1. **Add the requesting IP to the allowlist**: Use [IP Access rules](/waf/tools/ip-access-rules/) to allowlist the IP. This is the best option if the affected users always connect from the same IP address and does not reduce site security for other visitors.
+2. **Disable the specific WAF rule**: Turn off only the rule causing the false positive. This reduces security slightly but stops the incorrect block or challenge. It is recommended that you turn off a single rule rather than turning off an entire rule group.
+3. **Create a skip rule**: Create a [custom rule](/waf/custom-rules/skip/) with the _Skip_ action to skip the **Managed rules (previous version)** component. Target a specific URL combined with IP address or user-agent conditions.
+4. **Adjust OWASP settings**: If the blocking rule is `981176` (rule ID in the legacy OWASP managed ruleset), increase the OWASP score threshold and/or lower the OWASP paranoia level. Refer to [OWASP ModSecurity Core Rule Set](/waf/reference/legacy/old-waf-managed-rules/#owasp-modsecurity-core-rule-set) for more information.
+5. **Create a WAF override via API** (deprecated): Use the [WAF Overrides API](/api/resources/firewall/subresources/waf/subresources/overrides) to disable a specific legacy WAF rule for a particular URI without affecting other traffic. These overrides apply only to the previous version of the WAF.
 
 ## Troubleshoot false negatives
 


### PR DESCRIPTION
## Summary

Adds WAF troubleshooting guidance for the two most common WAF-related support topics, based on an audit of active support macros.

### Changes

- **WAF false positives**: Add a remediation decision tree covering both legacy WAF actions (Simulate, Challenge, Block, etc.) and new WAF managed rules, with steps to identify the triggering rule and create exceptions
- **Domain categorization**: Document how to request recategorization of a miscategorized domain via Radar

### Context

These changes are driven by recurring support cases. If you want to see the underlying support data (macro frequency, case volume by topic), reach out to @dmmulroy internally.