### PR TITLE
[Registrar] Add troubleshooting section to transfer page

### DIFF
--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -16,7 +16,7 @@ Transferring a domain moves your registration from your current registrar to Clo
 - **Cost:** Cloudflare domains are at-cost with no markup fees. Most transfers include a one-year extension from your current expiration date. Some country-code domains (such as `.uk`) have no transfer fee.
 
 :::note
-Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare). You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare). You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
 :::
 
 :::note
@@ -198,6 +198,17 @@ The process for transferring domains in bulk is the same as transferring a singl
 
 ---
 
-If your transfer is stuck or failing, refer to [Troubleshoot failed domain transfers](/registrar/troubleshooting/).
+## Having issues?
+
+Here are suggestions for how to handle common transfer issues:
+
+- [Domain is still locked](/registrar/troubleshooting/#domain-is-still-locked)
+- [Authorization code is invalid or expired](/registrar/troubleshooting/#authorization-code-is-invalid-or-expired)
+- [Cannot find where to enter your authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code)
+- [Transfer rejected](/registrar/troubleshooting/#transfer-rejected)
+- [Transfer is taking too long](/registrar/troubleshooting/#transfer-is-taking-too-long)
+- [Payment failed during transfer](/registrar/troubleshooting/#payment-failed-during-transfer)
+
+For a full list of issues, refer to [Troubleshoot failed domain transfers](/registrar/troubleshooting/).
 
 <Render file="next-steps" product="registrar" />

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -16,7 +16,7 @@ Transferring a domain moves your registration from your current registrar to Clo
 - **Cost:** Cloudflare domains are at-cost with no markup fees. Most transfers include a one-year extension from your current expiration date. Some country-code domains (such as `.uk`) have no transfer fee.
 
 :::note
-Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare). You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare). You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with Shopify, Wix, or a similar platform, you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from Shopify, Block, or Wix](#transfer-from-shopify-block-or-wix) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
 :::
 
 :::note
@@ -161,13 +161,13 @@ Registrants transferring a `.us` domain will always receive a FOA email.
 
 ---
 
-## Transfer from website builders
+## Transfer from Shopify, Block, or Wix
 
-Some website builder platforms (such as Block, Shopify, and Wix) act as both your hosting provider and domain registrar. These platforms typically do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer is not possible.
+Some commerce and site-building platforms (such as Shopify, Block, and Wix) act as both your hosting provider and domain registrar. These platforms typically do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer is not possible.
 
 The workaround is to transfer your domain to another registrar first, wait 60 days, then transfer to Cloudflare:
 
-1. **Get your authorization code from the website builder.** Each platform has a different process. Refer to your platform documentation for instructions on transferring your domain away.
+1. **Get your authorization code from your current platform.** Each platform has a different process. Refer to your platform documentation for instructions on transferring your domain away.
 2. **Transfer to another registrar** that allows nameserver changes. Enter the authorization code there and complete the transfer. This usually takes 3-5 days.
 3. **Update nameservers to Cloudflare.** Once the domain is at the new registrar, update the nameservers to Cloudflare. You can use all Cloudflare features (CDN, DNS, security) immediately after this step.
 4. **Transfer to Cloudflare Registrar after 60 days.** ICANN requires a 60-day wait between transfers. After that period, initiate the transfer to Cloudflare from the [Transfer Domains](#enter-your-authorization-code-and-confirm-payment) page.

--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -198,7 +198,7 @@ The process for transferring domains in bulk is the same as transferring a singl
 
 ---
 
-## Having issues?
+## Common transfer issues
 
 Here are suggestions for how to handle common transfer issues:
 

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -129,6 +129,14 @@ Instead, the losing registrar changes the domain's IPS tag to the gaining regist
 
 If the transfer does not proceed, contact the current registrar and confirm that they have updated the IPS tag correctly.
 
+## Email verification required
+
+Cloudflare may send a verification email to your registrant contact email address when you register or transfer a domain, or when you update your registrant email. Per ICANN requirements, if the registrant email is not verified within 15 days, a hold is placed on the domain and nameservers are replaced with a parking server until verification is complete. After successful verification, nameservers are automatically restored.
+
+Verification is triggered when your registrant contact email differs from your verified Cloudflare account email.
+
+Some TLDs — including `.mx`, `.nz`, and `.ca` — may send verification through a third-party service. In these cases, the verification email will come from `noreply@emailverification.info` rather than Cloudflare. Check your spam folder if you do not receive it.
+
 ## Restart your transfer
 
 :::note

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -109,7 +109,7 @@ Your domain may not appear on the [Transfer Domains](https://dash.cloudflare.com
 
 ## Cannot update nameservers at your current registrar
 
-Some website builder platforms (such as Block, Shopify, and Wix) do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer from these platforms is not possible. For the recommended workaround, refer to [Transfer from website builders](/registrar/get-started/transfer-domain-to-cloudflare/#transfer-from-website-builders).
+Some commerce and site-building platforms (such as Shopify, Block, and Wix) do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer from these platforms is not possible. For the recommended workaround, refer to [Transfer from Shopify, Block, or Wix](/registrar/get-started/transfer-domain-to-cloudflare/#transfer-from-shopify-block-or-wix).
 
 ## Email verification required
 
@@ -128,14 +128,6 @@ For these TLDs, if verification is not completed in time, the registry may tempo
 Instead, the losing registrar changes the domain's IPS tag to the gaining registrar. If you are transferring a `.uk` family domain to Cloudflare and cannot find an auth-code field, this behavior is expected.
 
 If the transfer does not proceed, contact the current registrar and confirm that they have updated the IPS tag correctly.
-
-## Email verification required
-
-Cloudflare may send a verification email to your registrant contact email address when you register or transfer a domain, or when you update your registrant email. Per ICANN requirements, if the registrant email is not verified within 15 days, a hold is placed on the domain and nameservers are replaced with a parking server until verification is complete. After successful verification, nameservers are automatically restored.
-
-Verification is triggered when your registrant contact email differs from your verified Cloudflare account email.
-
-Some TLDs — including `.mx`, `.nz`, and `.ca` — may send verification through a third-party service. In these cases, the verification email will come from `noreply@emailverification.info` rather than Cloudflare. Check your spam folder if you do not receive it.
 
 ## Restart your transfer
 


### PR DESCRIPTION
Adds a 'Having issues?' section to the bottom of the transfer guide with direct links to the most common troubleshooting scenarios. Previously, the 'Troubleshooting' page was only text-linked from this main transfers page and not easy to discover. This changes that.

- Adds a named 'Having issues?' section with links to 6 common issues (locked domain, invalid auth code, transfer rejected, etc.)
- Catch-all link to the full troubleshooting page at the bottom