### PR TITLE
[Rules] Add cf.timings.worker_msec field and changelog

### DIFF
--- a/src/content/changelog/rules/2026-03-18-worker-timing-field.mdx
+++ b/src/content/changelog/rules/2026-03-18-worker-timing-field.mdx
@@ -1,0 +1,23 @@
+---
+title: Worker execution timing field now available in Rules
+description: Use the new cf.timings.worker_msec field to build rules based on Cloudflare Worker execution time.
+date: 2026-03-18
+---
+
+The `cf.timings.worker_msec` field is now available in the Ruleset Engine. This field reports the wall-clock time that a Cloudflare Worker spent handling a request, measured in milliseconds.
+
+You can use this field to identify slow Worker executions, detect performance regressions, or build rules that respond differently based on Worker processing time, such as logging requests that exceed a latency threshold.
+
+### Field details
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `cf.timings.worker_msec` | Integer | The time spent executing a Cloudflare Worker in milliseconds. Returns `0` if no Worker was invoked. |
+
+Example filter expression:
+
+```
+cf.timings.worker_msec > 500
+```
+
+For more information, refer to the [Fields reference](/ruleset-engine/rules-language/fields/reference/cf.timings.worker_msec/).

--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -940,6 +940,23 @@ entries:
       # Matches requests where the origin response time (TTFB) was greater than 2 seconds:
       cf.timings.origin_ttfb_msec > 2000
 
+  - name: cf.timings.worker_msec
+    data_type: Integer
+    categories: [Request]
+    keywords: [request, timing, workers, performance, latency]
+    summary: The time spent executing a Cloudflare Worker in milliseconds.
+    description: |-
+      This field provides the wall-clock time that a Cloudflare Worker spent handling the request, measured in milliseconds.
+
+      Use this field to identify slow Worker executions, set up alerts for performance regressions, or add Worker execution time as a request header using Transform Rules for downstream observability.
+
+      If the request did not invoke a Worker, the value of this field will be `0`.
+    example_value: |-
+      12
+    example_block: |-
+      # Matches requests where the Worker execution time exceeded 500 milliseconds
+      cf.timings.worker_msec > 500
+
   - name: cf.waf.content_scan.has_obj
     data_type: Boolean
     categories: [Request]


### PR DESCRIPTION
## Summary

- Adds the new `cf.timings.worker_msec` field to the Ruleset Engine fields reference (`src/content/fields/index.yaml`)
- Adds a changelog entry for the Rules product announcing the field availability

The `cf.timings.worker_msec` field reports the wall-clock time a Cloudflare Worker spent handling a request in milliseconds. The unstable flag was removed and the field is now fully released.

Related: CR-1497636