### PR TITLE
Skip deploy preview action on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
   publish-preview:
     name: Deploy Preview
     needs: build
-    if: github.repository == 'cloudflare/cloudflare-docs'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Summary

Recent changes (#28975) caused previews to try to run on forks, and then fail. 