### PR TITLE
docs(cloudflare-one): fix BYOPKI cert generation commands and clarify OIDC Claims selector scope

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
@@ -8,7 +8,7 @@ description: Configure the Cloudflare One Client to use a custom root certificat
   Cloudflare certificate.
 ---
 
-import { Render, Tabs, TabItem, APIRequest } from "~/components";
+import { Render, Tabs, TabItem, APIRequest, Details } from "~/components";
 
 :::note
 Only available on Enterprise plans.
@@ -28,14 +28,6 @@ If your users need to connect to self-signed origin servers, create an HTTP Allo
 
 ## Generate a custom root CA
 
-Before you generate a custom root CA, make sure you have [OpenSSL](https://www.openssl.org/) **1.1.1 or later** installed. The certificate generation command uses the `-addext` flag, which is not available in older versions.
-
-To check your OpenSSL version, run:
-
-```sh
-openssl version
-```
-
 1. Open a terminal.
 
 2. (Optional) Create a directory for the root CA and change into it.
@@ -53,7 +45,11 @@ openssl version
    openssl genrsa -out <CUSTOM-ROOT-PRIVATE-KEY>.pem 2048
    ```
 
-   The `2048` value specifies the RSA key size in bits. You can use `4096` for stronger security at the cost of slightly slower TLS handshakes. Keep this file secure — if it is compromised, an attacker could issue trusted certificates on your behalf.
+   The `2048` value specifies the RSA key size in bits. You can use `4096` for stronger security at the cost of slightly slower TLS handshakes.
+
+	 :::caution
+	 Keep the private key secure — if it is compromised, an attacker could issue trusted certificates on your behalf.
+	 :::
 
 4. Generate a self-signed root certificate.
 
@@ -70,8 +66,8 @@ openssl version
 
    The `-days 365` value controls certificate expiry. A shorter duration reduces risk if the key is compromised, but requires more frequent rotation. Rotating a deployed BYOPKI certificate is a disruptive operation, so choose an expiry that balances security with operational overhead.
 
-   :::note[OpenSSL older than 1.1.1]
-   If your system runs OpenSSL older than 1.1.1, the `-addext` flag is not available. Use a config file instead:
+   <Details header="Error: `Unknown cipher or option -addext`">
+   If your system runs OpenSSL versions older than 1.1.1, the `-addext` flag is not available. Use a config file instead:
 
    ```sh
    openssl req -x509 -sha256 -new -nodes \
@@ -81,40 +77,38 @@ openssl version
      -config <(printf '[req]\ndistinguished_name=dn\n[dn]\n[v3_ca]\nbasicConstraints=critical,CA:TRUE\nkeyUsage=critical,keyCertSign,cRLSign') \
      -extensions v3_ca
    ```
-   :::
+   </Details>
+
+5. Verify the required RFC 5280 extensions are present:
+
+	```sh
+	openssl x509 -in <CUSTOM-ROOT-CERT>.pem -noout -ext keyUsage,basicConstraints
+	```
+
+	The output should include:
+
+	```txt
+	X509v3 Basic Constraints: critical
+			CA:TRUE
+	X509v3 Key Usage: critical
+			Certificate Sign, CRL Sign
+	```
+
+	If these fields are missing, regenerate the certificate using the command in step 4.
+
+6. To review the private key, run the following command:
+
+	```sh
+	openssl rsa -in <CUSTOM-ROOT-PRIVATE-KEY>.pem -text
+	```
+
+	To review the certificate, run the following command:
+
+	```sh
+	openssl x509 -in <CUSTOM-ROOT-CERT>.pem -text
+	```
 
 When preparing your certificate and private key for upload, be sure to remove any unwanted characters, such as mismatching subdomains in the certificate's common name.
-
-To review the private key, run the following command:
-
-```sh
-openssl rsa -in <CUSTOM-ROOT-PRIVATE-KEY>.pem -text
-```
-
-To review the certificate, run the following command:
-
-```sh
-openssl x509 -in <CUSTOM-ROOT-CERT>.pem -text
-```
-
-:::tip
-Verify the required RFC 5280 extensions are present before uploading:
-
-```sh
-openssl x509 -in <CUSTOM-ROOT-CERT>.pem -noout -ext keyUsage,basicConstraints
-```
-
-The output should include:
-
-```txt
-X509v3 Basic Constraints: critical
-    CA:TRUE
-X509v3 Key Usage: critical
-    Certificate Sign, CRL Sign
-```
-
-If these fields are missing, regenerate the certificate using the command in step 4.
-:::
 
 ## Deploy a custom root certificate
 
@@ -233,12 +227,14 @@ When you upload a private key to Zero Trust, Cloudflare encrypts the key and sto
 
 To use a custom root certificate you generated and uploaded to Cloudflare, refer to [Activate a root certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/#activate-a-root-certificate).
 
-## Troubleshoot HTTP errors
+## Troubleshooting
 
-If Gateway returns an **HTTP Response Code: 526** after deploying a custom certificate, you can [troubleshoot errors with Gateway](/cloudflare-one/traffic-policies/troubleshooting/#error-526-invalid-ssl-certificate).
+### Error 526: Invalid SSL certificate
+
+If Gateway returns an **HTTP Response Code: 526** after deploying a custom certificate, refer to the [Error 526 documentation](/cloudflare-one/traffic-policies/troubleshooting/#error-526-invalid-ssl-certificate).
 
 ### Python 3.13+ SSL errors with the Cloudflare One Client
 
-Python 3.13 and later enable `ssl.VERIFY_X509_STRICT` by default, which requires CA certificates to comply with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280). If your BYOPKI certificate was generated without the `keyUsage` and `basicConstraints` extensions, Python HTTPS requests will fail when the Cloudflare One Client is active.
+Python 3.13 and later enable `ssl.VERIFY_X509_STRICT` by default, which requires CA certificates to comply with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280). If your BYOPKI certificate was generated without the `keyUsage` and `basicConstraints` extensions, Python HTTPS requests will fail when the Cloudflare One Client is active. To resolve the issue, [generate a new custom root CA](/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate/#generate-a-custom-root-ca) and upload it to Cloudflare.
 
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
@@ -241,4 +241,4 @@ If Gateway returns an **HTTP Response Code: 526** after deploying a custom certi
 
 Python 3.13 and later enable `ssl.VERIFY_X509_STRICT` by default, which requires CA certificates to comply with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280). If your BYOPKI certificate was generated without the `keyUsage` and `basicConstraints` extensions, Python HTTPS requests will fail when the Cloudflare One Client is active.
 
-To resolve this permanently, generate a new certificate using the updated command in step 4 and re-upload it.
+

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
@@ -32,12 +32,14 @@ Before you generate a custom root CA, make sure you have [OpenSSL](https://www.o
 
 1. Open a terminal.
 
-2. Create a directory for the root CA and change into it.
+2. (Optional) Create a directory for the root CA and change into it.
 
    ```sh
    mkdir -p /root/customca
    cd /root/customca
    ```
+
+   You can generate the certificate files in any directory. This step keeps things organized. If you skip it, files will be created in your current working directory.
 
 3. Generate a private key for the root CA.
 
@@ -45,13 +47,26 @@ Before you generate a custom root CA, make sure you have [OpenSSL](https://www.o
    openssl genrsa -out <CUSTOM-ROOT-PRIVATE-KEY>.pem 2048
    ```
 
+   The `2048` value specifies the RSA key size in bits. You can use `4096` for stronger security at the cost of slightly slower TLS handshakes. Keep this file secure — if it is compromised, an attacker could issue trusted certificates on your behalf.
+
 4. Generate a self-signed root certificate.
 
    ```sh
-   openssl req -x509 -sha256 -new -nodes -key <CUSTOM-ROOT-PRIVATE-KEY>.pem -days 365 -out <CUSTOM-ROOT-CERT>.pem
+   openssl req -x509 -sha256 -new -nodes \
+     -key <CUSTOM-ROOT-PRIVATE-KEY>.pem \
+     -days 365 \
+     -out <CUSTOM-ROOT-CERT>.pem \
+     -addext "basicConstraints=critical,CA:TRUE" \
+     -addext "keyUsage=critical,keyCertSign,cRLSign"
    ```
 
-When preparing your certificate and private key for upload, be sure to remove any unwanted characters, such as mismatching subdomains in the certificate's common name. To review the private key, run the following command:
+   The `-addext` flags add the `basicConstraints` and `keyUsage` extensions required by [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) for CA certificates. Without them, some TLS clients may reject certificates signed by your custom CA. In particular, Python 3.13 and later enforce strict RFC 5280 compliance by default (`ssl.VERIFY_X509_STRICT`), causing HTTPS requests to fail for devices using WARP when the uploaded CA does not include these extensions.
+
+   The `-days 365` value controls certificate expiry. A shorter duration reduces risk if the key is compromised, but requires more frequent rotation. Rotating a deployed BYOPKI certificate is a disruptive operation, so choose an expiry that balances security with operational overhead.
+
+When preparing your certificate and private key for upload, be sure to remove any unwanted characters, such as mismatching subdomains in the certificate's common name.
+
+To review the private key, run the following command:
 
 ```sh
 openssl rsa -in <CUSTOM-ROOT-PRIVATE-KEY>.pem -text
@@ -62,6 +77,23 @@ To review the certificate, run the following command:
 ```sh
 openssl x509 -in <CUSTOM-ROOT-CERT>.pem -text
 ```
+
+(Recommended) Verify the required RFC 5280 extensions are present before uploading:
+
+```sh
+openssl x509 -in <CUSTOM-ROOT-CERT>.pem -noout -ext keyUsage,basicConstraints
+```
+
+The output should include:
+
+```txt
+X509v3 Basic Constraints: critical
+    CA:TRUE
+X509v3 Key Usage: critical
+    Certificate Sign, CRL Sign
+```
+
+If these fields are missing, regenerate the certificate using the command in step 4.
 
 ## Deploy a custom root certificate
 
@@ -183,3 +215,21 @@ To use a custom root certificate you generated and uploaded to Cloudflare, refer
 ## Troubleshoot HTTP errors
 
 If Gateway returns an **HTTP Response Code: 526** after deploying a custom certificate, you can [troubleshoot errors with Gateway](/cloudflare-one/traffic-policies/troubleshooting/#error-526-invalid-ssl-certificate).
+
+### Python 3.13+ SSL errors with WARP
+
+Python 3.13 and later enable `ssl.VERIFY_X509_STRICT` by default, which requires CA certificates to comply with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280). If your BYOPKI certificate was generated without the `keyUsage` and `basicConstraints` extensions, Python HTTPS requests will fail when WARP is active.
+
+To resolve this permanently, generate a new certificate using the updated command in step 4 and re-upload it.
+
+If rotating the certificate is not immediately feasible, users can work around the issue by disabling strict verification in their Python code:
+
+```python
+import ssl
+ctx = ssl.create_default_context()
+ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+```
+
+:::note
+This workaround must be applied to every Python script or library that opens SSL connections. It is not a global setting.
+:::

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
@@ -66,7 +66,7 @@ openssl version
      -addext "keyUsage=critical,keyCertSign,cRLSign"
    ```
 
-   The `-addext` flags add the `basicConstraints` and `keyUsage` extensions required by [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) for CA certificates. Without them, some TLS clients may reject certificates signed by your custom CA. In particular, Python 3.13 and later enforce strict RFC 5280 compliance by default (`ssl.VERIFY_X509_STRICT`), causing HTTPS requests to fail for devices using WARP when the uploaded CA does not include these extensions.
+   The `-addext` flags add the `basicConstraints` and `keyUsage` extensions required by [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) for CA certificates. Without them, some TLS clients may reject certificates signed by your custom CA. In particular, Python 3.13 and later enforce strict RFC 5280 compliance by default (`ssl.VERIFY_X509_STRICT`), causing HTTPS requests to fail for devices using the Cloudflare One Client when the uploaded CA does not include these extensions.
 
    The `-days 365` value controls certificate expiry. A shorter duration reduces risk if the key is compromised, but requires more frequent rotation. Rotating a deployed BYOPKI certificate is a disruptive operation, so choose an expiry that balances security with operational overhead.
 
@@ -237,9 +237,9 @@ To use a custom root certificate you generated and uploaded to Cloudflare, refer
 
 If Gateway returns an **HTTP Response Code: 526** after deploying a custom certificate, you can [troubleshoot errors with Gateway](/cloudflare-one/traffic-policies/troubleshooting/#error-526-invalid-ssl-certificate).
 
-### Python 3.13+ SSL errors with WARP
+### Python 3.13+ SSL errors with the Cloudflare One Client
 
-Python 3.13 and later enable `ssl.VERIFY_X509_STRICT` by default, which requires CA certificates to comply with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280). If your BYOPKI certificate was generated without the `keyUsage` and `basicConstraints` extensions, Python HTTPS requests will fail when WARP is active.
+Python 3.13 and later enable `ssl.VERIFY_X509_STRICT` by default, which requires CA certificates to comply with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280). If your BYOPKI certificate was generated without the `keyUsage` and `basicConstraints` extensions, Python HTTPS requests will fail when the Cloudflare One Client is active.
 
 To resolve this permanently, generate a new certificate using the updated command in step 4 and re-upload it.
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
@@ -242,22 +242,3 @@ If Gateway returns an **HTTP Response Code: 526** after deploying a custom certi
 Python 3.13 and later enable `ssl.VERIFY_X509_STRICT` by default, which requires CA certificates to comply with [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280). If your BYOPKI certificate was generated without the `keyUsage` and `basicConstraints` extensions, Python HTTPS requests will fail when the Cloudflare One Client is active.
 
 To resolve this permanently, generate a new certificate using the updated command in step 4 and re-upload it.
