### PR TITLE
[Dynamic Workers] Fix Dynamic Workers Starter project URL

### DIFF
--- a/src/content/changelog/workers/2026-03-24-dynamic-workers-open-beta.mdx
+++ b/src/content/changelog/workers/2026-03-24-dynamic-workers-open-beta.mdx
@@ -67,9 +67,9 @@ Here are 3 new libraries to help you build with Dynamic Workers:
 
 **Dynamic Workers Starter**
 
-[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers)
+[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers-starter)
 
-Use this [starter](https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers) to deploy a Worker that can load and execute Dynamic Workers.
+Use this [starter](https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers-starter) to deploy a Worker that can load and execute Dynamic Workers.
 
 **Dynamic Workers Playground**
 

--- a/src/content/docs/dynamic-workers/examples/dynamic-workers-starter.mdx
+++ b/src/content/docs/dynamic-workers/examples/dynamic-workers-starter.mdx
@@ -2,7 +2,7 @@
 title: Dynamic Workers Starter
 description: A starter template for building with Dynamic Workers.
 pcx_content_type: example
-external_link: https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers
+external_link: https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers-starter
 sidebar:
   order: 1
 ---

--- a/src/content/docs/dynamic-workers/getting-started.mdx
+++ b/src/content/docs/dynamic-workers/getting-started.mdx
@@ -21,9 +21,9 @@ Dynamic Workers support two loading modes:
 
 #### Dynamic Workers Starter
 
-[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers)
+[![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers-starter)
 
-Use this "hello world" [starter](https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers) to get a Worker deployed that can load and execute Dynamic Workers.
+Use this "hello world" [starter](https://github.com/cloudflare/agents/tree/main/examples/dynamic-workers-starter) to get a Worker deployed that can load and execute Dynamic Workers.
 
 #### Dynamic Workers Playground
 


### PR DESCRIPTION
### Summary

Update the Dynamic Workers Starter project URL to reflect the change made in cloudflare/agents@2fac9d9.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
