### PR TITLE
[Cloudflare One] Add ipwhois.io to IP geolocation providers list

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -116,6 +116,7 @@ To verify that the IP geolocation has updated, check your dedicated egress IP in
 - [ipgeolocation.io](https://ipgeolocation.io/)
 - [ipify](https://www.ipify.org/)
 - [Ipstack](https://ipstack.com/)
+- [ipwhois.io](https://ipwhois.io/)
 
 </Details>
 


### PR DESCRIPTION
Add ipwhois.io to the list of IP geolocation providers.

ipwhois.io provides IP geolocation and IP intelligence lookup services via public API and can be useful for customers validating IP geolocation data.

This is a documentation-only change.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
