### PR TITLE
Privacy Proxy Metrics

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -3,6 +3,9 @@
 # STATIC REDIRECTS
 # ============================================================================
 
+# Privacy Proxy
+/privacy-proxy/reference/observability/ /privacy-proxy/reference/metrics/opentelemetry/ 301
+
 # homepage
 /docs/ /directory/ 301
 /support/ai/ / 301

--- a/src/content/docs/privacy-proxy/get-started.mdx
+++ b/src/content/docs/privacy-proxy/get-started.mdx
@@ -106,4 +106,4 @@ The response should show a `loc` value corresponding to the geohash region.
 
 - Learn about [deployment models](/privacy-proxy/concepts/deployment-models/) to understand single-hop versus double-hop architectures.
 - Review [authentication methods](/privacy-proxy/concepts/authentication/) for production deployments using Privacy Pass.
-- Configure [observability](/privacy-proxy/reference/observability/) to monitor proxy traffic with OpenTelemetry.
+- Configure [observability](/privacy-proxy/reference/metrics/) to monitor proxy traffic with GraphQL Analytics and OpenTelemetry.

--- a/src/content/docs/privacy-proxy/reference/client-libraries.mdx
+++ b/src/content/docs/privacy-proxy/reference/client-libraries.mdx
@@ -2,7 +2,7 @@
 title: Client libraries
 pcx_content_type: reference
 sidebar:
-  order: 3
+  order: 5
 ---
 
 This page lists open source libraries and tools you can use to connect to Privacy Proxy.

--- a/src/content/docs/privacy-proxy/reference/http-headers.mdx
+++ b/src/content/docs/privacy-proxy/reference/http-headers.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-This page documents the HTTP headers used by Privacy Proxy for authentication, geolocation, and observability.
+This page documents the HTTP headers used by Privacy Proxy for authentication, geolocation, and observability. For full observability details, refer to [GraphQL Analytics API](/privacy-proxy/reference/metrics/graphql/) and [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/).
 
 ## Request headers
 
@@ -31,6 +31,10 @@ Proxy-Authorization: PrivateToken token=<base64-encoded-token>
 | ----------- | ------------- |
 | `<key>` | The pre-shared key provided by Cloudflare |
 | `<base64-encoded-token>` | A base64-encoded Privacy Pass token |
+
+### GraphQL Analytics API request headers
+
+When querying Privacy Proxy metrics via the GraphQL Analytics API, send a `POST` request to `https://api.cloudflare.com/client/v4/graphql`. For required headers and authentication details, refer to [GraphQL Analytics API](/privacy-proxy/reference/metrics/graphql/).
 
 ### `sec-ch-geohash`
 
@@ -59,7 +63,7 @@ Privacy Proxy includes the following headers in responses.
 
 ### `Server-Timing`
 
-Provides timing information about proxy processing. Use this to measure latency introduced by the proxy.
+Provides timing information about proxy processing. Use this as a client-side latency signal to measure the processing time introduced by the proxy. This is part of the [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/) observability pipeline.
 
 ```http
 Server-Timing: proxy;dur=<milliseconds>
@@ -67,11 +71,15 @@ Server-Timing: proxy;dur=<milliseconds>
 
 | Parameter | Description |
 | ----------- | ------------- |
-| `<milliseconds>` | Processing time in milliseconds |
+| `<milliseconds>` | Processing time in milliseconds introduced by the proxy |
 
 ```http title="Example"
 Server-Timing: proxy;dur=8.2
 ```
+
+### GraphQL Analytics API response headers
+
+For response headers returned by the GraphQL API, refer to [GraphQL Analytics API](/privacy-proxy/reference/metrics/graphql/).
 
 ---
 

--- a/src/content/docs/privacy-proxy/reference/http-headers.mdx
+++ b/src/content/docs/privacy-proxy/reference/http-headers.mdx
@@ -63,7 +63,7 @@ Privacy Proxy includes the following headers in responses.
 
 ### `Server-Timing`
 
-Provides timing information about proxy processing. Use this as a client-side latency signal to measure the processing time introduced by the proxy. This is part of the [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/) observability pipeline.
+Provides timing information about proxy processing. This is part of the [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/) observability pipeline.
 
 ```http
 Server-Timing: proxy;dur=<milliseconds>

