### PR TITLE
fix: nested anchor tags in toc

### DIFF
--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -24,14 +24,9 @@ const { editUrl } = Astro.locals.starlightRoute;
 						<a
 							href={`/search/?tags=${tag}`}
 							class="rounded-full border border-[var(--sidebar-border)] bg-transparent px-3 py-1 text-[11px] font-medium text-[var(--sl-color-gray-3)] transition-colors duration-150 ease-out hover:border-[var(--sl-color-gray-2)] hover:text-[var(--sl-color-white)] focus-visible:ring-2 focus-visible:ring-[var(--sl-color-text-accent)] focus-visible:outline-none"
+							data-tag-serp-link={true}
 						>
-					<a
-						href={`/search/?tags=${tag}`}
-						class="rounded-full border border-[var(--sidebar-border)] bg-transparent px-3 py-1 text-[11px] font-medium text-[var(--sl-color-gray-3)] transition-colors duration-150 ease-out hover:border-[var(--sl-color-gray-2)] hover:text-[var(--sl-color-white)] focus-visible:ring-2 focus-visible:ring-[var(--sl-color-text-accent)] focus-visible:outline-none"
-						data-tag-serp-link={true}
-					>
-						{tag}
-					</a>
+							{tag}
 						</a>
 					))}
 				</div>


### PR DESCRIPTION
### Summary

Problem
When a docs page has tags: in its frontmatter, the right-hand sidebar rendered an empty ghost pill bubble before each tag. For example, a page with tags: [Postgres, TypeScript, SQL] would render six <a> elements instead of three — one empty, one with text, per tag.
This was introduced during the TOC redesign. When the tag link markup was updated, the new <a> (with the revised Tailwind classes and data-tag-serp-link attribute) was inserted inside the existing <a> rather than replacing it. The outer anchor had no text content, so it rendered as an empty pill. Nested <a> tags are also invalid HTML.

Fix
Collapsed the two nested <a> elements back into a single anchor, preserving the updated pill styles and the data-tag-serp-link analytics attribute.


### Screenshots (optional)
**Before**
<img width="283" height="131" alt="Screenshot 2026-03-20 at 20 03 59" src="https://github.com/user-attachments/assets/0ef4929a-44d0-4818-b3e7-96dfcd857e0d" />

**After**
<img width="291" height="100" alt="Screenshot 2026-03-20 at 20 04 28" src="https://github.com/user-attachments/assets/20d2d23a-3fe0-460a-81ac-29aa03df713f" />


<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
