### PR TITLE
Update mcp-servers-for-cloudflare.mdx

### DIFF
--- a/src/content/docs/agents/model-context-protocol/mcp-servers-for-cloudflare.mdx
+++ b/src/content/docs/agents/model-context-protocol/mcp-servers-for-cloudflare.mdx
@@ -43,6 +43,11 @@ When you connect, you will be redirected to Cloudflare to authorize via OAuth an
 
 For CI/CD or automation, you can create a [Cloudflare API token](https://dash.cloudflare.com/profile/api-tokens) with the permissions you need and pass it as a bearer token in the `Authorization` header. Both user tokens and account tokens are supported.
 
+Please note that [Client IP Address Filtering feature](https://developers.cloudflare.com/fundamentals/api/how-to/restrict-tokens/#client-ip-address-range-filtering) is not compatible with Cloudflare MCP servers. 
+MCP servers run as Cloudflare Workers, and API calls originate from Worker subrequest IPs (not your local IP). If you enable IP filtering on your API token, MCP requests will fail.
+Recommendation: Create a separate API token for MCP usage without Client IP Address Filtering, and scope it with only the necessary permissions.
+
+
 For more information, refer to the [Cloudflare MCP repository](https://github.com/cloudflare/mcp).
 
 ### Install via agent and IDE plugins


### PR DESCRIPTION
Adds documentation clarifying that Client IP Address Filtering on Cloudflare API tokens is incompatible with Cloudflare's MCP servers. Background:
- Cloudflare MCP servers run as Workers
- API requests originate from Worker subrequest IPs, not user eyeball IPs  
- IP allowlists cause MCP authentication to fail
- Worker IPs are not stable/guaranteed, so allowlisting them is not recommended This update helps users avoid authentication issues when creating API tokens for MCP usage. Related internal issue: CUSTESC-63123

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
