### PR TITLE
Document _dc-mx DNS records and improve email troubleshooting

### DIFF
--- a/src/content/docs/dns/manage-dns-records/troubleshooting/unexpected-dns-records.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/unexpected-dns-records.mdx
@@ -50,13 +50,13 @@ If you want to remove these records:
 
 ---
 
-## dc-##### and \_dc-mx subdomains
+## \_dc-mx and dc-##### subdomains
 
 You notice a `_dc-mx` or `dc-#####` subdomain that you did not create (for example, `_dc-mx.a1b2c3d4e5f6.example.com`). This response does not appear in your Cloudflare DNS records table, but will appear in `dig` responses.
 
 ### Cause
 
-When your `SRV` or `MX` record resolves to a domain configured to [proxy](/dns/proxy-status/) through Cloudflare, Cloudflare dynamically inserts a record into DNS responses that resolves to the origin IP address. This record is added at query time to ensure that mail or service traffic bypasses the Cloudflare proxy and reaches your server directly.
+When your `MX` or `SRV` record resolves to a domain configured to [proxy](/dns/proxy-status/) through Cloudflare, Cloudflare dynamically inserts a record into DNS responses that resolves to the origin IP address. This record is added at query time to ensure that mail or service traffic bypasses the Cloudflare proxy and reaches your server directly.
 
 The prefix of the auto-generated record depends on the record type that triggered it:
 

--- a/src/content/docs/dns/manage-dns-records/troubleshooting/unexpected-dns-records.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/unexpected-dns-records.mdx
@@ -52,16 +52,16 @@ If you want to remove these records:
 
 ## dc-##### and \_dc-mx subdomains
 
-You notice a `_dc-mx` or `dc-#####` subdomain in your DNS records that you did not create (for example, `_dc-mx.a1b2c3d4e5f6.example.com`).
+You notice a `_dc-mx` or `dc-#####` subdomain that you did not create (for example, `_dc-mx.a1b2c3d4e5f6.example.com`). This response does not appear in your Cloudflare DNS records table, but will appear in `dig` responses.
 
 ### Cause
 
-When your `SRV` or `MX` record resolves to a domain configured to [proxy](/dns/proxy-status/) through Cloudflare, Cloudflare automatically creates a DNS record that resolves to the origin IP address. This record ensures that mail or service traffic bypasses the Cloudflare proxy and reaches your server directly, while the proxy continues to work for all other traffic.
+When your `SRV` or `MX` record resolves to a domain configured to [proxy](/dns/proxy-status/) through Cloudflare, Cloudflare dynamically inserts a record into DNS responses that resolves to the origin IP address. This record is added at query time to ensure that mail or service traffic bypasses the Cloudflare proxy and reaches your server directly.
 
 The prefix of the auto-generated record depends on the record type that triggered it:
 
-- **MX records:** Cloudflare creates a record with the `_dc-mx` prefix (for example, `_dc-mx.a1b2c3d4e5f6.example.com`).
-- **SRV records:** Cloudflare creates a record with the `dc-` prefix (for example, `dc-a1b2c3d4e5f6.example.com`).
+- **MX records:** Cloudflare inserts a record with the `_dc-mx` prefix (for example, `_dc-mx.a1b2c3d4e5f6.example.com`).
+- **SRV records:** Cloudflare inserts a record with the `dc-` prefix (for example, `dc-a1b2c3d4e5f6.example.com`).
 
 #### How \_dc-mx records work
 
@@ -77,7 +77,7 @@ After using Cloudflare and proxying the `A` record, Cloudflare provides DNS resp
 
 `example.com A 203.0.113.1`
 
-Since proxying mail traffic through Cloudflare would break your mail services, Cloudflare detects this situation and creates a `_dc-mx` record:
+Since proxying mail traffic through Cloudflare would break your mail services, Cloudflare detects this situation and dynamically inserts a `_dc-mx` record into DNS responses:
 
 `example.com MX _dc-mx.a1b2c3d4e5f6.example.com`
 