--- a/src/content/docs/privacy-proxy/reference/metrics.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics.mdx
@@ -1,0 +1,788 @@
+---
+title: Metrics and analytics
+pcx_content_type: reference
+sidebar:
+  order: 2
+---
+
+import { Details, MetaInfo } from "~/components";
+
+Privacy Proxy exposes metrics through Cloudflare's [GraphQL Analytics API](/analytics/graphql-api/). All metrics are queryable through a single endpoint:
+
+```txt
+POST https://api.cloudflare.com/client/v4/graphql
+```
+
+To access your metrics, you need a Cloudflare API token with **Analytics Read** permissions. Refer to [Create an API token](/fundamentals/api/get-started/create-token/) for authentication details.
+
+---
+
+## Making a request
+
+The following example shows a complete request with authentication headers and variables. Replace the placeholder values with your own.
+
+```bash
+curl https://api.cloudflare.com/client/v4/graphql \
+  --header "Authorization: Bearer <API_TOKEN>" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "query": "query DailyRequestVolume($accountTag: String!, $startDate: Date!, $endDate: Date!) { viewer { accounts(filter: { accountTag: $accountTag }) { privacyProxyRequestMetricsAdaptiveGroups(filter: { date_geq: $startDate, date_leq: $endDate }, limit: 10000, orderBy: [date_ASC]) { sum { requests } dimensions { date datetimeHour } } } } }",
+    "variables": {
+      "accountTag": "<YOUR_ACCOUNT_TAG>",
+      "startDate": "2025-01-01",
+      "endDate": "2025-01-31"
+    }
+  }'
+```
+
+---
+
+## Available nodes
+
+Four GraphQL nodes are available. All four return aggregate data only — no raw per-connection records are exposed.
+
+1. `privacyProxyRequestMetricsAdaptiveGroups` — Query aggregate request volume, CONNECT request handling and tunnel setup latency percentiles (P50/P95/P99), filterable by time, location, endpoint, status code, proxy status, and tunnel type dimensions.
+2. `privacyProxyIngressConnMetricsAdaptiveGroups` — Query aggregate client-to-proxy connection volume, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, transport protocol, and TLS version dimensions.
+3. `privacyProxyEgressConnMetricsAdaptiveGroups` — Query aggregate proxy-to-origin connection volume, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, and transport protocol dimensions.
+4. `privacyProxyAuthMetricsAdaptiveGroups` — Query aggregate authentication attempt volume, filterable by time, location, endpoint, authentication method, and authentication result dimensions.
+
+:::note[Adaptive sampling]
+Each node uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudflare automatically scales the sampling rate based on traffic volume to keep query performance consistent. All returned values are extrapolated totals, not raw counts. Because each node has its own sampling rate, figures across nodes are not directly comparable.
+:::
+
+---
+
+## Metrics
+
+<Details header="Sum fields">
+
+- `requests` – `uint64` — Total number of proxy requests processed. _(Request node)_
+- `connections` – `uint64` — Total number of connections established. _(Ingress and egress connection nodes)_
+- `bytesSentToClient` – `uint64` — Total bytes sent from the proxy back to the client. _(Ingress connection node)_
+- `bytesReceivedFromClient` – `uint64` — Total bytes received by the proxy from the client. _(Ingress connection node)_
+- `bytesSentToOrigin` – `uint64` — Total bytes sent from the proxy to the upstream origin. _(Egress connection node)_
+- `bytesReceivedFromOrigin` – `uint64` — Total bytes received by the proxy from the upstream origin. _(Egress connection node)_
+- `authAttempts` – `uint64` — Total number of authentication attempts. _(Auth node)_
+
+</Details>
+
+<Details header="Quantile fields">
+
+- `connectRequestHandlingDurationUsP50` – `float64` — Median time to handle a CONNECT request, in microseconds. _(Request node)_
+- `connectRequestHandlingDurationUsP95` – `float64` — 95th percentile time to handle a CONNECT request, in microseconds. _(Request node)_
+- `connectRequestHandlingDurationUsP99` – `float64` — 99th percentile time to handle a CONNECT request, in microseconds. _(Request node)_
+- `connectTunnelSetupDurationUsP50` – `float64` — Median time to establish a tunnel after receiving a CONNECT request, in microseconds. _(Request node)_
+- `connectTunnelSetupDurationUsP95` – `float64` — 95th percentile tunnel setup time, in microseconds. _(Request node)_
+- `connectTunnelSetupDurationUsP99` – `float64` — 99th percentile tunnel setup time, in microseconds. _(Request node)_
+- `clientProxyConnectionDurationMsP50` – `float64` — Median client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
+- `clientProxyConnectionDurationMsP95` – `float64` — 95th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
+- `clientProxyConnectionDurationMsP99` – `float64` — 99th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
+- `clientProxyRttMsP50` – `float64` — Median round-trip time between client and proxy, in milliseconds. _(Ingress connection node)_
+- `clientProxyRttMsP95` – `float64` — 95th percentile RTT between client and proxy, in milliseconds. _(Ingress connection node)_
+- `clientProxyRttMsP99` – `float64` — 99th percentile RTT between client and proxy, in milliseconds. _(Ingress connection node)_
+- `proxyOriginConnectionDurationMsP50` – `float64` — Median proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
+- `proxyOriginConnectionDurationMsP95` – `float64` — 95th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
+- `proxyOriginConnectionDurationMsP99` – `float64` — 99th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
+- `proxyOriginRttMsP50` – `float64` — Median round-trip time between proxy and origin, in milliseconds. _(Egress connection node)_
+- `proxyOriginRttMsP95` – `float64` — 95th percentile RTT between proxy and origin, in milliseconds. _(Egress connection node)_
+- `proxyOriginRttMsP99` – `float64` — 99th percentile RTT between proxy and origin, in milliseconds. _(Egress connection node)_
+
+</Details>
+
+---
+
+## Dimensions
+
+<Details header="All nodes">
+
+- `date` – `Date` — Calendar date (day granularity).
+- `datetimeMinute` – `Time` — Timestamp truncated to the minute.
+- `datetimeFiveMinutes` – `Time` — Timestamp truncated to five-minute intervals.
+- `datetimeFifteenMinutes` – `Time` — Timestamp truncated to fifteen-minute intervals.
+- `datetimeHour` – `Time` — Timestamp truncated to the hour.
+- `colo` – `string` — Cloudflare data center that handled the request.
+- `endpoint` – `string` — The appId that generated traffic.
+
+</Details>
+
+<Details header="Request node only">
+
+- `statusCode` – `uint16` — HTTP status code returned by the proxy to the client.
+- `proxyStatus` – `string` — Proxy-level error classification. Refer to [proxy status reference](#proxy-status-reference) for possible values.
+- `tunnelType` – `string` — Tunnel protocol used (`connect-tcp`, `connect-udp`, `connect-ip`).
+
+</Details>
+
+<Details header="Ingress connection node only">
+
+- `ingressTransport` – `string` — Transport protocol on the client-to-proxy connection (`tcp`, `quic`).
+- `tlsVersion` – `string` — TLS version negotiated on the client-to-proxy connection.
+
+</Details>
+
+<Details header="Egress connection node only">
+
+- `egressTransport` – `string` — Transport protocol on the proxy-to-origin connection.
+
+</Details>
+
+<Details header="Auth node only">
+
+- `authMethod` – `string` — Authentication method used (for example, `token_hash`, `mtls`, `blind_rsa`).
+- `authResult` – `string` — Authentication outcome (`success`, `failure`).
+
+</Details>
+
+---
+
+## Arguments
+
+<Details header="Arguments">
+
+All four nodes share the same argument signature.
+
+- `filter` <MetaInfo text="required" /> — Filters your data. `accountTag` is always required inside the filter.
+- `limit` <MetaInfo text="required" /> — Maximum number of records to return.
+- `orderBy` <MetaInfo text="optional" /> — Sort order for results.
+
+</Details>
+
+---
+
+## Sample queries
+
+<Details header="privacyProxyRequestMetricsAdaptiveGroups">
+
+<Details header="Request volume overview">
+
+Get a high-level view of daily request volume over a date range.
+
+```graphql
+query DailyRequestVolume(
+  $accountTag: String!
+  $startDate: Date!
+  $endDate: Date!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyRequestMetricsAdaptiveGroups(
+        filter: {
+          date_geq: $startDate
+          date_leq: $endDate
+        }
+        limit: 10000
+        orderBy: [date_ASC]
+      ) {
+        sum {
+          requests
+        }
+        dimensions {
+          date
+          datetimeHour
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "startDate": "2025-01-01",
+  "endDate": "2025-01-31"
+}
+```
+
+</Details>
+
+<Details header="Error breakdown by status code and proxy status">
+
+Identify which HTTP status codes and proxy-level errors are occurring to pinpoint the source of failures.
+
+```graphql
+query ErrorBreakdown(
+  $accountTag: String!
+  $start: Time!
+  $end: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyRequestMetricsAdaptiveGroups(
+        filter: {
+          datetime_geq: $start
+          datetime_leq: $end
+          statusCode_geq: 400
+        }
+        limit: 10000
+        orderBy: [datetimeHour_ASC]
+      ) {
+        sum {
+          requests
+        }
+        dimensions {
+          datetimeHour
+          statusCode
+          proxyStatus
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "start": "2025-01-01T00:00:00Z",
+  "end": "2025-01-01T23:59:59Z"
+}
+```
+
+</Details>
+
+<Details header="Top proxy errors by frequency">
+
+Rank the most frequent proxy error types to prioritize investigation.
+
+```graphql
+query TopProxyErrors(
+  $accountTag: String!
+  $start: Time!
+  $end: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyRequestMetricsAdaptiveGroups(
+        filter: {
+          datetime_geq: $start
+          datetime_leq: $end
+          proxyStatus_neq: ""
+        }
+        limit: 10000
+        orderBy: [sum_requests_DESC]
+      ) {
+        sum {
+          requests
+        }
+        dimensions {
+          proxyStatus
+          statusCode
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "start": "2025-01-01T00:00:00Z",
+  "end": "2025-01-01T23:59:59Z"
+}
+```
+
+</Details>
+
+<Details header="Tunnel type distribution">
+
+Monitor the mix of `connect-tcp`, `connect-udp`, and `connect-ip` over time to understand how clients are connecting.
+
+```graphql
+query TunnelTypeDistribution(
+  $accountTag: String!
+  $startDate: Date!
+  $endDate: Date!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyRequestMetricsAdaptiveGroups(
+        filter: {
+          date_geq: $startDate
+          date_leq: $endDate
+        }
+        limit: 10000
+        orderBy: [datetimeHour_ASC]
+      ) {
+        sum {
+          requests
+        }
+        dimensions {
+          datetimeHour
+          tunnelType
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "startDate": "2025-01-01",
+  "endDate": "2025-01-31"
+}
+```
+
+</Details>
+
+</Details>
+
+<Details header="privacyProxyIngressConnMetricsAdaptiveGroups">
+
+<Details header="Connection volume and ingress bytes overview">
+
+Get a high-level view of daily ingress connection count and bytes transferred.
+
+```graphql
+query IngressTrafficOverview(
+  $accountTag: String!
+  $startDate: Date!
+  $endDate: Date!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyIngressConnMetricsAdaptiveGroups(
+        filter: {
+          date_geq: $startDate
+          date_leq: $endDate
+        }
+        limit: 10000
+        orderBy: [date_ASC]
+      ) {
+        sum {
+          connections
+          bytesSentToClient
+          bytesReceivedFromClient
+        }
+        dimensions {
+          date
+          datetimeHour
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "startDate": "2025-01-01",
+  "endDate": "2025-01-31"
+}
+```
+
+</Details>
+
+<Details header="Connection duration by data center">
+
+Compare client-to-proxy connection duration across data centers to identify regions with long-lived or stalled connections.
+
+```graphql
+query IngressDurationByColo(
+  $accountTag: String!
+  $startDate: Date!
+  $endDate: Date!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyIngressConnMetricsAdaptiveGroups(
+        filter: {
+          date_geq: $startDate
+          date_leq: $endDate
+        }
+        limit: 10000
+        orderBy: [quantiles_clientProxyConnectionDurationMsP50_DESC]
+      ) {
+        quantiles {
+          clientProxyConnectionDurationMsP50
+          clientProxyConnectionDurationMsP95
+          clientProxyConnectionDurationMsP99
+        }
+        dimensions {
+          colo
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "startDate": "2025-01-01",
+  "endDate": "2025-01-31"
+}
+```
+
+</Details>
+
+<Details header="Protocol and TLS version distribution">
+
+Monitor the breakdown of QUIC versus TCP and TLS version adoption over time.
+
+```graphql
+query IngressProtocolDistribution(
+  $accountTag: String!
+  $start: Time!
+  $end: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyIngressConnMetricsAdaptiveGroups(
+        filter: {
+          datetime_geq: $start
+          datetime_leq: $end
+        }
+        limit: 10000
+        orderBy: [datetimeHour_ASC]
+      ) {
+        sum {
+          connections
+        }
+        dimensions {
+          datetimeHour
+          ingressTransport
+          tlsVersion
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "start": "2025-01-01T00:00:00Z",
+  "end": "2025-01-01T23:59:59Z"
+}
+```
+
+</Details>
+
+</Details>
+
+<Details header="privacyProxyEgressConnMetricsAdaptiveGroups">
+
+<Details header="Egress bytes overview">
+
+Get a high-level view of daily bytes flowing between the proxy and the upstream origin.
+
+```graphql
+query EgressBytesOverview(
+  $accountTag: String!
+  $startDate: Date!
+  $endDate: Date!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyEgressConnMetricsAdaptiveGroups(
+        filter: {
+          date_geq: $startDate
+          date_leq: $endDate
+        }
+        limit: 10000
+        orderBy: [date_ASC]
+      ) {
+        sum {
+          connections
+          bytesSentToOrigin
+          bytesReceivedFromOrigin
+        }
+        dimensions {
+          date
+          datetimeHour
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "startDate": "2025-01-01",
+  "endDate": "2025-01-31"
+}
+```
+
+</Details>
+
+<Details header="Proxy-to-origin RTT by data center">
+
+Compare proxy-to-origin round-trip times across data centers to identify regions with degraded origin reachability.
+
+```graphql
+query EgressRttByColo(
+  $accountTag: String!
+  $startDate: Date!
+  $endDate: Date!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyEgressConnMetricsAdaptiveGroups(
+        filter: {
+          date_geq: $startDate
+          date_leq: $endDate
+        }
+        limit: 10000
+        orderBy: [quantiles_proxyOriginRttMsP50_DESC]
+      ) {
+        quantiles {
+          proxyOriginRttMsP50
+          proxyOriginRttMsP95
+          proxyOriginRttMsP99
+        }
+        dimensions {
+          colo
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "startDate": "2025-01-01",
+  "endDate": "2025-01-31"
+}
+```
+
+</Details>
+
+<Details header="Egress performance trend">
+
+Track proxy-to-origin RTT at fine granularity during an active incident or maintenance window.
+
+```graphql
+query EgressPerformanceTrend(
+  $accountTag: String!
+  $start: Time!
+  $end: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyEgressConnMetricsAdaptiveGroups(
+        filter: {
+          datetime_geq: $start
+          datetime_leq: $end
+        }
+        limit: 10000
+        orderBy: [datetimeFiveMinutes_ASC]
+      ) {
+        quantiles {
+          proxyOriginRttMsP50
+          proxyOriginRttMsP99
+        }
+        sum {
+          connections
+        }
+        dimensions {
+          datetimeFiveMinutes
+          datetimeHour
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "start": "2025-01-01T08:00:00Z",
+  "end": "2025-01-01T14:00:00Z"
+}
+```
+
+</Details>
+
+</Details>
+
+<Details header="privacyProxyAuthMetricsAdaptiveGroups">
+
+<Details header="Auth volume by method">
+
+Track daily authentication volume per method to understand adoption and spot anomalies.
+
+```graphql
+query AuthVolumeByMethod(
+  $accountTag: String!
+  $startDate: Date!
+  $endDate: Date!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyAuthMetricsAdaptiveGroups(
+        filter: {
+          date_geq: $startDate
+          date_leq: $endDate
+        }
+        limit: 10000
+        orderBy: [date_ASC]
+      ) {
+        sum {
+          authAttempts
+        }
+        dimensions {
+          date
+          datetimeHour
+          authMethod
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "startDate": "2025-01-01",
+  "endDate": "2025-01-31"
+}
+```
+
+</Details>
+
+<Details header="Auth failure spike detection">
+
+Detect surges in authentication failures and identify which auth method is failing.
+
+```graphql
+query AuthFailureSpike(
+  $accountTag: String!
+  $start: Time!
+  $end: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyAuthMetricsAdaptiveGroups(
+        filter: {
+          datetime_geq: $start
+          datetime_leq: $end
+          authResult: "failure"
+        }
+        limit: 10000
+        orderBy: [datetimeFiveMinutes_ASC]
+      ) {
+        sum {
+          authAttempts
+        }
+        dimensions {
+          datetimeFiveMinutes
+          datetimeHour
+          authMethod
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "start": "2025-01-01T10:00:00Z",
+  "end": "2025-01-01T14:00:00Z"
+}
+```
+
+</Details>
+
+<Details header="Auth success rate">
+
+Compare hourly success versus failure counts to compute auth success rate and spot degradation trends.
+
+```graphql
+query AuthSuccessRate(
+  $accountTag: String!
+  $start: Time!
+  $end: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyAuthMetricsAdaptiveGroups(
+        filter: {
+          datetime_geq: $start
+          datetime_leq: $end
+        }
+        limit: 10000
+        orderBy: [datetimeHour_ASC]
+      ) {
+        sum {
+          authAttempts
+        }
+        dimensions {
+          datetimeHour
+          authResult
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "start": "2025-01-01T00:00:00Z",
+  "end": "2025-01-01T23:59:59Z"
+}
+```
+
+</Details>
+
+</Details>
+
+---
+
+## Proxy status reference
+
+<Details header="proxyStatus values">
+
+The `proxyStatus` dimension provides proxy-level error classification. The following values may appear:
+
+- `dns_error` — The proxy encountered a DNS error when resolving the next hop hostname.
+- `dns_timeout` — The proxy timed out while resolving the next hop hostname.
+- `destination_not_found` — The proxy cannot determine the appropriate next hop for this request.
+- `destination_unavailable` — The proxy considers the next hop unavailable (for example, recent failures or health check down).
+- `destination_ip_prohibited` — The proxy is configured to prohibit connections to the next hop IP address.
+- `destination_ip_unroutable` — The proxy cannot find a route to the next hop IP address.
+- `connection_refused` — The proxy's connection to the next hop was refused.
+- `connection_terminated` — The proxy's connection to the next hop was closed before any response was received.
+- `connection_timeout` — The proxy's attempt to open a connection to the next hop timed out.
+- `connection_read_timeout` — The proxy was expecting data on a connection but received none within the configured time limit.
+- `connection_write_timeout` — The proxy was attempting to write data to a connection but was unable to.
+- `connection_limit_reached` — The proxy's configured connection limit to the next hop has been exceeded.
+- `source_addr_in_use` — The proxy cannot assign a source address when connecting to the next hop.
+- `source_addr_not_available` — The proxy cannot assign a source address (bind failure or source host resolution failure).
+- `tls_protocol_error` — The proxy encountered a TLS error when communicating with the next hop.
+- `tls_certificate_error` — The proxy encountered an error verifying the certificate presented by the next hop.
+- `http_request_error` — The proxy is generating a client (4xx) response on the origin's behalf.
+- `http_upgrade_failed` — The HTTP Upgrade between the proxy and the next hop failed.
+- `http_request_denied` — The proxy rejected the HTTP request based on its configuration or policy.
+- `proxy_internal_error` — The proxy encountered an internal error unrelated to the origin.
+- `proxy_loop_detected` — The proxy tried to forward the request to itself.
+- `http_protocol_error` — The proxy encountered an HTTP protocol error when communicating with the next hop.
+- `http_response_incomplete` — The proxy received an incomplete response from the next hop.
+- `rate_limit` — The client has reached the maximum number of connections per second to a single origin.
+
+</Details>
+
+---
+
+## Related resources
+
+- [GraphQL Analytics API — getting started](/analytics/graphql-api/getting-started/) — Authentication, pagination, and rate limits.
+- [GraphQL Analytics API — filtering](/analytics/graphql-api/features/filtering/) — Full filter syntax reference.
+- [Create an API token](/fundamentals/api/get-started/create-token/) — Set up a token with Analytics Read permissions.
+- [Observability](/privacy-proxy/reference/observability/) — OpenTelemetry integration for Privacy Proxy.

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-import { Details, MetaInfo } from "~/components";
+import { Details, MetaInfo, Tabs, TabItem } from "~/components";
 
 Privacy Proxy exposes metrics through Cloudflare's [GraphQL Analytics API](/analytics/graphql-api/). All metrics are queryable through a single endpoint:
 
@@ -19,7 +19,10 @@ To access your metrics, you need a Cloudflare API token. Contact your Cloudflare
 
 ## Making a request
 
-The following example shows a complete request with authentication headers and variables. Replace the placeholder values with your own.
+The following examples show how to query Privacy Proxy metrics using curl or a GraphQL client such as GraphiQL. Replace the placeholder values with your own.
+
+<Tabs>
+<TabItem label="curl">
 
 ```bash
 curl https://api.cloudflare.com/client/v4/graphql \
@@ -34,6 +37,77 @@ curl https://api.cloudflare.com/client/v4/graphql \
     }
   }'
 ```
+
+</TabItem>
+<TabItem label="GraphiQL">
+
+**Prerequisites**
+
+Before you begin, ensure you have:
+
+- **API token**: Contact your Cloudflare point of contact to obtain one.
+- **Account tag**: Your Cloudflare account ID, used as `$accountTag` in queries.
+
+**1. Set up GraphiQL**
+
+Open [GraphiQL](https://github.com/graphql/graphiql) or any GraphQL client and configure the following:
+
+- **Endpoint**: `https://api.cloudflare.com/client/v4/graphql`
+- **HTTP headers**:
+  - `Authorization`: `Bearer <API_TOKEN>`
+  - `Content-Type`: `application/json`
+
+**2. Paste the query**
+
+Paste the following into the query editor:
+
+```graphql
+query DailyRequestVolume(
+  $accountTag: String!
+  $startDate: Date!
+  $endDate: Date!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyRequestMetricsAdaptiveGroups(
+        filter: {
+          date_geq: $startDate
+          date_leq: $endDate
+        }
+        limit: 10000
+        orderBy: [date_ASC]
+      ) {
+        sum {
+          requests
+        }
+        dimensions {
+          date
+          datetimeHour
+        }
+      }
+    }
+  }
+}
+```
+
+**3. Add variables**
+
+Paste the following into the **Query Variables** pane (bottom-left) and replace the placeholder values:
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "startDate": "2025-01-01",
+  "endDate": "2025-01-31"
+}
+```
+
+**4. Run the query**
+
+Select the **Play** button to execute. Results appear in the right-hand response pane.
+
+</TabItem>
+</Tabs>
 
 ---
 

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -539,6 +539,50 @@ query IngressProtocolDistribution(
 
 </Details>
 
+<Details header="Approximate active connections">
+
+Estimate the number of connections that were still open during a short time window by subtracting short-lived connections from the total established. Query a narrow window (one to five minutes) and sum `connections` — this gives the count of connections that started in that window. Connections with a duration longer than your window were established earlier and will not appear, so this query underestimates long-lived connections.
+
+```graphql
+query ApproximateActiveConnections(
+  $accountTag: String!
+  $start: Time!
+  $end: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      privacyProxyIngressConnMetricsAdaptiveGroups(
+        filter: {
+          datetime_geq: $start
+          datetime_leq: $end
+        }
+        limit: 10000
+        orderBy: [datetimeMinute_ASC]
+      ) {
+        sum {
+          connections
+        }
+        dimensions {
+          datetimeMinute
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "accountTag": "<YOUR_ACCOUNT_TAG>",
+  "start": "2025-01-01T12:00:00Z",
+  "end": "2025-01-01T12:05:00Z"
+}
+```
+
+To approximate active connections, sum the `connections` values returned across all minute buckets in the window. The result represents connections that were initiated during that period. For a more conservative estimate of concurrency, divide the total by the window duration in minutes to get an average connections-per-minute rate.
+
+</Details>
+
 </Details>
 
 <Details header="privacyProxyEgressConnMetricsAdaptiveGroups node">

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -112,7 +112,7 @@ All four nodes expose a `count` field that returns the total number of sampled e
 | `datetimeFiveMinutes` | `Time` | Timestamp truncated to five-minute intervals. |
 | `datetimeFifteenMinutes` | `Time` | Timestamp truncated to fifteen-minute intervals. |
 | `datetimeHour` | `Time` | Timestamp truncated to the hour. |
-| `colo` | `string` | Cloudflare data center that handled the request. |
+| `coloCode` | `string` | Cloudflare data center that handled the request. |
 | `endpoint` | `string` | The appId that generated traffic. |
 
 </Details>

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -13,7 +13,7 @@ Privacy Proxy exposes metrics through Cloudflare's [GraphQL Analytics API](/anal
 POST https://api.cloudflare.com/client/v4/graphql
 ```
 
-To access your metrics, you need a Cloudflare API token with **Analytics Read** permissions. Refer to [Create an API token](/fundamentals/api/get-started/create-token/) for authentication details.
+To access your metrics, you need a Cloudflare API token. Contact your Cloudflare point of contact to obtain one.
 
 ---
 
@@ -782,5 +782,5 @@ The `proxyStatus` dimension provides proxy-level error classification. This fiel
 
 ## Related resources
 
-- [GraphQL Analytics API — getting started](/analytics/graphql-api/getting-started/) — Authentication, pagination, and rate limits.
-- [GraphQL Analytics API — filtering](/analytics/graphql-api/features/filtering/) — Full filter syntax reference.
+- [GraphQL Analytics API — getting started](/analytics/graphql-api/getting-started/)
+- [GraphQL Analytics API — filtering](/analytics/graphql-api/features/filtering/)

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -15,7 +15,7 @@ POST https://api.cloudflare.com/client/v4/graphql
 
 Before you begin, you will need:
 
-- **API token** — Create a token with _Account Analytics_ read permissions. For more information, refer to [Configure an Analytics API token](/analytics/graphql-api/getting-started/authentication/api-token-auth/). You may also contact your Cloudflare point of contact to obtain one.
+- **API token** — Create a token with _Account Analytics_ read permissions. For more information, refer to our Analytics API token documentation: [Configure an Analytics API token](/analytics/graphql-api/getting-started/authentication/api-token-auth/). 
 - **Account ID** — Your Cloudflare account ID, passed as `accountTag` in queries. For more information, refer to [Find account and zone IDs](/fundamentals/account/find-account-and-zone-ids/). You may also contact your Cloudflare point of contact if you need help locating your account ID.
 
 ---

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -411,7 +411,7 @@ query IngressDurationByColo(
           durationMsP99
         }
         dimensions {
-          colo
+          coloCode
         }
       }
     }

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -587,7 +587,7 @@ query EgressLatencyByColo(
           handshakeDurationUsP99
         }
         dimensions {
-          colo
+          coloCode
         }
       }
     }

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -32,8 +32,8 @@ curl https://api.cloudflare.com/client/v4/graphql \
     "query": "query DailyRequestVolume($accountTag: String!, $startDate: Date!, $endDate: Date!) { viewer { accounts(filter: { accountTag: $accountTag }) { privacyProxyRequestMetricsAdaptiveGroups(filter: { date_geq: $startDate, date_leq: $endDate }, limit: 10000, orderBy: [date_ASC]) { count dimensions { date } } } } }",
     "variables": {
       "accountTag": "<YOUR_ACCOUNT_TAG>",
-      "startDate": "2026-01-01",
-      "endDate": "2026-01-31"
+      "startDate": "2026-04-04",
+      "endDate": "2026-04-06"
     }
   }'
 ```
@@ -206,8 +206,8 @@ query DailyRequestVolume(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2026-01-01",
-  "endDate": "2026-01-31"
+  "startDate": "2026-04-04",
+  "endDate": "2026-04-06"
 }
 ```
 
