### PR TITLE
Upgrade from deprecated v20 github actions

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -14,10 +14,10 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: npm-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -24,12 +24,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: "package.json"
           cache: "npm"

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -25,12 +25,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: "package.json"
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
             node_modules/.astro/assets
           key: static
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -198,7 +198,7 @@ jobs:
 
       - run: npm ci
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
@@ -270,7 +270,7 @@ jobs:
 
       - run: npm ci
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     name: Compiles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "npm"
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             node_modules/.astro/assets
@@ -70,7 +70,7 @@ jobs:
 
       - run: npm run check:worker
 
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         with:
           path: |
             node_modules/.astro/assets
@@ -98,11 +98,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm
@@ -127,7 +127,7 @@ jobs:
 
       - run: npm ci
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             node_modules/.astro/assets
@@ -168,13 +168,13 @@ jobs:
             echo "failed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         with:
           path: |
             node_modules/.astro/assets
           key: static
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: dist
           path: dist
@@ -187,11 +187,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm
@@ -233,11 +233,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm
@@ -259,11 +259,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/image-audit.yml
+++ b/.github/workflows/image-audit.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Find Unused Files
         id: find-files

--- a/.github/workflows/issue-label-assign.yml
+++ b/.github/workflows/issue-label-assign.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/issue-label-assign
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/potential-redirects-or-partials.yml
+++ b/.github/workflows/potential-redirects-or-partials.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Potential redirects
         env:

--- a/.github/workflows/pr-label-assign.yml
+++ b/.github/workflows/pr-label-assign.yml
@@ -41,7 +41,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/assign-pr
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -29,7 +29,7 @@ jobs:
         name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: site-html

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -12,15 +12,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: npm
       - run: npm ci
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             node_modules/.astro/assets
@@ -29,7 +29,7 @@ jobs:
         name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         continue-on-error: true
         with:
           name: site-html
@@ -38,7 +38,7 @@ jobs:
         name: Deploy to Cloudflare Workers
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v5
         if: always()
         with:
           path: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # fetch full history so Semgrep can compare against the base branch
           fetch-depth: 0

--- a/.github/workflows/update-api-schemas.yml
+++ b/.github/workflows/update-api-schemas.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout docs repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get latest api-schemas commit
         id: get-commit


### PR DESCRIPTION
## Summary

Node 20 is being deprecated on GitHub Actions runners ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Actions pinned to versions that specify `runs: using: node20` in their `action.yml` will stop working when GitHub removes Node 20 from runners (June 2, 2026 — runners default to Node 24; fall 2026 — Node 20 removed entirely).

Note: it is the **Node 20 runner runtime** being deprecated, not the action versions themselves. The version bumps here are necessary because the older action versions hard-code `node20` as their runtime.

## What changed

Updated 5 actions across 11 workflow files:

| Action                                           | From          | To   | First Node 24 version |
| ------------------------------------------------ | ------------- | ---- | --------------------- |
| `actions/checkout`                               | `v4` (node20) | `v6` | v5                    |
| `actions/setup-node`                             | `v4` (node20) | `v6` | v5                    |
| `actions/cache` / `cache/restore` / `cache/save` | `v4` (node20) | `v5` | v5                    |
| `actions/upload-artifact`                        | `v4` (node20) | `v7` | v6                    |
| `actions/download-artifact`                      | `v4` (node20) | `v8` | v8                    |

**Files modified:** `ci.yml`, `publish-production.yml`, `anchor-link-audit.yml`, `bonk.yml`, `bigbonk.yml`, `update-api-schemas.yml`, `potential-redirects-or-partials.yml`, `pr-label-assign.yml`, `semgrep.yml`, `image-audit.yml`, `issue-label-assign.yml`

## Breaking changes

None. All version bumps only change the Node runtime (20 → 24). No inputs, outputs, or behavior changed between the old and new versions. Requires runner v2.327.1+, which GitHub-hosted runners already satisfy.
