### PR TITLE
feat: custom package manager component

### DIFF
--- a/src/components/LayerCard.astro
+++ b/src/components/LayerCard.astro
@@ -1,0 +1,42 @@
+---
+interface Props {
+	header?: string;
+	href?: string;
+}
+
+const { header = "Next Steps", href } = Astro.props;
+---
+
+<div
+	class="flex w-full flex-col overflow-hidden rounded-lg bg-cl1-gray-9 text-base ring-1 ring-cl1-gray-8 dark:bg-cl1-gray-0 dark:ring-cl1-gray-1"
+>
+	<div
+		class="-my-2 flex items-center justify-between gap-2 bg-cl1-gray-9 p-4 text-base font-medium text-cl1-gray-4 dark:bg-cl1-gray-1 dark:text-cl1-gray-7"
+	>
+		<div>{header}</div>
+		{
+			href && (
+				<a
+					href={href}
+					class="flex size-[1.625rem] shrink-0 cursor-pointer items-center justify-center rounded-md bg-transparent text-cl1-gray-0 no-underline hover:bg-cl1-gray-8 focus-visible:outline focus-visible:outline-1 focus-visible:outline-cl1-gray-8 dark:text-cl1-gray-7 dark:hover:bg-cl1-gray-2 dark:focus-visible:outline-cl1-gray-3"
+					aria-label={`Go to ${header.toLowerCase()}`}
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="16"
+						height="16"
+						fill="currentColor"
+						viewBox="0 0 256 256"
+					>
+						<path d="M221.66,133.66l-72,72a8,8,0,0,1-11.32-11.32L196.69,136H40a8,8,0,0,1,0-16H196.69L138.34,61.66a8,8,0,0,1,11.32-11.32l72,72A8,8,0,0,1,221.66,133.66Z" />
+					</svg>
+				</a>
+			)
+		}
+	</div>
+	<div
+		class="relative mt-0 flex flex-col gap-2 overflow-hidden rounded-lg bg-cl1-white p-4 pr-3 ring-1 ring-cl1-gray-8 dark:bg-cl1-gray-2 dark:ring-cl1-gray-2"
+	>
+		<slot />
+	</div>
+</div>

--- a/src/components/PackageManagers.astro
+++ b/src/components/PackageManagers.astro
@@ -1,13 +1,150 @@
 ---
-import {
-	PackageManagers as PackageManagersComponent,
-	type PackageManagersProps,
-} from "starlight-package-managers";
+import { getTabs } from "~/util/package-managers";
+import type { CommandType, CommandOptions } from "~/util/package-managers";
 
-type Props = PackageManagersProps;
+interface Props extends CommandOptions {
+	pkg?: string;
+	type?: CommandType;
+	frame?: "terminal" | "none";
+}
+
+const { pkg, type = "add", args, dev, comment, prefix, frame = "terminal" } =
+	Astro.props;
+const tabs = getTabs(type, pkg, { args, dev, comment, prefix });
+
+// Unique suffix per render to avoid duplicate IDs when multiple instances appear on a page.
+const uid = Math.random().toString(36).slice(2, 8);
 ---
 
