### PR TITLE
Remove note on presigned URL support for s3mini

### DIFF
--- a/src/content/docs/r2/examples/aws/s3mini.mdx
+++ b/src/content/docs/r2/examples/aws/s3mini.mdx
@@ -13,10 +13,6 @@ import { Render } from "~/components";
 
 Unlike the AWS SDKs, s3mini expects a **bucket-scoped endpoint** — the bucket name is part of the endpoint URL, so you do not pass a separate `bucket` parameter to each operation.
 
-:::note
-s3mini does not support presigned URL generation. If you need presigned URLs, refer to the [aws-sdk-js-v3](/r2/examples/aws/aws-sdk-js-v3/#generate-presigned-urls) or [aws4fetch](/r2/examples/aws/aws4fetch/#generate-presigned-urls) examples instead.
-:::
-
 ## Install
 
 ```sh


### PR DESCRIPTION
Removed note about presigned URL generation limitations. New version o s3mini 0.9.2 supports presigned URL generation.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
