### PR TITLE
Adds exporting of ContainerProxy to container egress

### DIFF
--- a/src/content/docs/containers/platform-details/outbound-traffic.mdx
+++ b/src/content/docs/containers/platform-details/outbound-traffic.mdx
@@ -17,7 +17,8 @@ Use outbound Workers to route requests to Workers functions and their bindings (
 Use `outbound` to intercept outbound HTTP traffic regardless of destination:
 
 ```js
-import { Container } from "@cloudflare/containers";
+import { Container, ContainerProxy } from "@cloudflare/containers";
+export { ContainerProxy };
 
 export class MyContainer extends Container {}
 
@@ -40,7 +41,8 @@ If needed, you can also upgrade requests to TLS from the Worker itself.
 Use `outboundByHost` to map specific domain names or IP addresses to handler functions:
 
 ```js
-import { Container } from "@cloudflare/containers";
+import { Container, ContainerProxy } from "@cloudflare/containers";
+export { ContainerProxy };
 
 export class MyContainer extends Container {}
 

--- a/src/content/docs/sandbox/guides/outbound-traffic.mdx
+++ b/src/content/docs/sandbox/guides/outbound-traffic.mdx
@@ -18,7 +18,8 @@ Use `outbound` to intercept outbound HTTP traffic regardless of destination:
 
 <TypeScriptExample>
 ```ts
-import { Sandbox } from "@cloudflare/sandbox";
+import { Sandbox, ContainerProxy } from "@cloudflare/sandbox";
+export { ContainerProxy }
 
 export class MySandbox extends Sandbox {}
 
@@ -44,7 +45,8 @@ Use `outboundByHost` to map specific domain names or IP addresses to handler fun
 
 <TypeScriptExample>
 ```ts
-import { Sandbox } from "@cloudflare/sandbox";
+import { Sandbox, ContainerProxy } from "@cloudflare/sandbox";
+export { ContainerProxy }
 
 export class MySandbox extends Sandbox {}
 
@@ -123,7 +125,8 @@ Use `outboundHandlers` to define named handlers, then assign them to specific ho
 
 <TypeScriptExample>
 ```ts
-import { Sandbox } from "@cloudflare/sandbox";
+import { Sandbox, ContainerProxy } from "@cloudflare/sandbox";
+export { ContainerProxy }
 
 export class MySandbox extends Sandbox {}
 
@@ -142,7 +145,8 @@ Apply handlers to hosts programmatically from your Worker:
 
 <TypeScriptExample>
 ```ts
-import { getSandbox } from "@cloudflare/sandbox";
+import { Sandbox, ContainerProxy, getSandbox } from "@cloudflare/sandbox";
+export { ContainerProxy }
 
 export default {
   async fetch(request: Request, env: Env) {


### PR DESCRIPTION
### Summary

Examples missing the export of ContainerProxy which is needed for this to work properly.