-<PackageManagersComponent
-	pkgManagers={["npm", "yarn", "pnpm"]}
-	{...Astro.props}
-/>
+<script is:inline>
+if (!customElements.get("lc-pm-restore")) {
+	customElements.define("lc-pm-restore", class extends HTMLElement {
+		connectedCallback() {
+			const card = this.closest("[data-lc-pm]");
+			if (!card) return;
+			let saved;
+			try { saved = sessionStorage.getItem("lc-pm-active-tab"); } catch { /* storage unavailable */ }
+			if (!saved) return;
+			const idx = Number(saved);
+			card.querySelectorAll("[data-lc-pm-tab]").forEach(function(t, i) { t.setAttribute("aria-selected", String(i === idx)); });
+			card.querySelectorAll("[data-lc-pm-panel]").forEach(function(p, i) { p.hidden = i !== idx; });
+		}
+	});
+}
+</script>
+
+<div
+	class:list={[
+		"flex w-full flex-col overflow-hidden rounded-lg text-base",
+		frame !== "none" && "bg-cl1-gray-9 ring-1 ring-cl1-gray-8 dark:bg-cl1-gray-0 dark:ring-cl1-gray-2",
+	]}
+	data-lc-pm
+>
+	<div
+		class:list={[
+			"-my-2 flex items-center gap-2 py-4 px-4",
+			frame !== "none" && "bg-cl1-gray-9 dark:bg-cl1-gray-1",
+		]}
+		role="tablist"
+		aria-label="Package manager"
+	>
+		{tabs.map((tab, i) => (
+			<button
+				role="tab"
+				type="button"
+				aria-selected={i === 0 ? "true" : "false"}
+				aria-controls={`lc-pm-panel-${uid}-${tab.mgr}`}
+				id={`lc-pm-tab-${uid}-${tab.mgr}`}
+				data-lc-pm-tab
+				class="cursor-pointer rounded-md border-0 bg-transparent px-2.5 py-1 text-xs font-medium transition-colors
+					text-cl1-gray-4 hover:bg-cl1-gray-8 hover:text-cl1-gray-0
+					aria-selected:bg-cl1-gray-8 aria-selected:text-cl1-gray-0
+					dark:text-cl1-gray-7 dark:hover:bg-cl1-gray-3 dark:hover:text-cl1-white
+					dark:aria-selected:bg-cl1-gray-3 dark:aria-selected:text-cl1-white
+					focus-visible:outline focus-visible:outline-1 focus-visible:outline-cl1-gray-8
+					dark:focus-visible:outline-cl1-gray-3 m-0"
+			>
+				{tab.mgr}
+			</button>
+		))}
+	</div>
+
+	{tabs.map((tab, i) => {
+		// Split off any leading comment lines (e.g. from the `comment` prop) so syntax
+		// coloring applies only to the actual command line, not the "# …" prefix.
+		const cmdLines = tab.cmd.split("\n");
+		const commentPrefix = cmdLines.length > 1 ? cmdLines.slice(0, -1).join("\n") + "\n" : "";
+		const codeLine = cmdLines[cmdLines.length - 1];
+		const spaceIdx = codeLine.indexOf(" ");
+		const codeFirst = spaceIdx === -1 ? codeLine : codeLine.slice(0, spaceIdx);
+		const codeRest = spaceIdx === -1 ? "" : codeLine.slice(spaceIdx);
+		return (
+		<div
+			role="tabpanel"
+			id={`lc-pm-panel-${uid}-${tab.mgr}`}
+			aria-labelledby={`lc-pm-tab-${uid}-${tab.mgr}`}
+			hidden={i !== 0}
+			data-lc-pm-panel
+			class="m-0 group relative overflow-hidden rounded-lg bg-cl1-white ring-1 ring-cl1-gray-8 dark:bg-cl1-gray-2 dark:ring-cl1-gray-3"
+		>
+			<pre class="my-0 border-0 overflow-x-auto whitespace-pre px-4 py-3 text-sm leading-relaxed"><code>{commentPrefix}<span style="--0:#57C78F;--1:#00783C">{codeFirst}</span><span style="--0:#FDDA68;--1:#A84E00">{codeRest}</span></code></pre>
+			<button
+				type="button"
+				data-lc-pm-copy
+				data-command={tab.cmd}
+				aria-label="Copy to clipboard"
+				class="absolute top-1/2 right-2 -translate-y-1/2 flex size-8 cursor-pointer items-center justify-center rounded-md border-0 m-0
+				bg-transparent text-cl1-gray-4 opacity-0 transition-all
+				hover:bg-cl1-gray-9 hover:text-cl1-gray-0 hover:opacity-100 hover:ring-1 hover:ring-cl1-gray-8
+				focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cl1-gray-8
+				group-hover:opacity-100
+				dark:text-cl1-gray-7 dark:hover:bg-cl1-gray-1 dark:hover:text-cl1-gray-9 dark:hover:ring-cl1-gray-3
+				dark:focus-visible:ring-cl1-gray-3"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256">
+					<path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z" />
+				</svg>
+			</button>
+		</div>
+		); })}
+	<lc-pm-restore style="display:contents"></lc-pm-restore>
+</div>
+
+<style>
+	/* Light: --1, dark: --0 — matches Expressive Code convention */
+	pre span { color: var(--1, inherit); }
+	:root[data-theme="dark"] pre span { color: var(--0, inherit); }
+</style>
+
+<script>
+	const SYNC_KEY = "lc-pm-active-tab";
+
+	function activate(card: Element, index: number) {
+		card.querySelectorAll("[data-lc-pm-tab]").forEach((tab, i) =>
+			tab.setAttribute("aria-selected", String(i === index))
+		);
+		card.querySelectorAll<HTMLElement>("[data-lc-pm-panel]").forEach((panel, i) => {
+			panel.hidden = i !== index;
+		});
+	}
+
+	document.querySelectorAll("[data-lc-pm]").forEach((card) => {
+		card.querySelectorAll("[data-lc-pm-tab]").forEach((tab, i) => {
+			tab.addEventListener("click", () => {
+				document.querySelectorAll("[data-lc-pm]").forEach((c) => activate(c, i));
+				try { sessionStorage.setItem(SYNC_KEY, String(i)); } catch { /* storage unavailable */ }
+			});
+		});
+
+		card.querySelectorAll<HTMLButtonElement>("[data-lc-pm-copy]").forEach((btn) => {
+			btn.addEventListener("click", async () => {
+				try {
+					await navigator.clipboard.writeText(btn.dataset.command ?? "");
+					const prev = btn.innerHTML;
+					btn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256"><path d="M173.66,98.34a8,8,0,0,1,0,11.32l-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35A8,8,0,0,1,173.66,98.34Z"/></svg>`;
+					setTimeout(() => { btn.innerHTML = prev; }, 1500);
+				} catch { /* clipboard unavailable */ }
+			});
+		});
+	});
+</script>

