### PR TITLE
[Tunnel] Add dns-resolver-addrs run parameter

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
@@ -175,13 +175,13 @@ Requires `cloudflared` version 2025.7.0 or later.
 | ------------------------------------------------------------------------- | --------------------------- |
 | `cloudflared tunnel run --dns-resolver-addrs <IP:PORT> <UUID or NAME>`    | `TUNNEL_DNS_RESOLVER_ADDRS` |
 
-Specifies custom DNS resolver addresses for `cloudflared` to use. Each address must be in `ip:port` format — providing an IP address without a port will cause `cloudflared` to fail to start. You can specify multiple resolvers by repeating the flag. For example,
+Specifies custom DNS resolver addresses for `cloudflared` to use instead of the host machine's default resolvers. Each address must be in `ip:port` format — providing an IP address without a port will cause `cloudflared` to fail to start. You can specify multiple resolvers by repeating the flag. For example,
 
 ```sh
 cloudflared tunnel run --dns-resolver-addrs 1.1.1.1:53 --dns-resolver-addrs 1.0.0.1:53 <UUID or NAME>
 ```
 
-A maximum of 10 resolver addresses are allowed.
+When multiple resolvers are specified, `cloudflared` randomly selects one for each DNS request. A maximum of 10 resolver addresses are allowed.
 
 ### `edge-bind-address`
 

--- a/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
@@ -168,27 +168,20 @@ Specifies the path to a <a href={props.configurationFileURL}>configuration file<
 ### `dns-resolver-addrs`
 
 :::note
-
-Requires `2025.7.0` or later.
+Requires `cloudflared` version 2025.7.0 or later.
 :::
 
 | Syntax                                                                    | Environment Variable        |
 | ------------------------------------------------------------------------- | --------------------------- |
 | `cloudflared tunnel run --dns-resolver-addrs <IP:PORT> <UUID or NAME>`    | `TUNNEL_DNS_RESOLVER_ADDRS` |
 
-Specifies custom DNS resolver addresses for `cloudflared` to use. Each address must be in `ip:port` format — providing an IP address without a port will cause `cloudflared` to fail to start. You can specify multiple resolvers by repeating the flag.
-
-A maximum of 10 resolver addresses are allowed.
-
-```sh
-cloudflared tunnel run --dns-resolver-addrs 1.1.1.1:53 <UUID or NAME>
-```
-
-To use multiple resolvers:
+Specifies custom DNS resolver addresses for `cloudflared` to use. Each address must be in `ip:port` format — providing an IP address without a port will cause `cloudflared` to fail to start. You can specify multiple resolvers by repeating the flag. For example,
 
 ```sh
 cloudflared tunnel run --dns-resolver-addrs 1.1.1.1:53 --dns-resolver-addrs 1.0.0.1:53 <UUID or NAME>
 ```
+
+A maximum of 10 resolver addresses are allowed.
 
 ### `edge-bind-address`
 

--- a/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/run-parameters.mdx
@@ -165,6 +165,31 @@ For locally-managed tunnels only.
 
 Specifies the path to a <a href={props.configurationFileURL}>configuration file</a> in YAML format.
 
+### `dns-resolver-addrs`
+
+:::note
+
+Requires `2025.7.0` or later.
+:::
+
+| Syntax                                                                    | Environment Variable        |
+| ------------------------------------------------------------------------- | --------------------------- |
+| `cloudflared tunnel run --dns-resolver-addrs <IP:PORT> <UUID or NAME>`    | `TUNNEL_DNS_RESOLVER_ADDRS` |
+
+Specifies custom DNS resolver addresses for `cloudflared` to use. Each address must be in `ip:port` format — providing an IP address without a port will cause `cloudflared` to fail to start. You can specify multiple resolvers by repeating the flag.
+
+A maximum of 10 resolver addresses are allowed.
+
+```sh
+cloudflared tunnel run --dns-resolver-addrs 1.1.1.1:53 <UUID or NAME>
+```
+
+To use multiple resolvers:
+
+```sh
+cloudflared tunnel run --dns-resolver-addrs 1.1.1.1:53 --dns-resolver-addrs 1.0.0.1:53 <UUID or NAME>
+```
+
 ### `edge-bind-address`
 
 | Syntax                                                           | Environment Variable       |


### PR DESCRIPTION
## Summary

- Documents the `--dns-resolver-addrs` flag for `cloudflared tunnel run`
- Addresses must be in `ip:port` format (bare IP causes cloudflared to fail)
- Maximum of 10 resolver addresses allowed
- Requires cloudflared `2025.7.0` or later
- Added to the shared partial so it appears on both `/tunnel/advanced/run-parameters/` and `/cloudflare-one/.../run-parameters/`