### PR TITLE
feat: emit per-file annotations for broken links in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     needs: pre-build
     runs-on: ubuntu-latest
     outputs:
-      link_validation_failed: ${{ steps.build_step.outputs.link_validation_failed }}
+      link_check_failed: ${{ steps.check_link_result.outputs.failed }}
     permissions:
       contents: read
       pull-requests: write
@@ -148,14 +148,34 @@ jobs:
           restore-keys: |
             astro-assets-
 
-      - name: Build
+      # The starlight-links-validator plugin runs in astro:build:done, which fires
+      # AFTER all pages have been written to dist/. If link validation fails, the
+      # build exits non-zero but dist/ is complete. We use continue-on-error so the
+      # job succeeds (allowing deploy + post-build to run), then check the outcome below.
+      # We tee stdout+stderr to build.log so post-build can parse it for annotations.
+      - run: pnpm run build 2>&1 | tee build.log; exit ${PIPESTATUS[0]}
         id: build_step
+        name: Build
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_LINK_CHECK: true
+
+      # Distinguish between "link check failed" (dist/ exists) and "real build failure" (no dist/).
+      # If the build produced no output, we must fail the job immediately.
+      - name: Check build result
+        id: check_link_result
         run: |
-          set -o pipefail
-          pnpm run build 2>&1 | tee /tmp/build-output.log
+          if [ ! -d dist ] || [ -z "$(ls -A dist)" ]; then
+            echo "::error::Build failed before producing output. Check the Build job logs for the error."
+            exit 1
+          fi
+          if [ "${{ steps.build_step.outcome }}" = "failure" ]; then
+            echo "failed=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Build succeeded but link validation failed. Preview will still be deployed."
+          else
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload build artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -163,12 +183,12 @@ jobs:
           name: dist
           path: dist
 
-      - name: Upload link validation report
-        if: steps.build_step.outputs.link_validation_failed == 'true'
+      - name: Upload build log
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        if: always()
         with:
-          name: link-validation-report
-          path: .starlight-links-validator/errors.json
+          name: build-log
+          path: build.log
 
   post-build:
     name: Post Build
@@ -215,15 +235,15 @@ jobs:
       - name: Tests (Workers)
         run: pnpm run test:postbuild
 
-      - name: Download link validation report
-        if: needs.build.outputs.link_validation_failed == 'true'
+      - name: Download build log
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        if: needs.build.outputs.link_check_failed == 'true'
         with:
-          name: link-validation-report
-          path: .starlight-links-validator
+          name: build-log
 
       - name: Link validation
-        run: pnpm exec tsx bin/check-link-validation/index.ts
+        if: needs.build.outputs.link_check_failed == 'true'
+        run: pnpm exec tsx bin/annotate-link-errors.ts build.log
 
   notify:
     name: Notify
@@ -267,20 +287,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm exec tsx bin/post-pr-ci-failure-comment/index.ts
-
-      - name: Download link validation report
-        if: needs.build.outputs.link_validation_failed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: link-validation-report
-          path: .starlight-links-validator
-
-      - name: Post link validation comment
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm exec tsx bin/post-link-validation-comment/index.ts
 
   publish-preview:
     name: Deploy Preview

--- a/bin/annotate-link-errors.ts
+++ b/bin/annotate-link-errors.ts
@@ -95,15 +95,9 @@ function findLinkLine(filePath: string, link: string): number | null {
 	return null;
 }
 
