### PR TITLE
style: main content spacing and alignment

### DIFF
--- a/src/components/Description.astro
+++ b/src/components/Description.astro
@@ -1,3 +1,3 @@
-<div class="mb-4 text-xl leading-6" style="color: var(--sl-color-white);">
+<div class="mt-2 text-xl leading-relaxed text-[var(--sl-color-gray-2)]">
 	<slot />
 </div>

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -45,7 +45,7 @@ import ImageZoom from "starlight-image-zoom/components/ImageZoom.astro";
 		:global(
 			:not(.heading-wrapper) + :is(.heading-wrapper):not(:where(.not-content *))
 		) {
-		margin-top: 1.5em;
+		margin-top: 2rem;
 	}
 
 	/* Set font-size on wrapper element, so line-height, margins etc. match heading size. */

--- a/src/components/overrides/Page.astro
+++ b/src/components/overrides/Page.astro
@@ -63,9 +63,3 @@ if (data.reviewed) {
 ---
 
 <Default set:html={html} />
-
-<style>
-	html:not([data-has-toc]) {
-		--sl-content-width: 67.5rem;
-	}
-</style>

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -128,10 +128,6 @@ if (!hideBreadcrumbs) {
 		padding: 0.5rem 0;
 	}
 
-	:global(main > .content-panel:first-of-type) {
-		padding-block: 1rem;
-	}
-
 	:global(.c-breadcrumbs__link) {
 		font-size: 0.75rem;
 		line-height: 1.25rem;

--- a/src/styles/asides.css
+++ b/src/styles/asides.css
@@ -26,10 +26,10 @@
 
 :root[data-theme="dark"] {
 	.starlight-aside--note {
-		background-color: rgb(0, 28, 67);
+		background-color: var(--color-cl1-blue-1);
 	}
 
 	.starlight-aside--caution {
-		background-color: rgb(98, 73, 10);
+		background-color: var(--color-cl1-gold-0);
 	}
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -52,8 +52,7 @@ main > .content-panel:first-of-type {
 
 /* h1: small top margin to breathe from breadcrumbs */
 main > .content-panel:first-of-type h1 {
-	margin-top: var(--layout-space-3); /* 12px */
-	margin-bottom: var(--layout-space-4); /* 16px */
+	margin-bottom: var(--layout-space-0);
 }
 
 main > .content-panel + .content-panel {
@@ -76,12 +75,6 @@ main > .content-panel + .content-panel {
 .content-panel + .content-panel {
 	border-top: none;
 	/* background: orange; */
-}
-
-@media (min-width: 72rem) {
-	[data-has-sidebar][data-has-toc] .main-pane {
-		--sl-content-margin-inline: auto var(--layout-space-8);
-	}
 }
 
 .right-sidebar-panel .sl-container {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,101 @@
+/* ═══════════════════════════════════════════════════════════════════
+   Layout System
+   ═══════════════════════════════════════════════════════════════════
+   Single source of truth for spacing, column widths, and alignment.
+   Unlayered — overrides Starlight's @layer starlight.* defaults.
+   Everything snaps to an 8px (0.5rem) grid.
+   ─────────────────────────────────────────────────────────────── */
+
+/* ── Spacing Scale ── */
+:root {
+	--layout-space-1: 0.25rem; /*  4px  */
+	--layout-space-2: 0.5rem; /*  8px  */
+	--layout-space-3: 0.75rem; /* 12px  */
+	--layout-space-4: 1rem; /* 16px  */
+	--layout-space-5: 1.25rem; /* 20px  */
+	--layout-space-6: 1.5rem; /* 24px  */
+	--layout-space-8: 2rem; /* 32px  */
+	--layout-space-10: 2.5rem; /* 40px  */
+	--layout-space-12: 3rem; /* 48px  */
+}
+
+/* ── Column Widths ── */
+:root {
+	--sl-content-width: 45rem; /* 720px */
+	--sl-sidebar-width: 18.75rem; /* 300px */
+	--layout-toc-width: 18rem; /* 288px */
+	--sl-content-pad-x: var(--layout-space-4); /* 16px mobile */
+	--sl-content-gap-y: var(--layout-space-4); /* 16px */
+	--sl-main-pad: 0 0 var(--layout-space-6) 0;
+}
+
+html:not([data-has-toc]) {
+	--sl-content-width: 67.5rem;
+}
+
+@media (min-width: 72rem) {
+	html[data-has-sidebar]:not([data-has-toc]) {
+		--sl-content-margin-inline: 0 var(--layout-space-8);
+	}
+}
+
+@media (min-width: 72rem) {
+	:root {
+		--sl-content-pad-x: var(--layout-space-6); /* 24px desktop */
+	}
+}
+
+/* ── First Content Panel (breadcrumbs + title area) ── */
+main > .content-panel:first-of-type {
+	padding-block: var(--layout-space-4);
+}
+
+/* h1: small top margin to breathe from breadcrumbs */
+main > .content-panel:first-of-type h1 {
+	margin-top: var(--layout-space-3); /* 12px */
+	margin-bottom: var(--layout-space-4); /* 16px */
+}
+
+main > .content-panel + .content-panel {
+	padding-top: var(--layout-space-0);
+}
+
+/* ── Right Sidebar (TOC) Alignment ── */
+.right-sidebar-panel {
+	padding-top: var(--layout-space-6);
+	padding-left: var(--layout-space-6);
+}
+
+/* ── Dividers ── */
+/* TOC vertical divider — whitespace does the separation work */
+.right-sidebar {
+	border-inline-start: none;
+}
+
+/* Header/body horizontal divider — replaced by spacing only */
+.content-panel + .content-panel {
+	border-top: none;
+	/* background: orange; */
+}
+
+@media (min-width: 72rem) {
+	[data-has-sidebar][data-has-toc] .main-pane {
+		--sl-content-margin-inline: auto var(--layout-space-8);
+	}
+}
+
+.right-sidebar-panel .sl-container {
+	width: 100%;
+	max-width: var(--layout-toc-width);
+}
+
+/* ── Breadcrumb Spacing ── */
+.c-breadcrumbs {
+	padding-top: 0;
+	padding-bottom: var(--layout-space-2);
+}
+
+/* ── Pagination ── */
+.pagination-links {
+	margin-top: var(--layout-space-12);
+}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -34,12 +34,6 @@ html:not([data-has-toc]) {
 }
 
 @media (min-width: 72rem) {
-	html[data-has-sidebar]:not([data-has-toc]) {
-		--sl-content-margin-inline: 0 var(--layout-space-8);
-	}
-}
-
-@media (min-width: 72rem) {
 	:root {
 		--sl-content-pad-x: var(--layout-space-6); /* 24px desktop */
 	}

--- a/src/styles/pagination.css
+++ b/src/styles/pagination.css
@@ -1,7 +1,7 @@
 .pagination-links {
 	display: flex !important;
 	justify-content: space-between;
-	margin-top: 3rem;
+	margin-top: var(--layout-space-12, 3rem);
 
 	& > a {
 		flex-basis: unset;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -195,18 +195,4 @@
 		--color-header-btn-bg: var(--color-cl1-brand-orange);
 		--color-header-btn-text: var(--color-cl1-black);
 	}
-
-	/* Override Starlight's restrictive right-sidebar TOC container width */
-	.right-sidebar-panel .sl-container {
-		width: 100%;
-		max-width: 18rem;
-	}
-
-	/* Align "On this page" baseline with the breadcrumbs / "Copy page" button text.
-	   Content panel top = 1rem + breadcrumb padding-top = 0.5rem → 1.5rem to text baseline.
-	   Starlight's default is 1rem, so bump it to match. */
-	.right-sidebar-panel {
-		padding-top: 1.5rem !important;
-		padding-left: 1.5rem !important;
-	}
 }


### PR DESCRIPTION
### Summary

- Panel padding (layout.css): reduces the h1-to-body gap from ~44px to 32px by aligning both sides of the panel boundary to --layout-space-4 (16px). Adds 12px of breathing room between the breadcrumbs and the h1, which previously had none.
- Heading spacing (MarkdownContent.astro): changes margin-top on headings from 1.5em to 2rem. The em unit caused h2 headings to get ~36px of space while h4 headings only got ~24px — now all heading levels get a consistent 32px gap from preceding content.
- Aside dark-mode colors (asides.css): replaces hardcoded rgb(0, 28, 67) and rgb(98, 73, 10) with --color-cl1-blue-1 and --color-cl1-gold-0 from the design token system.

### Screenshots
**Before**
<img width="992" height="570" alt="before" src="https://github.com/user-attachments/assets/2ccda4c2-bf6d-4b93-b869-1212f44623bb" />


**After**
<img width="1079" height="618" alt="after" src="https://github.com/user-attachments/assets/9cc6b55e-9f1c-4eed-8429-c053c5f39623" />


