### PR TITLE
ELI5: Improve clarity of Email Routing docs

### DIFF
--- a/src/content/docs/email-routing/index.mdx
+++ b/src/content/docs/email-routing/index.mdx
@@ -26,23 +26,23 @@ Create custom email addresses for your domain and route incoming emails to your 
 
 <Render file="email-routing-definition" product="email-routing" />
 
-It is available to all Cloudflare customers [using Cloudflare as an authoritative nameserver](/dns/zone-setups/full-setup/).
+It is available to all Cloudflare customers [using Cloudflare as an authoritative nameserver](/dns/zone-setups/full-setup/), meaning Cloudflare manages your domain's DNS records.
 
 ---
 
 ## Features
 
 <Feature header="Email Workers" href="/email-routing/email-workers/">
-	Leverage the power of Cloudflare Workers to implement any logic you need to
-	process your emails. Create rules as complex or simple as you need.
+	Process incoming emails with code using Cloudflare Workers. Filter by sender,
+	auto-reply, forward based on content, or build any custom logic you need.
 </Feature>
 
 <Feature
 	header="Custom addresses"
 	href="/email-routing/get-started/enable-email-routing/"
 >
-	With Email Routing you can have many custom email addresses to use for
-	specific situations.
+	Create separate email addresses for different purposes, such as shopping,
+	newsletters, or work contacts, all forwarding to a single inbox.
 </Feature>
 
 <Feature

--- a/src/content/docs/email-routing/limits.mdx
+++ b/src/content/docs/email-routing/limits.mdx
@@ -10,7 +10,7 @@ import { Render } from "~/components"
 
 ## Email Workers size limits
 
