### PR TITLE
feat: collapsible sidebar

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -270,7 +270,8 @@ metaTags.map((attrs) => {
 <script src="src/scripts/mermaid.ts"></script>
 <script src="src/scripts/analytics.ts"></script>
 
-{/* Sidebar collapse: apply persisted state before first paint to prevent flash */}
+{/* Sidebar collapse: apply persisted state before first paint to prevent flash.
+    Key must stay in sync with STORAGE_KEY in Header.astro. */}
 <script is:inline>
 (function () {
 	try {

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -269,4 +269,16 @@ metaTags.map((attrs) => {
 <script src="src/scripts/footnotes.ts"></script>
 <script src="src/scripts/mermaid.ts"></script>
 <script src="src/scripts/analytics.ts"></script>
+
+{/* Sidebar collapse: apply persisted state before first paint to prevent flash */}
+<script is:inline>
+(function () {
+	try {
+		if (localStorage.getItem("cf-docs-sidebar-collapsed") === "true") {
+			document.documentElement.setAttribute("data-sidebar-collapsed", "");
+		}
+	} catch (_) {}
+})();
+</script>
+
 <Default><slot /></Default>

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -277,7 +277,9 @@ metaTags.map((attrs) => {
 		if (localStorage.getItem("cf-docs-sidebar-collapsed") === "true") {
 			document.documentElement.setAttribute("data-sidebar-collapsed", "");
 		}
-	} catch (_) {}
+	} catch (_) {
+		// Silently ignore localStorage errors (e.g., private browsing mode)
+	}
 })();
 </script>
 

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -90,12 +90,9 @@ import AgentDirective from "../AgentDirective.astro";
 		line-height: 1;
 		white-space: nowrap;
 		text-decoration: none;
-		transition: color 150ms, background-color 150ms, border-color 150ms;
-	}
-
-	.header-login {
 		background-color: var(--color-header-fill);
 		color: var(--color-header-text);
+		transition: color 150ms, background-color 150ms, border-color 150ms;
 	}
 
 	.header-login:hover {
@@ -152,44 +149,7 @@ import AgentDirective from "../AgentDirective.astro";
 		gap: 0.25rem;
 	}
 
-	/* ── Sidebar Reopen Tab ── */
-	#sidebar-reopen-tab {
-		display: none;
-		position: fixed;
-		top: calc(var(--sl-nav-height) + 0.75rem);
-		left: 0;
-		z-index: var(--sl-z-index-menu);
-		align-items: center;
-		justify-content: center;
-		width: 2rem;
-		height: 2.5rem;
-		padding: 0;
-		border: 1px solid var(--sl-color-hairline-shade);
-		border-left: none;
-		border-radius: 0 0.5rem 0.5rem 0;
-		background: var(--sl-color-bg-sidebar);
-		color: var(--sidebar-text-strong, #1a1a1a);
-		cursor: pointer;
-		box-shadow: 2px 1px 4px rgba(0, 0, 0, 0.08);
-		transition: color 150ms, background-color 150ms, box-shadow 150ms;
-	}
-
-	#sidebar-reopen-tab:hover {
-		background: var(--sidebar-hover-bg, #f0f0f0);
-		color: var(--sidebar-hover-text, #1a1a1a);
-		box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.12);
-	}
-
-	#sidebar-reopen-tab:focus-visible {
-		outline: 2px solid var(--sl-color-accent);
-		outline-offset: 2px;
-	}
-
 	@media (min-width: 50rem) {
-		:global([data-sidebar-collapsed]) #sidebar-reopen-tab {
-			display: flex;
-		}
-
 		#right-group {
 			display: flex;
 		}
@@ -223,30 +183,39 @@ import AgentDirective from "../AgentDirective.astro";
 		});
 
 	// ── Sidebar collapse/expand ──
+	// Keep in sync with the inline IIFE in Head.astro (FOUC prevention).
 	const STORAGE_KEY = "cf-docs-sidebar-collapsed";
-	const reducedMotion = matchMedia("(prefers-reduced-motion: reduce)");
+	const html = document.documentElement;
+	const sidebar = document.querySelector<HTMLElement>(".sidebar-pane");
 	const reopenTab =
 		document.querySelector<HTMLButtonElement>("#sidebar-reopen-tab");
 	const collapseBtn =
 		document.querySelector<HTMLButtonElement>("#sidebar-collapse-btn");
