### PR TITLE
[Cloudflare One] Refine troubleshooting overview and update WARP guid…

### DIFF
--- a/src/content/docs/cloudflare-one/troubleshooting/contact-support.mdx
+++ b/src/content/docs/cloudflare-one/troubleshooting/contact-support.mdx
@@ -38,7 +38,7 @@ For issues related to authentication loops, blocked websites, or policy enforcem
 - **HAR file**: Provide a [HAR file](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/#generate-a-har-file) captured while reproducing the issue.
 - **Ray ID**: If you see a Cloudflare error page, provide the **Ray ID** displayed at the bottom of the page.
 - **Identity Provider logs**: Relevant logs from your identity provider (IdP) if the issue involves login failures.
-- **Request ID**: For Gateway issues, you can find the `oxy.request_id` in your [Gateway logs](/cloudflare-one/traffic-policies/troubleshooting/).
+- **Request ID**: For Gateway issues, you can find the `request_id` (HTTP logs) or `query_id` (DNS logs) in your [Gateway logs](/cloudflare-one/traffic-policies/troubleshooting/).
 
 ### Digital Experience Monitoring (DEX)
 For issues with DEX tests or device monitoring, provide a [remote capture](/cloudflare-one/insights/dex/remote-captures/) from the Zero Trust dashboard.

--- a/src/content/docs/cloudflare-one/troubleshooting/index.mdx
+++ b/src/content/docs/cloudflare-one/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting Cloudflare One
+title: Troubleshooting
 pcx_content_type: navigation
 sidebar:
   order: 22
@@ -7,22 +7,10 @@ sidebar:
 description: Find troubleshooting guides for Cloudflare One products and learn how to collect information for Cloudflare Support.
 ---
 
-import { LinkTitleCard, CardGrid, Render, LinkButton } from "~/components";
+import { LinkButton, DirectoryListing } from "~/components";
 
-Explore troubleshooting resources for Cloudflare One products.
+Cloudflare One provides troubleshooting guides to help you diagnose and resolve common connectivity, configuration, and security issues across your Zero Trust organization.
 
-## Product troubleshooting
+If you cannot resolve an issue using these guides, you can collect diagnostic information and [contact Cloudflare Support](/cloudflare-one/troubleshooting/contact-support/).
 
-<CardGrid>
-  <LinkTitleCard title="Access" href="/cloudflare-one/troubleshooting/access/" icon="lock" />
-  <LinkTitleCard title="Gateway" href="/cloudflare-one/troubleshooting/gateway/" icon="shield" />
-  <LinkTitleCard title="Tunnel" href="/cloudflare-one/troubleshooting/tunnel/" icon="network" />
-  <LinkTitleCard title="Cloudflare One Client" href="/cloudflare-one/troubleshooting/warp-client/" icon="laptop" />
-  <LinkTitleCard title="CASB" href="/cloudflare-one/troubleshooting/casb/" icon="search" />
-  <LinkTitleCard title="DLP" href="/cloudflare-one/troubleshooting/dlp/" icon="filter" />
-  <LinkTitleCard title="Browser Isolation" href="/cloudflare-one/troubleshooting/browser-isolation/" icon="browser" />
-  <LinkTitleCard title="Digital Experience Monitoring (DEX)" href="/cloudflare-one/troubleshooting/dex/" icon="chart-line" />
-  <LinkTitleCard title="Email Security" href="/cloudflare-one/troubleshooting/email-security/" icon="email" />
-  <LinkTitleCard title="Cloudflare WAN" href="/cloudflare-one/troubleshooting/wan/" icon="network" />
-  <LinkTitleCard title="Contact Cloudflare Support" href="/cloudflare-one/troubleshooting/contact-support/" icon="laptop" />
-</CardGrid>
+<DirectoryListing />


### PR DESCRIPTION
### Summary

Refinements to the new Troubleshooting Cloudflare One Overview Page

### Screenshots (optional)

<img width="1501" height="719" alt="Screenshot 2026-03-25 at 6 04 59 PM" src="https://github.com/user-attachments/assets/15f4c878-2304-41b5-a02b-2cb7052e886b" />

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
