### PR TITLE
fix OHTTP hostname and path 

### DIFF
--- a/src/content/docs/privacy-gateway/get-started.mdx
+++ b/src/content/docs/privacy-gateway/get-started.mdx
@@ -73,5 +73,5 @@ Before sending any requests, you need to first set up your account with Cloudfla
 Then, make sure you are forwarding requests to a mutually agreed URL with the following conventions.
 
 ```txt
-https://<APPLICATION_NAME>.privacy-gateway.cloudflare.com/
+https://privacy-relay.cloudflare.com/<GATEWAY_SERVER_NAME>
 ```


### PR DESCRIPTION
### Summary

change OHTTP hostname from `https://<APPLICATION_NAME>.privacy-gateway.cloudflare.com/` to `https://privacy-relay.cloudflare.com/<GATEWAY_SERVER_NAME>`
