### PR TITLE
ELI5 on Egress Policies

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -11,9 +11,11 @@ import { Details, Render } from "~/components";
 Only available as an add-on to Zero Trust Enterprise plans.
 :::
 
-Dedicated egress IPs are static IP addresses that can be used to allowlist traffic from your organization. These IPs are unique to your account and are not used by any other customers routing traffic through Cloudflare's network. Each dedicated egress IP consists of an IPv4 address and an IPv6 range that are assigned to a specific Cloudflare data center. At minimum, Cloudflare will provision your account with two dedicated egress IPs corresponding to data centers in two different cities.
+Many third-party services require you to allowlist specific source IP addresses before they accept connections. Dedicated egress IPs are static IP addresses assigned exclusively to your account — no other Cloudflare customer shares them.
 
-An account can have any number of additional dedicated egress IPs. To request additional dedicated egress IPs, contact your account team to schedule a service window.
+Each dedicated egress IP consists of an IPv4 address and an IPv6 range, both tied to a specific Cloudflare data center. Cloudflare provisions your account with at least two dedicated egress IPs in two different cities.
+
+You can request additional dedicated egress IPs at any time. Contact your account team to schedule a service window.
 
 ## Turn on egress IPs
 
@@ -36,15 +38,15 @@ To check if your device is using the correct dedicated egress IP:
 3. Determine the source IPv6 address of your device by going to `https://ipv6.icanhazip.com/`.
 4. Verify that the source IPv4 and IPv6 addresses match your dedicated egress IP.
 
