### PR TITLE
Respect robots.txt in llms.txt generation

### DIFF
--- a/src/pages/[...product]/llms.txt.ts
+++ b/src/pages/[...product]/llms.txt.ts
@@ -1,6 +1,7 @@
 import type { APIRoute, GetStaticPaths, InferGetStaticPropsType } from "astro";
 import { getCollection } from "astro:content";
 import dedent from "dedent";
+import { isDisallowedByRobots } from "~/util/robots";
 
 /**
  * Maximum number of prose characters allowed alongside a DirectoryListing
@@ -44,6 +45,9 @@ export const getStaticPaths = (async () => {
 			if (!productUrl || productUrl === "/" || productUrl.includes("#"))
 				return null;
 
+			// Skip products whose top-level URL is disallowed by robots.txt
+			if (isDisallowedByRobots(productUrl)) return null;
+
 			const urlPath = productUrl.slice(1, -1); // strip leading/trailing slashes
 			if (!urlPath) return null;
 
@@ -51,7 +55,8 @@ export const getStaticPaths = (async () => {
 			const pages = docs.filter(
 				(e) =>
 					(e.id.startsWith(prefix + "/") || e.id === prefix) &&
-					!isDirectoryOnlyPage(e.body ?? ""),
+					!isDirectoryOnlyPage(e.body ?? "") &&
+					!isDisallowedByRobots(`/${e.id}/`),
 			);
 
 			if (pages.length === 0) return null;
@@ -61,7 +66,7 @@ export const getStaticPaths = (async () => {
 				props: { entry, pages },
 			};
 		})
-		.filter((p) => p !== null);
+		.filter((p): p is NonNullable<typeof p> => p !== null);
 }) satisfies GetStaticPaths;
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 import dedent from "dedent";
+import { isDisallowedByRobots } from "~/util/robots";
 
 export const GET: APIRoute = async ({ url }) => {
 	const base = url.origin;
@@ -30,11 +31,13 @@ export const GET: APIRoute = async ({ url }) => {
 		return false;
 	}
 
-	// Build a set of product IDs that actually have docs pages and are not sub-products
+	// Build a set of product IDs that actually have docs pages, are not sub-products,
+	// and are not disallowed by robots.txt
 	const productsWithDocs = new Set(
 		directory
 			.filter((entry) => {
 				if (isSubProduct(entry.data.entry.url)) return false;
+				if (isDisallowedByRobots(entry.data.entry.url)) return false;
 				const prefix = entry.data.entry.url.slice(1, -1);
 				return docs.some(
 					(e) => e.id.startsWith(prefix + "/") || e.id === prefix,
@@ -51,12 +54,13 @@ export const GET: APIRoute = async ({ url }) => {
 		),
 	).sort(([a], [b]) => a.localeCompare(b));
 
-	// Find ungrouped directory entries that have their own top-level docs section
-	// (not nested under another product's URL path)
+	// Find ungrouped directory entries that have their own top-level docs section,
+	// are not nested under another product's URL path, and are not disallowed by robots.txt
 	const ungrouped = allDirectory
 		.filter((entry) => {
 			if (entry.data.entry.group) return false;
 			if (isSubProduct(entry.data.entry.url)) return false;
+			if (isDisallowedByRobots(entry.data.entry.url)) return false;
 			const prefix = entry.data.entry.url.slice(1, -1);
 			return docs.some((e) => e.id.startsWith(prefix + "/") || e.id === prefix);
 		})

--- a/src/util/robots.ts
+++ b/src/util/robots.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Parses the `Disallow` directives from `public/robots.txt` for the wildcard
+ * user-agent (`*`) and returns them as an array of path prefixes.
+ *
+ * Only the first `User-agent: *` block is considered. Blank `Disallow` entries
+ * (which re-allow everything) are ignored.
+ */
+function parseDisallowedPaths(): string[] {
+	const robotsTxt = readFileSync(
+		join(process.cwd(), "public", "robots.txt"),
+		"utf-8",
+	);
+
+	const disallowed: string[] = [];
+	let inWildcardBlock = false;
+
+	for (const rawLine of robotsTxt.split("\n")) {
+		const line = rawLine.trim();
+
+		if (line.startsWith("#") || line === "") continue;
+
+		if (line.toLowerCase().startsWith("user-agent:")) {
+			const agent = line.slice("user-agent:".length).trim();
+			inWildcardBlock = agent === "*";
+			continue;
+		}
+
+		if (!inWildcardBlock) continue;
+
+		if (line.toLowerCase().startsWith("disallow:")) {
+			const path = line.slice("disallow:".length).trim();
+			if (path) disallowed.push(path);
+		}
+	}
+
+	return disallowed;
+}
+
+// Evaluated once at build time.
+const DISALLOWED_PATHS = parseDisallowedPaths();
+
+/**
+ * Returns `true` if the given URL path is disallowed by `robots.txt`.
+ *
+ * Matching follows the standard robots.txt prefix rule: a disallow entry
+ * matches any path that starts with the entry's value.
+ *
+ * @param urlPath - An absolute URL path starting with `/`, e.g. `/plans/`.
+ */
+export function isDisallowedByRobots(urlPath: string): boolean {
+	return DISALLOWED_PATHS.some((disallowed) => urlPath.startsWith(disallowed));
+}


### PR DESCRIPTION
Filters disallowed routes from `robots.txt` out of the generated `llms.txt` files.

- Adds `src/util/robots.ts` — parses `Disallow` directives from `public/robots.txt` at build time
- Filters disallowed product URLs from the top-level `/llms.txt` directory
- Filters disallowed product routes and individual pages from per-product `llms.txt` files