### PR TITLE
[Fundamentals] Add Service Key authentication deprecation notice and changelog

### DIFF
--- a/src/content/changelog/fundamentals/2026-03-19-service-key-authentication-deprecated.mdx
+++ b/src/content/changelog/fundamentals/2026-03-19-service-key-authentication-deprecated.mdx
@@ -1,0 +1,21 @@
+---
+title: Service Key authentication deprecated
+description: "Service Key authentication for the Cloudflare API is deprecated and will be removed on September 30, 2026. Migrate to API Tokens."
+products:
+  - fundamentals
+date: 2026-03-19
+---
+
+Service Key authentication for the Cloudflare API is deprecated. Service Keys will stop working on September 30, 2026.
+
+[API Tokens](/fundamentals/api/get-started/create-token/) replace Service Keys with fine-grained permissions, expiration, and revocation.
+
+## What you need to do
+
+Replace any use of the `X-Auth-User-Service-Key` header with an [API Token](/fundamentals/api/get-started/create-token/) scoped to the permissions your integration requires.
+
+If you use `cloudflared`, update to a version from November 2022 or later. These versions already use API Tokens.
+
+If you use [origin-ca-issuer](https://github.com/cloudflare/origin-ca-issuer), update to a version that supports API Token authentication.
+
+For more information, refer to [API deprecations](/fundamentals/api/reference/deprecations/).

--- a/src/content/docs/fundamentals/api/get-started/ca-keys.mdx
+++ b/src/content/docs/fundamentals/api/get-started/ca-keys.mdx
@@ -3,24 +3,25 @@ pcx_content_type: how-to
 title: Get Origin CA keys
 sidebar:
   order: 5
-
+  badge:
+    text: Deprecated
 ---
 
 import { DashButton } from "~/components";
 
-Origin CA keys are often used as the value of header `X-AUTH-USER-SERVICE-KEY` when interacting with [Origin CA certificates](/ssl/origin-configuration/origin-ca/) API. It is also used by [Keyless SSL](/ssl/keyless-ssl/) key server.
-
-:::note
-You can also interact with the [Origin CA certificates API](/ssl/origin-configuration/origin-ca/#api-calls) using an [API token](/fundamentals/api/get-started/create-token/) with **Permissions** that include `Zone`-`SSL and Certificates`-`Edit`.
+:::caution[Deprecated]
+Origin CA keys (Service Keys) are deprecated and will be removed on September 30, 2026. Use an [API Token](/fundamentals/api/get-started/create-token/) with `Zone`-`SSL and Certificates`-`Edit` permissions instead. For more information, refer to [API deprecations](/fundamentals/api/reference/deprecations/).
 :::
+
+Origin CA keys are often used as the value of header `X-AUTH-USER-SERVICE-KEY` when interacting with [Origin CA certificates](/ssl/origin-configuration/origin-ca/) API. It is also used by [Keyless SSL](/ssl/keyless-ssl/) key server.
 
 The key value always starts with `v1.0-`.
 
 ## Limitations
 
-* Changing the Origin CA key is not recorded by [Audit Logs](/fundamentals/account/account-security/review-audit-logs/).
-* Each time you view the Origin CA key, it will be presented as a different value. All these different values are **simultaneously valid** until you click the `Change` button, which immediately invalidates all previously generated values.
-* Origin CA keys have access to every account the user has access to.
+- Changing the Origin CA key is not recorded by [Audit Logs](/fundamentals/account/account-security/review-audit-logs/).
+- Each time you view the Origin CA key, it will be presented as a different value. All these different values are **simultaneously valid** until you click the `Change` button, which immediately invalidates all previously generated values.
+- Origin CA keys have access to every account the user has access to.
 
 ## View/Change your Origin CA keys
 
@@ -28,7 +29,7 @@ To retrieve your Origin CA keys:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com).
 
-    <DashButton url="/?to=/:account/home" />
+   <DashButton url="/?to=/:account/home" />
 
 2. Go to **User Profile** > **API Tokens**.
 3. In the **API Keys** section, select `Origin CA Key`.

--- a/src/content/docs/ssl/origin-configuration/origin-ca/index.mdx
+++ b/src/content/docs/ssl/origin-configuration/origin-ca/index.mdx
@@ -8,7 +8,15 @@ head: []
 description: Encrypt traffic between Cloudflare and your origin web server and reduce origin bandwidth consumption.
 ---
 
-import { Details, FeatureTable, Render, TabItem, Tabs, DashButton, GlossaryTooltip } from "~/components";
+import {
+	Details,
+	FeatureTable,
+	Render,
+	TabItem,
+	Tabs,
+	DashButton,
+	GlossaryTooltip,
+} from "~/components";
 
 If your origin only receives traffic from <GlossaryTooltip term="proxy status">proxied records</GlossaryTooltip>, use Cloudflare origin CA certificates to encrypt traffic between Cloudflare and your origin web server and reduce bandwidth consumption. Once deployed, these certificates are compatible with [Strict SSL mode](/ssl/origin-configuration/ssl-modes/full-strict/).
 
@@ -130,7 +138,7 @@ Wildcards may only cover one level, but can be used multiple times on the same c
 
 ## API calls
 
-To automate processes involving Origin CA certificates, use the following API calls. To authenticate, use either [Origin CA Keys](/fundamentals/api/get-started/ca-keys/) or an [API token](/fundamentals/api/get-started/create-token/) with **Permissions** that include `Zone`-`SSL and Certificates`-`Edit`.
+To automate processes involving Origin CA certificates, use the following API calls. To authenticate, use an [API token](/fundamentals/api/get-started/create-token/) with **Permissions** that include `Zone`-`SSL and Certificates`-`Edit`.
 
 | Operation                                                                   | Method   | Endpoint                           |
 | --------------------------------------------------------------------------- | -------- | ---------------------------------- |

--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -3,6 +3,24 @@ link: "/fundamentals/api/reference/deprecations/"
 productName: API deprecations
 productLink: "/fundamentals/"
 entries:
+  - publish_date: "2026-03-19"
+    title: "Service Key Authentication"
+    description: |-
+      Deprecation date: March 19, 2026
+
+      End of life date: September 30, 2026
+
+      Service Key authentication for the Cloudflare API is deprecated and will be removed on September 30, 2026. [API Tokens](/fundamentals/api/get-started/create-token/) are capable of providing all functionality of Service Keys, with additional support for fine-grained permission scoping, expiration, and IP address restrictions.
+
+      Deprecated behavior:
+      * Authenticating API requests using the `X-Auth-User-Service-Key` header.
+      * Generating new Service Keys via the Cloudflare dashboard or API. The ability to generate new Service Keys from the Dashboard will be removed soon.
+
+      Replacement:
+      * [Create an API Token](/fundamentals/api/get-started/create-token/) with the appropriate permissions for your use case. API Tokens support fine-grained scoping, expiration, and revocation.
+
+      Users of `cloudflared` should ensure they are running a version from November 2022 or later, which uses API Tokens instead of Service Keys. Users of [origin-ca-issuer](https://github.com/cloudflare/origin-ca-issuer) should update to a version that supports API Token authentication.
+
   - publish_date: "2026-01-23"
     title: "DNS Record Type Updates via API"
     description: |-


### PR DESCRIPTION
### Summary

Adds a deprecation notice for Service Key authentication to the [API deprecations page](/fundamentals/api/reference/deprecations/) and a corresponding changelog entry. Service Key authentication will be removed on September 30, 2026.

Related: ACCT-11873

### Screenshots (optional)

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] ~~If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.~~
- [ ] ~~Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).~~
