### PR TITLE
[Cloudflare One] ELI5 on DNS Policies

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/dns-policies/common-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/dns-policies/common-policies.mdx
@@ -69,7 +69,7 @@ The categories included in this policy are not always a security threat, but blo
 
 ## Block a dynamic list of categories
 
-You can add a list of category IDs to the [EDNS header](https://datatracker.ietf.org/doc/html/rfc6891) of a request sent to Gateway as a JSON object using OPT code `65050`. For example:
+You can add a list of category IDs to the [EDNS (Extension Mechanisms for DNS)](https://datatracker.ietf.org/doc/html/rfc6891) header of a request sent to Gateway as a JSON object using OPT code `65050`. A client application or custom DNS resolver embeds these IDs in the DNS query so Gateway can filter by categories not known at policy creation time. For example:
 
 ```json
 {
@@ -200,10 +200,10 @@ To protect against [sophisticated phishing attacks](https://blog.cloudflare.com/
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-| Selector | Operator      | Value                                       | Logic | Action |
-| -------- | ------------- | ------------------------------------------- | ----- | ------ |
-| Domain   | not in list   | _Corporate Domains_                         | And   | Block  |
-| Domain   | matches regex | `.*okta.*\|.*cloudflare.*\|.*mfa.*\|.sso.*` |       |        |
+| Selector | Operator      | Value                                        | Logic | Action |
+| -------- | ------------- | -------------------------------------------- | ----- | ------ |
+| Domain   | not in list   | _Corporate Domains_                          | And   | Block  |
+| Domain   | matches regex | `.*okta.*\|.*cloudflare.*\|.*mfa.*\|.*sso.*` |       |        |
 
 </TabItem>
 
@@ -220,7 +220,7 @@ To protect against [sophisticated phishing attacks](https://blog.cloudflare.com/
 		action: "block",
 		filters: ["dns"],
 		traffic:
-			'not(any(dns.domains[*] in $<LIST_UUID>)) and any(dns.domains[*] matches ".*okta.*\\|.*cloudflare.*\\|.*mfa.*\\|.sso.*")',
+			'not(any(dns.domains[*] in $<LIST_UUID>)) and any(dns.domains[*] matches ".*okta.*\\|.*cloudflare.*\\|.*mfa.*\\|.*sso.*")',
 		identity: "",
 	}}
 />

--- a/src/content/docs/cloudflare-one/traffic-policies/dns-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/dns-policies/index.mdx
@@ -9,7 +9,9 @@ sidebar:
 
 import { Details, InlineBadge, Render } from "~/components";
 
-When a user makes a DNS request to Gateway, Gateway matches the request against the DNS policies you have set up for your organization. If the domain does not belong to any blocked categories, or if it matches an Override policy, the user's client receives an address based on the DNS resolution from Cloudflare's 1.1.1.1 servers. Alternatively, you can use a [resolver policy](/cloudflare-one/traffic-policies/resolver-policies/) to redirect DNS requests to a custom server.
+DNS policies allow you to filter and control which domain names users in your organization can resolve. Because DNS policies operate at the DNS layer, they block connections before any data is transferred — making them a fast, low-overhead first layer of security in [Cloudflare Gateway](/cloudflare-one/gateway/).
+
+When a user makes a DNS request to Gateway, Gateway matches the request against the DNS policies you have set up for your organization. If the domain does not belong to any blocked categories, or if it matches an Override policy, the user's client receives an address based on the DNS resolution from Cloudflare's public DNS resolver (1.1.1.1). Alternatively, you can use a [resolver policy](/cloudflare-one/traffic-policies/resolver-policies/) to redirect DNS requests to a custom server.
 
 A DNS policy consists of an **Action** as well as a logical expression that determines the scope of the action. To build an expression, you need to choose a **Selector** and an **Operator**, and enter a value or range of values in the **Value** field. You can use **And** and **Or** logical operators to evaluate multiple conditions.
 
@@ -145,7 +147,7 @@ Policies with Block actions block DNS queries to reach destinations you specify 
 
 When choosing the Block action, turn on **Modify Gateway block behavior** to respond to queries with a block page to display to users who go to blocked websites. Optionally, you can override your global block page setting with a URL redirect for the specific DNS policy. For more information, refer to [Block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/).
 
-If the block page is turned off for a policy, Gateway will respond to queries blocked at the DNS level with an `A` record of `0.0.0.0` for IPv4 destinations, or with an `AAAA` record of `::` for IPv6 destinations. The browser will display its default connection error page.
+If the block page is turned off for a policy, Gateway will respond to queries blocked at the DNS level with an `A` record (IPv4 address) of `0.0.0.0`, or with an `AAAA` record (IPv6 address) of `::`. Both are non-routable addresses, so the browser will display its default connection error page.
 
 <Render file="gateway/block-page-dns-records" product="cloudflare-one" />
 
@@ -285,7 +287,13 @@ This setup ensures users will be blocked from accessing offensive sites using DN
 
 ## Selectors
 
-Gateway matches DNS queries against the following selectors, or criteria:
+Gateway matches DNS queries against the following selectors, or criteria.
+
+Each selector is available at a specific **evaluation phase**, which determines when Gateway can inspect that attribute during the DNS query lifecycle:
+
+- **Before DNS resolution** — Gateway has the query (domain name, source IP, user identity) but has not yet resolved it. Most selectors are available at this phase.
+- **During DNS resolution** — Gateway is actively resolving the domain and can inspect metadata such as the authoritative nameserver IP.
+- **After DNS resolution** — Gateway has the resolved answer (IP address, CNAME records, geolocation). Selectors at this phase cannot be used with the [Override](#override) action, because the override replaces the answer before it exists.
 
 ### Application
 
@@ -428,7 +436,7 @@ Use this selector to filter based on the IP addresses that the query resolves to
 
 ### Request Context Categories
 
-Use this selector to match a dynamic list of [category IDs](/cloudflare-one/traffic-policies/domain-categories/#category-and-subcategory-ids) sent in the [EDNS](https://datatracker.ietf.org/doc/html/rfc6891) portion of a DNS query. Gateway includes request context with the OPT code `65050`.
+Use this selector to match a dynamic list of [category IDs](/cloudflare-one/traffic-policies/domain-categories/#category-and-subcategory-ids) sent in the [EDNS (Extension Mechanisms for DNS)](https://datatracker.ietf.org/doc/html/rfc6891) portion of a DNS query. EDNS is a protocol extension that allows extra data to be attached to a standard DNS query. A client application or custom DNS resolver can embed category IDs in the EDNS OPT record (code `65050`), and Gateway will read and match them against your policy.
 
 | UI name                    | API example                                 | Evaluation phase      |
 | -------------------------- | ------------------------------------------- | --------------------- |
@@ -473,7 +481,13 @@ Use this selector to apply policies to the source internal IP address of a DNS q
 <Render
 	file="gateway/value"
 	product="cloudflare-one"
-	params={{ selector: "Host", selectordescription: "hostname", operator: "matches regex", valueOne: ".*whispersystems.org", valueTwo: ".*signal.org" }}
+	params={{
+		selector: "Host",
+		selectordescription: "hostname",
+		operator: "matches regex",
+		valueOne: ".*whispersystems.org",
+		valueTwo: ".*signal.org",
+	}}
 />
 
 ## Logical operators

--- a/src/content/docs/cloudflare-one/traffic-policies/dns-policies/test-dns-filtering.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/dns-policies/test-dns-filtering.mdx
@@ -9,15 +9,15 @@ sidebar:
 
 import { Details } from "~/components";
 
-This section covers how to validate your Gateway DNS configuration.
+After creating a DNS policy, test it to confirm Gateway is intercepting and filtering queries as expected. Policies can appear to fail because of DNS caching, incorrect DNS location assignment, or fallback DNS servers.
 
 ## Prerequisites
 
-Before you start, make sure you are connected to a network that is associated with the [DNS location](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/) where the policy is applied.
+Before you start, make sure your device sends DNS queries through a Gateway [DNS location](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/). If you use the WARP client, queries are routed automatically. If you use a DNS-only deployment, confirm your device or network resolver points to your location's assigned [DNS resolver IP addresses](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/dns-resolver-ips/).
 
 ## Test a DNS policy
 
-Once you have created a DNS policy to block a domain, you can use either `dig` or `nslookup` to see if the policy is working as intended.
+Once you have created a DNS policy to block a domain, you can use either `dig` (Linux/macOS) or `nslookup` (Windows) to query DNS servers from the command line and verify the policy is working as intended.
 
 For example, if you created a policy to block `example.com`, you can do the following to see if Gateway is successfully blocking `example.com`:
 
@@ -25,7 +25,7 @@ For example, if you created a policy to block `example.com`, you can do the foll
 
 2. Type `dig example.com` (`nslookup example.com` if you are using Windows) and press **Enter**.
 
-3. If the [block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) is turned off for the policy, you should see `REFUSED` in the answer section:
+3. If the [block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) is turned off for the policy, you should see `REFUSED` in the answer section. `REFUSED` is a DNS response code that means Gateway explicitly declined to answer the query:
 
    ```sh
    dig example.com
@@ -48,7 +48,7 @@ For example, if you created a policy to block `example.com`, you can do the foll
    ;; MSG SIZE  rcvd: 29
    ```
 
-   If the [block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) is enabled for the policy, you should see `NOERROR` in the answer section with `162.159.36.12` and `162.159.46.12` as the answers:
+   If the [block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) is enabled for the policy, you should see `NOERROR` in the answer section. The IP addresses `162.159.36.12` and `162.159.46.12` are Cloudflare's block page servers — your browser will load the block page from these addresses:
 
    ```sh null
    dig example.com
@@ -116,7 +116,7 @@ Once you have configured your Gateway policy to block the category, the test dom
 
 ## Test EDNS configuration
 
-If you [enabled EDNS client subnet](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/) for your DNS location, you can validate EDNS as follows:
+EDNS client subnet (ECS) sends a portion of the user's IP address to upstream DNS resolvers so they can return geographically optimized answers. If you [enabled EDNS client subnet](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/) for your DNS location, you can validate it as follows:
 
 1. Obtain your DNS location's DOH subdomain:
    1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Networks** > **Resolvers & Proxies** > **DNS locations**.

--- a/src/content/docs/cloudflare-one/traffic-policies/dns-policies/timed-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/dns-policies/timed-policies.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { APIRequest, Tabs, TabItem } from "~/components";
 
-By default, Cloudflare Gateway policies apply at all times when turned on. With timed DNS policies, you can control when DNS policies are active. You can configure a policy to be active during specific time periods or set the policy to expire after a certain duration.
+By default, Cloudflare Gateway policies apply at all times when turned on. With timed DNS policies, you can control when DNS policies are active. This is useful for scenarios like restricting social media access during work hours, temporarily allowing a blocked category for a specific project, or enforcing different policies on weekdays versus weekends. You can configure a policy to be active during specific time periods or set the policy to expire after a certain duration.
 
 There are two timed DNS policy options:
 
@@ -30,7 +30,7 @@ To set a duration for a DNS policy:
 
 When a policy turns off, it will remain off until you turn it back on.
 
-Policies with a set duration will retain their duration when turned off or on. For example, you can create a policy at 12:00 PM and set it to turn off after six hours. If you turn the policy off at 3:00 PM and turn it back on 4:00 PM, the policy will still turn off at 6:00 PM, six hours after the original time.
+The expiration time is fixed when the policy is first turned on and does not pause if you temporarily turn the policy off. For example, if you create a policy at 12:00 PM with a six-hour duration, it will expire at 6:00 PM. If you turn the policy off at 3:00 PM and back on at 4:00 PM, the policy will still turn off at 6:00 PM.
 
 ### Reset a policy's duration
 
@@ -87,7 +87,11 @@ The policy's schedule will appear in Cloudflare One under **Traffic policies** >
 
 If you [assign a time zone](#example-fixed-time-zone) to your schedule, Gateway will always use the current time at that time zone regardless of the user's location. This allows you to enable a policy during a certain fixed time period.
 
-If you [do not specify a time zone](#example-users-time-zone), Gateway will enable the DNS policy based on the user's local time zone. The user's time zone is inferred from the IP geolocation of their source IP address. If Gateway is unable to determine the time zone from the source IP, we will fall back to the time zone of the data center where the query was received.
+If you [do not specify a time zone](#example-users-time-zone), Gateway will enable the DNS policy based on the user's local time zone. The user's time zone is inferred from the IP geolocation of their source IP address. If Gateway is unable to determine the time zone from the source IP, it falls back to the time zone of the data center where the query was received.
+
+:::note
+IP-based geolocation may be inaccurate for users on VPNs or mobile networks. If precise time zone control is important, assign an explicit time zone to the schedule.
+:::
 
 #### Example: Fixed time zone
 


### PR DESCRIPTION
Improves readability and accuracy across all four pages in the DNS policies folder (`src/content/docs/cloudflare-one/traffic-policies/dns-policies/`), based on an ELI5 accessibility review.

- **Add "why" framing to `index.mdx`** — New opening paragraph explains what DNS policies do and why they matter before diving into how Gateway processes queries. Clarifies that 1.1.1.1 is Cloudflare's public DNS resolver.
- **Define "evaluation phase" in `index.mdx`** — Every selector table references this concept but it was never defined. Added a three-bullet explanation before the Selectors section covering Before/During/After DNS resolution, including why Override cannot use post-resolution selectors.
- **Clarify A/AAAA record behavior in `index.mdx`** — Adds inline context that `A` records are IPv4 and `AAAA` are IPv6, and explains that `0.0.0.0`/`::` are non-routable.
- **Define EDNS inline in `index.mdx` and `common-policies.mdx`** — Expands "EDNS" to "Extension Mechanisms for DNS" on first use and adds a sentence explaining what it does and who sends the data.
- **Fix regex bug in `common-policies.mdx`** — The phishing policy regex `.sso.*` was missing the leading `*` wildcard. Changed to `.*sso.*` in both the Dashboard table and the API traffic expression to match domains containing "sso" anywhere in the name.
- **Improve `test-dns-filtering.mdx` prerequisites** — Replaces vague "connected to a network" language with specific guidance for WARP vs. DNS-only deployments. Adds context for `dig`/`nslookup` tools and explains what `REFUSED` and block page IPs mean in `dig` output.
- **Define EDNS client subnet in `test-dns-filtering.mdx`** — Adds one-sentence definition of ECS before the validation steps.
- **Add use-case framing to `timed-policies.mdx`** — Opening paragraph now includes example scenarios (work-hours restrictions, temporary access, weekday/weekend differences).
- **Fix first-person voice in `timed-policies.mdx`** — Changes "we will fall back" to "it falls back" per Cloudflare docs style. Adds a note about IP geolocation inaccuracy on VPNs.
- **Clarify duration behavior in `timed-policies.mdx`** — Rephrases "retain their duration" to make clear the expiration clock does not pause when a policy is temporarily turned off.