### PR TITLE
doc: add logLevel for vitest-pool-worker

### DIFF
--- a/src/content/changelog/workers/2026-03-22-vitest-pool-workers-log-level.mdx
+++ b/src/content/changelog/workers/2026-03-22-vitest-pool-workers-log-level.mdx
@@ -1,0 +1,28 @@
+---
+title: Configurable log level for @cloudflare/vitest-pool-workers
+description: You can now control the verbosity of pool log messages when using the Workers Vitest integration.
+products:
+  - workers
+date: 2026-03-22
+---
+
+The [`@cloudflare/vitest-pool-workers`](/workers/testing/vitest-integration/) package now supports a `logLevel` option in `cloudflareTest()`, letting you control the verbosity of `[vpw:*]` pool log messages.
+
+Previously, the pool always logged at the `verbose` level. The new default is `"info"`, which reduces noise during test runs. You can set `logLevel` to `"verbose"` or `"debug"` for detailed debugging output, or `"none"` to suppress all pool messages.
+
+```ts
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [
+		cloudflareTest({
+			logLevel: "warn",
+		}),
+	],
+});
+```
+
+Accepted values are `"none"`, `"error"`, `"warn"`, `"info"`, `"debug"`, and `"verbose"`.
+
+See the [configuration reference](/workers/testing/vitest-integration/configuration/#cloudflaretestoptions) for full details.

--- a/src/content/docs/workers/testing/vitest-integration/configuration.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/configuration.mdx
@@ -121,6 +121,9 @@ Options passed directly to `cloudflareTest()`.
 - `main`: string optional
   - Entry point to Worker run in the same isolate/context as tests. This option is required to use Durable Objects without an explicit `scriptName` if classes are defined in the same Worker. This file goes through Vite transforms and can be TypeScript. Note that `import module from "<path-to-main>"` inside tests gives exactly the same `module` instance as is used internally for `exports` and Durable Object bindings. If `wrangler.configPath` is defined and this option is not, it will be read from the `main` field in that configuration file.
 
+- `logLevel`: `"none" | "error" | "warn" | "info" | "debug" | "verbose"` optional, defaults to `"info"`
+  - Controls the verbosity of `[vpw:*]` pool log messages. Set to `"verbose"` or `"debug"` for detailed debugging output, or `"none"` to suppress all pool messages.
+
 - `miniflare`: `SourcelessWorkerOptions & { workers?: WorkerOptions\[]; }` optional
   - Use this to provide configuration information that is typically stored within the [Wrangler configuration file](/workers/wrangler/configuration/), such as [bindings](/workers/runtime-apis/bindings/), [compatibility dates](/workers/configuration/compatibility-dates/), and [compatibility flags](/workers/configuration/compatibility-flags/). The `WorkerOptions` interface is defined [here](https://github.com/cloudflare/workers-sdk/tree/main/packages/miniflare#interface-workeroptions). Use the `main` option above to configure the entry point, instead of the Miniflare `script`, `scriptPath`, or `modules` options.
 

--- a/src/content/docs/workers/testing/vitest-integration/debugging.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/debugging.mdx
@@ -85,3 +85,22 @@ To setup VS Code for breakpoint debugging in your Worker tests, create a `.vscod
 ```
 
 Select **Debug Workers tests** at the top of the **Run & Debug** panel to open an inspector with Vitest and attach a debugger to the Workers runtime. Then you can add breakpoints to your test files and start debugging.
+
+## Increase log verbosity
+
+If your tests are failing or behaving unexpectedly, increasing the pool log level can surface useful diagnostic information. Set `logLevel` to `"verbose"` or `"debug"` in your Vitest configuration:
+
+```ts
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [
+		cloudflareTest({
+			logLevel: "verbose",
+		}),
+	],
+});
+```
+
+The default log level is `"info"`. See the [configuration reference](/workers/testing/vitest-integration/configuration/#cloudflaretestoptions) for all accepted values.


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Adding documentation for the change on logLevel for vitest-pool-workers https://github.com/cloudflare/workers-sdk/pull/13007

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