--- a/src/components/PackageManagers.astro
+++ b/src/components/PackageManagers.astro
@@ -106,13 +106,7 @@ const uid = Math.random().toString(36).slice(2, 8);
 					class="bg-cl1-white ring-cl1-gray-8 dark:bg-cl1-gray-2 dark:ring-cl1-gray-3 m-0 overflow-hidden rounded-lg ring-1"
 				>
 					<div class="flex items-stretch">
-						<pre class="my-0 min-w-0 grow overflow-x-auto border-0 px-4 py-3 text-sm leading-relaxed whitespace-pre">
-							<code>
-								{commentPrefix}
-								<span style="--0:#57C78F;--1:#00783C">{codeFirst}</span>
-								<span style="--0:#FDDA68;--1:#A84E00">{codeRest}</span>
-							</code>
-						</pre>
+						<pre class="my-0 min-w-0 grow overflow-x-auto border-0 px-4 py-3 text-sm leading-relaxed whitespace-pre"><code>{commentPrefix}<span style="--0:#57C78F;--1:#00783C">{codeFirst}</span><span style="--0:#FDDA68;--1:#A84E00">{codeRest}</span></code></pre>
 						<button
 							type="button"
 							data-lc-pm-copy

--- a/src/components/PackageManagers.astro
+++ b/src/components/PackageManagers.astro
@@ -87,7 +87,7 @@ if (!customElements.get("lc-pm-restore")) {
 			data-lc-pm-panel
 			class="m-0 group relative overflow-hidden rounded-lg bg-cl1-white ring-1 ring-cl1-gray-8 dark:bg-cl1-gray-2 dark:ring-cl1-gray-3"
 		>
-			<pre class="my-0 border-0 overflow-x-auto whitespace-pre px-4 py-3 text-sm leading-relaxed"><code>{commentPrefix}<span style="--0:#57C78F;--1:#00783C">{codeFirst}</span><span style="--0:#FDDA68;--1:#A84E00">{codeRest}</span></code></pre>
+		<pre class="my-0 border-0 overflow-x-auto whitespace-pre px-4 py-3 text-sm leading-relaxed"><code>{commentPrefix}<span class="pm-cmd-first">{codeFirst}</span><span class="pm-cmd-rest">{codeRest}</span></code></pre>
 			<button
 				type="button"
 				data-lc-pm-copy

--- a/src/components/PackageManagers.astro
+++ b/src/components/PackageManagers.astro
@@ -85,26 +85,27 @@ if (!customElements.get("lc-pm-restore")) {
 			aria-labelledby={`lc-pm-tab-${uid}-${tab.mgr}`}
 			hidden={i !== 0}
 			data-lc-pm-panel
-			class="m-0 group relative overflow-hidden rounded-lg bg-cl1-white ring-1 ring-cl1-gray-8 dark:bg-cl1-gray-2 dark:ring-cl1-gray-3"
+			class="m-0 overflow-hidden rounded-lg bg-cl1-white ring-1 ring-cl1-gray-8 dark:bg-cl1-gray-2 dark:ring-cl1-gray-3"
 		>
-			<pre class="my-0 border-0 overflow-x-auto whitespace-pre px-4 py-3 text-sm leading-relaxed"><code>{commentPrefix}<span style="--0:#57C78F;--1:#00783C">{codeFirst}</span><span style="--0:#FDDA68;--1:#A84E00">{codeRest}</span></code></pre>
-			<button
-				type="button"
-				data-lc-pm-copy
-				data-command={tab.cmd}
-				aria-label="Copy to clipboard"
-				class="absolute top-1/2 right-2 -translate-y-1/2 flex size-8 cursor-pointer items-center justify-center rounded-md border-0 m-0
-				bg-transparent text-cl1-gray-4 opacity-0 transition-all
-				hover:bg-cl1-gray-9 hover:text-cl1-gray-0 hover:opacity-100 hover:ring-1 hover:ring-cl1-gray-8
-				focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cl1-gray-8
-				group-hover:opacity-100
-				dark:text-cl1-gray-7 dark:hover:bg-cl1-gray-1 dark:hover:text-cl1-gray-9 dark:hover:ring-cl1-gray-3
-				dark:focus-visible:ring-cl1-gray-3"
-			>
-				<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256">
-					<path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z" />
-				</svg>
-			</button>
+			<div class="flex items-stretch">
+				<pre class="my-0 min-w-0 grow border-0 overflow-x-auto whitespace-pre px-4 py-3 text-sm leading-relaxed"><code>{commentPrefix}<span style="--0:#57C78F;--1:#00783C">{codeFirst}</span><span style="--0:#FDDA68;--1:#A84E00">{codeRest}</span></code></pre>
+				<button
+					type="button"
+					data-lc-pm-copy
+					data-command={tab.cmd}
+					aria-label="Copy to clipboard"
+					class="flex shrink-0 cursor-pointer items-center justify-center border-0 border-l border-solid border-cl1-gray-8 px-3 m-0
+					bg-transparent text-cl1-gray-4 transition-colors
+					hover:bg-cl1-gray-9 hover:text-cl1-gray-0
+					focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-cl1-gray-8
+					dark:border-cl1-gray-3 dark:text-cl1-gray-7 dark:hover:bg-cl1-gray-1 dark:hover:text-cl1-gray-9
+					dark:focus-visible:ring-cl1-gray-3"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256">
+						<path d="M216,32H88a8,8,0,0,0-8,8V80H40a8,8,0,0,0-8,8V216a8,8,0,0,0,8,8H168a8,8,0,0,0,8-8V176h40a8,8,0,0,0,8-8V40A8,8,0,0,0,216,32ZM160,208H48V96H160Zm48-48H176V88a8,8,0,0,0-8-8H96V48H208Z" />
+					</svg>
+				</button>
+			</div>
 		</div>
 		); })}
 	<lc-pm-restore style="display:contents"></lc-pm-restore>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -39,6 +39,7 @@ export { default as ListTutorials } from "./ListTutorials.astro";
 export { default as Markdown } from "./Markdown.astro";
 export { default as MetaInfo } from "./MetaInfo.astro";
 export { default as PackageManagers } from "./PackageManagers.astro";
