### PR TITLE
[Workers] Clarify accessing Workflow from another Worker requires Single dev commands

### DIFF
--- a/src/content/docs/workers/development-testing/multi-workers.mdx
+++ b/src/content/docs/workers/development-testing/multi-workers.mdx
@@ -59,11 +59,11 @@ Then run:
 
 - You want the simplest setup for development
 - Workers are part of the same application or codebase
-- You need to access a Durable Object namespace from another Worker using `script_name`, or setup Queues where the producer and consumer Workers are seperated.
+- You need to access a Durable Object namespace or Workflow from another Worker using `script_name`, or set up Queues where the producer and consumer Workers are separated.
 
 ## Multiple dev commands
 
-You can also run each Worker in a separate dev commands, each with its own terminal and configuration.
+You can also run each Worker in separate dev commands, each with its own terminal and configuration.
 
 <PackageManagers
   comment="Terminal 1"


### PR DESCRIPTION
### Summary

Close https://github.com/cloudflare/workers-sdk/issues/12860. It isn't clear Workflows requires single dev commands right now.

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
