### PR TITLE
chore: Update http requests dataset for web assets

### DIFF
--- a/src/content/changelog/api-shield/2026-03-23-web-assets-graphql-fields.mdx
+++ b/src/content/changelog/api-shield/2026-03-23-web-assets-graphql-fields.mdx
@@ -1,0 +1,16 @@
+---
+title: Web Assets fields now available in GraphQL Analytics API
+description: Query matched operation IDs and managed labels per request using the httpRequestsAdaptive and httpRequestsAdaptiveGroups GraphQL datasets.
+date: 2026-03-23
+---
+
+Two new fields are now available in the `httpRequestsAdaptive` and `httpRequestsAdaptiveGroups` [GraphQL Analytics API](/analytics/graphql-api/) datasets:
+
+- `webAssetsOperationId` — the ID of the [saved endpoint](/api-shield/management-and-monitoring/) that matched the incoming request.
+- `webAssetsLabelsManaged` — the [managed labels](/api-shield/management-and-monitoring/endpoint-labels/#managed-labels) mapped to the matched operation at the time of the request (for example, `cf-llm`, `cf-log-in`). At most 10 labels are returned per request.
+
+Both fields are empty when no operation matched. `webAssetsLabelsManaged` is also empty when no managed labels are assigned to the matched operation.
+
+These fields allow you to determine, per request, which Web Assets operation was matched and which managed labels were active. This is useful for troubleshooting downstream security detection verdicts — for example, understanding why [AI Security for Apps](/waf/detections/ai-security-for-apps/) did or did not flag a request.
+
+Refer to [Endpoint labeling service](/api-shield/management-and-monitoring/endpoint-labels/#analytics) for GraphQL query examples.

--- a/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
+++ b/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
@@ -7,7 +7,7 @@ sidebar:
   label: Labeling service
 ---
 
-import { Render, Steps, Tabs, TabItem, DashButton } from "~/components";
+import { Render, Steps, Tabs, TabItem, DashButton, GlossaryTooltip } from "~/components";
 
 API Shield's labeling service will help you organize your endpoints and address vulnerabilities in your API. The labeling service comes with managed and user-defined labels.
 
@@ -86,9 +86,9 @@ Cloudflare will only add authentication labels to endpoints with successful resp
 How you address risks to your endpoints will depend on its label(s). The following steps provide you with general guidelines on how to take action on them.
 
 <Steps>
-1. Review risks to endpoints. 
-   
-   View the endpoints labeled as risks and identify if they have been labeled for other risks. 
+1. Review risks to endpoints.
+
+   View the endpoints labeled as risks and identify if they have been labeled for other risks.
 
    For example, endpoints labeled `cf-risk-sensitive` and `cf-risk-missing-auth` or `cf-risk-mixed-auth` may contain sensitive data that is available to unauthenticated users.
 
@@ -98,7 +98,7 @@ How you address risks to your endpoints will depend on its label(s). The followi
 
 2. Review traffic to these labeled endpoints in Security Analytics.
 
-   Check for unexpected traffic sources and note any irregular traffic patterns. 
+   Check for unexpected traffic sources and note any irregular traffic patterns.
 
    :::caution[Filtering]
    Filtering by risk label includes all traffic to all endpoints labeled with that risk, not only the traffic that prompted Cloudflare to apply the label.
@@ -108,11 +108,56 @@ How you address risks to your endpoints will depend on its label(s). The followi
 
 3. Review your origin's authorization and authentication policies with your development team.
 
-   Speak with your developers or application owners in your organization to understand whether or not all requests to these endpoints should be authenticated. Modify your application to consistently enforce the authentication requirement for all traffic accessing these endpoints. 
+   Speak with your developers or application owners in your organization to understand whether or not all requests to these endpoints should be authenticated. Modify your application to consistently enforce the authentication requirement for all traffic accessing these endpoints.
 
 	Refer to [Authentication Posture](/api-shield/security/authentication-posture/) for more information.
-   
+
 </Steps>
+
+---
+
+## Analytics
+
+### GraphQL Analytics API
+
+You can query the matched operation and managed labels for individual requests using the [GraphQL Analytics API](/analytics/graphql-api/). The `webAssetsOperationId` and `webAssetsLabelsManaged` fields are available in the `httpRequestsAdaptive` and `httpRequestsAdaptiveGroups` datasets. Use [introspection](/analytics/graphql-api/features/discovery/introspection/) to explore the full schema and available filter operators.
+
+`webAssetsLabelsManaged` returns at most 10 labels per request.
+
+#### Example: query requests by managed label
+
+The following query returns the count of requests per operation ID and managed label set, filtered to requests where the matched operation carries the `cf-log-in` managed label.
+
+```graphql
+query GetAdaptiveGroups($start: DateTime!, $end: DateTime!) {
+	viewer {
+		zones(filter: { zoneTag: $zoneTag }) {
+			httpRequestsAdaptiveGroups(
+				filter: {
+					datetime_geq: $start
+					datetime_leq: $end
+					requestSource: "eyeball"
+					webAssetsLabelsManaged_hasany: ["cf-log-in"]
+				}
+				limit: 25
+				orderBy: [count_DESC]
+			) {
+				count
+				dimensions {
+					webAssetsOperationId
+					webAssetsLabelsManaged
+				}
+			}
+		}
+	}
+}
+```
+
+Replace `cf-log-in` with any [managed label](#managed-labels) or [risk label](#risk-labels). You can also omit the `webAssetsLabelsManaged_hasany` filter and use `webAssetsOperationId` as the sole dimension to group traffic by matched operation regardless of label.
+
+### Logpush
+
+You can export per-request Web Assets data to your storage or <GlossaryTooltip term="SIEM">SIEM system</GlossaryTooltip> of choice using [Logpush](/logs/logpush/). The `WebAssetsOperationID` and `WebAssetsLabelsManaged` fields are available in the [HTTP requests dataset](/logs/logpush/logpush-job/datasets/zone/http_requests/#webassetslabelsmanaged).
 
 ---
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -247,7 +247,7 @@ List of content types.
 
 Type: `object`
 
-String key-value pairs for Cookies. This field is populated based on [Logpush Custom fields](/logs/logpush/logpush-job/custom-fields/), which need to be configured.
+String key-value pairs for cookies. This field is populated based on [Logpush Custom fields](/logs/logpush/logpush-job/custom-fields/), which need to be configured.
 
 ## EdgeCFConnectingO2O
 
@@ -505,13 +505,13 @@ ID of the request.
 
 Type: `object`
 
-String key-value pairs for RequestHeaders. This field is populated based on [Logpush Custom fields](/logs/logpush/logpush-job/custom-fields/), which need to be configured.
+String key-value pairs for request headers. This field is populated based on [Logpush Custom fields](/logs/logpush/logpush-job/custom-fields/), which need to be configured.
 
 ## ResponseHeaders
 
 Type: `object`
 
-String key-value pairs for ResponseHeaders. This field is populated based on [Logpush Custom fields](/logs/logpush/logpush-job/custom-fields/), which need to be configured.
+String key-value pairs for response headers. This field is populated based on [Logpush Custom fields](/logs/logpush/logpush-job/custom-fields/), which need to be configured.
 
 ## SecurityAction
 
@@ -602,6 +602,18 @@ WAF score for an SQLi attack.
 Type: `int`
 
 WAF score for an XSS attack.
+
+## WebAssetsLabelsManaged
+
+Type: `array[string]`
+
+Cloudflare-defined labels matched for the request.
+
+## WebAssetsOperationID
+
+Type: `string`
+
+UUID of the matched web asset operation.
 
 ## WorkerCPUTime
 


### PR DESCRIPTION
### Summary

This change explains the newly available managed labels in analytics and logpush.
I have also vendored the updated list of fields from the http requests dataset in logpush.

### Screenshots (optional)

<img width="752" height="1258" alt="image" src="https://github.com/user-attachments/assets/8c72c499-82e6-4c84-b2cc-25f2bf371f1d" />

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
