### PR TITLE
[Chore] Optimize info call in WranglerNamespace

### DIFF
--- a/src/components/WranglerNamespace.astro
+++ b/src/components/WranglerNamespace.astro
@@ -1,6 +1,6 @@
 ---
 import { z } from "astro/zod";
-import { experimental_getWranglerCommands } from "wrangler";
+import { commands } from "~/util/wrangler";
 import WranglerCommand from "./WranglerCommand.astro";
 
 const props = z.object({
@@ -10,7 +10,7 @@ const props = z.object({
 
 const { namespace, headingLevel } = props.parse(Astro.props);
 
-const { registry } = experimental_getWranglerCommands();
+const { registry } = commands;
 
 const node = registry.subtree.get(namespace);
 


### PR DESCRIPTION
### Summary

We ignore the exported `commands` in WranglerNamespace and instead re-call Wrangler to grab those commands.

Might save a bit of duration on build times.
- https://github.com/cloudflare/cloudflare-docs/blob/production/src/util/wrangler.ts#L3
- https://github.com/cloudflare/cloudflare-docs/blob/production/src/components/WranglerCommand.astro#L8
