### PR TITLE
[Chore] Remove outdated test

### DIFF
--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -12,14 +12,6 @@ describe("Cloudflare Docs", () => {
 			expect(await response.text()).toContain("Cloudflare Docs");
 		});
 
-		// Remove once the whacky double-slash rules get removed
-		it("responds with index.html at `//`", async () => {
-			const request = new Request("http://fakehost//");
-			const response = await SELF.fetch(request);
-			expect(response.status).toBe(200);
-			expect(await response.text()).toContain("Cloudflare Docs");
-		});
-
 		it("responds with 404.html at `/non-existent`", async () => {
 			const request = new Request("http://fakehost/non-existent");
 			const response = await SELF.fetch(request);


### PR DESCRIPTION
Do we need this anymore?
https://github.com/cloudflare/cloudflare-docs/commit/815145bf185d55a8041d4a2297016b1057eb1728#diff-ed9b82a41eafb2916053294532595ab1637a3e2564673da23e9f8985f4d93a36R12

Historical context is that we used to have a weird redirect rule that replaced slashes and such, and -- from a recent trace -- no longer seeing this in our project.
