### PR TITLE
Reference R2 credentials over AWS in Sandbox mounting docs

### DIFF
--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -60,9 +60,13 @@ Mounted buckets are visible across all sessions since they share the filesystem.
 Set credentials as Worker secrets and the SDK automatically detects them:
 
 ```sh
-npx wrangler secret put AWS_ACCESS_KEY_ID
-npx wrangler secret put AWS_SECRET_ACCESS_KEY
+npx wrangler secret put R2_ACCESS_KEY_ID
+npx wrangler secret put R2_SECRET_ACCESS_KEY
 ```
+
+:::note[R2 credentials]
+We also automatically detect `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for compatibility with other S3-compatible providers.
+:::
 
 <TypeScriptExample>
 ```typescript
@@ -306,6 +310,13 @@ For provider-specific configuration, see the [s3fs-fuse wiki](https://github.com
 **Error**: `MissingCredentialsError: No credentials found`
 
 **Solution**: Set credentials as Worker secrets:
+
+```sh
+npx wrangler secret put R2_ACCESS_KEY_ID
+npx wrangler secret put R2_SECRET_ACCESS_KEY
+```
+
+or
 
 ```sh
 npx wrangler secret put AWS_ACCESS_KEY_ID


### PR DESCRIPTION
### Summary

In https://github.com/cloudflare/sandbox-sdk/pull/503 we added support for automatically detected R2 credentials to favour R2 over AWS, updating the docs here to outline this change but keeping a comment to ensure people are aware we still support detecting AWS credentials by default

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
