### PR TITLE
[Domain Connect] inform Service Providers APEXCNAME is not supported

### DIFF
--- a/src/content/docs/dns/reference/domain-connect.mdx
+++ b/src/content/docs/dns/reference/domain-connect.mdx
@@ -113,6 +113,7 @@ For the full list, refer to the [Domain Connect Specification](https://github.co
 - **Essential**: Is not supported and will be ignored.
 - **TXT Conflict Matching Mode**: Is not supported and will be ignored.
 - **TXT Conflict Matching Prefix**: Is not supported and will be ignored.
+- **APEXCNAME**: This custom record type is not supported. A standard CNAME record will work when combined with proxying (an orange-clouded record), which will [flatten the CNAME](/dns/cname-flattening/).
 
 ## Template updates
 

--- a/src/content/docs/dns/reference/domain-connect.mdx
+++ b/src/content/docs/dns/reference/domain-connect.mdx
@@ -114,6 +114,7 @@ For the full list, refer to the [Domain Connect Specification](https://github.co
 - **TXT Conflict Matching Mode**: Is not supported and will be ignored.
 - **TXT Conflict Matching Prefix**: Is not supported and will be ignored.
 - **APEXCNAME**: This custom record type is not supported. A standard CNAME record will work when combined with proxying (an orange-clouded record), which will [flatten the CNAME](/dns/cname-flattening/).
+- **REDIR301** and **REDIR302**: When applied, these records are converted to zone-specific [bulk redirect](/rules/url-forwarding/bulk-redirects/) rules. If a zone has existing bulk redirects before applying the template, they will be replaced.
 
 ## Template updates
 

--- a/src/content/docs/dns/reference/domain-connect.mdx
+++ b/src/content/docs/dns/reference/domain-connect.mdx
@@ -113,7 +113,7 @@ For the full list, refer to the [Domain Connect Specification](https://github.co
 - **Essential**: Is not supported and will be ignored.
 - **TXT Conflict Matching Mode**: Is not supported and will be ignored.
 - **TXT Conflict Matching Prefix**: Is not supported and will be ignored.
-- **APEXCNAME**: This custom record type is not supported. A standard CNAME record will work when combined with proxying (an orange-clouded record), which will [flatten the CNAME](/dns/cname-flattening/).
+- **APEXCNAME**: This custom record type is not supported and will cause the onboarding to fail. You can use a standard CNAME record instead, as Cloudflare automatically applies [CNAME flattening](/dns/cname-flattening/) at the zone apex.
 - **REDIR301** and **REDIR302**: When applied, these records are converted to zone-specific [bulk redirect](/rules/url-forwarding/bulk-redirects/) rules. If a zone has existing bulk redirects before applying the template, they will be replaced.
 
 ## Template updates

--- a/src/content/docs/dns/reference/domain-connect.mdx
+++ b/src/content/docs/dns/reference/domain-connect.mdx
@@ -113,6 +113,11 @@ For the full list, refer to the [Domain Connect Specification](https://github.co
 - **Essential**: Is not supported and will be ignored.
 - **TXT Conflict Matching Mode**: Is not supported and will be ignored.
 - **TXT Conflict Matching Prefix**: Is not supported and will be ignored.
+
+#### Custom record types
+
+The following record types are described in the [extensions/exclusions](https://github.com/Domain-Connect/spec/blob/master/Domain%20Connect%20Spec%20Draft.adoc#extensionsexclusions) section of the Domain Connect Specification. Below are the details specific to Cloudflare.
+
 - **APEXCNAME**: This custom record type is not supported and will cause the onboarding to fail. You can use a standard CNAME record instead, as Cloudflare automatically applies [CNAME flattening](/dns/cname-flattening/) at the zone apex.
 - **REDIR301** and **REDIR302**: When applied, these records are converted to zone-specific [bulk redirect](/rules/url-forwarding/bulk-redirects/) rules. If a zone has existing bulk redirects before applying the template, they will be replaced.
 


### PR DESCRIPTION
### Summary

Domain Connect draft has custom APEXCNAME DNS record, that is not supported by Cloudflare.  We need to tell this in the public facing documentation so that Service Providers who request template onboarding have better expecations we can offer for them.

### Screenshots (optional)

Not needed. This is pure documentation.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).