### PR TITLE
[Workers VPC] Document new VPC Networks API

### DIFF
--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-import { WranglerConfig } from "~/components";
+import { Tabs, TabItem, WranglerConfig, Render } from "~/components";
 
 VPC Networks allow your Workers to access any service in your private network without pre-registering individual hosts or ports. You can bind to a specific [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/) to reach any service behind that tunnel, or bind to [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) to reach any Mesh node, client device, or IP route in your account.
 
@@ -17,7 +17,11 @@ Workers VPC is currently in beta. Features and APIs may change before general av
 
 :::
 
-## Bind to a tunnel
+## Binding types
+
+VPC Network bindings support three ways to connect your Worker to a private network:
+
+### Bind to a tunnel
 
 Reference a specific Cloudflare Tunnel directly by its UUID:
 
@@ -37,7 +41,7 @@ Reference a specific Cloudflare Tunnel directly by its UUID:
 
 The `remote` flag must be set to `true` to enable remote bindings during local development.
 
-## Bind to Cloudflare Mesh
+### Bind to Cloudflare Mesh
 
 [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) (formerly WARP Connector) connects your services, devices, and Workers through Cloudflare's global network. When you bind a Worker to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any Mesh node, client device, or IP route in your account — without specifying a particular tunnel UUID.
 
@@ -68,6 +72,107 @@ Bind to Cloudflare Mesh using `network_id: "cf1:network"`:
 }
 ```
 </WranglerConfig>
+
+### Bind to an explicit VPC Network
+
+You can create an explicit VPC Network that associates a tunnel with optional custom DNS resolver IPs. Bind your Worker to it using the network's UUID:
+
+<WranglerConfig>
+```jsonc
+{
+  "vpc_networks": [
+    {
+      "binding": "MY_VPC",
+      "network_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "remote": true
+    }
+  ]
+}
+```
+</WranglerConfig>
+
+Explicit VPC Networks are useful when you need:
+
+- **Custom DNS resolver IPs** — override the default DNS resolver used by the tunnel. For example, point to an internal DNS server, use split-horizon DNS, or integrate with service discovery tools like Consul or CoreDNS.
+- **Named network references** — create a named network entity that can be managed independently of your Worker configuration. Update the network's tunnel or DNS settings without modifying Worker bindings.
+- **Multiple networks with different resolvers** — bind different Workers to different networks, each with their own DNS configuration.
+
+:::note
+
+`tunnel_id` and `network_id` are mutually exclusive in a binding configuration. Use `tunnel_id` to bind directly to a tunnel, or `network_id` to bind to Cloudflare Mesh (`cf1:network`) or an explicit VPC Network (UUID).
+
+:::
+
+## Create a VPC Network
+
+<Tabs>
+<TabItem label="Wrangler CLI">
+
+```sh
+npx wrangler vpc network create my-network \
+  --tunnel-id 550e8400-e29b-41d4-a716-446655440000
+```
+
+To specify custom DNS resolver IPs:
+
+```sh
+npx wrangler vpc network create my-network \
+  --tunnel-id 550e8400-e29b-41d4-a716-446655440000 \
+  --resolver-ips 10.0.0.1,10.0.0.2
+```
+
+For the full list of options, refer to [Wrangler VPC commands](/workers/wrangler/commands/vpc/).
+
+</TabItem>
+<TabItem label="Dashboard">
+
+1. Go to the [Workers VPC dashboard](https://dash.cloudflare.com/?to=/:account/workers/vpc) and select the **Networks** tab.
+2. Select **Create** and choose **Create VPC Network**.
+3. Enter a **Network name** (lowercase alphanumeric and hyphens, 1-63 characters).
+4. Select a **Tunnel** from the dropdown.
+5. Optionally, configure **DNS Resolver IPs** — enter comma-separated IP addresses, or leave empty to use the tunnel's default DNS resolver.
+6. Select **Create network**.
+
+</TabItem>
+<TabItem label="API">
+
+Use the [Connectivity Directory Networks API](/api/resources/connectivity/subresources/directory/subresources/networks/) to create a network:
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/connectivity/directory/networks" \
+  -H "Authorization: Bearer {api_token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-network",
+    "tunnel_id": "550e8400-e29b-41d4-a716-446655440000"
+  }'
+```
+
+To specify custom DNS resolver IPs, include the `resolver_ips` field:
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/connectivity/directory/networks" \
+  -H "Authorization: Bearer {api_token}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-network",
+    "tunnel_id": "550e8400-e29b-41d4-a716-446655440000",
+    "resolver_ips": ["10.0.0.1", "10.0.0.2"]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Manage VPC Networks
+
+You can list, update, and delete VPC Networks with [Wrangler VPC commands](/workers/wrangler/commands/vpc/) or the [Connectivity Directory Networks API](/api/resources/connectivity/subresources/directory/subresources/networks/).
+
+:::caution
+
+You cannot delete a VPC Network that has active Worker bindings. The API returns a `400 Bad Request` error with a list of bound Workers. Remove the bindings from all Workers before deleting the network.
+
+:::
 
 ## Runtime usage
 
