### PR TITLE
[GHA] Expands caching node_modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,14 @@ jobs:
             exit 1
           fi
 
-      - name: Cache node_modules
+      - name: Restore node_modules (cache hit)
         id: node-modules-cache
         uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run sync (if cache hit)
-        run: npm run sync
-        if: steps.node-modules-cache.outputs.cache-hit == 'true'
-
-      - name: Node install (cache miss)
+      - name: Install node_modules (cache miss)
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
@@ -138,18 +134,14 @@ jobs:
             exit 1
           fi
 
-      - name: Cache node_modules
+      - name: Restore node_modules (cache hit)
         id: node-modules-cache
         uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run sync (if cache hit)
-        run: npm run sync
-        if: steps.node-modules-cache.outputs.cache-hit == 'true'
-
-      - name: Node install (cache miss)
+      - name: Install node_modules (cache miss)
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
@@ -222,18 +214,14 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - name: Cache node_modules
+      - name: Restore node_modules (cache hit)
         id: node-modules-cache
         uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run sync (if cache hit)
-        run: npm run sync
-        if: steps.node-modules-cache.outputs.cache-hit == 'true'
-
-      - name: Node install (cache miss)
+      - name: Install node_modules (cache miss)
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
@@ -281,18 +269,14 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - name: Cache node_modules
+      - name: Restore node_modules (cache hit)
         id: node-modules-cache
         uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run sync (if cache hit)
-        run: npm run sync
-        if: steps.node-modules-cache.outputs.cache-hit == 'true'
-
-      - name: Node install (cache miss)
+      - name: Install node_modules (cache miss)
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
@@ -320,18 +304,14 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - name: Cache node_modules
+      - name: Restore node_modules (cache hit)
         id: node-modules-cache
         uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run sync (if cache hit)
-        run: npm run sync
-        if: steps.node-modules-cache.outputs.cache-hit == 'true'
-
-      - name: Node install (cache miss)
+      - name: Install node_modules (cache miss)
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,20 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - run: npm ci
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run sync (if cache hit)
+        run: npm run sync
+        if: steps.node-modules-cache.outputs.cache-hit == 'true'
+
+      - name: Node install (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,20 @@ jobs:
             exit 1
           fi
 
-      - run: npm ci
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run sync (if cache hit)
+        run: npm run sync
+        if: steps.node-modules-cache.outputs.cache-hit == 'true'
+
+      - name: Node install (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - run: npx tsx bin/post-codeowners-comment/index.ts
         continue-on-error: true
@@ -209,7 +222,20 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - run: npm ci
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run sync (if cache hit)
+        run: npm run sync
+        if: steps.node-modules-cache.outputs.cache-hit == 'true'
+
+      - name: Node install (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - uses: actions/download-artifact@v8
         with:
@@ -255,7 +281,20 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - run: npm ci
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run sync (if cache hit)
+        run: npm run sync
+        if: steps.node-modules-cache.outputs.cache-hit == 'true'
+
+      - name: Node install (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Post PR CI failure comment
         continue-on-error: true


### PR DESCRIPTION
### Summary

Adds caching to other steps of `CI`, as well as removes the `npm run sync` logic. This line was redundant, as we can see from [build logs](https://github.com/cloudflare/cloudflare-docs/actions/runs/23347411356/job/67916457087#step:9:22) and the [Astro docs](https://docs.astro.build/en/reference/cli-reference/#astro-sync) (`Running astro dev, astro build or astro check will run the sync command as well.`).
