### PR TITLE
[Pipelines] Update max ingestion payload size from 1 MB to 5 MB

### DIFF
--- a/src/content/docs/pipelines/platform/limits.mdx
+++ b/src/content/docs/pipelines/platform/limits.mdx
@@ -12,7 +12,7 @@ While in open beta, the following limits are currently in effect:
 | Feature                                    | Limit  |
 | ------------------------------------------ | ------ |
 | Maximum streams per account                | 20     |
-| Maximum payload size per ingestion request | 1 MB   |
+| Maximum payload size per ingestion request | 5 MB   |
 | Maximum ingest rate per stream             | 5 MB/s |
 | Maximum sinks per account                  | 20     |
 | Maximum pipelines per account              | 20     |


### PR DESCRIPTION
### Summary

Update max ingestion payload size from 1 MB to 5 MB for Pipelines

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
