### PR TITLE
Fix VLAN tagging standard in Cloudflare One Appliance doc

### DIFF
--- a/src/content/docs/reference-architecture/diagrams/sase/cloudflare-one-appliance-deployment.mdx
+++ b/src/content/docs/reference-architecture/diagrams/sase/cloudflare-one-appliance-deployment.mdx
@@ -22,7 +22,7 @@ Every organization and network is different, and as such there is no one-size-fi
 
 The first decision for a Cloudflare One Appliance deployment is its location in the network, and this relates to whether the organization wants to keep the existing Customer Premises Equipment (CPE, edge router or firewall at a site), and if so, for what reason. Experience shows that this decision usually leads to three different topologies:
 
-- **Connector replacing the CPE** (Figure 1a): When the link is an Internet connection and the organization does not have any real use of existing equipment since the Connector supports all the required networking features such as DHCP, DNS, NAT, Trunking (801.1Q), IP access lists, breakout traffic, etc. Examples could be:
+- **Connector replacing the CPE** (Figure 1a): When the link is an Internet connection and the organization does not have any real use of existing equipment since the Connector supports all the required networking features such as DHCP, DNS, NAT, Trunking (802.1Q), IP access lists, breakout traffic, etc. Examples could be:
   - The transition from MPLS to Internet-based connectivity, where the MPLS router probably does not add any value in the deployment.
   - An Internet-facing CPE reaching, or already having exceeded, its end of life.
   - An Internet-facing CPE that is redundant with Cloudflare One Appliance and can be removed for simplicity's sake.


### PR DESCRIPTION
Corrected the VLAN tagging standard from 801.1Q to 802.1Q in the deployment documentation.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
