### PR TITLE
[Log Explorer] Adding missing line in example

### DIFF
--- a/src/content/docs/log-explorer/example-queries.mdx
+++ b/src/content/docs/log-explorer/example-queries.mdx
@@ -127,6 +127,7 @@ SELECT
   SUM(CASE WHEN EdgeResponseStatus >= 500 THEN 1 ELSE 0 END) AS errors
 FROM http_requests
 WHERE {{ timeFilter }}
+GROUP BY ClientRequestPath
 ORDER BY avg_ttfb DESC
-LIMIT 10
+LIMIT 10 
 ```


### PR DESCRIPTION
Fixed a missing line in the example query. Related to PCX-21019