### PR TITLE
Update Astro Cloudflare integration command

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-an-astro-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-an-astro-site.mdx
@@ -47,7 +47,7 @@ You can deploy an Astro Server-side Rendered (SSR) site to Cloudflare Pages usin
 Add the [`@astrojs/cloudflare` adapter](https://github.com/withastro/adapters/tree/main/packages/cloudflare#readme) to your project's `package.json` by running:
 
 ```sh
-npm run astro add cloudflare
+npx astro add cloudflare
 ```
 
 <Render file="tutorials-before-you-start" product="pages" />


### PR DESCRIPTION

### Summary

Corrected the Astro Cloudflare integration command in the documentation by replacing `npm run astro add cloudflare` with `npx astro add cloudflare`. This update aligns with Astro’s recommended usage and ensures the command functions without requiring a predefined npm script.

