### PR TITLE
[Fundamentals] Improve permissions discovery

### DIFF
--- a/src/content/docs/fundamentals/get-started.mdx
+++ b/src/content/docs/fundamentals/get-started.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-Before you can begin using Cloudflare products, first [create an account](/fundamentals/account/create-account/). 
+Before you can begin using Cloudflare products, first [create an account](/fundamentals/account/create-account/). If multiple people manage your Cloudflare account, [set up member permissions](/fundamentals/manage-members/) to control which resources each person can access.
 
 ## Learn about Cloudflare's offerings
 

--- a/src/content/docs/fundamentals/manage-members/index.mdx
+++ b/src/content/docs/fundamentals/manage-members/index.mdx
@@ -1,17 +1,20 @@
 ---
 pcx_content_type: navigation
-title: Members
+title: Members and permissions
 sidebar:
   order: 5
+  label: Members and permissions
 head:
   - tag: title
-    content: Account members
+    content: Members and permissions
 
 ---
 
 import { DirectoryListing } from "~/components"
 
 On any Cloudflare account, you can collaborate by adding members to your account and assigning them access via one or several policies.
+
+Configuring permissions for each member helps prevent accidental changes to your account. For example, you can scope a team member to only manage staging domains, so they do not accidentally modify a production site. Use policies to grant each member the minimum level of access they need.
 
 Every policy has three parts:
 

--- a/src/content/docs/fundamentals/manage-members/scope.mdx
+++ b/src/content/docs/fundamentals/manage-members/scope.mdx
@@ -12,6 +12,11 @@ Scopes are one of three constituent parts of a policy that allows granting of ac
 
 To allow for flexible combinations of access to users, Cloudflare currently has account-level scopes, domain scopes, and resource-specific scopes. Each scope is associated with a different set of [roles](/fundamentals/manage-members/roles/).
 
+- **Account scope:** Use when the member needs access across the entire account, for example, billing or account-level settings.
+- **Specific domains:** Use when the member should only manage certain domains, for example, a developer who works on staging domains but should not modify production.
+- **Domain groups:** Use when you have related domains that share the same access needs, for example, all production domains.
+- **Specific resources:** Use when access should be limited to individual resources.
+
 ***
 
 ## Choose the scope of roles


### PR DESCRIPTION
## Summary

Improves discoverability of member permissions documentation.

### Changes

- **Rename "Members" to "Members and permissions"** in page title, sidebar label, and head tag — so users searching for "permissions" can find this section
- **Add motivating context** to the manage-members landing page explaining *why* you would configure scoped permissions, with a concrete example (staging vs production)
- **Add "when to use each scope" guidance** to the scope reference page — four bullets covering account, domain, domain group, and resource scopes
- **Add permissions nudge to Get Started page** — one sentence directing multi-person accounts to set up member permissions

### Context

The main finding was a discoverability gap: the section was called "Members" with no mention of "permissions" in titles or navigation, making it hard for users to find via search. The content was also purely mechanical (how to configure) with almost no explanation of why you would scope permissions.

3 files changed, 11 insertions, 3 deletions. Surgical edits only.