### PR TITLE
docs(ai-search): add how-to guides and tutorials

### DIFF
--- a/src/content/docs/ai-search/how-to/ingest-external-content.mdx
+++ b/src/content/docs/ai-search/how-to/ingest-external-content.mdx
@@ -1,0 +1,266 @@
+---
+pcx_content_type: how-to
+title: Ingest external content into AI Search
+sidebar:
+  order: 11
+description: Build a Worker that fetches content from an external source, uploads it to R2, and uses AI Search auto-indexing for semantic search.
+tags:
+  - AI
+products:
+  - ai-search
+  - r2
+  - workers
+reviewed: 2026-04-20
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+You can programmatically ingest content from external sources into AI Search by uploading files to an R2 bucket that AI Search is configured to index. AI Search automatically indexes files in R2 when the instance is created and periodically after that. You can trigger a manual sync from the dashboard for immediate results.
+
+This pattern works for any external source: code repositories, CMS content, API responses, documentation sites, or database exports.
+
+## Prerequisites
+
+- An R2 bucket. For more information, refer to [R2 documentation](/r2/).
+- An AI Search instance connected to the R2 bucket. For more information, refer to [R2 data source](/ai-search/configuration/data-source/r2/).
+
+## 1. Configure bindings
+
+<WranglerConfig>
+
+```toml
+name = "content-ingestion"
+main = "src/index.ts"
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+
+[[ai_search_namespaces]]
+binding = "AI_SEARCH"
+namespace = "default"
+
+[[r2_buckets]]
+binding = "CONTENT_BUCKET"
+bucket_name = "my-content"
+
+[vars]
+AI_SEARCH_INSTANCE = "my-search-index"
+```
+
+</WranglerConfig>
+
+The R2 bucket name must match the data source configured in your AI Search instance.
+
+## 2. Upload content to R2 with metadata
+
+When uploading files to R2, use a hierarchical key structure that preserves the source organization. AI Search uses the folder path as filterable metadata.
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	AI_SEARCH: AiSearchNamespace;
+	CONTENT_BUCKET: R2Bucket;
+	AI_SEARCH_INSTANCE: string;
+}
+
+async function uploadContent(
+	bucket: R2Bucket,
+	files: Array<{ path: string; content: string }>,
+	source: string,
+): Promise<{ uploaded: number; failed: number }> {
+	let uploaded = 0;
+	let failed = 0;
+
+	// Process in batches of 10
+	for (let i = 0; i < files.length; i += 10) {
+		const batch = files.slice(i, i + 10);
+		const results = await Promise.allSettled(
+			batch.map(async (file) => {
+				const key = `${source}/${file.path}`;
+				await bucket.put(key, file.content, {
+					httpMetadata: { contentType: "text/plain; charset=utf-8" },
+					customMetadata: {
+						source,
+						file_path: file.path,
+						indexed_at: new Date().toISOString(),
+					},
+				});
+			}),
+		);
+
+		for (const r of results) {
+			if (r.status === "fulfilled") uploaded++;
+			else failed++;
+		}
+	}
+
+	return { uploaded, failed };
+}
+```
+
+</TypeScriptExample>
+
+The key structure `{source}/{path}` creates folder-based organization that AI Search can filter on. The `source`, `file_path`, and `indexed_at` custom metadata keys are stored with the R2 object. To make custom metadata filterable, define a [custom metadata schema](/ai-search/configuration/indexing/metadata/#custom-metadata) in your AI Search instance configuration.
+
+## 3. Fetch content from an external source
+
+Implement a function that retrieves content from an external URL and returns it as an array of files. The example below fetches a JSON feed -- replace the fetch logic with whatever suits your source (API pagination, HTML scraping, git clone).
+
+<TypeScriptExample>
+
+```ts
+async function fetchContentFromSource(
+	sourceUrl: string,
+): Promise<Array<{ path: string; content: string }>> {
+	const response = await fetch(sourceUrl);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch source: ${response.status}`);
+	}
+
+	// Expects a JSON array of { path, content } objects.
+	// Adapt this to your source format (RSS, API, sitemap, etc.).
+	const items = (await response.json()) as Array<{
+		path: string;
+		content: string;
+	}>;
+
+	return items.map((item) => ({
+		path: item.path.replace(/[^a-zA-Z0-9_\-/.]/g, "_"),
+		content: item.content,
+	}));
+}
+```
+
+</TypeScriptExample>
+
+## 4. Create an ingestion API endpoint
+
+Build a Worker endpoint that accepts an external source URL, fetches the content, and uploads it to R2.
+
+<TypeScriptExample>
+
+```ts
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		if (request.method !== "POST") {
+			return new Response("Method not allowed", { status: 405 });
+		}
+
+		try {
+			const { sourceUrl, sourceName } = (await request.json()) as {
+				sourceUrl: string;
+				sourceName: string;
+			};
+
+			const files = await fetchContentFromSource(sourceUrl);
+			const result = await uploadContent(env.CONTENT_BUCKET, files, sourceName);
+
+			return Response.json({
+				status: "success",
+				files_uploaded: result.uploaded,
+				files_failed: result.failed,
+				message: `Uploaded ${result.uploaded} files. AI Search indexes files when the instance is created and periodically after that. You can manually trigger indexing from the dashboard for immediate results.`,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Unknown error";
+			return Response.json({ status: "error", message }, { status: 500 });
+		}
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+## 5. Search with source filtering
+
+Use folder-based metadata filtering to scope searches to content from a specific source.
+
+<TypeScriptExample>
+
+```ts
+async function searchContent(
+	env: Env,
+	query: string,
+	source?: string,
+): Promise<Response> {
+	try {
+		// Range filter: $gte + $lt is the starts-with pattern for folder prefixes
+		const filters = source
+			? { folder: { $gte: `${source}/`, $lt: `${source}0` } }
+			: undefined;
+
+		const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+		const result = await instance.search({
+			messages: [{ role: "user", content: query }],
+			ai_search_options: {
+				retrieval: {
+					max_num_results: 10,
+					match_threshold: 0.3,
+					...(filters && { filters }),
+				},
+				query_rewrite: { enabled: true },
+			},
+		});
+
+		return Response.json({
+			search_query: result.search_query,
+			sources: (result.chunks ?? []).map((chunk) => ({
+				key: chunk.item?.key ?? "",
+				score: chunk.score,
+				content: chunk.text ?? "",
+			})),
+		});
+	} catch (err) {
+		const message = err instanceof Error ? err.message : "Search failed";
+		return Response.json({ error: message }, { status: 500 });
+	}
+}
+```
+
+</TypeScriptExample>
+
+For more information on folder filtering, refer to [Path filtering](/ai-search/configuration/indexing/path-filtering/) and [Metadata](/ai-search/configuration/indexing/metadata/).
+
+## Indexing timing considerations
+
+After uploading content to R2, there is a delay before it becomes searchable:
+
+- **Automatic indexing**: AI Search indexes files when the instance is created and periodically after that.
+- **Manual sync**: Go to the [Cloudflare dashboard](https://dash.cloudflare.com/), select your AI Search instance, and select **Sync Index** for immediate indexing.
+
+Your ingestion API response should inform callers about this delay.
+
+## Use case: index a GitHub repository
+
+The same pattern works for indexing code from GitHub. Use the [GitHub Contents API](https://docs.github.com/en/rest/repos/contents) to list files, fetch their contents, and upload them to R2 with keys like `{owner}/{repo}/{branch}/{path}`. A folder filter then scopes searches to a single repository:
+
+<TypeScriptExample>
+
+```ts
+const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+const result = await instance.chatCompletions({
+	messages: [{ role: "user", content: query }],
+	model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+	ai_search_options: {
+		retrieval: {
+			max_num_results: 10,
+			match_threshold: 0.3,
+			filters: {
+				folder: { $gte: "facebook/react/", $lt: "facebook/react0" },
+			},
+		},
+	},
+});
+```
+
+</TypeScriptExample>
+
+Using `chatCompletions()` instead of `search()` provides an LLM-generated answer grounded in the code search results -- useful for answering questions like "how does this codebase handle errors?" with a synthesized explanation and source citations.
+
+## Related resources
+
+- [R2 data source configuration](/ai-search/configuration/data-source/r2/)
+- [Path filtering](/ai-search/configuration/indexing/path-filtering/)
+- [Metadata filtering](/ai-search/configuration/indexing/metadata/)
+- [Build per-tenant search](/ai-search/how-to/per-tenant-search/) for tenant-scoped ingestion
+- [Persistent memory for AI agents](/ai-search/tutorials/persistent-memory-for-agents/) for a related R2-based pattern

--- a/src/content/docs/ai-search/how-to/use-as-agent-tool.mdx
+++ b/src/content/docs/ai-search/how-to/use-as-agent-tool.mdx
@@ -1,0 +1,326 @@
+---
+pcx_content_type: how-to
+title: Use AI Search as an agent tool
+sidebar:
+  order: 14
+description: Integrate AI Search into an AI agent as a callable tool for retrieval-augmented generation, using the Agents SDK or any framework with tool calling support.
+tags:
+  - AI
+products:
+  - ai-search
+  - workers
+  - workers-ai
+  - agents
+reviewed: 2026-04-20
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+You can give any AI agent the ability to search your indexed content by exposing AI Search as a callable tool. The agent decides when to search, what to search for, and how to use the results to ground its responses.
+
+## Agents SDK
+
+The [Agents SDK](/agents/) is the recommended way to build stateful agents on Cloudflare. Extend `AIChatAgent` to get WebSocket management, message persistence, and SQLite-backed conversation history. Define AI Search as a tool that the agent's LLM can call.
+
+### Configure bindings
+
+<WranglerConfig>
+
+```toml
+name = "my-agent"
+main = "src/index.ts"
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+
+[[ai_search_namespaces]]
+binding = "AI_SEARCH"
+namespace = "default"
+
+[ai]
+binding = "AI"
+
+[durable_objects]
+bindings = [
+  { name = "MyAgent", class_name = "MyAgent" }
+]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyAgent"]
+```
+
+</WranglerConfig>
+
+The `new_sqlite_classes` migration is required for `AIChatAgent` to persist conversation history in the Durable Object's embedded SQLite.
+
+### Define the search tool
+
+<TypeScriptExample>
+
+```ts
+import { tool } from "ai";
+import { z } from "zod";
+
+interface Env {
+	AI: Ai;
+	AI_SEARCH: AiSearchNamespace;
+	MyAgent: DurableObjectNamespace;
+}
+
+function createSearchTool(env: Env, instanceName: string) {
+	return tool({
+		description:
+			"Search indexed documents for relevant information. Use this before answering questions about the content.",
+		inputSchema: z.object({
+			query: z.string().describe("The search query"),
+			maxResults: z.number().optional().default(5),
+		}),
+		execute: async ({ query, maxResults }) => {
+			try {
+				const instance = env.AI_SEARCH.get(instanceName);
+				const result = await instance.search({
+					messages: [{ role: "user", content: query }],
+					ai_search_options: {
+						retrieval: {
+							max_num_results: maxResults,
+							match_threshold: 0.3,
+						},
+					},
+				});
+
+				return (result.chunks ?? []).map((chunk) => ({
+					key: chunk.item?.key ?? "",
+					score: chunk.score,
+					content: chunk.text ?? "",
+				}));
+			} catch (err) {
+				console.error("Search failed:", err);
+				return [];
+			}
+		},
+	});
+}
+```
+
+</TypeScriptExample>
+
+Using `search()` (retrieval only) is recommended when the agent LLM will synthesize the answer from the chunks. Use `chatCompletions()` instead if you want AI Search to generate an answer that the agent can relay directly.
+
+### Create the agent
+
+<TypeScriptExample>
+
+```ts
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { createWorkersAI } from "workers-ai-provider";
+import { streamText, convertToModelMessages, pruneMessages, stepCountIs } from "ai";
+
+export class MyAgent extends AIChatAgent {
+	async onChatMessage() {
+		const workersai = createWorkersAI({ binding: this.env.AI });
+
+		const result = streamText({
+			model: workersai("@cf/meta/llama-3.3-70b-instruct-fp8-fast"),
+			system:
+				"You are a helpful assistant. Search documents before answering questions.",
+			messages: pruneMessages({
+				messages: await convertToModelMessages(this.messages),
+				toolCalls: "before-last-2-messages",
+			}),
+			tools: {
+				search: createSearchTool(this.env, "my-index"),
+			},
+			stopWhen: stepCountIs(5),
+		});
+
+		return result.toUIMessageStreamResponse();
+	}
+}
+```
+
+</TypeScriptExample>
+
+The `stepCountIs(5)` parameter allows the agent up to 5 tool-use rounds per user message. Increase this if the agent needs to make multiple sequential searches. `pruneMessages` trims older tool call history to keep the context window manageable.
+
+### Route requests to the agent
+
+<TypeScriptExample>
+
+```ts
+import { routeAgentRequest } from "agents";
+
+export { MyAgent };
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		return (
+			(await routeAgentRequest(request, env)) ||
+			new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+Install the required packages and deploy:
+
+```bash
+npm install @cloudflare/ai-chat agents ai workers-ai-provider zod
+npx wrangler deploy
+```
+
+Users connect via WebSocket to `/agents/my-agent/{instance-id}`. The agent persists conversation history in SQLite and uses AI Search to ground its responses.
+
+## Vercel AI SDK (without Agents SDK)
+
+If you do not need stateful Durable Object agents and just want to add search tools to a standard Worker, use the Vercel AI SDK `tool` function directly:
+
+<TypeScriptExample>
+
+```ts
+import { streamText, stepCountIs } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
+import { tool } from "ai";
+import { z } from "zod";
+
+interface Env {
+	AI: Ai;
+	AI_SEARCH: AiSearchNamespace;
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const { messages } = (await request.json()) as { messages: any[] };
+		const workersai = createWorkersAI({ binding: env.AI });
+
+		const result = streamText({
+			model: workersai("@cf/meta/llama-3.3-70b-instruct-fp8-fast"),
+			system: "You are a helpful assistant. Search before answering.",
+			messages,
+			tools: {
+				search: tool({
+					description: "Search indexed documents.",
+					inputSchema: z.object({
+						query: z.string(),
+						maxResults: z.number().optional().default(5),
+					}),
+					execute: async ({ query, maxResults }) => {
+						try {
+							const instance = env.AI_SEARCH.get("my-index");
+							const result = await instance.search({
+								messages: [{ role: "user", content: query }],
+								ai_search_options: {
+									retrieval: {
+										max_num_results: maxResults,
+										match_threshold: 0.3,
+									},
+								},
+							});
+							return (result.chunks ?? []).map((chunk) => ({
+								key: chunk.item?.key ?? "",
+								score: chunk.score,
+								content: chunk.text ?? "",
+							}));
+						} catch {
+							return [];
+						}
+					},
+				}),
+			},
+			stopWhen: stepCountIs(3),
+		});
+
+		return result.toTextStreamResponse();
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+This approach is simpler but does not include WebSocket transport, conversation persistence, or Durable Object state management.
+
+## Filtered search tool
+
+To let the agent narrow searches by path, expose a `folder` parameter in the tool definition. Use the [starts-with filter pattern](/ai-search/configuration/indexing/metadata/#starts-with-filter-for-folders) to match all files under a path prefix.
+
+<TypeScriptExample>
+
+```ts
+function createFilteredSearchTool(env: Env, instanceName: string) {
+	return tool({
+		description: `Search indexed documents. Use the folder parameter to scope results to a specific path prefix.`,
+		inputSchema: z.object({
+			query: z.string().describe("The search query"),
+			folder: z
+				.string()
+				.optional()
+				.describe(
+					"Folder prefix to scope the search, for example: guides/ — matches all files under that path",
+				),
+			maxResults: z.number().optional().default(5),
+		}),
+		execute: async ({ query, folder, maxResults }) => {
+			try {
+				const folderValue = folder
+					? folder.endsWith("/")
+						? folder
+						: `${folder}/`
+					: null;
+
+				// Range filter: $gte + $lt is the canonical starts-with pattern
+				const filters = folderValue
+					? { folder: { $gte: folderValue, $lt: `${folderValue.slice(0, -1)}0` } }
+					: undefined;
+
+				const instance = env.AI_SEARCH.get(instanceName);
+				const result = await instance.search({
+					messages: [{ role: "user", content: query }],
+					ai_search_options: {
+						retrieval: {
+							max_num_results: maxResults,
+							match_threshold: 0.3,
+							...(filters && { filters }),
+						},
+					},
+				});
+
+				return (result.chunks ?? []).map((chunk) => ({
+					key: chunk.item?.key ?? "",
+					score: chunk.score,
+					content: chunk.text ?? "",
+				}));
+			} catch {
+				return [];
+			}
+		},
+	});
+}
+```
+
+</TypeScriptExample>
+
+The `folder` parameter uses the [starts-with filter pattern](/ai-search/configuration/indexing/metadata/#starts-with-filter-for-folders) to match all files under a path prefix. You can also filter on `filename`, `timestamp`, and any [custom metadata](/ai-search/configuration/indexing/metadata/#custom-metadata) fields defined in your schema.
+
+## REST API variant
+
+If your agent runs outside a Cloudflare Worker (for example, in a local development environment or external service), use the [REST API](/ai-search/api/search/rest-api/) instead of the Workers binding:
+
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai-search/instances/<INSTANCE_NAME>/search" \
+  -H "Authorization: Bearer <API_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "your search query"}'
+```
+
+Wrap this HTTP call in your agent framework's tool definition.
+
+## Related resources
+
+- [Workers binding reference](/ai-search/api/search/workers-binding/)
+- [REST API reference](/ai-search/api/search/rest-api/)
+- [Metadata filtering](/ai-search/configuration/indexing/metadata/)
+- [Path filtering](/ai-search/configuration/indexing/path-filtering/)
+- [Agents SDK documentation](/agents/)
+- [Agentic deep research with RAG](/ai-search/tutorials/agentic-deep-research/) for a full multi-step research agent

--- a/src/content/docs/ai-search/tutorials/agentic-deep-research.mdx
+++ b/src/content/docs/ai-search/tutorials/agentic-deep-research.mdx
@@ -1,0 +1,392 @@
+---
+pcx_content_type: tutorial
+title: "Agentic deep research with RAG"
+sidebar:
+  order: 6
+description: Build a research agent that runs parallel AI Search queries across multiple facets and synthesizes results into a narrative with Workers AI.
+tags:
+  - AI
+products:
+  - ai-search
+  - workers
+  - workers-ai
+  - agents
+reviewed: 2026-04-20
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+A single search query often misses the full picture. "What patterns does this codebase use?" requires searching for file structure, dependencies, naming conventions, and architecture decisions -- all in parallel. This walkthrough shows how to build a research agent that decomposes a question into multiple facets, runs parallel AI Search queries, and synthesizes the results into a coherent narrative.
+
+## Prerequisites
+
+- An AI Search instance with indexed content. For more information, refer to [R2 data source](/ai-search/configuration/data-source/r2/).
+- The [Agents SDK](/agents/). For more information, refer to [Get started with Agents](/agents/getting-started/).
+
+## 1. Configure bindings
+
+<WranglerConfig>
+
+```toml
+name = "research-agent"
+main = "src/index.ts"
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+
+[ai]
+binding = "AI"
+
+[[ai_search_namespaces]]
+binding = "AI_SEARCH"
+namespace = "default"
+
+[vars]
+AI_SEARCH_INSTANCE = "my-index"
+```
+
+</WranglerConfig>
+
+## 2. Define research queries
+
+Instead of asking the LLM to decide what to search for, define a set of facet queries that cover different aspects of the topic. Each query targets a specific dimension with terms optimized for semantic retrieval.
+
+<TypeScriptExample>
+
+```ts
+interface ResearchQuery {
+	label: string;
+	query: string;
+	maxResults: number;
+}
+
+const RESEARCH_QUERIES: ResearchQuery[] = [
+	{
+		label: "Overview",
+		query: "overview summary description purpose architecture design",
+		maxResults: 30,
+	},
+	{
+		label: "Implementation Details",
+		query: "implementation code function class method handler endpoint",
+		maxResults: 25,
+	},
+	{
+		label: "Configuration",
+		query: "configuration setup environment variables settings options",
+		maxResults: 20,
+	},
+	{
+		label: "Dependencies",
+		query: "dependencies packages imports libraries frameworks tools",
+		maxResults: 20,
+	},
+	{
+		label: "Error Handling",
+		query: "error handling exception catch retry fallback validation",
+		maxResults: 15,
+	},
+	{
+		label: "Testing",
+		query: "test testing spec assertion mock fixture coverage",
+		maxResults: 15,
+	},
+	{
+		label: "Performance",
+		query: "performance optimization cache latency throughput memory",
+		maxResults: 15,
+	},
+	{
+		label: "Security",
+		query: "security authentication authorization token secret encryption",
+		maxResults: 15,
+	},
+];
+```
+
+</TypeScriptExample>
+
+Using deterministic queries rather than LLM-driven decomposition ensures consistent coverage and eliminates one round of inference latency.
+
+## 3. Run parallel research queries
+
+Execute all facet queries against AI Search simultaneously using `Promise.all`. Each query is independent and can fail without affecting the others.
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	AI: Ai;
+	AI_SEARCH: AiSearchNamespace;
+	AI_SEARCH_INSTANCE: string;
+}
+
+interface ResearchResult {
+	label: string;
+	query: string;
+	resultCount: number;
+	chunks: Array<{
+		key: string;
+		score: number;
+		text: string;
+	}>;
+	error?: string;
+}
+
+async function runResearch(
+	env: Env,
+	onProgress?: (label: string) => Promise<void>,
+): Promise<{ context: string; results: ResearchResult[] }> {
+	const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+
+	const results = await Promise.all(
+		RESEARCH_QUERIES.map(async (rq): Promise<ResearchResult> => {
+			if (onProgress) await onProgress(rq.label);
+
+			try {
+				const response = await instance.search({
+					messages: [{ role: "user", content: rq.query }],
+					ai_search_options: {
+						retrieval: { max_num_results: rq.maxResults },
+					},
+				});
+
+				return {
+					label: rq.label,
+					query: rq.query,
+					resultCount: (response.chunks ?? []).length,
+					chunks: (response.chunks ?? []).map((chunk) => ({
+						key: chunk.item?.key ?? "",
+						score: chunk.score ?? 0,
+						text: chunk.text ?? "",
+					})),
+				};
+			} catch (err) {
+				return {
+					label: rq.label,
+					query: rq.query,
+					resultCount: 0,
+					chunks: [],
+					error: err instanceof Error ? err.message : "Unknown error",
+				};
+			}
+		}),
+	);
+
+	const context = formatContext(results);
+	return { context, results };
+}
+```
+
+</TypeScriptExample>
+
+The `onProgress` callback lets you stream progress indicators to the client as each query label is dispatched.
+
+## 4. Format the context document
+
+Assemble all research results into a single structured document that the LLM can use as its knowledge base.
+
+<TypeScriptExample>
+
+```ts
+function formatContext(results: ResearchResult[]): string {
+	const sections: string[] = [
+		"# RESEARCH DATA",
+		"Use ONLY this data to write the analysis. Do not fabricate information.",
+		"",
+	];
+
+	for (const result of results) {
+		sections.push(`## ${result.label}`);
+		sections.push(`Query: "${result.query}"`);
+		sections.push(`Results found: ${result.resultCount}`);
+
+		if (result.error) {
+			sections.push(`Error: ${result.error}`);
+			continue;
+		}
+
+		for (const chunk of result.chunks) {
+			sections.push(
+				`### File: ${chunk.key} (score: ${chunk.score.toFixed(3)})`,
+			);
+			// Truncate long chunks to keep context window manageable
+			const text =
+				chunk.text.length > 2000
+					? chunk.text.slice(0, 2000) + "\n... [truncated]"
+					: chunk.text;
+			sections.push(text);
+		}
+		sections.push("");
+	}
+
+	return sections.join("\n");
+}
+```
+
+</TypeScriptExample>
+
+Truncating individual chunks to 2000 characters prevents any single result from dominating the context window while preserving the most relevant content.
+
+## 5. Synthesize with streaming
+
+Feed the context document to Workers AI and stream the response token-by-token.
+
+<TypeScriptExample>
+
+```ts
+const SYSTEM_PROMPT = `You are a research analyst. Given a set of research data, write a comprehensive analysis.
+
+Rules:
+- Use ONLY the provided research data. Never fabricate information.
+- When data is missing, say so explicitly.
+- Cite filenames when referencing specific findings.
+- Structure the response with clear headings.`;
+
+async function synthesize(
+	ai: Ai,
+	context: string,
+): Promise<ReadableStream<string>> {
+	const response = await ai.run("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
+		messages: [
+			{ role: "system", content: SYSTEM_PROMPT },
+			{
+				role: "user",
+				content: `Analyze the following research data and write a comprehensive report:\n\n${context}`,
+			},
+		],
+		stream: true,
+	});
+
+	// Workers AI streaming returns SSE-framed text (data: {...}\n\n).
+	// Parse each frame and extract the token text.
+	const sseStream = response as ReadableStream<Uint8Array>;
+	let buffer = "";
+
+	return new ReadableStream<string>({
+		async start(controller) {
+			const reader = sseStream.getReader();
+			const decoder = new TextDecoder();
+
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+
+					buffer += decoder.decode(value, { stream: true });
+					const lines = buffer.split("\n");
+					buffer = lines.pop() ?? "";
+
+					for (const line of lines) {
+						if (!line.startsWith("data: ")) continue;
+						const payload = line.slice(6).trim();
+						if (payload === "[DONE]") continue;
+						try {
+							const parsed = JSON.parse(payload);
+							const token = parsed.response ?? "";
+							if (token) controller.enqueue(token);
+						} catch {
+							// Skip malformed frames
+						}
+					}
+				}
+			} finally {
+				reader.releaseLock();
+				controller.close();
+			}
+		},
+	});
+}
+```
+
+</TypeScriptExample>
+
+## 6. Build the streaming response pipeline
+
+Combine the research phase and synthesis phase into a single streaming response using a `TransformStream`.
+
+<TypeScriptExample>
+
+```ts
+async function handleResearch(env: Env): Promise<Response> {
+	const encoder = new TextEncoder();
+	const { readable, writable } = new TransformStream();
+	const writer = writable.getWriter();
+
+	const writeEvent = (data: string) =>
+		writer.write(encoder.encode(`data: ${data}\n\n`));
+
+	// Run pipeline in the background
+	const pipeline = (async () => {
+		try {
+			// Phase 1: Research
+			await writeEvent(
+				JSON.stringify({ type: "status", message: "Researching..." }),
+			);
+
+			const { context } = await runResearch(env, async (label) => {
+				await writeEvent(JSON.stringify({ type: "progress", label }));
+			});
+
+			// Phase 2: Synthesis
+			await writeEvent(
+				JSON.stringify({ type: "status", message: "Synthesizing..." }),
+			);
+
+			const stream = await synthesize(env.AI, context);
+			const reader = stream.getReader();
+
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				await writeEvent(JSON.stringify({ type: "text", content: value }));
+			}
+
+			await writeEvent(JSON.stringify({ type: "done" }));
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Unknown error";
+			// Ignore write errors if the client already disconnected
+			await writeEvent(JSON.stringify({ type: "error", message })).catch(
+				() => {},
+			);
+		} finally {
+			await writer.close().catch(() => {});
+		}
+	})().catch(() => {}); // Suppress unhandled rejection if client disconnects mid-stream
+
+	void pipeline;
+	return new Response(readable, {
+		headers: { "Content-Type": "text/event-stream" },
+	});
+}
+```
+
+</TypeScriptExample>
+
+The `TransformStream` pattern returns the readable side immediately while the pipeline writes to the writable side in the background. This enables streaming from the very first progress label through the final synthesis token.
+
+## 7. Add follow-up chat with search tools
+
+After the initial research, let users ask follow-up questions with the LLM having access to AI Search as a callable tool. For the full implementation pattern -- defining search tools, wiring them into an agent, and handling multi-step tool calls -- refer to [Use AI Search as an agent tool](/ai-search/how-to/use-as-agent-tool/).
+
+## How it works
+
+1. **Parallel research** runs all facet queries simultaneously with `Promise.all`. Total research time equals the slowest single query, not the sum of all queries.
+2. **Deterministic facets** ensure consistent coverage. Rather than relying on an LLM to decide what to search for (which adds latency and unpredictability), the facets are predefined to cover the dimensions that matter for the use case. An alternative approach is to let the agent decide what to search: give it multiple specialized tools and let the LLM invoke them autonomously across multiple steps.
+3. **Context document assembly** creates a structured knowledge base that the LLM can reference. Including filenames and scores helps the model cite specific sources.
+4. **Streaming pipeline** returns results progressively -- progress labels during research, then synthesis tokens. The user sees activity from the first second.
+
+## `search()` vs `chatCompletions()`
+
+This tutorial uses `search()` for the research phase and Workers AI directly for synthesis. An alternative is to use `chatCompletions()`, which combines retrieval and generation in a single call:
+
+- **`search()`** -- returns source chunks only. Use this when you want to control the generation step yourself, run multiple searches before synthesizing, or pass results to an external model.
+- **`chatCompletions()`** -- returns a generated answer alongside the retrieved chunks. Use this when you want AI Search to handle both retrieval and generation in one call.
+
+For the research agent pattern, `search()` is the better choice because the agent needs to gather results from many queries before synthesizing. Using `chatCompletions()` would generate a response per query, wasting tokens on intermediate answers that get discarded.
+
+## Related resources
+
+- [Agents SDK](/agents/)
+- [Use AI Search as an agent tool](/ai-search/how-to/use-as-agent-tool/)
+- [Workers AI models](/workers-ai/models/)

--- a/src/content/docs/ai-search/tutorials/ecommerce-product-search.mdx
+++ b/src/content/docs/ai-search/tutorials/ecommerce-product-search.mdx
@@ -1,0 +1,346 @@
+---
+pcx_content_type: tutorial
+title: "AI e-commerce product search"
+sidebar:
+  order: 1
+description: Expand a natural language shopping query into category-targeted sub-queries using Workers AI, run parallel AI Search calls with folder filters, and compose a curated product collection.
+tags:
+  - AI
+products:
+  - ai-search
+  - r2
+  - workers
+  - workers-ai
+reviewed: 2026-04-20
+---
+
+import { TypeScriptExample, WranglerConfig, FileTree } from "~/components";
+
+Users rarely search for a single item -- they describe a vibe. "Beach vacation outfit" means shoes, a bag, sunglasses, and a dress, all matching a mood. This walkthrough shows how to build a search pipeline that takes a single user query, expands it into category-targeted sub-queries using an LLM, runs them in parallel against AI Search with folder filters, and composes the results into a curated collection.
+
+## Prerequisites
+
+- An R2 bucket with product content organized in category folders (for example, `shoes/`, `bags/`, `dresses/`).
+- An AI Search instance connected to the R2 bucket. For more information, refer to [R2 data source](/ai-search/configuration/data-source/r2/).
+
+## 1. Configure bindings
+
+<WranglerConfig>
+
+```toml
+name = "product-search"
+main = "src/index.ts"
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+
+[ai]
+binding = "AI"
+
+[[ai_search_namespaces]]
+binding = "AI_SEARCH"
+namespace = "default"
+
+[[r2_buckets]]
+binding = "PRODUCTS_BUCKET"
+bucket_name = "my-products"
+
+[vars]
+AI_SEARCH_INSTANCE = "my-product-catalog"
+```
+
+</WranglerConfig>
+
+## 2. Organize products in R2
+
+Store product descriptions as Markdown files in category folders. AI Search uses the folder path as filterable metadata.
+
+<FileTree>
+
+- shoes/
+  - 1001.md
+  - 1002.md
+- bags/
+  - 2001.md
+  - 2002.md
+- dresses/
+  - 3001.md
+- accessories/
+  - 4001.md
+
+</FileTree>
+
+Each `.md` file contains a product description that AI Search will chunk and embed:
+
+```md
+---
+id: "1001"
+name: "Coastal Woven Sandals"
+brand: "Shore"
+price: 89.99
+color: "tan"
+---
+
+# Coastal Woven Sandals
+
+Brand: Shore
+
+Handwoven leather sandals with a cushioned footbed. Perfect for beachside dining and boardwalk strolls.
+```
+
+## 3. Expand the query into category sub-queries
+
+Use Workers AI to decompose the user's natural language query into category-targeted sub-queries. Each sub-query targets one product category and includes style descriptors.
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	AI: Ai;
+	AI_SEARCH: AiSearchNamespace;
+	PRODUCTS_BUCKET: R2Bucket;
+	AI_SEARCH_INSTANCE: string;
+}
+
+interface ExpandedQuery {
+	query: string;
+	category: string;
+	role: "hero" | "supporting" | "accent";
+	priority: number;
+}
+
+interface Expansion {
+	reasoning: string;
+	queries: ExpandedQuery[];
+}
+
+const CATEGORIES = [
+	"tops",
+	"bottoms",
+	"dresses",
+	"outerwear",
+	"shoes",
+	"bags",
+	"accessories",
+	"jewelry",
+];
+
+async function expandQuery(ai: Ai, userQuery: string): Promise<Expansion> {
+	const prompt = `You are a fashion stylist. Given a style query, expand it into specific product searches that form a complete look.
+
+Each query MUST target exactly ONE category from: ${CATEGORIES.join(", ")}
+
+Return ONLY valid JSON:
+{
+  "reasoning": "<brief look concept>",
+  "queries": [
+    { "query": "<8-15 word product search>", "category": "<category>", "role": "hero"|"supporting"|"accent", "priority": 1|2|3 }
+  ]
+}
+
+Rules:
+- 3-6 queries total. First query is the "hero" piece.
+- Include at least shoes and one bag or accessory.
+- Queries describe the PRODUCT, not the occasion.
+User query: "${userQuery}"`;
+
+	const response = await ai.run("@cf/meta/llama-3.1-8b-instruct-fp8", {
+		messages: [{ role: "user", content: prompt }],
+		max_tokens: 500,
+	});
+
+	const text = response.response || "";
+	const match = text.match(/\{[\s\S]*\}/);
+	if (!match) {
+		return { reasoning: userQuery, queries: [] };
+	}
+
+	let parsed: { reasoning?: string; queries?: ExpandedQuery[] };
+	try {
+		parsed = JSON.parse(match[0]);
+	} catch {
+		return { reasoning: userQuery, queries: [] };
+	}
+	return {
+		reasoning: parsed.reasoning || userQuery,
+		queries: (parsed.queries || []).filter(
+			(q) =>
+				typeof q.query === "string" &&
+				typeof q.category === "string" &&
+				CATEGORIES.includes(q.category),
+		),
+	};
+}
+```
+
+</TypeScriptExample>
+
+The LLM is instructed to return structured JSON with category assignments. Each query is validated against the known category list to prevent hallucinated categories from reaching AI Search.
+
+## 4. Run parallel filtered searches
+
+Run one AI Search call per expanded query, each scoped to a category folder with a `folder` filter. `Promise.all` runs them concurrently, keeping total latency close to a single search call.
+
+<TypeScriptExample>
+
+```ts
+interface SearchResult {
+	category: string;
+	key: string;
+	score: number;
+	content: string;
+}
+
+async function searchByCategory(
+	env: Env,
+	queries: ExpandedQuery[],
+): Promise<SearchResult[][]> {
+	const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+
+	return Promise.all(
+		queries.map(async (eq) => {
+			try {
+				const response = await instance.search({
+					messages: [{ role: "user", content: eq.query }],
+					ai_search_options: {
+						retrieval: {
+							max_num_results: 6,
+							match_threshold: 0.1,
+							filters: { folder: `${eq.category}/` },
+						},
+					},
+				});
+
+				return (response.chunks ?? []).map((chunk) => ({
+					category: eq.category,
+					key: chunk.item?.key ?? "",
+					score: chunk.score,
+					content: chunk.text ?? "",
+				}));
+			} catch {
+				return [] as SearchResult[];
+			}
+		}),
+	);
+}
+```
+
+</TypeScriptExample>
+
+Setting `max_num_results` to 6 instead of 1 provides enough candidates for deduplication -- if the R2 bucket contains both `.md` and image files for the same product, extra results ensure you still get a text match.
+
+## 5. Compose and deduplicate results
+
+Process queries by priority so must-have items get first pick. Deduplicate by key to prevent the same product appearing twice.
+
+<TypeScriptExample>
+
+```ts
+interface ComposedItem {
+	key: string;
+	category: string;
+	role: "hero" | "supporting" | "accent";
+	score: number;
+	content: string;
+}
+
+function composeResults(
+	queries: ExpandedQuery[],
+	searchResults: SearchResult[][],
+): ComposedItem[] {
+	const seen = new Set<string>();
+	const items: ComposedItem[] = [];
+
+	// Process by priority (1 = must-have first)
+	const sorted = queries
+		.map((q, i) => ({ query: q, results: searchResults[i] || [] }))
+		.sort((a, b) => a.query.priority - b.query.priority);
+
+	for (const { query, results } of sorted) {
+		for (const result of results) {
+			if (seen.has(result.key)) continue;
+			seen.add(result.key);
+
+			items.push({
+				key: result.key,
+				category: query.category,
+				role: query.role,
+				score: result.score,
+				content: result.content,
+			});
+			break; // Best match per category query
+		}
+	}
+
+	// Display order: hero first, then supporting, then accent
+	const roleOrder = { hero: 0, supporting: 1, accent: 2 };
+	return items.sort((a, b) => roleOrder[a.role] - roleOrder[b.role]);
+}
+```
+
+</TypeScriptExample>
+
+## 6. Put it together
+
+<TypeScriptExample>
+
+```ts
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		try {
+			const url = new URL(request.url);
+			const query = url.searchParams.get("query");
+			if (!query) {
+				return Response.json(
+					{ error: "Missing query parameter" },
+					{ status: 400 },
+				);
+			}
+
+			// 1. Expand query into category sub-queries
+			const expansion = await expandQuery(env.AI, query);
+			if (expansion.queries.length === 0) {
+				return Response.json(
+					{ error: "Could not expand query into categories" },
+					{ status: 422 },
+				);
+			}
+
+			// 2. Parallel search -- one call per category
+			const searchResults = await searchByCategory(env, expansion.queries);
+
+			// 3. Compose and deduplicate
+			const items = composeResults(expansion.queries, searchResults);
+
+			return Response.json({
+				query,
+				concept: expansion.reasoning,
+				expansions: expansion.queries.map((q) => ({
+					query: q.query,
+					category: q.category,
+					role: q.role,
+				})),
+				results: items,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Unknown error";
+			return Response.json({ error: message }, { status: 500 });
+		}
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+## How it works
+
+1. **Query expansion** adds one Workers AI inference call (~200-400ms). A smaller, faster model like Llama 3.1 8B minimizes this overhead.
+2. **Parallel search** runs all category searches concurrently with `Promise.all`. Total search latency is the time of the slowest single call, not the sum.
+3. **Folder filters** (for example, `{ folder: "shoes/" }`) are the key pattern. They guarantee category isolation -- a shoes query only returns shoes. Without this, unrelated categories pollute results and the query expansion is wasted. This works for flat folder structures where product files are directly inside the category folder. For nested subfolders, use the [starts-with filter](/ai-search/configuration/indexing/metadata/#starts-with-filter-for-folders) instead.
+4. **Priority-based composition** ensures must-have items (hero pieces) get first pick from the result pool before optional accent items.
+
+## Related resources
+
+- [Path filtering](/ai-search/configuration/indexing/path-filtering/)
+- [Metadata filtering](/ai-search/configuration/indexing/metadata/)
+- [Build per-tenant search](/ai-search/how-to/per-tenant-search/) for a related folder-filtering pattern
+- [Workers AI models](/workers-ai/models/)

--- a/src/content/docs/ai-search/tutorials/full-stack-app-with-search.mdx
+++ b/src/content/docs/ai-search/tutorials/full-stack-app-with-search.mdx
@@ -1,0 +1,361 @@
+---
+pcx_content_type: tutorial
+title: "Full-stack app with AI Search"
+sidebar:
+  order: 7
+description: Build a full-stack application using D1 for storage, R2 as a content mirror for AI Search indexing, KV as a write buffer, and Service Bindings to connect components.
+tags:
+  - AI
+products:
+  - ai-search
+  - d1
+  - r2
+  - kv
+  - workers
+reviewed: 2026-04-20
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+When AI Search is part of a full application -- not just a search endpoint -- you need to keep the search index in sync with your primary database. This walkthrough shows how to build a task management application where D1 is the source of truth, R2 mirrors content as Markdown for AI Search indexing, KV provides a fast write buffer for rapid captures, and Service Bindings connect the API Worker to a frontend.
+
+## Prerequisites
+
+- A D1 database. For more information, refer to [D1 documentation](/d1/).
+- An R2 bucket. For more information, refer to [R2 documentation](/r2/).
+- A KV namespace. For more information, refer to [KV documentation](/kv/).
+- An AI Search instance connected to the R2 bucket.
+
+## 1. Configure the API Worker
+
+<WranglerConfig>
+
+```toml
+name = "my-app-api"
+main = "src/index.ts"
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+
+[[ai_search_namespaces]]
+binding = "AI_SEARCH"
+namespace = "default"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "my-app-db"
+database_id = "<DATABASE_ID>"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "<KV_NAMESPACE_ID>"
+
+[[r2_buckets]]
+binding = "R2"
+bucket_name = "my-app-content"
+
+[vars]
+AI_SEARCH_INSTANCE = "my-app-search"
+```
+
+</WranglerConfig>
+
+## 2. Configure the Web Worker with a Service Binding
+
+The frontend Worker connects to the API Worker through a Service Binding -- zero-latency Worker-to-Worker calls with no network hop.
+
+<WranglerConfig>
+
+```toml
+name = "my-app-web"
+main = ".svelte-kit/cloudflare/_worker.js"
+compatibility_date = "$today"
+
+[[services]]
+binding = "API"
+service = "my-app-api"
+```
+
+</WranglerConfig>
+
+The web Worker calls the API like a local function:
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	API: Fetcher;
+}
+
+async function callApi<T>(
+	api: Fetcher,
+	path: string,
+	init?: RequestInit,
+): Promise<T> {
+	const response = await api.fetch(
+		new Request(`https://api.internal${path}`, init),
+	);
+	return response.json() as Promise<T>;
+}
+
+// Usage in a server-side load function
+const tasks = await callApi<Task[]>(env.API, "/api/tasks");
+```
+
+</TypeScriptExample>
+
+The hostname `api.internal` is arbitrary -- Service Bindings ignore it. What matters is the path, which the API Worker routes normally.
+
+## 3. Create the D1 schema
+
+```sql
+-- migrations/0001_initial.sql
+CREATE TABLE IF NOT EXISTS tasks (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'todo',
+  priority TEXT NOT NULL DEFAULT 'medium',
+  scratchpad TEXT DEFAULT '',
+  due_date TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  UNIQUE(user_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS task_tags (
+  task_id TEXT NOT NULL,
+  tag_id TEXT NOT NULL,
+  PRIMARY KEY (task_id, tag_id),
+  FOREIGN KEY (task_id) REFERENCES tasks(id),
+  FOREIGN KEY (tag_id) REFERENCES tags(id)
+);
+
+CREATE TABLE IF NOT EXISTS inbox_entries (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  text TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_user ON tasks(user_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(user_id, status);
+CREATE INDEX IF NOT EXISTS idx_inbox_user ON inbox_entries(user_id);
+```
+
+## 4. Mirror D1 writes to R2 with `waitUntil`
+
+After every D1 write, generate a Markdown representation and write it to R2. Use `waitUntil` so the R2 write does not block the response.
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	AI_SEARCH: AiSearchNamespace;
+	DB: D1Database;
+	KV: KVNamespace;
+	R2: R2Bucket;
+	AI_SEARCH_INSTANCE: string;
+}
+
+interface Task {
+	id: string;
+	user_id: string;
+	title: string;
+	status: string;
+	priority: string;
+	scratchpad: string;
+	due_date: string | null;
+	tags: string[];
+}
+
+function taskToMarkdown(task: Task): string {
+	const lines = [
+		"---",
+		`id: ${task.id}`,
+		`type: task`,
+		`status: ${task.status}`,
+		`priority: ${task.priority}`,
+		`tags: [${task.tags.join(", ")}]`,
+		task.due_date ? `due: ${task.due_date}` : null,
+		"---",
+		"",
+		`# ${task.title}`,
+	]
+		.filter(Boolean)
+		.map(String);
+
+	if (task.scratchpad) {
+		lines.push("", "## Notes", task.scratchpad);
+	}
+
+	return lines.join("\n");
+}
+
+async function syncToR2(r2: R2Bucket, task: Task): Promise<void> {
+	const key = `${task.user_id}/tasks/${task.id}.md`;
+	await r2.put(key, taskToMarkdown(task), {
+		httpMetadata: { contentType: "text/markdown" },
+		customMetadata: {
+			entity_type: "task",
+			entity_id: task.id,
+			context: `Task: ${task.title}. Status: ${task.status}. Priority: ${task.priority}.`,
+		},
+	});
+}
+
+async function removeFromR2(
+	r2: R2Bucket,
+	userId: string,
+	taskId: string,
+): Promise<void> {
+	await r2.delete(`${userId}/tasks/${taskId}.md`);
+}
+```
+
+</TypeScriptExample>
+
+The R2 key structure `{user_id}/tasks/{task_id}.md` provides user-scoped isolation. AI Search's folder metadata lets you filter searches to a specific user's content.
+
+## 5. Use KV as a fast write buffer
+
+For rapid capture endpoints (like a quick inbox), write to KV first for sub-100ms response times, then flush to D1 and R2 asynchronously.
+
+<TypeScriptExample>
+
+```ts
+interface InboxEntry {
+	id: string;
+	user_id: string;
+	text: string;
+	created_at: string;
+}
+
+async function captureToInbox(
+	env: Env,
+	ctx: ExecutionContext,
+	userId: string,
+	text: string,
+): Promise<InboxEntry> {
+	const entry: InboxEntry = {
+		id: crypto.randomUUID(),
+		user_id: userId,
+		text,
+		created_at: new Date().toISOString(),
+	};
+
+	// Write to KV immediately (sub-100ms response)
+	await env.KV.put(`inbox:${userId}:${entry.id}`, JSON.stringify(entry), {
+		expirationTtl: 86400, // 24h TTL as safety net
+	});
+
+	// Async flush to D1 + R2, then clean up KV
+	ctx.waitUntil(
+		(async () => {
+			try {
+				await env.DB.prepare(
+					"INSERT INTO inbox_entries (id, user_id, text, created_at) VALUES (?, ?, ?, ?)",
+				)
+					.bind(entry.id, userId, text, entry.created_at)
+					.run();
+
+				const key = `${userId}/inbox/${entry.id}.md`;
+				await env.R2.put(key, `# Quick capture\n\n${text}`, {
+					httpMetadata: { contentType: "text/markdown" },
+				});
+
+				// Only delete from KV after both D1 and R2 succeed
+				await env.KV.delete(`inbox:${userId}:${entry.id}`);
+			} catch (err) {
+				// KV entry is retained (24h TTL) so the flush can be retried.
+				// In production, log the error and consider a retry mechanism.
+				console.error("Flush failed for inbox entry:", entry.id, err);
+			}
+		})(),
+	);
+
+	return entry;
+}
+```
+
+</TypeScriptExample>
+
+When reading the inbox, merge KV entries (not yet flushed) with D1 results to avoid data loss during the async window.
+
+## 6. Search with user-scoped filtering
+
+Use AI Search with folder-based filtering to scope results to the current user.
+
+<TypeScriptExample>
+
+```ts
+async function searchTasks(
+	env: Env,
+	userId: string,
+	query: string,
+	includeAnswer: boolean = false,
+): Promise<Response> {
+	// Range filter: match all keys that start with "{userId}/"
+	const filters = {
+		folder: { $gte: `${userId}/`, $lt: `${userId}0` },
+	};
+
+	const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+
+	if (includeAnswer) {
+		const result = await instance.chatCompletions({
+			messages: [{ role: "user", content: query }],
+			model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+			ai_search_options: {
+				retrieval: {
+					max_num_results: 10,
+					match_threshold: 0.3,
+					filters,
+				},
+				query_rewrite: { enabled: true },
+			},
+		});
+		return Response.json(result);
+	}
+
+	const result = await instance.search({
+		messages: [{ role: "user", content: query }],
+		ai_search_options: {
+			retrieval: {
+				max_num_results: 10,
+				match_threshold: 0.3,
+				filters,
+			},
+		},
+	});
+	return Response.json(result);
+}
+```
+
+</TypeScriptExample>
+
+The `$gte` + `$lt` filter on `{userId}/` acts as a [starts-with match](/ai-search/configuration/indexing/metadata/#starts-with-filter-for-folders), scoping results to all content belonging to that user -- tasks, inbox entries, and any other entity types stored in R2.
+
+## How it works
+
+1. **D1 is the source of truth.** All CRUD operations write to D1 first. The application reads from D1, not from R2 or AI Search.
+2. **R2 is a read-only mirror for AI Search.** Every D1 write triggers a `waitUntil` that converts the entity to Markdown and writes it to R2. AI Search indexes the R2 bucket automatically.
+3. **KV as a write buffer** decouples capture latency from storage latency. The KV write completes in single-digit milliseconds, while the D1 + R2 flush happens asynchronously.
+4. **`waitUntil` is the orchestration primitive.** It lets you run R2 syncs and AI tagging after the response is sent, keeping response times fast while ensuring data consistency.
+5. **Service Bindings** eliminate network hops between the frontend and API Workers. Calls look like `fetch()` but execute within the same Cloudflare location.
+6. **Folder-based user isolation** means every user's content is in their own R2 prefix. A `$gte` + `$lt` filter on `folder` scopes all searches to the authenticated user.
+
+## Related resources
+
+- [D1 documentation](/d1/)
+- [KV documentation](/kv/)
+- [R2 documentation](/r2/)
+- [Service Bindings](/workers/runtime-apis/bindings/service-bindings/)
+- [Build per-tenant search](/ai-search/how-to/per-tenant-search/)
+- [Ingest external content into AI Search](/ai-search/how-to/ingest-external-content/)
+- [Path filtering](/ai-search/configuration/indexing/path-filtering/)

--- a/src/content/docs/ai-search/tutorials/image-semantic-search.mdx
+++ b/src/content/docs/ai-search/tutorials/image-semantic-search.mdx
@@ -1,0 +1,288 @@
+---
+pcx_content_type: tutorial
+title: "Image semantic search"
+sidebar:
+  order: 4
+description: Build natural language search over an image collection stored in R2, using AI Search for semantic matching and R2 as an image CDN.
+tags:
+  - AI
+products:
+  - ai-search
+  - r2
+  - workers
+reviewed: 2026-04-20
+---
+
+import { TypeScriptExample, WranglerConfig, FileTree } from "~/components";
+
+AI Search can index images stored in R2 and make them searchable with natural language queries. This walkthrough shows how to build an image search application where users type descriptions like "cat sleeping on a windowsill" and get back matching images, without any manual tagging or classification.
+
+## Prerequisites
+
+- An R2 bucket with images. For more information, refer to [R2 documentation](/r2/).
+- An AI Search instance connected to the R2 bucket. For more information, refer to [R2 data source](/ai-search/configuration/data-source/r2/).
+
+## 1. Configure bindings
+
+<WranglerConfig>
+
+```toml
+name = "image-search"
+main = "src/index.ts"
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+
+[[ai_search_namespaces]]
+binding = "AI_SEARCH"
+namespace = "default"
+
+[[r2_buckets]]
+binding = "IMAGES_BUCKET"
+bucket_name = "my-images"
+
+[vars]
+AI_SEARCH_INSTANCE = "my-image-index"
+```
+
+</WranglerConfig>
+
+## 2. Organize images in R2
+
+Structure image filenames to encode searchable metadata. AI Search indexes the full R2 key path, so descriptive naming makes images discoverable.
+
+<FileTree>
+
+- nature/
+  - Sunset Over Ocean Waves.jpg
+  - Mountain Peak Above Clouds.jpg
+- architecture/
+  - Gothic Cathedral Interior.jpg
+  - Modern Glass Skyscraper.jpg
+- animals/
+  - Cat Sleeping on Windowsill.jpg
+  - Golden Retriever in Snow.jpg
+
+</FileTree>
+
+The folder name provides a category, and the filename describes the scene. AI Search will embed these descriptions and match them against user queries.
+
+## 3. Parse search results into image metadata
+
+When AI Search returns results, each chunk's `item.key` field contains the R2 key. Parse it to extract displayable metadata.
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	AI_SEARCH: AiSearchNamespace;
+	IMAGES_BUCKET: R2Bucket;
+	AI_SEARCH_INSTANCE: string;
+}
+
+interface ImageResult {
+	key: string;
+	category: string;
+	description: string;
+	imageUrl: string;
+	thumbnailUrl: string;
+	score: number;
+}
+
+function parseKey(key: string, score: number): ImageResult | null {
+	// Expected format: "category/Description.ext"
+	const parts = key.split("/");
+	if (parts.length < 2) return null;
+
+	const category = parts[0];
+	const fileWithExt = parts.slice(1).join("/");
+	const description = fileWithExt.replace(/\.\w+$/, "");
+
+	return {
+		key,
+		category,
+		description,
+		imageUrl: `/images/${encodeURIComponent(key)}`,
+		thumbnailUrl: `/thumbnails/${encodeURIComponent(key.replace(/\.\w+$/, ".webp"))}`,
+		score,
+	};
+}
+```
+
+</TypeScriptExample>
+
+## 4. Search images with natural language
+
+<TypeScriptExample>
+
+```ts
+async function searchImages(env: Env, query: string): Promise<ImageResult[]> {
+	const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+	const response = await instance.search({
+		messages: [{ role: "user", content: query }],
+		ai_search_options: {
+			retrieval: {
+				max_num_results: 30,
+				match_threshold: 0.25,
+			},
+		},
+	});
+
+	return (response.chunks ?? [])
+		.map((chunk) => parseKey(chunk.item?.key ?? "", chunk.score))
+		.filter((r): r is ImageResult => r !== null);
+}
+```
+
+</TypeScriptExample>
+
+The low score threshold (0.25) is intentional for image search -- semantic matching on short descriptions benefits from more candidates.
+
+## 5. Find similar images
+
+Given an existing image, use its filename as a search query to find visually or thematically similar images.
+
+<TypeScriptExample>
+
+```ts
+async function findSimilar(env: Env, key: string): Promise<ImageResult[]> {
+	const parsed = parseKey(key, 1);
+	if (!parsed) return [];
+
+	// Use the description + category as the search query
+	const query = `${parsed.description} ${parsed.category}`;
+
+	const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+	const response = await instance.search({
+		messages: [{ role: "user", content: query }],
+		ai_search_options: {
+			retrieval: {
+				max_num_results: 12,
+				match_threshold: 0.2,
+			},
+		},
+	});
+
+	return (response.chunks ?? [])
+		.filter((chunk) => chunk.item?.key !== key) // Exclude the original
+		.slice(0, 8)
+		.map((chunk) => parseKey(chunk.item?.key ?? "", chunk.score))
+		.filter((r): r is ImageResult => r !== null);
+}
+```
+
+</TypeScriptExample>
+
+## 6. Serve images from R2
+
+Proxy R2 images through the Worker with aggressive caching. This turns R2 into an image CDN.
+
+<TypeScriptExample>
+
+```ts
+async function serveImage(bucket: R2Bucket, key: string): Promise<Response> {
+	const object = await bucket.get(key);
+	if (!object) {
+		return new Response("Image not found", { status: 404 });
+	}
+
+	return new Response(object.body, {
+		headers: {
+			"Content-Type": object.httpMetadata?.contentType || "image/jpeg",
+			"Cache-Control": "public, max-age=31536000, immutable",
+			"Content-Length": String(object.size),
+		},
+	});
+}
+```
+
+</TypeScriptExample>
+
+The `immutable` cache directive tells browsers and CDNs this image will never change at this URL. For mutable images, use content-hashed URLs instead.
+
+## 7. Put it together
+
+<TypeScriptExample>
+
+```ts
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+
+		try {
+			// Search endpoint
+			if (url.pathname === "/api/search") {
+				const query = url.searchParams.get("q");
+				if (!query) {
+					return Response.json(
+						{ error: "Missing q parameter" },
+						{ status: 400 },
+					);
+				}
+				const results = await searchImages(env, query);
+				return Response.json({ query, results });
+			}
+
+			// Similar images endpoint
+			if (url.pathname === "/api/similar") {
+				const key = url.searchParams.get("key");
+				if (!key) {
+					return Response.json(
+						{ error: "Missing key parameter" },
+						{ status: 400 },
+					);
+				}
+				const results = await findSimilar(env, key);
+				return Response.json({ results });
+			}
+
+			// Image proxy
+			if (url.pathname.startsWith("/images/")) {
+				const key = decodeURIComponent(url.pathname.replace("/images/", ""));
+				return serveImage(env.IMAGES_BUCKET, key);
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Unknown error";
+			return Response.json({ error: message }, { status: 500 });
+		}
+
+		return new Response("Not found", { status: 404 });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+## How it works
+
+1. **AI Search indexes images automatically.** When you connect an R2 bucket containing images, AI Search processes them -- extracting visual features and indexing filenames -- to build a semantic search index.
+2. **Filenames are the metadata layer.** Descriptive filenames like `Sunset Over Ocean Waves.jpg` give AI Search text to embed alongside the image content. The combination of visual features and text descriptions provides strong semantic matching.
+3. **No tagging required.** Unlike traditional image search that requires manual tags, AI Search's semantic understanding matches natural language queries to image content directly.
+4. **R2 as CDN.** Serving images through the Worker with long-lived cache headers turns R2 into an efficient image delivery network.
+
+## Extending with image upload search
+
+You can accept uploaded images and convert them to text queries using a Workers AI vision model:
+
+<TypeScriptExample>
+
+```ts
+const imageBytes = new Uint8Array(await file.arrayBuffer());
+const aiResponse = await env.AI.run("@cf/llava-hf/llava-1.5-7b-hf", {
+	image: [...imageBytes],
+	prompt: "Describe this image in detail.",
+	max_tokens: 256,
+});
+const description = aiResponse.description ?? "";
+// Use description as the search query
+const results = await searchImages(env, description);
+```
+
+</TypeScriptExample>
+
+This enables "search by image" -- upload a photo, get a text description from the vision model, then find similar images in your collection.
+
+## Related resources
+
+- [R2 data source configuration](/ai-search/configuration/data-source/r2/)
+- [Workers AI models](/workers-ai/models/)
+- [R2 documentation](/r2/)

--- a/src/content/docs/ai-search/tutorials/index.mdx
+++ b/src/content/docs/ai-search/tutorials/index.mdx
@@ -1,0 +1,12 @@
+---
+pcx_content_type: navigation
+title: Tutorials
+sidebar:
+  order: 9
+  group:
+    hideIndex: true
+---
+
+import { DirectoryListing } from "~/components";
+
+<DirectoryListing />

--- a/src/content/docs/ai-search/tutorials/persistent-memory-for-agents.mdx
+++ b/src/content/docs/ai-search/tutorials/persistent-memory-for-agents.mdx
@@ -1,0 +1,471 @@
+---
+pcx_content_type: tutorial
+title: "Persistent memory for AI agents"
+sidebar:
+  order: 2
+description: Build a memory service that stores structured memories in R2, uses AI Search for semantic recall, and deduplicates on save to prevent redundant entries.
+tags:
+  - AI
+products:
+  - ai-search
+  - r2
+  - workers
+reviewed: 2026-04-20
+---
+
+import { TypeScriptExample, WranglerConfig, FileTree } from "~/components";
+
+AI agents lose context between sessions. This walkthrough shows how to build a persistent memory service on Cloudflare Workers that gives any agent -- whether connected via [MCP](/ai-search/mcp-server/), REST API, or tool calling -- the ability to save, recall, and manage memories across sessions. Memories are stored as Markdown in R2, AI Search provides semantic recall, and a deduplication layer prevents the same insight from being stored repeatedly.
+
+:::note
+Cloudflare offers two managed alternatives to building your own memory layer:
+
+- **[Agent Memory](https://blog.cloudflare.com/introducing-agent-memory/)** (private beta) is a managed service that extracts, stores, and recalls memories from agent conversations. It handles extraction, deduplication, classification, and retrieval automatically via a simple binding (`env.MEMORY.getProfile()`). Use this when you want turnkey agent memory without managing storage or search infrastructure.
+- **[Agents SDK Session memory](/agents/concepts/memory/)** provides conversation history, writable context, searchable knowledge, and loadable skills built into the Agents SDK's Session API, backed by Durable Object SQLite.
+
+The tutorial below is for cases where you need a standalone memory service with custom storage (R2) and semantic search (AI Search), want full control over the memory format and deduplication logic, or need to integrate memory into an existing architecture outside the Agents SDK.
+:::
+
+This is a **simplified take on agent memory** -- enough to get a working system and understand the core pattern. Production memory systems typically add access control, TTL-based expiry, vector re-ranking, and more sophisticated deduplication. The focus here is the **memory service pattern** itself, not the transport layer. The same `save()`, `recall()`, and `delete()` functions work whether exposed as MCP tools, REST endpoints, or [agent tool definitions](/ai-search/how-to/use-as-agent-tool/).
+
+## Prerequisites
+
+- An R2 bucket. For more information, refer to [R2 documentation](/r2/).
+- An AI Search instance connected to the R2 bucket. For more information, refer to [R2 data source](/ai-search/configuration/data-source/r2/).
+
+## 1. Configure bindings
+
+<WranglerConfig>
+
+```toml
+name = "memory-service"
+main = "src/index.ts"
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+
+[[ai_search_namespaces]]
+binding = "AI_SEARCH"
+namespace = "default"
+
+[[r2_buckets]]
+binding = "MEMORIES_BUCKET"
+bucket_name = "memories"
+
+[vars]
+AI_SEARCH_INSTANCE = "memory-index"
+```
+
+</WranglerConfig>
+
+## 2. Define the memory format
+
+Each memory is a Markdown file with YAML frontmatter for structured metadata. This format is human-readable for debugging and machine-parseable for structured recall.
+
+<FileTree>
+
+- memory-index/
+  - global/
+    - mem_lz1abc_12345678.md
+  - project/
+    - mem_lz1def_87654321.md
+
+</FileTree>
+
+The key structure `{instance}/{scope}/{id}.md` provides:
+
+- **Scope isolation**: `global/` for cross-project memories, `project/` for project-specific ones.
+- **Folder filtering**: AI Search can filter by the `folder` attribute to scope searches to a specific scope prefix.
+
+Each file looks like:
+
+```md
+---
+id: mem_lz1abc_12345678
+timestamp: 2026-02-26T10:30:00.000Z
+type: decision
+tags: [auth, jwt]
+scope: global
+importance: high
+repository: my-api
+branch: feat/auth-refactor
+---
+
+We decided to use JWT tokens with RS256 for API authentication because
+symmetric signing would require sharing secrets across services.
+```
+
+## 3. Serialize and parse memories
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	AI_SEARCH: AiSearchNamespace;
+	MEMORIES_BUCKET: R2Bucket;
+	AI_SEARCH_INSTANCE: string;
+}
+
+interface Memory {
+	id: string;
+	content: string;
+	timestamp: string;
+	type: "decision" | "pattern" | "preference" | "context";
+	tags: string[];
+	scope: "global" | "project";
+	importance: "low" | "medium" | "high";
+	metadata: Record<string, unknown>;
+	score?: number;
+}
+
+function toMarkdown(memory: Memory): string {
+	const lines = [
+		"---",
+		`id: ${memory.id}`,
+		`timestamp: ${memory.timestamp}`,
+		`type: ${memory.type}`,
+		`tags: [${memory.tags.join(", ")}]`,
+		`scope: ${memory.scope}`,
+		`importance: ${memory.importance}`,
+	];
+
+	// Additional metadata fields go into frontmatter
+	for (const [key, val] of Object.entries(memory.metadata)) {
+		if (val !== undefined && val !== null && val !== "") {
+			const formatted = Array.isArray(val)
+				? `[${val.join(", ")}]`
+				: String(val);
+			lines.push(`${key}: ${formatted}`);
+		}
+	}
+
+	lines.push("---", "", memory.content);
+	return lines.join("\n");
+}
+
+function fromMarkdown(raw: string, score?: number): Memory | null {
+	const match = raw.match(/^---\n([\s\S]*?)\n---\n\n?([\s\S]*)$/);
+	if (!match) return null;
+
+	const frontmatter: Record<string, string> = {};
+	for (const line of match[1].split("\n")) {
+		const idx = line.indexOf(": ");
+		if (idx > 0) frontmatter[line.slice(0, idx)] = line.slice(idx + 2);
+	}
+
+	const tags = (frontmatter.tags || "[]")
+		.replace(/[\[\]]/g, "")
+		.split(",")
+		.map((t) => t.trim())
+		.filter(Boolean);
+
+	const coreKeys = new Set([
+		"id",
+		"timestamp",
+		"type",
+		"tags",
+		"scope",
+		"importance",
+	]);
+	const metadata: Record<string, unknown> = {};
+	for (const [key, val] of Object.entries(frontmatter)) {
+		if (!coreKeys.has(key)) metadata[key] = val;
+	}
+
+	return {
+		id: frontmatter.id,
+		content: match[2].trim(),
+		timestamp: frontmatter.timestamp,
+		type: frontmatter.type as Memory["type"],
+		tags,
+		scope: frontmatter.scope as Memory["scope"],
+		importance: frontmatter.importance as Memory["importance"],
+		metadata,
+		score,
+	};
+}
+```
+
+</TypeScriptExample>
+
+## 4. Save memories with deduplication
+
+Before saving a new memory, search for existing similar memories. Near-duplicates (score `>= 0.85`) are automatically replaced. Similar memories (score `>= 0.6`) are flagged as warnings so the caller can decide what to do.
+
+<TypeScriptExample>
+
+```ts
+const REPLACE_THRESHOLD = 0.85;
+const SIMILAR_THRESHOLD = 0.6;
+
+async function saveMemory(
+	env: Env,
+	content: string,
+	options: {
+		type?: Memory["type"];
+		scope?: Memory["scope"];
+		importance?: Memory["importance"];
+		tags?: string[];
+		metadata?: Record<string, unknown>;
+	} = {},
+): Promise<{
+	memory: Memory;
+	action: "created" | "replaced" | "similar_exists";
+	replaced: string[];
+	similar: string[];
+}> {
+	const id = `mem_${Date.now().toString(36)}_${crypto.randomUUID().slice(0, 8)}`;
+	const scope = options.scope ?? "project";
+	const replaced: string[] = [];
+	const similar: string[] = [];
+
+	// Dedup: search for similar existing memories
+	try {
+		const existing = await recallMemories(env, content, {
+			scope,
+			limit: 5,
+			matchThreshold: SIMILAR_THRESHOLD,
+		});
+
+		for (const match of existing) {
+			if ((match.score ?? 0) >= REPLACE_THRESHOLD) {
+				// Near-duplicate: auto-replace
+				await deleteMemory(env, match.id, scope);
+				replaced.push(match.id);
+			} else if ((match.score ?? 0) >= SIMILAR_THRESHOLD) {
+				// Similar but distinct: flag for caller
+				similar.push(match.id);
+			}
+		}
+	} catch {
+		// Skip dedup if AI Search index is not ready yet
+	}
+
+	const memory: Memory = {
+		id,
+		content,
+		timestamp: new Date().toISOString(),
+		type: options.type ?? "context",
+		tags: options.tags ?? [],
+		scope,
+		importance: options.importance ?? "medium",
+		metadata: options.metadata ?? {},
+	};
+
+	const key = `${env.AI_SEARCH_INSTANCE}/${scope}/${id}.md`;
+	await env.MEMORIES_BUCKET.put(key, toMarkdown(memory), {
+		httpMetadata: { contentType: "text/markdown" },
+		customMetadata: {
+			memoryId: id,
+			type: memory.type,
+			scope,
+			importance: memory.importance,
+			tags: memory.tags.join(","),
+		},
+	});
+
+	const action =
+		replaced.length > 0
+			? "replaced"
+			: similar.length > 0
+				? "similar_exists"
+				: "created";
+
+	return { memory, action, replaced, similar };
+}
+```
+
+</TypeScriptExample>
+
+The two-threshold design balances precision and recall:
+
+- **0.85+ (replace)**: The memories say essentially the same thing. Delete the old one, keep the new.
+- **0.6-0.85 (flag)**: The memories are related but distinct. Inform the caller so it can decide -- the agent might want to update the existing memory rather than create a new one.
+- **Below 0.6**: No meaningful similarity. Save without warning.
+
+If the AI Search index is not ready (for example, on first use before the first indexing cycle), deduplication is skipped entirely and the memory is saved regardless.
+
+## 5. Recall memories with semantic search
+
+Use AI Search to find memories by meaning. Each search result contains an R2 key, which is fetched to reconstruct the full memory with all metadata.
+
+<TypeScriptExample>
+
+```ts
+async function recallMemories(
+	env: Env,
+	query: string,
+	options: {
+		scope?: "global" | "project" | "both";
+		limit?: number;
+		matchThreshold?: number;
+		type?: Memory["type"];
+		importance?: Memory["importance"];
+	} = {},
+): Promise<Memory[]> {
+	const limit = options.limit ?? 10;
+	const matchThreshold = options.matchThreshold ?? 0.3;
+
+	// Scope filter: folder is a built-in filterable attribute
+	const folderFilter =
+		options.scope && options.scope !== "both"
+			? { folder: `${env.AI_SEARCH_INSTANCE}/${options.scope}/` }
+			: undefined;
+
+	const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+	const response = await instance.search({
+		messages: [{ role: "user", content: query }],
+		ai_search_options: {
+			retrieval: {
+				max_num_results: limit,
+				match_threshold: matchThreshold,
+				...(folderFilter && { filters: folderFilter }),
+			},
+		},
+	});
+
+	// Fetch full memories from R2 in parallel
+	const results = await Promise.all(
+		(response.chunks ?? []).map(async (chunk) => {
+			const key = chunk.item?.key;
+			if (!key) return null;
+
+			const obj = await env.MEMORIES_BUCKET.get(key);
+			if (!obj) return null; // Stale index entry -- file was deleted
+
+			return fromMarkdown(await obj.text(), chunk.score);
+		}),
+	);
+
+	// Deduplicate: multiple chunks can come from the same .md file
+	const deduped = new Map<string, Memory>();
+	for (const m of results) {
+		if (!m) continue;
+		const existing = deduped.get(m.id);
+		if (!existing || (m.score ?? 0) > (existing.score ?? 0)) {
+			deduped.set(m.id, m);
+		}
+	}
+
+	// Client-side filtering on type and importance (parsed from R2 Markdown frontmatter)
+	return Array.from(deduped.values()).filter((m) => {
+		if (options.type && m.type !== options.type) return false;
+		if (options.importance && m.importance !== options.importance) return false;
+		return true;
+	});
+}
+```
+
+</TypeScriptExample>
+
+Two important details:
+
+- **Scope filtering is server-side.** The `folder` filter uses the [metadata filter syntax](/ai-search/configuration/indexing/metadata/) to narrow results to a specific scope prefix before retrieval. When `scope` is `"both"`, no folder filter is applied, so memories from both `global/` and `project/` are returned. Filtering on `type` and `importance` is done client-side after fetching the full memory from R2, unless you have defined these as [custom metadata fields](/ai-search/configuration/indexing/metadata/#custom-metadata).
+- **Stale index entries are handled gracefully.** When a memory is deleted from R2 but AI Search still has it indexed, `bucket.get(key)` returns `null` and the result is filtered out.
+
+## 6. Delete memories
+
+<TypeScriptExample>
+
+```ts
+async function deleteMemory(
+	env: Env,
+	memoryId: string,
+	scope: "global" | "project",
+): Promise<boolean> {
+	const key = `${env.AI_SEARCH_INSTANCE}/${scope}/${memoryId}.md`;
+	const obj = await env.MEMORIES_BUCKET.head(key);
+	if (!obj) return false;
+
+	await env.MEMORIES_BUCKET.delete(key);
+	return true;
+}
+```
+
+</TypeScriptExample>
+
+After deletion, the memory disappears from R2 immediately. AI Search will remove it from the index on the next sync cycle. In the meantime, `recallMemories` handles this gracefully -- if a search result points to a deleted R2 key, it is filtered out.
+
+## 7. Wire up the Worker
+
+Expose the memory service as REST endpoints. The same functions can be used as MCP tool handlers, [agent tool definitions](/ai-search/how-to/use-as-agent-tool/), or any other integration pattern.
+
+:::note
+The example below uses a plain `fetch` handler for brevity. For production Workers with multiple routes, consider [Hono](https://hono.dev/) -- it adds routing, middleware, and error handling with minimal overhead and runs natively on Workers.
+:::
+
+<TypeScriptExample>
+
+```ts
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+
+		try {
+			if (url.pathname === "/save" && request.method === "POST") {
+				const body = (await request.json()) as {
+					content: string;
+					type?: Memory["type"];
+					scope?: Memory["scope"];
+					importance?: Memory["importance"];
+					tags?: string[];
+					metadata?: Record<string, unknown>;
+				};
+				const result = await saveMemory(env, body.content, body);
+				return Response.json(result);
+			}
+
+			if (url.pathname === "/recall" && request.method === "POST") {
+				const body = (await request.json()) as {
+					query: string;
+					limit?: number;
+					scope?: "global" | "project" | "both";
+					type?: Memory["type"];
+					importance?: Memory["importance"];
+				};
+				const memories = await recallMemories(env, body.query, body);
+				return Response.json({ memories });
+			}
+
+			if (url.pathname === "/delete" && request.method === "POST") {
+				const body = (await request.json()) as {
+					memoryId: string;
+					scope: "global" | "project";
+				};
+				const deleted = await deleteMemory(env, body.memoryId, body.scope);
+				return Response.json({ deleted });
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Unknown error";
+			return Response.json({ error: message }, { status: 500 });
+		}
+
+		return new Response("Not found", { status: 404 });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+## How it works
+
+1. **R2 is the source of truth.** Every memory is a Markdown file. AI Search indexes the bucket automatically, enabling semantic search without a separate vector database.
+2. **Semantic recall** uses AI Search to find memories by meaning. A query like "how did we handle auth?" finds a memory about "JWT tokens with RS256" because the concepts are semantically related.
+3. **Deduplication on save** uses the memory's own content as a search query to find similar existing entries. The two-threshold system (0.85 auto-replace, 0.6 flag) prevents redundant storage while preserving distinct but related memories.
+4. **Markdown with YAML frontmatter** serves a dual purpose -- structured metadata for filtering and classification, plus free-text content for semantic search.
+5. **Folder-based isolation** scopes memories by instance, scope (global/project), and user. AI Search inherits this structure through its folder metadata, and the service enforces it post-search.
+
+## Indexing timing
+
+After saving a memory to R2, there is a delay before it becomes searchable via AI Search:
+
+- **Automatic indexing**: AI Search indexes files in R2 when the instance is created and periodically after that. New files are picked up on the next indexing cycle.
+- **Manual sync**: Use the [Cloudflare dashboard](https://dash.cloudflare.com/) to trigger immediate indexing.
+
+## Related resources
+
+- [Agents SDK Session memory](/agents/concepts/memory/) for managed agent memory built into the Agents SDK
+- [R2 data source configuration](/ai-search/configuration/data-source/r2/)
+- [Build per-tenant search](/ai-search/how-to/per-tenant-search/) for per-user folder isolation
+- [Use AI Search as an agent tool](/ai-search/how-to/use-as-agent-tool/)
+- [AI Search MCP server](/ai-search/mcp-server/) for the built-in MCP integration
+- [Ingest external content into AI Search](/ai-search/how-to/ingest-external-content/)

--- a/src/content/docs/ai-search/tutorials/search-over-d1.mdx
+++ b/src/content/docs/ai-search/tutorials/search-over-d1.mdx
@@ -1,0 +1,421 @@
+---
+pcx_content_type: tutorial
+title: "Search over D1 data"
+sidebar:
+  order: 3
+description: Keep a D1 database searchable with AI Search by mirroring rows to R2 as Markdown on every write, and triggering an index sync so results stay current.
+tags:
+  - AI
+products:
+  - ai-search
+  - d1
+  - r2
+  - workers
+difficulty: Intermediate
+reviewed: 2026-04-20
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+D1 is the right place to store structured application data. AI Search is built for unstructured text -- it embeds and retrieves natural language content like descriptions, notes, and summaries. The two work together by treating R2 as a mirror: every time a row is written to D1, the row's text content is written to R2 as a Markdown file. AI Search indexes those files automatically, so the search index stays in sync with the database.
+
+The key idea is that the R2 mirror contains the **text** you want to be searchable -- not a serialized copy of the database row. Structured fields like IDs, prices, and timestamps belong in D1. The R2 file should read like a document: a title, a description, any prose that helps someone find this record with a natural language query.
+
+This tutorial shows how to build a product catalog where records live in D1 and product descriptions are searchable through AI Search.
+
+## Prerequisites
+
+- A D1 database. For more information, refer to [D1 documentation](/d1/).
+- An R2 bucket. For more information, refer to [R2 documentation](/r2/).
+- An AI Search instance connected to the R2 bucket. For more information, refer to [R2 data source](/ai-search/configuration/data-source/r2/).
+
+## 1. Configure bindings
+
+<WranglerConfig>
+
+```toml
+name = "product-catalog"
+main = "src/index.ts"
+compatibility_date = "$today"
+
+[[ai_search_namespaces]]
+binding = "AI_SEARCH"
+namespace = "default"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "products-db"
+database_id = "<DATABASE_ID>"
+
+[[r2_buckets]]
+binding = "CONTENT"
+bucket_name = "products-content"
+
+[vars]
+AI_SEARCH_INSTANCE = "product-search"
+```
+
+</WranglerConfig>
+
+## 2. Create the D1 schema
+
+```sql
+CREATE TABLE IF NOT EXISTS products (
+  id        TEXT PRIMARY KEY,
+  name      TEXT NOT NULL,
+  category  TEXT NOT NULL,
+  price     REAL NOT NULL,
+  summary   TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_products_category ON products(category);
+```
+
+Apply this migration with Wrangler:
+
+```bash
+npx wrangler d1 execute products-db --file=migrations/0001_products.sql
+```
+
+## 3. Mirror D1 rows to R2
+
+For each product write, generate a Markdown document that contains the text content you want AI Search to index. Keep structured fields (price, ID, timestamps) in D1 -- the R2 file should read like a short product description, not a serialized database row.
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	AI_SEARCH: AiSearchNamespace;
+	DB: D1Database;
+	CONTENT: R2Bucket;
+	AI_SEARCH_INSTANCE: string;
+}
+
+interface Product {
+	id: string;
+	name: string;
+	category: string;
+	price: number;
+	summary: string;
+	created_at: string;
+	updated_at: string;
+}
+
+function productToMarkdown(product: Product): string {
+	return [
+		`# ${product.name}`,
+		"",
+		`Category: ${product.category}`,
+		"",
+		product.summary,
+	].join("\n");
+}
+
+// R2 key: "{category}/{id}.md" — gives folder-based category filtering
+function r2Key(product: Pick<Product, "id" | "category">): string {
+	return `${product.category}/${product.id}.md`;
+}
+
+async function syncToR2(bucket: R2Bucket, product: Product): Promise<void> {
+	await bucket.put(r2Key(product), productToMarkdown(product), {
+		httpMetadata: { contentType: "text/markdown" },
+		customMetadata: {
+			context: `${product.name} — ${product.category} product.`,
+		},
+	});
+}
+
+async function removeFromR2(
+	bucket: R2Bucket,
+	product: Pick<Product, "id" | "category">,
+): Promise<void> {
+	await bucket.delete(r2Key(product));
+}
+```
+
+</TypeScriptExample>
+
+The key structure `{category}/{id}.md` creates a folder hierarchy that AI Search uses as filterable metadata. A search scoped to `{ folder: "shoes/" }` returns only products in the `shoes` category.
+
+## 4. Write to D1 and mirror to R2
+
+Use `ctx.waitUntil` to write to R2 after the D1 write completes, without blocking the HTTP response. The response goes back to the caller immediately while the mirror write runs in the background.
+
+<TypeScriptExample>
+
+```ts
+async function createProduct(
+	env: Env,
+	ctx: ExecutionContext,
+	input: Omit<Product, "created_at" | "updated_at">,
+): Promise<Product> {
+	const now = new Date().toISOString();
+	const product: Product = { ...input, created_at: now, updated_at: now };
+
+	await env.DB.prepare(
+		`INSERT INTO products (id, name, category, price, summary, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	)
+		.bind(
+			product.id,
+			product.name,
+			product.category,
+			product.price,
+			product.summary,
+			product.created_at,
+			product.updated_at,
+		)
+		.run();
+
+	// Mirror to R2 after D1 write — does not block the response
+	ctx.waitUntil(syncToR2(env.CONTENT, product));
+
+	return product;
+}
+
+async function updateProduct(
+	env: Env,
+	ctx: ExecutionContext,
+	id: string,
+	patch: Partial<Pick<Product, "name" | "summary" | "price">>,
+): Promise<Product | null> {
+	const updated_at = new Date().toISOString();
+	// Allowlist field names before interpolating into SQL to prevent injection
+	const ALLOWED_FIELDS = new Set<keyof Product>(["name", "summary", "price"]);
+	const fields = (Object.keys(patch) as Array<keyof typeof patch>).filter((f) =>
+		ALLOWED_FIELDS.has(f),
+	);
+	if (fields.length === 0) return null;
+
+	const setClauses = fields.map((f) => `${f} = ?`).join(", ");
+	const values = fields.map((f) => patch[f]);
+
+	await env.DB.prepare(
+		`UPDATE products SET ${setClauses}, updated_at = ? WHERE id = ?`,
+	)
+		.bind(...values, updated_at, id)
+		.run();
+
+	const row = await env.DB.prepare("SELECT * FROM products WHERE id = ?")
+		.bind(id)
+		.first<Product>();
+
+	if (!row) return null;
+
+	ctx.waitUntil(syncToR2(env.CONTENT, row));
+	return row;
+}
+
+async function deleteProduct(
+	env: Env,
+	ctx: ExecutionContext,
+	id: string,
+): Promise<boolean> {
+	// Fetch category before deletion to build the correct R2 key
+	const row = await env.DB.prepare(
+		"SELECT id, category FROM products WHERE id = ?",
+	)
+		.bind(id)
+		.first<Pick<Product, "id" | "category">>();
+
+	if (!row) return false;
+
+	await env.DB.prepare("DELETE FROM products WHERE id = ?").bind(id).run();
+
+	ctx.waitUntil(removeFromR2(env.CONTENT, row));
+	return true;
+}
+```
+
+</TypeScriptExample>
+
+The `waitUntil` pattern keeps writes fast while guaranteeing the R2 mirror is updated before the isolate shuts down. If the R2 write fails, the D1 row still exists — a retry on the next write or a background sync job can recover the mirror.
+
+## 5. Search with AI Search
+
+Query AI Search to find products by natural language. Optionally scope results to a category using a folder filter.
+
+<TypeScriptExample>
+
+```ts
+interface SearchResult {
+	id: string;
+	key: string;
+	score: number;
+	excerpt: string;
+}
+
+async function searchProducts(
+	env: Env,
+	query: string,
+	category?: string,
+): Promise<SearchResult[]> {
+	const filter = category
+		? { folder: `${category}/` }
+		: undefined;
+
+	const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE);
+	const response = await instance.search({
+		messages: [{ role: "user", content: query }],
+		ai_search_options: {
+			retrieval: {
+				max_num_results: 10,
+				match_threshold: 0.3,
+				...(filter && { filters: filter }),
+			},
+			query_rewrite: { enabled: true },
+		},
+	});
+
+	return (response.chunks ?? []).map((chunk) => ({
+		id: (chunk.item?.key ?? "").replace(/^.*\//, "").replace(/\.md$/, ""),
+		key: chunk.item?.key ?? "",
+		score: chunk.score,
+		excerpt: chunk.text ?? "",
+	}));
+}
+```
+
+</TypeScriptExample>
+
+## 6. Enrich search results from D1
+
+AI Search returns R2 keys and text excerpts. To return full product records, fetch the matching rows from D1 using the IDs parsed from the keys.
+
+<TypeScriptExample>
+
+```ts
+async function searchAndEnrich(
+	env: Env,
+	query: string,
+	category?: string,
+): Promise<Array<Product & { score: number; excerpt: string }>> {
+	const searchResults = await searchProducts(env, query, category);
+	if (searchResults.length === 0) return [];
+
+	// Fetch D1 rows for all matched IDs in one query
+	const ids = searchResults.map((r) => r.id);
+	const placeholders = ids.map(() => "?").join(", ");
+	const rows = await env.DB.prepare(
+		`SELECT * FROM products WHERE id IN (${placeholders})`,
+	)
+		.bind(...ids)
+		.all<Product>();
+
+	const byId = new Map(rows.results.map((r) => [r.id, r]));
+
+	// Preserve search result ordering (highest score first)
+	return searchResults
+		.map((r) => {
+			const product = byId.get(r.id);
+			if (!product) return null;
+			return { ...product, score: r.score, excerpt: r.excerpt };
+		})
+		.filter(
+			(r): r is Product & { score: number; excerpt: string } => r !== null,
+		);
+}
+```
+
+</TypeScriptExample>
+
+Preserving the AI Search result order matters — it is ranked by semantic relevance. Re-sorting by a D1 field (such as price) after the fact discards that signal.
+
+## 7. Put it together
+
+<TypeScriptExample>
+
+```ts
+export default {
+	async fetch(
+		request: Request,
+		env: Env,
+		ctx: ExecutionContext,
+	): Promise<Response> {
+		const url = new URL(request.url);
+
+		try {
+			// Search endpoint: GET /search?q=...&category=...
+			if (url.pathname === "/search" && request.method === "GET") {
+				const query = url.searchParams.get("q");
+				if (!query) {
+					return Response.json(
+						{ error: "Missing q parameter" },
+						{ status: 400 },
+					);
+				}
+				const category = url.searchParams.get("category") ?? undefined;
+				const results = await searchAndEnrich(env, query, category);
+				return Response.json({ query, results });
+			}
+
+			// Create product: POST /products
+			if (url.pathname === "/products" && request.method === "POST") {
+				const body = (await request.json()) as Omit<
+					Product,
+					"created_at" | "updated_at"
+				>;
+				const product = await createProduct(env, ctx, body);
+				return Response.json(product, { status: 201 });
+			}
+
+			// Update product: PATCH /products/:id
+			const updateMatch = url.pathname.match(/^\/products\/([^/]+)$/);
+			if (updateMatch && request.method === "PATCH") {
+				const id = updateMatch[1];
+				const patch = (await request.json()) as Partial<
+					Pick<Product, "name" | "summary" | "price">
+				>;
+				const product = await updateProduct(env, ctx, id, patch);
+				if (!product) {
+					return Response.json({ error: "Not found" }, { status: 404 });
+				}
+				return Response.json(product);
+			}
+
+			// Delete product: DELETE /products/:id
+			const deleteMatch = url.pathname.match(/^\/products\/([^/]+)$/);
+			if (deleteMatch && request.method === "DELETE") {
+				const id = deleteMatch[1];
+				const deleted = await deleteProduct(env, ctx, id);
+				if (!deleted) {
+					return Response.json({ error: "Not found" }, { status: 404 });
+				}
+				return new Response(null, { status: 204 });
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Unknown error";
+			return Response.json({ error: message }, { status: 500 });
+		}
+
+		return new Response("Not found", { status: 404 });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+## How it works
+
+1. **D1 is the source of truth.** All reads and structured queries go to D1. AI Search is only queried for semantic search.
+2. **R2 mirrors the text, not the row.** The R2 file contains the natural language content -- name, category, description -- that AI Search embeds and retrieves. Structured fields like price and timestamps stay in D1.
+3. **Folder structure encodes category.** The key `{category}/{id}.md` lets AI Search filter by category using a folder filter -- no custom metadata required.
+4. **Search results are enriched from D1.** AI Search returns keys and text excerpts. The full product record (price, timestamps) is fetched from D1 in a single `IN` query.
+5. **`waitUntil` keeps responses fast.** The R2 mirror write runs after the HTTP response is sent. If it fails, the D1 row is unaffected and the search index will be slightly stale until the next write or a manual sync.
+
+## Indexing timing
+
+After writing a row to R2, there is a delay before it becomes searchable via AI Search:
+
+- **Automatic indexing**: AI Search indexes files in R2 when the instance is created and periodically after that. New files are picked up on the next indexing cycle.
+- **Manual sync**: Go to the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/ai/ai-search), select your AI Search instance, and select **Sync Index** for immediate indexing.
+
+## Related resources
+
+- [D1 documentation](/d1/)
+- [R2 data source configuration](/ai-search/configuration/data-source/r2/)
+- [Path filtering](/ai-search/configuration/indexing/path-filtering/)
+- [Full-stack app with AI Search](/ai-search/tutorials/full-stack-app-with-search/) for a more complete application pattern with KV buffering and Service Bindings
+- [Ingest external content into AI Search](/ai-search/how-to/ingest-external-content/)


### PR DESCRIPTION
## Summary

- Updates the existing simple search engine how-to with improved examples and correct API usage
- Adds two new how-to guides: ingest external content into AI Search, and use AI Search as an agent tool
- Adds a tutorials section with 6 new tutorials: ecommerce product search, agentic deep research, image semantic search, persistent memory for agents, full-stack app with AI Search, and search over D1
- All code examples use the canonical `env.AI.autorag()` binding, correct response shape (`data[].filename/score/content`), and documented filter syntax

## Commits

Each commit is one page

1. `update simple search engine how-to`
2. `add ingest external content how-to`
3. `add use AI Search as agent tool how-to`
4. `add tutorials section index`
5. `add ecommerce product search tutorial`
6. `add agentic deep research tutorial`
7. `add image semantic search tutorial`
8. `add persistent memory for agents tutorial`
9. `add full-stack app with AI Search tutorial`
10. `add search over D1 tutorial`

## Notes

- No existing pages were deleted or broken
- All pages pass `npm run check` (0 errors)
- Only `folder`, `filename`, and `timestamp` are used as filter attributes