### PR TITLE
Clarify billing period in Durable Objects pricing table

### DIFF
--- a/src/content/partials/durable-objects/durable-objects-pricing.mdx
+++ b/src/content/partials/durable-objects/durable-objects-pricing.mdx
@@ -12,8 +12,8 @@ Durable Objects are billed for compute duration (wall-clock time) while the Dura
 
 |                      | Free plan         | Paid plan                                                                                                                               |
 | -------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Requests             | 100,000 / day     | 1 million, + $0.15/million<br/> Includes HTTP requests, RPC sessions<sup>1</sup>, WebSocket messages<sup>2</sup>, and alarm invocations |
-| Duration<sup>3</sup> | 13,000 GB-s / day | 400,000 GB-s, + $12.50/million GB-s<sup>4,5</sup>                                                                                       |
+| Requests             | 100,000 / day     | 1 million / month, + $0.15/million<br/> Includes HTTP requests, RPC sessions<sup>1</sup>, WebSocket messages<sup>2</sup>, and alarm invocations |
+| Duration<sup>3</sup> | 13,000 GB-s / day | 400,000 GB-s / month, + $12.50/million GB-s<sup>4,5</sup>                                                                                       |
 
 <Details header="Footnotes" open={true}>
 


### PR DESCRIPTION
## Summary

- Add "/ month" to the Paid plan column in the **Compute billing** table for Durable Objects pricing
- The Free plan column already specifies "/ day", but the Paid plan column omitted the billing period, creating ambiguity
- The Storage billing section on the same page already uses "/ month" explicitly — this change aligns the Compute billing section for consistency

Fixes #28944