### PR TITLE
[vitest-integration] Removed version requirements note

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
@@ -26,7 +26,7 @@ First, make sure that:
 - Vitest and `@cloudflare/vitest-pool-workers` are installed in your project as dev dependencies
 
   <PackageManagers
-  	pkg="vitest@~3.2.0 @cloudflare/vitest-pool-workers"
+  	pkg="vitest @cloudflare/vitest-pool-workers"
   	dev="true"
   />
 

--- a/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
@@ -30,12 +30,6 @@ First, make sure that:
   	dev="true"
   />
 
-  :::note
-
-  Currently, the `@cloudflare/vitest-pool-workers` package _only_ works with Vitest 2.0.x - 3.2.x.
-
-  :::
-
 ## Define Vitest configuration
 
 In your `vitest.config.ts` file, use `defineWorkersConfig` to configure the Workers Vitest integration.


### PR DESCRIPTION
### Summary

Removed note about package compatibility with Vitest versions. Also removed version requirement from PackageManager tag. Note previously stated that Vitest pool workers required Vitest 2.0.x - 3.2.x, but this appears to no longer be true. I encountered errors when trying to install Vitest 3.2.4, but was able to install Vitest 4.1.0 and execute my test suite.

### Screenshots (optional)

<img width="1324" height="618" alt="image" src="https://github.com/user-attachments/assets/5c8b8683-8224-4075-98ef-c4f086b84910" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
