### PR TITLE
[DNS] Revise record size limit documentation

### DIFF
--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -16,7 +16,7 @@ import {
 This page provides information about some of the different types of DNS records that you can manage on Cloudflare. For guidance on how to add, edit, or delete DNS records, refer to [Manage DNS records](/dns/manage-dns-records/how-to/create-dns-records/).
 
 :::note
-The wire format size of any single record must not exceed 4,096 bytes. If you have multiple records with the same name and type, their combined content length must not exceed 8,192 characters.
+Each DNS record has a maximum [wire-format](https://www.rfc-editor.org/rfc/rfc1035.html#section-3.2.1) size of 4,096 bytes. Wire format refers to how a record is encoded when transmitted over the DNS protocol. If you have multiple records with the same name and type, their combined content must not exceed 8,192 characters.
 :::
 
 ---
@@ -31,16 +31,16 @@ At least one **IP address resolution** record is required for each domain on Clo
 
 These records include the following fields:
 
+<Render file="records-name-field" product="dns" />- **IPv4/IPv6 address**: Your
+origin server address (cannot be a [Cloudflare
+IP](https://www.cloudflare.com/ips))
 
-<Render file="records-name-field" product="dns" />
-- **IPv4/IPv6 address**: Your origin server address (cannot be a [Cloudflare IP](https://www.cloudflare.com/ips))
+:::note
 
-  :::note
+Cloudflare uses the [canonical notation](https://www.rfc-editor.org/rfc/rfc5952.html#section-4.2) to store DNS records. This means that an AAAA record with content `fe80::0:0:1` is stored and returned as `fe80::1`, for example.
 
-  Cloudflare uses the [canonical notation](https://www.rfc-editor.org/rfc/rfc5952.html#section-4.2) to store DNS records. This means that an AAAA record with content `fe80::0:0:1` is stored and returned as `fe80::1`, for example.
-
-  Alternative notations of IPv4 addresses (`1.1` for `1.0.0.1`, for example) are not supported for A records.
-  :::
+Alternative notations of IPv4 addresses (`1.1` for `1.0.0.1`, for example) are not supported for A records.
+:::
 
 - **TTL**: Time to live, which controls how long DNS resolvers should cache a response before revalidating it.
   - If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which is 300 seconds.
@@ -104,13 +104,13 @@ When creating A or AAAA records [using the API](/dns/manage-dns-records/how-to/c
 
 These records include the following fields:
 
-
-<Render file="records-name-field" product="dns" />
-- **Target**: The hostname where traffic should be directed (`example.com`).
-- **TTL**: Time to live, which controls how long DNS resolvers should cache a response before revalidating it.
-  - If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which is 300 seconds.
-  - If the **Proxy Status** is **DNS Only**, you can customize the value.
-- **Proxy status**: For more details, refer to [Proxied DNS records](/dns/proxy-status/).
+<Render file="records-name-field" product="dns" />- **Target**: The hostname
+where traffic should be directed (`example.com`). - **TTL**: Time to live, which
+controls how long DNS resolvers should cache a response before revalidating it.
+- If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which
+is 300 seconds. - If the **Proxy Status** is **DNS Only**, you can customize the
+value. - **Proxy status**: For more details, refer to [Proxied DNS
+records](/dns/proxy-status/).
 
 #### Proxied CNAME records
 
@@ -125,7 +125,7 @@ DNS management for **example.com**:
 
 | Type  | Name | Content                | Proxy status |
 | ----- | ---- | ---------------------- | ------------ |
-| CNAME | abc  | `target.external.test` | Proxied     |
+| CNAME | abc  | `target.external.test` | Proxied      |
 
 </Example>
 
@@ -415,6 +415,7 @@ Your assigned Cloudflare nameservers, custom nameservers, and their correspondin
 :::
 
 #### Limits
+
 <Render file="ns-delegation-name-limit" product="dns" />
 
 ### DS and DNSKEY

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -18,7 +18,7 @@ This page provides information about some of the different types of DNS records 
 :::note
 Each DNS record has a maximum wire format size of 4,096 bytes. Wire format refers to how a record is encoded when transmitted over the DNS protocol ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html#section-3.2.1)).
 
-If you have multiple records with the same name and type, their combined content lengt must not exceed 8,192 characters.
+If you have multiple records with the same name and type, their combined content length must not exceed 8,192 characters.
 :::
 
 ---

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -16,7 +16,9 @@ import {
 This page provides information about some of the different types of DNS records that you can manage on Cloudflare. For guidance on how to add, edit, or delete DNS records, refer to [Manage DNS records](/dns/manage-dns-records/how-to/create-dns-records/).
 
 :::note
-Each DNS record has a maximum [wire-format](https://www.rfc-editor.org/rfc/rfc1035.html#section-3.2.1) size of 4,096 bytes. Wire format refers to how a record is encoded when transmitted over the DNS protocol. If you have multiple records with the same name and type, their combined content must not exceed 8,192 characters.
+Each DNS record has a maximum wire-format size of 4,096 bytes. Wire format refers to how a record is encoded when transmitted over the DNS protocol ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html#section-3.2.1)).
+
+If you have multiple records with the same name and type, their combined content lenght must not exceed 8,192 characters.
 :::
 
 ---

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -15,6 +15,10 @@ import {
 
 This page provides information about some of the different types of DNS records that you can manage on Cloudflare. For guidance on how to add, edit, or delete DNS records, refer to [Manage DNS records](/dns/manage-dns-records/how-to/create-dns-records/).
 
+:::note
+The wire format size of any single record must not exceed 4,096 bytes. If you have multiple records with the same name and type, their combined content length must not exceed 8,192 characters.
+:::
+
 ---
 
 ## IP address resolution
@@ -251,14 +255,6 @@ At Cloudflare, TXT records are most commonly used to demonstrate domain ownershi
 You could also use TXT to create email authentication records, but we recommend that you use our [Email security Wizard](/dns/manage-dns-records/how-to/email-records/#prevent-domain-spoofing) instead.
 
 <Render file="api-field-definitions" product="dns" />
-
-:::note
-
-The **Content** for each TXT record must be 2,048 characters or less.
-
-If you have multiple TXT records with the same **Name**, there is also a limit for the sum of their **Content** characters, which must be 8,192 or less.
-
-:::
 
 ### CAA
 

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -16,9 +16,9 @@ import {
 This page provides information about some of the different types of DNS records that you can manage on Cloudflare. For guidance on how to add, edit, or delete DNS records, refer to [Manage DNS records](/dns/manage-dns-records/how-to/create-dns-records/).
 
 :::note
-Each DNS record has a maximum wire-format size of 4,096 bytes. Wire format refers to how a record is encoded when transmitted over the DNS protocol ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html#section-3.2.1)).
+Each DNS record has a maximum wire format size of 4,096 bytes. Wire format refers to how a record is encoded when transmitted over the DNS protocol ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html#section-3.2.1)).
 
-If you have multiple records with the same name and type, their combined content lenght must not exceed 8,192 characters.
+If you have multiple records with the same name and type, their combined content lengt must not exceed 8,192 characters.
 :::
 
 ---

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -33,16 +33,15 @@ At least one **IP address resolution** record is required for each domain on Clo
 
 These records include the following fields:
 
-<Render file="records-name-field" product="dns" />- **IPv4/IPv6 address**: Your
-origin server address (cannot be a [Cloudflare
-IP](https://www.cloudflare.com/ips))
+<Render file="records-name-field" product="dns" />
+- **IPv4/IPv6 address**: Your origin server address (cannot be a [Cloudflare IP](https://www.cloudflare.com/ips))
 
-:::note
+  :::note
 
-Cloudflare uses the [canonical notation](https://www.rfc-editor.org/rfc/rfc5952.html#section-4.2) to store DNS records. This means that an AAAA record with content `fe80::0:0:1` is stored and returned as `fe80::1`, for example.
+  Cloudflare uses the [canonical notation](https://www.rfc-editor.org/rfc/rfc5952.html#section-4.2) to store DNS records. This means that an AAAA record with content `fe80::0:0:1` is stored and returned as `fe80::1`, for example.
 
-Alternative notations of IPv4 addresses (`1.1` for `1.0.0.1`, for example) are not supported for A records.
-:::
+  Alternative notations of IPv4 addresses (`1.1` for `1.0.0.1`, for example) are not supported for A records.
+  :::
 
 - **TTL**: Time to live, which controls how long DNS resolvers should cache a response before revalidating it.
   - If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which is 300 seconds.
@@ -106,13 +105,13 @@ When creating A or AAAA records [using the API](/dns/manage-dns-records/how-to/c
 
 These records include the following fields:
 
-<Render file="records-name-field" product="dns" />- **Target**: The hostname
-where traffic should be directed (`example.com`). - **TTL**: Time to live, which
-controls how long DNS resolvers should cache a response before revalidating it.
-- If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which
-is 300 seconds. - If the **Proxy Status** is **DNS Only**, you can customize the
-value. - **Proxy status**: For more details, refer to [Proxied DNS
-records](/dns/proxy-status/).
+
+<Render file="records-name-field" product="dns" />
+- **Target**: The hostname where traffic should be directed (`example.com`).
+- **TTL**: Time to live, which controls how long DNS resolvers should cache a response before revalidating it.
+  - If the **Proxy Status** is **Proxied**, this value defaults to **Auto**, which is 300 seconds.
+  - If the **Proxy Status** is **DNS Only**, you can customize the value.
+- **Proxy status**: For more details, refer to [Proxied DNS records](/dns/proxy-status/).
 
 #### Proxied CNAME records
 


### PR DESCRIPTION
### Summary

- Remove TXT-specific 2,048 character limit for individual records
- Move 8,192 combined content length limit from TXT section to page intro, as it applies to all record types
- Add 4,096 byte wire format size limit for individual records