### PR TITLE
Add docs and changelog entry for Wrangler `secrets` property

### DIFF
--- a/src/content/changelog/workers/2026-03-24-secrets-config-property.mdx
+++ b/src/content/changelog/workers/2026-03-24-secrets-config-property.mdx
@@ -1,0 +1,37 @@
+---
+title: Declare required secrets in your Wrangler configuration
+description: The new experimental `secrets` configuration property lets you declare which secrets your Worker requires.
+products:
+  - workers
+date: 2026-03-24
+---
+
+import { WranglerConfig } from "~/components";
+
+The new experimental `secrets` configuration property lets you declare the secret names your Worker requires in your Wrangler configuration file. Required secrets are validated during local development and deploy, and used as the source of truth for type generation.
+
+<WranglerConfig>
+
+```jsonc
+{
+	"secrets": {
+		"required": ["API_KEY", "DB_PASSWORD"],
+	},
+}
+```
+
+</WranglerConfig>
+
+### Local development
+
+When `secrets` is defined, `wrangler dev` and `vite dev` load only the keys listed in `secrets.required` from `.dev.vars` or `.env`/`process.env`. Additional keys in those files are excluded. If any required secrets are missing, a warning is logged listing the missing names.
+
+### Type generation
+
+`wrangler types` generates typed bindings from `secrets.required` instead of inferring names from `.dev.vars` or `.env`. This lets you run type generation in CI or other environments where those files are not present. Per-environment secrets are supported — the aggregated `Env` type marks secrets that only appear in some environments as optional.
+
+### Deploy
+
+`wrangler deploy` and `wrangler versions upload` validate that all secrets in `secrets.required` are configured on the Worker before the operation succeeds. If any required secrets are missing, the command fails with an error listing which secrets need to be set.
+
+For more information, refer to the [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental) reference.

--- a/src/content/changelog/workers/2026-03-24-secrets-config-property.mdx
+++ b/src/content/changelog/workers/2026-03-24-secrets-config-property.mdx
@@ -1,6 +1,6 @@
 ---
 title: Declare required secrets in your Wrangler configuration
-description: The new experimental `secrets` configuration property lets you declare which secrets your Worker requires.
+description: The new `secrets` configuration property lets you declare which secrets your Worker requires.
 products:
   - workers
 date: 2026-03-24
@@ -8,7 +8,7 @@ date: 2026-03-24
 
 import { WranglerConfig } from "~/components";
 
-The new experimental `secrets` configuration property lets you declare the secret names your Worker requires in your Wrangler configuration file. Required secrets are validated during local development and deploy, and used as the source of truth for type generation.
+The new `secrets` configuration property lets you declare the secret names your Worker requires in your Wrangler configuration file. Required secrets are validated during local development and deploy, and used as the source of truth for type generation.
 
 <WranglerConfig>
 
@@ -34,4 +34,4 @@ When `secrets` is defined, `wrangler dev` and `vite dev` load only the keys list
 
 `wrangler deploy` and `wrangler versions upload` validate that all secrets in `secrets.required` are configured on the Worker before the operation succeeds. If any required secrets are missing, the command fails with an error listing which secrets need to be set.
 
-For more information, refer to the [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental) reference.
+For more information, refer to the [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property) reference.

--- a/src/content/changelog/workers/2026-03-24-secrets-config-property.mdx
+++ b/src/content/changelog/workers/2026-03-24-secrets-config-property.mdx
@@ -3,7 +3,7 @@ title: Declare required secrets in your Wrangler configuration
 description: The new `secrets` configuration property lets you declare which secrets your Worker requires.
 products:
   - workers
-date: 2026-03-24
+date: 2026-03-25
 ---
 
 import { WranglerConfig } from "~/components";

--- a/src/content/docs/workers/configuration/secrets.mdx
+++ b/src/content/docs/workers/configuration/secrets.mdx
@@ -73,6 +73,10 @@ Secrets described on this page are defined and managed on a per-Worker level. If
 
 ## Secrets on deployed Workers
 
+### Validate secrets before deploy
+
+You can declare the secret names your Worker requires using the experimental [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental) in your Wrangler configuration. When defined, `wrangler deploy` and `wrangler versions upload` will fail with a clear error if any required secrets are not configured on the Worker.
+
 ### Adding secrets to your project
 
 #### Via Wrangler
@@ -98,6 +102,7 @@ npx wrangler versions secret put <KEY>
 #### Via the dashboard
 
 To add a secret via the dashboard:
+
 1. In the Cloudflare dashboard, go to the **Workers & Pages** page.
 
    <DashButton url="/?to=/:account/workers-and-pages" />
