### PR TITLE
[Bots, Browser Rendering, BYOIP] Fix broken anchor links

### DIFF
--- a/src/content/docs/bots/additional-configurations/sequence-rules.mdx
+++ b/src/content/docs/bots/additional-configurations/sequence-rules.mdx
@@ -5,9 +5,16 @@ sidebar:
   order: 4
 ---
 
-import { Render, Steps } from "~/components"
+import { Render, Steps } from "~/components";
 
-<Render file="sequence-rules" product="bots" params={{ one: "Sequence rules", two: "/bots/additional-configurations/sequence-rules/" }} />
+<Render
+	file="sequence-rules"
+	product="bots"
+	params={{
+		one: "Sequence rules",
+		two: "/bots/additional-configurations/sequence-rules/",
+	}}
+/>
 
 :::caution[`431` error]
 Too many concurrent requests to your zone may add cookies that create a header that is too large, causing a `431` error.
@@ -18,7 +25,7 @@ Too many concurrent requests to your zone may add cookies that create a header t
 - Your account must have the Fraud Detection subscription.
 - Each zone must configure the endpoints to track via Endpoint Management.
 
-You can [create a sequence custom rule via the Cloudflare dashboard](#create-a-sequence-custom-rule-via-the-cloudflare-dashboard) or [using the API](#manage-sequence-rules-via-the-api).
+You can [build a sequence custom rule via the Cloudflare dashboard](#build-a-sequence-custom-rule-via-the-cloudflare-dashboard) or [using the API](#manage-sequence-rules-via-the-api).
 
 ---
 
@@ -39,15 +46,20 @@ You can [create a sequence custom rule via the Cloudflare dashboard](#create-a-s
 ### Enable sequence rules
 
 <Steps>
-1. [Create an API token](/fundamentals/api/get-started/create-token/) if you do not already have one. The API token must include the _Zone_ > _Fraud Detection_ > _Edit_ permission.
-2. [Get the zone ID](/fundamentals/account/find-account-and-zone-ids/) for the zone(s) where you want to enable sequence rules.
-3. [Add the endpoints](/api-shield/management-and-monitoring/) that you want to track in your sequence rules using API Shield's Endpoint Management and make note of the short ID. 
-4. Enable the sequence cookie by adding your API token and zone ID to the following API call.
+	1. [Create an API token](/fundamentals/api/get-started/create-token/) if you
+	do not already have one. The API token must include the _Zone_ > _Fraud
+	Detection_ > _Edit_ permission. 2. [Get the zone
+	ID](/fundamentals/account/find-account-and-zone-ids/) for the zone(s) where
+	you want to enable sequence rules. 3. [Add the
+	endpoints](/api-shield/management-and-monitoring/) that you want to track in
+	your sequence rules using API Shield's Endpoint Management and make note of
+	the short ID. 4. Enable the sequence cookie by adding your API token and zone
+	ID to the following API call.
 </Steps>
 
 :::note
 
-The short ID will not be visible until your account team has enabled this feature for you. 
+The short ID will not be visible until your account team has enabled this feature for you.
 :::
 
 ```bash title="API call"
@@ -61,7 +73,7 @@ https://api.cloudflare.com/client/v4/zones/{zone_id}/fraud_detection/sequence_co
 5. Use the expression editor to write sequence or timing based rules via [custom rules](/waf/custom-rules/), [rate limiting rules](/waf/rate-limiting-rules/), or [transform rules](/rules/transform/). You can put these rules in log only mode to monitor.
 
 :::note
-When you enable sequence rules, Cloudflare will start setting cookies for all requests that match your endpoints. 
+When you enable sequence rules, Cloudflare will start setting cookies for all requests that match your endpoints.
 :::
 
 Once you have enabled sequence rules, the rules fields will be populated and you can now use the new fields in your rules.
@@ -73,14 +85,19 @@ Disabling sequence rules will stop the rules fields from being populated. If you
 To disable sequence rules:
 
 <Steps>
-1. [Create an API token](/fundamentals/api/get-started/create-token/) if you do not already have one. The API token must include the _Zone_ > _Fraud Detection_ > _Edit_ permission.
-2. [Get the zone ID](/fundamentals/account/find-account-and-zone-ids/) for the zone(s) where you want to enable sequence rules.
-3. [Add the endpoints](/api-shield/management-and-monitoring/) that you want to track in your sequence rules using API Shield's Endpoint Management and make note of the short ID.
-4. Disable the sequence cookie using your API token, zone ID, and by setting `enabled` to `false` on the following API call.
+	1. [Create an API token](/fundamentals/api/get-started/create-token/) if you
+	do not already have one. The API token must include the _Zone_ > _Fraud
+	Detection_ > _Edit_ permission. 2. [Get the zone
+	ID](/fundamentals/account/find-account-and-zone-ids/) for the zone(s) where
+	you want to enable sequence rules. 3. [Add the
+	endpoints](/api-shield/management-and-monitoring/) that you want to track in
+	your sequence rules using API Shield's Endpoint Management and make note of
+	the short ID. 4. Disable the sequence cookie using your API token, zone ID,
+	and by setting `enabled` to `false` on the following API call.
 </Steps>
 
 :::note
-The short ID will not be visible until your account team has enabled this feature for you. 
+The short ID will not be visible until your account team has enabled this feature for you.
 :::
 
 ```bash title="API call"
@@ -90,7 +107,6 @@ curl --request PUT https://api.cloudflare.com/client/v4/zones/{zone_id}/fraud_de
 ```
 
 ---
-
 
 ## Rules fields
 
@@ -123,7 +139,6 @@ cf.sequence.msec_since_op["aaaaaaaa"] ge 1000
 cf.sequence.current_op eq "bbbbbbbb" and
 not cf.sequence.msec_since_op["aaaaaaaa"] ge 1000
 ```
-
 
 ---
 

--- a/src/content/docs/bots/reference/alerts.mdx
+++ b/src/content/docs/bots/reference/alerts.mdx
@@ -11,8 +11,8 @@ import { AvailableNotifications, Steps, DashButton } from "~/components"
 Bot alerts inform you when Cloudflare detects spikes in your traffic with any of the following characteristics:
 
 - A global spike in traffic that have a bot score of less than 30.
-- An increase in traffic on available dimensions in [Custom Bot Detection Alerts](#custom-bot-detection-alerts).
-- Filters of your choosing in [Custom Bot Detection Alerts](#custom-bot-detection-alerts).
+- An increase in traffic on available dimensions in [Set up a bot detection alert](#set-up-a-bot-detection-alert).
+- Filters of your choosing in [Set up a bot detection alert](#set-up-a-bot-detection-alert).
 
 --- 
 

--- a/src/content/docs/browser-rendering/faq.mdx
+++ b/src/content/docs/browser-rendering/faq.mdx
@@ -12,7 +12,7 @@ import { GlossaryTooltip, Render, DashButton, Steps } from "~/components";
 
 Below you will find answers to our most commonly asked questions about Browser Rendering.
 
-For pricing questions, visit the [pricing FAQ](/browser-rendering/pricing/#faq).
+For pricing questions, visit the [pricing FAQ](/browser-rendering/pricing/#pricing-faq).
 For usage limits questions, visit the [limits FAQ](/browser-rendering/limits/#faq).
 If you cannot find the answer you are looking for, join us on [Discord](https://discord.cloudflare.com).
 
@@ -35,6 +35,7 @@ To resolve this error, [upgrade to a Workers Paid plan](/workers/platform/pricin
 A `422 Unprocessable Entity` error usually means that Browser Rendering wasn't able to complete an action because of an issue with the site.
 
 This can happen if:
+
 - The website consumes too much memory during rendering.
 - The page itself crashed or returned an error before the action completed.
 - The request exceeded one of the [timeout limits](/browser-rendering/reference/timeouts/) for page load, element load, or an action.
@@ -49,22 +50,24 @@ JavaScript-heavy pages and Single Page Applications (SPAs) often load content dy
 
 To fix this, use the `goToOptions.waitUntil` parameter with one of these values:
 
-| Value              | Use when                                                                 |
-| ------------------ | ------------------------------------------------------------------------ |
-| `networkidle0`     | The page must be completely idle (no network requests for 500 ms). Best for pages that load all content upfront. |
-| `networkidle2`     | The page can have up to 2 ongoing connections (like analytics or websockets). Best for most dynamic pages. |
+| Value          | Use when                                                                                                         |
+| -------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `networkidle0` | The page must be completely idle (no network requests for 500 ms). Best for pages that load all content upfront. |
+| `networkidle2` | The page can have up to 2 ongoing connections (like analytics or websockets). Best for most dynamic pages.       |
 
 REST API example:
+
 ```json
 {
-  "url": "https://example.com",
-  "goToOptions": {
-    "waitUntil": "networkidle2"
-  }
+	"url": "https://example.com",
+	"goToOptions": {
+		"waitUntil": "networkidle2"
+	}
 }
 ```
 
 If content is still missing:
+
 - Use `waitForSelector` to wait for a specific element to appear before capturing.
 - Increase `goToOptions.timeout` (up to 60 seconds) for slow-loading pages.
 - Check if the page requires authentication or returns different content to bots.
@@ -78,6 +81,7 @@ For a complete reference, see [REST API timeouts](/browser-rendering/reference/t
 ### Does local development support all Browser Rendering features?
 
 Not yet. Local development currently has the following limitation(s):
+
 - Requests larger than 1 MB are not supported.
 
 <Render file="remote-binding-note" product="workers" />
@@ -90,10 +94,10 @@ HTTP Basic Auth:
 
 ```json
 {
-  "authenticate": {
-    "username": "user",
-    "password": "pass"
-  }
+	"authenticate": {
+		"username": "user",
+		"password": "pass"
+	}
 }
 ```
 
@@ -101,16 +105,16 @@ Cookie-based authentication:
 
 ```json
 {
-  "cookies": [
-    {
-      "name": "session_id",
-      "value": "abc123",
-      "domain": "example.com",
-      "path": "/",
-      "secure": true,
-      "httpOnly": true
-    }
-  ]
+	"cookies": [
+		{
+			"name": "session_id",
+			"value": "abc123",
+			"domain": "example.com",
+			"path": "/",
+			"secure": true,
+			"httpOnly": true
+		}
+	]
 }
 ```
 
@@ -118,9 +122,9 @@ Token-based authentication:
 
 ```json
 {
-  "setExtraHTTPHeaders": {
-    "Authorization": "Bearer your-token"
-  }
+	"setExtraHTTPHeaders": {
+		"Authorization": "Bearer your-token"
+	}
 }
 ```
 
@@ -146,7 +150,7 @@ Browser Rendering uses different [bot detection IDs](/browser-rendering/referenc
 2. To create a new empty rule, select **Create rule** > **Custom rules**.
 3. Enter a descriptive name for the rule in **Rule name**, such as `Allow Browser Rendering`.
 4. Under **When incoming requests match**, use the **Field** dropdown to choose _Bot Detection ID_. For **Operator**, select _equals_. For **Value**, enter the [bot detection ID](/browser-rendering/reference/automatic-request-headers/#bot-detection) for the method you want to allowlist.
-5. Under **Then take action**, in the **Choose action** dropdown, select  **Skip**.
+5. Under **Then take action**, in the **Choose action** dropdown, select **Skip**.
 6. Under **Place at**, select the order of the rule in the **Select order** dropdown to be **First**. Setting the order as **First** allows this rule to be applied before subsequent rules.
 7. To save and deploy your rule, select **Deploy**.
 
@@ -164,10 +168,7 @@ There is no fixed limit on the number of requests per browser session. A single 
 
 Yes. If your webpage or PDF requires a font that is not pre-installed, you can load custom fonts at render time using `addStyleTag`. This works with both the [REST API](/browser-rendering/rest-api/) and [Workers Bindings](/browser-rendering/workers-bindings/). For instructions and examples, refer to [Custom fonts](/browser-rendering/features/custom-fonts/).
 
-<Render
-  file="manage-concurrency-faq"
-  product="browser-rendering"
-/>
+<Render file="manage-concurrency-faq" product="browser-rendering" />
 
 ---
 

--- a/src/content/docs/browser-rendering/how-to/pdf-generation.mdx
+++ b/src/content/docs/browser-rendering/how-to/pdf-generation.mdx
@@ -35,8 +35,8 @@ The following example shows you how to generate a PDF using [Puppeteer](/browser
 ```jsonc
 {
 	"browser": {
-		"binding": "BROWSER"
-	}
+		"binding": "BROWSER",
+	},
 }
 ```
 
@@ -277,7 +277,7 @@ With your script now running, you can pass in a `?name` parameter to the local U
 
 If your PDF requires a specific font that is not pre-installed in the Browser Rendering environment, you can load custom fonts using `addStyleTag`. This allows you to inject fonts from a CDN or embed them as Base64 strings before generating your PDF.
 
-For detailed instructions and examples, refer to [Use your own custom font](/browser-rendering/reference/supported-fonts/#use-your-own-custom-font).
+For detailed instructions and examples, refer to [Use your own custom font](/browser-rendering/features/custom-fonts/).
 
 ---
 

--- a/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/pdf-endpoint.mdx
@@ -18,14 +18,16 @@ https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/pdf
 ```
 
 ## Required fields
+
 You must provide either `url` or `html`:
--  `url` (string)
--  `html` (string)
+
+- `url` (string)
+- `html` (string)
 
 ## Common use cases
 
--  Capture a PDF of a webpage
--  Generate PDFs, such as invoices, licenses, reports, and certificates, directly from HTML
+- Capture a PDF of a webpage
+- Generate PDFs, such as invoices, licenses, reports, and certificates, directly from HTML
 
 ## Basic usage
 
@@ -60,9 +62,7 @@ const client = new Cloudflare({
 const pdf = await client.browserRendering.pdf.create({
 	account_id: process.env["CLOUDFLARE_ACCOUNT_ID"],
 	url: "https://example.com/",
-    addStyleTag: [
-        { content: "body { font-family: Arial; }" }
-    ]
+	addStyleTag: [{ content: "body { font-family: Arial; }" }],
 });
 
 console.log(pdf);
@@ -201,19 +201,10 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-
 
 ### Use custom fonts
 
-If your PDF requires a font that is not pre-installed in the Browser Rendering environment, you can load custom fonts using the `addStyleTag` parameter. For instructions and examples, refer to [Use your own custom font](/browser-rendering/reference/supported-fonts/#rest-api).
+If your PDF requires a font that is not pre-installed in the Browser Rendering environment, you can load custom fonts using the `addStyleTag` parameter. For instructions and examples, refer to [Use your own custom font](/browser-rendering/features/custom-fonts/#rest-api).
 
-<Render
-  file="javascript-heavy-pages"
-  product="browser-rendering"
-/>
+<Render file="javascript-heavy-pages" product="browser-rendering" />
 
-<Render
-  file="setting-custom-user-agent"
-  product="browser-rendering"
-/>
+<Render file="setting-custom-user-agent" product="browser-rendering" />
 
-<Render
-  file="faq"
-  product="browser-rendering"
-/>
+<Render file="faq" product="browser-rendering" />

--- a/src/content/docs/byoip/service-bindings/magic-transit-with-cdn.mdx
+++ b/src/content/docs/byoip/service-bindings/magic-transit-with-cdn.mdx
@@ -31,14 +31,14 @@ It is important to note that traffic routed to the CDN pipeline is protected at 
 
 - Plan for what IPs will be used:
 
-    <Render
-    	file="service-bindings-prereqs"
-    	product="byoip"
-    	params={{
-    		pre_existing_product: "Magic Transit",
-    		added_product: "CDN",
-    	}}
-    />
+  <Render
+  	file="service-bindings-prereqs"
+  	product="byoip"
+  	params={{
+  		pre_existing_product: "Magic Transit",
+  		added_product: "CDN",
+  	}}
+  />
 
 ## 1. Get account information
 
@@ -51,7 +51,7 @@ It is important to note that traffic routed to the CDN pipeline is protected at 
 	}}
 />
 
-## 2. Create service binding
+## 2. Create service bindings
 
 <Render
 	file="service-bindings-create-binding"

--- a/src/content/partials/byoip/service-bindings-prereqs.mdx
+++ b/src/content/partials/byoip/service-bindings-prereqs.mdx
@@ -1,7 +1,7 @@
 ---
 params:
- - pre_existing_product
- - added_product
+  - pre_existing_product
+  - added_product
 ---
 
 import { Details } from "~/components";
@@ -30,5 +30,5 @@ Add one discrete {props.added_product} service binding for `203.0.113.16` with a
 Once a service binding is created (or deleted), it will take **four to six hours** to propagate across Cloudflare's global network. Services for the IP addresses in scope will likely be disrupted during this window.
 
 :::note
-This guide assumes that the prefix is tied to a single Cloudflare account that has both {props.pre_existing_product} and {props.added_product} properties. If you are using [prefix delegations](/byoip/concepts/prefix-delegations/), the service bindings must be [created](#2-create-service-binding) on the parent account.
+This guide assumes that the prefix is tied to a single Cloudflare account that has both {props.pre_existing_product} and {props.added_product} properties. If you are using [prefix delegations](/byoip/concepts/prefix-delegations/), the service bindings must be [created](#2-create-service-bindings) on the parent account.
 :::


### PR DESCRIPTION
## Summary

- Fixes 6 broken anchor links across `bots/`, `browser-rendering/`, and `byoip/` docs identified by the [anchor link audit workflow](/.github/workflows/anchor-link-audit.yml).

### Changes

| Source file | Broken anchor | Fixed to | Reason |
|---|---|---|---|
| `bots/additional-configurations/sequence-rules.mdx` | `#create-a-sequence-custom-rule-via-the-cloudflare-dashboard` | `#build-a-sequence-custom-rule-via-the-cloudflare-dashboard` | Heading renamed from "Create" to "Build" |
| `bots/reference/alerts.mdx` (×2) | `#custom-bot-detection-alerts` | `#set-up-a-bot-detection-alert` | No "Custom Bot Detection Alerts" heading; closest match is "Set up a bot detection alert" |
| `browser-rendering/faq.mdx` | `pricing/#faq` | `pricing/#pricing-faq` | Heading is "Pricing FAQ" not just "FAQ" |
| `browser-rendering/how-to/pdf-generation.mdx` | `reference/supported-fonts/#use-your-own-custom-font` | `features/custom-fonts/` | Custom fonts content moved to `features/custom-fonts/` |
| `browser-rendering/rest-api/pdf-endpoint.mdx` | `reference/supported-fonts/#rest-api` | `features/custom-fonts/#rest-api` | Same page move as above |
| `partials/byoip/service-bindings-prereqs.mdx` | `#2-create-service-binding` | `#2-create-service-bindings` | Heading uses plural "bindings" |
| `byoip/service-bindings/magic-transit-with-cdn.mdx` | n/a (heading fix) | `## 2. Create service bindings` | Made heading plural to match the shared partial's anchor and the sibling `cdn-and-spectrum` page |

### Verification

- Full site build succeeded (7,442 pages).
- `htmltest` confirms zero `hash does not exist` errors originating from `bots/`, `browser-rendering/`, or `byoip/` directories.
- All target anchor IDs confirmed present in the built HTML.

Batch 5 of the anchor link audit effort.