### PR TITLE
[Workers] Added Traceway to OpenTelemetry data exporting section

### DIFF
--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
@@ -32,6 +32,7 @@ Below are common OTLP endpoint formats for popular observability providers. Refe
 | [**Datadog**](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/)              | Coming soon, pending release from Datadog                    | `https://otlp.{SITE}.datadoghq.com/v1/logs`                  |
 | [**Splunk Observability**](https://dev.splunk.com/observability/reference/api/ingest_data/latest) | `https://ingest.{REALM}.signalfx.com/v2/trace/otlp` | N/A |
 | [**Splunk Platform**](https://github.com/splunk/splunk-connect-for-otlp) | `http://splunk.internal:4318/v1/traces` | `http://splunk.internal:4318/v1/logs` |
+| [**Traceway**](https://docs.tracewayapp.com/client/cloudflare) | `https://cloud.tracewayapp.com/api/otel/v1/traces` | N/A |
 
 :::note[Authentication]
 Most providers require authentication headers. Refer to your provider's documentation for specific authentication requirements.


### PR DESCRIPTION
### Summary

Added Traceway as an OpenTelemetry-compatible tracing provider to the data exporting section.

### Screenshots (optional)

N/A — single-line addition. 

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/). 