### PR TITLE
Revise JSON output example in markdown endpoint

### DIFF
--- a/src/content/docs/browser-rendering/rest-api/markdown-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/markdown-endpoint.mdx
@@ -46,7 +46,7 @@ curl -X 'POST' 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browse
 ```
 
 ```json output
-
+{
 	"success": true,
 	"result": "# Example Domain\n\nThis domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.\n\n[More information...](https://www.iana.org/domains/example)"
 }


### PR DESCRIPTION
Updated JSON output example in markdown-endpoint.mdx. It's missing a `{` at the start.