-function emitAnnotation(
-	file: string,
-	line: number | null,
-	link: string,
-	errorType: string,
-): void {
+function emitAnnotation(file: string, line: number | null, link: string): void {
 	const location = line !== null ? `file=${file},line=${line}` : `file=${file}`;
-	// GHA annotation format: ::error file=<path>,line=<n>::<message>
-	console.log(`::error ${location}::${link} — ${errorType}`);
+	console.log(`::error ${location}::Invalid link: "${link}" was not resolved.`);
 }
 
 function run(): void {
@@ -148,20 +142,19 @@ function run(): void {
 		const linkMatch = content.match(/^\s*[├└]─\s+(\S+)\s+-\s+(.+)$/);
 		if (linkMatch && currentSlug) {
 			const link = linkMatch[1];
-			const errorType = linkMatch[2].trim();
 
 			const sourceFile = findSourceFile(currentSlug);
 			if (!sourceFile) {
 				// Can't map to a file — emit a generic annotation on the run.
 				console.log(
-					`::error::${link} — ${errorType} (in ${currentSlug}, source file not found)`,
+					`::error::Invalid link: "${link}" was not resolved. (in ${currentSlug}, source file not found)`,
 				);
 				annotationCount++;
 				continue;
 			}
 
 			const lineNumber = findLinkLine(sourceFile, link);
-			emitAnnotation(sourceFile, lineNumber, link, errorType);
+			emitAnnotation(sourceFile, lineNumber, link);
 			annotationCount++;
 		}
 	}

--- a/bin/annotate-link-errors.ts
+++ b/bin/annotate-link-errors.ts
@@ -85,7 +85,8 @@ function run(): void {
 
 		const slugMatch = content.match(/^▶\s+(.+)$/);
 		if (slugMatch) {
-			currentSlug = slugMatch[1].trim();
+			// Strip both leading and trailing slashes — the validator may emit a leading slash.
+			currentSlug = slugMatch[1].trim().replace(/^\//, "");
 			continue;
 		}
 

--- a/bin/annotate-link-errors.ts
+++ b/bin/annotate-link-errors.ts
@@ -1,0 +1,126 @@
+/**
+ * Parses build.log for starlight-links-validator errors and emits GitHub Actions
+ * annotations pointing to the source MDX file and line number of each broken link.
+ *
+ * Usage: npx tsx bin/annotate-link-errors.ts [path/to/build.log]
+ * Defaults to build.log in the current working directory.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const DOCS_DIR = "src/content/docs";
+const LOG_PATH = process.argv[2] ?? "build.log";
+
+// Strip ANSI escape codes.
+function stripAnsi(str: string): string {
+	// eslint-disable-next-line no-control-regex
+	return str.replace(/\x1B\[[0-9;]*[mGKHF]/g, "");
+}
+
+// Find the source MDX file for a given slug (e.g. "workers/get-started/").
+// Checks <slug>/index.mdx first, then <slug>.mdx (without trailing slash).
+function findSourceFile(slug: string): string | null {
+	const bare = slug.replace(/\/$/, "");
+	const candidates = [
+		path.join(DOCS_DIR, bare, "index.mdx"),
+		path.join(DOCS_DIR, `${bare}.mdx`),
+	];
+	for (const candidate of candidates) {
+		if (fs.existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+
+// Search for the first occurrence of a link URL in a file and return its 1-based line number.
+// Returns null if not found.
+function findLinkLine(filePath: string, link: string): number | null {
+	const lines = fs.readFileSync(filePath, "utf8").split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i].includes(link)) return i + 1;
+	}
+	return null;
+}
+
+function emitAnnotation(
+	file: string,
+	line: number | null,
+	link: string,
+	errorType: string,
+): void {
+	const location = line !== null ? `file=${file},line=${line}` : `file=${file}`;
+	// GHA annotation format: ::error file=<path>,line=<n>::<message>
+	console.log(`::error ${location}::${link} — ${errorType}`);
+}
+
+function run(): void {
+	if (!fs.existsSync(LOG_PATH)) {
+		console.error(`build.log not found at ${LOG_PATH}`);
+		process.exit(1);
+	}
+
+	const raw = fs.readFileSync(LOG_PATH, "utf8");
+	const lines = raw.split("\n").map(stripAnsi);
+
+	// Find the "validating links" section.
+	const startIdx = lines.findIndex((l) => l.includes("validating links"));
+	if (startIdx === -1) {
+		// No link validation ran — nothing to annotate.
+		process.exit(0);
+	}
+
+	// Parse (slug → broken links) from the validator output.
+	// Format after stripping ANSI and timestamps:
+	//   ▶ <slug>/
+	//     ├─ <link> - <error type>
+	//     └─ <link> - <error type>
+	let currentSlug: string | null = null;
+	let annotationCount = 0;
+
+	for (let i = startIdx; i < lines.length; i++) {
+		const line = lines[i];
+
+		// Strip leading timestamp like "22:12:36 " produced by Astro's logger.
+		const content = line.replace(/^\d{2}:\d{2}:\d{2}\s+/, "").trimEnd();
+
+		const slugMatch = content.match(/^▶\s+(.+)$/);
+		if (slugMatch) {
+			currentSlug = slugMatch[1].trim();
+			continue;
+		}
+
+		// ├─ or └─ line: a broken link under the current slug.
+		// Leading spaces may be consumed by the timestamp strip, so match with optional spaces.
+		const linkMatch = content.match(/^\s*[├└]─\s+(\S+)\s+-\s+(.+)$/);
+		if (linkMatch && currentSlug) {
+			const link = linkMatch[1];
+			const errorType = linkMatch[2].trim();
+
+			const sourceFile = findSourceFile(currentSlug);
+			if (!sourceFile) {
+				// Can't map to a file — emit a generic annotation on the run.
+				console.log(
+					`::error::${link} — ${errorType} (in ${currentSlug}, source file not found)`,
+				);
+				annotationCount++;
+				continue;
+			}
+
+			const lineNumber = findLinkLine(sourceFile, link);
+			emitAnnotation(sourceFile, lineNumber, link, errorType);
+			annotationCount++;
+		}
+	}
+
+	if (annotationCount === 0) {
+		// Validator ran but produced no parseable errors — fall back to a generic annotation.
+		console.log(
+			"::error::starlight-links-validator found broken internal links. See the Build job logs for details.",
+		);
+	}
+
+	// Always exit non-zero so the step fails the job.
+	process.exit(1);
+}
+
+run();

--- a/bin/annotate-link-errors.ts
+++ b/bin/annotate-link-errors.ts
@@ -33,11 +33,33 @@ function findSourceFile(slug: string): string | null {
 }
 
 // Search for the first occurrence of a link URL in a file and return its 1-based line number.
-// Returns null if not found.
+// Returns null if not found or if the file cannot be read.
+// Tries progressively looser matches to handle trailing slashes and hash fragments.
 function findLinkLine(filePath: string, link: string): number | null {
-	const lines = fs.readFileSync(filePath, "utf8").split("\n");
-	for (let i = 0; i < lines.length; i++) {
-		if (lines[i].includes(link)) return i + 1;
+	let lines: string[];
+	try {
+		lines = fs.readFileSync(filePath, "utf8").split("\n");
+	} catch {
+		return null;
+	}
+
+	// Build a list of candidate strings to search for, from most to least specific.
+	const candidates = new Set<string>([link]);
+	// Strip hash fragment: "/path/#anchor" → "/path/"
+	const withoutHash = link.replace(/#.*$/, "");
+	if (withoutHash !== link) candidates.add(withoutHash);
+	// Strip trailing slash: "/path/" → "/path"
+	const withoutTrailingSlash = link.replace(/\/$/, "");
+	if (withoutTrailingSlash !== link) candidates.add(withoutTrailingSlash);
+	// Strip both hash and trailing slash
+	const withoutHashOrSlash = withoutHash.replace(/\/$/, "");
+	if (withoutHashOrSlash !== withoutHash) candidates.add(withoutHashOrSlash);
+
+	for (const candidate of candidates) {
+		if (!candidate) continue;
+		for (let i = 0; i < lines.length; i++) {
+			if (lines[i].includes(candidate)) return i + 1;
+		}
 	}
 	return null;
 }

--- a/bin/annotate-link-errors.ts
+++ b/bin/annotate-link-errors.ts
@@ -44,19 +44,25 @@ function findLinkLine(filePath: string, link: string): number | null {
 	}
 
 	// Build a list of candidate strings to search for, from most to least specific.
-	const candidates = new Set<string>([link]);
+	// Each variant is tried both as a bare string and wrapped in markdown link syntax "(<url>)".
+	const variants = new Set<string>([link]);
 	// Strip hash fragment: "/path/#anchor" → "/path/"
 	const withoutHash = link.replace(/#.*$/, "");
-	if (withoutHash !== link) candidates.add(withoutHash);
+	if (withoutHash !== link) variants.add(withoutHash);
 	// Strip trailing slash: "/path/" → "/path"
 	const withoutTrailingSlash = link.replace(/\/$/, "");
-	if (withoutTrailingSlash !== link) candidates.add(withoutTrailingSlash);
+	if (withoutTrailingSlash !== link) variants.add(withoutTrailingSlash);
 	// Strip both hash and trailing slash
 	const withoutHashOrSlash = withoutHash.replace(/\/$/, "");
-	if (withoutHashOrSlash !== withoutHash) candidates.add(withoutHashOrSlash);
+	if (withoutHashOrSlash !== withoutHash) variants.add(withoutHashOrSlash);
+
+	// For each variant, try markdown syntax first ("(url)"), then bare string.
+	const candidates: string[] = [];
+	for (const v of variants) {
+		if (v) candidates.push(`(${v})`, v);
+	}
 
 	for (const candidate of candidates) {
-		if (!candidate) continue;
 		for (let i = 0; i < lines.length; i++) {
 			if (lines[i].includes(candidate)) return i + 1;
 		}

--- a/bin/annotate-link-errors.ts
+++ b/bin/annotate-link-errors.ts
@@ -9,7 +9,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-const DOCS_DIR = "src/content/docs";
+const CONTENT_DIR = "src/content";
 const LOG_PATH = process.argv[2] ?? "build.log";
 
 // Strip ANSI escape codes.
@@ -18,14 +18,39 @@ function stripAnsi(str: string): string {
 	return str.replace(/\x1B\[[0-9;]*[mGKHF]/g, "");
 }
 
-// Find the source MDX file for a given slug (e.g. "workers/get-started/").
-// Checks <slug>/index.mdx first, then <slug>.mdx (without trailing slash).
+// Find the source MDX file for a built page slug (e.g. "changelog/fundamentals/2026-test/").
+//
+// The slug corresponds to a URL path, but the source file may live in any content collection
+// under src/content/ — not just src/content/docs/. For example:
+//   changelog/fundamentals/2026-test/ → src/content/changelog/fundamentals/2026-test.mdx
+//   workers/get-started/              → src/content/docs/workers/get-started/index.mdx
+//
+// Strategy: try <collection>/<rest>/index.mdx and <collection>/<rest>.mdx for every collection,
+// where <collection> is the first path segment and <rest> is the remainder.
 function findSourceFile(slug: string): string | null {
 	const bare = slug.replace(/\/$/, "");
-	const candidates = [
-		path.join(DOCS_DIR, bare, "index.mdx"),
-		path.join(DOCS_DIR, `${bare}.mdx`),
-	];
+	const segments = bare.split("/");
+
+	// Build candidate paths to check, ordered from most to least specific.
+	const candidates: string[] = [];
+
+	// 1. Try each content collection whose name matches the first slug segment.
+	//    e.g. "changelog/fundamentals/2026-test" → src/content/changelog/fundamentals/2026-test.mdx
+	const [first, ...rest] = segments;
+	if (first && rest.length > 0) {
+		const restPath = rest.join("/");
+		candidates.push(
+			path.join(CONTENT_DIR, first, restPath, "index.mdx"),
+			path.join(CONTENT_DIR, first, `${restPath}.mdx`),
+		);
+	}
+
+	// 2. Try under src/content/docs/ with the full slug (handles most docs pages).
+	candidates.push(
+		path.join(CONTENT_DIR, "docs", bare, "index.mdx"),
+		path.join(CONTENT_DIR, "docs", `${bare}.mdx`),
+	);
+
 	for (const candidate of candidates) {
 		if (fs.existsSync(candidate)) return candidate;
 	}


### PR DESCRIPTION
### Summary

@kodster28: I seem to keep getting link validation issues when I'm using Opencode to write new content, and I found that scrolling through the log was kind of cumbersome. Open to a change like this that would create per line annotations of the link validation issues in the source?  

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