@@ -107,9 +107,9 @@ dig _dc-mx.a1b2c3d4e5f6.example.com a +short
 
 ### Solution
 
-These records are safe to leave in place — they ensure your mail traffic reaches your server correctly. Do not delete them directly, as Cloudflare will recreate them.
+These records are safe — they ensure your mail traffic reaches your server correctly.
 
-If you want to remove a `_dc-mx` or `dc-#####` record, you must address the underlying proxy conflict:
+If you want to avoid a `_dc-mx` or `dc-#####` response, you must address the underlying proxy conflict:
 
 - If no mail is received for the domain, delete the `MX` record.
 - If mail is received for the domain, update the `MX` record to resolve to a separate `A` record for a mail subdomain that is not proxied by Cloudflare:

--- a/src/content/docs/dns/manage-dns-records/troubleshooting/unexpected-dns-records.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/unexpected-dns-records.mdx
@@ -50,6 +50,83 @@ If you want to remove these records:
 
 ---
 
+## dc-##### and \_dc-mx subdomains
+
+You notice a `_dc-mx` or `dc-#####` subdomain in your DNS records that you did not create (for example, `_dc-mx.a1b2c3d4e5f6.example.com`).
+
+### Cause
+
+When your `SRV` or `MX` record resolves to a domain configured to [proxy](/dns/proxy-status/) through Cloudflare, Cloudflare automatically creates a DNS record that resolves to the origin IP address. This record ensures that mail or service traffic bypasses the Cloudflare proxy and reaches your server directly, while the proxy continues to work for all other traffic.
+
+The prefix of the auto-generated record depends on the record type that triggered it:
+
+- **MX records:** Cloudflare creates a record with the `_dc-mx` prefix (for example, `_dc-mx.a1b2c3d4e5f6.example.com`).
+- **SRV records:** Cloudflare creates a record with the `dc-` prefix (for example, `dc-a1b2c3d4e5f6.example.com`).
+
+#### How \_dc-mx records work
+
+Before using Cloudflare, suppose your DNS records for mail are as follows:
+
+`example.com MX example.com`
+
+`example.com A 192.0.2.1`
+
+After using Cloudflare and proxying the `A` record, Cloudflare provides DNS responses with a [Cloudflare IP address](/fundamentals/concepts/cloudflare-ip-addresses/) (`203.0.113.1` in the example below):
+
+`example.com MX example.com`
+
+`example.com A 203.0.113.1`
+
+Since proxying mail traffic through Cloudflare would break your mail services, Cloudflare detects this situation and creates a `_dc-mx` record:
+
+`example.com MX _dc-mx.a1b2c3d4e5f6.example.com`
+
+`_dc-mx.a1b2c3d4e5f6.example.com A 192.0.2.1`
+
+`example.com A 203.0.113.1`
+
+You can verify this behavior by querying your domain's MX records (replace `example.com` with your domain):
+
+```sh
+dig example.com mx +short
+```
+
+```sh output
+100 _dc-mx.a1b2c3d4e5f6.example.com.
+```
+
+The `_dc-mx` record resolves directly to your origin IP:
+
+```sh
+dig _dc-mx.a1b2c3d4e5f6.example.com a +short
+```
+
+```sh output
+192.0.2.1
+```
+
+### Solution
+
+These records are safe to leave in place — they ensure your mail traffic reaches your server correctly. Do not delete them directly, as Cloudflare will recreate them.
+
+If you want to remove a `_dc-mx` or `dc-#####` record, you must address the underlying proxy conflict:
+
+- If no mail is received for the domain, delete the `MX` record.
+- If mail is received for the domain, update the `MX` record to resolve to a separate `A` record for a mail subdomain that is not proxied by Cloudflare:
+
+  `example.com MX mail.example.com`
+
+  `mail.example.com A 192.0.2.1`
+
+  `example.com A 203.0.113.1`
+
+:::caution
+
+If your mail server resides on the same IP as your web server, your MX record will expose your origin IP address, since it is not hidden behind the Cloudflare proxy.
+:::
+
+---
+
 ## Incorrect results for DNS queries
 
 You notice DNS queries returning incorrect results even after you waited for the [TTL](/dns/manage-dns-records/reference/ttl/) to expire.

