### PR TITLE
Add RFC 8288 Link response header for agent discovery

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,9 @@
 /*
 	Access-Control-Allow-Origin: *
 
+/
+	Link: </api/>; rel="service-doc"
+
 /_astro/*
 	Cache-Control: public, max-age=604800, immutable
 


### PR DESCRIPTION
## Summary

Adds a `Link` response header to the homepage per [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) to help agents discover the Cloudflare API reference:

```
Link: </api/>; rel="service-doc"
```

`rel="service-doc"` is a registered IANA relation type ([RFC 8631](https://www.rfc-editor.org/rfc/rfc8631)) that identifies a human/machine-readable documentation resource for a service.