-
-If rotating the certificate is not immediately feasible, users can work around the issue by disabling strict verification in their Python code:
-
-```python
-import ssl
-import urllib.request
-
-ctx = ssl.create_default_context()
-ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
-
-# Pass the context to your HTTP call, for example:
-urllib.request.urlopen("https://example.com", context=ctx)
-```
-
-For third-party libraries, pass the context using their SSL configuration option — for example, `httpx.Client(verify=ctx)` or `requests` via a custom `HTTPAdapter`.
-
-:::note
-This workaround must be applied to every Python script or library that opens SSL connections. It is not a global setting.
-:::

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx
@@ -28,7 +28,13 @@ If your users need to connect to self-signed origin servers, create an HTTP Allo
 
 ## Generate a custom root CA
 
-Before you generate a custom root CA, make sure you have [OpenSSL](https://www.openssl.org/) installed.
+Before you generate a custom root CA, make sure you have [OpenSSL](https://www.openssl.org/) **1.1.1 or later** installed. The certificate generation command uses the `-addext` flag, which is not available in older versions.
+
+To check your OpenSSL version, run:
+
+```sh
+openssl version
+```
 
 1. Open a terminal.
 
@@ -64,6 +70,19 @@ Before you generate a custom root CA, make sure you have [OpenSSL](https://www.o
 
    The `-days 365` value controls certificate expiry. A shorter duration reduces risk if the key is compromised, but requires more frequent rotation. Rotating a deployed BYOPKI certificate is a disruptive operation, so choose an expiry that balances security with operational overhead.
 
+   :::note[OpenSSL older than 1.1.1]
+   If your system runs OpenSSL older than 1.1.1, the `-addext` flag is not available. Use a config file instead:
+
+   ```sh
+   openssl req -x509 -sha256 -new -nodes \
+     -key <CUSTOM-ROOT-PRIVATE-KEY>.pem \
+     -days 365 \
+     -out <CUSTOM-ROOT-CERT>.pem \
+     -config <(printf '[req]\ndistinguished_name=dn\n[dn]\n[v3_ca]\nbasicConstraints=critical,CA:TRUE\nkeyUsage=critical,keyCertSign,cRLSign') \
+     -extensions v3_ca
+   ```
+   :::
+
 When preparing your certificate and private key for upload, be sure to remove any unwanted characters, such as mismatching subdomains in the certificate's common name.
 
 To review the private key, run the following command:
@@ -78,7 +97,8 @@ To review the certificate, run the following command:
 openssl x509 -in <CUSTOM-ROOT-CERT>.pem -text
 ```
 
-(Recommended) Verify the required RFC 5280 extensions are present before uploading:
+:::tip
+Verify the required RFC 5280 extensions are present before uploading:
 
 ```sh
 openssl x509 -in <CUSTOM-ROOT-CERT>.pem -noout -ext keyUsage,basicConstraints
@@ -94,6 +114,7 @@ X509v3 Key Usage: critical
 ```
 
 If these fields are missing, regenerate the certificate using the command in step 4.
+:::
 
 ## Deploy a custom root certificate
 
@@ -226,9 +247,16 @@ If rotating the certificate is not immediately feasible, users can work around t
 
 ```python
 import ssl
+import urllib.request
+
 ctx = ssl.create_default_context()
 ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+
+# Pass the context to your HTTP call, for example:
+urllib.request.urlopen("https://example.com", context=ctx)
 ```
+
+For third-party libraries, pass the context using their SSL configuration option — for example, `httpx.Client(verify=ctx)` or `requests` via a custom `HTTPAdapter`.
 
 :::note
 This workaround must be applied to every Python script or library that opens SSL connections. It is not a global setting.

--- a/src/content/docs/cloudflare-one/traffic-policies/identity-selectors.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/identity-selectors.mdx
@@ -44,6 +44,10 @@ Gateway will automatically detect changes in user name, title, and group members
 
 Specify a value from a [custom OIDC claim](/cloudflare-one/integrations/identity-providers/generic-oidc/#custom-oidc-claims) configured on your identity provider.
 
+:::note
+This selector is only available for the [Generic OIDC](/cloudflare-one/integrations/identity-providers/generic-oidc/) identity provider integration. Named OIDC providers such as Okta and Microsoft Entra ID do not support custom OIDC claims in Gateway policies — use the [User Group Names](#user-group-names) or [User Group IDs](#user-group-ids) selectors for those providers instead.
+:::
+
 <Render file="gateway/selectors/oidc-claims" product="cloudflare-one" />
 
 ### SAML Attributes


### PR DESCRIPTION
## Summary

- **Fix `openssl` command for BYOPKI cert generation** — the existing `openssl req -x509` command did not include the `basicConstraints` and `keyUsage` extensions required by RFC 5280 for CA certificates. Python 3.13+ enables `ssl.VERIFY_X509_STRICT` by default, which enforces RFC 5280 compliance, causing HTTPS requests to silently fail for devices using the Cloudflare One Client with a custom certificate generated from the current docs.
- **Add optional/impact annotations** to the generate steps — calls out which steps are optional (directory creation), and adds context on key size and certificate expiry tradeoffs.
- **Add a validation step** to verify RFC 5280 extensions are present before uploading.
- **Add a troubleshooting section** for Python 3.13+ SSL errors with the Cloudflare One Client, including a temporary workaround for users who cannot immediately rotate their certificate.
- **Clarify OIDC Claims selector scope** — adds a note that the OIDC Claims Gateway selector is only available for the Generic OIDC integration, not named OIDC providers like Okta or Microsoft Entra ID.

## Files changed

- `src/content/docs/cloudflare-one/team-and-resources/devices/user-side-certificates/custom-certificate.mdx`
- `src/content/docs/cloudflare-one/traffic-policies/identity-selectors.mdx`