### PR TITLE
[Cloudflare One] Fix Replace VPN sidebar link

### DIFF
--- a/src/content/docs/cloudflare-one/implementation-guides/replace-vpn.mdx
+++ b/src/content/docs/cloudflare-one/implementation-guides/replace-vpn.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: navigation
 title: Replace your VPN
-external_link: /cloudflare-one/setup/replace-vpn/
+external_link: /learning-paths/replace-vpn/concepts/
 sidebar:
   order: 2
 ---


### PR DESCRIPTION
Fixes the Implementation guides sidebar link for "Replace your VPN" to point to the learning path instead of the onboarding guide. The card on the same page was corrected in PR #28903 but the sidebar `external_link` was missed.