### PR TITLE
Filter directory pages from llms.txt

### DIFF
--- a/src/pages/[...product]/llms.txt.ts
+++ b/src/pages/[...product]/llms.txt.ts
@@ -2,6 +2,33 @@ import type { APIRoute, GetStaticPaths, InferGetStaticPropsType } from "astro";
 import { getCollection } from "astro:content";
 import dedent from "dedent";
 
+/**
+ * Maximum number of prose characters allowed alongside a DirectoryListing
+ * component before a page is considered to have real standalone content.
+ * Pages at or below this threshold are treated as pure navigation containers
+ * and excluded from llms.txt — their child pages are already listed individually.
+ */
+const DIRECTORY_PROSE_THRESHOLD = 250;
+
+/**
+ * Returns true if the page body consists of a DirectoryListing component with
+ * DIRECTORY_PROSE_THRESHOLD characters or fewer of surrounding prose. These
+ * pages are pure section index/navigation containers with no standalone content
+ * worth including in llms.txt — the child pages are already listed individually.
+ */
+function isDirectoryOnlyPage(body: string): boolean {
+	if (!body.includes("DirectoryListing")) return false;
+	// Strip import lines
+	let prose = body.replace(/^import\s+.*?from\s+['"].*?['"];?\s*\n?/gm, "");
+	// Strip self-closing component tags e.g. <DirectoryListing />
+	prose = prose.replace(/<[A-Z][^>]*\/>/g, "");
+	// Strip paired component tags and their children e.g. <Description>...</Description>
+	prose = prose.replace(/<[A-Z][^>]*>[\s\S]*?<\/[A-Z][^>]*>/g, "");
+	// Strip JSX comments
+	prose = prose.replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+	return prose.trim().length <= DIRECTORY_PROSE_THRESHOLD;
+}
+
 export const getStaticPaths = (async () => {
 	const directory = await getCollection("directory");
 
@@ -22,7 +49,9 @@ export const getStaticPaths = (async () => {
 
 			const prefix = urlPath;
 			const pages = docs.filter(
-				(e) => e.id.startsWith(prefix + "/") || e.id === prefix,
+				(e) =>
+					(e.id.startsWith(prefix + "/") || e.id === prefix) &&
+					!isDirectoryOnlyPage(e.body ?? ""),
 			);
 
 			if (pages.length === 0) return null;


### PR DESCRIPTION
### Summary

Per-product `llms.txt` files previously included section index pages whose only content is a `<DirectoryListing />` component — pages that exist purely as sidebar navigation containers. These pages have no standalone value for an LLM (the `llms.txt` file itself already serves as a directory), and they were failing the `content-start-position` audit check because 100% of their rendered content is navigation links.

This adds an `isDirectoryOnlyPage()` helper that strips imports, component tags, and JSX comments from a page's raw MDX body, then returns `true` if the page contains a `<DirectoryListing />` with ≤ 250 characters of surrounding prose. Any page matching that condition is excluded from the per-product `llms.txt` filter in `getStaticPaths`.

- ~415 pure directory index pages are removed from per-product `llms.txt` outputs
- Pages with real prose alongside `<DirectoryListing />` (>250 chars) are preserved
- Pages that don't use `<DirectoryListing />` at all are unaffected
- No build time impact — operates on `e.body` already loaded in memory by `getCollection`
- The global `/llms.txt` (product directory) is unchanged