### PR TITLE
[Workers/Pages] Add SvelteKit to build caching frameworks

### DIFF
--- a/src/content/docs/pages/configuration/build-caching.mdx
+++ b/src/content/docs/pages/configuration/build-caching.mdx
@@ -34,14 +34,15 @@ Some frameworks provide a cache directory that is typically populated by the fra
 
 The following frameworks support build output caching:
 
-| Framework  | Directories cached                            |
-| ---------- | --------------------------------------------- |
-| Astro      | `node_modules/.astro`                         |
-| Docusaurus | `node_modules/.cache`, `.docusaurus`, `build` |
-| Eleventy   | `.cache`                                      |
-| Gatsby     | `.cache`, `public`                            |
-| Next.js    | `.next/cache`                                 |
-| Nuxt       | `node_modules/.cache/nuxt`                    |
+| Framework  | Directories cached                                          |
+| ---------- | ----------------------------------------------------------- |
+| Astro      | `node_modules/.astro`                                       |
+| Docusaurus | `node_modules/.cache`, `.docusaurus`, `build`               |
+| Eleventy   | `.cache`                                                    |
+| Gatsby     | `.cache`, `public`                                          |
+| Next.js    | `.next/cache`                                               |
+| Nuxt       | `node_modules/.cache/nuxt`                                  |
+| SvelteKit  | `node_modules/.cache/imagetools`, `.svelte-kit`             |
 
 ### Limits
 

--- a/src/content/docs/pages/configuration/build-caching.mdx
+++ b/src/content/docs/pages/configuration/build-caching.mdx
@@ -42,7 +42,7 @@ The following frameworks support build output caching:
 | Gatsby     | `.cache`, `public`                                          |
 | Next.js    | `.next/cache`                                               |
 | Nuxt       | `node_modules/.cache/nuxt`                                  |
-| SvelteKit  | `node_modules/.cache/imagetools`, `.svelte-kit`             |
+| SvelteKit  | `node_modules/.cache/imagetools`                            |
 
 ### Limits
 

--- a/src/content/docs/workers/ci-cd/builds/build-caching.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-caching.mdx
@@ -41,7 +41,7 @@ The following frameworks support build output caching:
 | Gatsby     | `.cache`, `public`                                          |
 | Next.js    | `.next/cache`                                               |
 | Nuxt       | `node_modules/.cache/nuxt`                                  |
-| SvelteKit  | `node_modules/.cache/imagetools`, `.svelte-kit`             |
+| SvelteKit  | `node_modules/.cache/imagetools`                            |
 
 :::note
 [Static assets](/workers/static-assets/) and [frameworks](/workers/framework-guides/) are now supported in Cloudflare Workers.

--- a/src/content/docs/workers/ci-cd/builds/build-caching.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-caching.mdx
@@ -33,14 +33,15 @@ Some frameworks provide a cache directory that is typically populated by the fra
 
 The following frameworks support build output caching:
 
-| Framework  | Directories cached                            |
-| ---------- | --------------------------------------------- |
-| Astro      | `node_modules/.astro`                         |
-| Docusaurus | `node_modules/.cache`, `.docusaurus`, `build` |
-| Eleventy   | `.cache`                                      |
-| Gatsby     | `.cache`, `public`                            |
-| Next.js    | `.next/cache`                                 |
-| Nuxt       | `node_modules/.cache/nuxt`                    |
+| Framework  | Directories cached                                          |
+| ---------- | ----------------------------------------------------------- |
+| Astro      | `node_modules/.astro`                                       |
+| Docusaurus | `node_modules/.cache`, `.docusaurus`, `build`               |
+| Eleventy   | `.cache`                                                    |
+| Gatsby     | `.cache`, `public`                                          |
+| Next.js    | `.next/cache`                                               |
+| Nuxt       | `node_modules/.cache/nuxt`                                  |
+| SvelteKit  | `node_modules/.cache/imagetools`, `.svelte-kit`             |
 
 :::note
 [Static assets](/workers/static-assets/) and [frameworks](/workers/framework-guides/) are now supported in Cloudflare Workers.


### PR DESCRIPTION
## Summary

- Adds SvelteKit to the supported frameworks table for build caching in both the Pages and Workers Builds docs
- SvelteKit caches `node_modules/.cache/imagetools` 
