### PR TITLE
[ZT] WARP Client --> Cloudflare One Client in changelog

### DIFF
--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -36,18 +36,20 @@ async function getWARPReleases(): Promise<Array<CollectionEntry<"changelog">>> {
 		return true;
 	});
 
+	// Versions up to and including 2026.3.566.1 render as "WARP client";
+	// newer versions render as "Cloudflare One Client".
+	const isLegacyVersion = (ver: string): boolean => {
+		const legacyThreshold = [2026, 3, 566, 1];
+		const parts = ver.split(".").map(Number);
+		for (let i = 0; i < legacyThreshold.length; i++) {
+			if ((parts[i] ?? 0) < legacyThreshold[i]) return true;
+			if ((parts[i] ?? 0) > legacyThreshold[i]) return false;
+		}
+		return true;
+	};
+
 	return releases.map((release) => {
 		const { platformName, version, releaseNotes, releaseDate } = release.data;
-
-		const isLegacyVersion = (ver: string): boolean => {
-			const legacyThreshold = [2026, 3, 566, 1];
-			const parts = ver.split(".").map(Number);
-			for (let i = 0; i < legacyThreshold.length; i++) {
-				if ((parts[i] ?? 0) < legacyThreshold[i]) return true;
-				if ((parts[i] ?? 0) > legacyThreshold[i]) return false;
-			}
-			return true;
-		};
 
 		const clientName = isLegacyVersion(version)
 			? "WARP client"

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -49,7 +49,9 @@ async function getWARPReleases(): Promise<Array<CollectionEntry<"changelog">>> {
 			return true;
 		};
 
-		const clientName = isLegacyVersion(version) ? "WARP client" : "Cloudflare One Client";
+		const clientName = isLegacyVersion(version)
+			? "WARP client"
+			: "Cloudflare One Client";
 		const title = `${clientName} for ${platformName} (version ${version})`;
 
 		const [platform, track] = release.id.split("/");

--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -38,7 +38,19 @@ async function getWARPReleases(): Promise<Array<CollectionEntry<"changelog">>> {
 
 	return releases.map((release) => {
 		const { platformName, version, releaseNotes, releaseDate } = release.data;
-		const title = `WARP client for ${platformName} (version ${version})`;
+
+		const isLegacyVersion = (ver: string): boolean => {
+			const legacyThreshold = [2026, 3, 566, 1];
+			const parts = ver.split(".").map(Number);
+			for (let i = 0; i < legacyThreshold.length; i++) {
+				if ((parts[i] ?? 0) < legacyThreshold[i]) return true;
+				if ((parts[i] ?? 0) > legacyThreshold[i]) return false;
+			}
+			return true;
+		};
+
+		const clientName = isLegacyVersion(version) ? "WARP client" : "Cloudflare One Client";
+		const title = `${clientName} for ${platformName} (version ${version})`;
 
 		const [platform, track] = release.id.split("/");
 
@@ -53,7 +65,7 @@ async function getWARPReleases(): Promise<Array<CollectionEntry<"changelog">>> {
 				? "[stable releases downloads page](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/)"
 				: "[beta releases downloads page](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/beta-releases/)";
 
-		const prefix = `A new ${prettyTrack} release for the ${prettyPlatform} WARP client is now available on the ${link}.`;
+		const prefix = `A new ${prettyTrack} release for the ${prettyPlatform} ${clientName} is now available on the ${link}.`;
 
 		return {
 			id: `${releaseDate.toISOString().slice(0, 10)}-warp-${platform}-${track}`,


### PR DESCRIPTION
Render [changelog ](https://developers.cloudflare.com/cloudflare-one/changelog/cloudflare-one-client/)title and prefix based on client version #. Old entries remain "WARP client". Newer entries (starting with the next GA) will use "Cloudflare One Client".

Example from test environment:
<img width="736" height="175" alt="image" src="https://github.com/user-attachments/assets/91c1ad48-ed93-46f1-a63b-715ef603923f" />

<img width="736" height="175" alt="image" src="https://github.com/user-attachments/assets/17d227b8-53cb-4411-b321-f2e469492bea" />