+	const searchInput =
+		document.querySelector<HTMLInputElement>("#sidebar-search");
+
+	/** Check whether an event target is an editable field. */
+	function isEditable(el: EventTarget | null): boolean {
+		if (!el || !("tagName" in el)) return false;
+		const t = el as HTMLElement;
+		return (
+			t.tagName === "INPUT" ||
+			t.tagName === "TEXTAREA" ||
+			t.tagName === "SELECT" ||
+			t.isContentEditable
+		);
+	}
+
+	function isCollapsed(): boolean {
+		return html.hasAttribute("data-sidebar-collapsed");
+	}
 
 	function applySidebarState(collapsed: boolean, animate: boolean) {
-		const html = document.documentElement;
-		const sidebar =
-			document.querySelector<HTMLElement>(".sidebar-pane");
-
 		if (!animate) {
-			// Suppress transitions on initial load to prevent animation flash.
-			// CSS handles the layout via [data-sidebar-collapsed] selectors;
-			// we only need to temporarily disable transitions.
-			const mainFrame =
-				document.querySelector<HTMLElement>(".main-frame");
-			mainFrame?.style.setProperty("transition", "none");
 			sidebar?.style.setProperty("transition", "none");
-			requestAnimationFrame(() => {
-				mainFrame?.style.removeProperty("transition");
-				sidebar?.style.removeProperty("transition");
-			});
+			requestAnimationFrame(() =>
+				sidebar?.style.removeProperty("transition"),
+			);
 		}
 
 		if (collapsed) {
@@ -259,59 +228,22 @@ import AgentDirective from "../AgentDirective.astro";
 			sidebar?.removeAttribute("aria-hidden");
 		}
 
-		// Update aria-expanded on both toggle buttons
 		collapseBtn?.setAttribute("aria-expanded", String(!collapsed));
 		reopenTab?.setAttribute("aria-expanded", String(!collapsed));
 	}
 
-	/** Move focus to a target element, using transitionend when appropriate. */
-	function focusAfterTransition(
-		target: HTMLElement,
-		transitionEl?: HTMLElement | null,
-	) {
-		if (reducedMotion.matches || !transitionEl) {
-			requestAnimationFrame(() => target.focus());
-		} else {
-			transitionEl.addEventListener(
-				"transitionend",
-				() => target.focus(),
-				{ once: true },
-			);
-		}
-	}
-
 	function toggleSidebar(moveFocus: "reopen" | "collapse" | null = null) {
-		const willCollapse =
-			!document.documentElement.hasAttribute("data-sidebar-collapsed");
+		const willCollapse = !isCollapsed();
 		applySidebarState(willCollapse, true);
 		localStorage.setItem(STORAGE_KEY, String(willCollapse));
 		track(willCollapse ? "sidebar collapsed" : "sidebar expanded");
 
-		// Move focus to the appropriate toggle after transition
 		if (moveFocus === "reopen" && reopenTab) {
 			requestAnimationFrame(() => reopenTab.focus());
 		} else if (moveFocus === "collapse" && collapseBtn) {
-			const sidebar =
-				document.querySelector<HTMLElement>(".sidebar-pane");
-			focusAfterTransition(collapseBtn, sidebar);
+			requestAnimationFrame(() => collapseBtn.focus());
 		}
 	}
-
-	/**
-	 * Expand the sidebar without triggering focus management.
-	 * Used by the "/" shortcut to avoid a focus race — the shortcut
-	 * needs focus to land on the search input, not the collapse button.
-	 */
-	function expandSidebar() {
-		if (!document.documentElement.hasAttribute("data-sidebar-collapsed"))
-			return;
-		applySidebarState(false, true);
-		localStorage.setItem(STORAGE_KEY, "false");
-		track("sidebar expanded");
-	}
-
-	// Expose expandSidebar for Sidebar.astro's "/" shortcut handler
-	(window as any).__expandSidebar = expandSidebar;
 
 	// Restore persisted state on load (no animation)
 	if (localStorage.getItem(STORAGE_KEY) === "true") {
@@ -319,28 +251,33 @@ import AgentDirective from "../AgentDirective.astro";
 	}
 
 	// Reopen tab click — expand sidebar, move focus to collapse button
