### PR TITLE
Handle index.md redirects to preserve markdown format

### DIFF
--- a/src/pages/[...product]/llms.txt.ts
+++ b/src/pages/[...product]/llms.txt.ts
@@ -1,6 +1,7 @@
 import type { APIRoute, GetStaticPaths, InferGetStaticPropsType } from "astro";
 import { getCollection } from "astro:content";
 import dedent from "dedent";
+import { isExternalRedirect, resolveRedirect } from "~/util/redirects";
 import { isDisallowedByRobots } from "~/util/robots";
 
 /**
@@ -56,7 +57,8 @@ export const getStaticPaths = (async () => {
 				(e) =>
 					(e.id.startsWith(prefix + "/") || e.id === prefix) &&
 					!isDirectoryOnlyPage(e.body ?? "") &&
-					!isDisallowedByRobots(`/${e.id}/`),
+					!isDisallowedByRobots(`/${e.id}/`) &&
+					!isExternalRedirect(`/${e.id}/`),
 			);
 
 			if (pages.length === 0) return null;
@@ -74,7 +76,8 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 type Page = InferGetStaticPropsType<typeof getStaticPaths>["pages"][number];
 
 function formatPage(base: string, e: Page) {
-	const line = `- [${e.data.title}](${base}/${e.id}/index.md)`;
+	const resolved = resolveRedirect(`/${e.id}/`);
+	const line = `- [${e.data.title}](${base}${resolved}index.md)`;
 	return e.data.description ? line.concat(`: ${e.data.description}`) : line;
 }
 
@@ -145,9 +148,10 @@ export const GET: APIRoute<Props> = async ({ props, url }) => {
 
 	const prefix = productUrl.slice(1, -1);
 	const rootPage = pages.find((e) => e.id === prefix);
+	const resolvedProductUrl = resolveRedirect(productUrl);
 	const rootLink = rootPage
 		? formatPage(base, rootPage)
-		: `- [${title}](${base}${productUrl}index.md)`;
+		: `- [${title}](${base}${resolvedProductUrl}index.md)`;
 
 	const sections = buildSections(prefix, pages);
 

--- a/src/util/redirects.ts
+++ b/src/util/redirects.ts
@@ -52,6 +52,10 @@ function parseRedirects(): {
 // Evaluated once at build time.
 const { staticRules, dynamicRules } = parseRedirects();
 
+function isExternalUrl(url: string): boolean {
+	return url.startsWith("http://") || url.startsWith("https://");
+}
+
 /** Maximum number of redirect hops to follow when resolving chains. */
 const MAX_HOPS = 10;
 
