### PR TITLE
Add changelog: Retry-After HTTP header for retryable 1xxx errors

### DIFF
--- a/src/content/changelog/fundamentals/2026-03-12-retry-after-header-for-1xxx-errors.mdx
+++ b/src/content/changelog/fundamentals/2026-03-12-retry-after-header-for-1xxx-errors.mdx
@@ -1,0 +1,43 @@
+---
+title: Retry-After HTTP header for retryable 1xxx errors
+description: "Cloudflare-generated 1xxx error responses now include a standard Retry-After HTTP header when the error is retryable, letting HTTP clients honour the server-suggested wait time directly from response headers."
+products:
+  - fundamentals
+date: 2026-03-12
+---
+
+Cloudflare-generated 1xxx error responses now include a standard `Retry-After` HTTP header when the error is retryable. Agents and HTTP clients can read the recommended wait time from response headers alone — no body parsing required.
+
+## Changes
+
+Seven retryable error codes now emit `Retry-After`:
+
+| Error code | Retry-After (seconds) | Error name |
+|---|---|---|
+| 1004 | 120 | DNS resolution error |
+| 1005 | 120 | Banned zone |
+| 1015 | 30 | Rate limited |
+| 1033 | 120 | Argo Tunnel error |
+| 1038 | 60 | HTTP headers limit exceeded |
+| 1200 | 60 | Cache connection limit |
+| 1205 | 5 | Too many redirects |
+
+The header value matches the existing `retry_after` body field in JSON and Markdown responses.
+
+If a WAF rate-limiting rule has already set a dynamic `Retry-After` value on the response, that value takes precedence.
+
+## Availability
+
+Available for all zones on all plans.
+
+## Verify
+
+Check for the header on any retryable error:
+
+```bash
+curl -s --compressed -D - -o /dev/null -H "Accept: application/json" -A "TestAgent/1.0" -H "Accept-Encoding: gzip, deflate" "<YOUR_DOMAIN>/cdn-cgi/error/1015" | grep -i retry-after
+```
+
+References:
+- [RFC 9110 §10.2.3 — Retry-After](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.3)
+- [Cloudflare 1xxx error documentation](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/)

--- a/src/content/changelog/fundamentals/2026-03-12-retry-after-header-for-1xxx-errors.mdx
+++ b/src/content/changelog/fundamentals/2026-03-12-retry-after-header-for-1xxx-errors.mdx
@@ -24,7 +24,7 @@ Seven retryable error codes now emit `Retry-After`:
 
 The header value matches the existing `retry_after` body field in JSON and Markdown responses.
 
-If a WAF rate-limiting rule has already set a dynamic `Retry-After` value on the response, that value takes precedence.
+If a WAF rate limiting rule has already set a dynamic `Retry-After` value on the response, that value takes precedence.
 
 ## Availability
 
@@ -39,5 +39,5 @@ curl -s --compressed -D - -o /dev/null -H "Accept: application/json" -A "TestAge
 ```
 
 References:
-- [RFC 9110 §10.2.3 — Retry-After](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.3)
+- [RFC 9110 section 10.2.3 - Retry-After](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.3)
 - [Cloudflare 1xxx error documentation](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/)


### PR DESCRIPTION
## Summary

- Adds changelog entry for the new `Retry-After` HTTP header on retryable Cloudflare 1xxx error responses
- Seven error codes (1004, 1005, 1015, 1033, 1038, 1200, 1205) now emit the standard header
- Documents WAF rate-limiting precedence behaviour
- Feature is live in production as of today

Related FL2 MR: https://gitlab.cfdata.org/cloudflare/fl/fl2/-/merge_requests/5596