-	reopenTab?.addEventListener("click", () =>
-		toggleSidebar("collapse"),
-	);
+	reopenTab?.addEventListener("click", () => toggleSidebar("collapse"));
 
 	// Collapse button inside sidebar — collapse, move focus to reopen tab
-	collapseBtn?.addEventListener("click", () =>
-		toggleSidebar("reopen"),
-	);
+	collapseBtn?.addEventListener("click", () => toggleSidebar("reopen"));
 
-	// Keyboard shortcut: [ to toggle
-	document.addEventListener("keydown", (e) => {
-		if (e.key !== "[") return;
-		const t = e.target as HTMLElement | null;
-		if (
-			t?.tagName === "INPUT" ||
-			t?.tagName === "TEXTAREA" ||
-			t?.tagName === "SELECT" ||
-			t?.isContentEditable
-		)
-			return;
-		const willCollapse =
-			!document.documentElement.hasAttribute("data-sidebar-collapsed");
-		toggleSidebar(willCollapse ? "reopen" : "collapse");
-	});
+	// Keyboard shortcuts: "[" to toggle, "/" to expand + focus search
+	document.addEventListener(
+		"keydown",
+		(e) => {
+			if (isEditable(e.target)) return;
+
+			if (e.key === "[") {
+				toggleSidebar(isCollapsed() ? "collapse" : "reopen");
+				return;
+			}
+
+			if (e.key === "/" && searchInput) {
+				e.preventDefault();
+				e.stopPropagation();
+				if (isCollapsed()) {
+					applySidebarState(false, true);
+					localStorage.setItem(STORAGE_KEY, "false");
+					track("sidebar expanded");
+				}
+				searchInput.focus();
+			}
+		},
+		{ capture: true },
+	);
 </script>

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -34,6 +34,20 @@ import AgentDirective from "../AgentDirective.astro";
 	</div>
 </div>
 
+<!-- Sidebar reopen tab — fixed position, outside .sidebar-pane transform context -->
+<button
+	type="button"
+	id="sidebar-reopen-tab"
+	aria-label="Expand sidebar navigation"
+	aria-controls="starlight__sidebar"
+	aria-expanded="false"
+	class="print:hidden"
+>
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="16" height="16" fill="currentColor" aria-hidden="true">
+		<path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40ZM40,56H80V200H40ZM216,200H96V56H216V200Z"/>
+	</svg>
+</button>
+
 <style>
 	.header-inner {
 		display: flex;
@@ -138,7 +152,44 @@ import AgentDirective from "../AgentDirective.astro";
 		gap: 0.25rem;
 	}
 
-	@media screen and (min-width: 800px) {
+	/* ── Sidebar Reopen Tab ── */
+	#sidebar-reopen-tab {
+		display: none;
+		position: fixed;
+		top: calc(var(--sl-nav-height) + 0.75rem);
+		left: 0;
+		z-index: var(--sl-z-index-menu);
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2.5rem;
+		padding: 0;
+		border: 1px solid var(--sl-color-hairline-shade);
+		border-left: none;
+		border-radius: 0 0.5rem 0.5rem 0;
+		background: var(--sl-color-bg-sidebar);
+		color: var(--sidebar-text-strong, #1a1a1a);
+		cursor: pointer;
+		box-shadow: 2px 1px 4px rgba(0, 0, 0, 0.08);
+		transition: color 150ms, background-color 150ms, box-shadow 150ms;
+	}
+
+	#sidebar-reopen-tab:hover {
+		background: var(--sidebar-hover-bg, #f0f0f0);
+		color: var(--sidebar-hover-text, #1a1a1a);
+		box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.12);
+	}
+
+	#sidebar-reopen-tab:focus-visible {
+		outline: 2px solid var(--sl-color-accent);
+		outline-offset: 2px;
+	}
+
+	@media (min-width: 50rem) {
+		:global([data-sidebar-collapsed]) #sidebar-reopen-tab {
+			display: flex;
+		}
+
 		#right-group {
 			display: flex;
 		}
@@ -170,4 +221,126 @@ import AgentDirective from "../AgentDirective.astro";
 		?.addEventListener("click", () => {
 			track("clicked header login button");
 		});
