### PR TITLE
Changelog for updates to Access advanced auth

### DIFF
--- a/src/content/changelog/fundamentals/2025-10-01-fine-grained-permissioning-beta.mdx
+++ b/src/content/changelog/fundamentals/2025-10-01-fine-grained-permissioning-beta.mdx
@@ -3,7 +3,7 @@ title: Fine-grained Permissioning for Access for Apps, IdPs, & Targets now in Pu
 description: Expanding Role-Based-Access-Control with resource-level controls in Cloudflare Zero Trust.
 products:
   - fundamentals
-	- access
+  - access
 date: 2025-10-02
 ---
 

--- a/src/content/changelog/fundamentals/2025-10-01-fine-grained-permissioning-beta.mdx
+++ b/src/content/changelog/fundamentals/2025-10-01-fine-grained-permissioning-beta.mdx
@@ -3,6 +3,7 @@ title: Fine-grained Permissioning for Access for Apps, IdPs, & Targets now in Pu
 description: Expanding Role-Based-Access-Control with resource-level controls in Cloudflare Zero Trust.
 products:
   - fundamentals
+	- access
 date: 2025-10-02
 ---
 

--- a/src/content/changelog/fundamentals/2026-02-13-access-policy-service-token-permissions.mdx
+++ b/src/content/changelog/fundamentals/2026-02-13-access-policy-service-token-permissions.mdx
@@ -3,7 +3,7 @@ title: Fine-grained permissions for Access policies and service tokens
 description: New resource-scoped roles allow administrators to grant permissions to specific Access policies and service tokens.
 products:
   - fundamentals
-	- access
+  - access
 date: 2026-02-13
 ---
 

--- a/src/content/changelog/fundamentals/2026-02-13-access-policy-service-token-permissions.mdx
+++ b/src/content/changelog/fundamentals/2026-02-13-access-policy-service-token-permissions.mdx
@@ -1,0 +1,28 @@
+---
+title: Fine-grained permissions for Access policies and service tokens
+description: New resource-scoped roles allow administrators to grant permissions to specific Access policies and service tokens.
+products:
+  - fundamentals
+	- access
+date: 2026-02-13
+---
+
+Fine-grained permissions for **Access policies** and **Access service tokens** are available. These new resource-scoped roles expand the existing RBAC model, enabling administrators to grant permissions scoped to individual resources.
+
+### New roles
+
+- **Cloudflare Access policy admin**: Can edit a specific [Access policy](/cloudflare-one/access-controls/policies/) in an account.
+- **Cloudflare Access service token admin**: Can edit a specific [Access service token](/cloudflare-one/access-controls/service-credentials/service-tokens/) in an account.
+
+These roles complement the existing resource-scoped roles for Access applications, identity providers, and infrastructure targets.
+
+For more information:
+
+- [Resource-scoped roles](/fundamentals/manage-members/roles/#resource-scoped-roles)
+- [Role scopes](/fundamentals/manage-members/scope/)
+
+<Aside>
+
+Resource-scoped roles is currently in beta.
+
+</Aside>

--- a/src/content/changelog/fundamentals/2026-02-13-access-policy-service-token-permissions.mdx
+++ b/src/content/changelog/fundamentals/2026-02-13-access-policy-service-token-permissions.mdx
@@ -21,8 +21,8 @@ For more information:
 - [Resource-scoped roles](/fundamentals/manage-members/roles/#resource-scoped-roles)
 - [Role scopes](/fundamentals/manage-members/scope/)
 
-<Aside>
+:::note
 
 Resource-scoped roles is currently in beta.
 
-</Aside>
+:::


### PR DESCRIPTION
### Summary

Cloudflare Access now supports policies and service tokens for resource-scoped roles.  I also added in the Access product to the earlier changelog that announced support for IdPs, applications, and targets (10/2/25).

### Screenshots (optional)

### Documentation checklist
- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).