### PR TITLE
Add bundling issues section in Wrangler module aliasing documentation

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1500,6 +1500,18 @@ import { bar } from "foo";
 console.log(bar); // returns "baz"
 ```
 
+### Bundling issues
+
+When Wrangler bundles your Worker, it might fail to resolve dependencies. Setting up an alias for such dependencies is a simple way to fix the issue.
+
+However, before doing so, verify that the package is correctly installed in your project, either as a direct dependency in `package.json` or as a transitive dependency.
+
+If an alias is the correct solution for your dependency issue, you have several options:
+
+- **Alternative implementation** — Implement the module's logic in a Worker-compatible manner, ensuring that all the functionality remains intact.
+- **No-op module** — If the module's logic is unused or irrelevant, point the alias to an empty file. This makes the module a no-op while fixing the bundling issue.
+- **Runtime error** — If the module's logic is unused and the Worker should not attempt to use it (for example, because of security vulnerabilities), point the alias to a file with a single top-level `throw` statement. This fixes the bundling issue while ensuring the module is never actually used.
+
 ### Example: Aliasing dependencies from NPM
 
 You can use module aliasing to provide an implementation of an NPM package that does not work on Workers — even if you only rely on that NPM package indirectly, as a dependency of one of your Worker's dependencies.


### PR DESCRIPTION
Add a clarification in the Wrangler `alias` documentation that this configuration option can be used to solve Wrangler bundling issues. 

This PR is related to https://github.com/cloudflare/workers-sdk/pull/12931 (see: https://github.com/cloudflare/workers-sdk/pull/12931#discussion_r2946263631)