### PR TITLE
Organize CI build and validation into pre-build, build, and post-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
+      - name: Restore Astro assets from cache
       - uses: actions/cache@v5
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
-      - uses: actions/cache/restore@v5
+      - uses: actions/cache@v5
         with:
           path: |
             node_modules/.astro/assets
@@ -229,12 +229,6 @@ jobs:
           else
             echo "failed=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - uses: actions/cache/save@v5
-        with:
-          path: |
-            node_modules/.astro/assets
-          key: static
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         run: npx tsm bin/validate-redirects.ts
 
       - name: Tests
-        run: npm run test
+        run: npm run test:prebuild
 
   build:
     name: Build
@@ -257,6 +257,38 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run sync (if cache hit)
+        run: npm run sync
+        if: steps.node-modules-cache.outputs.cache-hit == 'true'
+
+      - name: Node install (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - name: Tests (Workers)
+        run: npm run test:postbuild
+
       - name: Link validation
         if: needs.build.outputs.link_check_failed == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx tsx bin/post-pr-ci-failure-comment/index.ts
 
-  build:
-    name: Build
+  pre-build:
+    name: Pre Build
     runs-on: ubuntu-latest
-    outputs:
-      link_check_failed: ${{ steps.check_link_result.outputs.failed }}
     permissions:
       contents: read
       pull-requests: write
@@ -114,7 +112,8 @@ jobs:
             exit 1
           fi
 
-      - run: |
+      - name: Check for invalid file extensions
+        run: |
           FILES=$(
             find src/content \
               -type f \
@@ -147,12 +146,6 @@ jobs:
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
-      - uses: actions/cache/restore@v5
-        with:
-          path: |
-            node_modules/.astro/assets
-          key: static
-
       - run: npx tsx bin/post-codeowners-comment/index.ts
         continue-on-error: true
         env:
@@ -160,10 +153,67 @@ jobs:
 
       - run: npm run check
 
+      - run: npm run check:worker
+
+      - uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail_level: error
+          filter_mode: nofilter
+
+      - run: npm run format:core:check
+
+      - name: Validate redirects
+        run: npx tsm bin/validate-redirects.ts
+
+      - name: Tests
+        run: npm run test
+
+  build:
+    name: Build
+    needs: pre-build
+    runs-on: ubuntu-latest
+    outputs:
+      link_check_failed: ${{ steps.check_link_result.outputs.failed }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run sync (if cache hit)
+        run: npm run sync
+        if: steps.node-modules-cache.outputs.cache-hit == 'true'
+
+      - name: Node install (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+
+      - uses: actions/cache/restore@v5
+        with:
+          path: |
+            node_modules/.astro/assets
+          key: static
+
       # The starlight-links-validator plugin runs in astro:build:done, which fires
       # AFTER all pages have been written to dist/. If link validation fails, the
       # build exits non-zero but dist/ is complete. We use continue-on-error so the
-      # job succeeds (allowing deploy + validate to run), then check the outcome below.
+      # job succeeds (allowing deploy + post-build to run), then check the outcome below.
       - run: npm run build
         id: build_step
         name: Build
@@ -199,45 +249,14 @@ jobs:
           name: dist
           path: dist
 
-  validate:
-    name: Validate
+  post-build:
+    name: Post Build
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22.x
-          cache: npm
-
-      - run: npm ci
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist
-
-      - uses: reviewdog/action-eslint@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-          fail_level: error
-          filter_mode: nofilter
-
-      - run: npm run format:core:check
-
-      - name: Validate redirects
-        run: npx tsm bin/validate-redirects.ts
-
-      - name: Tests
-        run: npm run test
-
       - name: Link validation
         if: needs.build.outputs.link_check_failed == 'true'
         run: |
@@ -246,7 +265,7 @@ jobs:
 
   notify:
     name: Notify
-    needs: [build, validate]
+    needs: [pre-build, build, post-build]
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Restore Astro assets from cache
-      - uses: actions/cache@v5
+        uses: actions/cache@v5
         with:
           path: |
             node_modules/.astro/assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,18 +131,14 @@ jobs:
             exit 1
           fi
 
-      - name: Cache node_modules
+      - name: Restore node_modules (cache hit)
         id: node-modules-cache
         uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run sync (if cache hit)
-        run: npm run sync
-        if: steps.node-modules-cache.outputs.cache-hit == 'true'
-
-      - name: Node install (cache miss)
+      - name: Install node_modules (cache miss)
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
@@ -189,18 +185,14 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - name: Cache node_modules
+      - name: Restore node_modules (cache hit)
         id: node-modules-cache
         uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run sync (if cache hit)
-        run: npm run sync
-        if: steps.node-modules-cache.outputs.cache-hit == 'true'
-
-      - name: Node install (cache miss)
+      - name: Install node_modules (cache miss)
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
@@ -266,18 +258,14 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - name: Cache node_modules
+      - name: Restore node_modules (cache hit)
         id: node-modules-cache
         uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Run sync (if cache hit)
-        run: npm run sync
-        if: steps.node-modules-cache.outputs.cache-hit == 'true'
-
-      - name: Node install (cache miss)
+      - name: Install node_modules (cache miss)
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
@@ -313,7 +301,16 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules (cache hit)
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install node_modules (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - name: Post PR CI failure comment
         continue-on-error: true
@@ -339,7 +336,16 @@ jobs:
           node-version: 22.x
           cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules (cache hit)
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install node_modules (cache miss)
+        run: npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - uses: actions/download-artifact@v8
         with:

--- a/bin/post-pr-ci-failure-comment/index.ts
+++ b/bin/post-pr-ci-failure-comment/index.ts
@@ -32,7 +32,7 @@ async function run(): Promise<void> {
 		);
 
 		if (ciJobs.length === 0) {
-			core.setFailed(`Could not find Build or Validate jobs`);
+			core.setFailed(`Could not find Pre Build, Build, or Post Build jobs`);
 			process.exit();
 		}
 

--- a/bin/post-pr-ci-failure-comment/index.ts
+++ b/bin/post-pr-ci-failure-comment/index.ts
@@ -25,7 +25,10 @@ async function run(): Promise<void> {
 		});
 
 		const ciJobs = run.jobs.filter(
-			(job) => job.name === "Build" || job.name === "Validate",
+			(job) =>
+				job.name === "Pre Build" ||
+				job.name === "Build" ||
+				job.name === "Post Build",
 		);
 
 		if (ciJobs.length === 0) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
 		"start": "npx astro dev",
 		"sync": "npx astro sync",
 		"test": "npx vitest",
+		"test:prebuild": "npx vitest --project Node --project Astro",
+		"test:postbuild": "npx vitest --project Workers",
 		"lint": "npx eslint",
 		"ai-setup:import-from-opencode": "npx rulesync import --targets opencode --features rules,commands,subagents",
 		"ai-setup:claudecode": "npm run ai-setup:import-from-opencode && npx rulesync generate --targets claudecode --features rules,commands,subagents",


### PR DESCRIPTION
## Summary

### What changed

The CI pipeline had a `build` + `validate` structure where lint, formatting, and test failures were only surfaced after waiting 20+ minutes for the build to complete. This restructures the pipeline into three explicit phases.

## New job topology

```
pre-build ───────────────────────────────► build ──────────────────────► post-build
  CRLF check                                 │                               Workers tests (require dist/)
  invalid file extension check               │                               link validation
  type check (check + check:worker)          │
  eslint (reviewdog)                         ├──────────────────────────► publish-preview
  format check                               │
  redirect validation                        └──────────────────────────► notify
  Node + Astro tests
```

### Changes at a glance

- **`pre-build` (new):** All fast validation steps that do not require a built `dist/` move here — CRLF check, file extension check, type checking, ESLint, format check, redirect validation, and Node/Astro tests (`test:prebuild`). Failures surface in ~2-3 minutes instead of after the full build.
- **`build`:** Now `needs: pre-build`. Stripped of all steps moved to `pre-build` — responsible only for running `npm run build` and uploading the `dist/` artifact.
- **`post-build` (renamed from `validate`):** Runs after `build`. Downloads the `dist/` artifact, runs the Workers test suite (`test:postbuild`) which requires `dist/` to exist, then surfaces any link validation failures.
- **`notify`:** Updated `needs` to `[pre-build, build, post-build]` and job name filters updated to match new names.
- **`compile`:** Untouched (pending separate removal).
- **`publish-preview`:** Untouched.

### Why tests are split

The Workers vitest pool reads `wrangler.toml` at startup, which specifies `assets.directory = "./dist"`. Running all tests in `pre-build` caused an immediate crash since `dist/` doesn't exist yet. Two scripts were added to `package.json` — `test:prebuild` (Node + Astro suites) and `test:postbuild` (Workers suite) — to split them across the appropriate phases.