-When you process emails with Email Workers and you are on [Workers’ free pricing tier](/workers/platform/pricing/) you might encounter an allocation error. This may happen due to the size of the emails you are processing and/or the complexity of your Email Worker. Refer to [Worker limits](/workers/platform/limits/#account-plan-limits) for more information.
+When you process emails with Email Workers on the [Workers Free plan](/workers/platform/pricing/), your Worker may exceed its CPU or memory allocation and fail with an error. This is more likely with large emails or complex processing logic. Refer to [Worker limits](/workers/platform/limits/#account-plan-limits) for more information.
 
 You can use the [log functionality for Workers](/workers/observability/logs/) to look for messages related to CPU limits (such as `EXCEEDED_CPU`) and troubleshoot any issues regarding allocation errors.
 
@@ -21,6 +21,8 @@ If you encounter these error messages frequently, consider upgrading to the [Wor
 Currently, Email Routing does not support messages bigger than 25 MiB.
 
 ## Rules and addresses
+
+Each rule maps one custom email address (like `info@yourdomain.com`) to one destination address or an [Email Worker](/email-routing/email-workers/).
 
 | Feature                                                                          | Limit |
 | -------------------------------------------------------------------------------- | ----- |

--- a/src/content/docs/email-routing/postmaster.mdx
+++ b/src/content/docs/email-routing/postmaster.mdx
@@ -16,7 +16,7 @@ Here you will find information regarding Email Routing, along with best practice
 
 ### Authenticated Received Chain (ARC)
 
-Email Routing supports [Authenticated Received Chain (ARC)](http://arc-spec.org/). ARC is an email authentication system designed to allow an intermediate email server (such as Email Routing) to preserve email authentication results. Google also supports ARC.
+Email Routing supports [Authenticated Received Chain (ARC)](http://arc-spec.org/). When an email is forwarded, the destination server may not be able to verify the original sender's authentication because the email now comes from Cloudflare's servers rather than the sender's. ARC is an email authentication system that allows an intermediate email server (such as Email Routing) to attach a record of the original authentication results so the destination server can verify the email was legitimate before forwarding. Google also supports ARC.
 
 ### Contact information
 
@@ -28,7 +28,7 @@ The best way to contact us is using our [community forum](https://community.clou
 
 Through this standard, the sender publishes its public key to a domain's DNS once, and then signs the body of each message before it leaves the server. The recipient server reads the message, gets the domain public key from the domain's DNS, and validates the signature to ensure the message was not altered in transit.
 
-Email Routing adds two new signatures to the emails in transit, one on behalf of the Cloudflare domain used for sender rewriting `email.cloudflare.net`, and another one on behalf of the customer's recipient domain.
+Email Routing adds two new signatures to the emails in transit, one on behalf of the Cloudflare domain used for [sender rewriting](#sender-rewriting) (`email.cloudflare.net`), and another one on behalf of the customer's recipient domain.
 
 Below is the DKIM key for `email.cloudflare.net`:
 
@@ -48,7 +48,8 @@ dig TXT cf2024-1._domainkey.example.com +short
 
 ### DMARC enforcing
 
-Email Routing enforces Domain-based Message Authentication, Reporting & Conformance (DMARC). Depending on the sender's DMARC policy, Email Routing will reject emails when there is an authentication failure. Refer to [dmarc.org](https://dmarc.org/) for more information on this protocol.
+Email Routing enforces Domain-based Message Authentication, Reporting & Conformance (DMARC). DMARC allows domain owners to publish a policy that tells receiving servers what to do when an email fails SPF and DKIM checks. Depending on the sender's DMARC policy, Email Routing will reject emails when there is an authentication failure. Refer to [dmarc.org](https://dmarc.org/) for more information on this protocol.
+
 It is recommended that all senders implement the DMARC protocol in order to successfully deliver email to Cloudflare.
 
 ### Mail authentication requirement
@@ -142,17 +143,17 @@ a-h.cloudflare-email.net.
 
 ### Sender rewriting
 
-Email Routing rewrites the SMTP envelope sender (`MAIL FROM`) to the forwarding domain to avoid issues with [SPF](#spf-record). Email Routing uses the [Sender Rewriting Scheme](https://en.wikipedia.org/wiki/Sender_Rewriting_Scheme) to achieve this.
+Every email has two sender addresses: the envelope sender (the `MAIL FROM` address used during the SMTP transaction, which receiving servers check against SPF records) and the header `From:` address (what the recipient sees in their email client). When Email Routing forwards an email, the original sender's SPF record does not authorize Cloudflare's servers to send on their behalf, so SPF checks would fail at the destination.
 
-This has no effect to the end user's experience, though. The message headers will still report the original sender's `From:` address.
+To prevent this, Email Routing rewrites the envelope sender (`MAIL FROM`) to the forwarding domain using the [Sender Rewriting Scheme](https://en.wikipedia.org/wiki/Sender_Rewriting_Scheme). The header `From:` address remains unchanged — recipients still see the original sender's address.
 
 ### SMTP errors
 
-In most cases, Email Routing forwards the upstream SMTP errors back to the sender client in-session.
+In most cases, Email Routing forwards the upstream SMTP errors back to the sender during the same SMTP connection (in-session), rather than generating a separate bounce message later.
 
 ### Realtime Block Lists
 
-Email Routing uses an internal Domain Name System Blocklists (DNSBL) service to check if the sender's IP is present in one or more Realtime Block Lists (RBL) lists. When the system detects an abusive IP, it blocks the email and returns an SMTP error:
+Email Routing checks the sender's IP address against blocklists — databases of IP addresses known to send spam or abusive email. These blocklists, called Realtime Block Lists (RBLs), are queried through a Domain Name System Blocklist (DNSBL) service. When the system detects an abusive IP, it blocks the email and returns an SMTP error:
 
 ```txt
 554 <YOUR_IP_ADDRESS> found on one or more RBLs (abusixip). Refer to https://developers.cloudflare.com/email-routing/postmaster/#spam-and-abusive-traffic/
@@ -168,7 +169,7 @@ In addition to DNSBL, Email Routing uses advanced heuristic and statistical anal
 X-Cf-Spamh-Score: 2
 ```
 
-This header is visible in the forwarded email. The higher the score, 5 being the maximum, the more likely the email is spam. Currently, this system is experimental and passive; we do not act on it and suggest that upstream servers and email clients don't act on it either.
+This header is visible in the forwarded email. The higher the score, 5 being the maximum, the more likely the email is spam. Currently, this system is experimental and passive; we do not act on it and suggest that upstream servers and email clients do not act on it either.
 
 We will update this page with more information as we fine-tune the system.
 
@@ -230,6 +231,6 @@ Due to the nature of email forwarding, restrictive DMARC policies might make for
 
 Email Routing does not support sending or replying from your Cloudflare domain. When you reply to emails forwarded by Email Routing, the reply will be sent from your destination address (like `my-name@gmail.com`), not your custom address (like `info@my-company.com`).
 
-### "`.`" is treated as normal characters for custom addresses
+### "`.`" is treated as a normal character for custom addresses
 
-The `.` character, which perform special actions in email providers like Gmail, is treated as a normal character on custom addresses.
+The `.` character, which performs special actions in email providers like Gmail, is treated as a normal character on custom addresses.


### PR DESCRIPTION
Applied a reusable AI documentation skill (“ELI5”) to transform complex content into clearer, more accessible language, enhancing content structure for AEO and improving performance in AI-powered search and retrieval systems.



Improves clarity and accessibility of the three substantive pages at the root of /email-routing/, based on an ELI5 analysis with adversarial review.

Changes by file
postmaster.mdx (8 edits)

- ARC section: Expanded to explain why forwarding breaks authentication and how ARC fixes it
- DKIM section: Added forward reference link to sender rewriting section
- DMARC section: Added functional definition
- Sender rewriting: Rewrote to explain envelope sender vs header From: and why SPF breaks during forwarding
- SMTP errors: Defined "in-session" (same SMTP connection, not a separate bounce)
- RBL section: Rewrote intro to lead with the concept before acronyms
- Anti-spam: Fixed contraction "don't" → "do not" (style guide)
- Dot character section: Fixed grammar ("characters" → "character", "perform" → "performs")
- limits.mdx (2 edits)

- Clarified "allocation error" as exceeding CPU or memory allocation
- Added 1-sentence definition before the rules/addresses limit table
- index.mdx (3 edits)

- Added inline definition of "authoritative nameserver"
- Replaced vague Email Workers description with concrete examples
- Replaced vague Custom addresses description with real examples

Adversarial review notes
All changes were verified against source documentation. The following were intentionally not changed (unverifiable):

- Behavior when 25 MiB message limit is exceeded
- Whether rule/address limits are per-zone or per-account
- Mechanism behind Workers emails showing as "dropped" in analytics