### PR TITLE
[Logs] Add millisecond and nanosecond timestamp formats for Logpush

### DIFF
--- a/src/content/changelog/logs/2026-03-25-logpush-granular-timestamps.mdx
+++ b/src/content/changelog/logs/2026-03-25-logpush-granular-timestamps.mdx
@@ -1,0 +1,18 @@
+---
+title: Logpush — More granular timestamps
+description: Configure millisecond or nanosecond timestamp precision for Logpush jobs.
+products:
+  - logpush
+date: 2026-03-25
+---
+
+Logpush now supports higher-precision timestamp formats for log output. You can configure jobs to output timestamps at millisecond or nanosecond precision. This is available in both the Logpush UI in the Cloudflare dashboard and the [Logpush API](/api/resources/logpush/subresources/jobs/).
+
+To use the new formats, set `timestamp_format` in your Logpush job's `output_options`:
+
+- `rfc3339ms` — `2024-02-17T23:52:01.123Z`
+- `rfc3339ns` — `2024-02-17T23:52:01.123456789Z`
+
+Default timestamp formats apply unless explicitly set. The dashboard defaults to `rfc3339` and the API defaults to `unixnano`.
+
+For more information, refer to the [Log output options](/logs/logpush/logpush-job/log-output-options/) documentation.

--- a/src/content/docs/logs/logpush/logpush-job/log-output-options.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/log-output-options.mdx
@@ -3,16 +3,15 @@ pcx_content_type: concept
 title: Log Output Options
 sidebar:
   order: 6
-
 ---
 
-import { Details } from "~/components"
+import { Details } from "~/components";
 
-Jobs in Logpush now have a new key, **output\_options**, which replaces **logpull\_options** and allows for more flexible formatting. You can modify **output\_options** via the API.
+Jobs in Logpush now have a new key, **output_options**, which replaces **logpull_options** and allows for more flexible formatting. You can modify **output_options** via the API.
 
-## Replace logpull\_options
+## Replace logpull_options
 
