### PR TITLE
[GHA] Introduce node module caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,20 @@ jobs:
             exit 1
           fi
 
-      - run: npm ci
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run sync (if cache hit)
+        run: npm run sync
+        if: steps.node-modules-cache.outputs.cache-hit == 'true'
+
+      - name: Node install (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - uses: actions/cache/restore@v5
         with:


### PR DESCRIPTION
### Summary

Introduce cache keys for caching node modules in our build step. We'll run it here for a while and -- once confident this works -- upgrade to publish production workflow.
