### PR TITLE
[Email Routing, Fundamentals, Hyperdrive, Images] Fix broken anchor links

### DIFF
--- a/src/content/docs/email-routing/email-workers/enable-email-workers.mdx
+++ b/src/content/docs/email-routing/email-workers/enable-email-workers.mdx
@@ -15,7 +15,7 @@ Follow these steps to enable and add your first Email Worker. If you have never 
 
 2. Select **Get started**.
 3. In **Custom address**, enter the custom email address you want to use (for example, `my-new-email`).
-4. In **Destination**, choose the email address or Email Worker you want your emails to be forwarded to — for example, `your-name@gmail.com`. You can only choose a destination address you have already verified. To add a new destination address, refer to [Destination addresses](#destination-addresses).
+4. In **Destination**, choose the email address or Email Worker you want your emails to be forwarded to — for example, `your-name@gmail.com`. You can only choose a destination address you have already verified. To add a new destination address, refer to [Destination addresses](/email-routing/setup/email-routing-addresses/#destination-addresses).
 5. Select **Create and continue**.
 6. Verify your destination address and select **Continue**.
 7. Configure your DNS records and select **Add records and enable**.

--- a/src/content/docs/fundamentals/account/account-security/leaked-password-notifications.mdx
+++ b/src/content/docs/fundamentals/account/account-security/leaked-password-notifications.mdx
@@ -28,4 +28,4 @@ Users leveraging [Single Sign-On (SSO)](/fundamentals/manage-members/dashboard-s
 
 We encourage you to enable two-factor authentication to secure your account.
 
-Cloudflare account Super Administrators can also require that [all members enable 2FA](/fundamentals/user-profiles/2fa/#enable-two-factor-authentication-for-your-cloudflare-account). This functionality can be enabled by going to **Manage Account** > **Members** in the Cloudflare dashboard.
+Cloudflare account Super Administrators can also require that [all members enable 2FA](/fundamentals/user-profiles/2fa/). This functionality can be enabled by going to **Manage Account** > **Members** in the Cloudflare dashboard.

--- a/src/content/docs/fundamentals/account/account-security/scim-setup/authentik.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/authentik.mdx
@@ -16,7 +16,7 @@ Once you have [gathered the required data](/fundamentals/account/account-securit
 1. In the Authentik Admin interface, go to **Applications** > **Providers**.
 2. Select **Create** and choose **SCIM Provider**.
 3. Name your provider (for example, `Cloudflare SCIM`).
-4. In **URL**, enter: `https://api.cloudflare.com/client/v4/accounts/<accountID>/scim/v2`, substituting `<accountID>` for your [Cloudflare Account ID](/fundamentals/account/account-security/scim-setup/#get-your-account-id).
+4. In **URL**, enter: `https://api.cloudflare.com/client/v4/accounts/<accountID>/scim/v2`, substituting `<accountID>` for your [Cloudflare Account ID](/fundamentals/account/account-security/scim-setup/#get-the-account-id).
 5. In **Token**, Paste the SCIM provisioning API token.
 6. (Optional) Adjust the **User filtering** and **Group filtering** settings to control which users and groups are synchronized.
 7. Select **Finish** to create the provider.

--- a/src/content/docs/fundamentals/account/account-security/scim-setup/okta.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/okta.mdx
@@ -31,7 +31,7 @@ The **Update User Attributes** option is not supported.
 
 1. In your integration page, go to **Provisioning** > **Configure API Integration**.
 2. Enable **Enable API Integration**.
-3. In SCIM 2.0 Base URL, enter: `https://api.cloudflare.com/client/v4/accounts/<accountID>/scim/v2`, substituting `accountID` for your [Cloudflare Account ID](/fundamentals/account/account-security/scim-setup/#get-your-account-id).
+3. In SCIM 2.0 Base URL, enter: `https://api.cloudflare.com/client/v4/accounts/<accountID>/scim/v2`, substituting `accountID` for your [Cloudflare Account ID](/fundamentals/account/account-security/scim-setup/#get-the-account-id).
 4. In the **OAuth Bearer Token** field, enter your API token value.
 5. Deselect **Import Groups**.
 

--- a/src/content/docs/fundamentals/user-profiles/2fa.mdx
+++ b/src/content/docs/fundamentals/user-profiles/2fa.mdx
@@ -21,7 +21,7 @@ A security key provides phishing-resistant multifactor authentication to your Cl
 
 Cloudflare recommends configuring multiple security keys. With multiple keys, you can still use 2FA if the primary key is unavailable or if you are working on a different device.
 
-After [enabling 2FA on your Cloudflare account](/fundamentals/user-profiles/2fa/#enable-two-factor-authentication-for-your-cloudflare-account), you can select **Manage** to configure 2FA security key authentication.
+After [enabling 2FA on your Cloudflare account](/fundamentals/user-profiles/2fa/#configure-totp-mobile-application-authentication), you can select **Manage** to configure 2FA security key authentication.
 
 ### Built-in authenticators
 

--- a/src/content/docs/fundamentals/user-profiles/delete-account.mdx
+++ b/src/content/docs/fundamentals/user-profiles/delete-account.mdx
@@ -25,7 +25,7 @@ Before Cloudflare can cancel your account and delete your personal information, 
 - [Remove Cloudflare nameservers at your domain registrar](/dns/zone-setups/full-setup/setup/)
 - [Disable auto-renew for your Registrar domain(s)](/registrar/account-options/renew-domains#set-up-automatic-renewals)
 - If you are using a Cloudflare [CNAME setup](/dns/zone-setups/partial-setup/), [update your DNS records](/dns/manage-dns-records/how-to/create-dns-records/#edit-dns-records) at your DNS provider to point to your website IPs or hostnames instead of Cloudflare.
-- [Delete payment information](/billing/update-billing-info/#delete-your-current-payment-method)
+- [Delete payment information](/billing/update-billing-info/#delete-a-payment-method)
 - (*Optional*) [Download a copy of your invoices](/billing/invoices/#download-invoice). Once deleted, the invoices will no longer be accessible and cannot be re-sent to you.
 
 ## Delete your Cloudflare account

--- a/src/content/docs/hyperdrive/configuration/connect-to-private-database.mdx
+++ b/src/content/docs/hyperdrive/configuration/connect-to-private-database.mdx
@@ -33,7 +33,7 @@ If your organization also uses [Super Bot Fight Mode](/bots/get-started/super-bo
 
 ## Prerequisites
 
-- A database in your private network, [configured to use TLS/SSL](/hyperdrive/examples/connect-to-postgres/#supported-tls-ssl-modes).
+- A database in your private network, [configured to use TLS/SSL](/hyperdrive/examples/connect-to-postgres/).
 - A hostname on your Cloudflare account, which will be used to route requests to your database.
 
 ## 1. Create a tunnel in your private network
@@ -127,7 +127,7 @@ The service token will be used to restrict requests to the tunnel, and is needed
 
 8. Enter a **Policy name** and set the **Action** to _Service Auth_.
 
-9. Create an **Include** rule. Specify a **Selector** of _Service Token_ and the **Value** of the service token you created in step [2. Create a service token](#21-create-a-service-token).
+9. Create an **Include** rule. Specify a **Selector** of _Service Token_ and the **Value** of the service token you created in step [2. Create a service token](#21-manual-create-a-service-token).
 
 10. Save the policy.
 

--- a/src/content/docs/images/tutorials/optimize-user-uploaded-image.mdx
+++ b/src/content/docs/images/tutorials/optimize-user-uploaded-image.mdx
@@ -24,7 +24,7 @@ You will learn how to connect Developer Platform services to your Worker through
 Before you begin, you will need to do the following:
 
 - Add an [Images Paid](/images/pricing/#images-paid) subscription to your account. This allows you to bind the Images API to your Worker.
-- Create an [R2 bucket](/r2/get-started/#2-create-a-bucket), where the transformed images will be uploaded.
+- Create an [R2 bucket](/r2/get-started/), where the transformed images will be uploaded.
 - Create a new Worker project.
 
 If you are new, review how to [create your first Worker](/workers/get-started/guide/).

--- a/src/content/partials/workers/request-dot-clone-warning.mdx
+++ b/src/content/partials/workers/request-dot-clone-warning.mdx
@@ -7,6 +7,6 @@
 The body of a [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) can only be accessed once. If you previously used `request.formData()` in the same request, you may encounter a TypeError when attempting to access `request.body`.
 
 To avoid errors, create a clone of the Request object with `request.clone()` for each subsequent attempt to access a Request's body.
-Keep in mind that Workers have a [memory limit of 128 MB per Worker](/workers/platform/limits#worker-limits) and loading particularly large files into a Worker's memory multiple times may reach this limit. To ensure memory usage does not reach this limit, consider using [Streams](/workers/runtime-apis/streams/).
+Keep in mind that Workers have a [memory limit of 128 MB per Worker](/workers/platform/limits/#memory) and loading particularly large files into a Worker's memory multiple times may reach this limit. To ensure memory usage does not reach this limit, consider using [Streams](/workers/runtime-apis/streams/).
 
 :::


### PR DESCRIPTION
## Summary

- Fixes 10 broken anchor links across `email-routing/`, `fundamentals/`, `hyperdrive/`, and `images/` docs identified by the [anchor link audit workflow](/.github/workflows/anchor-link-audit.yml).
- No broken anchors were found in `email-security/`, `firewall/`, `google-tag-gateway/`, or `health-checks/`.

### Changes

| Source file | Broken anchor | Fixed to | Reason |
|---|---|---|---|
| `email-routing/.../enable-email-workers.mdx` | `#destination-addresses` | `/email-routing/setup/email-routing-addresses/#destination-addresses` | Heading is on a different page |
| `fundamentals/.../leaked-password-notifications.mdx` | `2fa/#enable-two-factor-authentication-for-your-cloudflare-account` | `2fa/` | No matching heading; anchor removed |
| `fundamentals/.../scim-setup/authentik.mdx` | `scim-setup/#get-your-account-id` | `scim-setup/#get-the-account-id` | "your" → "the" in heading |
| `fundamentals/.../scim-setup/okta.mdx` | `scim-setup/#get-your-account-id` | `scim-setup/#get-the-account-id` | Same rename |
| `fundamentals/user-profiles/2fa.mdx` | `2fa/#enable-two-factor-authentication-for-your-cloudflare-account` | `2fa/#configure-totp-mobile-application-authentication` | Heading renamed |
| `fundamentals/.../delete-account.mdx` | `update-billing-info/#delete-your-current-payment-method` | `update-billing-info/#delete-a-payment-method` | Heading renamed |
| `hyperdrive/.../connect-to-private-database.mdx` | `#21-create-a-service-token` | `#21-manual-create-a-service-token` | Heading includes "(Manual)" prefix |
| `hyperdrive/.../connect-to-private-database.mdx` | `connect-to-postgres/#supported-tls-ssl-modes` | `connect-to-postgres/` | No matching heading; anchor removed |
| `images/.../optimize-user-uploaded-image.mdx` | `r2/get-started/#2-create-a-bucket` | `r2/get-started/` | No matching heading; anchor removed |
| `partials/workers/request-dot-clone-warning.mdx` | `workers/platform/limits#worker-limits` | `workers/platform/limits/#memory` | Heading renamed to "Memory" |

### Verification

- Full site build succeeded (7,445 pages).
- `htmltest` confirms zero `hash does not exist` errors originating from all 8 target directories.
- All target anchor IDs confirmed present in the built HTML.

Batch 7 of the anchor link audit effort.