### PR TITLE
Update roles required to perform cloudflared login and route traffic to public hostnames

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/account-scoped-roles.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/account-scoped-roles.mdx
@@ -6,5 +6,6 @@
 Minimum permissions needed to create, delete, and configure tunnels for an account:
 - [Cloudflare Access](/cloudflare-one/roles-permissions/)
 
-Additional permissions needed to [route traffic to a public hostname](/cloudflare-one/networks/connectors/cloudflare-tunnel/routing-to-tunnel/):
+Additional permissions needed to [route traffic to a public hostname](/cloudflare-one/networks/connectors/cloudflare-tunnel/routing-to-tunnel/) and to be able to perform `cloudflared login`:
 - [DNS](/fundamentals/manage-members/roles/)
+- [Load Balancer](/fundamentals/manage-members/roles/)


### PR DESCRIPTION
### Summary
The current documentation at https://developers.cloudflare.com/tunnel/advanced/local-management/tunnel-permissions/#account-scoped-roles states that the following roles are sufficient to create, delete, and configure tunnels for an account:
* Cloudflare Access
* DNS

This is incorrect. Users with only those roles encounter the error:
> Failed common permission check against resources. ...

The documentation should be updated to reflect the correct minimum required roles for managing Cloudflare Tunnels with `cloudflared login`:
* Cloudflare Access
* DNS
* Load Balancer