+
+	// ── Sidebar collapse/expand ──
+	const STORAGE_KEY = "cf-docs-sidebar-collapsed";
+	const reducedMotion = matchMedia("(prefers-reduced-motion: reduce)");
+	const reopenTab =
+		document.querySelector<HTMLButtonElement>("#sidebar-reopen-tab");
+	const collapseBtn =
+		document.querySelector<HTMLButtonElement>("#sidebar-collapse-btn");
+
+	function applySidebarState(collapsed: boolean, animate: boolean) {
+		const html = document.documentElement;
+		const sidebar =
+			document.querySelector<HTMLElement>(".sidebar-pane");
+
+		if (!animate) {
+			// Suppress transitions on initial load to prevent animation flash.
+			// CSS handles the layout via [data-sidebar-collapsed] selectors;
+			// we only need to temporarily disable transitions.
+			const mainFrame =
+				document.querySelector<HTMLElement>(".main-frame");
+			mainFrame?.style.setProperty("transition", "none");
+			sidebar?.style.setProperty("transition", "none");
+			requestAnimationFrame(() => {
+				mainFrame?.style.removeProperty("transition");
+				sidebar?.style.removeProperty("transition");
+			});
+		}
+
+		if (collapsed) {
+			html.setAttribute("data-sidebar-collapsed", "");
+			sidebar?.setAttribute("inert", "");
+			sidebar?.setAttribute("aria-hidden", "true");
+		} else {
+			html.removeAttribute("data-sidebar-collapsed");
+			sidebar?.removeAttribute("inert");
+			sidebar?.removeAttribute("aria-hidden");
+		}
+
+		// Update aria-expanded on both toggle buttons
+		collapseBtn?.setAttribute("aria-expanded", String(!collapsed));
+		reopenTab?.setAttribute("aria-expanded", String(!collapsed));
+	}
+
+	/** Move focus to a target element, using transitionend when appropriate. */
+	function focusAfterTransition(
+		target: HTMLElement,
+		transitionEl?: HTMLElement | null,
+	) {
+		if (reducedMotion.matches || !transitionEl) {
+			requestAnimationFrame(() => target.focus());
+		} else {
+			transitionEl.addEventListener(
+				"transitionend",
+				() => target.focus(),
+				{ once: true },
+			);
+		}
+	}
+
+	function toggleSidebar(moveFocus: "reopen" | "collapse" | null = null) {
+		const willCollapse =
+			!document.documentElement.hasAttribute("data-sidebar-collapsed");
+		applySidebarState(willCollapse, true);
+		localStorage.setItem(STORAGE_KEY, String(willCollapse));
+		track(willCollapse ? "sidebar collapsed" : "sidebar expanded");
+
+		// Move focus to the appropriate toggle after transition
+		if (moveFocus === "reopen" && reopenTab) {
+			requestAnimationFrame(() => reopenTab.focus());
+		} else if (moveFocus === "collapse" && collapseBtn) {
+			const sidebar =
+				document.querySelector<HTMLElement>(".sidebar-pane");
+			focusAfterTransition(collapseBtn, sidebar);
+		}
+	}
+
+	/**
+	 * Expand the sidebar without triggering focus management.
+	 * Used by the "/" shortcut to avoid a focus race — the shortcut
+	 * needs focus to land on the search input, not the collapse button.
+	 */
+	function expandSidebar() {
+		if (!document.documentElement.hasAttribute("data-sidebar-collapsed"))
+			return;
+		applySidebarState(false, true);
+		localStorage.setItem(STORAGE_KEY, "false");
+		track("sidebar expanded");
+	}
+
+	// Expose expandSidebar for Sidebar.astro's "/" shortcut handler
+	(window as any).__expandSidebar = expandSidebar;
+
+	// Restore persisted state on load (no animation)
+	if (localStorage.getItem(STORAGE_KEY) === "true") {
+		applySidebarState(true, false);
+	}
+
+	// Reopen tab click — expand sidebar, move focus to collapse button
+	reopenTab?.addEventListener("click", () =>
+		toggleSidebar("collapse"),
+	);
+
+	// Collapse button inside sidebar — collapse, move focus to reopen tab
+	collapseBtn?.addEventListener("click", () =>
+		toggleSidebar("reopen"),
+	);
+
+	// Keyboard shortcut: [ to toggle
+	document.addEventListener("keydown", (e) => {
+		if (e.key !== "[") return;
+		const t = e.target as HTMLElement | null;
+		if (
+			t?.tagName === "INPUT" ||
+			t?.tagName === "TEXTAREA" ||
+			t?.tagName === "SELECT" ||
+			t?.isContentEditable
+		)
+			return;
+		const willCollapse =
+			!document.documentElement.hasAttribute("data-sidebar-collapsed");
+		toggleSidebar(willCollapse ? "reopen" : "collapse");
+	});
 </script>

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -10,13 +10,25 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 <div
 	class="sticky top-0 z-[1] flex flex-col gap-2 bg-[var(--sl-color-black)] py-3.5 min-[50rem]:bg-[var(--sl-color-bg-sidebar)]"
 >
