### PR TITLE
[Rules] Fix RFC 9440 mTLS size limits

### DIFF
--- a/src/content/changelog/rules/2026-03-25-rfc9440-mtls-fields.mdx
+++ b/src/content/changelog/rules/2026-03-25-rfc9440-mtls-fields.mdx
@@ -13,7 +13,7 @@ Each certificate is DER-encoded, Base64-encoded, and wrapped in colons. For exam
 | Field                                             | Type    | Description                                                                                                                                                      |
 | ------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cf.tls_client_auth.cert_rfc9440`                 | String  | The client leaf certificate in RFC 9440 format. Empty if no client certificate was presented.                                                                    |
-| `cf.tls_client_auth.cert_rfc9440_too_large`       | Boolean | `true` if the leaf certificate exceeded 16 KB and was omitted. In practice this will almost always be `false`.                                                   |
+| `cf.tls_client_auth.cert_rfc9440_too_large`       | Boolean | `true` if the leaf certificate exceeded 10 KB and was omitted. In practice this will almost always be `false`.                                                   |
 | `cf.tls_client_auth.cert_chain_rfc9440`           | String  | The intermediate certificate chain in RFC 9440 format as a comma-separated list. Empty if no intermediate certificates were sent or if the chain exceeded 16 KB. |
 | `cf.tls_client_auth.cert_chain_rfc9440_too_large` | Boolean | `true` if the intermediate chain exceeded 16 KB and was omitted.                                                                                                 |
 

--- a/src/content/fields/index.yaml
+++ b/src/content/fields/index.yaml
@@ -856,9 +856,9 @@ entries:
     data_type: Boolean
     categories: [Request, mTLS]
     keywords: [request, ssl, mtls, client, visitor, rfc9440, certificate]
-    summary: Returns `true` if the client leaf certificate exceeded the 16 KB encoding limit and was omitted from `cf.tls_client_auth.cert_rfc9440`.
+    summary: Returns `true` if the client leaf certificate exceeded the 10 KB encoding limit and was omitted from `cf.tls_client_auth.cert_rfc9440`.
     description: |-
-      When `true`, [`cf.tls_client_auth.cert_rfc9440`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_rfc9440/) will be empty. In practice, leaf certificates are almost always well under 16 KB, so this field will almost always be `false`.
+      When `true`, [`cf.tls_client_auth.cert_rfc9440`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_rfc9440/) will be empty. In practice, leaf certificates are almost always well under 10 KB, so this field will almost always be `false`.
 
       This field is only filled in if the request includes a client certificate for [mTLS authentication](/ssl/client-certificates/enable-mtls/).
 


### PR DESCRIPTION
### Summary

Fix size limits: leaf cert is 10 KB, chain is 16 KB.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