-Previously, Logpush jobs could be customized by specifying the list of fields, sampling rate, and timestamp format in **logpull\_options** as [URL-encoded parameters](/logs/logpush/logpush-job/api-configuration/#options). For example:
+Previously, Logpush jobs could be customized by specifying the list of fields, sampling rate, and timestamp format in **logpull_options** as [URL-encoded parameters](/logs/logpush/logpush-job/api-configuration/#options). For example:
 
 ```json
 {
@@ -25,7 +24,7 @@ Previously, Logpush jobs could be customized by specifying the list of fields, s
 }
 ```
 
-We have replaced this with **output\_options** as it is used for both Logpull and Logpush.
+We have replaced this with **output_options** as it is used for both Logpull and Logpush.
 
 ```json
 {
@@ -46,46 +45,51 @@ We have replaced this with **output\_options** as it is used for both Logpull an
 
 By default Logpush outputs each record as a single line of JSON (also known as `ndjson`).
 
-With **output\_options** you can switch to CSV or single JSON object, further customize prefixes, suffixes, delimiters, or provide your own record template (in a stripped-down version of Go [text/template](https://pkg.go.dev/text/template) syntax).
+With **output_options** you can switch to CSV or single JSON object, further customize prefixes, suffixes, delimiters, or provide your own record template (in a stripped-down version of Go [text/template](https://pkg.go.dev/text/template) syntax).
 
-The **output\_options** object has the following settings:
+The **output_options** object has the following settings:
 
-* **field\_names**: array of strings. For the moment, there is no option to add all fields at once, you need to specify the fields names.
-* **output\_type**: string to specify output type, such as `ndjson` or `csv` (default `ndjson`). This sets default values for the rest of the settings depending on the chosen output type. Some formatting rules (like string quoting) are different between output types.
-* **batch\_prefix**: string to be prepended before each batch.
-* **batch\_suffix**: string to be appended after each batch.
-* **record\_prefix**: string to be prepended before each record.
-* **record\_suffix**: string to be appended after each record.
-* **record\_template**: string to use as template for each record instead of the default comma-separated list. All fields used in the template must be present in **field\_names** as well, otherwise they will end up as `null`. Format as a Go text/template without any standard functions (like conditionals, loops, sub-templates, etc.). The template can only consist of these three types of tokens:
-  * Action: this is either a `{{ .Field }}` or a `{{ "constant text" }}`.
-  * Text: this is just constant text in-between the `{{ actions }}`.
-  * Comment: the `{{/* comments */}}` are silently dropped.
-* **record\_delimiter**: string to be inserted in-between the records as separator.
-* **field\_delimiter**: string to join fields. Will be ignored when **record\_template** is set.
-* **timestamp\_format**: string to specify format for timestamps, such as `unixnano` (nanoseconds unit), `unix` (seconds unit), or `rfc3339` (seconds unit). Default `unixnano`. The API default is `unixnano` when `timestamp_format` is not specified for a job. However, when creating a Logpush job in the Cloudflare dashboard, `timestamp_format` will be set explicitly to `rfc3339` as the default.
-* **sample\_rate**: floating number to specify sampling rate (default 1.0: no sampling). Sampling is applied on top of filtering, and regardless of the current sample\_interval of the data.
-* **CVE-2021-44228**: bool, default false. If set to true, will cause all occurrences of `${` in the generated files to be replaced with `x{`.
+- **field_names**: array of strings. For the moment, there is no option to add all fields at once, you need to specify the fields names.
+- **output_type**: string to specify output type, such as `ndjson` or `csv` (default `ndjson`). This sets default values for the rest of the settings depending on the chosen output type. Some formatting rules (like string quoting) are different between output types.
+- **batch_prefix**: string to be prepended before each batch.
+- **batch_suffix**: string to be appended after each batch.
+- **record_prefix**: string to be prepended before each record.
+- **record_suffix**: string to be appended after each record.
+- **record_template**: string to use as template for each record instead of the default comma-separated list. All fields used in the template must be present in **field_names** as well, otherwise they will end up as `null`. Format as a Go text/template without any standard functions (like conditionals, loops, sub-templates, etc.). The template can only consist of these three types of tokens:
+  - Action: this is either a `{{ .Field }}` or a `{{ "constant text" }}`.
+  - Text: this is just constant text in-between the `{{ actions }}`.
+  - Comment: the `{{/* comments */}}` are silently dropped.
+- **record_delimiter**: string to be inserted in-between the records as separator.
+- **field_delimiter**: string to join fields. Will be ignored when **record_template** is set.
+- **timestamp_format**: string to specify the format for timestamps. Supported values are:
+  - `unixnano` — nanoseconds unit
+  - `unix` — seconds unit
+  - `rfc3339` — seconds unit, for example: `2024-02-17T23:52:01Z`
+  - `rfc3339ms` — milliseconds unit, for example: `2024-02-17T23:52:01.123Z`
+  - `rfc3339ns` — nanoseconds unit, for example: `2024-02-17T23:52:01.123456789Z`
+
+  Default timestamp formats apply unless explicitly set. The dashboard defaults to `rfc3339` and the API defaults to `unixnano`.
+
+- **sample_rate**: floating number to specify sampling rate (default 1.0: no sampling). Sampling is applied on top of filtering, and regardless of the current sample_interval of the data.
+- **CVE-2021-44228**: bool, default false. If set to true, will cause all occurrences of `${` in the generated files to be replaced with `x{`.
 
 ## Examples
 
-Specifying **field\_names** and **output\_type** will result in the remaining options being configured as below for the specified **output\_type**:
+Specifying **field_names** and **output_type** will result in the remaining options being configured as below for the specified **output_type**:
 
 ### ndjson
-
 
 <Details header="Default output_options for `ndjson`">
 
 ```json
 {
-  "record_prefix": "{",
-  "record_suffix": "}\n",
-  "field_delimiter": ","
+	"record_prefix": "{",
+	"record_suffix": "}\n",
+	"field_delimiter": ","
 }
 ```
 
-
 </Details>
-
 
 <Details header="Example output_options">
 
@@ -96,9 +100,7 @@ Specifying **field\_names** and **output\_type** will result in the remaining op
 }
 ```
 
-
 </Details>
-
 
 <Details header="Example output">
 
@@ -108,11 +110,9 @@ Specifying **field\_names** and **output\_type** will result in the remaining op
 {"ClientIP":"89.163.242.208","EdgeStartTimestamp":1506702504433000400,"RayID":"3a6050bcbe121a89"}
 ```
 
-
 </Details>
 
-* `ndjson` with different field names:
-
+- `ndjson` with different field names:
 
 <Details header="Example output_options">
 
@@ -124,9 +124,7 @@ Specifying **field\_names** and **output\_type** will result in the remaining op
 }
 ```
 
-
 </Details>
-
 
 <Details header="Example output">
 
@@ -138,24 +136,20 @@ Specifying **field\_names** and **output\_type** will result in the remaining op
 
 Literal with double curly-braces `({{}})`, that is, `"double{{curly}}braces"`, can be inserted following go text/template convention, that is, `"{{`doublecurlybraces`}}"`.
 
-
 </Details>
 
 ### csv
-
 
 <Details header="Default output_options for CSV">
 
 ```json
 {
-  "record_suffix": "\n",
-  "field_delimiter": ","
+	"record_suffix": "\n",
+	"field_delimiter": ","
 }
 ```
 
-
 </Details>
-
 
 <Details header="Example output_options">
 
@@ -166,9 +160,7 @@ Literal with double curly-braces `({{}})`, that is, `"double{{curly}}braces"`, c
 }
 ```
 
-
 </Details>
-
 
 <Details header="Example output">
 
@@ -179,15 +171,13 @@ Literal with double curly-braces `({{}})`, that is, `"double{{curly}}braces"`, c
 
 ```
 
-
 </Details>
 
 ### csv/json variants
 
 Based on above, other formats similar to csv or json are also supported:
 
-* csv with header:
-
+- csv with header:
 
 <Details header="Example output_options">
 
@@ -199,9 +189,7 @@ Based on above, other formats similar to csv or json are also supported:
 }
 ```
 
-
 </Details>
-
 
 <Details header="Example output">
 
@@ -212,11 +200,9 @@ ClientIP,EdgeStartTimestamp,RayID
 "89.163.242.208",1506702504433000400,"3a6050bcbe121a89"
 ```
 
-
 </Details>
 
-* tsv with header:
-
+- tsv with header:
 
 <Details header="Example output_options">
 
@@ -229,9 +215,7 @@ ClientIP,EdgeStartTimestamp,RayID
 }
 ```
 
-
 </Details>
-
 
 <Details header="Example output">
 
@@ -242,11 +226,9 @@ ClientIP EdgeStartTimestamp  RayID
 "89.163.242.208"    1506702504433000400 "3a6050bcbe121a89"
 ```
 
-
 </Details>
 
-* json with nested object:
-
+- json with nested object:
 
 <Details header="Example output_options">
 
@@ -262,33 +244,50 @@ ClientIP EdgeStartTimestamp  RayID
 }
 ```
 
-
 </Details>
-
 
 <Details header="Example output">
 
 ```json
-{"events":[
-  {"info":{"ClientIP":"89.163.242.206","EdgeStartTimestamp":1506702504433000200,"RayID":"3a6050bcbe121a87"}},
-  {"info":{"ClientIP":"89.163.242.207","EdgeStartTimestamp":1506702504433000300,"RayID":"3a6050bcbe121a88"}},
-  {"info":{"ClientIP":"89.163.242.208","EdgeStartTimestamp":1506702504433000400,"RayID":"3a6050bcbe121a89"}}
-]}
+{
+	"events": [
+		{
+			"info": {
+				"ClientIP": "89.163.242.206",
+				"EdgeStartTimestamp": 1506702504433000200,
+				"RayID": "3a6050bcbe121a87"
+			}
+		},
+		{
+			"info": {
+				"ClientIP": "89.163.242.207",
+				"EdgeStartTimestamp": 1506702504433000300,
+				"RayID": "3a6050bcbe121a88"
+			}
+		},
+		{
+			"info": {
+				"ClientIP": "89.163.242.208",
+				"EdgeStartTimestamp": 1506702504433000400,
+				"RayID": "3a6050bcbe121a89"
+			}
+		}
+	]
+}
 ```
-
 
 </Details>
 
 ## How to migrate
 
-In order to migrate your jobs from using **logpull\_options** to the new **output\_options**, take these steps:
+In order to migrate your jobs from using **logpull_options** to the new **output_options**, take these steps:
 
 1. Change the `&fields=ClientIP,EdgeStartTimestamp,RayID` parameter to an array in `output_options.field_names`.
 2. Change the `&sample=0.1` parameter to `output_options.sample_rate`.
 3. Change the `&timestamps=rfc3339` parameter to `output_options.timestamp_format`.
 4. Change the `&CVE-2021-44228=true` parameter to `output_options.CVE-2021-44228`.
 
-For example, if logpull\_options are `fields=ClientIP,EdgeStartTimestamp,RayID&sample=0.1&timestamps=rfc3339&CVE-2021-44228=true`, the output\_options would be:
+For example, if logpull_options are `fields=ClientIP,EdgeStartTimestamp,RayID&sample=0.1&timestamps=rfc3339&CVE-2021-44228=true`, the output_options would be:
 
 ```json
 "output_options": {


### PR DESCRIPTION
Documents new `rfc3339ms` and `rfc3339ns` timestamp formats for Logpush job output options, available in both the dashboard and API.

- Expanded the `timestamp_format` reference in the log output options page to list all five supported values (`unixnano`, `unix`, `rfc3339`, `rfc3339ms`, `rfc3339ns`) with examples and default behavior
- Added changelog entry for the new granular timestamp precision feature