### PR TITLE
Add docs for steps that return readable streams

### DIFF
--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -593,11 +593,25 @@ export default {
 
 When setting a [WorkflowStep timeout](/workflows/build/workers-api/#workflowstep), ensure that its duration is 30 minutes or less. If your use case requires a timeout greater than 30 minutes, consider using `step.waitForEvent()` instead.
 
-### Keep step return values under 1 MiB
+### Keep non-stream step return values under 1 MiB
 
-Each step can persist up to 1 MiB (2^20 bytes) of state. If your step returns data exceeding this limit, the step will fail. This is a common issue when fetching large API responses or processing large files.
+A non-stream `step.do()` return value can persist up to 1 MiB (2^20 bytes). If your step returns structured data exceeding this limit, the step will fail. This is a common issue when fetching large API responses or processing large files.
 
-To work around this limit, store large data externally (for example, in R2 or KV) and return only a reference:
+In JavaScript Workflows, `ReadableStream<Uint8Array>` is a supported serializable return type for larger binary output. When persisting this kind of output, you should:
+
+- Return a new stream from the step callback.
+- Keep individual chunks under 16 MB.
+- Do not return a locked stream or a stream that has already been read.
+- Rely only on streams returned from steps.
+:::note
+Only byte streams are supported - use `ReadableStream<Uint8Array>`.
+
+BYOB streams and BYOB readers are not supported.
+:::
+
+Note that streamed outputs are still considered part of the Workflow instance storage limit. 
+
+If these storage limits still do not work for you, consider storing your step outputs externally (for example, in [R2](/r2)) and saving a reference to it.
 
 <TypeScriptExample filename="index.ts">
 
@@ -610,7 +624,7 @@ export class MyWorkflow extends WorkflowEntrypoint {
 			return await response.json(); // Could exceed 1 MiB
 		});
 
-		// ✅ Good: Store large data externally and return a reference
+		// ✅ Good: Store large structured data externally and return a reference
 		const dataRef = await step.do("fetch and store large dataset", async () => {
 			const response = await fetch("https://api.example.com/large-dataset");
 			const data = await response.json();

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -78,20 +78,57 @@ Refer to the [events and parameters](/workflows/build/events-and-parameters/) do
 {/* prettier-ignore */}
 - <code>step.do(name: string, callback: (): RpcSerializable): Promise&lt;T&gt;</code>
 - <code>step.do(name: string, config?: WorkflowStepConfig, callback: ():
-  	RpcSerializable): Promise&lt;T&gt;</code>
+	RpcSerializable): Promise&lt;T&gt;</code>
   - `name` - the name of the step, up to 256 characters.
   - `config` (optional) - an optional `WorkflowStepConfig` for configuring [step specific retry behaviour](/workflows/build/sleeping-and-retrying/).
-  - `callback` - an asynchronous function that optionally returns serializable state for the Workflow to persist.
+  - `callback` - an asynchronous function that optionally returns serializable state for the Workflow to persist. In JavaScript Workflows, this includes a fresh, unlocked `ReadableStream<Uint8Array>` for large binary output.
 
 :::note[Returning state]
 
 When returning state from a `step`, ensure that the object you return is _serializable_.
 
-Primitive types like `string`, `number`, and `boolean`, along with composite structures such as `Array` and `Object` (provided they only contain serializable values), can be serialized.
+Primitive types like `string`, `number`, and `boolean`, along with composite structures such as `Array` and `Object` (provided they only contain serializable values), can be serialized. Any [structured-cloneable](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone) type can be serialized, as long it is no longer than 1 MB.
 
-Objects that include `Function` or `Symbol` types, and objects with circular references, cannot be serialized and the Workflow instance will throw an error if objects with those types is returned.
+On the other hand, objects that include `Function` or `Symbol` types, and objects with circular references, cannot be serialized. The Workflow instance will throw an error if objects with those types is returned.
+
+In JavaScript Workflows, `ReadableStream<Uint8Array>` is a supported serializable return type when a step needs to persist larger binary output than the normal 1 MiB non-stream step-result limit. 
+
+Return a new stream from the callback. 
+
+:::caution
+Do not return a locked stream or a stream that has already been read. BYOB streams and BYOB readers are not supported. 
+:::
+
+After a `ReadableStream<Uint8Array>` object has been persisted within a step, it should not be reused - rely on the new fresh stream that gets returned from step. The bytes are preserved from the original stream, but the implementation might differ.
 
 :::
+
+<TypeScriptExample>
+
+```ts
+type Env = {
+	MY_BUCKET: R2Bucket;
+};
+
+export class MyWorkflow extends WorkflowEntrypoint<Env> {
+	async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+		const reportStream = await step.do("read report from R2", async () => {
+			const object = await this.env.MY_BUCKET.get("reports/latest.csv");
+
+			if (!object?.body) {
+				throw new Error("Could not read reports/latest.csv from R2.");
+			}
+
+			return object.body;
+		});
+
+		const preview = await new Response(reportStream).text();
+		return { preview };
+	}
+}
+```
+
+</TypeScriptExample>
 
 {/* prettier-ignore */}
 - <code>step.sleep(name: string, duration: WorkflowDuration): Promise&lt;void&gt;</code>

--- a/src/content/docs/workflows/get-started/guide.mdx
+++ b/src/content/docs/workflows/get-started/guide.mdx
@@ -11,7 +11,7 @@ import {
 	Render,
 	PackageManagers,
 	WranglerConfig,
-	Steps
+	Steps,
 } from "~/components";
 
 Workflows allow you to build durable, multi-step applications using the Workers platform. A Workflow can automatically retry, persist state, run for hours or days, and coordinate between third-party APIs.
@@ -48,7 +48,11 @@ Follow the steps below to learn how to build a Workflow from scratch.
 
 1. Open a terminal and run the `create cloudflare` (C3) CLI tool to create your Worker project:
 
-   <PackageManagers type="create" pkg="cloudflare@latest" args={"my-workflow"} />
+   <PackageManagers
+   	type="create"
+   	pkg="cloudflare@latest"
+   	args={"my-workflow"}
+   />
 
    <Render
    	file="c3-post-run-steps"
@@ -69,7 +73,6 @@ Follow the steps below to learn how to build a Workflow from scratch.
    <Details header="What files did C3 create?">
 
    In your project directory, C3 will have generated the following:
-
    - `wrangler.jsonc`: Your [Wrangler configuration file](/workers/wrangler/configuration/#sample-wrangler-configuration).
    - `src/index.ts`: A minimal Worker written in TypeScript.
    - `package.json`: A minimal Node dependencies configuration file.
@@ -82,19 +85,22 @@ Follow the steps below to learn how to build a Workflow from scratch.
 ## 2. Write your Workflow
 
 <Steps>
+
 1. Create a new file `src/workflow.ts`:
 
    ```ts title="src/workflow.ts"
    import { WorkflowEntrypoint, WorkflowStep } from "cloudflare:workers";
    import type { WorkflowEvent } from "cloudflare:workers";
 
-   type Params = { name: string };
+   type Params = { name?: string };
    type IPResponse = { result: { ipv4_cidrs: string[] } };
 
    export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
    	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
    		const data = await step.do("fetch data", async () => {
-   			const response = await fetch("https://api.cloudflare.com/client/v4/ips");
+   			const response = await fetch(
+   				"https://api.cloudflare.com/client/v4/ips",
+   			);
    			return await response.json<IPResponse>();
    		});
 
@@ -105,7 +111,7 @@ Follow the steps below to learn how to build a Workflow from scratch.
    			{ retries: { limit: 3, delay: "5 seconds", backoff: "linear" } },
    			async () => {
    				return {
-   					name: event.payload.name,
+   					name: event.payload.name ?? "World",
    					ipCount: data.result.ipv4_cidrs.length,
    				};
    			},
@@ -119,13 +125,14 @@ Follow the steps below to learn how to build a Workflow from scratch.
    A Workflow extends `WorkflowEntrypoint` and implements a `run` method. This code also passes in our `Params` type as a [type parameter](/workflows/build/events-and-parameters/) so that events that trigger our Workflow are typed.
 
    The [`step`](/workflows/build/workers-api/#step) object is the core of the Workflows API. It provides methods to define durable steps in your Workflow:
+   - `step.do(name, callback)` - Executes code and persists the result. If the Workflow is interrupted or retried, it resumes from the last successful step rather than re-running completed work. The callback returns serializable data, including `ReadableStream<Uint8Array>` for large binary output in JavaScript Workflows.
+   - `step.sleep(name, duration)` - Pauses the Workflow for a duration (for example, `"10 seconds"`, `"1 hour"`).
 
-   - `step.do(name, callback)` - Executes code and persists the result. If the Workflow is interrupted or retried, it resumes from the last successful step rather than re-running completed work.
-   - `step.sleep(name, duration)` - Pauses the Workflow for a duration (e.g., `"10 seconds"`, `"1 hour"`).
+   If you return a stream, return a fresh, unlocked `ReadableStream<Uint8Array>`. BYOB streams and BYOB readers are not supported.
 
-   You can pass a [retry configuration](/workflows/build/sleeping-and-retrying/) to `step.do()` to customize how failures are handled. See the [full step API](/workflows/build/workers-api/#step) for additional methods like `sleepUntil` and `waitForEvent`.
+   You can pass a [retry configuration](/workflows/build/sleeping-and-retrying/) to `step.do()` to customize how failures are handled. See the [full step API](/workflows/build/workers-api/#step) for stream requirements, limits, and additional methods like `sleepUntil` and `waitForEvent`.
 
-   When deciding whether to break code into separate steps, ask yourself: "Do I want all of this code to run again if just one part fails?" Separate steps are ideal for operations like calling external APIs, querying databases, or reading files from storage — if a later step fails, your Workflow can retry from that point using data already fetched, avoiding redundant API calls or database queries.
+   When deciding whether to break code into separate steps, ask yourself: "Do I want all of this code to run again if just one part fails?" Separate steps are ideal for operations like calling external APIs, querying databases, or reading files from storage - if a later step fails, your Workflow can retry from that point using data already fetched, avoiding redundant API calls or database queries.
 
    For more guidance on how to define your Workflow logic, refer to [Rules of Workflows](/workflows/build/rules-of-workflows/).
 
@@ -134,6 +141,7 @@ Follow the steps below to learn how to build a Workflow from scratch.
 ## 3. Configure your Workflow
 
 <Steps>
+
 1. Open `wrangler.jsonc`, which is your [Wrangler configuration file](/workers/wrangler/configuration/) for your Workers project and your Workflow, and add the `workflows` configuration:
 
    <WranglerConfig>
@@ -253,9 +261,8 @@ Now, you'll need a place to call your Workflow.
    ```
 
    The output of `instances describe` shows:
-
    - The status (success, failure, running) of each step
-   - Any state emitted by the step
+   - Any state emitted by the step. For streamed output, the CLI shows a preview or summary instead of the full contents.
    - Any `sleep` state, including when the Workflow will wake up
    - Retries associated with each step
    - Errors, including exception messages

--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -17,25 +17,25 @@ Workflows cannot be deployed to Workers for Platforms namespaces, as Workflows d
 
 :::
 
-| Feature                                                                                       | Workers Free                                                                                | Workers Paid                                                                                              |
-| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Workflow class definitions per script                                                         | 3MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits) | 10MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits)              |
-| Total scripts per account                                                                     | 100                                                                                         | 500 (shared with [Worker script limits](/workers/platform/limits/#account-plan-limits)                    |
-| Compute time per step [^3]                                                                    | 10 ms                                                                                       | 30 seconds (default) / configurable to 5 minutes of [active CPU time](/workers/platform/limits/#cpu-time) |
-| Duration (wall clock) per step [^3]                                                           | Unlimited                                                                                   | Unlimited - for example, waiting on network I/O calls or querying a database                              |
-| Maximum persisted state per step                                                              | 1MiB (2^20 bytes)                                                                           | 1MiB (2^20 bytes)                                                                                         |
-| Maximum event [payload size](/workflows/build/events-and-parameters/)                         | 1MiB (2^20 bytes)                                                                           | 1MiB (2^20 bytes)                                                                                         |
-| Maximum state that can be persisted per Workflow instance                                     | 100MB                                                                                       | 1GB                                                                                                       |
-| Maximum `step.sleep` duration                                                                 | 365 days (1 year)                                                                           | 365 days (1 year)                                                                                         |
-| Maximum steps per Workflow [^5]                                                               | 1,024                                                                                       | 10,000 (default) / configurable up to 25,000                                                              |
-| Maximum Workflow executions                                                                   | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#account-plan-limits)  | Unlimited                                                                                                 |
-| Concurrent Workflow instances (executions) per account [^7]                                   | 100                                                                                         | 10,000                                                                                                    |
-| Maximum Workflow instance creation rate [^8]                                                  | 100 per second [^6]                                                                         | 100 per second [^6]                                                                                       |
-| Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 100,000                                                                                     | 1,000,000                                                                                                 |
-| Retention limit for completed Workflow instance state                                         | 3 days                                                                                      | 30 days [^2]                                                                                              |
-| Maximum length of a Workflow name [^4]                                                        | 64 characters                                                                               | 64 characters                                                                                             |
-| Maximum length of a Workflow instance ID [^4]                                                 | 100 characters                                                                              | 100 characters                                                                                            |
-| Maximum number of subrequests per Workflow instance                                           | 50/request                                                                                  | 10,000/request (default) / configurable up to 10 million                                                  |
+| Feature                                                                                       | Workers Free                                                                                     | Workers Paid                                                                                              |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| Workflow class definitions per script                                                         | 3MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits)      | 10MB max script size per [Worker size limits](/workers/platform/limits/#account-plan-limits)              |
+| Total scripts per account                                                                     | 100                                                                                              | 500 (shared with [Worker script limits](/workers/platform/limits/#account-plan-limits)                    |
+| Compute time per step [^3]                                                                    | 10 ms                                                                                            | 30 seconds (default) / configurable to 5 minutes of [active CPU time](/workers/platform/limits/#cpu-time) |
+| Duration (wall clock) per step [^3]                                                           | Unlimited                                                                                        | Unlimited - for example, waiting on network I/O calls or querying a database                              |
+| Maximum non-stream step result per step [^9]                                                  | 1MiB (2^20 bytes)                                                                                | 1MiB (2^20 bytes)                                                                                         |
+| Maximum event [payload size](/workflows/build/events-and-parameters/)                         | 1MiB (2^20 bytes)                                                                                | 1MiB (2^20 bytes)                                                                                         |
+| Maximum state that can be persisted per Workflow instance [^10]                               | 100MB                                                                                            | 1GB                                                                                                       |
+| Maximum `step.sleep` duration                                                                 | 365 days (1 year)                                                                                | 365 days (1 year)                                                                                         |
+| Maximum steps per Workflow [^5]                                                               | 1,024                                                                                            | 10,000 (default) / configurable up to 25,000                                                              |
+| Maximum Workflow executions                                                                   | 100,000 per day [shared with Workers daily limit](/workers/platform/limits/#account-plan-limits) | Unlimited                                                                                                 |
+| Concurrent Workflow instances (executions) per account [^7]                                   | 100                                                                                              | 10,000                                                                                                    |
+| Maximum Workflow instance creation rate [^8]                                                  | 100 per second [^6]                                                                              | 100 per second [^6]                                                                                       |
+| Maximum number of [queued instances](/workflows/observability/metrics-analytics/#event-types) | 100,000                                                                                          | 1,000,000                                                                                                 |
+| Retention limit for completed Workflow instance state                                         | 3 days                                                                                           | 30 days [^2]                                                                                              |
+| Maximum length of a Workflow name [^4]                                                        | 64 characters                                                                                    | 64 characters                                                                                             |
+| Maximum length of a Workflow instance ID [^4]                                                 | 100 characters                                                                                   | 100 characters                                                                                            |
+| Maximum number of subrequests per Workflow instance                                           | 50/request                                                                                       | 10,000/request (default) / configurable up to 10 million                                                  |
 
 [^2]: Workflow instance state and logs will be retained for 3 days on the Workers Free plan and for 30 days on the Workers Paid plan.
 
@@ -51,7 +51,13 @@ Workflows cannot be deployed to Workers for Platforms namespaces, as Workflows d
 
 [^8]: Each instance created or restarted counts towards this limit
 
+[^9]: Applies to non-stream `step.do()` return values. In JavaScript Workflows, `ReadableStream<Uint8Array>` is also a supported serializable return type for larger binary output.
+
+[^10]: This total includes persisted bytes from streamed step outputs returned from JavaScript `step.do()` calls.
+
 <Render file="limits_increase" product="workers" />
+
+In JavaScript Workflows, if you need to persist large binary output from a step, return a `ReadableStream<Uint8Array>`. Streamed outputs still count toward the per-instance storage limit, so store very large or long-lived artifacts in external storage such as [R2](/r2/) and return a reference when appropriate.
 
 ### `waiting` instances do not count towards instance concurrency limits
 
@@ -105,7 +111,7 @@ While a given Workflow instance is waiting for 30 days, it will transition to th
 
 ### Increasing Workflow step limits
 
-Each Workflow instance supports 10,000 steps by default, but this can be increased up to 25,000 steps in your Wrangler configuration. Refer to [Workflow step limits](/workflows/build/workers-api/#workflowsteplimit) for more information.
+Each Workflow instance supports 10,000 steps by default, but this can be increased up to 25,000 steps in your Wrangler configuration. Refer to [Workflow step limits](/workflows/build/workers-api/#workflow-step-limits) for more information.
 
 ### Increasing Workflow CPU limits
 

--- a/src/content/release-notes/workflows.yaml
+++ b/src/content/release-notes/workflows.yaml
@@ -3,6 +3,12 @@ link: "/workflows/reference/changelog/"
 productName: Workflows
 productLink: "/workflows/"
 entries:
+  - publish_date: "2026-03-26"
+    title: "JavaScript Workflows steps can now return streamed output"
+    description: |-
+      In JavaScript Workflows, `ReadableStream<Uint8Array>` is now a supported serializable return type for `step.do()`, which lets a step persist large binary output without fitting it into the normal 1 MiB non-stream step-result limit.
+
+      Streamed outputs still count toward Workflow instance storage limits. For requirements and caveats, refer to the [Workers API](/workflows/build/workers-api/#step).
   - publish_date: "2026-03-23"
     title: "Workflow instances now support pause(), resume(), restart(), and terminate() methods in local development"
     description: |-


### PR DESCRIPTION
### Summary

We're adding the option of returning a `ReadableStream<Uint8Array>` from workflow steps. This PR adds documentation, with examples and usage guidelines for this new pattern


- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
