### PR TITLE
docs(agents): add missing lifecycle methods to getCurrentAgent() context availability

### DIFF
--- a/src/content/docs/agents/api-reference/get-current-agent.mdx
+++ b/src/content/docs/agents/api-reference/get-current-agent.mdx
@@ -82,7 +82,7 @@ export class MyAgent extends AIChatAgent {
 
 ### Built-in vs custom methods
 
-- **Built-in methods** (`onRequest`, `onEmail`, `onStateChanged`): Already have context.
+- **Built-in methods** (`onStart`, `onRequest`, `onConnect`, `onMessage`, `onClose`, `onEmail`, `onStateChanged`): Already have context.
 - **Custom methods** (your methods): Automatically wrapped during initialization.
 - **External functions**: Access context through `getCurrentAgent()`.
 
@@ -231,13 +231,21 @@ The context available depends on how the method was invoked:
 
 | Invocation              | `agent` | `connection` | `request` | `email` |
 | ----------------------- | ------- | ------------ | --------- | ------- |
+| `onStart()`             | Yes     | No           | No        | No      |
 | `onRequest()`           | Yes     | No           | Yes       | No      |
 | `onConnect()`           | Yes     | Yes          | Yes       | No      |
 | `onMessage()`           | Yes     | Yes          | No        | No      |
+| `onClose()`             | Yes     | Yes          | No        | No      |
 | `onEmail()`             | Yes     | No           | No        | Yes     |
+| `onStateChanged()`      | Yes     | Inherited    | Inherited | Inherited |
+| `onError()`             | Yes     | Inherited    | Inherited | Inherited |
 | Custom method (via RPC) | Yes     | Yes          | No        | No      |
 | Scheduled task          | Yes     | No           | No        | No      |
-| Queue callback          | Yes     | Depends      | Depends   | Depends |
+| Queue callback          | Yes     | Inherited    | Inherited | Inherited |
+
+:::note
+"Inherited" means the value depends on the calling context. For example, `onStateChanged()` receives the `connection` when a client triggers a state update, but not when the server calls `setState()`. Similarly, `onError()` inherits whatever context was active when the error occurred.
+:::
 
 ## Best practices
 


### PR DESCRIPTION
## What

Adds missing lifecycle methods to the `getCurrentAgent()` context availability table on the [API reference page](https://developers.cloudflare.com/agents/api-reference/get-current-agent/#context-availability).

## Changes

### Context availability table
Added the following missing lifecycle methods:
- **`onStart()`** — agent only (no connection, request, or email)
- **`onClose()`** — agent + connection
- **`onStateChanged()`** — agent + inherited context from caller
- **`onError()`** — agent + inherited context from caller

### Built-in methods list
Updated the "Built-in vs custom methods" section to list all lifecycle methods that have context: `onStart`, `onRequest`, `onConnect`, `onMessage`, `onClose`, `onEmail`, `onStateChanged`.

### Inherited context note
Added a note explaining what "Inherited" means in the table — these methods receive whatever context was active when they were triggered (e.g., `onStateChanged()` gets the `connection` when a client triggers a state update, but not when the server calls `setState()`).

Also changed "Depends" to "Inherited" for queue callbacks for consistency.

## Verification

Audited against the SDK source (`packages/agents/src/index.ts`), checking every `agentContext.run()` call to confirm the exact context each lifecycle method receives.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/29193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
