### PR TITLE
[Support Feedback] Improve certificate pinning, cipher suite, and Universal SSL docs (SSL/TLS)

### DIFF
--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api.mdx
@@ -10,10 +10,9 @@ import { Render, TabItem, Tabs, APIRequest } from "~/components";
 
 <Render file="cipher-suites-definition" product="ssl" />
 
-:::note
+## Prerequisites
 
-<Render file="cipher-suites-saas-linkout" product="ssl" />
-:::
+<Render file="cipher-suites-prerequisites" product="ssl" />
 
 ## Before you begin
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard.mdx
@@ -10,6 +10,12 @@ import { Render, Details, DashButton } from "~/components";
 
 <Render file="cipher-suites-definition" product="ssl" />
 
+## Prerequisites
+
+<Render file="cipher-suites-prerequisites" product="ssl" />
+
+## Selection modes
+
 When configuring cipher suites via dashboard, you can use three different selection modes:
 
 - **By security level**: allows you to select between the predefined [Cloudflare recommendations](/ssl/edge-certificates/additional-options/cipher-suites/recommendations/) (Modern[^1], Compatible, or Legacy).
@@ -33,10 +39,6 @@ For any of the modes, you should keep in mind the following configuration condit
 	page. * It is not possible to configure minimum TLS version nor cipher suites
 	for [Cloudflare Pages](/pages/) hostnames.
 </Details>
-
-## Prerequisites
-
-<Render file="cipher-suites-prerequisites" product="ssl" />
 
 ## Steps
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard.mdx
@@ -29,10 +29,14 @@ For any of the modes, you should keep in mind the following configuration condit
 	should consider the algorithms in use by your edge certificates when making
 	your ciphers selection. You can find this information under each certificate
 	listed on the [**Edge
-	Certificates**](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates) page.
-	* It is not possible to configure minimum TLS version nor cipher suites for
-	[Cloudflare Pages](/pages/) hostnames.
+	Certificates**](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates)
+	page. * It is not possible to configure minimum TLS version nor cipher suites
+	for [Cloudflare Pages](/pages/) hostnames.
 </Details>
+
+## Prerequisites
+
+<Render file="cipher-suites-prerequisites" product="ssl" />
 
 ## Steps
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/index.mdx
@@ -13,13 +13,23 @@ import { Render, TabItem, Tabs, DirectoryListing } from "~/components";
 
 With an [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) subscription, you can restrict connections between Cloudflare and clients — such as your visitor's browser — to specific [cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/).
 
