### PR TITLE
[AI Gateway] Fix broken Replicate API tokens link

### DIFF
--- a/src/content/docs/ai-gateway/usage/providers/replicate.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/replicate.mdx
@@ -21,7 +21,7 @@ When making requests to Replicate, ensure you have the following:
 
 - Your AI Gateway Account ID.
 - Your AI Gateway gateway name.
-- An active Replicate API token. You can create one at [replicate.com/settings/api-tokens](https://replicate.com/settings/api-tokens)
+- An active Replicate API token. You can create one at [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens)
 - The name of the Replicate model you want to use, like `anthropic/claude-4.5-haiku` or `google/nano-banana`.
 
 ## Example


### PR DESCRIPTION
## Summary

- Updates the Replicate API tokens URL from `https://replicate.com/settings/api-tokens` to `https://replicate.com/account/api-tokens`

Fixes #29195