### PR TITLE
Remove enable date from python_workers

### DIFF
--- a/src/content/compatibility-flags/python-workers.md
+++ b/src/content/compatibility-flags/python-workers.md
@@ -5,6 +5,7 @@ _build:
   list: never
 
 name: "Python Workers"
+sort_date: "2024-01-29"
 enable_flag: "python_workers"
 ---
 

--- a/src/content/compatibility-flags/python-workers.md
+++ b/src/content/compatibility-flags/python-workers.md
@@ -5,8 +5,6 @@ _build:
   list: never
 
 name: "Python Workers"
-sort_date: "2024-01-29"
-enable_date: "2024-01-29"
 enable_flag: "python_workers"
 ---
 


### PR DESCRIPTION
This compat flag does not have an enable date, so changing this to fix our docs.
