### PR TITLE
[SSL] Add incomplete certificate chain as a cause of error 526

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526.mdx
@@ -15,13 +15,6 @@ This error occurs when these two conditions are true:
 - Cloudflare cannot validate the SSL certificate at your origin web server.
 - [_Full SSL (Strict)_](/ssl/origin-configuration/ssl-modes/full-strict/) **SSL** is set in the **Overview** tab of your Cloudflare **SSL/TLS** app.
 
-Cloudflare cannot validate the origin certificate when any of the following are true:
-
-- The certificate is expired or not yet valid.
-- The certificate is self-signed.
-- The certificate hostname does not match the requested domain.
-- The certificate chain is incomplete - the origin server is not serving the required intermediate CA certificate(s), preventing Cloudflare from building a trusted chain to a root CA.
-
 #### Resolution
 
 Here are some options to fix or workaround this issue:
@@ -37,6 +30,7 @@ Here are some options to fix or workaround this issue:
   - Certificate is not revoked.
   - Certificate is signed by a [Certificate Authority](https://en.wikipedia.org/wiki/Certificate_authority) (not self-signed).
   - The requested or target domain name and hostname are in the certificate's **Common Name** or **Subject Alternative Name**.
+  - The certificate chain is incomplete - the origin server is not serving the required intermediate CA certificate(s), preventing Cloudflare from building a trusted chain to a root CA.
   - Your origin web server accepts connections over port SSL port `443`.
   - [Temporarily pause Cloudflare](/fundamentals/manage-domains/pause-cloudflare/) and visit [https://www.sslshopper.com/ssl-checker.html#hostname=www.example.com](https://www.sslshopper.com/ssl-checker.html#hostname=www.example.com) (replace `www.example.com` with your hostname and domain) to verify no issues exists with the origin SSL certificate:
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526.mdx
@@ -15,6 +15,13 @@ This error occurs when these two conditions are true:
 - Cloudflare cannot validate the SSL certificate at your origin web server.
 - [_Full SSL (Strict)_](/ssl/origin-configuration/ssl-modes/full-strict/) **SSL** is set in the **Overview** tab of your Cloudflare **SSL/TLS** app.
 
+Cloudflare cannot validate the origin certificate when any of the following are true:
+
+- The certificate is expired or not yet valid.
+- The certificate is self-signed.
+- The certificate hostname does not match the requested domain.
+- The certificate chain is incomplete - the origin server is not serving the required intermediate CA certificate(s), preventing Cloudflare from building a trusted chain to a root CA.
+
 #### Resolution
 
 Here are some options to fix or workaround this issue:

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-526.mdx
@@ -30,7 +30,7 @@ Here are some options to fix or workaround this issue:
   - Certificate is not revoked.
   - Certificate is signed by a [Certificate Authority](https://en.wikipedia.org/wiki/Certificate_authority) (not self-signed).
   - The requested or target domain name and hostname are in the certificate's **Common Name** or **Subject Alternative Name**.
-  - The certificate chain is incomplete - the origin server is not serving the required intermediate CA certificate(s), preventing Cloudflare from building a trusted chain to a root CA.
+  - The certificate chain is complete - the origin server must serve the leaf certificate along with any required intermediate CA certificates so that Cloudflare can build a trusted chain to a root CA.
   - Your origin web server accepts connections over port SSL port `443`.
   - [Temporarily pause Cloudflare](/fundamentals/manage-domains/pause-cloudflare/) and visit [https://www.sslshopper.com/ssl-checker.html#hostname=www.example.com](https://www.sslshopper.com/ssl-checker.html#hostname=www.example.com) (replace `www.example.com` with your hostname and domain) to verify no issues exists with the origin SSL certificate:
 


### PR DESCRIPTION
### Summary

Adds "incomplete certificate chain" as a named cause of error 526. The existing list covered expired certificates, self-signed certificates, and hostname mismatches, but omitted the case where the origin server is not serving the required intermediate CA certificate(s). This prevents Cloudflare from building a trusted chain to a root CA under Full (Strict) mode and is a common real-world cause of 526 errors.

support case: `02030823`

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
