### PR TITLE
[Chore] Partial checkout versions bump

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - uses: actions/setup-node@v4

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/image-audit.yml
+++ b/.github/workflows/image-audit.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Find Unused Files
         id: find-files

--- a/.github/workflows/issue-label-assign.yml
+++ b/.github/workflows/issue-label-assign.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/issue-label-assign
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/potential-redirects-or-partials.yml
+++ b/.github/workflows/potential-redirects-or-partials.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Potential redirects
         env:

--- a/.github/workflows/pr-label-assign.yml
+++ b/.github/workflows/pr-label-assign.yml
@@ -41,7 +41,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/assign-pr
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # fetch full history so Semgrep can compare against the base branch
           fetch-depth: 0
@@ -65,7 +65,7 @@ jobs:
               $list_of_files \
               | jq --raw-output ".results[] | \"::warning file=\(.path),line=\(.start.line),title=\(.check_id)::\(.extra.message)\""
             #exit ${PIPESTATUS[0]}
-            # for the moment always return a successful run 
+            # for the moment always return a successful run
             exit 0
           else
             echo "No relevant files changed"

--- a/.github/workflows/update-api-schemas.yml
+++ b/.github/workflows/update-api-schemas.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout docs repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get latest api-schemas commit
         id: get-commit


### PR DESCRIPTION
### Summary

We need to upgrade to checkout v6. This bumps the non-critical actions for soak time