@@ -74,10 +78,7 @@ export function resolveRedirect(urlPath: string): string {
 		// Static lookup
 		const staticDest = staticRules.get(current);
 		if (staticDest) {
-			if (
-				staticDest.startsWith("http://") ||
-				staticDest.startsWith("https://")
-			) {
+			if (isExternalUrl(staticDest)) {
 				return staticDest;
 			}
 			current = staticDest;
@@ -91,7 +92,7 @@ export function resolveRedirect(urlPath: string): string {
 			if (m) {
 				const splat = m.groups?.splat ?? "";
 				const resolved = rule.dest.replace(":splat", splat);
-				if (resolved.startsWith("http://") || resolved.startsWith("https://")) {
+				if (isExternalUrl(resolved)) {
 					return resolved;
 				}
 				current = resolved;
@@ -111,6 +112,5 @@ export function resolveRedirect(urlPath: string): string {
  * `__redirects` (i.e. the final destination starts with `http://` or `https://`).
  */
 export function isExternalRedirect(urlPath: string): boolean {
-	const resolved = resolveRedirect(urlPath);
-	return resolved.startsWith("http://") || resolved.startsWith("https://");
+	return isExternalUrl(resolveRedirect(urlPath));
 }

--- a/src/util/redirects.ts
+++ b/src/util/redirects.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface DynamicRule {
+	regex: RegExp;
+	dest: string;
+}
+
+/**
+ * Parses `public/__redirects` and returns static (exact-match) and dynamic
+ * (splat/wildcard) redirect rules.
+ *
+ * Static rules are stored in a Map for O(1) lookup. Dynamic rules are stored
+ * as an ordered array of { regex, dest } objects, evaluated in file order.
+ */
+function parseRedirects(): {
+	staticRules: Map<string, string>;
+	dynamicRules: DynamicRule[];
+} {
+	const raw = readFileSync(
+		join(process.cwd(), "public", "__redirects"),
+		"utf-8",
+	);
+
+	const staticRules = new Map<string, string>();
+	const dynamicRules: DynamicRule[] = [];
+
+	for (const rawLine of raw.split("\n")) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#")) continue;
+
+		const parts = line.split(/\s+/);
+		if (parts.length < 2) continue;
+
+		const [source, dest] = parts;
+
+		if (source.includes("*")) {
+			// Convert splat pattern to regex: /foo/* → ^\/foo\/(?<splat>.*)$
+			const escaped = source
+				.split("*")
+				.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+				.join("(?<splat>.*)");
+			dynamicRules.push({ regex: new RegExp("^" + escaped + "$"), dest });
+		} else {
+			staticRules.set(source, dest);
+		}
+	}
+
+	return { staticRules, dynamicRules };
+}
+
+// Evaluated once at build time.
+const { staticRules, dynamicRules } = parseRedirects();
+
+/** Maximum number of redirect hops to follow when resolving chains. */
+const MAX_HOPS = 10;
+
+/**
+ * Resolves a URL path through `__redirects`, following redirect chains up to
+ * {@link MAX_HOPS} hops. Returns the final destination path.
+ *
+ * - Static (exact-match) rules are checked first.
+ * - Dynamic (splat) rules are checked in file order if no static match.
+ * - External destinations (starting with `http://` or `https://`) are
+ *   returned as-is — callers should check for this.
+ *
+ * @param urlPath - An absolute URL path starting with `/`, e.g. `/learning-paths/`.
+ * @returns The resolved path, or the original path if no redirect applies.
+ */
+export function resolveRedirect(urlPath: string): string {
+	let current = urlPath;
+
+	for (let hop = 0; hop < MAX_HOPS; hop++) {
+		// Static lookup
+		const staticDest = staticRules.get(current);
+		if (staticDest) {
+			if (
+				staticDest.startsWith("http://") ||
+				staticDest.startsWith("https://")
+			) {
+				return staticDest;
+			}
+			current = staticDest;
+			continue;
+		}
+
+		// Dynamic lookup
+		let matched = false;
+		for (const rule of dynamicRules) {
+			const m = current.match(rule.regex);
+			if (m) {
+				const splat = m.groups?.splat ?? "";
+				const resolved = rule.dest.replace(":splat", splat);
+				if (resolved.startsWith("http://") || resolved.startsWith("https://")) {
+					return resolved;
+				}
+				current = resolved;
+				matched = true;
+				break;
+			}
+		}
+
+		if (!matched) break;
+	}
+
+	return current;
+}
+
+/**
+ * Returns `true` if the given URL path resolves to an external URL through
+ * `__redirects` (i.e. the final destination starts with `http://` or `https://`).
+ */
+export function isExternalRedirect(urlPath: string): boolean {
+	const resolved = resolveRedirect(urlPath);
+	return resolved.startsWith("http://") || resolved.startsWith("https://");
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -8,6 +8,42 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 	maxDynamicRules: 2_000, // Usually 100
 });
 
+/**
+ * When a redirect response is returned for an index.md request, rewrite the
+ * Location header so the agent stays in Markdown land instead of landing on
+ * an HTML page.
+ *
+ * Only rewrites relative (same-origin) Location values — external redirects
+ * (e.g. to GitHub) are left untouched because appending index.md to a
+ * non-docs URL would be nonsensical.
+ */
+function rewriteRedirectForMarkdown(
+	redirect: Response,
+	requestUrl: URL,
+): Response {
+	const location = redirect.headers.get("Location");
+	if (!location) return redirect;
+
+	try {
+		const dest = new URL(location, requestUrl.origin);
+
+		// Only rewrite same-origin redirects that point to a docs path (trailing /)
+		if (dest.origin !== requestUrl.origin) return redirect;
+		if (!dest.pathname.endsWith("/")) return redirect;
+
+		dest.pathname += "index.md";
+
+		const headers = new Headers(redirect.headers);
+		headers.set("Location", dest.pathname + dest.search + dest.hash);
+		return new Response(redirect.body, {
+			status: redirect.status,
+			headers,
+		});
+	} catch {
+		return redirect;
+	}
+}
+
 export default class extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request) {
 		if (request.url.endsWith("/llms-full.txt")) {
@@ -21,11 +57,28 @@ export default class extends WorkerEntrypoint<Env> {
 			});
 		}
 
+		const url = new URL(request.url);
+		const isMarkdownRequest = url.pathname.endsWith("/index.md");
+
 		try {
 			try {
-				const redirect = await redirectsEvaluator(request, this.env.ASSETS);
+				// For index.md requests, evaluate redirects against the base path
+				// (without the index.md suffix) so that redirect rules written for
+				// the HTML path (e.g. /learning-paths/ → /resources/) still fire.
+				const evalRequest = isMarkdownRequest
+					? new Request(
+							url.origin +
+								url.pathname.slice(0, -"index.md".length) +
+								url.search,
+							request,
+						)
+					: request;
+
+				const redirect = await redirectsEvaluator(evalRequest, this.env.ASSETS);
 				if (redirect) {
-					return redirect;
+					return isMarkdownRequest
+						? rewriteRedirectForMarkdown(redirect, url)
+						: redirect;
 				}
 			} catch (error) {
 				console.error("Could not evaluate redirects", error);
@@ -41,7 +94,9 @@ export default class extends WorkerEntrypoint<Env> {
 					this.env.ASSETS,
 				);
 				if (redirect) {
-					return redirect;
+					return isMarkdownRequest
+						? rewriteRedirectForMarkdown(redirect, url)
+						: redirect;
 				}
 			} catch (error) {
 				console.error(

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -148,6 +148,24 @@ describe("Cloudflare Docs", () => {
 			const text = await response.text();
 			expect(text).toContain("# Cloudflare Developer Documentation");
 		});
+
+		it("index.md requests preserve markdown through redirects", async () => {
+			// /learning-paths/ redirects to /resources/ — an index.md request
+			// should redirect to /resources/index.md, not the HTML page.
+			const request = new Request("http://fakehost/learning-paths/index.md");
+			const response = await SELF.fetch(request, { redirect: "manual" });
+
+			expect(response.status).toBe(301);
+			expect(response.headers.get("Location")).toBe("/resources/index.md");
+		});
+
+		it("index.md requests for non-redirected paths pass through", async () => {
+			const request = new Request("http://fakehost/workers/index.md");
+			const response = await SELF.fetch(request);
+
+			// Should not be a redirect — just serve normally via ASSETS
+			expect(response.status).not.toBe(301);
+		});
 	});
 
 	describe("head tags", async () => {


### PR DESCRIPTION
## Problem

When an agent follows an `index.md` link from `llms.txt`, requests for pages with `__redirects` rules get a `301` to the HTML destination. The Cloudflare "Markdown for Agents" network rule never fires because the response is already a redirect, not HTML to convert.

11 URLs across all product `llms.txt` files are affected — 9 redirect to other docs pages (landing on HTML) and 2 redirect to external sites (langchain.com, GitHub).

| Listed in llms.txt | Redirects to | Type |
|---|---|---|
| `/bots/additional-configurations/javascript-detections/index.md` | `/cloudflare-challenges/challenge-types/javascript-detections/` | internal |
| `/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/regional-services-for-saas/index.md` | `/data-localization/regional-services/get-started/` | internal |
| `/cloudflare-for-platforms/workers-for-platforms/reference/metadata/index.md` | `/workers/configuration/multipart-upload-metadata/` | internal |
| `/containers/platform-details/index.md` | `/containers/platform-details/architecture/` | internal |
| `/learning-paths/index.md` | `/resources/` | internal |
| `/turnstile/troubleshooting/challenge-solve-issues/index.md` | `/cloudflare-challenges/troubleshooting/challenge-solve-issues/` | internal |
| `/vectorize/examples/langchain/index.md` | `https://js.langchain.com/...` | external |
| `/vectorize/examples/rag/index.md` | `/reference-architecture/diagrams/ai/ai-rag/` | internal |
| `/workers-ai/platform/storage-options/index.md` | `/workers/platform/storage-options/` | internal |
| `/workers/configuration/bindings/index.md` | `/workers/runtime-apis/bindings/` | internal |
| `/workers/platform/changelog/wrangler/index.md` | `https://github.com/cloudflare/workers-sdk/releases` | external |

## Fix

Two complementary changes:

### 1. Build-time: resolve redirects in `llms.txt` generation

New `src/util/redirects.ts` parses `public/__redirects` at build time and exposes `resolveRedirect()` and `isExternalRedirect()`.

`src/pages/[...product]/llms.txt.ts` now:
- **Resolves internal redirects** — `formatPage` emits the canonical destination URL directly (e.g. `/workers/platform/storage-options/index.md` instead of `/workers-ai/platform/storage-options/index.md`), eliminating the redirect round-trip
- **Excludes external redirects** — pages like `/vectorize/examples/langchain/` (→ langchain.com) and `/workers/platform/changelog/wrangler/` (→ GitHub) are dropped from `llms.txt` entirely since there is no valid `index.md` to serve

### 2. Runtime: worker rewrites redirect `Location` for `index.md` requests

For any `index.md` request that hits a redirect, the worker strips the `index.md` suffix before evaluating `__redirects`, then appends `index.md` to the redirect destination. This is a safety net for redirects added between builds, shared URLs, and `Accept: text/markdown` requests.

External (cross-origin) redirect destinations are left untouched.