### PR TITLE
[Zaraz] Fix outdated Logpush settings dashboard link and navigation path

### DIFF
--- a/src/content/docs/zaraz/advanced/logpush.mdx
+++ b/src/content/docs/zaraz/advanced/logpush.mdx
@@ -27,8 +27,17 @@ Follow these steps to configure Logpush support for Zaraz:
 
 ### 2. Enable Logpush from Zaraz settings
 
-1. Go to your website's [Zaraz settings](https://dash.cloudflare.com/?to=/:account/:zone/zaraz/settings).
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com), go to **Delivery & Performance** > **Web tag management** > **Tag setup** > select your domain > **Settings**.
+
+   Alternatively, navigate directly to [Zaraz settings](https://dash.cloudflare.com/?to=/:account/tag-management/zaraz/:zone/tools-config/tools)
+
 2. Enable **Export Zaraz Logs**.
+
+:::note
+
+Zaraz must already be configured on your zone to access the Settings page. If Zaraz has not been set up yet, you will be prompted to complete the initial setup first.
+
+:::
 
 ## Fields
 


### PR DESCRIPTION
### Summary

The Zaraz settings page has moved from the old path (`/:account/:zone/zaraz/settings`) to the new tag management path (`/:account/tag-management/zaraz/:zone/tools-config/settings`).

This PR:
- Updates the DashButton URL to point to the correct location
- Updates the navigation instructions to reflect the current dashboard structure (Delivery & Performance > Web tag management > Tag setup > domain > Settings)
- Adds a note that Zaraz must be configured on the zone before the Settings page is accessible

support case: `02029732`

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).