### PR TITLE
[WAF] Sunset old rate limiting rules

### DIFF
--- a/src/content/docs/waf/concepts.mdx
+++ b/src/content/docs/waf/concepts.mdx
@@ -69,7 +69,7 @@ Cloudflare evaluates different types of rules when processing incoming requests.
 3. [Custom rules](/waf/custom-rules/)
 4. [Rate limiting rules](/waf/rate-limiting-rules/)
 5. [Managed Rules](/waf/managed-rules/)
-6. [Cloudflare Rate Limiting](/waf/reference/legacy/old-rate-limiting/) (previous version, deprecated)
+6. [Cloudflare Rate Limiting](/waf/reference/legacy/old-rate-limiting/) (previous version, no longer available)
 
 Rules are evaluated in order. If there is a match for a rule with a [terminating action](/ruleset-engine/rules-language/actions/), the rule evaluation will stop and the action will be executed immediately. Rules with a non-terminating action (such as _Log_) will not prevent subsequent rules from being evaluated and executed. For more information on how rules are evaluated, refer to [Rule evaluation](/ruleset-engine/about/rules/#rule-evaluation) in the Ruleset Engine documentation.
 

--- a/src/content/docs/waf/rate-limiting-rules/index.mdx
+++ b/src/content/docs/waf/rate-limiting-rules/index.mdx
@@ -59,4 +59,4 @@ For Terraform examples, refer to [Rate limiting rules configuration using Terraf
 
 - [Learning Center: What is rate limiting?](https://www.cloudflare.com/learning/bots/what-is-rate-limiting/)
 
-- [Cloudflare Rate Limiting (previous version, now deprecated)](/waf/reference/legacy/old-rate-limiting/): Documentation for the previous version of rate limiting rules (billed based on usage).
+- [Cloudflare Rate Limiting (previous version, no longer available)](/waf/reference/legacy/old-rate-limiting/): Documentation for the previous version of rate limiting rules (billed based on usage).

--- a/src/content/docs/waf/reference/legacy/old-rate-limiting/index.mdx
+++ b/src/content/docs/waf/reference/legacy/old-rate-limiting/index.mdx
@@ -13,9 +13,9 @@ Cloudflare Rate Limiting automatically identifies and mitigates excessive reques
 
 :::caution
 
-The information in this page refers to the previous version of rate limiting rules, which are billed based on usage.
+The information in this page refers to the previous version of rate limiting rules, which was billed based on usage and is no longer available.
 
-Cloudflare is upgrading all rate limiting rules to the [new version of rate limiting rules](/waf/rate-limiting-rules/). For more information on what changed in the new version, refer to [Rate limiting (previous version) upgrade](/waf/reference/legacy/old-rate-limiting/upgrade/).
+Cloudflare has upgraded all rate limiting rules to the [new version of rate limiting rules](/waf/rate-limiting-rules/). For more information on what changed in the new version, refer to [Rate limiting (previous version) upgrade](/waf/reference/legacy/old-rate-limiting/upgrade/).
 
 :::
 

--- a/src/content/docs/waf/reference/legacy/old-rate-limiting/upgrade.mdx
+++ b/src/content/docs/waf/reference/legacy/old-rate-limiting/upgrade.mdx
@@ -10,15 +10,15 @@ head:
 description: Guide on upgrading rate limiting rules from the previous version to the new version.
 ---
 
-Cloudflare is upgrading all rate limiting rules created in the [previous version](/waf/reference/legacy/old-rate-limiting/) to the [new version of rate limiting rules](/waf/rate-limiting-rules/).
+Cloudflare has upgraded all rate limiting rules created in the [previous version](/waf/reference/legacy/old-rate-limiting/) to the [new version of rate limiting rules](/waf/rate-limiting-rules/).
 
-The Cloudflare dashboard will now show all your rate limiting rules in a single list.
+The Cloudflare dashboard now shows all your rate limiting rules in a single list.
 
-:::caution[Deprecation notice]
+:::caution[Sunset notice]
 
-**The [Rate Limiting API](/api/resources/rate_limits/) and the [`cloudflare_rate_limit`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/rate_limit) Terraform resource for the previous version of rate limiting rules are now deprecated.**
+**The [Rate Limiting API](/api/resources/rate_limits/) and the [`cloudflare_rate_limit`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/rate_limit) Terraform resource for the previous version of rate limiting rules stopped being supported on 2025-06-15 and are no longer available.**
 
-This API and Terraform resource are no longer supported since 2025-06-15. You must use the [Rulesets API](/ruleset-engine/rulesets-api/) and the [`cloudflare_ruleset`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) Terraform resource to configure rate limiting rules.
+You must now use the [Rulesets API](/ruleset-engine/rulesets-api/) and the [`cloudflare_ruleset`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) Terraform resource to configure rate limiting rules.
 
 :::
 


### PR DESCRIPTION
### Summary

The Rate Limiting upgrade from the previous version has finished. The API is no longer available.
Minimal changes for now; will make bigger changes later.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
