### PR TITLE
[Cloudflare One] Add secure private apps get started pages

### DIFF
--- a/src/content/docs/cloudflare-one/setup/index.mdx
+++ b/src/content/docs/cloudflare-one/setup/index.mdx
@@ -39,7 +39,7 @@ These use cases match the guided onboarding in the [Cloudflare One dashboard](ht
 
 <LinkTitleCard
 	title="Secure private apps without a client"
-	href="/learning-paths/clientless-access/concepts/"
+	href="/cloudflare-one/setup/secure-private-apps/"
 	icon="laptop"
 >
 	Provide browser-based access to internal web applications, SSH servers, and

--- a/src/content/docs/cloudflare-one/setup/secure-private-apps/clientless-ssh.mdx
+++ b/src/content/docs/cloudflare-one/setup/secure-private-apps/clientless-ssh.mdx
@@ -1,0 +1,51 @@
+---
+pcx_content_type: get-started
+title: "Clientless SSH"
+sidebar:
+  order: 2
+  label: Clientless SSH
+description: Provide in-browser SSH access to an internal server through Cloudflare Access.
+products:
+  - cloudflare-one
+tags:
+  - Private networks
+---
+
+import { Render } from "~/components";
+
+Provide secure, in-browser command line access to an internal server without SSH client software on the user's device. This is useful when you need to give developers or IT staff remote access to servers for administration or troubleshooting from any browser.
+
+To explore other access scenarios, refer to [Secure private apps](/cloudflare-one/setup/secure-private-apps/).
+
+This guide follows the same steps as the **Get Started** experience in the [Cloudflare One dashboard](https://one.dash.cloudflare.com).
+
+## How it works
+
+[Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) connects your private network to Cloudflare without opening any ports on your network. You install `cloudflared`, a connector service that runs in the background, on a device that can reach your server. It creates a secure connection from your network out to Cloudflare, so no firewall changes are required.
+
+[Cloudflare Access](/cloudflare-one/access-controls/) sits in front of the server and verifies who each user is before letting them through. Users sign in through a browser using an email one-time PIN or your identity provider, then interact with the server through an in-browser terminal.
+
+## Prerequisites
+
+- A Cloudflare account with a Zero Trust organization. If you have not set this up, refer to [Get started](/cloudflare-one/setup/).
+- An [active domain on your Cloudflare account](/fundamentals/manage-domains/add-site/). A public subdomain is created on this domain for your application.
+- A Linux, Windows, or macOS device on your private network that can reach the server. This is where you install the tunnel.
+- A server on your private network with SSH enabled.
+
+## Step 1: Define your application
+
+In this step, you describe the internal server you want to make available through Cloudflare.
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com), select the **Get Started** tab.
+2. For **Securely access private web apps without an agent**, select **Get started**.
+3. For **Configure clientless SSH access to an internal service**, select **Continue**.
+4. On the **Zero Trust SSH terminal directly from your browser** screen, select **Continue**.
+5. Enter a name for your application.
+6. Enter the hostname or IP address of the server. Use the IP address if you are not sure (for example, `10.10.1.25`).
+7. Enter the SSH port (the default is `22`).
+8. Select **Continue**.
+
+<Render
+	file="access/secure-private-apps-shared-steps"
+	product="cloudflare-one"
+/>

--- a/src/content/docs/cloudflare-one/setup/secure-private-apps/clientless-ssh.mdx
+++ b/src/content/docs/cloudflare-one/setup/secure-private-apps/clientless-ssh.mdx
@@ -25,6 +25,8 @@ This guide follows the same steps as the **Get Started** experience in the [Clou
 
 [Cloudflare Access](/cloudflare-one/access-controls/) sits in front of the server and verifies who each user is before letting them through. Users sign in through a browser using an email one-time PIN or your identity provider, then interact with the server through an in-browser terminal.
 
+For details on connection methods and advanced configuration, refer to [Connect to SSH in the browser](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-browser-rendering/).
+
 ## Prerequisites
 
 - A Cloudflare account with a Zero Trust organization. If you have not set this up, refer to [Get started](/cloudflare-one/setup/).

--- a/src/content/docs/cloudflare-one/setup/secure-private-apps/in-browser-rdp.mdx
+++ b/src/content/docs/cloudflare-one/setup/secure-private-apps/in-browser-rdp.mdx
@@ -1,0 +1,52 @@
+---
+pcx_content_type: get-started
+title: "In-browser remote desktop"
+sidebar:
+  order: 3
+  label: In-browser remote desktop
+description: Provide in-browser remote desktop access to Windows hosts through Cloudflare Access.
+products:
+  - cloudflare-one
+tags:
+  - Private networks
+  - Windows
+---
+
+import { Render } from "~/components";
+
+Provide secure, in-browser remote desktop access to Windows hosts without Remote Desktop Protocol (RDP) client software on the user's device. This is useful when you need to give IT staff or support teams remote access to Windows machines for administration or troubleshooting from any browser.
+
+To explore other access scenarios, refer to [Secure private apps](/cloudflare-one/setup/secure-private-apps/).
+
+This guide follows the same steps as the **Get Started** experience in the [Cloudflare One dashboard](https://one.dash.cloudflare.com).
+
+## How it works
+
+[Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) connects your private network to Cloudflare without opening any ports on your network. You install `cloudflared`, a connector service that runs in the background, on a device that can reach the Windows host. It creates a secure connection from your network out to Cloudflare, so no firewall changes are required.
+
+[Cloudflare Access](/cloudflare-one/access-controls/) sits in front of the host and verifies who each user is before letting them through. Users sign in through a browser using an email one-time PIN or your identity provider, then interact with the Windows desktop through an in-browser remote desktop session.
+
+## Prerequisites
+
+- A Cloudflare account with a Zero Trust organization. If you have not set this up, refer to [Get started](/cloudflare-one/setup/).
+- An [active domain on your Cloudflare account](/fundamentals/manage-domains/add-site/). A public subdomain is created on this domain for your application.
+- A Linux, Windows, or macOS device on your private network that can reach the Windows host. This is where you install the tunnel.
+- A Windows host on your private network that accepts Remote Desktop connections.
+
+## Step 1: Define your application
+
+In this step, you describe the Windows host you want to make available through Cloudflare.
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com), select the **Get Started** tab.
+2. For **Securely access private web apps without an agent**, select **Get started**.
+3. For **Enable in-browser remote desktop sessions to Windows hosts**, select **Continue**.
+4. On the **Zero Trust RDP client directly from your browser** screen, select **Continue**.
+5. Enter a name for your application.
+6. Enter the local IP address of the Windows host (for example, `10.10.1.25`).
+7. Enter the RDP port (the default is `3389`).
+8. Select **Continue**.
+
+<Render
+	file="access/secure-private-apps-shared-steps"
+	product="cloudflare-one"
+/>

--- a/src/content/docs/cloudflare-one/setup/secure-private-apps/in-browser-rdp.mdx
+++ b/src/content/docs/cloudflare-one/setup/secure-private-apps/in-browser-rdp.mdx
@@ -26,6 +26,8 @@ This guide follows the same steps as the **Get Started** experience in the [Clou
 
 [Cloudflare Access](/cloudflare-one/access-controls/) sits in front of the host and verifies who each user is before letting them through. Users sign in through a browser using an email one-time PIN or your identity provider, then interact with the Windows desktop through an in-browser remote desktop session.
 
+For details on supported operating systems, connection methods, and known limitations, refer to [Connect to RDP in a browser](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/rdp/rdp-browser/).
+
 ## Prerequisites
 
 - A Cloudflare account with a Zero Trust organization. If you have not set this up, refer to [Get started](/cloudflare-one/setup/).

--- a/src/content/docs/cloudflare-one/setup/secure-private-apps/index.mdx
+++ b/src/content/docs/cloudflare-one/setup/secure-private-apps/index.mdx
@@ -1,0 +1,50 @@
+---
+pcx_content_type: navigation
+title: Secure private apps
+sidebar:
+  order: 2
+description: Provide browser-based access to internal web applications, SSH servers, and remote desktops without installing software on user devices.
+---
+
+import { CardGrid, LinkTitleCard } from "~/components";
+
+Cloudflare Access lets users reach internal applications through a browser without a VPN or client software on their device. You connect your application to Cloudflare using a secure connection called a tunnel, then protect it with policies that control who can access it. For more background, refer to [What is clientless access?](/learning-paths/clientless-access/concepts/what-is-clientless-access/).
+
+How you set this up depends on the type of application you are securing. Choose the scenario that matches your use case:
+
+<CardGrid>
+
+<LinkTitleCard
+	title="Private web application"
+	href="/cloudflare-one/setup/secure-private-apps/private-web-app/"
+	icon="laptop"
+>
+	Connect an internal web application to Cloudflare and control who can access
+	it. Best for applications like company intranets, internal wikis, or admin
+	panels.
+</LinkTitleCard>
+
+<LinkTitleCard
+	title="Clientless SSH"
+	href="/cloudflare-one/setup/secure-private-apps/clientless-ssh/"
+	icon="seti:shell"
+>
+	Provide in-browser command line access to an internal server without SSH
+	client software on the user's device.
+</LinkTitleCard>
+
+<LinkTitleCard
+	title="In-browser remote desktop"
+	href="/cloudflare-one/setup/secure-private-apps/in-browser-rdp/"
+	icon="seti:windows"
+>
+	Provide in-browser remote desktop access to Windows hosts without remote
+	desktop client software on the user's device.
+</LinkTitleCard>
+
+</CardGrid>
+
+:::note
+
+For in-depth guidance on clientless access and advanced configuration, refer to the [Clientless access learning path](/learning-paths/clientless-access/concepts/what-is-clientless-access/).
+:::

--- a/src/content/docs/cloudflare-one/setup/secure-private-apps/private-web-app.mdx
+++ b/src/content/docs/cloudflare-one/setup/secure-private-apps/private-web-app.mdx
@@ -1,0 +1,52 @@
+---
+pcx_content_type: get-started
+title: "Private web application"
+sidebar:
+  order: 1
+  label: Private web application
+description: Connect a private web application to Cloudflare and protect it with Access.
+products:
+  - cloudflare-one
+tags:
+  - Private networks
+---
+
+import { Render } from "~/components";
+
+Connect a self-hosted web application to Cloudflare so authorized users can access it from a browser without a VPN. This is useful when you need to give employees or contractors secure access to applications like company intranets, internal wikis, or admin panels.
+
+To explore other access scenarios, refer to [Secure private apps](/cloudflare-one/setup/secure-private-apps/).
+
+This guide follows the same steps as the **Get Started** experience in the [Cloudflare One dashboard](https://one.dash.cloudflare.com).
+
+## How it works
+
+[Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) connects your private network to Cloudflare without opening any ports on your network. You install `cloudflared`, a connector service that runs in the background, on a device that can reach your application. It creates a secure connection from your network out to Cloudflare, so no firewall changes are required.
+
+[Cloudflare Access](/cloudflare-one/access-controls/) sits in front of the application and verifies who each user is before letting them through. Users sign in through a browser using an email one-time PIN or your identity provider.
+
+## Prerequisites
+
+- A Cloudflare account with a Zero Trust organization. If you have not set this up, refer to [Get started](/cloudflare-one/setup/).
+- An [active domain on your Cloudflare account](/fundamentals/manage-domains/add-site/). A public subdomain is created on this domain for your application.
+- A Linux, Windows, or macOS device on your private network that can reach the application. This is where you install the tunnel.
+- A running web application on your private network (for example, `http://10.10.1.25` or `http://grafana.local`).
+
+## Step 1: Define your application
+
+In this step, you describe the internal application you want to make available through Cloudflare.
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com), select the **Get Started** tab.
+2. For **Securely access private web apps without an agent**, select **Get started**.
+3. For **Connect a private web application**, select **Continue**.
+4. On the **Connect and access private web applications** screen, select **Continue**.
+5. Enter a name for your application (for example, `grafana-gcp`).
+6. Enter the hostname or IP address where the application is running. Use the IP address if you are not sure (for example, `10.10.1.25`).
+7. Select the protocol your application uses (HTTP or HTTPS).
+8. Enter the port your application listens on. This is usually part of the URL you use to access the application locally (for example, the `80` in `http://10.10.1.25:80`).
+9. Select **Continue**.
+
+<Render
+	file="access/secure-private-apps-shared-steps"
+	product="cloudflare-one"
+/>

--- a/src/content/partials/cloudflare-one/access/secure-private-apps-shared-steps.mdx
+++ b/src/content/partials/cloudflare-one/access/secure-private-apps-shared-steps.mdx
@@ -1,0 +1,61 @@
+---
+{}
+---
+
+## Step 2: Select a public domain
+
+Your application needs a public URL so users can reach it from a browser. Cloudflare creates a public URL on one of your existing domains for the application.
+
+1. Select a domain from the dropdown.
+2. Enter a subdomain (for example, `grafana`). A preview of the full URL appears (for example, `grafana.example.com`).
+3. Select **Continue**.
+
+## Step 3: Add your first policy
+
+An Access policy controls who can reach your application. In this step, you create a simple policy using email-based one-time PINs. Users you add here receive a one-time PIN by email when they try to access the application.
+
+1. Enter the email addresses of users you want to grant access to.
+2. Select **Continue**.
+
+:::note
+You can add your identity provider (for example, Okta or Google Workspace) to the application later. For more information, refer to [Identity providers](/cloudflare-one/integrations/identity-providers/).
+:::
+
+## Step 4: Assign a tunnel
+
+A tunnel connects your private network to Cloudflare so traffic can reach your application. You can select an existing tunnel or create a new one.
+
+1. In the **Choose or create a Tunnel** dropdown, select an existing tunnel or enter a name to create a new one.
+2. Select **Continue**.
+
+## Step 5: Deploy your tunnel
+
+Install `cloudflared` on a device in your private network that can reach the application. The dashboard generates commands specific to your operating system.
+
+1. Select your operating system from the dropdown.
+2. Copy and run the commands shown in the dashboard. For Windows, open Command Prompt as an administrator. For all other operating systems, use a terminal window.
+3. After the tunnel connects, select **Continue**.
+
+## Step 6: Review details
+
+The dashboard confirms that your application is available and protected behind Cloudflare Access.
+
+## Recommended next steps
+
+- **Test your application**:
+  1.  Select **Test login** on the success screen.
+  2.  On the Access login screen, enter one of the email addresses you added to your Access policy.
+  3.  Select **Send me a code**.
+  4.  Enter the code from your email and select **Sign in**.
+
+- **Explore more with Zero Trust**: Review your applications, policies, and tunnels in the [Cloudflare One dashboard](https://one.dash.cloudflare.com).
+- **Configure an identity provider**: Replace email one-time PINs with your organization's identity provider for a seamless login experience. For more information, refer to [Identity providers](/cloudflare-one/integrations/identity-providers/).
+
+For in-depth guidance on clientless access, refer to the [Clientless access learning path](/learning-paths/clientless-access/concepts/what-is-clientless-access/).
+
+## Troubleshoot
+
+If you have issues connecting, refer to these resources:
+
+- [Troubleshoot tunnels](/cloudflare-one/networks/connectors/cloudflare-tunnel/troubleshoot-tunnels/): diagnose tunnel connectivity and routing problems.
+- [Troubleshooting](/cloudflare-one/faq/troubleshooting/): resolve common Zero Trust errors and issues.


### PR DESCRIPTION
Adds get-started pages for the three **Securely access private web apps without an agent** dashboard wizard flows (PCX-20919, PCX-20920, PCX-20922).

- **Index page** with cards for all three flows: private web application, clientless SSH, in-browser remote desktop
- **Three get-started pages**, each mirroring the 6-step dashboard wizard. Step 1 is flow-specific (different input fields per protocol). Steps 2–6 are identical across all three flows.
- **Shared partial** (`secure-private-apps-shared-steps.mdx`) containing Steps 2–6, recommended next steps, and troubleshoot links to avoid content duplication across the three pages
- **Updated parent setup index** card to point to the new section

Applied an ELI5 (plain language clarity) pass across all content to ensure the pages are accessible to non-technical users unfamiliar with Cloudflare-specific terminology.

Related: PCX-20919, PCX-20920, PCX-20922