### PR TITLE
[SSL] Document zone-level AOP setup and separate Cloudflare certificate

### DIFF
--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/explanation.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/explanation.mdx
@@ -6,7 +6,6 @@ sidebar:
 head:
   - tag: title
     content: How Authenticated Origin Pulls works
-
 ---
 
 ## Simple explanation
@@ -19,11 +18,9 @@ This block also applies for requests to [unproxied DNS records](/dns/proxy-statu
 
 :::caution
 
+The [Cloudflare-provided certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate/) is not exclusive to your account, only guaranteeing that a request is coming from the Cloudflare network.
 
-Note that the certificate Cloudflare provides for you to [set up Authenticated Origin Pulls](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/) is not exclusive to your account, only guaranteeing that a request is coming from the Cloudflare network.
-
-For more strict security, you should set up Authenticated Origin Pulls with your own certificate and consider [other security measures for your origin](/fundamentals/security/protect-your-origin-server/).
-
+For stricter security, set up Authenticated Origin Pulls with your own certificate using [zone-level](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/) or [per-hostname](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/) setup. Also consider [other security measures for your origin](/fundamentals/security/protect-your-origin-server/).
 
 :::
 
@@ -33,7 +30,7 @@ Cloudflare enforces authenticated origin pulls by adding an extra layer of TLS c
 
 For more details, refer to the [introductory blog post](https://blog.cloudflare.com/protecting-the-origin-with-tls-authenticated-origin-pulls/).
 
-***
+---
 
 ### Types of handshakes
 
@@ -60,7 +57,7 @@ This is true even if you have [**Full**](/ssl/origin-configuration/ssl-modes/ful
       D[External device] --Standard TLS Handshake ----> C
 ```
 
-<br/>
+<br />
 
 This lack of authentication means that - even if your origin is [protected behind Cloudflare](/fundamentals/concepts/how-cloudflare-works/) - attackers with your origin's IP address will still receive a response from your origin for HTTPS requests.
 
@@ -74,6 +71,6 @@ With Authenticated Origin Pulls, Cloudflare performs standard TLS handshakes bet
       D[External device] --Standard TLS Handshake -----x C
 ```
 
-<br/>
+<br />
 
 This additional layer of authentication ensures that any HTTPS requests outside of Cloudflare will not receive a response from your origin.

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/index.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/index.mdx
@@ -6,10 +6,9 @@ sidebar:
 head: []
 description: Authenticated Origin Pulls helps ensure requests to your origin
   server come from the Cloudflare network.
-
 ---
 
-import { FeatureTable, Render } from "~/components"
+import { FeatureTable, Render } from "~/components";
 
 Authenticated Origin Pulls (AOP) helps ensure requests to your origin server come from the Cloudflare network, which provides an additional layer of security on top of [Full](/ssl/origin-configuration/ssl-modes/full/) or [Full (strict)](/ssl/origin-configuration/ssl-modes/full-strict/) encryption modes.
 
@@ -19,9 +18,19 @@ This authentication becomes particularly important with the [Cloudflare Web Appl
 
 <FeatureTable id="ssl.authenticated_origin_pulls" />
 
+## Setup options
+
+There are three ways to configure Authenticated Origin Pulls, each with different levels of security and granularity:
+
+| Setup                                                                                                        | Certificate type              | Scope                | Description                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------ | ----------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Cloudflare certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate/) | Shared Cloudflare certificate | Entire zone          | Uses a Cloudflare-provided certificate. Simplest to set up, but shared across all accounts and only guarantees the request comes from Cloudflare. |
+| [Zone-level](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/)                         | Custom certificate            | Entire zone          | Uses your own certificate uploaded via the API. Provides stricter security because the certificate is exclusive to your account.                  |
+| [Per-hostname](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/)                     | Custom certificate            | Individual hostnames | Uses your own certificates on a per-hostname basis. Provides the most granular control, allowing different certificates for different hostnames.  |
+
 ## Aspects to consider
 
-Although Cloudflare provides you a certificate to easily [configure zone-level authenticated origin pulls](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/), this certificate is not exclusive to your account and only guarantees that a request is coming from the Cloudflare network. If you want more strict security, you should consider [additional security measures for your origin](/fundamentals/security/protect-your-origin-server/) and upload your own certificate when setting up Authenticated Origin Pulls.
+Cloudflare provides a [shared certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate/) for an easy setup. However, this certificate is not exclusive to your account and only guarantees that a request comes from the Cloudflare network. For stricter security, use a [zone-level custom certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/) or [per-hostname certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/) and consider [additional security measures for your origin](/fundamentals/security/protect-your-origin-server/).
 
 Using a custom certificate is possible with both [zone-level](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/) and [per-hostname](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/) authenticated origin pulls and is required if you need your domain to be [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) compliant.
 
@@ -36,5 +45,5 @@ Authenticated Origin Pulls does not apply when your [SSL/TLS encryption mode](/s
 
 ## Related topics
 
-* [SSL/TLS Encryption Modes](/ssl/origin-configuration/ssl-modes/)
-* [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/)
+- [SSL/TLS Encryption Modes](/ssl/origin-configuration/ssl-modes/)
+- [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/)

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate.mdx
@@ -1,0 +1,71 @@
+---
+pcx_content_type: how-to
+title: Cloudflare certificate
+sidebar:
+  order: 1
+head:
+  - tag: title
+    content: Authenticated origin pulls with Cloudflare certificate
+description: Set up Authenticated Origin Pulls using the shared Cloudflare certificate. This certificate is not exclusive to your account and only guarantees that a request is coming from the Cloudflare network.
+---
+
+import { AvailableNotifications, Render } from "~/components";
+
+When you enable Authenticated Origin Pulls (AOP) using the Cloudflare certificate, all proxied traffic to your zone is authenticated at the origin web server using a certificate provided by Cloudflare.
+
+:::caution
+
+The Cloudflare-provided certificate is shared across all Cloudflare accounts. It is not exclusive to your account and only guarantees that a request comes from the Cloudflare network. For stricter security, use a [zone-level custom certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/) or [per-hostname certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/) instead.
+
+Using a custom certificate is required if you need your domain to be [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) compliant.
+
+:::
+
+## Before you begin
+
+Make sure your zone is using an [SSL/TLS encryption mode](/ssl/origin-configuration/ssl-modes/) of **Full** or higher.
+
+:::caution
+
+Cloudflare certificate AOP is applied to all proxied hostnames on your zone, including [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/) configured on a Cloudflare for SaaS zone.
+If you need a different AOP certificate to apply to different custom hostnames, use [per-hostname AOP](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/).
+
+:::
+
+## 1. Upload certificate to origin
+
+[Download the Cloudflare authenticated origin pull certificate (.PEM file)](/ssl/static/authenticated_origin_pull_ca.pem) and upload it to your origin server. This certificate is **not** the same as the [Cloudflare Origin CA certificate](/ssl/origin-configuration/origin-ca/) and will not appear on your Dashboard.
+
+## 2. Configure origin to accept client certificates
+
+<Render
+	file="aop-configure-origin"
+	product="ssl"
+	params={{
+		one: "To use the Cloudflare certificate, download it from step 1 above, rename the .PEM file, and then upload it to `/path/to/origin-pull-ca.pem` before applying the settings.",
+		two: " To use the Cloudflare certificate, download it from step 1 above, rename the .PEM file, and then upload it to `/etc/nginx/certs/cloudflare.crt` before applying the settings.",
+	}}
+/>
+
+## 3. Configure Cloudflare to use client certificate
+
+<Render file="aop-enable-feature" product="ssl" />
+
+## 4. Enforce validation check on your origin
+
+<Render file="aop-enforce-validation" product="ssl" />
+
+## 5. (Optional) Set up expiration alerts
+
+You can configure alerts to receive notifications before your AOP certificates expire.
+
+<AvailableNotifications
+	product="SSL/TLS"
+	notificationFilter="Zone-level Authenticated Origin Pulls Certificate Expiration Alert"
+/>
+
+<Render file="get-started" product="notifications" />
+
+## Further options
+
+Refer to [Manage certificates](/ssl/origin-configuration/authenticated-origin-pull/set-up/manage-certificates/) for further options.

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/manage-certificates.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/manage-certificates.mdx
@@ -2,11 +2,10 @@
 pcx_content_type: how-to
 title: Manage certificates
 sidebar:
-  order: 3
+  order: 4
 head:
   - tag: title
     content: Manage AOP certificates
-
 ---
 
 import { APIRequest } from "~/components";
@@ -27,7 +26,7 @@ Make sure you have [notifications](/notifications/notification-available/#ssltls
 
 To apply different client certificates simultaneously at both the zone and hostname level, you can combine zone-level and per-hostname custom certificates.
 
-First, set up [zone-level pulls](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/) using a certificate. Then, upload multiple, specialized certificates for [individual hostnames](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/). Since per-hostname certificates are more specific, they take precedence over zone certificates.
+First, set up zone-level pulls using a [Cloudflare certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate/) or a [custom certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/). Then, upload multiple, specialized certificates for [individual hostnames](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/). Since per-hostname certificates are more specific, they take precedence over zone certificates.
 
 ---
 
@@ -47,13 +46,13 @@ Cloudflare does not delete client certificates upon expiration unless you send a
 	path="/zones/{zone_id}/origin_tls_client_auth/hostnames"
 	method="PUT"
 	json={{
-		"config": [
+		config: [
 			{
-				"enabled": true,
-				"hostname": "<HOSTNAME>",
-				"cert_id": "<CERT_ID>"
-			}
-		]
+				enabled: true,
+				hostname: "<HOSTNAME>",
+				cert_id: "<CERT_ID>",
+			},
+		],
 	}}
 />
 

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: how-to
 title: Per-hostname
 sidebar:
-  order: 2
+  order: 3
 head:
   - tag: title
     content: Per-hostname authenticated origin pulls
@@ -66,6 +66,19 @@ You can configure alerts to receive notifications before your AOP certificates e
 />
 
 <Render file="get-started" product="notifications" />
+
+## API reference
+
+The following API endpoints are available for managing per-hostname AOP certificates:
+
+| Operation                  | Endpoint                                                                                                                               |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Upload certificate         | [Upload a hostname client certificate](/api/resources/origin_tls_client_auth/subresources/hostname_certificates/methods/create/)       |
+| List certificates          | [List hostname client certificates](/api/resources/origin_tls_client_auth/subresources/hostname_certificates/methods/list/)            |
+| Get certificate details    | [Get a hostname client certificate](/api/resources/origin_tls_client_auth/subresources/hostname_certificates/methods/get/)             |
+| Delete certificate         | [Delete a hostname client certificate](/api/resources/origin_tls_client_auth/subresources/hostname_certificates/methods/delete/)       |
+| Get hostname status        | [Get the hostname status for client authentication](/api/resources/origin_tls_client_auth/subresources/hostnames/methods/get/)         |
+| Enable or disable hostname | [Enable or disable a hostname for client authentication](/api/resources/origin_tls_client_auth/subresources/hostnames/methods/update/) |
 
 ## Further options
 

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/rollback.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/rollback.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: how-to
 title: Roll back per-hostname AOP
 sidebar:
-  order: 4
+  order: 5
   label: Rollback
 ---
 

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level.mdx
@@ -2,15 +2,24 @@
 pcx_content_type: how-to
 title: Zone-level
 sidebar:
-  order: 1
+  order: 2
 head:
   - tag: title
-    content: Zone-level authenticated origin pulls
+    content: Zone-level authenticated origin pulls with custom certificate
+description: Set up zone-level Authenticated Origin Pulls using your own custom certificate uploaded via the API. This provides stricter security than the shared Cloudflare certificate.
 ---
 
-import { AvailableNotifications, Render } from "~/components";
+import { AvailableNotifications, Render, Details } from "~/components";
 
-When you enable Authenticated Origin Pulls (AOP) for a zone, all proxied traffic to your zone is authenticated at the origin web server.
+Zone-level Authenticated Origin Pulls (AOP) with a custom certificate authenticates all proxied traffic to your zone at the origin web server. The certificate is exclusive to your account. You can use client certificates from your Private PKI to authenticate connections from Cloudflare.
+
+Unlike the [Cloudflare certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate/) option, a custom zone-level certificate is not shared across Cloudflare accounts. This provides stronger security because only your zone's traffic can present this specific certificate to your origin.
+
+:::note
+
+For a simpler setup without account-exclusive authentication, use the [Cloudflare certificate](/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate/) option instead.
+
+:::
 
 ## Before you begin
 
@@ -19,40 +28,60 @@ Make sure your zone is using an [SSL/TLS encryption mode](/ssl/origin-configurat
 :::caution
 
 Zone-level AOP certificates are also applied to [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/) configured on a Cloudflare for SaaS zone.
-If you need a different AOP certificate to apply to different custom hostnames, use [Per-hostname AOP](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/).
+If you need a different AOP certificate to apply to different custom hostnames, use [per-hostname AOP](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/).
 
 :::
 
-## 1. Upload certificate to origin
+Refer to the steps below for an example of how to generate a custom certificate using OpenSSL. The CA root certificate that you use to issue the custom certificate should be the same CA that you will [upload to your origin](#2-configure-origin-to-accept-client-certificates).
 
-First, upload a certificate to your origin.
+<Details header="OpenSSL example">
+	<Render file="custom-cert-openssl-commands" product="ssl" />
+</Details>
 
-To use a Cloudflare certificate (which uses a specific CA), [download the .PEM file](/ssl/static/authenticated_origin_pull_ca.pem) and upload it to your origin. This certificate is **not** the same as the [Cloudflare origin CA certificate](/ssl/origin-configuration/origin-ca/) and will not appear on your Dashboard.
+## 1. Upload custom certificate
 
-To use a custom certificate, follow the API instructions to [upload a custom certificate to Cloudflare](/ssl/edge-certificates/custom-certificates/uploading/#upload-a-custom-certificate), but use the [`origin_tls_client_auth` endpoint](/api/resources/origin_tls_client_auth/subresources/zone_certificates/methods/create/). Then, upload the certificate to your origin.
+Use the [Upload a zone-level client certificate](/api/resources/origin_tls_client_auth/subresources/zone_certificates/methods/create/) endpoint to upload your custom certificate.
 
-:::caution
+:::note
 
-Although Cloudflare provides you a certificate to easily configure zone-level authenticated origin pulls, this certificate is not exclusive to your account and only guarantees that a request is coming from the Cloudflare network. If you want more strict security, you should upload your own certificate.
-
-Using a custom certificate is required if you need your domain to be [FIPS](https://en.wikipedia.org/wiki/Federal_Information_Processing_Standards) compliant.
-
+You must upload a [leaf certificate](/ssl/concepts/#chain-of-trust). If you upload a root CA instead, the API will return a `missing leaf certificate` error.
 :::
+
+```bash
+MYCERT="$(cat cert.crt|perl -pe 's/\r?\n/\\n/'|sed -e 's/..$//')"
+MYKEY="$(cat cert.key|perl -pe 's/\r?\n/\\n/'|sed -e's/..$//')"
+
+request_body=$(< <(cat <<EOF
+{
+"certificate": "$MYCERT",
+"private_key": "$MYKEY"
+}
+EOF
+))
+
+curl --silent \
+"https://api.cloudflare.com/client/v4/zones/$ZONEID/origin_tls_client_auth" \
+--header "Content-Type: application/json" \
+--header "X-Auth-Email: $MYAUTHEMAIL" \
+--header "X-Auth-Key: $MYAUTHKEY" \
+--data "$request_body"
+```
+
+In the API response, save the certificate `id` since it will be required in step 3.
 
 ## 2. Configure origin to accept client certificates
 
 <Render
 	file="aop-configure-origin"
+	params={{ one: " ", two: " " }}
 	product="ssl"
-	params={{
-		one: "To use the Cloudflare certificate, download it from step 1 above, rename the .PEM file, and then upload it to `/path/to/origin-pull-ca.pem` before applying the settings.",
-		two: " To use the Cloudflare certificate, download it from step 1 above, rename the .PEM file, and then upload it to `/etc/nginx/certs/cloudflare.crt` before applying the settings.",
-	}}
 />
 
-## 3. Configure Cloudflare to use client certificate
+## 3. Enable Authenticated Origin Pulls for the zone
 
-<Render file="aop-enable-feature" product="ssl" />
+Use the Cloudflare API to send a [`PUT`](/api/resources/origin_tls_client_auth/subresources/settings/methods/update/) request to enable Authenticated Origin Pulls for the zone.
+
+If you had set up logging on your origin during step 2, test and confirm that Authenticated Origin Pulls is working.
 
 ## 4. Enforce validation check on your origin
 
@@ -68,6 +97,19 @@ You can configure alerts to receive notifications before your AOP certificates e
 />
 
 <Render file="get-started" product="notifications" />
+
+## API reference
+
+The following API endpoints are available for managing zone-level custom AOP certificates:
+
+| Operation                 | Endpoint                                                                                                                |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Upload certificate        | [Create a zone-level certificate](/api/resources/origin_tls_client_auth/subresources/zone_certificates/methods/create/) |
+| List certificates         | [List zone-level certificates](/api/resources/origin_tls_client_auth/subresources/zone_certificates/methods/list/)      |
+| Get certificate details   | [Get a zone-level certificate](/api/resources/origin_tls_client_auth/subresources/zone_certificates/methods/get/)       |
+| Delete certificate        | [Delete a zone-level certificate](/api/resources/origin_tls_client_auth/subresources/zone_certificates/methods/delete/) |
+| Get zone-level setting    | [Get zone-level AOP setting](/api/resources/origin_tls_client_auth/subresources/settings/methods/get/)                  |
+| Update zone-level setting | [Update zone-level AOP setting](/api/resources/origin_tls_client_auth/subresources/settings/methods/update/)            |
 
 ## Further options
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520.mdx
@@ -18,7 +18,7 @@ This error is often triggered by:
 - Empty or malformed responses lacking an HTTP status code or response body.
 - Missing response headers or origin web server not returning [proper HTTP error responses](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
 - Incorrect HTTP/2 configuration at the origin server.
-- Authentication Origin Pull enabled on Cloudflare but the origin is [not configured as expected](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/#2-configure-origin-to-accept-client-certificates).
+- Authentication Origin Pull enabled on Cloudflare but the origin is [not configured as expected](/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate/#2-configure-origin-to-accept-client-certificates).
 
 :::note
 

--- a/src/content/partials/ssl/aop-disablement-callout.mdx
+++ b/src/content/partials/ssl/aop-disablement-callout.mdx
@@ -2,4 +2,4 @@
 {}
 ---
 
-[Zone-level AOP](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/) and [per-hostname AOP](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/) are two separate configurations. Disabling one does not disable the other.
+[Cloudflare certificate AOP](/ssl/origin-configuration/authenticated-origin-pull/set-up/cloudflare-certificate/), [zone-level AOP](/ssl/origin-configuration/authenticated-origin-pull/set-up/zone-level/), and [per-hostname AOP](/ssl/origin-configuration/authenticated-origin-pull/set-up/per-hostname/) are separate configurations. Disabling one does not disable the others.


### PR DESCRIPTION
PCX-21418

### Summary

Split the existing zone-level AOP page into two distinct pages to document all three Authenticated Origin Pull flavors:

- Cloudflare certificate: shared cert (formerly 'Zone-level')
- Zone-level: custom certificate uploaded via origin_tls_client_auth API
- Per-hostname: custom certificate per hostname (existing)

Add API reference tables to both zone-level and per-hostname pages, update cross-references, and fix sidebar ordering.

### Screenshots (optional)

New "zone-level" AOP documentation
<img width="1215" height="1063" alt="Screenshot 2026-03-27 at 11 09 54 AM" src="https://github.com/user-attachments/assets/800272e9-8a19-42fd-b18d-6b007ba85031" />

Sub nav updates. Existing "Zone-level" --> "Cloudflare certificate. Then added "Zone-level", which is custom cert on the zone level.
<img width="202" height="176" alt="Screenshot 2026-03-27 at 11 09 45 AM" src="https://github.com/user-attachments/assets/e35f6186-ded1-45e5-b4dd-9ea89467d630" />

New table for API reference on per-hostname page
<img width="1252" height="1109" alt="Screenshot 2026-03-27 at 11 09 01 AM" src="https://github.com/user-attachments/assets/789ef0f6-26e2-439e-a1ab-fd45c4dad05a" />

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).

Two callouts here. 

1. For item 2, only an internal ticket exists. 
2. For item 3 and existing route "zone-level" now hosts new instructions. The old instructions have been moved to the Cloudflare certificate page. Maybe we should handle this a different way instead so the old url would redirect to the old page? Then the new page would have it's own net-new URL?
