### PR TITLE
Replace R2 llms-full.txt with middlecache proxy (request-time)

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -8,8 +8,7 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 	maxDynamicRules: 2_000, // Usually 100
 });
 
-const LLMS_FULL_BASE_URL =
-	"https://middlecache.ced.cloudflare.com/v1/cloudflare-docs-llms-full";
+const LLMS_FULL_R2_PREFIX = "v1/cloudflare-docs-llms-full";
 
 /**
  * When a redirect response is returned for an index.md request, rewrite the
@@ -52,14 +51,16 @@ export default class extends WorkerEntrypoint<Env> {
 		if (request.url.endsWith("/llms-full.txt")) {
 			const { pathname } = new URL(request.url);
 			// pathname is e.g. "/llms-full.txt" or "/workers/llms-full.txt"
-			const upstreamUrl = `${LLMS_FULL_BASE_URL}${pathname}`;
+			// R2 key: "v1/cloudflare-docs-llms-full/llms-full.txt" or
+			//         "v1/cloudflare-docs-llms-full/workers/llms-full.txt"
+			const r2Key = `${LLMS_FULL_R2_PREFIX}${pathname}`;
+			const object = await this.env.MIDDLECACHE.get(r2Key);
 
-			const upstream = await fetch(upstreamUrl);
-			if (!upstream.ok) {
+			if (!object) {
 				return new Response("llms-full.txt not found", { status: 404 });
 			}
 
-			return new Response(upstream.body, {
+			return new Response(object.body, {
 				headers: {
 					"Content-Type": "text/markdown; charset=utf-8",
 				},

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -8,7 +8,8 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 	maxDynamicRules: 2_000, // Usually 100
 });
 
-const LLMS_FULL_R2_PREFIX = "v1/cloudflare-docs-llms-full";
+const LLMS_FULL_BASE_URL =
+	"https://middlecache.ced.cloudflare.com/v1/cloudflare-docs-llms-full";
 
 /**
  * When a redirect response is returned for an index.md request, rewrite the
@@ -51,16 +52,14 @@ export default class extends WorkerEntrypoint<Env> {
 		if (request.url.endsWith("/llms-full.txt")) {
 			const { pathname } = new URL(request.url);
 			// pathname is e.g. "/llms-full.txt" or "/workers/llms-full.txt"
-			// R2 key: "v1/cloudflare-docs-llms-full/llms-full.txt" or
-			//         "v1/cloudflare-docs-llms-full/workers/llms-full.txt"
-			const r2Key = `${LLMS_FULL_R2_PREFIX}${pathname}`;
-			const object = await this.env.MIDDLECACHE.get(r2Key);
+			const upstreamUrl = `${LLMS_FULL_BASE_URL}${pathname}`;
 
-			if (!object) {
+			const upstream = await fetch(upstreamUrl);
+			if (!upstream.ok) {
 				return new Response("llms-full.txt not found", { status: 404 });
 			}
 
-			return new Response(object.body, {
+			return new Response(upstream.body, {
 				headers: {
 					"Content-Type": "text/markdown; charset=utf-8",
 				},

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -8,6 +8,9 @@ const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
 	maxDynamicRules: 2_000, // Usually 100
 });
 
+const LLMS_FULL_BASE_URL =
+	"https://middlecache.ced.cloudflare.com/v1/cloudflare-docs-llms-full";
+
 /**
  * When a redirect response is returned for an index.md request, rewrite the
  * Location header so the agent stays in Markdown land instead of landing on
@@ -48,9 +51,15 @@ export default class extends WorkerEntrypoint<Env> {
 	override async fetch(request: Request) {
 		if (request.url.endsWith("/llms-full.txt")) {
 			const { pathname } = new URL(request.url);
-			const res = await this.env.VENDORED_MARKDOWN.get(pathname.slice(1));
+			// pathname is e.g. "/llms-full.txt" or "/workers/llms-full.txt"
+			const upstreamUrl = `${LLMS_FULL_BASE_URL}${pathname}`;
 
-			return new Response(res?.body, {
+			const upstream = await fetch(upstreamUrl);
+			if (!upstream.ok) {
+				return new Response("llms-full.txt not found", { status: 404 });
+			}
+
+			return new Response(upstream.body, {
 				headers: {
 					"Content-Type": "text/markdown; charset=utf-8",
 				},

--- a/worker/worker-configuration.d.ts
+++ b/worker/worker-configuration.d.ts
@@ -2,6 +2,7 @@
 
 interface Env {
 	ASSETS: Fetcher;
+	MIDDLECACHE: R2Bucket;
 }
 declare module "*/__redirects" {
 	const value: string;

--- a/worker/worker-configuration.d.ts
+++ b/worker/worker-configuration.d.ts
@@ -2,7 +2,6 @@
 
 interface Env {
 	ASSETS: Fetcher;
-	VENDORED_MARKDOWN: R2Bucket;
 }
 declare module "*/__redirects" {
 	const value: string;

--- a/worker/worker-configuration.d.ts
+++ b/worker/worker-configuration.d.ts
@@ -2,7 +2,6 @@
 
 interface Env {
 	ASSETS: Fetcher;
-	MIDDLECACHE: R2Bucket;
 }
 declare module "*/__redirects" {
 	const value: string;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,9 +18,5 @@ binding = "ASSETS"
 not_found_handling = "404-page"
 run_worker_first = true
 
-[[r2_buckets]]
-binding = "MIDDLECACHE"
-bucket_name = "middlecache"
-
 [observability]
 enabled = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,5 +18,9 @@ binding = "ASSETS"
 not_found_handling = "404-page"
 run_worker_first = true
 
+[[r2_buckets]]
+binding = "MIDDLECACHE"
+bucket_name = "middlecache"
+
 [observability]
 enabled = true

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -18,9 +18,5 @@ binding = "ASSETS"
 not_found_handling = "404-page"
 run_worker_first = true
 
-[[r2_buckets]]
-binding = "VENDORED_MARKDOWN"
-bucket_name = "vendored-markdown"
-
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary

- Replaces the `VENDORED_MARKDOWN` R2 bucket binding with a `MIDDLECACHE` R2 binding pointing to the `middlecache` bucket (same account)
- The worker reads llms-full.txt files directly from the middlecache R2 bucket via internal binding (no HTTP overhead)
- R2 keys follow the middlecache path convention: `v1/cloudflare-docs-llms-full/{path}`

## Approach

**Request-time R2 read**: When a request for `/llms-full.txt` or `/{product}/llms-full.txt` arrives, the worker maps the pathname to an R2 key (e.g. `/workers/llms-full.txt` → `v1/cloudflare-docs-llms-full/workers/llms-full.txt`) and reads directly from the `middlecache` R2 bucket. This is a local IPC call with no DNS/TLS/HTTP overhead.

This is one of two approaches being tested — compare with #29302 which fetches per-product files at build time and serves them as static assets.

## Changes

- `worker/index.ts` — Replace R2 `.get()` on `VENDORED_MARKDOWN` with `.get()` on `MIDDLECACHE` using the `v1/cloudflare-docs-llms-full/` key prefix, with 404 handling
- `wrangler.toml` — Replace `VENDORED_MARKDOWN` → `vendored-markdown` binding with `MIDDLECACHE` → `middlecache` binding
- `worker/worker-configuration.d.ts` — Replace `VENDORED_MARKDOWN: R2Bucket` with `MIDDLECACHE: R2Bucket` in `Env` interface