@@ -101,9 +206,14 @@ The following table summarizes the differences:
 | Feature              | VPC Networks                                                                  | VPC Services              |
 | -------------------- | ----------------------------------------------------------------------------- | ------------------------- |
 | Scope                | Entire tunnel or full Mesh network                                            | Specific host + port      |
-| Configuration        | `tunnel_id` (single tunnel) or `cf1:network` (all tunnels and Mesh nodes)     | `service_id`              |
+| Configuration        | `tunnel_id`, `network_id` (UUID), or `cf1:network`                            | `service_id`              |
 | Service registration | Not required                                                                  | Required for each target  |
+| Custom DNS resolvers | Supported (explicit networks only)                                            | Supported per service     |
 | Use when             | Dynamic discovery, network-wide access, reaching services across your account | Fixed, cataloged services |
+
+## Required roles
+
+<Render file="required-roles" product="workers-vpc" />
 
 ## Next steps
 
@@ -111,3 +221,4 @@ The following table summarizes the differences:
 - [Set up Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/get-started/)
 - Try the [Connect Workers to Cloudflare Mesh](/workers-vpc/examples/connect-to-cloudflare-mesh/) example
 - Learn about the [Workers Binding API](/workers-vpc/api/)
+- Manage VPC Networks with [Wrangler commands](/workers/wrangler/commands/vpc/)

--- a/src/content/docs/workers-vpc/reference/limits.mdx
+++ b/src/content/docs/workers-vpc/reference/limits.mdx
@@ -12,6 +12,7 @@ import { Render } from "~/components";
 | Resource                 | Limit |
 | ------------------------ | ----- |
 | VPC Services per account | 1000  |
+| VPC Networks per account | 1000  |
 
 Standard Workers limits apply for request size, timeout, and subrequests.
 

