### PR TITLE
Fix date inconsistency in bindings changelog date

### DIFF
--- a/src/content/changelog/stream/2026-03-18-media-transformations-workers-binding.mdx
+++ b/src/content/changelog/stream/2026-03-18-media-transformations-workers-binding.mdx
@@ -3,7 +3,7 @@ title: Media Transformations binding for Workers
 description: Transform videos directly in Workers without requiring public URL access to source files.
 products:
   - stream
-date: 2026-02-20
+date: 2026-03-18
 ---
 
 import { WranglerConfig, TypeScriptExample } from "~/components";


### PR DESCRIPTION
This changelog was posted but I didn't realize the date in the filename is not used, and I had an old date hanging around in frontmatter.