### PR TITLE
[Chore] Slight tweaks to publish workflow

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -31,30 +31,30 @@ jobs:
         run: npm ci
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
-      - uses: actions/cache/restore@v5
+      - name: Restore Astro assets from cache
+        uses: actions/cache@v5
         with:
           path: |
             node_modules/.astro/assets
           key: static
-      - run: npm run build
-        name: Build
+
+      - name: Build
+        run: npm run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v7
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: site-html
           path: dist
-      - run: npx wrangler deploy
-        name: Deploy to Cloudflare Workers
+
+      - name: Deploy to Cloudflare Workers
+        run: npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      - uses: actions/cache/save@v5
-        if: always()
-        with:
-          path: |
-            node_modules/.astro/assets
-          key: static
+
       - name: Notify Google Chat on failure
         if: failure()
         run: |


### PR DESCRIPTION
### Summary

Moves us to the pattern we're using with other workflows, where we use the generic `cache` action instead of `save`, then `restore`.

Also, standardizes the presence + order of `name` entries for each step.