### PR TITLE
changelog: Cache Response Rules

### DIFF
--- a/src/content/changelog/cache/2026-03-16-cache-response-rules.mdx
+++ b/src/content/changelog/cache/2026-03-16-cache-response-rules.mdx
@@ -1,0 +1,29 @@
+---
+title: Cache Response Rules
+description: Increase cacheability with the ability to modify cache-control directives, manage cache tags, or strip Set-Cookie headers from origin responses before they are cached.
+products:
+  - cache
+date: 2026-03-16
+---
+
+You can now control how Cloudflare handles origin responses without changing your origin. Cache Response Rules let you modify `Cache-Control` directives, manage cache tags, and strip headers like `Set-Cookie` from origin responses *before* they reach Cloudflare's cache. Whether traffic is cached or passed through dynamically, these rules give you control over origin response behavior that was previously out of reach.
+
+## What changed
+
+Cache Rules previously only operated on request attributes. Cache Response Rules introduce a new response phase that evaluates origin responses and lets you act on them before caching. You can now:
+
+- **Modify `Cache-Control` directives**: Set or remove individual directives like `no-store`, `no-cache`, `max-age`, `s-maxage`, `stale-while-revalidate`, `immutable`, and more. For example, remove a `no-cache` directive your origin sends so Cloudflare can cache the asset, or set an `s-maxage` to control how long Cloudflare stores it.
+- **Set a different browser `Cache-Control`**: Send a different `Cache-Control` header downstream to browsers and other clients than what Cloudflare uses internally, giving you independent control over edge and browser caching strategies.
+- **Manage cache tags**: Add, set, or remove cache tags on responses, including sourcing tags dynamically from other response headers. This is especially useful if you are migrating from another CDN that uses a different tag format.
+- **Strip headers that block caching**: Remove `Set-Cookie`, `ETag`, or `Last-Modified` headers from origin responses before caching, so responses that would otherwise be treated as uncacheable can be stored and served from cache.
+
+## Benefits
+
+- **No origin changes required**: Fix caching behavior entirely from Cloudflare, even when your origin configuration is locked down or managed by a different team.
+- **Simpler CDN migration**: Match caching behavior from other CDN providers without rewriting your origin. Translate cache tag formats and override directives that do not align with Cloudflare's defaults.
+- **Native support, fewer workarounds**: Functionality that previously required workarounds is now built into Cache Rules with full Tiered Cache compatibility.
+- **Fine-grained control**: Use expressions to match on request and response attributes, then apply precise cache settings per rule. Rules are stackable and composable with existing Cache Rules.
+
+## Get started
+
+Configure Cache Response Rules in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/:zone/caching/cache-rules) under **Caching** > **Cache Rules**, or via the [Rulesets API](https://developers.cloudflare.com/ruleset-engine/rulesets-api/). For more details, refer to the [Cache Rules documentation](https://developers.cloudflare.com/cache/how-to/cache-rules/).

--- a/src/content/changelog/cache/2026-03-24-cache-response-rules.mdx
+++ b/src/content/changelog/cache/2026-03-24-cache-response-rules.mdx
@@ -3,7 +3,7 @@ title: Cache Response Rules
 description: Increase cacheability with the ability to modify cache-control directives, manage cache tags, or strip Set-Cookie headers from origin responses before they are cached.
 products:
   - cache
-date: 2026-03-16
+date: 2026-03-24
 ---
 
 You can now control how Cloudflare handles origin responses without changing your origin. Cache Response Rules let you modify `Cache-Control` directives, manage cache tags, and strip headers like `Set-Cookie` from origin responses *before* they reach Cloudflare's cache. Whether traffic is cached or passed through dynamically, these rules give you control over origin response behavior that was previously out of reach.
@@ -14,7 +14,7 @@ Cache Rules previously only operated on request attributes. Cache Response Rules
 
 - **Modify `Cache-Control` directives**: Set or remove individual directives like `no-store`, `no-cache`, `max-age`, `s-maxage`, `stale-while-revalidate`, `immutable`, and more. For example, remove a `no-cache` directive your origin sends so Cloudflare can cache the asset, or set an `s-maxage` to control how long Cloudflare stores it.
 - **Set a different browser `Cache-Control`**: Send a different `Cache-Control` header downstream to browsers and other clients than what Cloudflare uses internally, giving you independent control over edge and browser caching strategies.
-- **Manage cache tags**: Add, set, or remove cache tags on responses, including sourcing tags dynamically from other response headers. This is especially useful if you are migrating from another CDN that uses a different tag format.
+- **Manage cache tags**: Add, set, or remove cache tags on responses, including converting tags from another CDN's header format into Cloudflare's `Cache-Tag` header. This is especially useful if you are migrating from a CDN that uses a different tag header or delimiter.
 - **Strip headers that block caching**: Remove `Set-Cookie`, `ETag`, or `Last-Modified` headers from origin responses before caching, so responses that would otherwise be treated as uncacheable can be stored and served from cache.
 
 ## Benefits


### PR DESCRIPTION
### Summary

changelog: Cache Response Rules

Follows docs: https://github.com/cloudflare/cloudflare-docs/pull/28725

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).