### PR TITLE
Disable auto-formatter in OpenCode.

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,6 +1,15 @@
 {
 	"$schema": "https://opencode.ai/config.json",
 	"permission": "allow",
+
+	// OpenCode tries to auto-run prettier whenever the agent makes an edit, but it seems to run it
+	// in the wrong mode, formatting mdx files as if they were jsx files, causing breaking changes
+	// to the formatting, like adding newlines inside `<code>` elements that actually get rendered
+	// as line breaks. This has caused actual broken formatting in production because people don't
+	// notice it happening. Let's disable it. When you run prettier manually (not through OpenCode),
+	// it doesn't cause problems.
+	"formatter": false,
+
 	"experimental": {
 		"continue_loop_on_deny": true,
 	},


### PR DESCRIPTION
OpenCode tries to "helpfully" run prettier after every change an agent makes.

But somehow it does it in a way that actually breaks formatting.

Here is where OpenCode actually broke the formatting of a page: https://github.com/cloudflare/cloudflare-docs/pull/28343#discussion_r2976024973

That change got merged and the formatting on that page remains broken today, a month later. Nobody noticed.

Running `prettier` by hand does not cause this. It's only when OpenCode runs it, for some reason.

This change disables the feature entirely because it is causing much more harm than good.