-	<div class="sidebar-product-title">
+	<div class="sidebar-product-title flex items-center justify-between">
 		<a href={"/" + product + "/"} class="flex items-center gap-1 no-underline">
 			<AstroIcon name={product} size="32px" class="text-cl1-brand-orange" />
 			<span class="text-xl font-semibold text-black">
 				{lookupProductTitle(product, module)}
 			</span>
 		</a>
+		<button
+			type="button"
+			id="sidebar-collapse-btn"
+			aria-label="Collapse sidebar navigation"
+			aria-controls="starlight__sidebar"
+			aria-expanded="true"
+			class="hidden min-[50rem]:flex items-center justify-center w-7 h-7 shrink-0 rounded-md border-none bg-transparent text-[var(--sidebar-text)] cursor-pointer transition-colors duration-150 hover:bg-[var(--sidebar-hover-bg)] hover:text-[var(--sidebar-hover-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:focus-visible:outline-blue-400"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="16" height="16" fill="currentColor" aria-hidden="true">
+				<path d="M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40ZM40,56H80V200H40ZM216,200H96V56H216V200Z"/>
+			</svg>
+		</button>
 	</div>
 
 	<!-- Search Input -->
@@ -362,6 +374,15 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 				if (keyboardEvent.key === "/" && !isInput) {
 					keyboardEvent.preventDefault();
 					keyboardEvent.stopPropagation();
+
+					// Auto-expand sidebar if collapsed so search input is visible.
+					// Uses expandSidebar() directly to avoid a focus race —
+					// .click() on the reopen tab would trigger transitionend focus
+					// management that steals focus from the search input.
+					if (document.documentElement.hasAttribute("data-sidebar-collapsed")) {
+						(window as any).__expandSidebar?.();
+					}
+
 					searchInput.focus();
 				}
 			},

--- a/src/components/overrides/Sidebar.astro
+++ b/src/components/overrides/Sidebar.astro
@@ -357,39 +357,6 @@ const [product, module] = Astro.url.pathname.split("/").filter(Boolean);
 				sessionStorage.setItem(storageKey, JSON.stringify(state));
 			} catch (_) {} // eslint-disable-line no-empty
 		});
