### PR TITLE
[Vectorize] changelog entry: topK limit increased to 50

### DIFF
--- a/src/content/changelog/vectorize/2026-03-16-topk-limit-increased-to-50.mdx
+++ b/src/content/changelog/vectorize/2026-03-16-topk-limit-increased-to-50.mdx
@@ -1,0 +1,11 @@
+---
+title: Return up to 50 query results with values or metadata
+description: Vectorize increases the `topK` limit to 50 when queries return values or full metadata.
+products:
+  - vectorize
+date: 2026-03-16
+---
+
+You can now set `topK` up to `50` when a Vectorize query returns values or full metadata. This raises the previous limit of `20` for queries that use `returnValues: true` or `returnMetadata: "all"`.
+
+Use the higher limit when you need more matches in a single query response without dropping values or metadata. Refer to the [Vectorize API reference](/vectorize/reference/client-api/) for query options and current `topK` limits.

--- a/src/content/docs/vectorize/platform/limits.mdx
+++ b/src/content/docs/vectorize/platform/limits.mdx
@@ -20,7 +20,7 @@ To request an adjustment to a limit, complete the [Limit Increase Request Form](
 | Precision per vector dimension                                | 32 bits (float32)                   |
 | Maximum vector ID length                                      | 64 bytes                            |
 | Metadata per vector                                           | 10KiB                               |
-| Maximum returned results (`topK`) with values or metadata     | 20                                  |
+| Maximum returned results (`topK`) with values or metadata     | 50                                  |
 | Maximum returned results (`topK`) without values and metadata | 100                                 |
 | Maximum upsert batch size (per batch)                         | 1000 (Workers) / 5000 (HTTP API)    |
 | Maximum vectors in a list-vectors page                        | 1000                                |

--- a/src/content/docs/vectorize/reference/client-api.mdx
+++ b/src/content/docs/vectorize/reference/client-api.mdx
@@ -67,7 +67,7 @@ let matches = await env.YOUR_INDEX.query(queryVector, {
 
 #### topK
 
-The `topK` can be configured to specify the number of matches returned by the query operation. Vectorize now supports an upper limit of `100` for the `topK` value. However, for a query operation with `returnValues` set to `true` or `returnMetadata` set to `all`, `topK` would be limited to a maximum value of `20`.
+The `topK` can be configured to specify the number of matches returned by the query operation. Vectorize now supports an upper limit of `100` for the `topK` value. However, for a query operation with `returnValues` set to `true` or `returnMetadata` set to `all`, `topK` is limited to a maximum value of `50`.
 
 #### returnMetadata
 
@@ -75,7 +75,7 @@ The `returnMetadata` field provides three ways to fetch vector metadata while qu
 
 1. `none`: Do not fetch metadata.
 2. `indexed`: Fetched metadata only for the indexed metadata fields. There is no latency overhead with this option, but long text fields may be truncated.
-3. `all`: Fetch all metadata associated with a vector. Queries may run slower with this option, and `topK` would be limited to 20.
+3. `all`: Fetch all metadata associated with a vector. Queries may run slower with this option, and `topK` is limited to 50.
 
 :::note[`topK` and `returnMetadata` for legacy Vectorize indexes]
 
@@ -233,9 +233,9 @@ Vectorize indexes are bound by name. A binding for an index named `production-do
 	"vectorize": [
 		{
 			"binding": "PROD_SEARCH", // the index will be available as env.PROD_SEARCH in your Worker
-			"index_name": "production-doc-search"
-		}
-	]
+			"index_name": "production-doc-search",
+		},
+	],
 }
 ```
 


### PR DESCRIPTION


### Summary

Vectorize change log entry: Return up to 50 query results with values or metadata.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
