### PR TITLE
Remove `/api` to `/api/` redirect

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -6,7 +6,6 @@
 # homepage
 /docs/ /directory/ 301
 /support/ai/ / 301
-/api /api/ 301
 /products/ /directory/ 301
 /zero-trust/ /products/?product-group=Cloudflare+One 301
 /dashboard-landing/ / 301


### PR DESCRIPTION
Covered by a redirect rule in the CF dash. Moving to a rule makes the behavior more transparent + less chance of accidental changes.

Screenshot of trace for `https://developers.cloudflare.com/api`

<img width="864" height="653" alt="image" src="https://github.com/user-attachments/assets/858125e5-ea6c-4973-aa4e-ca4135957a6d" />
