### PR TITLE
Update docs to document changes in control port

### DIFF
--- a/src/content/docs/sandbox/api/ports.mdx
+++ b/src/content/docs/sandbox/api/ports.mdx
@@ -69,7 +69,7 @@ const response = await sandbox.exposePort(port: number, options: ExposePortOptio
 
 **Parameters**:
 
-- `port` - Port number to expose (1024-65535)
+- `port` - Port number to expose (1024-65535, excluding the control port — 8671 by default, or the value of [`SANDBOX_CONTROL_PORT`](/sandbox/configuration/environment-variables/#sandbox_control_port))
 - `options`:
   - `hostname` - Your Worker's domain name (e.g., `'example.com'`). Required to construct preview URLs with wildcard subdomains like `https://8080-sandbox-abc123token.example.com`. Cannot be a `.workers.dev` domain as it doesn't support wildcard DNS patterns.
   - `name` - Friendly name for the port (optional)
@@ -253,7 +253,7 @@ const response = await sandbox.wsConnect(request: Request, port: number): Promis
 **Parameters**:
 
 - `request` - Incoming WebSocket upgrade request
-- `port` - Port number (1024-65535, excluding 3000)
+- `port` - Port number (1024-65535, excluding 8671 or your configured [`SANDBOX_CONTROL_PORT`](/sandbox/configuration/environment-variables/#sandbox_control_port))
 
 **Returns**: `Promise<Response>` - WebSocket response establishing the connection
 

--- a/src/content/docs/sandbox/concepts/preview-urls.mdx
+++ b/src/content/docs/sandbox/concepts/preview-urls.mdx
@@ -154,7 +154,7 @@ const admin = await sandbox.exposePort(3001, { hostname, name: "admin" });
 - Raw TCP/UDP connections
 - Custom protocols (must wrap in HTTP)
 - Ports outside range 1024-65535
-- Port 3000 (used internally by the SDK)
+- Port 8671 (used internally by the SDK, configurable via [`SANDBOX_CONTROL_PORT`](/sandbox/configuration/environment-variables/#sandbox_control_port))
 
 ## WebSocket Support
 
@@ -246,10 +246,10 @@ For custom domain issues, see [Production Deployment troubleshooting](/sandbox/g
 When using `wrangler dev`, you must expose ports in your Dockerfile:
 
 ```dockerfile
-FROM docker.io/cloudflare/sandbox:0.3.3
+FROM docker.io/cloudflare/sandbox:0.8.0
 
 # Required for local development
-EXPOSE 3000
+EXPOSE 8671
 EXPOSE 8080
 ```
 

--- a/src/content/docs/sandbox/concepts/preview-urls.mdx
+++ b/src/content/docs/sandbox/concepts/preview-urls.mdx
@@ -248,10 +248,13 @@ When using `wrangler dev`, you must expose ports in your Dockerfile:
 ```dockerfile
 FROM docker.io/cloudflare/sandbox:0.8.0
 
-# Required for local development
+# SDK control plane port (required for local dev)
 EXPOSE 8671
+# Your application port
 EXPOSE 8080
 ```
+
+`EXPOSE 8671` is needed because that is the default SDK control plane port. If you set [`SANDBOX_CONTROL_PORT`](/sandbox/configuration/environment-variables/#sandbox_control_port) to a different value, expose that port instead.
 
 Without `EXPOSE`, you'll see: `connect(): Connection refused: container port not found`
 

--- a/src/content/docs/sandbox/configuration/dockerfile.mdx
+++ b/src/content/docs/sandbox/configuration/dockerfile.mdx
@@ -36,6 +36,14 @@ Always match the Docker image version to your npm package version. If you're usi
 See [Version compatibility](/sandbox/concepts/sandboxes/#version-compatibility) for troubleshooting version mismatch warnings.
 :::
 
+:::note[Control port changed from 3000 to 8671]
+The internal control plane port changed from `3000` to `8671`. If you upgrade the SDK but your Docker image still uses an older version, the SDK will automatically fall back to port 3000 and log a deprecation warning. This keeps existing deployments working during the transition, but adds a one-time startup delay while the SDK detects the mismatch.
+
+Update your base image to match the SDK version to avoid this fallback. This backwards compatibility will be removed in a future release.
+
+If your Dockerfile has `EXPOSE 3000` for the control port, update it to `EXPOSE 8671`. Port 3000 is now available for your own services. See [`SANDBOX_CONTROL_PORT`](/sandbox/configuration/environment-variables/#sandbox_control_port) for details.
+:::
+
 ### Default image
 
 The default image is optimized for JavaScript and TypeScript workloads:

--- a/src/content/docs/sandbox/configuration/environment-variables.mdx
+++ b/src/content/docs/sandbox/configuration/environment-variables.mdx
@@ -34,6 +34,31 @@ Controls the transport protocol for SDK-to-container communication. WebSocket tr
 
 See [Transport modes](/sandbox/configuration/transport/) for a complete guide including when to use each transport, performance considerations, and migration instructions.
 
+### SANDBOX_CONTROL_PORT
+
+| | |
+|---|---|
+| **Type** | `number` (as string) |
+| **Default** | `8671` |
+
+Configures the internal port used for SDK-to-container communication. The default port was changed from `3000` to `8671` to avoid conflicts with common user services (Express, Next.js, etc.) that bind to port 3000.
+
+Most users do not need to set this. Only change it if port 8671 conflicts with a service you need to run inside the container.
+
+<WranglerConfig>
+```jsonc
+{
+	"vars": {
+		"SANDBOX_CONTROL_PORT": "9500"
+	}
+}
+```
+</WranglerConfig>
+
+:::note
+For local development with `wrangler dev`, update the `EXPOSE` directive in your Dockerfile to match the custom port. This is not required in production, where all container ports are accessible automatically.
+:::
+
 ### COMMAND_TIMEOUT_MS
 
 | | |

--- a/src/content/docs/sandbox/guides/expose-services.mdx
+++ b/src/content/docs/sandbox/guides/expose-services.mdx
@@ -306,21 +306,21 @@ In production, all ports are available and controlled programmatically via `expo
 
 ## Troubleshooting
 
-### Port 3000 is reserved
+### Control plane port is reserved
 
-Port 3000 is used by the internal Bun server and cannot be exposed:
+Port 8671 is used by the SDK control plane and cannot be exposed. If you configured a custom control port via [`SANDBOX_CONTROL_PORT`](/sandbox/configuration/environment-variables/#sandbox_control_port), that port is reserved instead.
 
 <TypeScriptExample>
 ```
 // Extract hostname from request
 const { hostname } = new URL(request.url);
 
-// ❌ This will fail
-await sandbox.exposePort(3000, { hostname });  // Error: Port 3000 is reserved
+// ❌ This will fail — 8671 is the default control plane port
+await sandbox.exposePort(8671, { hostname });  // Error: Port 8671 is reserved
 
-// ✅ Use a different port
-await sandbox.startProcess('node server.js', { env: { PORT: '8080' } });
-await sandbox.exposePort(8080, { hostname });
+// ✅ Port 3000 is available for your services
+await sandbox.startProcess('node server.js', { env: { PORT: '3000' } });
+await sandbox.exposePort(3000, { hostname });
 ```
 </TypeScriptExample>
 
@@ -384,7 +384,7 @@ See [Sandbox options - normalizeId](/sandbox/configuration/sandbox-options/#norm
 
 **Local development**: `http://localhost:8787/...`
 
-**Note**: Port 3000 is reserved for the internal Bun server and cannot be exposed.
+**Note**: Port 8671 (the default control plane port) is reserved and cannot be exposed. See [`SANDBOX_CONTROL_PORT`](/sandbox/configuration/environment-variables/#sandbox_control_port) to configure a different control port.
 
 ## Related resources
 


### PR DESCRIPTION
## **DO NOT MERGE until latest version of Sandbox SDK is shipped (current version is 0.80)**


### Summary

Documents the configurable control port feature from [cloudflare/sandbox-sdk#490](https://github.com/cloudflare/sandbox-sdk/pull/490). The default control port changed from 3000 to 8671, and is now configurable via `SANDBOX_CONTROL_PORT`.

#### Changes
- **environment-variables.mdx**: New `SANDBOX_CONTROL_PORT` section
- **dockerfile.mdx**: Upgrade note about port change and backwards-compatible fallback
- **expose-services.mdx**: "Port 3000 is reserved" → "Control plane port is reserved" (8671)
- **preview-urls.mdx**: Updated reserved port reference and `EXPOSE` example
- **ports.mdx**: Updated `exposePort` and `wsConnect` parameter docs to reflect new reserved port

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

1. Updated to include that you cannot call `exposePort` or `wsConnect` with the same port as the control port

<img width="815" height="707" alt="image" src="https://github.com/user-attachments/assets/d209cf7b-7076-4313-95d7-3757358c39d0" />

<img width="816" height="691" alt="image" src="https://github.com/user-attachments/assets/38f43d18-d1a0-4ff4-bc95-06e20869caf1" />

2. Updated Preview URLs page 

<img width="783" height="563" alt="image" src="https://github.com/user-attachments/assets/537393d3-61a9-47a6-a580-5043a516e546" />
<img width="807" height="222" alt="image" src="https://github.com/user-attachments/assets/66223a0c-a431-4d8f-8b79-b4a6362b5c98" />

3. Documented control port change for docker file reference

<img width="808" height="347" alt="image" src="https://github.com/user-attachments/assets/2a4b5f40-2f0c-416a-b0bc-973b0f168152" />

4. Documented the addition of a new environment variable

<img width="786" height="742" alt="image" src="https://github.com/user-attachments/assets/e3789069-c088-4bed-afd0-f033d69ac4dd" />

5. Updated troubleshooting 

<img width="790" height="539" alt="image" src="https://github.com/user-attachments/assets/cfd105da-03c9-4744-b45d-af684f14088c" />

<img width="765" height="340" alt="image" src="https://github.com/user-attachments/assets/3a91e8a8-08ab-4ea0-8815-8382f77e2652" />