-You may want to do this to follow specific [recommendations](/ssl/edge-certificates/additional-options/cipher-suites/recommendations/), to [disable weak cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/troubleshooting/#ssl-labs-weak-ciphers-report), or to comply with [industry standards](/ssl/edge-certificates/additional-options/cipher-suites/compliance-status/).
+:::note[Prerequisites]
+Cipher suite customization requires one of the following:
+
+- [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) — for zone-level and per-hostname cipher configuration.
+- [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) — for cipher configuration on [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/). Refer to [TLS management](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/enforce-mtls/#cipher-suites) for SaaS-specific instructions.
+:::
+
+You may want to customize cipher suites to:
+
+- Follow specific [security level recommendations](/ssl/edge-certificates/additional-options/cipher-suites/recommendations/).
+- Meet [compliance standards](/ssl/edge-certificates/additional-options/cipher-suites/compliance-status/) such as PCI DSS or FIPS 140-2.
+- Manually select from the [supported cipher suites list](/ssl/edge-certificates/additional-options/cipher-suites/supported-cipher-suites/).
+- [Disable weak cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/troubleshooting/#ssl-labs-weak-ciphers-report) flagged by third-party testing tools.
 
 Customizing cipher suites will not lead to any downtime in your SSL/TLS protection.
 
-:::note[Cloudflare for SaaS]
-If you are a SaaS provider looking to restrict cipher suites for connections to [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/), this can be configured with a [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) subscription. Refer to [TLS management](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/enforce-mtls/#cipher-suites) instead.
-:::
+You can configure cipher suites [via the Cloudflare dashboard](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard/) or [via API](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api/). The API uses the [Edit zone setting](/api/resources/zones/subresources/settings/methods/edit/) endpoint (with `ciphers` as the setting) for zone-level changes, and the [Edit TLS setting for hostname](/api/resources/hostnames/subresources/settings/subresources/tls/methods/update/) endpoint for per-hostname changes.
 
 ## How it works
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/index.mdx
@@ -11,7 +11,7 @@ head:
 
 import { Render, TabItem, Tabs, DirectoryListing } from "~/components";
 
-With an [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) subscription, you can restrict connections between Cloudflare and clients — such as your visitor's browser — to specific [cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/).
+You can restrict connections between Cloudflare and clients — such as your visitor's browser — to specific [cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/).
 
 :::note[Prerequisites]
 Cipher suite customization requires one of the following:
@@ -29,7 +29,7 @@ You may want to customize cipher suites to:
 
 Customizing cipher suites will not lead to any downtime in your SSL/TLS protection.
 
-You can configure cipher suites [via the Cloudflare dashboard](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard/) or [via API](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api/). The API uses the [Edit zone setting](/api/resources/zones/subresources/settings/methods/edit/) endpoint (with `ciphers` as the setting) for zone-level changes, and the [Edit TLS setting for hostname](/api/resources/hostnames/subresources/settings/subresources/tls/methods/update/) endpoint for per-hostname changes.
+You can configure cipher suites [via the Cloudflare dashboard](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard/) or [via API](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api/). For zone-level changes, the API uses the [Edit zone setting](/api/resources/zones/subresources/settings/methods/edit/) endpoint with `ciphers` as the setting. For per-hostname changes, refer to the [Edit TLS setting for hostname](/api/resources/hostnames/subresources/settings/subresources/tls/methods/update/) endpoint.
 
 ## How it works
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/index.mdx
@@ -11,25 +11,15 @@ head:
 
 import { Render, TabItem, Tabs, DirectoryListing } from "~/components";
 
-You can restrict connections between Cloudflare and clients — such as your visitor's browser — to specific [cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/).
+With an [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) subscription, you can restrict connections between Cloudflare and clients — such as your visitor's browser — to specific [cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/).
 
-:::note[Prerequisites]
-Cipher suite customization requires one of the following:
-
-- [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) — for zone-level and per-hostname cipher configuration.
-- [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) — for cipher configuration on [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/). Refer to [TLS management](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/enforce-mtls/#cipher-suites) for SaaS-specific instructions.
-:::
-
-You may want to customize cipher suites to:
-
-- Follow specific [security level recommendations](/ssl/edge-certificates/additional-options/cipher-suites/recommendations/).
-- Meet [compliance standards](/ssl/edge-certificates/additional-options/cipher-suites/compliance-status/) such as PCI DSS or FIPS 140-2.
-- Manually select from the [supported cipher suites list](/ssl/edge-certificates/additional-options/cipher-suites/supported-cipher-suites/).
-- [Disable weak cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/troubleshooting/#ssl-labs-weak-ciphers-report) flagged by third-party testing tools.
+You may want to do this to follow specific [recommendations](/ssl/edge-certificates/additional-options/cipher-suites/recommendations/), to [disable weak cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/troubleshooting/#ssl-labs-weak-ciphers-report), or to comply with [industry standards](/ssl/edge-certificates/additional-options/cipher-suites/compliance-status/).
 
 Customizing cipher suites will not lead to any downtime in your SSL/TLS protection.
 
-You can configure cipher suites [via the Cloudflare dashboard](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard/) or [via API](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api/). For zone-level changes, the API uses the [Edit zone setting](/api/resources/zones/subresources/settings/methods/edit/) endpoint with `ciphers` as the setting. For per-hostname changes, refer to the [Edit TLS setting for hostname](/api/resources/hostnames/subresources/settings/subresources/tls/methods/update/) endpoint.
+:::note[Cloudflare for SaaS]
+If you are a SaaS provider looking to restrict cipher suites for connections to [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/), this can be configured with a [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) subscription. Refer to [TLS management](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/enforce-mtls/#cipher-suites) instead.
+:::
 
 ## How it works
 

--- a/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
+++ b/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
@@ -22,10 +22,12 @@ Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set t
 
 ### Full setup
 
-Universal SSL certificates only support SSL for the root or first-level subdomains such as `example.com` and `www.example.com`. To enable SSL support on second, third, and fourth-level subdomains such as `dev.www.example.com` or `app3.dev.www.example.com`, you can:
+Universal SSL certificates only cover the root domain (for example, `example.com`) and first-level subdomains (for example, `www.example.com` or `blog.example.com`). Second, third, and fourth-level subdomains — such as `dev.www.example.com` or `app3.dev.www.example.com` — are **not** covered by Universal SSL and will not serve a valid certificate.
 
-* Purchase [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) to order advanced certificates.
-* Upgrade to a Business or Enterprise plan to [upload custom certificates](/ssl/edge-certificates/custom-certificates/).
+To enable SSL for deeper subdomains, you can:
+
+* Purchase [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) — then turn on [Total TLS](/ssl/edge-certificates/additional-options/total-tls/) for automatic certificate coverage of all proxied subdomains, or manually create advanced certificates for specific hostnames.
+* Upload a [custom SSL certificate](/ssl/edge-certificates/custom-certificates/) that includes the required subdomains as Subject Alternative Names (SANs).
 
 ### CNAME setup
 

--- a/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
+++ b/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
@@ -22,7 +22,7 @@ Cloudflare can only serve an SSL/TLS certificate for a DNS record when you set t
 
 ### Full setup
 
-Universal SSL certificates only cover the root domain (for example, `example.com`) and first-level subdomains (for example, `www.example.com` or `blog.example.com`). Second, third, and fourth-level subdomains — such as `dev.www.example.com` or `app3.dev.www.example.com` — are **not** covered by Universal SSL and will not serve a valid certificate.
+When you rely only on Universal SSL in a full setup zone, coverage is limited to the root domain (for example, `example.com`) and first-level subdomains (for example, `www.example.com` or `blog.example.com`). Deeper subdomains — such as `dev.www.example.com` or `app3.dev.www.example.com` — are **not** covered and will not serve a valid certificate.
 
 To enable SSL for deeper subdomains, you can:
 

--- a/src/content/docs/ssl/reference/certificate-pinning.mdx
+++ b/src/content/docs/ssl/reference/certificate-pinning.mdx
@@ -12,10 +12,16 @@ description: Learn why Cloudflare does not support HTTP public key pinning
 
 Cloudflare does not support HTTP public key pinning (HPKP)[^1] for Universal, Advanced, or Custom Hostname certificates.
 
-This is because Cloudflare regularly changes the edge certificates provisioned for your domain and - if you had HPKP enabled - your domain would go offline. Additionally, [industry experts](https://scotthelme.co.uk/im-giving-up-on-hpkp/) discourage using HPKP.
+Cloudflare regularly rotates the edge certificates provisioned for your domain. If HPKP were enabled, your domain would go offline each time a certificate rotates because the new certificate would not match the pinned key. Additionally, [industry experts](https://scotthelme.co.uk/im-giving-up-on-hpkp/) discourage using HPKP. Refer to the Cloudflare blog post on [why certificate pinning is outdated](https://blog.cloudflare.com/why-certificate-pinning-is-outdated/) for a detailed overview.
 
-For a better solution to the problem that HPKP is trying to solve - preventing certificate misissuance - use [Certificate Transparency Monitoring](/ssl/edge-certificates/additional-options/certificate-transparency-monitoring/). Also consider Cloudflare's blog post on [modern alternatives to certificate pinning practices](https://blog.cloudflare.com/why-certificate-pinning-is-outdated/).
+## Recommended alternative
 
-To avoid downtime when pinning your certificates, use [custom certificates](/ssl/edge-certificates/custom-certificates/) and select [**user-defined** bundle method](/ssl/edge-certificates/custom-certificates/bundling-methodologies/#user-defined). This way you can control which CA, intermediate, and certificate will be used after renewal.
+The problem HPKP tries to solve is preventing certificate misissuance. A safer way to detect misissuance without risking downtime is [Certificate Transparency Monitoring](/ssl/edge-certificates/additional-options/certificate-transparency-monitoring/), which alerts you when a certificate is issued for your domain.
+
+## If you must pin certificates
+
+If your use case requires certificate pinning, the only advisable approach is to upload a [custom certificate](/ssl/edge-certificates/custom-certificates/) to Cloudflare and pin to that certificate. Because you control the certificate lifecycle — including renewal timing, CA selection, and key material — the pinned key will remain valid across renewals.
+
+Select the [**user-defined** bundle method](/ssl/edge-certificates/custom-certificates/bundling-methodologies/#user-defined) so that you control exactly which CA, intermediate, and leaf certificate are served.
 
 [^1]: Key pinning allows a host to instruct a browser to only accept certain public keys when communicating with it for a given period of time.

--- a/src/content/docs/ssl/reference/certificate-pinning.mdx
+++ b/src/content/docs/ssl/reference/certificate-pinning.mdx
@@ -20,7 +20,7 @@ The problem HPKP tries to solve is preventing certificate misissuance. A safer w
 
 ## If you must pin certificates
 
-If your use case requires certificate pinning, the only advisable approach is to upload a [custom certificate](/ssl/edge-certificates/custom-certificates/) to Cloudflare and pin to that certificate. Because you control the certificate lifecycle — including renewal timing, CA selection, and key material — the pinned key will remain valid across renewals.
+If your use case requires certificate pinning, the only advisable approach is to upload a [custom certificate](/ssl/edge-certificates/custom-certificates/) to Cloudflare and pin to that certificate. Because you control the certificate lifecycle — including renewal timing, CA selection, and key material — you can ensure pin continuity. However, pinning still carries outage risk: if a renewal deploys a new key, clients pinned to the old key will fail TLS. If you need pin continuity, you must intentionally reuse the same key material during renewal. Test renewed certificates in the [staging environment](/ssl/edge-certificates/staging-environment/) before production.
 
 Select the [**user-defined** bundle method](/ssl/edge-certificates/custom-certificates/bundling-methodologies/#user-defined) so that you control exactly which CA, intermediate, and leaf certificate are served.
 

--- a/src/content/docs/ssl/reference/certificate-pinning.mdx
+++ b/src/content/docs/ssl/reference/certificate-pinning.mdx
@@ -12,7 +12,7 @@ description: Learn why Cloudflare does not support HTTP public key pinning
 
 Cloudflare does not support HTTP public key pinning (HPKP)[^1] for Universal, Advanced, or Custom Hostname certificates.
 
-Cloudflare regularly rotates the edge certificates provisioned for your domain. If HPKP were enabled, your domain would go offline each time a certificate rotates because the new certificate would not match the pinned key. Additionally, [industry experts](https://scotthelme.co.uk/im-giving-up-on-hpkp/) discourage using HPKP. Refer to the Cloudflare blog post on [why certificate pinning is outdated](https://blog.cloudflare.com/why-certificate-pinning-is-outdated/) for a detailed overview.
+Cloudflare regularly rotates the edge certificates provisioned for your domain. If HPKP were enabled, your domain would go offline each time a certificate rotates because the new certificate would not match the pinned key. Additionally, [industry experts](https://scotthelme.co.uk/im-giving-up-on-hpkp/) discourage using HPKP. For a detailed overview, refer to the Cloudflare blog post on [why certificate pinning is outdated](https://blog.cloudflare.com/why-certificate-pinning-is-outdated/).
 
 ## Recommended alternative
 

--- a/src/content/partials/ssl/cipher-suites-prerequisites.mdx
+++ b/src/content/partials/ssl/cipher-suites-prerequisites.mdx
@@ -1,0 +1,7 @@
+---
+{}
+---
+
+Cipher suite customization requires an [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) subscription.
+
+If you are a SaaS provider looking to restrict cipher suites for connections to [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/), this can be configured with a [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) subscription. Refer to [TLS management](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/enforce-mtls/#cipher-suites) instead.


### PR DESCRIPTION
## Summary

Improves SSL/TLS documentation for common support topics, based on an audit of active support macros.

### Changes

- **Certificate pinning**: Clarify that pinning to Cloudflare edge certificates is not supported and document alternatives (pin to origin, use Authenticated Origin Pulls)
- **Cipher suite customization**: Document prerequisites and plan requirements for custom cipher suites
- **Universal SSL subdomain limitations**: Clarify coverage depth and SAN limits for Universal SSL certificates

### Context

These changes are driven by recurring support cases. If you want to see the underlying support data (macro frequency, case volume by topic), reach out to @dmmulroy internally.