@@ -249,8 +249,8 @@ query ErrorBreakdown(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2026-01-01T00:00:00Z",
-  "end": "2026-01-01T23:59:59Z"
+  "start": "2026-04-04T00:00:00Z",
+  "end": "2026-04-06T23:59:59Z"
 }
 ```
 
@@ -291,8 +291,8 @@ query TopProxyErrors(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2026-01-01",
-  "end": "2026-01-02"
+  "start": "2026-04-04",
+  "end": "2026-04-06"
 }
 ```
 
@@ -332,8 +332,8 @@ query TunnelTypeDistribution(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2026-01-01",
-  "endDate": "2026-01-31"
+  "startDate": "2026-04-04",
+  "endDate": "2026-04-06"
 }
 ```
 
@@ -380,8 +380,8 @@ query IngressTrafficOverview(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2026-01-01",
-  "endDate": "2026-01-31"
+  "startDate": "2026-04-04",
+  "endDate": "2026-04-06"
 }
 ```
 
@@ -424,8 +424,8 @@ query IngressDurationByColo(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2026-01-01",
-  "endDate": "2026-01-31"
+  "startDate": "2026-04-04",
+  "endDate": "2026-04-06"
 }
 ```
 
@@ -466,8 +466,8 @@ query IngressProtocolDistribution(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2026-01-01T00:00:00Z",
-  "end": "2026-01-01T23:59:59Z"
+  "start": "2026-04-04T00:00:00Z",
+  "end": "2026-04-06T23:59:59Z"
 }
 ```
 
@@ -514,8 +514,8 @@ query EgressBytesOverview(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2026-01-01",
-  "endDate": "2026-01-31"
+  "startDate": "2026-04-04",
+  "endDate": "2026-04-06"
 }
 ```
 
@@ -558,8 +558,8 @@ query EgressLatencyByColo(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2026-01-01",
-  "endDate": "2026-01-31"
+  "startDate": "2026-04-04",
+  "endDate": "2026-04-06"
 }
 ```
 
@@ -603,8 +603,8 @@ query EgressPerformanceTrend(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2026-01-01T08:00:00Z",
-  "end": "2026-01-01T14:00:00Z"
+  "start": "2026-04-04T08:00:00Z",
+  "end": "2026-04-06T14:00:00Z"
 }
 ```
 
@@ -648,8 +648,8 @@ query AuthVolumeByMethod(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2026-01-01",
-  "endDate": "2026-01-31"
+  "startDate": "2026-04-04",
+  "endDate": "2026-04-06"
 }
 ```
 
@@ -690,8 +690,8 @@ query AuthFailureSpike(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2026-01-01T10:00:00Z",
-  "end": "2026-01-01T14:00:00Z"
+  "start": "2026-04-04T10:00:00Z",
+  "end": "2026-04-06T14:00:00Z"
 }
 ```
 
@@ -731,8 +731,8 @@ query AuthSuccessRate(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2026-01-01T00:00:00Z",
-  "end": "2026-01-01T23:59:59Z"
+  "start": "2026-04-04T00:00:00Z",
+  "end": "2026-04-06T23:59:59Z"
 }
 ```
 

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -37,9 +37,9 @@ curl https://api.cloudflare.com/client/v4/graphql \
 
 ---
 
-## Available datasets
+## Available nodes
 
-Four GraphQL datasets are available. All four return aggregate data only — no raw per-connection records are exposed.
+Four GraphQL nodes are available. All four return aggregate data only — no raw per-connection records are exposed.
 
 1. `privacyProxyRequestMetricsAdaptiveGroups` — Query aggregate request volume, CONNECT request handling and tunnel setup latency percentiles (P50/P95/P99), filterable by time, location, endpoint, status code, proxy status, and tunnel type dimensions.
 2. `privacyProxyIngressConnMetricsAdaptiveGroups` — Query aggregate client-to-proxy connection volume, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, transport protocol, and TLS version dimensions.
@@ -47,7 +47,7 @@ Four GraphQL datasets are available. All four return aggregate data only — no 
 4. `privacyProxyAuthMetricsAdaptiveGroups` — Query aggregate authentication attempt volume, filterable by time, location, endpoint, authentication method, and authentication result dimensions.
 
 :::note[Adaptive sampling]
-Each dataset uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudflare automatically scales the sampling rate based on traffic volume to keep query performance consistent. All returned values are extrapolated totals, not raw counts. Because each dataset has its own sampling rate, figures across datasets are not directly comparable.
+Each node uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudflare automatically scales the sampling rate based on traffic volume to keep query performance consistent. All returned values are extrapolated totals, not raw counts. Because each node has its own sampling rate, figures across nodes are not directly comparable.
 :::
 
 ---
@@ -58,36 +58,36 @@ Each dataset uses an independent adaptive bit-rate (ABR) sampling pipeline. Clou
 
 <Details header="Sum fields">
 
-- `requests` – `uint64` — Total number of proxy requests processed. _(Request dataset)_
-- `connections` – `uint64` — Total number of connections established. _(Ingress and egress connection datasets)_
-- `bytesSentToClient` – `uint64` — Total bytes sent from the proxy back to the client. _(Ingress connection dataset)_
-- `bytesReceivedFromClient` – `uint64` — Total bytes received by the proxy from the client. _(Ingress connection dataset)_
-- `bytesSentToOrigin` – `uint64` — Total bytes sent from the proxy to the upstream origin. _(Egress connection dataset)_
-- `bytesReceivedFromOrigin` – `uint64` — Total bytes received by the proxy from the upstream origin. _(Egress connection dataset)_
-- `authAttempts` – `uint64` — Total number of authentication attempts. _(Auth dataset)_
+- `requests` – `uint64` — Total number of proxy requests processed. _(Request node)_
+- `connections` – `uint64` — Total number of connections established. _(Ingress and egress connection nodes)_
+- `bytesSentToClient` – `uint64` — Total bytes sent from the proxy back to the client. _(Ingress connection node)_
+- `bytesReceivedFromClient` – `uint64` — Total bytes received by the proxy from the client. _(Ingress connection node)_
+- `bytesSentToOrigin` – `uint64` — Total bytes sent from the proxy to the upstream origin. _(Egress connection node)_
+- `bytesReceivedFromOrigin` – `uint64` — Total bytes received by the proxy from the upstream origin. _(Egress connection node)_
+- `authAttempts` – `uint64` — Total number of authentication attempts. _(Auth node)_
 
 </Details>
 
 <Details header="Quantile fields">
 
-- `connectRequestHandlingDurationUsP50` – `float64` — Median time to handle a CONNECT request, in microseconds. _(Request dataset)_
-- `connectRequestHandlingDurationUsP95` – `float64` — 95th percentile time to handle a CONNECT request, in microseconds. _(Request dataset)_
-- `connectRequestHandlingDurationUsP99` – `float64` — 99th percentile time to handle a CONNECT request, in microseconds. _(Request dataset)_
-- `connectTunnelSetupDurationUsP50` – `float64` — Median time to establish a tunnel after receiving a CONNECT request, in microseconds. _(Request dataset)_
-- `connectTunnelSetupDurationUsP95` – `float64` — 95th percentile tunnel setup time, in microseconds. _(Request dataset)_
-- `connectTunnelSetupDurationUsP99` – `float64` — 99th percentile tunnel setup time, in microseconds. _(Request dataset)_
-- `clientProxyConnectionDurationMsP50` – `float64` — Median client-to-proxy connection lifetime, in milliseconds. _(Ingress connection dataset)_
-- `clientProxyConnectionDurationMsP95` – `float64` — 95th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection dataset)_
-- `clientProxyConnectionDurationMsP99` – `float64` — 99th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection dataset)_
-- `clientProxyRttMsP50` – `float64` — Median round-trip time between client and proxy, in milliseconds. _(Ingress connection dataset)_
-- `clientProxyRttMsP95` – `float64` — 95th percentile RTT between client and proxy, in milliseconds. _(Ingress connection dataset)_
-- `clientProxyRttMsP99` – `float64` — 99th percentile RTT between client and proxy, in milliseconds. _(Ingress connection dataset)_
-- `proxyOriginConnectionDurationMsP50` – `float64` — Median proxy-to-origin connection lifetime, in milliseconds. _(Egress connection dataset)_
-- `proxyOriginConnectionDurationMsP95` – `float64` — 95th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection dataset)_
-- `proxyOriginConnectionDurationMsP99` – `float64` — 99th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection dataset)_
-- `proxyOriginRttMsP50` – `float64` — Median round-trip time between proxy and origin, in milliseconds. _(Egress connection dataset)_
-- `proxyOriginRttMsP95` – `float64` — 95th percentile RTT between proxy and origin, in milliseconds. _(Egress connection dataset)_
-- `proxyOriginRttMsP99` – `float64` — 99th percentile RTT between proxy and origin, in milliseconds. _(Egress connection dataset)_
+- `connectRequestHandlingDurationUsP50` – `float64` — Median time to handle a CONNECT request, in microseconds. _(Request node)_
+- `connectRequestHandlingDurationUsP95` – `float64` — 95th percentile time to handle a CONNECT request, in microseconds. _(Request node)_
+- `connectRequestHandlingDurationUsP99` – `float64` — 99th percentile time to handle a CONNECT request, in microseconds. _(Request node)_
+- `connectTunnelSetupDurationUsP50` – `float64` — Median time to establish a tunnel after receiving a CONNECT request, in microseconds. _(Request node)_
+- `connectTunnelSetupDurationUsP95` – `float64` — 95th percentile tunnel setup time, in microseconds. _(Request node)_
+- `connectTunnelSetupDurationUsP99` – `float64` — 99th percentile tunnel setup time, in microseconds. _(Request node)_
+- `clientProxyConnectionDurationMsP50` – `float64` — Median client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
+- `clientProxyConnectionDurationMsP95` – `float64` — 95th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
+- `clientProxyConnectionDurationMsP99` – `float64` — 99th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
+- `clientProxyRttMsP50` – `float64` — Median round-trip time between client and proxy, in milliseconds. _(Ingress connection node)_
+- `clientProxyRttMsP95` – `float64` — 95th percentile RTT between client and proxy, in milliseconds. _(Ingress connection node)_
+- `clientProxyRttMsP99` – `float64` — 99th percentile RTT between client and proxy, in milliseconds. _(Ingress connection node)_
+- `proxyOriginConnectionDurationMsP50` – `float64` — Median proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
+- `proxyOriginConnectionDurationMsP95` – `float64` — 95th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
+- `proxyOriginConnectionDurationMsP99` – `float64` — 99th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
+- `proxyOriginRttMsP50` – `float64` — Median round-trip time between proxy and origin, in milliseconds. _(Egress connection node)_
+- `proxyOriginRttMsP95` – `float64` — 95th percentile RTT between proxy and origin, in milliseconds. _(Egress connection node)_
+- `proxyOriginRttMsP99` – `float64` — 99th percentile RTT between proxy and origin, in milliseconds. _(Egress connection node)_
 
 </Details>
 
@@ -95,7 +95,7 @@ Each dataset uses an independent adaptive bit-rate (ABR) sampling pipeline. Clou
 
 <Details header="Dimensions">
 
-<Details header="All datasets">
+<Details header="All nodes">
 
 - `date` – `Date` — Calendar date (day granularity).
 - `datetimeMinute` – `Time` — Timestamp truncated to the minute.
@@ -107,7 +107,7 @@ Each dataset uses an independent adaptive bit-rate (ABR) sampling pipeline. Clou
 
 </Details>
 
