### PR TITLE
[DNS] Add caution for DNSSEC Pre-signed on secondary-to-full zone conversion

### DIFF
--- a/src/content/docs/dns/zone-setups/conversions/convert-secondary-to-full.mdx
+++ b/src/content/docs/dns/zone-setups/conversions/convert-secondary-to-full.mdx
@@ -23,6 +23,11 @@ Follow the steps below to achieve this conversion.
 ## 2. Prepare for the conversion
 
 1. Plan for [DNSSEC settings](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/dnssec-for-secondary/). If you were previously using [Pre-signed DNSSEC](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/dnssec-for-secondary/#set-up-pre-signed-dnssec), consider disabling DNSSEC before starting the conversion.
+
+   :::caution
+   Leaving Pre-signed DNSSEC enabled after converting to a full zone can prevent DNS records from propagating to Cloudflare's edge, causing your zone to return `REFUSED` responses. If you experience this after converting, verify by querying your assigned nameservers using [digwebinterface.com](https://digwebinterface.com/), then check the [DNSSEC Details endpoint](/api/resources/dns/subresources/dnssec/methods/get/) for `dnssec_presigned: true` and disable it using the [Edit DNSSEC Status endpoint](/api/resources/dns/subresources/dnssec/methods/edit/) with `dnssec_presigned` set to `false`.
+   :::
+
 2. Make sure the [proxy statuses](/dns/proxy-status/) of your DNS records are consistently set:
    - If you have [Secondary DNS override](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/proxy-traffic/), confirm each record has the appropriate setting (**Proxied** or **DNS only**).
    - If [Secondary DNS override](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/proxy-traffic/) is disabled, make sure all of your DNS records are listed as **DNS only**.


### PR DESCRIPTION
### Summary

Strengthens the DNSSEC Pre-signed guidance in the secondary-to-full zone conversion tutorial from "consider disabling" to "you must disable", and adds a caution callout explaining the consequences of not doing so.

Previously, step 2.1 used soft language ("consider disabling DNSSEC") which led to an Enterprise customer's zone becoming completely unresolvable after conversion. The leftover `dnssec_presigned` flag can block DNS record propagation to the edge, causing the zone to return REFUSED with EDE 20 (Not Authoritative) despite appearing active in the dashboard.

Reference: CUSTESC-63534

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).