+export { default as LayerCard } from "./LayerCard.astro";
 export { default as PagesBuildEnvironment } from "./PagesBuildEnvironment.astro";
 export { default as PagesBuildEnvironmentLanguages } from "./PagesBuildEnvironmentLanguages.astro";
 export { default as PagesBuildEnvironmentTools } from "./PagesBuildEnvironmentTools.astro";

--- a/src/util/package-managers.ts
+++ b/src/util/package-managers.ts
@@ -66,7 +66,8 @@ export function getCommand(
 	if (dev && type === "add") cmd += ` ${commands[mgr].dev}`;
 	if (pkg) {
 		// For `yarn create`, strip only a trailing @version tag (e.g. `pkg@latest` → `pkg`).
-		// The original /@[^\s]+/ matches the very first @, which destroys scoped packages
+		// For yarn create, strip only trailing version tags (e.g., @latest).
+		// This regex strips @ that is NOT followed by / (not a scope prefix) at the end.
 		// like `@cloudflare/workers` (first @ is the scope, not a version).
 		// The corrected regex only strips an @ that is NOT immediately followed by a `/`
 		// (i.e. not a scope prefix) and only at the end of the package name.

--- a/src/util/package-managers.ts
+++ b/src/util/package-managers.ts
@@ -1,0 +1,92 @@
+export type Manager = "npm" | "yarn" | "pnpm";
+export type CommandType =
+	| "add"
+	| "create"
+	| "dlx"
+	| "exec"
+	| "install"
+	| "remove"
+	| "run";
+
+export interface CommandOptions {
+	args?: string;
+	dev?: boolean;
+	comment?: string;
+	prefix?: string;
+}
+
+const commands: Record<
+	Manager,
+	Partial<Record<CommandType, string>> & { dev: string }
+> = {
+	npm: {
+		add: "npm i",
+		create: "npm create",
+		dlx: "npx",
+		exec: "npx",
+		install: "npm install",
+		run: "npm run",
+		remove: "npm uninstall",
+		dev: "-D",
+	},
+	yarn: {
+		add: "yarn add",
+		create: "yarn create",
+		dlx: "yarn dlx",
+		exec: "yarn",
+		install: "yarn install",
+		run: "yarn run",
+		remove: "yarn remove",
+		dev: "-D",
+	},
+	pnpm: {
+		add: "pnpm add",
+		create: "pnpm create",
+		dlx: "pnpx",
+		exec: "pnpm",
+		install: "pnpm install",
+		run: "pnpm run",
+		remove: "pnpm remove",
+		dev: "-D",
+	},
+};
+
+export const MANAGERS: Manager[] = ["npm", "yarn", "pnpm"];
+
+export function getCommand(
+	mgr: Manager,
+	type: CommandType,
+	pkg?: string,
+	{ args, dev = false, comment, prefix }: CommandOptions = {},
+): string | undefined {
+	let cmd = commands[mgr][type];
+	if (cmd === undefined) return undefined;
+	if (prefix) cmd = `${prefix} ${cmd}`;
+	if (comment) cmd = `# ${comment.replaceAll("{PKG}", mgr)}\n${cmd}`;
+	if (dev && type === "add") cmd += ` ${commands[mgr].dev}`;
+	if (pkg) {
+		// For `yarn create`, strip only a trailing @version tag (e.g. `pkg@latest` → `pkg`).
+		// The original /@[^\s]+/ matches the very first @, which destroys scoped packages
+		// like `@cloudflare/workers` (first @ is the scope, not a version).
+		// The corrected regex only strips an @ that is NOT immediately followed by a `/`
+		// (i.e. not a scope prefix) and only at the end of the package name.
+		const processedPkg =
+			type === "create" && mgr === "yarn"
+				? pkg.replace(/@(?![^@]*\/)[^\s]*$/, "")
+				: pkg;
+		cmd += ` ${processedPkg}`;
+	}
+	if (args)
+		cmd += `${mgr === "npm" && !["dlx", "exec", "run"].includes(type) ? " --" : ""} ${args}`;
+	return cmd;
+}
+
+export function getTabs(
+	type: CommandType,
+	pkg?: string,
+	options: CommandOptions = {},
+) {
+	return MANAGERS.filter((mgr) => commands[mgr][type] !== undefined).map(
+		(mgr) => ({ mgr, cmd: getCommand(mgr, type, pkg, options)! }),
+	);
+}


### PR DESCRIPTION
### Summary

Main reasoning behind this change was that existing `starlight-package-managers ` third-party dependency was a significant limitation — its design was fixed and could not be customised, which was a blocker for the visual redesign of one of the most visible and frequently used components across the docs site. This PR replaces it with a fully custom implementation.

- update PackageManagers component to use a self-contained astro component - we weren't able to change much of the design on the old component that we were using, so it made sense to just build or own version - this component 
- create a new generic card component (LayerCard) based on the kumo component

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

**Before**
<img width="717" height="229" alt="Screenshot 2026-03-25 at 18 20 46" src="https://github.com/user-attachments/assets/2c2673b5-0b28-402a-9df2-752767efd772" />

**After**

<img width="718" height="185" alt="Screenshot 2026-03-25 at 18 18 18" src="https://github.com/user-attachments/assets/13796d46-0e48-4fd4-9c60-9c0ee0b6973a" />

**Screen recording**

https://github.com/user-attachments/assets/effa00ac-67fc-4522-9ed7-b720e0891f5a