-When testing against another origin, you may see either an IPv4 or IPv6 address. Gateway has no control over whether connections are made over IPv4 or IPv6. Some origins are only available over IPv4, while others are only available over IPv6. When both protocols are supported, the decision is made by the operating system and browser on the client device. For example, Windows will by default [favor IPv6](https://learn.microsoft.com/troubleshoot/windows-server/networking/configure-ipv6-in-windows) over IPv4.
+When testing against another origin, you may see either an IPv4 or IPv6 address. Gateway does not control which protocol is used — some origins only support one protocol, and when both are available, the client operating system and browser decide. For example, Windows [favors IPv6 by default](https://learn.microsoft.com/troubleshoot/windows-server/networking/configure-ipv6-in-windows).
 
 ## IPs
 
 ### Bring your own IP address (BYOIP)
 
-Enterprise users can use their own authority-provided IPv4 and IPv6 addresses as dedicated egress IPs. Gateway supports bringing your own IPv4 and IPv6 addresses. To obtain an IPv6 range, refer to [American Registry for Internet Numbers (ARIN)](https://www.arin.net/resources/guide/ipv6/first_request/) or [Regional Internet Registry for Europe, Middle East and Central Asia (RIPE NCC)](https://www.ripe.net/manage-ips-and-asns/ipv6/request-ipv6/).
+If your organization already owns IPv4 or IPv6 addresses from a regional Internet registry, you can use them as dedicated egress IPs instead of Cloudflare-provided addresses. To obtain an IPv6 range, refer to [American Registry for Internet Numbers (ARIN)](https://www.arin.net/resources/guide/ipv6/first_request/) or [Regional Internet Registry for Europe, Middle East and Central Asia (RIPE NCC)](https://www.ripe.net/manage-ips-and-asns/ipv6/request-ipv6/).
 
-After you onboard your IP addresses, the IP addresses will appear when you create a [egress policy](/cloudflare-one/traffic-policies/egress-policies/) and choose **Use dedicated egress IPs (Cloudflare or BYOIP)** as the [egress method](/cloudflare-one/traffic-policies/egress-policies/#egress-methods). BYOIP dedicated egress IPs do not support [IP geolocation](#ip-geolocation).
+After you onboard your IP addresses, they appear as options when you create an [egress policy](/cloudflare-one/traffic-policies/egress-policies/) and choose **Use dedicated egress IPs (Cloudflare or BYOIP)** as the [egress method](/cloudflare-one/traffic-policies/egress-policies/#egress-methods). BYOIP dedicated egress IPs do not support [IP geolocation](#ip-geolocation).
 
 For more information, refer to [Cloudflare BYOIP](/byoip/) or contact your account team.
 
@@ -64,18 +66,16 @@ If you do not have your own authority-provided IPv4 and IPv6 addresses, you can 
 
 ### Concurrent connections
 
-Each dedicated egress IP assigned to your organization supports 40,000 concurrent connections per destination IP and destination port. You can configure multiple origins for each combination of dedicated egress IP and source port.
+Each dedicated egress IP supports up to 40,000 concurrent connections per unique combination of destination IP and destination port. You can configure multiple origins for each combination of dedicated egress IP and source port.
 
 ### Unsupported traffic
 
-Dedicated egress IPs do not apply to:
+Dedicated egress IPs do not apply to the following traffic types. These connections use the default shared IPs because Cloudflare identifies them by other means (for example, tunnel ID or account context) rather than source IP.
 
 - DNS queries resolved through Gateway
 - Private networks connected to Zero Trust via Cloudflare Tunnel
 - Traffic destined for private networks connected to Zero Trust via [Cloudflare WAN](/cloudflare-wan/)
-- ICMP traffic (such as `ping`)
-
-These origins will see the default shared IPs instead of the dedicated egress IPs. This is because Cloudflare can filter traffic to these origins by identifiers other than source IP.
+- ICMP traffic (for example, `ping`)
 
 ### Traffic resilience
 
@@ -93,9 +93,9 @@ If the location for your primary egress IPs goes down and there is no secondary 
 IP geolocation will take at least six weeks to update across databases.
 :::
 
-Your egress traffic will geolocate to the city selected in your [egress policies](/cloudflare-one/traffic-policies/egress-policies/). If the traffic does not match an egress policy, IP geolocation defaults to the closest dedicated egress location to the user. We recommend you create a [catch-all egress policy](/cloudflare-one/traffic-policies/egress-policies/#catch-all-policy) before dedicated egress IPs are assigned to your account. This will prevent incorrect geolocation for your users' traffic while geolocation databases update.
+Websites and services use third-party IP geolocation databases to determine where a visitor is located. When you turn on dedicated egress IPs, Gateway updates these databases so they associate your new IPs with the correct city. Until the databases finish updating, services like Google Search may show incorrect regional content — for example, directing users in India to the United States landing page.
 
-When you turn on dedicated egress IPs, Gateway will update third-party IP geolocation databases. Other websites, such as Google Search, will check these databases to geolocate a user's source IP. For example, if your users are in India, Google will direct them to the United States Google landing page instead of the India landing page until Google recognizes the updated IP geolocation.
+Your egress traffic geolocates to the city selected in your [egress policies](/cloudflare-one/traffic-policies/egress-policies/). Traffic that does not match an egress policy defaults to the closest dedicated egress location. Create a [catch-all egress policy](/cloudflare-one/traffic-policies/egress-policies/#catch-all-policy) before dedicated egress IPs are assigned to your account to prevent incorrect geolocation while databases update.
 
 To verify that the IP geolocation has updated, check your dedicated egress IP in one of the supported databases:
 
@@ -121,7 +121,7 @@ To verify that the IP geolocation has updated, check your dedicated egress IP in
 
 ### Egress location
 
-Your users' physical egress location will vary depending on whether their connection is over IPv4 or IPv6.
+Where your users' traffic physically exits the Cloudflare network depends on whether the connection uses IPv4 or IPv6.
 
 | Protocol | Destination proxied by Cloudflare | Physical egress location             | IP geolocation                       |
 | -------- | --------------------------------- | ------------------------------------ | ------------------------------------ |
@@ -132,9 +132,9 @@ Your users' physical egress location will vary depending on whether their connec
 
 #### IPv4
 
-To physically egress from a specific location, traffic must be proxied to Cloudflare via IPv4. The end user connects to the nearest Cloudflare data center, but Cloudflare will internally route their traffic to egress from the dedicated location configured in your [egress policies](/cloudflare-one/traffic-policies/egress-policies/). Therefore, the connected data center shown in the user's Cloudflare One Client preferences may not match their actual egress location.
+IPv4 addresses are scarce, so Cloudflare must physically route IPv4 traffic to the data center where your dedicated address is provisioned. The user connects to the nearest Cloudflare data center, and Cloudflare internally routes the traffic to the dedicated egress location configured in your [egress policies](/cloudflare-one/traffic-policies/egress-policies/). As a result, the data center shown in the user's Cloudflare One Client preferences may differ from the actual egress location.
 
-We are able to offer better IPv4 performance when users visit domains proxied by Cloudflare (also known as an [orange-clouded](/dns/proxy-status/) domain). In this scenario, IPv4 traffic will physically egress from the most performant data center in our network while still appearing to egress from your dedicated location.
+Performance is better when users visit domains proxied by Cloudflare ([orange-clouded](/dns/proxy-status/) domains). In this case, IPv4 traffic physically exits from the most performant data center while still appearing to originate from your dedicated egress location.
 
 For example, assume you have a primary dedicated egress IP in Los Angeles and a secondary dedicated egress IP in New York. A user in Las Vegas would see Las Vegas as their connected data center. If they go to a site not proxied by Cloudflare ([gray-clouded](/dns/proxy-status/#dns-only-records)), such as `espn.com`, they will egress from Los Angeles (or whichever city is in the matching egress policy). If they go to an orange-clouded site such as `cloudflare.com`, they will physically egress from Las Vegas but use Los Angeles as their IP geolocation.
 
@@ -144,7 +144,7 @@ IPv4 addresses are limited, so Cloudflare must physically route traffic to the d
 
 #### IPv6
 
-Traffic proxied via IPv6, unlike IPv4, will physically egress from the connected data center but logically egress with one of your dedicated IP geolocations. This is possible because IPv6 has significantly more address space available, allowing Cloudflare to assign IPv6 ranges from all possible geolocations to every data center. Each account receives a /64 IPv6 range, which provides ample space for this approach.
+Unlike IPv4, IPv6 traffic physically exits from the user's connected data center while still appearing to originate from the dedicated egress IP geolocation. This works because IPv6 has enough address space for Cloudflare to assign IPv6 ranges from all possible geolocations to every data center. Each account receives a /64 IPv6 range.
 
 In the example above, the Las Vegas user would physically egress from Las Vegas but their traffic would IP geolocate to Los Angeles. This means:
 
@@ -162,7 +162,7 @@ No, egress IPs are limited to a single data center.
 
 ### Can my users in different locations egress from their closest data center via a single egress IP?
 
-No, traffic will only egress from the data center where the egress IP is provisioned. If you have users in locations far apart, we recommend reserving multiple egress IPs across different data centers and provisioning your users to their closest data centers.
+No, traffic exits from the data center where the egress IP is provisioned. If your users are spread across multiple regions, reserve multiple egress IPs in different data centers and assign each user group to the closest one.
 
 ### Can I use dedicated egress IPs with traffic proxied via [PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/)?
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/egress-cloudflared.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/egress-cloudflared.mdx
@@ -71,7 +71,7 @@ In your WARP [Split Tunnels](/cloudflare-one/team-and-resources/devices/cloudfla
 
 When users connect to a public hostname route, Gateway will assign an <GlossaryTooltip term="initial resolved IP">initial resolved IP</GlossaryTooltip> to the DNS query from the following range:
 
-Gateway's network engine operates at Layer 3/Layer 4 of the [OSI model](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/), where it can only see IP addresses — not hostnames. The initial resolved IP acts as a signal: when a packet's destination IP falls within the `100.80.0.0/16` Carrier-Grade NAT (CGNAT) range, Gateway recognizes that the IP maps to a public hostname route and sends the traffic through the corresponding Cloudflare Tunnel.
+Gateway's network engine operates at Layer 3/Layer 4 of the [OSI model](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/), where only IP addresses are available — not hostnames. The initial resolved IP acts as a signal: when a packet's destination IP falls within the `100.80.0.0/16` Carrier-Grade NAT (CGNAT) range, Gateway recognizes that the IP maps to a public hostname route and sends the traffic through the corresponding Cloudflare Tunnel.
 
 To route initial resolved IPs through the Cloudflare One Client:
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/egress-cloudflared.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/egress-cloudflared.mdx
@@ -11,9 +11,9 @@ import { Render, Details, GlossaryTooltip } from "~/components";
 
 <Render file="gateway/egress-selector-warp-version" product="cloudflare-one" />
 
-A Cloudflare Tunnel can be used for source IP anchoring when you want to use existing egress IPs instead of purchasing [Cloudflare dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/). Some third-party websites may have an Access Control List (ACL) that only allows connections from certain source IPs. If you already have a non-Cloudflare IP on their allowlist (such as an egress IP provided by an ISP or a cloud provider like AWS), you can configure `cloudflared` to anchor user traffic to the same IPs that you use today.
+Some third-party services only accept connections from specific source IPs listed in an Access Control List (ACL). If a non-Cloudflare IP (for example, an IP from your ISP or a cloud provider like AWS) is already on their allowlist, you can route traffic through a Cloudflare Tunnel so that it exits using that same IP. This is called source IP anchoring — it allows you to keep your existing egress IPs without purchasing [Cloudflare dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/).
 
-For example, assume that your organization's banking service, `app.bank.com`, expects user traffic to come from an AWS IP. You can install `cloudflared` in your AWS environment and add a public hostname route pointing to `app.bank.com`. When users connect to `app.bank.com` using the Cloudflare One Client, Gateway will apply your network policies and route the filtered traffic down the corresponding Cloudflare Tunnel to AWS. The traffic can then egress to the public Internet using your AWS egress IP.
+For example, assume your banking service at `app.bank.com` expects traffic from an AWS IP. You install `cloudflared` in your AWS environment and add a public hostname route for `app.bank.com`. When users connect to `app.bank.com` through the Cloudflare One Client, Gateway applies your network policies and routes the filtered traffic through the Cloudflare Tunnel to AWS. The traffic then exits to the public Internet using your AWS egress IP.
 
 ```mermaid
     flowchart LR
@@ -37,7 +37,7 @@ To learn more about how Gateway applies hostname-based egress policies, refer to
 
 ## Prerequisites
 
-User traffic is on-ramped to Gateway using one of the following methods:
+User traffic must be on-ramped to Gateway using one of the following methods:
 
 <Render file="gateway/egress-selector-onramps" product="cloudflare-one" />
 
@@ -71,7 +71,7 @@ In your WARP [Split Tunnels](/cloudflare-one/team-and-resources/devices/cloudfla
 
 When users connect to a public hostname route, Gateway will assign an <GlossaryTooltip term="initial resolved IP">initial resolved IP</GlossaryTooltip> to the DNS query from the following range:
 
-The initial resolved IP is required because Gateway's network engine operates at L3/L4 and can only see IPs (not hostnames) when processing the connection. If a packet's destination IP falls within the initial resolved IP CGNAT range, Gateway knows that the IP maps to a public hostname route and sends the traffic down the corresponding Cloudflare Tunnel.
+Gateway's network engine operates at Layer 3/Layer 4 of the [OSI model](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/), where it can only see IP addresses — not hostnames. The initial resolved IP acts as a signal: when a packet's destination IP falls within the `100.80.0.0/16` Carrier-Grade NAT (CGNAT) range, Gateway recognizes that the IP maps to a public hostname route and sends the traffic through the corresponding Cloudflare Tunnel.
 
 To route initial resolved IPs through the Cloudflare One Client:
 
@@ -83,7 +83,7 @@ Your private network's CIDR block should also route through the WARP tunnel. For
 
 ## 4. (Optional) Configure network policies
 
-You can build [Gateway network policies](/cloudflare-one/traffic-policies/network-policies/) to filter HTTPS traffic to your public hostname on port `443`. For example, suppose that you want to block all Cloudflare One Client users from accessing `app.bank.com` except for a specific set of users or groups. Additionally, those authorized users should only access `app.bank.com` using your AWS egress IP. You can accomplish this using two policies: the first allows specific users to reach `app.bank.com`, and the second blocks all other port `443` traffic to `app.bank.com`.
+You can build [Gateway network policies](/cloudflare-one/traffic-policies/network-policies/) to filter HTTPS traffic to your public hostname on port `443`. For example, to restrict `app.bank.com` so that only certain users or groups can access it through your AWS egress IP, create two policies: one to allow authorized users, and one to block everyone else.
 
 1. Allow company employees:
 
@@ -99,7 +99,7 @@ You can build [Gateway network policies](/cloudflare-one/traffic-policies/networ
    | -------- | -------- | -------------- | ------ |
    | SNI      | in       | `app.bank.com` | Block  |
 
-Gateway does not currently support hostname-based filtering for traffic on non-`443` ports. To block traffic to `app.bank.com` on all ports, you will need to use the [Destination IP](/cloudflare-one/traffic-policies/network-policies/#destination-ip) selector and specify the public IP space of `app.bank.com`.
+Gateway does not support hostname-based filtering for traffic on non-`443` ports. To block traffic to `app.bank.com` on all ports, use the [Destination IP](/cloudflare-one/traffic-policies/network-policies/#destination-ip) selector and specify the public IP range of `app.bank.com`.
 
 ## 5. Test the connection
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
@@ -10,25 +10,28 @@ import { Tabs, TabItem, Details, APIRequest, Render } from "~/components";
 <Details header="Feature availability">
 
 | [Client modes](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/) | [Zero Trust plans](https://www.cloudflare.com/teams-pricing/) |
-| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| Traffic and DNS mode                                                                        | Enterprise                                                    |
+| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Traffic and DNS mode                                                                              | Enterprise                                                    |
 
 | System   | Availability | Minimum client version |
-| -------- | ------------ | -------------------- |
-| Windows  | ✅           | 2025.4.929.0         |
-| macOS    | ✅           | 2025.4.929.0         |
-| Linux    | ✅           | 2025.4.929.0         |
-| iOS      | ✅           | 1.11                 |
-| Android  | ✅           | 2.4.2                |
-| ChromeOS | ✅           | 2.4.2                |
+| -------- | ------------ | ---------------------- |
+| Windows  | ✅           | 2025.4.929.0           |
+| macOS    | ✅           | 2025.4.929.0           |
+| Linux    | ✅           | 2025.4.929.0           |
+| iOS      | ✅           | 1.11                   |
+| Android  | ✅           | 2.4.2                  |
+| ChromeOS | ✅           | 2.4.2                  |
 
 </Details>
 
-When Gateway receives a DNS query for hostname covered by the [Application](/cloudflare-one/traffic-policies/egress-policies/#application), [Content Categories](/cloudflare-one/traffic-policies/egress-policies/#content-categories), [Domain](/cloudflare-one/traffic-policies/egress-policies/#domain), and [Host](/cloudflare-one/traffic-policies/egress-policies/#host) selectors in an Egress policy, Gateway initially resolves DNS to an IP in the `100.80.0.0/16` or `2606:4700:0cf1:4000::/64` range. This process allows Gateway to map a destination IP with a hostname at [layer 4](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/) (where Gateway evaluates Egress policies). The destination IP for a hostname is not usually known at layer 4. Prior to evaluating Egress policies, the initially resolved IP is overwritten with the correct destination IP.
+Egress policies are evaluated at [Layer 4](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/) of the OSI model, where Gateway can only see IP addresses — not hostnames. The [Application](/cloudflare-one/traffic-policies/egress-policies/#application), [Content Categories](/cloudflare-one/traffic-policies/egress-policies/#content-categories), [Domain](/cloudflare-one/traffic-policies/egress-policies/#domain), and [Host](/cloudflare-one/traffic-policies/egress-policies/#host) selectors need to match traffic by hostname, so Gateway uses a two-step process:
+
+1. When Gateway receives a DNS query for a hostname that matches one of these selectors, it initially resolves the query to a temporary IP in the `100.80.0.0/16` or `2606:4700:0cf1:4000::/64` range.
+2. When traffic arrives with this temporary destination IP, Gateway can identify which hostname the connection belongs to, apply the correct egress policy, then replace the temporary IP with the real destination IP before forwarding the traffic.
 
 ![Example egress policy flow](~/assets/images/cloudflare-one/policies/host-selector-diagram.png)
 
-Additional configuration is required when using policies with these selectors.
+These selectors require additional configuration before they work.
 
 ## Turn on Host selectors
 
@@ -63,22 +66,22 @@ Traffic must be on-ramped to Gateway with the following methods:
 
 | On-ramp method                                                                                      | Compatibility |
 | --------------------------------------------------------------------------------------------------- | ------------- |
-| [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/)                                            | ✅            |
+| [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/)          | ✅            |
 | [PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/)                        | ✅            |
 | [Browser Isolation](/cloudflare-one/remote-browser-isolation/)                                      | ✅            |
 | [WARP Connector](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/) | ❌            |
-| [Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/)                                              | ✅            |
+| [Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/)                                    | ✅            |
 
-Unsupported traffic will be resolved with your default Gateway settings. If you use DNS locations to send a DNS query to Gateway with IPv4, IPv6, DoT, or DoH, Gateway will not return the initial resolved IP for supported traffic nor resolve unsupported traffic.
+Traffic from unsupported on-ramp methods resolves using your default Gateway settings. If you use DNS locations to send DNS queries to Gateway (over IPv4, IPv6, DNS over TLS, or DNS over HTTPS), Gateway does not return the initial resolved IP and the host selectors do not apply.
 
 ### Configuration changes
 
 To configure your Zero Trust organization to use Host selectors with Egress policies:
 
 1.  Make sure you deploy the following version of the Cloudflare One Client on your users' devices:
-    - **Desktop**: [Cloudflare One Client version 2025.4.929.0](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/) or later 
+    - **Desktop**: [Cloudflare One Client version 2025.4.929.0](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/) or later
     - **iOS**: [Cloudflare One Client version 1.11](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/#ios) or later
-    - **Android and Chrome OS**: [Cloudflare One Client version 2.4.2](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/#android) or later. 
+    - **Android and Chrome OS**: [Cloudflare One Client version 2.4.2](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/#android) or later.
 
     If you need to support devices running prior versions of WARP, add and deploy the following key-value pair to your devices' [WARP configuration file](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/) (`mdm.xml` on Windows and Linux or `com.cloudflare.warp.plist` on macOS):
 
@@ -95,7 +98,7 @@ To configure your Zero Trust organization to use Host selectors with Egress poli
 
 2. <Render file="gateway/egress-selector-split-tunnels" product="cloudflare-one"/>
 
-The Cloudflare One Client must be set to _Traffic and DNS mode_ mode for traffic affected by these selectors to route correctly.
+The Cloudflare One Client must be set to _Traffic and DNS mode_ for traffic affected by these selectors to route correctly.
 
 {/* prettier-ignore-end */}
 
@@ -103,4 +106,4 @@ The Cloudflare One Client must be set to _Traffic and DNS mode_ mode for traffic
 
 ### Google Chrome restricts local network access
 
-<Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one"/>
+<Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
@@ -24,7 +24,7 @@ import { Tabs, TabItem, Details, APIRequest, Render } from "~/components";
 
 </Details>
 
-Egress policies are evaluated at [Layer 4](https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/) of the OSI model, where Gateway can only see IP addresses — not hostnames. The [Application](/cloudflare-one/traffic-policies/egress-policies/#application), [Content Categories](/cloudflare-one/traffic-policies/egress-policies/#content-categories), [Domain](/cloudflare-one/traffic-policies/egress-policies/#domain), and [Host](/cloudflare-one/traffic-policies/egress-policies/#host) selectors need to match traffic by hostname, so Gateway uses a two-step process:
+Egress policies are evaluated at Layer 4 (https://www.cloudflare.com/learning/ddos/glossary/open-systems-interconnection-model-osi/) of the OSI model, where only IP addresses are available — not hostnames. The [Application](/cloudflare-one/traffic-policies/egress-policies/#application), [Content Categories](/cloudflare-one/traffic-policies/egress-policies/#content-categories), [Domain](/cloudflare-one/traffic-policies/egress-policies/#domain), and [Host](/cloudflare-one/traffic-policies/egress-policies/#host) selectors need to match traffic by hostname, so Gateway uses a two-step process:
 
 1. When Gateway receives a DNS query for a hostname that matches one of these selectors, it initially resolves the query to a temporary IP in the `100.80.0.0/16` or `2606:4700:0cf1:4000::/64` range.
 2. When traffic arrives with this temporary destination IP, Gateway can identify which hostname the connection belongs to, apply the correct egress policy, then replace the temporary IP with the real destination IP before forwarding the traffic.

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/index.mdx
@@ -19,21 +19,25 @@ import {
 Only available on Enterprise plans.
 :::
 
-When your users connect to the Internet through Cloudflare Gateway, by default their traffic is assigned a source IP address that is shared across all the Cloudflare One Client users. Enterprise users can purchase [dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) to ensure that egress traffic from your organization is assigned a unique, static IP. These source IPs are dedicated to your account and can be used within allowlists on upstream services.
+Many third-party services (for example, a bank or partner API) only allow connections from a known list of IP addresses. By default, traffic that exits through Cloudflare Gateway shares a source IP address with all other Cloudflare One Client users, so upstream services cannot identify your organization by IP alone.
 
-Egress policies allow you to control which dedicated egress IP is used and when, based on attributes such as identity, IP address, and geolocation. Traffic that does not match an egress policy will default to using the most performant dedicated egress IP.
+[Dedicated egress IPs](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/) solve this problem. They are static IP addresses assigned only to your account, which you can add to upstream allowlists.
 
-Cloudflare does not publish Cloudflare One Client egress IP ranges. Cloudflare One Client egress IPs are not documented at [Cloudflare's IP Ranges](https://cloudflare.com/ips). To obtain a dedicated Cloudflare One Client egress IP, contact your account team.
+Egress policies control which dedicated egress IP is used for a given connection. You can match traffic on attributes such as user identity, source or destination IP address, and geolocation. Traffic that does not match an egress policy defaults to the most performant dedicated egress IP.
+
+Cloudflare does not publish Cloudflare One Client egress IP ranges. Cloudflare One Client egress IPs are not listed at [Cloudflare's IP Ranges](https://cloudflare.com/ips). To obtain a dedicated Cloudflare One Client egress IP, contact your account team.
 
 <Render file="gateway/terraform-precedence-warning" product="cloudflare-one" />
 
 ## Load balancing
 
-When using either the default Cloudflare egress IPs or any dedicated egress IPs, Gateway traffic that does not match an egress policy will egress from the closest Cloudflare data center with a default Gateway egress IP. If there are two data centers of equal distance from the user, Gateway will split the traffic between the two data centers, and the load balancer will retain the same user selection and egress IP regardless of data center.
+Traffic that does not match any egress policy exits from the closest Cloudflare data center using a default Gateway egress IP. This applies whether your account uses dedicated egress IPs or the default shared IPs.
+
+If two data centers are equally close to the user, Gateway splits traffic between them. The load balancer keeps each user on the same egress IP regardless of which data center handles the request.
 
 ## Force IP version
 
-To control whether only IPv4 or IPv6 is used to egress, ensure you are [filtering DNS traffic](/cloudflare-one/traffic-policies/get-started/dns/), then create a DNS policy to [block AAAA or A records](/cloudflare-one/traffic-policies/dns-policies/common-policies/#control-ip-version).
+Some upstream services only accept connections over a specific IP version. To force all egress traffic to use IPv4 or IPv6 only, first verify you are [filtering DNS traffic](/cloudflare-one/traffic-policies/get-started/dns/), then create a DNS policy to [block AAAA or A records](/cloudflare-one/traffic-policies/dns-policies/common-policies/#control-ip-version).
 
 ## Example policies
 
@@ -46,13 +50,13 @@ The following egress policy configures all traffic destined for a third-party ne
 
 ### Catch-all policy
 
-For the best performance, we recommend creating a catch-all policy to route all other users through the default Zero Trust IP range:
+Without a catch-all policy, any traffic that does not match an explicit egress policy will attempt to use the closest dedicated egress IP location. To avoid unexpected IP assignments and maintain the best performance, create a catch-all policy that routes remaining traffic through the default Zero Trust IP range:
 
 | Policy name           | Selector | Operator | Value                    | Egress method                    |
 | --------------------- | -------- | -------- | ------------------------ | -------------------------------- |
 | Default egress policy | Protocol | in       | `All options (Protocol)` | Cloudflare default egress method |
 
-Since Gateway policies evaluate from [top to bottom](/cloudflare-one/traffic-policies/order-of-enforcement/#order-of-precedence) in the UI, be sure to place the catch-all policy at the bottom of the list. If you do not include a catch-all policy, all other traffic will attempt to use the closest dedicated egress IP location. To control which egress IP Gateway uses, create an egress policy.
+Gateway policies evaluate from [top to bottom](/cloudflare-one/traffic-policies/order-of-enforcement/#order-of-precedence) in the UI. Place the catch-all policy at the bottom of the list so that more specific policies are evaluated first.
 
 ## Egress methods
 
@@ -60,19 +64,19 @@ When you configure your egress policy, you can choose whether to egress traffic 
 
 ### Use default Cloudflare egress method
 
-**Use default Cloudflare egress method** uses the default source IP range shared across all Zero Trust accounts. Ensures the most performant Internet experience as user traffic egresses from the nearest Cloudflare data center.
+**Use default Cloudflare egress method** routes traffic through the default source IP range shared across all Zero Trust accounts. Traffic exits from the nearest Cloudflare data center, which provides the best performance.
 
 ### Use dedicated egress IPs
 
-**Use dedicated egress IPs (Cloudflare or BYOIP)** uses the primary IPv4 address and IPv6 range selected in the dropdown menus. <Render file="gateway/secondary-ipv4-requirement" product="cloudflare-one" />
+**Use dedicated egress IPs (Cloudflare or BYOIP)** routes traffic through the primary IPv4 address and IPv6 range you select in the dropdown menus. <Render file="gateway/secondary-ipv4-requirement" product="cloudflare-one" />
 
-If the data center associated with your primary dedicated egress IPv4 goes down, Gateway will egress from the secondary data center to avoid traffic drops during reroutes. There is no need for a secondary IPv6 because IPv6 traffic can egress from any Cloudflare data center. Dedicated egress IPs can be provided by either Cloudflare or [BYOIP](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/#bring-your-own-ip-address-byoip).
+If the data center associated with your primary IPv4 address goes down, Gateway fails over to the secondary data center to prevent traffic drops. A secondary IPv6 address is not required because IPv6 traffic can exit from any Cloudflare data center. You can use IPs provided by Cloudflare or [bring your own IP addresses (BYOIP)](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/#bring-your-own-ip-address-byoip).
 
 To learn more about IPv4 and IPv6 egress behavior, refer to [Egress locations](/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips/#egress-location).
 
 ## Selectors
 
-Gateway matches egress traffic against the following selectors, or criteria:
+Selectors are the criteria that Gateway uses to match egress traffic against a policy. Gateway evaluates the following selectors:
 
 ### Application <Badge text="Beta" variant="caution"/>
 
@@ -228,4 +232,4 @@ Gateway uses Rust to evaluate regular expressions. The Rust implementation is sl
 
 ### Selector prerequisites
 
-The [Application](#application), [Content Categories](#content-categories), [Domain](#domain), and [Host](#host) selectors require configuration changes in order to be operational. Before deploying policies with these selectors, refer to [Host selectors](/cloudflare-one/traffic-policies/egress-policies/host-selectors).
+The [Application](#application), [Content Categories](#content-categories), [Domain](#domain), and [Host](#host) selectors require additional setup before they work in egress policies. Before deploying policies with these selectors, refer to [Host selectors](/cloudflare-one/traffic-policies/egress-policies/host-selectors).


### PR DESCRIPTION
Clarity improvements across all four pages in the egress policies section, applying the ELI5 methodology to make the content more accessible without sacrificing technical accuracy.

- **index.mdx**: Lead with the problem (third-party allowlisting) before introducing the solution (dedicated egress IPs). Rewrite load balancing section as two shorter paragraphs. Add "why" context to Force IP version. Restructure catch-all policy section to lead with the consequence of not having one. Clarify egress method descriptions.
- **dedicated-egress-ips.mdx**: Open with the use case (allowlisting) rather than the feature definition. Simplify IPv4/IPv6 protocol selection explanation. Rewrite BYOIP section to lead with the prerequisite (owning IPs from a registry). Restructure unsupported traffic section to explain *why* shared IPs are used. Reorder IP geolocation section so the "how it works" context comes before the "what to do" instructions.
- **egress-cloudflared.mdx**: Define "source IP anchoring" inline on first use. Condense the example paragraph. Expand L3/L4 explanation with OSI link and explain the CGNAT signaling mechanism. Simplify network policy example intro.
- **host-selectors.mdx**: Replace the dense single-paragraph explanation of how host selectors work with a numbered two-step process. Expand DoT/DoH abbreviations on first use. Fix duplicate "mode mode" typo.