@@ -145,4 +150,5 @@ To delete a secret from your Worker project via the dashboard:
 ## Related resources
 
 - [Wrangler secret commands](/workers/wrangler/commands/general/#secret) - Review the Wrangler commands to create, delete and list secrets.
+- [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental) - Declare required secret names in your Wrangler configuration to validate secrets during local development, type generation, and deploy.
 - [Cloudflare Secrets Store](/secrets-store/) - Encrypt and store sensitive information as secrets that are securely reusable across your account.

--- a/src/content/docs/workers/configuration/secrets.mdx
+++ b/src/content/docs/workers/configuration/secrets.mdx
@@ -75,7 +75,7 @@ Secrets described on this page are defined and managed on a per-Worker level. If
 
 ### Validate secrets before deploy
 
-You can declare the secret names your Worker requires using the experimental [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental) in your Wrangler configuration. When defined, `wrangler deploy` and `wrangler versions upload` will fail with a clear error if any required secrets are not configured on the Worker.
+You can declare the secret names your Worker requires using the [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property) in your Wrangler configuration. When defined, `wrangler deploy` and `wrangler versions upload` will fail with a clear error if any required secrets are not configured on the Worker.
 
 ### Adding secrets to your project
 
@@ -150,5 +150,5 @@ To delete a secret from your Worker project via the dashboard:
 ## Related resources
 
 - [Wrangler secret commands](/workers/wrangler/commands/general/#secret) - Review the Wrangler commands to create, delete and list secrets.
-- [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental) - Declare required secret names in your Wrangler configuration to validate secrets during local development, type generation, and deploy.
+- [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property) - Declare required secret names in your Wrangler configuration. Used for validation during local development and deploy, and as the source of truth for type generation.
 - [Cloudflare Secrets Store](/secrets-store/) - Encrypt and store sensitive information as secrets that are securely reusable across your account.

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1511,7 +1511,7 @@ You can configure various aspects of local development, such as the local protoc
 This property is experimental and subject to change.
 :::
 
-The `secrets` configuration property lets you declare the secret names your Worker requires. When defined, Wrangler uses it to validate secrets during local development, type generation, and deploy.
+The `secrets` configuration property lets you declare the secret names your Worker requires in your Wrangler configuration file. Required secrets are validated during local development and deploy, and used as the source of truth for type generation.
 
 <WranglerConfig>
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -280,8 +280,8 @@ Non-inheritable keys are configurable at the top-level, but cannot be inherited 
 - `tail_consumers` <Type text="object" /> <MetaInfo text="optional" />
   - A list of the Tail Workers your Worker sends data to. Refer to [Tail Workers](/workers/observability/logs/tail-workers/).
 
-- `secrets` <Type text="object" /> <MetaInfo text="optional experimental" />
-  - Declares the secret names your Worker requires. Refer to [Secrets](#secrets).
+- `secrets` <Type text="object" /> <MetaInfo text="optional" />
+  - Declares the secret names your Worker requires. Used for validation during local development and deploy, and as the source of truth for type generation. Refer to [Secrets](#secrets).
   - `required` <Type text="string[]" /> <MetaInfo text="optional" /> — A list of secret names that must be set to deploy your Worker.
 
 ## Types of routes
@@ -1505,7 +1505,7 @@ You can configure various aspects of local development, such as the local protoc
 
 <Render file="secrets-in-dev" product="workers" />
 
-### `secrets` configuration property (experimental)
+### `secrets` configuration property
 
 :::note
 This property is experimental and subject to change.

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -280,6 +280,10 @@ Non-inheritable keys are configurable at the top-level, but cannot be inherited 
 - `tail_consumers` <Type text="object" /> <MetaInfo text="optional" />
   - A list of the Tail Workers your Worker sends data to. Refer to [Tail Workers](/workers/observability/logs/tail-workers/).
 
+- `secrets` <Type text="object" /> <MetaInfo text="optional experimental" />
+  - Declares the secret names your Worker requires. Refer to [Secrets](#secrets).
+  - `required` <Type text="string[]" /> <MetaInfo text="optional" /> — A list of secret names that must be set to deploy your Worker.
+
 ## Types of routes
 
 There are three types of [routes](/workers/configuration/routing/): [Custom Domains](/workers/configuration/routing/custom-domains/), [routes](/workers/configuration/routing/routes/), and [`workers.dev`](/workers/configuration/routing/workers-dev/).
@@ -1493,11 +1497,43 @@ You can configure various aspects of local development, such as the local protoc
 
 </WranglerConfig>
 
-### Secrets
+## Secrets
 
 [Secrets](/workers/configuration/secrets/) are a type of binding that allow you to [attach encrypted text values](/workers/wrangler/commands/general/#secret) to your Worker.
 
+### Local development
+
 <Render file="secrets-in-dev" product="workers" />
+
+### `secrets` configuration property (experimental)
+
+:::note
+This property is experimental and subject to change.
+:::
+
+The `secrets` configuration property lets you declare the secret names your Worker requires. When defined, Wrangler uses it to validate secrets during local development, type generation, and deploy.
+
+<WranglerConfig>
+
+```jsonc
+{
+	"secrets": {
+		"required": ["API_KEY", "DB_PASSWORD"],
+	},
+}
+```
+
+</WranglerConfig>
+
+**Type generation**
+
+When `secrets` is defined at any config level, `wrangler types` generates typed bindings from the names listed in `secrets.required` and no longer infers secret names from `.dev.vars` or `.env` files. This lets you run type generation in environments where those files are not present.
+
+Per-environment secrets are supported. Each named environment produces its own interface, and the aggregated `Env` type marks secrets that only appear in some environments as optional.
+
+**Deploy**
+
+When `secrets` is defined, `wrangler deploy` and `wrangler versions upload` validate that all secrets in `secrets.required` are configured on the Worker before the operation succeeds. If any required secrets are missing, the command fails with an error listing which secrets need to be set.
 
 ## Module Aliasing
 

--- a/src/content/partials/workers/secrets-in-dev.mdx
+++ b/src/content/partials/workers/secrets-in-dev.mdx
@@ -8,6 +8,10 @@ Do not use `vars` to store sensitive information in your Worker's Wrangler confi
 
 Put secrets for use in local development in either a `.dev.vars` file or a `.env` file, in the same directory as the Wrangler configuration file.
 
+:::note
+You can use the experimental [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental) to declare which secret names your Worker requires. When defined, only the keys listed in `secrets.required` are loaded from `.dev.vars` or `.env`. Additional keys are excluded and missing keys produce a warning.
+:::
+
 :::info
 Choose to use either `.dev.vars` or `.env` but not both. If you define a `.dev.vars` file, then values in `.env` files will not be included in the `env` object during local development.
 :::
@@ -38,6 +42,6 @@ When you select a Cloudflare environment in your local development, the correspo
 It is possible to control how `.env` files are loaded in local development by setting environment variables on the process running the tools.
 
 - To disable loading local dev vars from `.env` files without providing a `.dev.vars` file, set the `CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV` environment variable to `"false"`.
-- To include every environment variable defined in your system's process environment as a local development variable, ensure there is no `.dev.vars` and then set the `CLOUDFLARE_INCLUDE_PROCESS_ENV` environment variable to `"true"`.
+- To include every environment variable defined in your system's process environment as a local development variable, ensure there is no `.dev.vars` and then set the `CLOUDFLARE_INCLUDE_PROCESS_ENV` environment variable to `"true"`. This is not needed when using the [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental), which loads from `process.env` automatically.
 
 :::

--- a/src/content/partials/workers/secrets-in-dev.mdx
+++ b/src/content/partials/workers/secrets-in-dev.mdx
@@ -9,7 +9,7 @@ Do not use `vars` to store sensitive information in your Worker's Wrangler confi
 Put secrets for use in local development in either a `.dev.vars` file or a `.env` file, in the same directory as the Wrangler configuration file.
 
 :::note
-You can use the experimental [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental) to declare which secret names your Worker requires. When defined, only the keys listed in `secrets.required` are loaded from `.dev.vars` or `.env`. Additional keys are excluded and missing keys produce a warning.
+You can use the [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property) to declare which secret names your Worker requires. When defined, only the keys listed in `secrets.required` are loaded from `.dev.vars` or `.env`. Additional keys are excluded and missing keys produce a warning.
 :::
 
 :::info
@@ -42,6 +42,6 @@ When you select a Cloudflare environment in your local development, the correspo
 It is possible to control how `.env` files are loaded in local development by setting environment variables on the process running the tools.
 
 - To disable loading local dev vars from `.env` files without providing a `.dev.vars` file, set the `CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV` environment variable to `"false"`.
-- To include every environment variable defined in your system's process environment as a local development variable, ensure there is no `.dev.vars` and then set the `CLOUDFLARE_INCLUDE_PROCESS_ENV` environment variable to `"true"`. This is not needed when using the [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property-experimental), which loads from `process.env` automatically.
+- To include every environment variable defined in your system's process environment as a local development variable, ensure there is no `.dev.vars` and then set the `CLOUDFLARE_INCLUDE_PROCESS_ENV` environment variable to `"true"`. This is not needed when using the [`secrets` configuration property](/workers/wrangler/configuration/#secrets-configuration-property), which loads from `process.env` automatically.
 
 :::


### PR DESCRIPTION
### Summary

Add docs and changelog entry for experimental Wrangler `secrets` property.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
