### PR TITLE
[Agents] Fix broken anchor links in remote-mcp-server guide

### DIFF
--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -38,9 +38,9 @@ The button below will guide you through everything you need to do to deploy an [
 
 [![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/ai/tree/main/demos/remote-mcp-authless)
 
-Once deployed, this server will be live at your `workers.dev` subdomain (for example, `remote-mcp-server-authless.your-account.workers.dev/mcp`). You can connect to it immediately using the [AI Playground](https://playground.ai.cloudflare.com/) (a remote MCP client), [MCP inspector](https://github.com/modelcontextprotocol/inspector) or [other MCP clients](/agents/guides/remote-mcp-server/#connect-your-remote-mcp-server-to-claude-and-other-mcp-clients-via-a-local-proxy).
+Once deployed, this server will be live at your `workers.dev` subdomain (for example, `remote-mcp-server-authless.your-account.workers.dev/mcp`). You can connect to it immediately using the [AI Playground](https://playground.ai.cloudflare.com/) (a remote MCP client), [MCP inspector](https://github.com/modelcontextprotocol/inspector) or [other MCP clients](/agents/guides/remote-mcp-server/#connect-from-an-mcp-client-via-a-local-proxy).
 
-A new git repository will be set up on your GitHub or GitLab account for your MCP server, configured to automatically deploy to Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can clone this repository, [develop locally](/agents/guides/remote-mcp-server/#local-development), and start customizing the MCP server with your own [tools](/agents/model-context-protocol/tools/).
+A new git repository will be set up on your GitHub or GitLab account for your MCP server, configured to automatically deploy to Cloudflare each time you push a change or merge a pull request to the main branch of the repository. You can clone this repository, [develop locally](/agents/guides/remote-mcp-server/#via-the-cli), and start customizing the MCP server with your own [tools](/agents/model-context-protocol/tools/).
 
 ### Via the CLI
 


### PR DESCRIPTION
## Summary

- Fixes 2 broken anchor links in `src/content/docs/agents/guides/remote-mcp-server.mdx` identified by the [anchor link audit workflow](/.github/workflows/anchor-link-audit.yml).

### Changes

| Broken anchor | Fixed to | Reason |
|---|---|---|
| `#connect-your-remote-mcp-server-to-claude-and-other-mcp-clients-via-a-local-proxy` | `#connect-from-an-mcp-client-via-a-local-proxy` | Heading was renamed to "Connect from an MCP client via a local proxy" |
| `#local-development` | `#via-the-cli` | No "Local development" heading exists; the CLI section covers local dev steps |

### Verification

- Ran full site build (`npm run build`) — 7,442 pages built successfully.
- Ran `htmltest` — zero `hash does not exist` errors originating from `agents/`, `1.1.1.1/`, or `ai-crawl-control/` directories.
- Confirmed both target anchor IDs exist in the built HTML output.

This is batch 1 of a larger anchor link audit effort.