### PR TITLE
Bump starlight patch

### DIFF
--- a/patches/@astrojs+starlight+0.38.2.patch
+++ b/patches/@astrojs+starlight+0.38.2.patch
@@ -4,17 +4,17 @@ index 66f1b2e..b52f3c9 100644
 +++ b/node_modules/@astrojs/starlight/user-components/Tabs.astro
 @@ -3,10 +3,11 @@ import Icon from './Icon.astro';
  import { processPanels } from './rehype-tabs';
- 
+
  interface Props {
 +	IconComponent?: typeof Icon;
  	syncKey?: string;
  }
- 
+
 -const { syncKey } = Astro.props;
 +const { syncKey, IconComponent = Icon } = Astro.props;
  const panelHtml = await Astro.slots.render('default');
  const { html, panels } = processPanels(panelHtml);
- 
+
 @@ -84,7 +85,7 @@ if (isSynced) {
  								aria-selected={idx === 0 ? 'true' : 'false'}
  								tabindex={idx !== 0 ? -1 : 0}

--- a/patches/@astrojs+starlight+0.38.2.patch
+++ b/patches/@astrojs+starlight+0.38.2.patch
@@ -4,17 +4,17 @@ index 66f1b2e..b52f3c9 100644
 +++ b/node_modules/@astrojs/starlight/user-components/Tabs.astro
 @@ -3,10 +3,11 @@ import Icon from './Icon.astro';
  import { processPanels } from './rehype-tabs';
-
+ 
  interface Props {
 +	IconComponent?: typeof Icon;
  	syncKey?: string;
  }
-
+ 
 -const { syncKey } = Astro.props;
 +const { syncKey, IconComponent = Icon } = Astro.props;
  const panelHtml = await Astro.slots.render('default');
  const { html, panels } = processPanels(panelHtml);
-
+ 
 @@ -84,7 +85,7 @@ if (isSynced) {
  								aria-selected={idx === 0 ? 'true' : 'false'}
  								tabindex={idx !== 0 ? -1 : 0}


### PR DESCRIPTION
Bumps the `@astrojs/starlight` patch from 0.38.1 to 0.38.2 and removes the old patch file.

<img width="668" height="481" alt="Screenshot 2026-03-24 at 8 56 10 AM" src="https://github.com/user-attachments/assets/7739edb6-cdcd-4c8e-becd-0b1f66abc260" />
