### PR TITLE
Document that locationHint is supported on DO getByName method

### DIFF
--- a/src/content/docs/durable-objects/api/namespace.mdx
+++ b/src/content/docs/durable-objects/api/namespace.mdx
@@ -174,6 +174,7 @@ const barStub = env.MY_DURABLE_OBJECT.getByName("bar");
 #### Parameters
 
 - A required string to be used to generate a [`DurableObjectStub`](/durable-objects/api/stub) corresponding to an instance of the Durable Object class with the provided name.
+- An optional object with the key `locationHint` and value of a [locationHint](/durable-objects/reference/data-location/#provide-a-location-hint) string.
 
 #### Return values
 


### PR DESCRIPTION
I went to the docs to confirm that this was supported, was surprised to see it wasn't, then confirmed in the source code that it actually is.

This is just adding some missing information that should have already been there; it's not due to some new release or anything like that.