### PR TITLE
[Bots] Clarify managed robots.txt page for accessibility

### DIFF
--- a/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
+++ b/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
@@ -6,25 +6,23 @@ sidebar:
   label: robots.txt setting
 ---
 
-import { Render, Tabs, TabItem, Steps, DashButton } from "~/components";
+import { Tabs, TabItem, Steps, DashButton } from "~/components";
 
-Protect your website or application from AI crawlers by implementing a `robots.txt` file on your domain to direct AI bot operators on what content they can and cannot scrape for AI model training.
+Use Cloudflare's managed `robots.txt` to tell AI bot operators whether they can scrape your content for AI model training.
 
-AI bots are expected to follow the `robots.txt` directives.
-
-`robots.txt` files express your preferences. They do not prevent crawler operators from crawling your content at a technical level. Some crawler operators may disregard your `robots.txt` preferences and crawl your content regardless of what your `robots.txt` file says.
+A `robots.txt` file expresses your preferences as the site owner. AI bots are expected to follow these directives, but compliance is voluntary — some crawler operators may disregard your preferences and crawl your content anyway.
 
 :::note
-Respecting `robots.txt` is voluntary. If you want to prevent crawling, use AI Crawl Control's [manage AI crawlers](/ai-crawl-control/features/manage-ai-crawlers/) feature.
+`robots.txt` does not block crawlers at a technical level. To actively prevent AI crawling, use [AI Crawl Control's manage AI crawlers](/ai-crawl-control/features/manage-ai-crawlers/) feature.
 :::
 
 ## Compatibility with existing `robots.txt` files
 
-Cloudflare will independently check whether your website has an existing `robots.txt` file and update the behavior of this feature based on your website.
+When you turn on this feature, Cloudflare checks whether your site already has a `robots.txt` file and adjusts accordingly.
 
 ### Existing robots.txt file
 
-If your website already has a `robots.txt` file — verified by a HTTP `200` response — Cloudflare will prepend our managed `robots.txt` before your existing `robots.txt`, combining both into a single response.
+If your website already serves a `robots.txt` file, Cloudflare adds its managed directives at the top of your existing file. Your original content remains unchanged below the managed block.
 
 For example, without this feature enabled, the `robots.txt` content of `crawlstop.com` would be:
 
@@ -37,7 +35,7 @@ Disallow: /langtest
 Sitemap: https://www.crawlstop.com/sitemap.xml
 ```
 
-With the managed `robots.txt` enabled, Cloudflare will prepend our managed content before your original content, resulting in what you can view at https://www.crawlstop.com/robots.txt.
+With the managed `robots.txt` enabled, Cloudflare adds its managed content at the top of your original file, resulting in what you can view at https://www.crawlstop.com/robots.txt.
 
 ```txt title="Feature enabled"
 # As a condition of accessing this website, you agree to abide by the
@@ -106,7 +104,7 @@ Sitemap: https://www.crawlstop.com/sitemap.xml
 
 ### No robots.txt file
 
-If your website does not have a `robots.txt` file, Cloudflare creates a new file with our managed block directives and serves it for you.
+If your website does not have a `robots.txt` file, Cloudflare creates one containing the managed AI crawler directives and serves it on your behalf.
 
 ## Implementation
 
@@ -139,9 +137,9 @@ To implement a `robots.txt` file on your domain:
 
 ## Content Signals Policy
 
-Free zones that do not have their own `robots.txt` file and do not use the managed `robots.txt` feature will display the Content Signals Policy when a crawler requests the `robots.txt` file for your zone.
+Content Signals are directives in a `robots.txt` file that express whether a site allows specific uses of its content — such as search indexing (`search`), AI input for generative responses (`ai-input`), or AI model training (`ai-train`).
 
-This file only outlines the Content Signals framework. It does not express your preferences or rights associated with your content.
+Zones on the Free plan that do not have their own `robots.txt` file and have not turned on the managed `robots.txt` feature will display the Content Signals Policy when a crawler requests the `robots.txt` file for the zone. This policy defines the Content Signals framework but does not express any preferences on your behalf.
 
 ```txt title="Content Signals Policy"
 # As a condition of accessing this website, you agree to abide by the
@@ -170,7 +168,7 @@ This file only outlines the Content Signals framework. It does not express your 
 # AND RELATED RIGHTS IN THE DIGITAL SINGLE MARKET.
 ```
 
-Cloudflare's Content Signals Policy is included by default in the `robots.txt` file when you turn on **robots.txt setting**.
+Cloudflare's Content Signals Policy is included by default in the `robots.txt` file when you turn on the managed `robots.txt` feature.
 
 If you would like to opt out of displaying the policy in your `robots.txt` file, you can uncheck **Display Content Signals Policy** under **Control AI Crawlers** in your zone's overview.
 


### PR DESCRIPTION
Improves clarity of the managed robots.txt reference page based on an ELI5 analysis. The page previously overpromised in its intro, used undefined jargon, and introduced Content Signals in code before defining them in prose.

- **Reframe intro** — Change "Protect your website" (overpromises) to "Use Cloudflare's managed `robots.txt` to tell AI bot operators…" (accurately describes the feature). Consolidate the limitation explanation into a tighter paragraph.
- **Define Content Signals before first use** — Add a plain-language definition of Content Signals (`search`, `ai-input`, `ai-train`) at the top of the Content Signals Policy section, before the code block.
- **Replace "Free zones"** with "Zones on the Free plan" — the original term is undefined Cloudflare jargon.
- **Simplify technical jargon** — Replace "HTTP `200` response" → "already serves a `robots.txt` file"; "prepend" → "adds…at the top"; "managed block directives" → "managed AI crawler directives".
- **Align terminology** — Change "robots.txt setting" to "managed `robots.txt` feature" to match terminology used elsewhere on the page.
- **Remove unused import** — `Render` was imported but never used.