-<Details header="Request dataset only">
+<Details header="Request node only">
 
 - `statusCode` – `uint16` — HTTP status code returned by the proxy to the client.
 - `proxyStatus` – `string` — Proxy-level error classification. Refer to [proxy status reference](#proxy-status-reference) for possible values.
@@ -115,20 +115,20 @@ Each dataset uses an independent adaptive bit-rate (ABR) sampling pipeline. Clou
 
 </Details>
 
-<Details header="Ingress connection dataset only">
+<Details header="Ingress connection node only">
 
 - `ingressTransport` – `string` — Transport protocol on the client-to-proxy connection (`tcp`, `quic`).
 - `tlsVersion` – `string` — TLS version negotiated on the client-to-proxy connection.
 
 </Details>
 
-<Details header="Egress connection dataset only">
+<Details header="Egress connection node only">
 
 - `egressTransport` – `string` — Transport protocol on the proxy-to-origin connection.
 
 </Details>
 
-<Details header="Auth dataset only">
+<Details header="Auth node only">
 
 - `authMethod` – `string` — Authentication method used (for example, `token_hash`, `mtls`, `blind_rsa`).
 - `authResult` – `string` — Authentication outcome (`success`, `failure`).
@@ -139,10 +139,10 @@ Each dataset uses an independent adaptive bit-rate (ABR) sampling pipeline. Clou
 
 <Details header="Arguments">
 
-All four datasets share the same argument signature.
+All four nodes share the same argument signature.
 
 - `filter` <MetaInfo text="required" /> — Filters your data. `accountTag` is always required inside the filter.
-- `limit` <MetaInfo text="required" /> — Maximum number of records to return.
+- `limit` <MetaInfo text="optional" /> — Maximum number of records to return.
 - `orderBy` <MetaInfo text="optional" /> — Sort order for results.
 
 </Details>
@@ -151,7 +151,7 @@ All four datasets share the same argument signature.
 
 ## Sample queries
 
-<Details header="privacyProxyRequestMetricsAdaptiveGroups">
+<Details header="privacyProxyRequestMetricsAdaptiveGroups node">
 
 <Details header="Request volume overview">
 
@@ -330,7 +330,7 @@ query TunnelTypeDistribution(
 
 </Details>
 
-<Details header="privacyProxyIngressConnMetricsAdaptiveGroups">
+<Details header="privacyProxyIngressConnMetricsAdaptiveGroups node">
 
 <Details header="Connection volume and ingress bytes overview">
 
@@ -467,7 +467,7 @@ query IngressProtocolDistribution(
 
 </Details>
 
-<Details header="privacyProxyEgressConnMetricsAdaptiveGroups">
+<Details header="privacyProxyEgressConnMetricsAdaptiveGroups node">
 
 <Details header="Egress bytes overview">
 
@@ -607,7 +607,7 @@ query EgressPerformanceTrend(
 
 </Details>
 
-<Details header="privacyProxyAuthMetricsAdaptiveGroups">
+<Details header="privacyProxyAuthMetricsAdaptiveGroups node">
 
 <Details header="Auth volume by method">
 
@@ -784,5 +784,3 @@ The `proxyStatus` dimension provides proxy-level error classification. The follo
 
 - [GraphQL Analytics API — getting started](/analytics/graphql-api/getting-started/) — Authentication, pagination, and rate limits.
 - [GraphQL Analytics API — filtering](/analytics/graphql-api/features/filtering/) — Full filter syntax reference.
-- [Create an API token](/fundamentals/api/get-started/create-token/) — Set up a token with Analytics Read permissions.
-- [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/) — OpenTelemetry integration for Privacy Proxy.

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -29,7 +29,7 @@ curl https://api.cloudflare.com/client/v4/graphql \
   --header "Authorization: Bearer <API_TOKEN>" \
   --header "Content-Type: application/json" \
   --data '{
-    "query": "query DailyRequestVolume($accountTag: String!, $startDate: Date!, $endDate: Date!) { viewer { accounts(filter: { accountTag: $accountTag }) { privacyProxyRequestMetricsAdaptiveGroups(filter: { date_geq: $startDate, date_leq: $endDate }, limit: 10000, orderBy: [date_ASC]) { sum { requests } dimensions { date datetimeHour } } } } }",
+    "query": "query DailyRequestVolume($accountTag: String!, $startDate: Date!, $endDate: Date!) { viewer { accounts(filter: { accountTag: $accountTag }) { privacyProxyRequestMetricsAdaptiveGroups(filter: { date_geq: $startDate, date_leq: $endDate }, limit: 10000, orderBy: [date_ASC]) { count dimensions { date } } } } }",
     "variables": {
       "accountTag": "<YOUR_ACCOUNT_TAG>",
       "startDate": "2026-01-01",
@@ -44,10 +44,10 @@ curl https://api.cloudflare.com/client/v4/graphql \
 
 Four GraphQL nodes are available. All four return aggregate data only — no raw per-connection records are exposed.
 
-1. `privacyProxyRequestMetricsAdaptiveGroups` — Query aggregate request volume, CONNECT request handling and tunnel setup latency percentiles (P50/P95/P99), filterable by time, location, endpoint, status code, proxy status, and tunnel type dimensions.
-2. `privacyProxyIngressConnMetricsAdaptiveGroups` — Query the number of client-to-proxy connections, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, transport protocol, and TLS version dimensions.
-3. `privacyProxyEgressConnMetricsAdaptiveGroups` — Query the number of proxy-to-origin connections, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, and transport protocol dimensions.
-4. `privacyProxyAuthMetricsAdaptiveGroups` — Query aggregate authentication attempt volume, filterable by time, location, endpoint, authentication method, and authentication result dimensions.
+1. `privacyProxyRequestMetricsAdaptiveGroups` — Query aggregate request volume and error rates, filterable by time, location, endpoint, status code, and proxy status dimensions.
+2. `privacyProxyIngressConnMetricsAdaptiveGroups` — Query client-to-proxy connection counts, bytes transferred, and latency percentiles, filterable by time, location, endpoint, and transport dimensions.
+3. `privacyProxyEgressConnMetricsAdaptiveGroups` — Query proxy-to-origin connection counts, bytes transferred, and latency percentiles, filterable by time, location, endpoint, and transport dimensions.
+4. `privacyProxyAuthMetricsAdaptiveGroups` — Query authentication attempt counts, filterable by time, location, endpoint, auth method, and auth result dimensions.
 
 :::note[Adaptive sampling]
 Requests are sampled.
@@ -63,13 +63,20 @@ Requests are sampled.
 
 | Field | Type | Description | Node |
 | --- | --- | --- | --- |
-| `requests` | `uint64` | Total number of proxy requests processed. | Request |
-| `connections` | `uint64` | Total number of connections established. | Ingress and egress connection |
 | `bytesSentToClient` | `uint64` | Total bytes sent from the proxy back to the client. | Ingress connection |
-| `bytesReceivedFromClient` | `uint64` | Total bytes received by the proxy from the client. | Ingress connection |
+| `bytesRecvdFromClient` | `uint64` | Total bytes received by the proxy from the client. | Ingress connection |
 | `bytesSentToOrigin` | `uint64` | Total bytes sent from the proxy to the upstream origin. | Egress connection |
-| `bytesReceivedFromOrigin` | `uint64` | Total bytes received by the proxy from the upstream origin. | Egress connection |
-| `authAttempts` | `uint64` | Total number of authentication attempts. | Auth |
+| `bytesRecvdFromOrigin` | `uint64` | Total bytes received by the proxy from the upstream origin. | Egress connection |
+| `packetsSentToClient` | `uint64` | Total packets sent from the proxy back to the client. | Ingress connection |
+| `packetsRecvdFromClient` | `uint64` | Total packets received by the proxy from the client. | Ingress connection |
+| `packetsSentToOrigin` | `uint64` | Total packets sent from the proxy to the upstream origin. | Egress connection |
+| `packetsRecvdFromOrigin` | `uint64` | Total packets received by the proxy from the upstream origin. | Egress connection |
+
+</Details>
+
+<Details header="Count fields">
+
+All four nodes expose a `count` field that returns the total number of sampled events (requests, connections, or auth attempts) matching the query filter.
 
 </Details>
 
@@ -77,24 +84,18 @@ Requests are sampled.
 
 | Field | Type | Description | Node |
 | --- | --- | --- | --- |
-| `connectRequestHandlingDurationUsP50` | `float64` | Median time to handle a CONNECT request, in microseconds. | Request |
-| `connectRequestHandlingDurationUsP95` | `float64` | 95th percentile time to handle a CONNECT request, in microseconds. | Request |
-| `connectRequestHandlingDurationUsP99` | `float64` | 99th percentile time to handle a CONNECT request, in microseconds. | Request |
-| `connectTunnelSetupDurationUsP50` | `float64` | Median time to establish a tunnel after receiving a CONNECT request, in microseconds. | Request |
-| `connectTunnelSetupDurationUsP95` | `float64` | 95th percentile tunnel setup time, in microseconds. | Request |
-| `connectTunnelSetupDurationUsP99` | `float64` | 99th percentile tunnel setup time, in microseconds. | Request |
-| `clientProxyConnectionDurationMsP50` | `float64` | Median client-to-proxy connection lifetime, in milliseconds. | Ingress connection |
-| `clientProxyConnectionDurationMsP95` | `float64` | 95th percentile client-to-proxy connection lifetime, in milliseconds. | Ingress connection |
-| `clientProxyConnectionDurationMsP99` | `float64` | 99th percentile client-to-proxy connection lifetime, in milliseconds. | Ingress connection |
-| `clientProxyRttMsP50` | `float64` | Median round-trip time between client and proxy, in milliseconds. | Ingress connection |
-| `clientProxyRttMsP95` | `float64` | 95th percentile RTT between client and proxy, in milliseconds. | Ingress connection |
-| `clientProxyRttMsP99` | `float64` | 99th percentile RTT between client and proxy, in milliseconds. | Ingress connection |
-| `proxyOriginConnectionDurationMsP50` | `float64` | Median proxy-to-origin connection lifetime, in milliseconds. | Egress connection |
-| `proxyOriginConnectionDurationMsP95` | `float64` | 95th percentile proxy-to-origin connection lifetime, in milliseconds. | Egress connection |
-| `proxyOriginConnectionDurationMsP99` | `float64` | 99th percentile proxy-to-origin connection lifetime, in milliseconds. | Egress connection |
-| `proxyOriginRttMsP50` | `float64` | Median round-trip time between proxy and origin, in milliseconds. | Egress connection |
-| `proxyOriginRttMsP95` | `float64` | 95th percentile RTT between proxy and origin, in milliseconds. | Egress connection |
-| `proxyOriginRttMsP99` | `float64` | 99th percentile RTT between proxy and origin, in milliseconds. | Egress connection |
+| `durationMsP50` | `float64` | Median lifetime of a connection, in milliseconds. | Ingress and egress connection |
+| `durationMsP95` | `float64` | 95th percentile connection lifetime, in milliseconds. | Ingress and egress connection |
+| `durationMsP99` | `float64` | 99th percentile connection lifetime, in milliseconds. | Ingress and egress connection |
+| `handshakeDurationUsP50` | `float64` | Median TCP+TLS/QUIC handshake time, in microseconds. | Ingress and egress connection |
+| `handshakeDurationUsP95` | `float64` | 95th percentile handshake time, in microseconds. | Ingress and egress connection |
+| `handshakeDurationUsP99` | `float64` | 99th percentile handshake time, in microseconds. | Ingress and egress connection |
+| `connectRequestHandlingDurationUsP50` | `float64` | Median time to handle a CONNECT request, in microseconds. _Not yet available._ | Request |
+| `connectRequestHandlingDurationUsP95` | `float64` | 95th percentile time to handle a CONNECT request, in microseconds. _Not yet available._ | Request |
+| `connectRequestHandlingDurationUsP99` | `float64` | 99th percentile time to handle a CONNECT request, in microseconds. _Not yet available._ | Request |
+| `connectTunnelSetupDurationUsP50` | `float64` | Median time to establish a tunnel after receiving a CONNECT request, in microseconds. _Not yet available._ | Request |
+| `connectTunnelSetupDurationUsP95` | `float64` | 95th percentile tunnel setup time, in microseconds. _Not yet available._ | Request |
+| `connectTunnelSetupDurationUsP99` | `float64` | 99th percentile tunnel setup time, in microseconds. _Not yet available._ | Request |
 
 </Details>
 
@@ -122,7 +123,7 @@ Requests are sampled.
 | --- | --- | --- |
 | `statusCode` | `uint16` | HTTP status code returned by the proxy to the client. |
 | `proxyStatus` | `string` | Proxy-level error classification. `null` when no proxy-level error occurred. Refer to [proxy status reference](/privacy-proxy/reference/proxy-status/) for possible values. |
-| `tunnelType` | `string` | Tunnel protocol used (`connect-tcp`, `connect-udp`, `connect-ip`). |
+| `tunnelType` | `string` | Tunnel protocol used (`connect-tcp`, `connect-udp`, `connect-ip`). _Not yet available._ |
 
 </Details>
 
@@ -130,8 +131,8 @@ Requests are sampled.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `ingressTransport` | `string` | Transport protocol on the client-to-proxy connection (`tcp`, `quic`). |
-| `tlsVersion` | `string` | TLS version negotiated on the client-to-proxy connection. |
+| `transport` | `string` | Transport protocol on the client-to-proxy connection (`tcp`, `quic`). |
+| `tlsVersion` | `string` | TLS version negotiated on the client-to-proxy connection. _Not yet available._ |
 
 </Details>
 
@@ -139,7 +140,7 @@ Requests are sampled.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `egressTransport` | `string` | Transport protocol on the proxy-to-origin connection. |
+| `transport` | `string` | Transport protocol on the proxy-to-origin connection (`tcp`, `quic`). |
 
 </Details>
 
@@ -147,7 +148,7 @@ Requests are sampled.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `authMethod` | `string` | Authentication method used (for example, `token_hash`, `mtls`, `blind_rsa`). |
+| `authMethod` | `string` | Authentication method used (for example, `Token`, `Psk`). |
 | `authResult` | `string` | Authentication outcome (`success`, `failure`). |
 
 </Details>
@@ -190,12 +191,9 @@ query DailyRequestVolume(
         limit: 10000
         orderBy: [date_ASC]
       ) {
-        sum {
-          requests
-        }
+        count
         dimensions {
           date
-          datetimeHour
         }
       }
     }
@@ -227,18 +225,16 @@ query ErrorBreakdown(
     accounts(filter: { accountTag: $accountTag }) {
       privacyProxyRequestMetricsAdaptiveGroups(
         filter: {
-          datetime_geq: $start
-          datetime_leq: $end
+          datetimeFifteenMinutes_geq: $start
+          datetimeFifteenMinutes_leq: $end
           statusCode_geq: 400
         }
         limit: 10000
-        orderBy: [datetimeHour_ASC]
+        orderBy: [datetimeFifteenMinutes_ASC]
       ) {
-        sum {
-          requests
-        }
+        count
         dimensions {
-          datetimeHour
+          datetimeFifteenMinutes
           statusCode
           proxyStatus
         }
@@ -265,23 +261,21 @@ Rank the most frequent proxy error types to prioritize investigation.
 ```graphql
 query TopProxyErrors(
   $accountTag: String!
-  $start: Time!
-  $end: Time!
+  $start: Date!
+  $end: Date!
 ) {
   viewer {
     accounts(filter: { accountTag: $accountTag }) {
       privacyProxyRequestMetricsAdaptiveGroups(
         filter: {
-          datetime_geq: $start
-          datetime_leq: $end
-          proxyStatus_neq: null
+          date_geq: $start
+          date_leq: $end
+          proxyStatus_neq: ""
         }
         limit: 10000
-        orderBy: [sum_requests_DESC]
+        orderBy: [count_DESC]
       ) {
-        sum {
-          requests
-        }
+        count
         dimensions {
           proxyStatus
           statusCode
@@ -295,8 +289,8 @@ query TopProxyErrors(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2026-01-01T00:00:00Z",
-  "end": "2026-01-01T23:59:59Z"
+  "start": "2026-01-01",
+  "end": "2026-01-02"
 }
 ```
 
@@ -320,13 +314,11 @@ query TunnelTypeDistribution(
           date_leq: $endDate
         }
         limit: 10000
-        orderBy: [datetimeHour_ASC]
+        orderBy: [date_ASC]
       ) {
-        sum {
-          requests
-        }
+        count
         dimensions {
-          datetimeHour
+          date
           tunnelType
         }
       }
@@ -369,14 +361,13 @@ query IngressTrafficOverview(
         limit: 10000
         orderBy: [date_ASC]
       ) {
+        count
         sum {
-          connections
           bytesSentToClient
-          bytesReceivedFromClient
+          bytesRecvdFromClient
         }
         dimensions {
           date
-          datetimeHour
         }
       }
     }
@@ -412,12 +403,12 @@ query IngressDurationByColo(
           date_leq: $endDate
         }
         limit: 10000
-        orderBy: [quantiles_clientProxyConnectionDurationMsP50_DESC]
+        orderBy: [quantiles_durationMsP50_DESC]
       ) {
         quantiles {
-          clientProxyConnectionDurationMsP50
-          clientProxyConnectionDurationMsP95
-          clientProxyConnectionDurationMsP99
+          durationMsP50
+          durationMsP95
+          durationMsP99
         }
         dimensions {
           colo
@@ -452,18 +443,16 @@ query IngressProtocolDistribution(
     accounts(filter: { accountTag: $accountTag }) {
       privacyProxyIngressConnMetricsAdaptiveGroups(
         filter: {
-          datetime_geq: $start
-          datetime_leq: $end
+          datetimeFifteenMinutes_geq: $start
+          datetimeFifteenMinutes_leq: $end
         }
         limit: 10000
-        orderBy: [datetimeHour_ASC]
+        orderBy: [datetimeFifteenMinutes_ASC]
       ) {
-        sum {
-          connections
-        }
+        count
         dimensions {
-          datetimeHour
-          ingressTransport
+          datetimeFifteenMinutes
+          transport
           tlsVersion
         }
       }
@@ -502,9 +491,7 @@ query ApproximateActiveConnections(
         limit: 10000
         orderBy: [datetimeMinute_ASC]
       ) {
-        sum {
-          connections
-        }
+        count
         dimensions {
           datetimeMinute
         }
@@ -522,7 +509,7 @@ query ApproximateActiveConnections(
 }
 ```
 
-To approximate active connections, sum the `connections` values returned across all minute buckets in the window. The result represents connections that were initiated during that period. For a more conservative estimate of concurrency, divide the total by the window duration in minutes to get an average connections-per-minute rate.
+To approximate active connections, sum the `count` values returned across all minute buckets in the window. The result represents connections that were initiated during that period. For a more conservative estimate of concurrency, divide the total by the window duration in minutes to get an average connections-per-minute rate.
 
 </Details>
 
@@ -550,14 +537,13 @@ query EgressBytesOverview(
         limit: 10000
         orderBy: [date_ASC]
       ) {
+        count
         sum {
-          connections
           bytesSentToOrigin
-          bytesReceivedFromOrigin
+          bytesRecvdFromOrigin
         }
         dimensions {
           date
-          datetimeHour
         }
       }
     }
@@ -575,12 +561,12 @@ query EgressBytesOverview(
 
 </Details>
 
-<Details header="Proxy-to-origin RTT by data center">
+<Details header="Proxy-to-origin latency by data center">
 
-Compare proxy-to-origin round-trip times across data centers to identify regions with degraded origin reachability.
+Compare proxy-to-origin handshake times across data centers to identify regions with degraded origin reachability.
 
 ```graphql
-query EgressRttByColo(
+query EgressLatencyByColo(
   $accountTag: String!
   $startDate: Date!
   $endDate: Date!
@@ -593,12 +579,12 @@ query EgressRttByColo(
           date_leq: $endDate
         }
         limit: 10000
-        orderBy: [quantiles_proxyOriginRttMsP50_DESC]
+        orderBy: [quantiles_handshakeDurationUsP50_DESC]
       ) {
         quantiles {
-          proxyOriginRttMsP50
-          proxyOriginRttMsP95
-          proxyOriginRttMsP99
+          handshakeDurationUsP50
+          handshakeDurationUsP95
+          handshakeDurationUsP99
         }
         dimensions {
           colo
@@ -621,7 +607,7 @@ query EgressRttByColo(
 
 <Details header="Egress performance trend">
 
-Track proxy-to-origin RTT at fine granularity during an active incident or maintenance window.
+Track proxy-to-origin handshake latency at fine granularity during an active incident or maintenance window.
 
 ```graphql
 query EgressPerformanceTrend(
@@ -633,22 +619,20 @@ query EgressPerformanceTrend(
     accounts(filter: { accountTag: $accountTag }) {
       privacyProxyEgressConnMetricsAdaptiveGroups(
         filter: {
-          datetime_geq: $start
-          datetime_leq: $end
+          datetimeFiveMinutes_geq: $start
+          datetimeFiveMinutes_leq: $end
         }
         limit: 10000
         orderBy: [datetimeFiveMinutes_ASC]
       ) {
         quantiles {
-          proxyOriginRttMsP50
-          proxyOriginRttMsP99
+          handshakeDurationUsP50
+          handshakeDurationUsP95
+          handshakeDurationUsP99
         }
-        sum {
-          connections
-        }
+        count
         dimensions {
           datetimeFiveMinutes
-          datetimeHour
         }
       }
     }
@@ -690,12 +674,9 @@ query AuthVolumeByMethod(
         limit: 10000
         orderBy: [date_ASC]
       ) {
-        sum {
-          authAttempts
-        }
+        count
         dimensions {
           date
-          datetimeHour
           authMethod
         }
       }
@@ -728,19 +709,16 @@ query AuthFailureSpike(
     accounts(filter: { accountTag: $accountTag }) {
       privacyProxyAuthMetricsAdaptiveGroups(
         filter: {
-          datetime_geq: $start
-          datetime_leq: $end
+          datetimeMinute_geq: $start
+          datetimeMinute_leq: $end
           authResult: "failure"
         }
         limit: 10000
         orderBy: [datetimeFiveMinutes_ASC]
       ) {
-        sum {
-          authAttempts
-        }
+        count
         dimensions {
           datetimeFiveMinutes
-          datetimeHour
           authMethod
         }
       }
@@ -773,15 +751,13 @@ query AuthSuccessRate(
     accounts(filter: { accountTag: $accountTag }) {
       privacyProxyAuthMetricsAdaptiveGroups(
         filter: {
-          datetime_geq: $start
-          datetime_leq: $end
+          datetimeHour_geq: $start
+          datetimeHour_leq: $end
         }
         limit: 10000
         orderBy: [datetimeHour_ASC]
       ) {
-        sum {
-          authAttempts
-        }
+        count
         dimensions {
           datetimeHour
           authResult

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -1,8 +1,8 @@
 ---
-title: Metrics and analytics
+title: GraphQL Analytics API
 pcx_content_type: reference
 sidebar:
-  order: 2
+  order: 1
 ---
 
 import { Details, MetaInfo } from "~/components";
@@ -785,4 +785,4 @@ The `proxyStatus` dimension provides proxy-level error classification. The follo
 - [GraphQL Analytics API — getting started](/analytics/graphql-api/getting-started/) — Authentication, pagination, and rate limits.
 - [GraphQL Analytics API — filtering](/analytics/graphql-api/features/filtering/) — Full filter syntax reference.
 - [Create an API token](/fundamentals/api/get-started/create-token/) — Set up a token with Analytics Read permissions.
-- [Observability](/privacy-proxy/reference/observability/) — OpenTelemetry integration for Privacy Proxy.
+- [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/) — OpenTelemetry integration for Privacy Proxy.

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-import { Details, MetaInfo, Tabs, TabItem } from "~/components";
+import { Details, MetaInfo } from "~/components";
 
 Privacy Proxy exposes metrics through Cloudflare's [GraphQL Analytics API](/analytics/graphql-api/). All metrics are queryable through a single endpoint:
 
@@ -13,16 +13,16 @@ Privacy Proxy exposes metrics through Cloudflare's [GraphQL Analytics API](/anal
 POST https://api.cloudflare.com/client/v4/graphql
 ```
 
-To access your metrics, you need a Cloudflare API token. Contact your Cloudflare point of contact to obtain one.
+Before you begin, you will need:
+
+- **API token** — Create a token with _Account Analytics_ read permissions. For more information, refer to [Configure an Analytics API token](/analytics/graphql-api/getting-started/authentication/api-token-auth/). You may also contact your Cloudflare point of contact to obtain one.
+- **Account ID** — Your Cloudflare account ID, passed as `accountTag` in queries. For more information, refer to [Find account and zone IDs](/fundamentals/account/find-account-and-zone-ids/). You may also contact your Cloudflare point of contact if you need help locating your account ID.
 
 ---
 
 ## Making a request
 
-The following examples show how to query Privacy Proxy metrics using curl or a GraphQL client such as GraphiQL. Replace the placeholder values with your own.
-
-<Tabs>
-<TabItem label="curl">
+The following example shows how to query Privacy Proxy metrics using curl. Replace the placeholder values with your own.
 
 ```bash
 curl https://api.cloudflare.com/client/v4/graphql \
@@ -32,82 +32,11 @@ curl https://api.cloudflare.com/client/v4/graphql \
     "query": "query DailyRequestVolume($accountTag: String!, $startDate: Date!, $endDate: Date!) { viewer { accounts(filter: { accountTag: $accountTag }) { privacyProxyRequestMetricsAdaptiveGroups(filter: { date_geq: $startDate, date_leq: $endDate }, limit: 10000, orderBy: [date_ASC]) { sum { requests } dimensions { date datetimeHour } } } } }",
     "variables": {
       "accountTag": "<YOUR_ACCOUNT_TAG>",
-      "startDate": "2025-01-01",
-      "endDate": "2025-01-31"
+      "startDate": "2026-01-01",
+      "endDate": "2026-01-31"
     }
   }'
 ```
-
-</TabItem>
-<TabItem label="GraphiQL">
-
-**Prerequisites**
-
-Before you begin, ensure you have:
-
-- **API token**: Contact your Cloudflare point of contact to obtain one.
-- **Account tag**: Your Cloudflare account ID, used as `$accountTag` in queries.
-
-**1. Set up GraphiQL**
-
-Open [GraphiQL](https://github.com/graphql/graphiql) or any GraphQL client and configure the following:
-
-- **Endpoint**: `https://api.cloudflare.com/client/v4/graphql`
-- **HTTP headers**:
-  - `Authorization`: `Bearer <API_TOKEN>`
-  - `Content-Type`: `application/json`
-
-**2. Paste the query**
-
-Paste the following into the query editor:
-
-```graphql
-query DailyRequestVolume(
-  $accountTag: String!
-  $startDate: Date!
-  $endDate: Date!
-) {
-  viewer {
-    accounts(filter: { accountTag: $accountTag }) {
-      privacyProxyRequestMetricsAdaptiveGroups(
-        filter: {
-          date_geq: $startDate
-          date_leq: $endDate
-        }
-        limit: 10000
-        orderBy: [date_ASC]
-      ) {
-        sum {
-          requests
-        }
-        dimensions {
-          date
-          datetimeHour
-        }
-      }
-    }
-  }
-}
-```
-
-**3. Add variables**
-
-Paste the following into the **Query Variables** pane (bottom-left) and replace the placeholder values:
-
-```json
-{
-  "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2025-01-01",
-  "endDate": "2025-01-31"
-}
-```
-
-**4. Run the query**
-
-Select the **Play** button to execute. Results appear in the right-hand response pane.
-
-</TabItem>
-</Tabs>
 
 ---
 
@@ -116,12 +45,12 @@ Select the **Play** button to execute. Results appear in the right-hand response
 Four GraphQL nodes are available. All four return aggregate data only — no raw per-connection records are exposed.
 
 1. `privacyProxyRequestMetricsAdaptiveGroups` — Query aggregate request volume, CONNECT request handling and tunnel setup latency percentiles (P50/P95/P99), filterable by time, location, endpoint, status code, proxy status, and tunnel type dimensions.
-2. `privacyProxyIngressConnMetricsAdaptiveGroups` — Query aggregate client-to-proxy connection volume, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, transport protocol, and TLS version dimensions.
-3. `privacyProxyEgressConnMetricsAdaptiveGroups` — Query aggregate proxy-to-origin connection volume, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, and transport protocol dimensions.
+2. `privacyProxyIngressConnMetricsAdaptiveGroups` — Query the number of client-to-proxy connections, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, transport protocol, and TLS version dimensions.
+3. `privacyProxyEgressConnMetricsAdaptiveGroups` — Query the number of proxy-to-origin connections, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, and transport protocol dimensions.
 4. `privacyProxyAuthMetricsAdaptiveGroups` — Query aggregate authentication attempt volume, filterable by time, location, endpoint, authentication method, and authentication result dimensions.
 
 :::note[Adaptive sampling]
-Each node uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudflare automatically scales the sampling rate based on traffic volume to keep query performance consistent. All returned values are extrapolated totals, not raw counts. Because each node has its own sampling rate, figures across nodes are not directly comparable.
+Requests are sampled.
 :::
 
 ---
@@ -263,8 +192,8 @@ query DailyRequestVolume(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2025-01-01",
-  "endDate": "2025-01-31"
+  "startDate": "2026-01-01",
+  "endDate": "2026-01-31"
 }
 ```
 
@@ -308,8 +237,8 @@ query ErrorBreakdown(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2025-01-01T00:00:00Z",
-  "end": "2025-01-01T23:59:59Z"
+  "start": "2026-01-01T00:00:00Z",
+  "end": "2026-01-01T23:59:59Z"
 }
 ```
 
@@ -352,8 +281,8 @@ query TopProxyErrors(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2025-01-01T00:00:00Z",
-  "end": "2025-01-01T23:59:59Z"
+  "start": "2026-01-01T00:00:00Z",
+  "end": "2026-01-01T23:59:59Z"
 }
 ```
 
@@ -395,8 +324,8 @@ query TunnelTypeDistribution(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2025-01-01",
-  "endDate": "2025-01-31"
+  "startDate": "2026-01-01",
+  "endDate": "2026-01-31"
 }
 ```
 
@@ -444,8 +373,8 @@ query IngressTrafficOverview(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2025-01-01",
-  "endDate": "2025-01-31"
+  "startDate": "2026-01-01",
+  "endDate": "2026-01-31"
 }
 ```
 
@@ -488,8 +417,8 @@ query IngressDurationByColo(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2025-01-01",
-  "endDate": "2025-01-31"
+  "startDate": "2026-01-01",
+  "endDate": "2026-01-31"
 }
 ```
 
@@ -497,7 +426,7 @@ query IngressDurationByColo(
 
 <Details header="Protocol and TLS version distribution">
 
-Monitor the breakdown of QUIC versus TCP and TLS version adoption over time.
+Understanding which transport protocols (QUIC versus TCP) and TLS versions your clients use helps you plan deprecations, detect misconfigured clients, and verify that traffic meets your security requirements.
 
 ```graphql
 query IngressProtocolDistribution(
@@ -532,8 +461,8 @@ query IngressProtocolDistribution(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2025-01-01T00:00:00Z",
-  "end": "2025-01-01T23:59:59Z"
+  "start": "2026-01-01T00:00:00Z",
+  "end": "2026-01-01T23:59:59Z"
 }
 ```
 
@@ -574,8 +503,8 @@ query ApproximateActiveConnections(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2025-01-01T12:00:00Z",
-  "end": "2025-01-01T12:05:00Z"
+  "start": "2026-01-01T12:00:00Z",
+  "end": "2026-01-01T12:05:00Z"
 }
 ```
 
@@ -625,8 +554,8 @@ query EgressBytesOverview(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2025-01-01",
-  "endDate": "2025-01-31"
+  "startDate": "2026-01-01",
+  "endDate": "2026-01-31"
 }
 ```
 
@@ -669,8 +598,8 @@ query EgressRttByColo(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2025-01-01",
-  "endDate": "2025-01-31"
+  "startDate": "2026-01-01",
+  "endDate": "2026-01-31"
 }
 ```
 
@@ -716,8 +645,8 @@ query EgressPerformanceTrend(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2025-01-01T08:00:00Z",
-  "end": "2025-01-01T14:00:00Z"
+  "start": "2026-01-01T08:00:00Z",
+  "end": "2026-01-01T14:00:00Z"
 }
 ```
 
@@ -764,8 +693,8 @@ query AuthVolumeByMethod(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "startDate": "2025-01-01",
-  "endDate": "2025-01-31"
+  "startDate": "2026-01-01",
+  "endDate": "2026-01-31"
 }
 ```
 
@@ -809,8 +738,8 @@ query AuthFailureSpike(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2025-01-01T10:00:00Z",
-  "end": "2025-01-01T14:00:00Z"
+  "start": "2026-01-01T10:00:00Z",
+  "end": "2026-01-01T14:00:00Z"
 }
 ```
 
@@ -852,8 +781,8 @@ query AuthSuccessRate(
 ```json
 {
   "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2025-01-01T00:00:00Z",
-  "end": "2025-01-01T23:59:59Z"
+  "start": "2026-01-01T00:00:00Z",
+  "end": "2026-01-01T23:59:59Z"
 }
 ```
 

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -110,7 +110,7 @@ Each node uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudfl
 <Details header="Request node only">
 
 - `statusCode` – `uint16` — HTTP status code returned by the proxy to the client.
-- `proxyStatus` – `string` — Proxy-level error classification. Refer to [proxy status reference](#proxy-status-reference) for possible values.
+- `proxyStatus` – `string` — Proxy-level error classification. `null` when no proxy-level error occurred. Refer to [proxy status reference](#proxy-status-reference) for possible values.
 - `tunnelType` – `string` — Tunnel protocol used (`connect-tcp`, `connect-udp`, `connect-ip`).
 
 </Details>
@@ -749,7 +749,7 @@ query AuthSuccessRate(
 
 <Details header="proxyStatus values">
 
-The `proxyStatus` dimension provides proxy-level error classification. The following values may appear:
+The `proxyStatus` dimension provides proxy-level error classification. This field is `null` when no proxy-level error occurred. The following values may appear:
 
 - `dns_error` — The proxy encountered a DNS error when resolving the next hop hostname.
 - `dns_timeout` — The proxy timed out while resolving the next hop hostname.

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -115,6 +115,8 @@ All four nodes expose a `count` field that returns the total number of sampled e
 | `coloCode` | `string` | Cloudflare data center that handled the request. |
 | `endpoint` | `string` | The appId that generated traffic. |
 
+All timestamp dimensions refer to the end of each connection or request, not the start.
+
 </Details>
 
 <Details header="Request node only">
@@ -471,49 +473,6 @@ query IngressProtocolDistribution(
 
 </Details>
 
-<Details header="Approximate active connections">
-
-Estimate the number of connections that were still open during a short time window by subtracting short-lived connections from the total established. Query a narrow window (one to five minutes) and sum `connections` — this gives the count of connections that started in that window. Connections with a duration longer than your window were established earlier and will not appear, so this query underestimates long-lived connections.
-
-```graphql
-query ApproximateActiveConnections(
-  $accountTag: String!
-  $start: Time!
-  $end: Time!
-) {
-  viewer {
-    accounts(filter: { accountTag: $accountTag }) {
-      privacyProxyIngressConnMetricsAdaptiveGroups(
-        filter: {
-          datetime_geq: $start
-          datetime_leq: $end
-          datetimeMinute_geq: $start
-          datetimeMinute_leq: $end
-        limit: 10000
-        orderBy: [datetimeMinute_ASC]
-      ) {
-        count
-        dimensions {
-          datetimeMinute
-        }
-      }
-    }
-  }
-}
-```
-
-```json
-{
-  "accountTag": "<YOUR_ACCOUNT_TAG>",
-  "start": "2026-01-01T12:00:00Z",
-  "end": "2026-01-01T12:05:00Z"
-}
-```
-
-To approximate active connections, sum the `count` values returned across all minute buckets in the window. The result represents connections that were initiated during that period. For a more conservative estimate of concurrency, divide the total by the window duration in minutes to get an average connections-per-minute rate.
-
-</Details>
-
 </Details>
 
 <Details header="privacyProxyEgressConnMetricsAdaptiveGroups node">
@@ -608,7 +567,7 @@ query EgressLatencyByColo(
 
 <Details header="Egress performance trend">
 
-Track proxy-to-origin handshake latency at fine granularity during an active incident or maintenance window.
+Track proxy-to-origin handshake latency at fine granularity over a specific time window.
 
 ```graphql
 query EgressPerformanceTrend(

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -257,7 +257,7 @@ query TopProxyErrors(
         filter: {
           datetime_geq: $start
           datetime_leq: $end
-          proxyStatus_neq: ""
+          proxyStatus_neq: null
         }
         limit: 10000
         orderBy: [sum_requests_DESC]

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -872,7 +872,7 @@ The `proxyStatus` dimension provides proxy-level error classification. This fiel
 - `dns_error` — The proxy encountered a DNS error when resolving the next hop hostname.
 - `dns_timeout` — The proxy timed out while resolving the next hop hostname.
 - `destination_not_found` — The proxy cannot determine the appropriate next hop for this request.
-- `destination_unavailable` — The proxy considers the next hop unavailable (for example, recent failures or health check down).
+- `destination_unavailable` — The proxy considers the next hop unavailable (for example, recent failures or a health check is down).
 - `destination_ip_prohibited` — The proxy is configured to prohibit connections to the next hop IP address.
 - `destination_ip_unroutable` — The proxy cannot find a route to the next hop IP address.
 - `connection_refused` — The proxy's connection to the next hop was refused.

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -15,14 +15,14 @@ POST https://api.cloudflare.com/client/v4/graphql
 
 Before you begin, you will need:
 
-- **API token** — Create a token with _Account Analytics_ read permissions. For more information, refer to our Analytics API token documentation: [Configure an Analytics API token](/analytics/graphql-api/getting-started/authentication/api-token-auth/). 
-- **Account ID** — Your Cloudflare account ID, passed as `accountTag` in queries. For more information, refer to [Find account and zone IDs](/fundamentals/account/find-account-and-zone-ids/). You may also contact your Cloudflare point of contact if you need help locating your account ID.
+- **API token** — Create a token with _Account Analytics_ read permissions. For more information, refer to our Analytics API token documentation: [Configure an Analytics API token](/analytics/graphql-api/getting-started/authentication/api-token-auth/).
+- **Account ID** — Your Cloudflare account ID, passed as `accountTag` in queries. For more information, refer to [Find account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
 
 ---
 
 ## Making a request
 
-The following example shows how to query Privacy Proxy metrics using curl. Replace the placeholder values with your own.
+The following example shows how to query your Privacy Proxy metrics daily request volume using curl. Replace the placeholder values with your own.
 
 ```bash
 curl https://api.cloudflare.com/client/v4/graphql \
@@ -61,36 +61,40 @@ Requests are sampled.
 
 <Details header="Sum fields">
 
-- `requests` – `uint64` — Total number of proxy requests processed. _(Request node)_
-- `connections` – `uint64` — Total number of connections established. _(Ingress and egress connection nodes)_
-- `bytesSentToClient` – `uint64` — Total bytes sent from the proxy back to the client. _(Ingress connection node)_
-- `bytesReceivedFromClient` – `uint64` — Total bytes received by the proxy from the client. _(Ingress connection node)_
-- `bytesSentToOrigin` – `uint64` — Total bytes sent from the proxy to the upstream origin. _(Egress connection node)_
-- `bytesReceivedFromOrigin` – `uint64` — Total bytes received by the proxy from the upstream origin. _(Egress connection node)_
-- `authAttempts` – `uint64` — Total number of authentication attempts. _(Auth node)_
+| Field | Type | Description | Node |
+| --- | --- | --- | --- |
+| `requests` | `uint64` | Total number of proxy requests processed. | Request |
+| `connections` | `uint64` | Total number of connections established. | Ingress and egress connection |
+| `bytesSentToClient` | `uint64` | Total bytes sent from the proxy back to the client. | Ingress connection |
+| `bytesReceivedFromClient` | `uint64` | Total bytes received by the proxy from the client. | Ingress connection |
+| `bytesSentToOrigin` | `uint64` | Total bytes sent from the proxy to the upstream origin. | Egress connection |
+| `bytesReceivedFromOrigin` | `uint64` | Total bytes received by the proxy from the upstream origin. | Egress connection |
+| `authAttempts` | `uint64` | Total number of authentication attempts. | Auth |
 
 </Details>
 
 <Details header="Quantile fields">
 
-- `connectRequestHandlingDurationUsP50` – `float64` — Median time to handle a CONNECT request, in microseconds. _(Request node)_
-- `connectRequestHandlingDurationUsP95` – `float64` — 95th percentile time to handle a CONNECT request, in microseconds. _(Request node)_
-- `connectRequestHandlingDurationUsP99` – `float64` — 99th percentile time to handle a CONNECT request, in microseconds. _(Request node)_
-- `connectTunnelSetupDurationUsP50` – `float64` — Median time to establish a tunnel after receiving a CONNECT request, in microseconds. _(Request node)_
-- `connectTunnelSetupDurationUsP95` – `float64` — 95th percentile tunnel setup time, in microseconds. _(Request node)_
-- `connectTunnelSetupDurationUsP99` – `float64` — 99th percentile tunnel setup time, in microseconds. _(Request node)_
-- `clientProxyConnectionDurationMsP50` – `float64` — Median client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
-- `clientProxyConnectionDurationMsP95` – `float64` — 95th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
-- `clientProxyConnectionDurationMsP99` – `float64` — 99th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
-- `clientProxyRttMsP50` – `float64` — Median round-trip time between client and proxy, in milliseconds. _(Ingress connection node)_
-- `clientProxyRttMsP95` – `float64` — 95th percentile RTT between client and proxy, in milliseconds. _(Ingress connection node)_
-- `clientProxyRttMsP99` – `float64` — 99th percentile RTT between client and proxy, in milliseconds. _(Ingress connection node)_
-- `proxyOriginConnectionDurationMsP50` – `float64` — Median proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
-- `proxyOriginConnectionDurationMsP95` – `float64` — 95th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
-- `proxyOriginConnectionDurationMsP99` – `float64` — 99th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
-- `proxyOriginRttMsP50` – `float64` — Median round-trip time between proxy and origin, in milliseconds. _(Egress connection node)_
-- `proxyOriginRttMsP95` – `float64` — 95th percentile RTT between proxy and origin, in milliseconds. _(Egress connection node)_
-- `proxyOriginRttMsP99` – `float64` — 99th percentile RTT between proxy and origin, in milliseconds. _(Egress connection node)_
+| Field | Type | Description | Node |
+| --- | --- | --- | --- |
+| `connectRequestHandlingDurationUsP50` | `float64` | Median time to handle a CONNECT request, in microseconds. | Request |
+| `connectRequestHandlingDurationUsP95` | `float64` | 95th percentile time to handle a CONNECT request, in microseconds. | Request |
+| `connectRequestHandlingDurationUsP99` | `float64` | 99th percentile time to handle a CONNECT request, in microseconds. | Request |
+| `connectTunnelSetupDurationUsP50` | `float64` | Median time to establish a tunnel after receiving a CONNECT request, in microseconds. | Request |
+| `connectTunnelSetupDurationUsP95` | `float64` | 95th percentile tunnel setup time, in microseconds. | Request |
+| `connectTunnelSetupDurationUsP99` | `float64` | 99th percentile tunnel setup time, in microseconds. | Request |
+| `clientProxyConnectionDurationMsP50` | `float64` | Median client-to-proxy connection lifetime, in milliseconds. | Ingress connection |
+| `clientProxyConnectionDurationMsP95` | `float64` | 95th percentile client-to-proxy connection lifetime, in milliseconds. | Ingress connection |
+| `clientProxyConnectionDurationMsP99` | `float64` | 99th percentile client-to-proxy connection lifetime, in milliseconds. | Ingress connection |
+| `clientProxyRttMsP50` | `float64` | Median round-trip time between client and proxy, in milliseconds. | Ingress connection |
+| `clientProxyRttMsP95` | `float64` | 95th percentile RTT between client and proxy, in milliseconds. | Ingress connection |
+| `clientProxyRttMsP99` | `float64` | 99th percentile RTT between client and proxy, in milliseconds. | Ingress connection |
+| `proxyOriginConnectionDurationMsP50` | `float64` | Median proxy-to-origin connection lifetime, in milliseconds. | Egress connection |
+| `proxyOriginConnectionDurationMsP95` | `float64` | 95th percentile proxy-to-origin connection lifetime, in milliseconds. | Egress connection |
+| `proxyOriginConnectionDurationMsP99` | `float64` | 99th percentile proxy-to-origin connection lifetime, in milliseconds. | Egress connection |
+| `proxyOriginRttMsP50` | `float64` | Median round-trip time between proxy and origin, in milliseconds. | Egress connection |
+| `proxyOriginRttMsP95` | `float64` | 95th percentile RTT between proxy and origin, in milliseconds. | Egress connection |
+| `proxyOriginRttMsP99` | `float64` | 99th percentile RTT between proxy and origin, in milliseconds. | Egress connection |
 
 </Details>
 
@@ -100,41 +104,51 @@ Requests are sampled.
 
 <Details header="All nodes">
 
-- `date` – `Date` — Calendar date (day granularity).
-- `datetimeMinute` – `Time` — Timestamp truncated to the minute.
-- `datetimeFiveMinutes` – `Time` — Timestamp truncated to five-minute intervals.
-- `datetimeFifteenMinutes` – `Time` — Timestamp truncated to fifteen-minute intervals.
-- `datetimeHour` – `Time` — Timestamp truncated to the hour.
-- `colo` – `string` — Cloudflare data center that handled the request.
-- `endpoint` – `string` — The appId that generated traffic.
+| Field | Type | Description |
+| --- | --- | --- |
+| `date` | `Date` | Calendar date (day granularity). |
+| `datetimeMinute` | `Time` | Timestamp truncated to the minute. |
+| `datetimeFiveMinutes` | `Time` | Timestamp truncated to five-minute intervals. |
+| `datetimeFifteenMinutes` | `Time` | Timestamp truncated to fifteen-minute intervals. |
+| `datetimeHour` | `Time` | Timestamp truncated to the hour. |
+| `colo` | `string` | Cloudflare data center that handled the request. |
+| `endpoint` | `string` | The appId that generated traffic. |
 
 </Details>
 
 <Details header="Request node only">
 
-- `statusCode` – `uint16` — HTTP status code returned by the proxy to the client.
-- `proxyStatus` – `string` — Proxy-level error classification. `null` when no proxy-level error occurred. Refer to [proxy status reference](#proxy-status-reference) for possible values.
-- `tunnelType` – `string` — Tunnel protocol used (`connect-tcp`, `connect-udp`, `connect-ip`).
+| Field | Type | Description |
+| --- | --- | --- |
+| `statusCode` | `uint16` | HTTP status code returned by the proxy to the client. |
+| `proxyStatus` | `string` | Proxy-level error classification. `null` when no proxy-level error occurred. Refer to [proxy status reference](/privacy-proxy/reference/proxy-status/) for possible values. |
+| `tunnelType` | `string` | Tunnel protocol used (`connect-tcp`, `connect-udp`, `connect-ip`). |
 
 </Details>
 
 <Details header="Ingress connection node only">
 
-- `ingressTransport` – `string` — Transport protocol on the client-to-proxy connection (`tcp`, `quic`).
-- `tlsVersion` – `string` — TLS version negotiated on the client-to-proxy connection.
+| Field | Type | Description |
+| --- | --- | --- |
+| `ingressTransport` | `string` | Transport protocol on the client-to-proxy connection (`tcp`, `quic`). |
+| `tlsVersion` | `string` | TLS version negotiated on the client-to-proxy connection. |
 
 </Details>
 
 <Details header="Egress connection node only">
 
-- `egressTransport` – `string` — Transport protocol on the proxy-to-origin connection.
+| Field | Type | Description |
+| --- | --- | --- |
+| `egressTransport` | `string` | Transport protocol on the proxy-to-origin connection. |
 
 </Details>
 
 <Details header="Auth node only">
 
-- `authMethod` – `string` — Authentication method used (for example, `token_hash`, `mtls`, `blind_rsa`).
-- `authResult` – `string` — Authentication outcome (`success`, `failure`).
+| Field | Type | Description |
+| --- | --- | --- |
+| `authMethod` | `string` | Authentication method used (for example, `token_hash`, `mtls`, `blind_rsa`). |
+| `authResult` | `string` | Authentication outcome (`success`, `failure`). |
 
 </Details>
 
@@ -792,42 +806,9 @@ query AuthSuccessRate(
 
 ---
 
-## Proxy status reference
-
-<Details header="proxyStatus values">
-
-The `proxyStatus` dimension provides proxy-level error classification. This field is `null` when no proxy-level error occurred. The following values may appear:
-
-- `dns_error` — The proxy encountered a DNS error when resolving the next hop hostname.
-- `dns_timeout` — The proxy timed out while resolving the next hop hostname.
-- `destination_not_found` — The proxy cannot determine the appropriate next hop for this request.
-- `destination_unavailable` — The proxy considers the next hop unavailable (for example, recent failures or a health check is down).
-- `destination_ip_prohibited` — The proxy is configured to prohibit connections to the next hop IP address.
-- `destination_ip_unroutable` — The proxy cannot find a route to the next hop IP address.
-- `connection_refused` — The proxy's connection to the next hop was refused.
-- `connection_terminated` — The proxy's connection to the next hop was closed before any response was received.
-- `connection_timeout` — The proxy's attempt to open a connection to the next hop timed out.
-- `connection_read_timeout` — The proxy was expecting data on a connection but received none within the configured time limit.
-- `connection_write_timeout` — The proxy was attempting to write data to a connection but was unable to.
-- `connection_limit_reached` — The proxy's configured connection limit to the next hop has been exceeded.
-- `source_addr_in_use` — The proxy cannot assign a source address when connecting to the next hop.
-- `source_addr_not_available` — The proxy cannot assign a source address (bind failure or source host resolution failure).
-- `tls_protocol_error` — The proxy encountered a TLS error when communicating with the next hop.
-- `tls_certificate_error` — The proxy encountered an error verifying the certificate presented by the next hop.
-- `http_request_error` — The proxy is generating a client (4xx) response on the origin's behalf.
-- `http_upgrade_failed` — The HTTP Upgrade between the proxy and the next hop failed.
-- `http_request_denied` — The proxy rejected the HTTP request based on its configuration or policy.
-- `proxy_internal_error` — The proxy encountered an internal error unrelated to the origin.
-- `proxy_loop_detected` — The proxy tried to forward the request to itself.
-- `http_protocol_error` — The proxy encountered an HTTP protocol error when communicating with the next hop.
-- `http_response_incomplete` — The proxy received an incomplete response from the next hop.
-- `rate_limit` — The client has reached the maximum number of connections per second to a single origin.
-
-</Details>
-
----
 
 ## Related resources
 
 - [GraphQL Analytics API — getting started](/analytics/graphql-api/getting-started/)
 - [GraphQL Analytics API — filtering](/analytics/graphql-api/features/filtering/)
+- [Proxy status reference](/privacy-proxy/reference/proxy-status/) — All possible `proxyStatus` values and their meanings.

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -37,9 +37,9 @@ curl https://api.cloudflare.com/client/v4/graphql \
 
 ---
 
-## Available nodes
+## Available datasets
 
-Four GraphQL nodes are available. All four return aggregate data only — no raw per-connection records are exposed.
+Four GraphQL datasets are available. All four return aggregate data only — no raw per-connection records are exposed.
 
 1. `privacyProxyRequestMetricsAdaptiveGroups` — Query aggregate request volume, CONNECT request handling and tunnel setup latency percentiles (P50/P95/P99), filterable by time, location, endpoint, status code, proxy status, and tunnel type dimensions.
 2. `privacyProxyIngressConnMetricsAdaptiveGroups` — Query aggregate client-to-proxy connection volume, bytes transferred, connection duration and round-trip latency percentiles (P50/P95/P99), filterable by time, location, endpoint, transport protocol, and TLS version dimensions.
@@ -47,53 +47,55 @@ Four GraphQL nodes are available. All four return aggregate data only — no raw
 4. `privacyProxyAuthMetricsAdaptiveGroups` — Query aggregate authentication attempt volume, filterable by time, location, endpoint, authentication method, and authentication result dimensions.
 
 :::note[Adaptive sampling]
-Each node uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudflare automatically scales the sampling rate based on traffic volume to keep query performance consistent. All returned values are extrapolated totals, not raw counts. Because each node has its own sampling rate, figures across nodes are not directly comparable.
+Each dataset uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudflare automatically scales the sampling rate based on traffic volume to keep query performance consistent. All returned values are extrapolated totals, not raw counts. Because each dataset has its own sampling rate, figures across datasets are not directly comparable.
 :::
 
 ---
 
-## Metrics
+## Schema
+
+<Details header="Metrics">
 
 <Details header="Sum fields">
 
-- `requests` – `uint64` — Total number of proxy requests processed. _(Request node)_
-- `connections` – `uint64` — Total number of connections established. _(Ingress and egress connection nodes)_
-- `bytesSentToClient` – `uint64` — Total bytes sent from the proxy back to the client. _(Ingress connection node)_
-- `bytesReceivedFromClient` – `uint64` — Total bytes received by the proxy from the client. _(Ingress connection node)_
-- `bytesSentToOrigin` – `uint64` — Total bytes sent from the proxy to the upstream origin. _(Egress connection node)_
-- `bytesReceivedFromOrigin` – `uint64` — Total bytes received by the proxy from the upstream origin. _(Egress connection node)_
-- `authAttempts` – `uint64` — Total number of authentication attempts. _(Auth node)_
+- `requests` – `uint64` — Total number of proxy requests processed. _(Request dataset)_
+- `connections` – `uint64` — Total number of connections established. _(Ingress and egress connection datasets)_
+- `bytesSentToClient` – `uint64` — Total bytes sent from the proxy back to the client. _(Ingress connection dataset)_
+- `bytesReceivedFromClient` – `uint64` — Total bytes received by the proxy from the client. _(Ingress connection dataset)_
+- `bytesSentToOrigin` – `uint64` — Total bytes sent from the proxy to the upstream origin. _(Egress connection dataset)_
+- `bytesReceivedFromOrigin` – `uint64` — Total bytes received by the proxy from the upstream origin. _(Egress connection dataset)_
+- `authAttempts` – `uint64` — Total number of authentication attempts. _(Auth dataset)_
 
 </Details>
 
 <Details header="Quantile fields">
 
-- `connectRequestHandlingDurationUsP50` – `float64` — Median time to handle a CONNECT request, in microseconds. _(Request node)_
-- `connectRequestHandlingDurationUsP95` – `float64` — 95th percentile time to handle a CONNECT request, in microseconds. _(Request node)_
-- `connectRequestHandlingDurationUsP99` – `float64` — 99th percentile time to handle a CONNECT request, in microseconds. _(Request node)_
-- `connectTunnelSetupDurationUsP50` – `float64` — Median time to establish a tunnel after receiving a CONNECT request, in microseconds. _(Request node)_
-- `connectTunnelSetupDurationUsP95` – `float64` — 95th percentile tunnel setup time, in microseconds. _(Request node)_
-- `connectTunnelSetupDurationUsP99` – `float64` — 99th percentile tunnel setup time, in microseconds. _(Request node)_
-- `clientProxyConnectionDurationMsP50` – `float64` — Median client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
-- `clientProxyConnectionDurationMsP95` – `float64` — 95th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
-- `clientProxyConnectionDurationMsP99` – `float64` — 99th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection node)_
-- `clientProxyRttMsP50` – `float64` — Median round-trip time between client and proxy, in milliseconds. _(Ingress connection node)_
-- `clientProxyRttMsP95` – `float64` — 95th percentile RTT between client and proxy, in milliseconds. _(Ingress connection node)_
-- `clientProxyRttMsP99` – `float64` — 99th percentile RTT between client and proxy, in milliseconds. _(Ingress connection node)_
-- `proxyOriginConnectionDurationMsP50` – `float64` — Median proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
-- `proxyOriginConnectionDurationMsP95` – `float64` — 95th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
-- `proxyOriginConnectionDurationMsP99` – `float64` — 99th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection node)_
-- `proxyOriginRttMsP50` – `float64` — Median round-trip time between proxy and origin, in milliseconds. _(Egress connection node)_
-- `proxyOriginRttMsP95` – `float64` — 95th percentile RTT between proxy and origin, in milliseconds. _(Egress connection node)_
-- `proxyOriginRttMsP99` – `float64` — 99th percentile RTT between proxy and origin, in milliseconds. _(Egress connection node)_
+- `connectRequestHandlingDurationUsP50` – `float64` — Median time to handle a CONNECT request, in microseconds. _(Request dataset)_
+- `connectRequestHandlingDurationUsP95` – `float64` — 95th percentile time to handle a CONNECT request, in microseconds. _(Request dataset)_
+- `connectRequestHandlingDurationUsP99` – `float64` — 99th percentile time to handle a CONNECT request, in microseconds. _(Request dataset)_
+- `connectTunnelSetupDurationUsP50` – `float64` — Median time to establish a tunnel after receiving a CONNECT request, in microseconds. _(Request dataset)_
+- `connectTunnelSetupDurationUsP95` – `float64` — 95th percentile tunnel setup time, in microseconds. _(Request dataset)_
+- `connectTunnelSetupDurationUsP99` – `float64` — 99th percentile tunnel setup time, in microseconds. _(Request dataset)_
+- `clientProxyConnectionDurationMsP50` – `float64` — Median client-to-proxy connection lifetime, in milliseconds. _(Ingress connection dataset)_
+- `clientProxyConnectionDurationMsP95` – `float64` — 95th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection dataset)_
+- `clientProxyConnectionDurationMsP99` – `float64` — 99th percentile client-to-proxy connection lifetime, in milliseconds. _(Ingress connection dataset)_
+- `clientProxyRttMsP50` – `float64` — Median round-trip time between client and proxy, in milliseconds. _(Ingress connection dataset)_
+- `clientProxyRttMsP95` – `float64` — 95th percentile RTT between client and proxy, in milliseconds. _(Ingress connection dataset)_
+- `clientProxyRttMsP99` – `float64` — 99th percentile RTT between client and proxy, in milliseconds. _(Ingress connection dataset)_
+- `proxyOriginConnectionDurationMsP50` – `float64` — Median proxy-to-origin connection lifetime, in milliseconds. _(Egress connection dataset)_
+- `proxyOriginConnectionDurationMsP95` – `float64` — 95th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection dataset)_
+- `proxyOriginConnectionDurationMsP99` – `float64` — 99th percentile proxy-to-origin connection lifetime, in milliseconds. _(Egress connection dataset)_
+- `proxyOriginRttMsP50` – `float64` — Median round-trip time between proxy and origin, in milliseconds. _(Egress connection dataset)_
+- `proxyOriginRttMsP95` – `float64` — 95th percentile RTT between proxy and origin, in milliseconds. _(Egress connection dataset)_
+- `proxyOriginRttMsP99` – `float64` — 99th percentile RTT between proxy and origin, in milliseconds. _(Egress connection dataset)_
 
 </Details>
 
----
+</Details>
 
-## Dimensions
+<Details header="Dimensions">
 
-<Details header="All nodes">
+<Details header="All datasets">
 
 - `date` – `Date` — Calendar date (day granularity).
 - `datetimeMinute` – `Time` — Timestamp truncated to the minute.
@@ -105,7 +107,7 @@ Each node uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudfl
 
 </Details>
 
-<Details header="Request node only">
+<Details header="Request dataset only">
 
 - `statusCode` – `uint16` — HTTP status code returned by the proxy to the client.
 - `proxyStatus` – `string` — Proxy-level error classification. Refer to [proxy status reference](#proxy-status-reference) for possible values.
@@ -113,33 +115,31 @@ Each node uses an independent adaptive bit-rate (ABR) sampling pipeline. Cloudfl
 
 </Details>
 
-<Details header="Ingress connection node only">
+<Details header="Ingress connection dataset only">
 
 - `ingressTransport` – `string` — Transport protocol on the client-to-proxy connection (`tcp`, `quic`).
 - `tlsVersion` – `string` — TLS version negotiated on the client-to-proxy connection.
 
 </Details>
 
-<Details header="Egress connection node only">
+<Details header="Egress connection dataset only">
 
 - `egressTransport` – `string` — Transport protocol on the proxy-to-origin connection.
 
 </Details>
 
-<Details header="Auth node only">
+<Details header="Auth dataset only">
 
 - `authMethod` – `string` — Authentication method used (for example, `token_hash`, `mtls`, `blind_rsa`).
 - `authResult` – `string` — Authentication outcome (`success`, `failure`).
 
 </Details>
 
----
-
-## Arguments
+</Details>
 
 <Details header="Arguments">
 
-All four nodes share the same argument signature.
+All four datasets share the same argument signature.
 
 - `filter` <MetaInfo text="required" /> — Filters your data. `accountTag` is always required inside the filter.
 - `limit` <MetaInfo text="required" /> — Maximum number of records to return.

--- a/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/graphql.mdx
@@ -487,7 +487,8 @@ query ApproximateActiveConnections(
         filter: {
           datetime_geq: $start
           datetime_leq: $end
-        }
+          datetimeMinute_geq: $start
+          datetimeMinute_leq: $end
         limit: 10000
         orderBy: [datetimeMinute_ASC]
       ) {

--- a/src/content/docs/privacy-proxy/reference/metrics/index.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/index.mdx
@@ -2,7 +2,7 @@
 title: Observability
 pcx_content_type: navigation
 sidebar:
-  order: 3
+  order: 4
 ---
 
 import { DirectoryListing } from "~/components";
@@ -10,3 +10,14 @@ import { DirectoryListing } from "~/components";
 Privacy Proxy provides two methods for accessing metrics and monitoring your proxy deployment. We recommend getting started with GraphQL as the default method for observability.
 
 <DirectoryListing />
+
+## Data privacy
+
+Regardless of whether you use the GraphQL Analytics API or OpenTelemetry, Privacy Proxy observability data does not include:
+
+- User IP addresses
+- Request content or headers (beyond what is needed for metrics)
+- Destination URLs or hostnames (aggregated only)
+- Authentication tokens or credentials
+
+Both methods export only operational metrics that help you monitor service health without compromising user privacy.

--- a/src/content/docs/privacy-proxy/reference/metrics/index.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Metrics and analytics
+title: Observability
 pcx_content_type: navigation
 sidebar:
   order: 2

--- a/src/content/docs/privacy-proxy/reference/metrics/index.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Metrics and analytics
+pcx_content_type: navigation
+sidebar:
+  order: 2
+---
+
+import { DirectoryListing } from "~/components";
+
+Privacy Proxy provides two methods for accessing metrics and monitoring your proxy deployment.
+
+<DirectoryListing />

--- a/src/content/docs/privacy-proxy/reference/metrics/index.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/index.mdx
@@ -2,7 +2,7 @@
 title: Observability
 pcx_content_type: navigation
 sidebar:
-  order: 2
+  order: 3
 ---
 
 import { DirectoryListing } from "~/components";

--- a/src/content/docs/privacy-proxy/reference/metrics/index.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/index.mdx
@@ -7,6 +7,6 @@ sidebar:
 
 import { DirectoryListing } from "~/components";
 
-Privacy Proxy provides two methods for accessing metrics and monitoring your proxy deployment.
+Privacy Proxy provides two methods for accessing metrics and monitoring your proxy deployment. We recommend getting started with GraphQL as the default method for observability.
 
 <DirectoryListing />

--- a/src/content/docs/privacy-proxy/reference/metrics/opentelemetry.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/opentelemetry.mdx
@@ -1,17 +1,15 @@
 ---
-title: Observability
+title: OpenTelemetry
 pcx_content_type: reference
 sidebar:
-  order: 1
+  order: 2
 ---
-
-Privacy Proxy supports OpenTelemetry for monitoring and observability. You can collect metrics and traces to understand proxy performance and usage.
-
-## OpenTelemetry integration
 
 Privacy Proxy exports telemetry data using the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/). You can configure an endpoint to receive this data and forward it to your observability platform.
 
-### Configure telemetry export
+---
+
+## Configure telemetry export
 
 During onboarding, provide Cloudflare with your OpenTelemetry collector endpoint:
 
@@ -20,7 +18,9 @@ During onboarding, provide Cloudflare with your OpenTelemetry collector endpoint
 
 Cloudflare configures your Privacy Proxy instance to export telemetry to this endpoint.
 
-### Supported signals
+---
+
+## Supported signals
 
 Privacy Proxy exports the following telemetry signals:
 
@@ -28,6 +28,8 @@ Privacy Proxy exports the following telemetry signals:
 | ------- | ----------------------------------------------------------------------------------------------------- |
 | Metrics | Connection counts, request rates, latency histograms, error rates                                     |
 | Traces  | Per-request traces showing proxy processing time. Traces are sampled at approximately 1% of requests. |
+
+---
 
 ## Metrics
 
@@ -56,6 +58,8 @@ Privacy Proxy exports metrics that help you understand usage patterns and perfor
 | ------------------------------------------ | ------------------------------------------- |
 | `privacy_proxy_connect_latency_seconds`    | Time to establish connection to destination |
 | `privacy_proxy_first_byte_latency_seconds` | Time to first byte from destination         |
+
+---
 
 ## `Server-Timing` header
 
@@ -86,6 +90,8 @@ histogram_quantile(0.95, rate(privacy_proxy_connect_latency_seconds_bucket[5m]))
 sum(rate(privacy_proxy_requests_by_status{status=~"5.."}[5m])) / sum(rate(privacy_proxy_requests_total[5m]))
 ```
 
+---
+
 ## Data privacy
 
 Telemetry data does not include:
@@ -97,6 +103,9 @@ Telemetry data does not include:
 
 Cloudflare exports only operational metrics that help you monitor service health without compromising user privacy.
 
+---
+
 ## Related resources
 
-- [OpenTelemetry documentation](https://opentelemetry.io/docs/) - Learn more about OpenTelemetry concepts and configuration.
+- [OpenTelemetry documentation](https://opentelemetry.io/docs/) — Learn more about OpenTelemetry concepts and configuration.
+- [GraphQL Analytics API](/privacy-proxy/reference/metrics/graphql/) — Query metrics programmatically via Cloudflare's GraphQL API.

--- a/src/content/docs/privacy-proxy/reference/metrics/opentelemetry.mdx
+++ b/src/content/docs/privacy-proxy/reference/metrics/opentelemetry.mdx
@@ -14,7 +14,7 @@ Privacy Proxy exports telemetry data using the [OpenTelemetry Protocol (OTLP)](h
 During onboarding, provide Cloudflare with your OpenTelemetry collector endpoint:
 
 - **Endpoint URL**: The HTTPS endpoint where telemetry data should be sent.
-- **Authentication**: Headers or credentials required to authenticate with your collector.
+- **Authentication**: Headers or credentials required to authenticate with your collector. Supported authentication types include bearer token headers, custom header-based authentication, and mutual TLS (mTLS).
 
 Cloudflare configures your Privacy Proxy instance to export telemetry to this endpoint.
 
@@ -89,19 +89,6 @@ histogram_quantile(0.95, rate(privacy_proxy_connect_latency_seconds_bucket[5m]))
 # Error rate
 sum(rate(privacy_proxy_requests_by_status{status=~"5.."}[5m])) / sum(rate(privacy_proxy_requests_total[5m]))
 ```
-
----
-
-## Data privacy
-
-Telemetry data does not include:
-
-- User IP addresses
-- Request content or headers (beyond what is needed for metrics)
-- Destination URLs or hostnames (aggregated only)
-- Authentication tokens or credentials
-
-Cloudflare exports only operational metrics that help you monitor service health without compromising user privacy.
 
 ---
 

--- a/src/content/docs/privacy-proxy/reference/proxy-status.mdx
+++ b/src/content/docs/privacy-proxy/reference/proxy-status.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Details } from "~/components";
 
-The `proxyStatus` dimension provides proxy-level error classification. This field is available in both [GraphQL Analytics API](/privacy-proxy/reference/metrics/graphql/) and [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/) metrics. The value is `null` when no proxy-level error occurred.
+The `proxyStatus` dimension provides proxy-level error classification. This field is available in both [GraphQL Analytics API](/privacy-proxy/reference/metrics/graphql/) and [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/) metrics. The value is an empty string when no proxy-level error occurred.
 
 ---
 

--- a/src/content/docs/privacy-proxy/reference/proxy-status.mdx
+++ b/src/content/docs/privacy-proxy/reference/proxy-status.mdx
@@ -1,0 +1,41 @@
+---
+title: Proxy status reference
+pcx_content_type: reference
+sidebar:
+  order: 3
+---
+
+import { Details } from "~/components";
+
+The `proxyStatus` dimension provides proxy-level error classification. This field is available in both [GraphQL Analytics API](/privacy-proxy/reference/metrics/graphql/) and [OpenTelemetry](/privacy-proxy/reference/metrics/opentelemetry/) metrics. The value is `null` when no proxy-level error occurred.
+
+---
+
+## `proxyStatus` values
+
+| Value | Description |
+| --- | --- |
+| `dns_error` | The proxy encountered a DNS error when resolving the next hop hostname. |
+| `dns_timeout` | The proxy timed out while resolving the next hop hostname. |
+| `destination_not_found` | The proxy cannot determine the appropriate next hop for this request. |
+| `destination_unavailable` | The proxy considers the next hop unavailable (for example, recent failures or health check is down). |
+| `destination_ip_prohibited` | The proxy is configured to prohibit connections to the next hop IP address. |
+| `destination_ip_unroutable` | The proxy cannot find a route to the next hop IP address. |
+| `connection_refused` | The proxy's connection to the next hop was refused. |
+| `connection_terminated` | The proxy's connection to the next hop was closed before any response was received. |
+| `connection_timeout` | The proxy's attempt to open a connection to the next hop timed out. |
+| `connection_read_timeout` | The proxy was expecting data on a connection but received none within the configured time limit. |
+| `connection_write_timeout` | The proxy was attempting to write data to a connection but was unable to. |
+| `connection_limit_reached` | The proxy's configured connection limit to the next hop has been exceeded. |
+| `source_addr_in_use` | The proxy cannot assign a source address when connecting to the next hop. |
+| `source_addr_not_available` | The proxy cannot assign a source address (bind failure or source host resolution failure). |
+| `tls_protocol_error` | The proxy encountered a TLS error when communicating with the next hop. |
+| `tls_certificate_error` | The proxy encountered an error verifying the certificate presented by the next hop. |
+| `http_request_error` | The proxy is generating a client (4xx) response on the origin's behalf. |
+| `http_upgrade_failed` | The HTTP Upgrade between the proxy and the next hop failed. |
+| `http_request_denied` | The proxy rejected the HTTP request based on its configuration or policy. |
+| `proxy_internal_error` | The proxy encountered an internal error unrelated to the origin. |
+| `proxy_loop_detected` | The proxy tried to forward the request to itself. |
+| `http_protocol_error` | The proxy encountered an HTTP protocol error when communicating with the next hop. |
+| `http_response_incomplete` | The proxy received an incomplete response from the next hop. |
+| `rate_limit` | The client has reached the maximum number of connections per second to a single origin. |

--- a/src/content/docs/privacy-proxy/reference/proxy-status.mdx
+++ b/src/content/docs/privacy-proxy/reference/proxy-status.mdx
@@ -38,4 +38,4 @@ The `proxyStatus` dimension provides proxy-level error classification. This fiel
 | `proxy_loop_detected` | The proxy tried to forward the request to itself. |
 | `http_protocol_error` | The proxy encountered an HTTP protocol error when communicating with the next hop. |
 | `http_response_incomplete` | The proxy received an incomplete response from the next hop. |
-| `rate_limit` | The client has reached the maximum number of connections per second to a single origin. |
+| `rate_limited` | The client has reached the maximum number of connections per second to a single origin. |


### PR DESCRIPTION
## Summary

Privacy Proxy recently introduced four new GraphQL Analytics API nodes (`privacyProxyRequestMetricsAdaptiveGroups`, `privacyProxyIngressConnMetricsAdaptiveGroups`, `privacyProxyEgressConnMetricsAdaptiveGroups`, `privacyProxyAuthMetricsAdaptiveGroups`) to give customers visibility into proxy traffic, errors, and latency. This PR adds comprehensive documentation for those nodes, restructures the existing metrics pages into a unified Observability section, and updates cross-references throughout the Privacy Proxy docs.

## Changes

- Added a new GraphQL Analytics API reference page (`privacy-proxy/reference/metrics/graphql/`) documenting all four nodes — schema details, available dimensions and metrics, authentication, and sample queries for common use cases (error breakdown, latency monitoring, protocol distribution, egress traffic analysis, etc.).
- Created an Observability landing page (`privacy-proxy/reference/metrics/index.mdx`) to group the GraphQL and OpenTelemetry metrics docs under a single section.
- Restructured the existing OpenTelemetry page to sit under the new metrics section and added related-resource links between the two observability paths.
- Added a full proxy status error reference (`privacy-proxy/reference/proxy-status/`) documenting all `proxyStatus` dimension values.
- Updated the HTTP headers reference to cross-link to the new observability docs.

| File | Description |
|---|---|
| `src/content/docs/privacy-proxy/reference/metrics/graphql.mdx` | Adds a comprehensive GraphQL Analytics API reference for Privacy Proxy metrics, with schema and sample queries. |
| `src/content/docs/privacy-proxy/reference/metrics/index.mdx` | Adds Observability navigation landing page for the metrics section. |
| `src/content/docs/privacy-proxy/reference/metrics/opentelemetry.mdx` | Renames/restructures the OpenTelemetry metrics reference and adds links to GraphQL metrics docs. |
| `src/content/docs/privacy-proxy/reference/proxy-status.mdx` | Adds proxy status error reference documenting all `proxyStatus` dimension values. |
| `src/content/docs/privacy-proxy/reference/http-headers.mdx` | Adds cross-links and short guidance tying headers to the new observability docs. |