### PR TITLE
Fix a typo in account-abuse-protection.mdx

### DIFF
--- a/src/content/docs/bots/account-abuse-protection.mdx
+++ b/src/content/docs/bots/account-abuse-protection.mdx
@@ -136,7 +136,7 @@ The following fields can be used in new and existing Security Rules.
 
 | Field | Description | Values |
 | --- | --- | --- |
-| `cf.fraud_detection.dispoable_domain` | Flags whether a domain for a given email is included in a known list of temporary email providers. | `True` or `False` |
+| `cf.fraud_detection.disposable_domain` | Flags whether a domain for a given email is included in a known list of temporary email providers. | `True` or `False` |
 | `cf.fraud.email_risk` | Measures risk of email based on randomness of characters in the username and domain. | `Low` represents low risk due to reduced randomness and simple emails. <br />`Medium` represents medium risk based on larger strings with slightly more randomness. <br />`High` represents high risk based on larger and random character strings. <br />`Unknown` |
 
 #### Other rules


### PR DESCRIPTION

### Summary

Correct a typo from `cf.fraud_detection.dispoable_domain` to `cf.fraud_detection.disposable_domain`

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).