--- a/src/content/docs/workers-vpc/reference/troubleshooting.mdx
+++ b/src/content/docs/workers-vpc/reference/troubleshooting.mdx
@@ -77,8 +77,28 @@ Workers VPC may return errors at runtime when connecting to private services thr
 | `Error: ProxyError: dns_error`  | Cloudflare Tunnel may be configured with `http2` protocol (`TUNNEL_TRANSPORT_PROTOCOL:http2`), which works for Cloudflare Zero Trust [(see note)](/workers-vpc/configuration/tunnel/#create-and-run-tunnel-cloudflared) traffic but prevents DNS resolution from Workers VPC. | Workers VPC requires Cloudflare Tunnel to connect using the [QUIC transport protocol](/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/run-parameters/#protocol). Ensure outbound UDP traffic on port 7844 is allowed through your firewall.                            |
 | Requests not staying within VPC | Worker requests using `.fetch()` with a public hostname are routing out of the VPC to the hostname configured for the VPC Service.                                                                                                                                            | Ensure your Worker code and the VPC Service use the internal VPC hostname for backend services, not a public hostname.                                                                                                                                                                         |
 
+## Network CRUD errors
+
+Errors that may occur when creating, updating, or deleting VPC Networks.
+
+| Error                                                | Details                                                                                                           | Recommended fixes                                                                                         |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `400 Bad Request` when deleting a network             | The network has active Worker bindings and cannot be deleted. The response body contains a list of bound Workers. | Remove the `vpc_networks` binding from all listed Workers and redeploy them before retrying the deletion. |
+| `404 Not Found` when binding to a network            | The `network_id` UUID in your Wrangler configuration does not match any network in your account.                  | Run `npx wrangler vpc network list` to confirm the network exists and the UUID is correct.                |
+| `422 Unprocessable Entity` when creating or updating | The `name` field is invalid (for example, contains uppercase letters, spaces, or exceeds 63 characters).          | Use a name consisting of lowercase alphanumeric characters and hyphens, 1-63 characters.                  |
+
+## Custom DNS resolver errors
+
+Errors that may occur when using custom DNS resolver IPs with VPC Networks.
+
+| Error                                               | Details                                                                                 | Recommended fixes                                                                                                                                                                       |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Error: ProxyError: dns_error` with custom resolver | DNS resolution failed using the configured custom resolver IP.                          | Verify that the resolver IP is reachable from within the tunnel's network, and that your `cloudflared` version is 2025.7.0 or later.                                                    |
+| Private hostnames not resolving                     | The custom DNS resolver is configured but cannot resolve internal hostnames.            | Confirm the resolver IP addresses a DNS server that has records for your private hostnames. Check that firewall rules allow UDP/TCP traffic on port 53 from the tunnel to the resolver. |
+| Resolver IPs not taking effect                      | The network was updated with new resolver IPs, but traffic still uses the old resolver. | Allow up to 60 seconds for the change to propagate globally. If the issue persists, redeploy any bound Workers to pick up the updated network configuration.                            |
+
 ## Permission errors
 
-If you cannot view, create, or bind VPC Services and Tunnels in the dashboard or via Wrangler, ensure your user has the required roles.
+If you cannot view, create, or bind VPC Services, VPC Networks, and Tunnels in the dashboard or via Wrangler, ensure your user has the required roles.
 
 <Render file="required-roles" product="workers-vpc" />

--- a/src/content/docs/workers/wrangler/commands/vpc.mdx
+++ b/src/content/docs/workers/wrangler/commands/vpc.mdx
@@ -1,11 +1,11 @@
 ---
 pcx_content_type: reference
 title: VPC
-description: Wrangler commands for managing Workers VPC services.
+description: Wrangler commands for managing VPC Services and VPC Networks.
 ---
 
-import { WranglerNamespace } from "~/components";
+import { Render } from "~/components";
 
-Manage [Workers VPC](/workers-vpc/) services using Wrangler. VPC services allow your Workers to connect to private services on your network through Cloudflare Tunnels.
+Manage [Workers VPC](/workers-vpc/) Services and Networks directly from Wrangler.
 
-<WranglerNamespace namespace="vpc" />
+<Render file="wrangler-commands/vpc" product="workers" />

--- a/src/content/partials/workers-vpc/required-roles.mdx
+++ b/src/content/partials/workers-vpc/required-roles.mdx
@@ -1,8 +1,8 @@
 Workers VPC uses the following account roles:
 
-- `Connectivity Directory Read` to view Workers VPC Services and Tunnels.
-- `Connectivity Directory Bind` to list/read services and bind them in Workers.
-- `Connectivity Directory Admin` to create, update, and delete services.
+- `Connectivity Directory Read` to view Workers VPC Services, VPC Networks, and Tunnels.
+- `Connectivity Directory Bind` to list/read services and networks and bind them in Workers.
+- `Connectivity Directory Admin` to create, update, and delete services and networks.
 
 For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
 

--- a/src/content/partials/workers/wrangler-commands/vpc.mdx
+++ b/src/content/partials/workers/wrangler-commands/vpc.mdx
@@ -1,0 +1,193 @@
+---
+{}
+---
+
+import { Render, AnchorHeading, Type, MetaInfo } from "~/components";
+
+Manage VPC Services and VPC Networks from the command line.
+
+<AnchorHeading
+	title="`vpc network create`"
+	slug="vpc-network-create"
+	depth={3}
+/>
+
+Create a new VPC Network.
+
+```txt
+wrangler vpc network create <NAME> --tunnel-id <TUNNEL_ID> [OPTIONS]
+```
+
+- `NAME` <Type text="string" /> <MetaInfo text="required" />
+  - A name for the network. Must be unique within your account. Lowercase alphanumeric characters and hyphens, 1-63 characters.
+- `--tunnel-id` <Type text="string" /> <MetaInfo text="required" />
+  - The UUID of the Cloudflare Tunnel to associate with this network.
+- `--resolver-ips` <Type text="string" /> <MetaInfo text="optional" />
+  - Comma-separated DNS resolver IP addresses. When omitted, the network uses the tunnel's default DNS resolver.
+
+```sh
+npx wrangler vpc network create my-network \
+  --tunnel-id 550e8400-e29b-41d4-a716-446655440000
+```
+
+```sh output
+Creating VPC network "my-network"
+Created VPC network.
+Network ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+Name: my-network
+Tunnel ID: 550e8400-e29b-41d4-a716-446655440000
+Resolver IPs: default
+```
+
+To specify custom DNS resolver IPs:
+
+```sh
+npx wrangler vpc network create my-network \
+  --tunnel-id 550e8400-e29b-41d4-a716-446655440000 \
+  --resolver-ips 10.0.0.1,10.0.0.2
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading title="`vpc network list`" slug="vpc-network-list" depth={3} />
+
+List all VPC Networks in your account.
+
+```txt
+wrangler vpc network list
+```
+
+```sh
+npx wrangler vpc network list
+```
+
+```sh output
+Listing VPC Networks
+
+Network ID                           Name         Tunnel ID                            Resolver IPs         Created
+a1b2c3d4-e5f6-7890-abcd-ef1234567890 my-network   550e8400-e29b-41d4-a716-446655440000 10.0.0.1, 10.0.0.2   2025-06-15T10:30:00Z
+b2c3d4e5-f6a7-8901-bcde-f12345678901 staging-net  660f9511-f3ac-52e5-c827-557766551111 default              2025-06-10T15:45:00Z
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading title="`vpc network get`" slug="vpc-network-get" depth={3} />
+
+Display details about a VPC Network, including its name, tunnel ID, resolver IPs, and creation time.
+
+```txt
+wrangler vpc network get <NETWORK_ID>
+```
+
+- `NETWORK_ID` <Type text="string" /> <MetaInfo text="required" />
+  - The UUID of the VPC Network to inspect.
+
+```sh
+npx wrangler vpc network get a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+```sh output
+Getting VPC network details
+Network ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+Name: my-network
+Tunnel ID: 550e8400-e29b-41d4-a716-446655440000
+Resolver IPs: 10.0.0.1, 10.0.0.2
+Created: 2025-06-15T10:30:00Z
+Updated: 2025-06-15T10:30:00Z
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading
+	title="`vpc network update`"
+	slug="vpc-network-update"
+	depth={3}
+/>
+
+Update a VPC Network's name and/or DNS resolver IPs.
+
+```txt
+wrangler vpc network update <NETWORK_ID> [OPTIONS]
+```
+
+- `NETWORK_ID` <Type text="string" /> <MetaInfo text="required" />
+  - The UUID of the VPC Network to update.
+- `--name` <Type text="string" /> <MetaInfo text="optional" />
+  - A new name for the network.
+- `--resolver-ips` <Type text="string" /> <MetaInfo text="optional" />
+  - Comma-separated DNS resolver IP addresses. Pass an empty string (`""`) to clear custom resolver IPs and revert to the tunnel's default DNS resolver.
+
+```sh
+npx wrangler vpc network update a1b2c3d4-e5f6-7890-abcd-ef1234567890 \
+  --name production-network \
+  --resolver-ips 10.0.0.1
+```
+
+```sh output
+Updating VPC network "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+Updated VPC network.
+Network ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+Name: production-network
+Resolver IPs: 10.0.0.1
+```
+
+To clear custom resolver IPs:
+
+```sh
+npx wrangler vpc network update a1b2c3d4-e5f6-7890-abcd-ef1234567890 \
+  --resolver-ips ""
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />
+
+---
+
+<AnchorHeading
+	title="`vpc network delete`"
+	slug="vpc-network-delete"
+	depth={3}
+/>
+
+Delete a VPC Network from your account.
+
+```txt
+wrangler vpc network delete <NETWORK_ID> [OPTIONS]
+```
+
+- `NETWORK_ID` <Type text="string" /> <MetaInfo text="required" />
+  - The UUID of the VPC Network to delete.
+- `--force` <Type text="boolean" /> <MetaInfo text="optional" />
+  - Skip the confirmation prompt.
+
+:::caution
+
+You cannot delete a VPC Network that has active Worker bindings. If any Workers are bound to the network, the command will fail with a list of bound Workers. Remove the bindings from all Workers before deleting the network.
+
+:::
+
+```sh
+npx wrangler vpc network delete a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+```sh output
+Are you sure you want to delete VPC network "a1b2c3d4-e5f6-7890-abcd-ef1234567890"? This action cannot be undone. (y/n)
+Deleting VPC network a1b2c3d4-e5f6-7890-abcd-ef1234567890
+VPC network deleted.
+```
+
+If the network has bound Workers:
+
+```sh output
+Error: Cannot delete VPC network "a1b2c3d4-e5f6-7890-abcd-ef1234567890" because the following Workers are bound to it:
+  - my-worker
+  - staging-api
+Remove the bindings from these Workers before deleting the network.
+```
+
+<Render file="wrangler-commands/global-flags" product="workers" />


### PR DESCRIPTION
### Summary

Add documentation for VPC Networks feature including configuration reference and Wrangler commands. Updated existing docs to cover both VPC Services and VPC Networks.

### Screenshots (optional)

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).