### PR TITLE
[Billing] Fix broken anchor links

### DIFF
--- a/src/content/docs/billing/billing-policy.mdx
+++ b/src/content/docs/billing/billing-policy.mdx
@@ -16,12 +16,12 @@ Add-on services are only billed monthly and cannot be billed annually.
 Cloudflare also collects sales tax as governed by local laws. Sales taxes are computed based on the nine (9) digit postal code of either the shipping or billing address on file for your Cloudflare account where applicable.
 
 :::note
-If you are a US-based customer, you can [file for sales tax exemption](/billing/sales-tax/#filing-for-us-sales-tax-exemption/).
+If you are a US-based customer, you can [file for sales tax exemption](/billing/sales-tax/#filing-for-us-sales-tax-exemption).
 :::
 
 Cloudflare issues a separate invoice for plans and subscriptions (or add-on services) for every domain added to a Cloudflare account.
 
-Cloudflare issues a monthly or annual invoice based on the plans you purchase. You will receive a $0 invoice even if your domain is on a Free plan. 
+Cloudflare issues a monthly or annual invoice based on the plans you purchase. You will receive a $0 invoice even if your domain is on a Free plan.
 
 :::note
 Subdomains do not count as billable domains.
@@ -35,9 +35,9 @@ If your account is dunned (downgraded and banned for non payment of dues), the n
 
 When ordering a paid plan, subscription, or add-on service, you must agree to the following:
 
-*By clicking "Enable" you agree that you are purchasing a continuous month-to-month subscription which will automatically renew, and that the price of your selected subscription plan level and/or add on(s) will be billed to your designated payment method monthly as a recurring charge, unless you cancel your subscription(s), through your account dashboard,* ***before*** *the beginning of your next monthly billing period.*
+_By clicking "Enable" you agree that you are purchasing a continuous month-to-month subscription which will automatically renew, and that the price of your selected subscription plan level and/or add on(s) will be billed to your designated payment method monthly as a recurring charge, unless you cancel your subscription(s), through your account dashboard,_ **_before_** _the beginning of your next monthly billing period._
 
-***You will be billed for the full monthly period in which you cancel and no refunds will be given. By purchasing a subscription, you agree to a minimum one month purchase obligation.***
+**_You will be billed for the full monthly period in which you cancel and no refunds will be given. By purchasing a subscription, you agree to a minimum one month purchase obligation._**
 
 :::note
 For more information on renewal terms and cancellation, refer to the [Terms of Use](https://www.cloudflare.com/terms/).
@@ -47,17 +47,16 @@ For more information on renewal terms and cancellation, refer to the [Terms of U
 
 If your domain is on a paid plan (for example, Pro) and you upgrade to a higher-priced plan (for example, Business),
 
-* Your invoice will reflect the prorated cost of the higher-tiered plan, until the end of your billing cycle.
-* Cloudflare credits the prorated cost of the lower-priced plan, until the end of the billing cycle.
-* At the beginning of the next billing cycle, your invoice will reflect the full cost of the higher-priced plan.
-* Your bill cycle start and end dates are calculated using the UTC (Coordinated Universal Time) time zone, and not your local time zone.
+- Your invoice will reflect the prorated cost of the higher-tiered plan, until the end of your billing cycle.
+- Cloudflare credits the prorated cost of the lower-priced plan, until the end of the billing cycle.
+- At the beginning of the next billing cycle, your invoice will reflect the full cost of the higher-priced plan.
+- Your bill cycle start and end dates are calculated using the UTC (Coordinated Universal Time) time zone, and not your local time zone.
 
 For example, if your billing date is January 1, but you upgrade from Pro to Business, on January 15,
 
-* Your invoice will reflect the prorated Business plan rate for the period of use January 15 - January 30.
-* Cloudflare credits the prorated Pro plan cost from January 1 - January 15.
-* Your invoice for the billing period of January 1 - January 30 will appear in the Cloudflare dashboard on January 31.
-
+- Your invoice will reflect the prorated Business plan rate for the period of use January 15 - January 30.
+- Cloudflare credits the prorated Pro plan cost from January 1 - January 15.
+- Your invoice for the billing period of January 1 - January 30 will appear in the Cloudflare dashboard on January 31.
 
 :::note
 Account credits are automatically added to your account and can only be used on recurring monthly charges for Cloudflare plans or add-on services. Your monthly invoice lists any credits.
@@ -67,14 +66,13 @@ All credits are added on the backend of your account and are not visible from th
 
 If your domain is on a paid plan (for example, Business) and you downgrade to a lower-priced plan (for example, Pro),
 
-* Your plan type and higher-tiered Cloudflare plan features are downgraded at the end of the current billing service period. 
-* You are billed at the lower-tiered plan and feature rate for the next billing service period.
+- Your plan type and higher-tiered Cloudflare plan features are downgraded at the end of the current billing service period.
+- You are billed at the lower-tiered plan and feature rate for the next billing service period.
 
 For example, if your billing date is February 1, but you downgrade to Pro from the Business plan on February 15,
 
-* You can access Business plan features and services until March 1.
-* Your March plan charges will reflect the downgraded cost.
-
+- You can access Business plan features and services until March 1.
+- Your March plan charges will reflect the downgraded cost.
 
 ## Billing and payment for Enterprise plans
 
@@ -95,7 +93,6 @@ Please ensure that you're using a valid payment method before changing your plan
 :::note
 Gift cards and pre-payment cards may not be accepted for payment as they are not associated with a billing address.
 :::
-
 
 ## Account Payment Method Preauthorization
 
@@ -119,6 +116,6 @@ The following occurences cannot be refunded:
 
 ## Related resources
 
-* [Cloudflare Self-Serve Subscription Agreement](https://www.cloudflare.com/terms/)
-* [Understanding Cloudflare Invoices](/billing/invoices/)
-* [Understanding Cloudflare sales tax](/billing/sales-tax/)
+- [Cloudflare Self-Serve Subscription Agreement](https://www.cloudflare.com/terms/)
+- [Understanding Cloudflare Invoices](/billing/invoices/)
+- [Understanding Cloudflare sales tax](/billing/sales-tax/)

--- a/src/content/docs/billing/resolve-zone-cannot-be-ugpraded.mdx
+++ b/src/content/docs/billing/resolve-zone-cannot-be-ugpraded.mdx
@@ -7,22 +7,24 @@ sidebar:
 
 When trying to upgrade a domain or purchase a subscription, you may see an error that contains one of the following phrases:
 
-* "this zone cannot be upgraded"
-* "there is a problem with your billing profile"
+- "this zone cannot be upgraded"
+- "there is a problem with your billing profile"
 
 ## Causes
-* Your account may have an outstanding unpaid balance
-* Another account previously associated with the domain / zone your purchase relates to has an outstanding unpaid balance
+
+- Your account may have an outstanding unpaid balance
+- Another account previously associated with the domain / zone your purchase relates to has an outstanding unpaid balance
 
 ## Solution
+
 This message appears when the account or domain involved has an outstanding unpaid balance. In the case of a domain, this may also be triggered by a previous account that owned the domain. To resolve this you will need to:
 
 1. Check each Cloudflare account you have access to for an outstanding balance. Refer to [Email address and password](/fundamentals/user-profiles/change-password-or-email/) if you have forgotten these details.
-2. Refer to [Pay an overdue balance](/billing/pay-invoices-overdue-balances/#pay-an-overdue-balance) to pay this balance
+2. Refer to [Pay an outstanding balance](/billing/pay-invoices-overdue-balances/#pay-an-outstanding-balance) to pay this balance
 3. Wait 24 hours after paying this balance
 4. Attempt to upgrade again
 
 As a reference, the full error messages you may see are:
 
-* "Due to a Billing related issue, the zone cannot be upgraded at this time. Please visit the Billing section to ensure there is no outstanding balance."
-* "Refer to https://cfl.re/3VUQyyL for assistance. For security reasons, there is a problem with your billing profile."
+- "Due to a Billing related issue, the zone cannot be upgraded at this time. Please visit the Billing section to ensure there is no outstanding balance."
+- "Refer to https://cfl.re/3VUQyyL for assistance. For security reasons, there is a problem with your billing profile."

--- a/src/content/docs/billing/troubleshoot-failed-payments.mdx
+++ b/src/content/docs/billing/troubleshoot-failed-payments.mdx
@@ -7,45 +7,55 @@ sidebar:
 
 This article will help if you are receiving errors about your payment failing when attempting to purchase something, change an existing subscription, pay an invoice or an outstanding balance. You may see one of the following error messages:
 
-* "The payment has failed. Please contact your bank or use a different payment method."
-* "Payment error: authorization failed for [“example.com”]"
+- "The payment has failed. Please contact your bank or use a different payment method."
+- "Payment error: authorization failed for [“example.com”]"
 
 Alternatively, you may receive an email from us about a subscription renewal payment failure with the subject: “[Cloudflare]: We couldn't process your renewal payment” which states “We were unable to process your renewal payment”.
 
 ## Automatic retries and product removal
+
 If the failed payment relates to a recurring charge for a Cloudflare plan, add-on, or subscription then after a five (5) day grace period, your account is automatically downgraded to a Free plan. Downgrading to a Free plan does not suspend your website, but you will lose any subscriptions or add-on services associated with the Pro, Business, or Enterprise plan.
 
-To avoid this, follow the Causes & Solution sections below to resolve the failing payment and retry. If you are unable to resolve the issue within the 5 day grace period, you’ll need to manually re-subscribe to these products. You may need to [pay an overdue balance](/billing/pay-invoices-overdue-balances/#pay-an-overdue-balance) relating to the five day grace period, if applicable.
+To avoid this, follow the Causes & Solution sections below to resolve the failing payment and retry. If you are unable to resolve the issue within the 5 day grace period, you’ll need to manually re-subscribe to these products. You may need to [pay an outstanding balance](/billing/pay-invoices-overdue-balances/#pay-an-outstanding-balance) relating to the five day grace period, if applicable.
 
 ## Causes
-* Your card details are incorrect
-* There are not enough funds in your account
-* You did not pass 3D Secure (3DS) correctly
-* Your bank is rate limiting payments from us
-* Your bank is declining the payment
+
+- Your card details are incorrect
+- There are not enough funds in your account
+- You did not pass 3D Secure (3DS) correctly
+- Your bank is rate limiting payments from us
+- Your bank is declining the payment
 
 ## Solution
+
 ### Check your details & contact your bank
+
 #### Check your card details
-* Check your address is valid and matches the one registered with your bank for the payment method you are using
-* Check that the Card Verification Value (CVC) you entered is correct for your card
-* If you are using PayPal, check for a verification email to your PayPal email address and follow the instructions to authorize
+
+- Check your address is valid and matches the one registered with your bank for the payment method you are using
+- Check that the Card Verification Value (CVC) you entered is correct for your card
+- If you are using PayPal, check for a verification email to your PayPal email address and follow the instructions to authorize
 
 #### Check you have enough funds
+
 Double check your payment method’s balance to ensure that your account has enough funds.
 
 #### Correctly authorise your transaction with 3D Secure (3DS)
+
 You may be using a bank that mandates the use of 3D Secure (3DS) for online card transactions. For one off or first time subscription payments, you need to be prepared to pass 3DS authentication when you attempt the payment in the Cloudflare dashboard. Your bank will contact you to authorise the transaction in real time. This contact typically comes via an SMS or push notification from your bank’s mobile application.
 
 Please note that for customers of Indian banks, 3DS is mandatory for all transactions as per the mandate from the Reserve Bank of India (RBI).
 
 #### Contact your bank if purchasing / renewing Registrar domains
+
 If you were purchasing or renewing multiple domains via [Cloudflare Registrar](/registrar) each domain will be charged as a separate transaction. This may be flagged as fraud by your credit card company. You will need to contact your bank in order to confirm and resolve this.
 
 #### Contact your bank to understand & fix the declined payment
+
 Cloudflare’s payment system does not know why a payment was declined, so you should contact your bank to confirm specifically why they declined the payment.
 
 ### Try your payment again
+
 Once you have checked the items above, you should try your transaction again by visiting the Cloudflare dashboard. If the payment that failed was a renewal payment, we will retry automatically 5 times in 5 days. However, we recommend you retry the payment manually in the dashboard to receive instant feedback. To do this:
 
 1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com) and select your account.
@@ -55,4 +65,5 @@ Once you have checked the items above, you should try your transaction again by 
 5. Follow the on screen instructions to try again.
 
 ### Try a new payment method
+
 If you cannot resolve this using your current payment method, you may wish to try an alternative payment method. We support multiple different credit card types and PayPal. To try this, refer [add a new payment method](/billing/update-billing-info/#update-payment-methods).


### PR DESCRIPTION
## Summary

- Fixes 3 broken anchor links in `billing/` docs identified by the [anchor link audit workflow](/.github/workflows/anchor-link-audit.yml).

### Changes

| Source file | Broken anchor | Fixed to | Reason |
|---|---|---|---|
| `billing/billing-policy.mdx` | `sales-tax/#filing-for-us-sales-tax-exemption/` | `sales-tax/#filing-for-us-sales-tax-exemption` | Trailing slash on anchor fragment |
| `billing/resolve-zone-cannot-be-ugpraded.mdx` | `pay-invoices-overdue-balances/#pay-an-overdue-balance` | `pay-invoices-overdue-balances/#pay-an-outstanding-balance` | Heading renamed from "overdue" to "outstanding" |
| `billing/troubleshoot-failed-payments.mdx` | `pay-invoices-overdue-balances/#pay-an-overdue-balance` | `pay-invoices-overdue-balances/#pay-an-outstanding-balance` | Same heading rename |

### Verification

- Full site build succeeded (7,442 pages).
- `htmltest` confirms zero `hash does not exist` errors originating from the `billing/` directory.
- All target anchor IDs confirmed present in the built HTML.

Batch 4 of the anchor link audit effort.