### PR TITLE
[SSL, CF1] Update GPG key name

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/cloudflared-debian-install.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/cloudflared-debian-install.mdx
@@ -6,13 +6,13 @@
 
 ```sh
 sudo mkdir -p --mode=0755 /usr/share/keyrings
-curl -fsSL https://pkg.cloudflare.com/cloudflare-public-v2.gpg | sudo tee /usr/share/keyrings/cloudflare-public-v2.gpg >/dev/null
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
 ```
 
 2. Add Cloudflare's apt repo to your apt repositories:
 
 ```sh
-echo "deb [signed-by=/usr/share/keyrings/cloudflare-public-v2.gpg] https://pkg.cloudflare.com/cloudflared any main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared any main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
 ```
 
 3. Update repositories and install cloudflared:

--- a/src/content/partials/ssl/keyless-key-server-setup.mdx
+++ b/src/content/partials/ssl/keyless-key-server-setup.mdx
@@ -20,10 +20,10 @@ These steps are also at the [Cloudflare package repository](https://pkg.cloudfla
 
 ```sh title="Debian or Ubuntu"
 sudo mkdir -p --mode=0755 /usr/share/keyrings
-curl -fsSL https://pkg.cloudflare.com/cloudflare-public-v2.gpg | sudo tee /usr/share/keyrings/cloudflare-public-v2.gpg >/dev/null
+curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
 
 # Add this repo to your apt repositories
-echo 'deb [signed-by=/usr/share/keyrings/cloudflare-public-v2.gpg] https://pkg.cloudflare.com/gokeyless buster main' | sudo tee /etc/apt/sources.list.d/cloudflare.list
+echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/gokeyless buster main' | sudo tee /etc/apt/sources.list.d/cloudflare.list
 
 # install gokeyless
 sudo apt-get update && sudo apt-get install gokeyless


### PR DESCRIPTION
### Summary

PCX-21326
https://pkg.cloudflare.com/index.html accounts for the new key (cloudflare-main.gpg) but the change had not been reflected on the dev docs