--- a/src/content/docs/dns/troubleshooting/email-issues.mdx
+++ b/src/content/docs/dns/troubleshooting/email-issues.mdx
@@ -29,7 +29,7 @@ This returns a list of mail servers for your domain. Compare the output to the M
 
 If the mail server listed does not match your email provider's expected value, update the MX record content to the correct value. Check your email provider's setup documentation for the correct MX record values.
 
-If your DNS query returns records you do not recognize, such as `_dc-mx` or `dc-#####` subdomains, refer to [Unexpected DNS records](/dns/manage-dns-records/troubleshooting/unexpected-dns-records/#dc--and-_dc-mx-subdomains).
+If your DNS query returns records you do not recognize, such as `_dc-mx` or `dc-#####` subdomains, refer to [Unexpected DNS records](/dns/manage-dns-records/troubleshooting/unexpected-dns-records/#_dc-mx-and-dc--subdomains).
 
 ## Are DNS records missing?
 
@@ -51,7 +51,7 @@ Refer to [Set up email records](/dns/manage-dns-records/how-to/email-records/) t
 
 Some email providers require `CNAME` records for features like DKIM authentication or autodiscover. When [CNAME flattening](/dns/cname-flattening/) is turned on — either globally for all `CNAME` records or individually on a specific record — the `CNAME` is flattened to an `A` record, which can prevent email providers from reading the record correctly.
 
-If your email provider requires `CNAME` records and those records are not resolving as expected, [CNAME flattening](/dns/cname-flattening/set-up-cname-flattening/) may need to be turned off.
+If your email provider requires `CNAME` records and those records are not resolving as expected, you may need to turn off [CNAME flattening](/dns/cname-flattening/set-up-cname-flattening/).
 
 ## Is your mail hostname proxied?
 
@@ -67,7 +67,10 @@ Common examples include:
 
 To fix this issue:
 
-1. Go to **DNS** > **Records**.
+1. Go to the **DNS Records** page.
+
+   <DashButton url="/?to=/:account/:zone/dns/records" />
+
 2. Locate the mail-related hostname.
 3. Change the [proxy status](/dns/proxy-status/) to **DNS only**.
 
@@ -90,7 +93,7 @@ Always confirm the exact values with your provider before making changes.
 
 ## Is Cloudflare Spectrum turned on?
 
-Cloudflare does not proxy email traffic (SMTP, port 25) by default. Unless you have explicitly configured [Cloudflare Spectrum](/spectrum/reference/configuration-options#smtp) to proxy SMTP traffic, email is delivered directly to your mail server and does not pass through the Cloudflare network. DNS records used for email should be set to [DNS-only](/dns/proxy-status/) to ensure mail traffic is not affected by the proxy.
+Cloudflare does not proxy email traffic (SMTP, port 25) by default. Unless you have explicitly configured [Cloudflare Spectrum](/spectrum/reference/configuration-options#smtp) to proxy SMTP traffic, email is delivered directly to your mail server and does not pass through the Cloudflare network. DNS records used for email should be set to [DNS only](/dns/proxy-status/) to ensure mail traffic is not affected by the proxy.
 
 <DashButton url="/?to=/:account/:zone/spectrum" />
 

--- a/src/content/docs/dns/troubleshooting/email-issues.mdx
+++ b/src/content/docs/dns/troubleshooting/email-issues.mdx
@@ -9,31 +9,49 @@ sidebar:
   order: 6
 ---
 
-import { Render } from "~/components";
+import { DashButton, Render } from "~/components";
 
 If you have issues sending or receiving mail, follow these troubleshooting steps.
 
 ## Are your records correct?
 
-Consult with your mail administrator or mail provider to ensure you have valid DNS record content.
+To check that your MX records are resolving correctly, run the following `dig` command in your terminal (replace `example.com` with your domain):
+
+```sh
+dig example.com mx +short
+```
+
+Alternatively, you can use a third-party tool to look up your MX records. For a list of options, refer to [Recommended third-party tools](/dns/reference/recommended-third-party-tools/).
+
+This returns a list of mail servers for your domain. Compare the output to the MX records on your Cloudflare DNS records page.
+
+<DashButton url="/?to=/:account/:zone/dns/records" />
+
+If the mail server listed does not match your email provider's expected value, update the MX record content to the correct value. Check your email provider's setup documentation for the correct MX record values.
+
+If your DNS query returns records you do not recognize, such as `_dc-mx` or `dc-#####` subdomains, refer to [Unexpected DNS records](/dns/manage-dns-records/troubleshooting/unexpected-dns-records/#dc--and-_dc-mx-subdomains).
 
 ## Are DNS records missing?
 
-Contact your mail administrator to confirm the DNS records for your domain are correct. Refer to our guide on [managing DNS records in Cloudflare](/dns/manage-dns-records/how-to/create-dns-records) if you need assistance to add or edit DNS records.
+If `dig` returns no results for your domain's MX records, your records may not have been created or may have been accidentally deleted.
 
-## Do you have NS records configured?
+Even if your MX records are correct, missing email authentication records can cause delivery failures:
 
-NS records are used to delegate the management of a hostname to another DNS provider (refer to [Delegate a subdomain (outgoing)](/dns/manage-dns-records/how-to/subdomains-outside-cloudflare/#delegate-a-subdomain-outgoing) for further context). If you have NS records configured on your DNS records table, confirm that these are expected and not generating conflicts.
+- **Missing `SPF` record:** receiving servers cannot verify that your domain authorizes the sending server, which may cause messages to be rejected or marked as spam.
+- **Missing `DKIM` record:** messages cannot be cryptographically verified as originating from your domain, which reduces trust with receiving servers.
+- **Missing `DMARC` record:** receiving servers have no policy for handling messages that fail `SPF` or `DKIM` checks, which can lead to inconsistent delivery or spoofing of your domain.
 
-## Do you have CNAME flattening enabled?
+Refer to [Set up email records](/dns/manage-dns-records/how-to/email-records/) to add missing records.
 
-When [**CNAME flattening for all CNAME records**](/dns/cname-flattening/set-up-cname-flattening/) is on, queries to all `CNAME` records will flatten to an `A` record; no `CNAME` records will be returned.
+## Do your MX records point to a delegated subdomain?
 
-Also, if `CNAME` records are not returned by the queried nameserver (sometimes nameservers will return `TXT` records), this may result in nothing being returned when **CNAME flattening for all CNAME records** is on. Turning off this feature should fix any issues with your `CNAME` records not being returned.
+`NS` records [delegate a subdomain](/dns/manage-dns-records/how-to/subdomains-outside-cloudflare/#delegate-a-subdomain-outgoing) to another DNS provider. If your MX record points to a subdomain that is delegated via `NS` records (for example, `mail.example.com`), the mail server records are managed by that external provider, not Cloudflare. Confirm that the external provider has the correct `A` or `AAAA` records for the mail subdomain.
 
-## Is Cloudflare Spectrum enabled on your account?
+## Is CNAME flattening turned on?
 
-Cloudflare does not proxy traffic on port 25 (SMTP) unless [Cloudflare Spectrum](/spectrum/reference/configuration-options#smtp) is turned on and configured to proxy email traffic across Cloudflare. If you do not have Spectrum turned on, then no email traffic (SMTP) passes through Cloudflare, and Cloudflare only resolves the DNS. This also means that any DNS record used to send email traffic must be DNS-only to bypass the Cloudflare network. For more information, refer to [Identifying subdomains compatible with Cloudflare's proxy](/dns/proxy-status/).
+Some email providers require `CNAME` records for features like DKIM authentication or autodiscover. When [CNAME flattening](/dns/cname-flattening/) is turned on — either globally for all `CNAME` records or individually on a specific record — the `CNAME` is flattened to an `A` record, which can prevent email providers from reading the record correctly.
+
+If your email provider requires `CNAME` records and those records are not resolving as expected, [CNAME flattening](/dns/cname-flattening/set-up-cname-flattening/) may need to be turned off.
 
 ## Is your mail hostname proxied?
 
@@ -70,55 +88,30 @@ Common examples include:
 
 Always confirm the exact values with your provider before making changes.
 
-## Contact your mail provider for assistance
+## Is Cloudflare Spectrum turned on?
 
-If your email does not work shortly after editing DNS records, contact your mail administrator or mail provider for further assistance in troubleshooting so that data about the issue can be provided to Cloudflare support.
+Cloudflare does not proxy email traffic (SMTP, port 25) by default. Unless you have explicitly configured [Cloudflare Spectrum](/spectrum/reference/configuration-options#smtp) to proxy SMTP traffic, email is delivered directly to your mail server and does not pass through the Cloudflare network. DNS records used for email should be set to [DNS-only](/dns/proxy-status/) to ensure mail traffic is not affected by the proxy.
 
-## dc-######### subdomain
+<DashButton url="/?to=/:account/:zone/spectrum" />
 
-The dc-##### subdomain is added to overcome a conflict created when your `SRV` or `MX` record resolves to a domain configured to [proxy](/dns/proxy-status/) to Cloudflare.
+## Is Email Routing turned on?
 
-Therefore, Cloudflare will create a `dc-#####` DNS record that resolves to the origin IP address. The `dc-#####` record ensures that traffic for your `MX` or `SRV` record is not proxied (it directly resolves to your origin IP) while the Cloudflare proxy works for all other traffic.
+If [Email Routing](/email-routing/) is turned on, Cloudflare manages your MX records and may create additional DNS records automatically.
 
-For example, before using Cloudflare, suppose your DNS records for mail are as follows:
+<DashButton url="/?to=/:account/:zone/email/routing" />
 
-`example.com MX example.com`
-
-`example.com A 192.0.2.1`
-
-After using Cloudflare and proxying the `A` record, Cloudflare will provide DNS responses with a Cloudflare IP (`203.0.113.1` in the example below):
-
-`example.com MX example.com`
-
-`example.com A 203.0.113.1`
-
-Since proxying mail traffic to Cloudflare would break your mail services, Cloudflare detects this situation and creates a `dc-#####` record:
-
-`example.com MX dc-1234abcd.example.com`
-
-`dc-1234abcd.example.com A 192.0.2.1`
-
-`example.com A 203.0.113.1`
-
-Removing the `dc-######` record is only possible via one of these methods:
-
-- If no mail is received for the domain, delete the `MX` record.
-- If mail is received for the domain, update the `MX` record to resolve to a separate `A` record for a mail subdomain that is not proxied by Cloudflare:
-
-   `example.com MX mail.example.com`
-
-   `mail.example.com A 192.0.2.1`
-
-   `example.com A 203.0.113.1`
-
-:::caution
-
-If your mail server resides on the same IP as your web server, your MX
-record will expose your origin IP address.
-:::
+If Email Routing is turned on but you use a different mail provider, the Email Routing MX records may conflict with your provider's records. You can [turn off Email Routing](/email-routing/setup/disable-email-routing/) to remove the managed records and configure your own.
 
 ---
 
 ## Best practices for MX records on Cloudflare
 
 <Render file="email-record-origin-ip" product="learning-paths" />
+
+---
+
+## Contact your mail provider for assistance
+
+If your email does not work shortly after editing DNS records, contact your mail administrator or mail provider with the specific error or bounce message you are receiving. They can confirm whether the issue is with DNS resolution, mail server configuration, or message delivery.
+
+If your provider confirms the issue is related to Cloudflare, [contact Cloudflare support](/support/contacting-cloudflare-support/).

--- a/src/content/docs/email-routing/setup/email-routing-dns-records.mdx
+++ b/src/content/docs/email-routing/setup/email-routing-dns-records.mdx
@@ -38,4 +38,4 @@ If you are having trouble with your account's DNS records, refer to the [Trouble
 
 If you see a DNS response with a `_dc-mx` prefix (for example, `_dc-mx.a1b2c3d4e5f6.example.com`), Cloudflare inserted it automatically. This response appears when your `MX` record points to a hostname that is [proxied](/dns/proxy-status/) through Cloudflare. The `_dc-mx` target itself resolves directly to your origin IP address so that mail traffic bypasses the proxy and reaches your mail server.
 
-For more information, refer to [dc-##### and _dc-mx subdomains](/dns/manage-dns-records/troubleshooting/unexpected-dns-records/#dc--and-_dc-mx-subdomains).
+For more information, refer to [_dc-mx and dc-##### subdomains](/dns/manage-dns-records/troubleshooting/unexpected-dns-records/#dc--and-_dc-mx-subdomains).

--- a/src/content/docs/email-routing/setup/email-routing-dns-records.mdx
+++ b/src/content/docs/email-routing/setup/email-routing-dns-records.mdx
@@ -33,3 +33,9 @@ Depending on your zone configuration, you might have your DNS records unlocked. 
 Select **View DNS records** for a list of the required `MX` and sender policy framework (SPF) records Email Routing is using.
 
 If you are having trouble with your account's DNS records, refer to the [Troubleshooting](/email-routing/troubleshooting/) section.
+
+## _dc-mx records
+
+If you see a DNS record with a `_dc-mx` prefix (for example, `_dc-mx.a1b2c3d4e5f6.example.com`), Cloudflare created it automatically. This record appears when your `MX` record points to a hostname that is [proxied](/dns/proxy-status/) through Cloudflare. The `_dc-mx` record resolves directly to your origin IP address so that mail traffic bypasses the proxy and reaches your mail server.
+
+For more information, refer to [dc-##### and _dc-mx subdomains](/dns/manage-dns-records/troubleshooting/unexpected-dns-records/#dc--and-_dc-mx-subdomains).

--- a/src/content/docs/email-routing/setup/email-routing-dns-records.mdx
+++ b/src/content/docs/email-routing/setup/email-routing-dns-records.mdx
@@ -34,8 +34,8 @@ Select **View DNS records** for a list of the required `MX` and sender policy fr
 
 If you are having trouble with your account's DNS records, refer to the [Troubleshooting](/email-routing/troubleshooting/) section.
 
-## _dc-mx records
+## _dc-mx DNS responses
 
-If you see a DNS record with a `_dc-mx` prefix (for example, `_dc-mx.a1b2c3d4e5f6.example.com`), Cloudflare created it automatically. This record appears when your `MX` record points to a hostname that is [proxied](/dns/proxy-status/) through Cloudflare. The `_dc-mx` record resolves directly to your origin IP address so that mail traffic bypasses the proxy and reaches your mail server.
+If you see a DNS response with a `_dc-mx` prefix (for example, `_dc-mx.a1b2c3d4e5f6.example.com`), Cloudflare inserted it automatically. This response appears when your `MX` record points to a hostname that is [proxied](/dns/proxy-status/) through Cloudflare. The `_dc-mx` target itself resolves directly to your origin IP address so that mail traffic bypasses the proxy and reaches your mail server.
 
 For more information, refer to [dc-##### and _dc-mx subdomains](/dns/manage-dns-records/troubleshooting/unexpected-dns-records/#dc--and-_dc-mx-subdomains).


### PR DESCRIPTION
## Summary

- Documents `_dc-mx` records — what they are and why Cloudflare creates them. Adds to the [Unexpected DNS records](/dns/manage-dns-records/troubleshooting/unexpected-dns-records/) page and cross-references from [Email Routing DNS records](/email-routing/setup/email-routing-dns-records/) and [Email issues troubleshooting](/dns/troubleshooting/email-issues/). 
- Rewrites the [Email issues troubleshooting](/dns/troubleshooting/email-issues/) page with actionable diagnostic steps, DashButton links, and specific guidance for common email DNS issues.