### PR TITLE
[Logs] Add GCS decompressive transcoding note to Logpush GCS destination page

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/google-cloud-storage.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/google-cloud-storage.mdx
@@ -53,3 +53,17 @@ To enable Logpush to GCS:
 1. Create a GCS bucket. Refer to [instructions from GCS](https://cloud.google.com/storage/docs/creating-buckets#storage-create-bucket-console).
 
 2. In **Storage** > **Browser** > **Bucket** > **Permissions**, add the member `logpush@cloudflare-data.iam.gserviceaccount.com` with `Storage Object Admin` permission.
+
+## Compression and decompressive transcoding
+
+Logpush always delivers log files in gzip-compressed format. When uploading to GCS, Logpush sets `Content-Encoding: gzip` on the object metadata.
+
+GCS performs [decompressive transcoding](https://cloud.google.com/storage/docs/transcoding) by default. This means that when a client downloads an object stored with `Content-Encoding: gzip`, GCS may automatically decompress the file in transit if the client does not include `Accept-Encoding: gzip` in the request headers. When this happens, the downloaded file contains uncompressed data even though the filename retains the `.gz` extension.
+
+To download log files in their original compressed format, use one of the following approaches:
+
+- **Include `Accept-Encoding: gzip` in your download request headers.** For example, when using gsutil:
+
+  ```sh
+  gsutil -h "Accept-Encoding: gzip" cp gs://your-bucket/path/file.log.gz .
+  ```


### PR DESCRIPTION
### Summary

Added a section to the Logpush GCS destination page explaining compression behaviour and GCS decompressive transcoding. Logpush always delivers gzip-compressed files with Content-Encoding: gzip metadata, but GCS automatically decompresses these on download by default, resulting in customers receiving plain JSON files with .gz extensions. This is a recurring source of support tickets. The new section explains the cause and provides two workarounds.

support case 02024585

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).