### PR TITLE
fix: select first non-disabled framework instead of first framework

### DIFF
--- a/src/components/realtimekit/RTKSDKSelector/RTKSDKSelector.tsx
+++ b/src/components/realtimekit/RTKSDKSelector/RTKSDKSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import {
 	useFramework,
 	type Platform,
@@ -82,6 +82,21 @@ export default function SDKSelector({ disabledPlatforms }: SDKSelectorProps) {
 		return subPlatform ? isPlatformDisabled(subPlatform) : false;
 	};
 
+	// Auto-select the first enabled framework when the current one is disabled
+	useEffect(() => {
+		if (!framework) return;
+		if (!isFrameworkDisabled(framework)) return;
+
+		const availableFrameworks =
+			platform === "web" ? webFrameworks : mobileFrameworks;
+		const firstEnabled = availableFrameworks.find(
+			(fw) => !isFrameworkDisabled(fw),
+		);
+		if (firstEnabled) {
+			setSelection(platform, firstEnabled);
+		}
+	}, [platform, framework, disabledPlatforms]);
+
 	const isWebPlatformDisabled = () => {
 		if (isPlatformDisabled("web")) return true;
 
@@ -132,10 +147,13 @@ export default function SDKSelector({ disabledPlatforms }: SDKSelectorProps) {
 								onClick={() => {
 									if (disabled) return;
 									const nextPlatform = p.id;
+									const candidates =
+										nextPlatform === "web" ? webFrameworks : mobileFrameworks;
 									const nextFramework =
-										nextPlatform === "web"
-											? webFrameworks[0]
-											: mobileFrameworks[0];
+										candidates.find((fw) => {
+											const sub = frameworkToPlatform[fw.id];
+											return sub ? !disabledPlatforms?.includes(sub) : true;
+										}) ?? candidates[0];
 
 									setSelection(nextPlatform, nextFramework);
 								}}


### PR DESCRIPTION
### Summary
Previously, switching platforms always picked the first framework (`webFrameworks[0]` or `mobileFrameworks[0]`). Now it finds the first non-disabled framework.
<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)
<img width="757" height="138" alt="image" src="https://github.com/user-attachments/assets/a65fed7b-1d85-42ef-a29c-cb38acc6c758" />


<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