-
-		document.addEventListener(
-			"keydown",
-			(keyboardEvent) => {
-				const target = keyboardEvent.target;
-
-				const isInput =
-					target instanceof EventTarget &&
-					(("tagName" in target &&
-						(target.tagName === "INPUT" ||
-							target.tagName === "TEXTAREA" ||
-							target.tagName === "SELECT")) ||
-						("isContentEditable" in target && target.isContentEditable));
-
-				if (keyboardEvent.key === "/" && !isInput) {
-					keyboardEvent.preventDefault();
-					keyboardEvent.stopPropagation();
-
-					// Auto-expand sidebar if collapsed so search input is visible.
-					// Uses expandSidebar() directly to avoid a focus race —
-					// .click() on the reopen tab would trigger transitionend focus
-					// management that steals focus from the search input.
-					if (document.documentElement.hasAttribute("data-sidebar-collapsed")) {
-						(window as any).__expandSidebar?.();
-					}
-
-					searchInput.focus();
-				}
-			},
-			{
-				capture: true,
-			},
-		);
 	}
 
 	// Initialize when DOM is loaded

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -86,5 +86,3 @@ main > .content-panel + .content-panel {
 .pagination-links {
 	margin-top: var(--layout-space-12);
 }
-
-/* ── Sidebar Collapse — main content stays in place ── */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -87,13 +87,4 @@ main > .content-panel + .content-panel {
 	margin-top: var(--layout-space-12);
 }
 
-/* ── Sidebar Collapse — main content shift ── */
-@media (min-width: 50rem) {
-	.main-frame {
-		transition: padding-inline-start 250ms cubic-bezier(0.77, 0, 0.175, 1);
-	}
-
-	[data-sidebar-collapsed] .main-frame {
-		padding-inline-start: 0 !important;
-	}
-}
+/* ── Sidebar Collapse — main content stays in place ── */

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -86,3 +86,14 @@ main > .content-panel + .content-panel {
 .pagination-links {
 	margin-top: var(--layout-space-12);
 }
+
+/* ── Sidebar Collapse — main content shift ── */
+@media (min-width: 50rem) {
+	.main-frame {
+		transition: padding-inline-start 250ms cubic-bezier(0.77, 0, 0.175, 1);
+	}
+
+	[data-sidebar-collapsed] .main-frame {
+		padding-inline-start: 0 !important;
+	}
+}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -38,3 +38,22 @@
 	--sl-color-sidebar-active: var(--sidebar-text-strong);
 	--sl-color-sidebar-hover: var(--color-cl1-gray-2);
 }
+
+/* ── Sidebar Collapse ── */
+@media (min-width: 50rem) {
+	.sidebar-pane {
+		transition: transform 250ms cubic-bezier(0.77, 0, 0.175, 1);
+		will-change: transform;
+	}
+
+	[data-sidebar-collapsed] .sidebar-pane {
+		transform: translateX(-100%);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.sidebar-pane,
+	.main-frame {
+		transition: none !important;
+	}
+}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -40,20 +40,58 @@
 }
 
 /* ── Sidebar Collapse ── */
+
+#sidebar-reopen-tab {
+	display: none;
+	position: fixed;
+	top: calc(var(--sl-nav-height) + 0.75rem);
+	left: 0;
+	z-index: var(--sl-z-index-menu);
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2.5rem;
+	padding: 0;
+	border: 1px solid var(--sl-color-hairline-shade);
+	border-left: none;
+	border-radius: 0 0.5rem 0.5rem 0;
+	background: var(--sl-color-bg-sidebar);
+	color: var(--sidebar-text-strong, #1a1a1a);
+	cursor: pointer;
+	box-shadow: 2px 1px 4px rgba(0, 0, 0, 0.08);
+	transition:
+		color 150ms,
+		background-color 150ms,
+		box-shadow 150ms;
+}
+
+#sidebar-reopen-tab:hover {
+	background: var(--sidebar-hover-bg, #f0f0f0);
+	color: var(--sidebar-hover-text, #1a1a1a);
+	box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+#sidebar-reopen-tab:focus-visible {
+	outline: 2px solid var(--sl-color-accent);
+	outline-offset: 2px;
+}
+
 @media (min-width: 50rem) {
 	.sidebar-pane {
 		transition: transform 250ms cubic-bezier(0.77, 0, 0.175, 1);
-		will-change: transform;
 	}
 
 	[data-sidebar-collapsed] .sidebar-pane {
 		transform: translateX(-100%);
 	}
+
+	[data-sidebar-collapsed] #sidebar-reopen-tab {
+		display: flex;
+	}
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.sidebar-pane,
-	.main-frame {
+	.sidebar-pane {
 		transition: none !important;
 	}
 }


### PR DESCRIPTION
### Summary

This change adds functionality to make the sidebar collapsible, this is a prereq for the landing page designs changes I have coming.

I had initially explored different ways of collapsing the sidebar that I decided against:
- Adding the trigger in the header: it would cause the logo in the top left to be offset
- Adding the trigger in the footer of the sidebar: this would mean that the sidebar would still be required to be visible on the page, which we don't want

This the least invasive, yet clean implementation I came up with, open to suggestions

### Screenshots (optional)

**Before**
<img width="300" height="900" alt="Screenshot 2026-03-26 at 12 19 52" src="https://github.com/user-attachments/assets/6f881640-0163-48a1-ac67-9fdfae6bd926" />


**After**

<img width="300" height="898" alt="Screenshot 2026-03-26 at 12 19 21" src="https://github.com/user-attachments/assets/da1aeccc-381d-477d-9c82-8b3b3c5ed726" />

<!-- Add imagery to convey the changes made by this PR (optional) -->

**Screen recording**

https://github.com/user-attachments/assets/8faba279-0487-4a92-ad0a-92b57ddfb31f

