### PR TITLE
fix: skip publish-production workflow on forks

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish:
+    if: github.repository == 'cloudflare/cloudflare-docs'
     name: Production
     runs-on: ubuntu-22.04
     permissions:


### PR DESCRIPTION
## Summary

- Add `if: github.repository == 'cloudflare/cloudflare-docs'` guard to `publish-production.yml`, matching the existing guard in `publish-preview.yml`

## Problem

When a fork syncs its `production` branch with upstream, the `publish-production.yml` workflow triggers and:

1. Spends ~18 minutes building the entire site
2. Fails at `wrangler deploy` because `CLOUDFLARE_API_TOKEN` is not available on forks
3. Also fails the Google Chat notification step because `CED_TEAM_ALERTS_CHANNEL_WEBHOOK` is empty

`publish-preview.yml` already handles this correctly with a repository check on [line 12](https://github.com/cloudflare/cloudflare-docs/blob/production/.github/workflows/publish-preview.yml#L12), but `publish-production.yml` is missing the same guard.

## Fix

One-line addition of the same `github.repository` condition that `publish-preview.yml` uses. The job will now be skipped on forks instead of running to failure.