### PR TITLE
[Cloudflare One] Document OIDC claims support in Gateway policies

### DIFF
--- a/src/content/docs/cloudflare-one/integrations/identity-providers/generic-oidc.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/generic-oidc.mdx
@@ -141,7 +141,7 @@ If you would like to build policies based on IdP groups:
 
 ### Custom OIDC claims
 
-All OIDC IdP integrations support the use of custom OIDC claims. Once configured, Access will add the claims to the [Access JWT](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/) for consumption by your origin services. You can reference the custom OIDC claims in [Access policies](/cloudflare-one/access-controls/policies/), offering a means to control user access to applications based on custom identity attributes. Custom OIDC claims are not currently supported in Gateway policies.
+All OIDC IdP integrations support the use of custom OIDC claims. Once configured, Access will add the claims to the [Access JWT](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/) for consumption by your origin services. You can reference the custom OIDC claims in [Access policies](/cloudflare-one/access-controls/policies/) and [Gateway policies](/cloudflare-one/traffic-policies/identity-selectors/#oidc-claims), offering a means to control user access to applications based on custom identity attributes.
 
 To add a custom OIDC claim to an IdP integration:
 
@@ -158,7 +158,7 @@ To add a custom OIDC claim to an IdP integration:
         	},
         ```
 
-You can now build an Access policy for the custom claim using the **OIDC Claim** or **IdP OIDC Claim** selector. The custom claim will also be passed to origins behind Access in a [JWT](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/#custom-saml-attributes-and-oidc-claims).
+You can now build an Access policy for the custom claim using the **OIDC Claim** or **IdP OIDC Claim** selector. You can also use custom OIDC claims as [identity-based selectors in Gateway policies](/cloudflare-one/traffic-policies/identity-selectors/#oidc-claims). The custom claim will also be passed to origins behind Access in a [JWT](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/#custom-saml-attributes-and-oidc-claims).
 
 #### Email claim
 

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/generic-oidc.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/generic-oidc.mdx
@@ -158,7 +158,7 @@ To add a custom OIDC claim to an IdP integration:
         	},
         ```
 
-You can now build an Access policy for the custom claim using the **OIDC Claim** or **IdP OIDC Claim** selector. You can also use custom OIDC claims as [identity-based selectors in Gateway policies](/cloudflare-one/traffic-policies/identity-selectors/#oidc-claims). The custom claim will also be passed to origins behind Access in a [JWT](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/#custom-saml-attributes-and-oidc-claims).
+You can now build an Access policy for the custom claim using the **OIDC Claim** or **IdP OIDC Claim** selector. You can also use custom OIDC claims as [identity-based selectors in Gateway policies](/cloudflare-one/traffic-policies/identity-selectors/#oidc-claims). The custom claim will be passed to origins behind Access in a [JWT](/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/#custom-saml-attributes-and-oidc-claims).
 
 #### Email claim
 

--- a/src/content/docs/cloudflare-one/traffic-policies/identity-selectors.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/identity-selectors.mdx
@@ -32,6 +32,12 @@ Gateway will automatically detect changes in user name, title, and group members
 
 ## Identity-based selectors
 
+### OIDC Claims
+
+Specify a value from a [custom OIDC claim](/cloudflare-one/integrations/identity-providers/generic-oidc/#custom-oidc-claims) configured on your identity provider.
+
+<Render file="gateway/selectors/oidc-claims" product="cloudflare-one" />
+
 ### SAML Attributes
 
 Specify a value from the SAML Attribute Assertion.
@@ -154,4 +160,8 @@ For a [generic SAML provider](/cloudflare-one/integrations/identity-providers/ge
 
 ### Generic OIDC IdP
 
-Custom OIDC claims are not supported in Gateway policies.
+For a [generic OIDC provider](/cloudflare-one/integrations/identity-providers/generic-oidc/), use the OIDC Claims selector to filter traffic based on [custom OIDC claims](/cloudflare-one/integrations/identity-providers/generic-oidc/#custom-oidc-claims) configured on your IdP:
+
+| Selector    | Claim name   | Claim value   |
+| ----------- | ------------ | ------------- |
+| OIDC Claims | `department` | `Engineering` |

--- a/src/content/partials/cloudflare-one/gateway/selectors/oidc-claims.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/oidc-claims.mdx
@@ -1,0 +1,7 @@
+---
+{}
+---
+
+| UI name     | API example                                     |
+| ----------- | ----------------------------------------------- |
+| OIDC Claims | `identity.oidc_claims[*] == "\"colors=blue\""` |

--- a/src/content/partials/cloudflare-one/gateway/selectors/oidc-claims.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/oidc-claims.mdx
@@ -4,4 +4,4 @@
 
 | UI name     | API example                                     |
 | ----------- | ----------------------------------------------- |
-| OIDC Claims | `identity.oidc_claims[*] == "\"colors=blue\""` |
+| OIDC Claims | `any(identity.oidc_claims[*] == "\"department=engineering\"")` |


### PR DESCRIPTION
## Summary

- Adds a new **OIDC Claims** identity-based selector to the Gateway identity selectors page, documenting that custom OIDC claims can now be used in DNS, HTTP, and Network policies.
- Updates the **Generic OIDC IdP** section on the identity selectors page to include a usage example (previously stated "not supported").
- Updates the **Generic OIDC** IdP configuration page to remove the "not currently supported in Gateway policies" caveat and adds cross-links to the new Gateway selector documentation.

## Files changed

- `src/content/partials/cloudflare-one/gateway/selectors/oidc-claims.mdx` — New partial for the OIDC Claims selector table (follows existing pattern used by SAML Attributes, User Email, etc.)
- `src/content/docs/cloudflare-one/traffic-policies/identity-selectors.mdx` — Added OIDC Claims selector section; updated Generic OIDC IdP section with usage example
- `src/content/docs/cloudflare-one/integrations/identity-providers/generic-oidc.mdx` — Removed "not supported in Gateway" caveat; added cross-links to Gateway selector docs