### PR TITLE
Improve llms.txt documentation and sidebar LLM Resources

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -7,8 +7,11 @@
 /_astro/*
 	Cache-Control: public, max-age=604800, immutable
 
+/*/llms.txt:
+  Content-Type: text/plain; charset=utf-8
+
 /*/llms-full.txt:
-  Content-Type: text/markdown; charset=utf-8
+  Content-Type: text/plain; charset=utf-8
 
 /*/index.md:
   Content-Type: text/markdown; charset=utf-8

--- a/src/components/AgentDirective.astro
+++ b/src/components/AgentDirective.astro
@@ -34,7 +34,8 @@ const directive = [
 
 <style>
 	/* Visually hidden from human readers but present in DOM for AI agents.
-	   Uses clip-rect (not display:none) so the element remains accessible to agents fetching raw HTML. */
+	   Uses clip-rect (not display:none) so the element remains accessible to agents fetching raw HTML.
+		 Is currently hidden from markdown for agents because we include it in an html <header /> */
 	.agent-directive {
 		position: absolute;
 		width: 1px;

--- a/src/content/docs/workers/get-started/prompting.mdx
+++ b/src/content/docs/workers/get-started/prompting.mdx
@@ -86,7 +86,11 @@ Depending on the model and user prompt, it may generate invalid code, configurat
 
 AI-enabled editors, including Cursor and Windsurf, can index documentation. Cursor includes the Cloudflare Developer Docs by default: you can use the [`@Docs`](https://cursor.com/docs/context/mentions#docs) command.
 
-In other editors, such as Zed or Windsurf, you can paste in URLs to add to your context. Use the _Copy Page_ button to paste in Cloudflare docs directly, or fetch docs for each product by appending `llms-full.txt` to the root URL. For example, `https://developers.cloudflare.com/agents/llms-full.txt` or `https://developers.cloudflare.com/workflows/llms-full.txt`.
+In other editors, such as Zed or Windsurf, you can use `llms-full.txt` files to provide comprehensive documentation context for indexing. For Workers-specific documentation indexing, use [`https://developers.cloudflare.com/workers/llms-full.txt`](https://developers.cloudflare.com/workers/llms-full.txt). For the complete Cloudflare documentation archive, use the root level [`https://developers.cloudflare.com/llms-full.txt`](https://developers.cloudflare.com/llms-full.txt) instead.
+
+You can also link an agent to `llms.txt` files while prompting to provide similar context without the need for offline indexing. For workers-specific documentation, use [`https://developers.cloudflare.com/workers/llms.txt`](https://developers.cloudflare.com/workers/llms.txt). For context of the entire Cloudflare documentation, use the root level [`https://developers.cloudflare.com/llms.txt`](https://developers.cloudflare.com/llms.txt).
+
+The _Copy Page_ button is also available on any individual page to paste that page's content directly.
 
 You can combine these with the Workers system prompt on this page to improve your editor or agent's understanding of the Workers APIs.
 

--- a/src/content/partials/style-guide/llms-txt.mdx
+++ b/src/content/partials/style-guide/llms-txt.mdx
@@ -11,14 +11,14 @@ We have implemented `llms.txt` and `llms-full.txt` as follows:
 
 To obtain a Markdown version of a single documentation page, you can:
 
+- Send a request to `/$page/index.md` — Add `/index.md` to the end of any page to get the Markdown version. For example, [`/style-guide/ai-tooling/index.md`](/style-guide/ai-tooling/index.md).
+
 - Send a request to any page with an `Accept: text/markdown` header — Uses [Markdown for Agents](/fundamentals/reference/markdown-for-agents/) to convert the page to Markdown at the network layer. For example:
 
   ```bash
   curl "https://developers.cloudflare.com/style-guide/ai-tooling/" \
     --header "Accept: text/markdown"
   ```
-
-- Send a request to `/$page/index.md` — Add `/index.md` to the end of any page to get the Markdown version. For example, [`/style-guide/ai-tooling/index.md`](/style-guide/ai-tooling/index.md).
 
 Both methods return the same Markdown output, powered by [Markdown for Agents](/fundamentals/reference/markdown-for-agents/).
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -11,7 +11,7 @@ export const GET: APIRoute = async ({ url }) => {
 	const docs = await getCollection("docs");
 
 	// Build a set of all canonical URL prefixes across the entire directory.
-	const allUrlPrefixes = new Set(
+	const allUrlPrefixes = new Set<string>(
 		allDirectory
 			.map((entry) => entry.data.entry.url)
 			.filter(
@@ -24,7 +24,7 @@ export const GET: APIRoute = async ({ url }) => {
 	// e.g. /logs/logpush/ is nested under /logs/  →  duplicate in parent's llms.txt
 	function isSubProduct(entryUrl: string): boolean {
 		if (!entryUrl || entryUrl === "/" || entryUrl.includes("#")) return false;
-		for (const otherUrl of allUrlPrefixes) {
+		for (const otherUrl of Array.from(allUrlPrefixes)) {
 			if (otherUrl === entryUrl) continue;
 			if (entryUrl.startsWith(otherUrl)) return true;
 		}
@@ -47,12 +47,19 @@ export const GET: APIRoute = async ({ url }) => {
 	);
 
 	// Group products by their group, skipping any without docs pages
-	const grouped = Object.entries(
-		Object.groupBy(
-			directory.filter((entry) => productsWithDocs.has(entry.id)),
-			(entry) => entry.data.entry.group as string,
-		),
-	).sort(([a], [b]) => a.localeCompare(b));
+	const groupedMap = new Map<string, typeof directory>();
+	for (const entry of directory.filter((entry) =>
+		productsWithDocs.has(entry.id),
+	)) {
+		const group = entry.data.entry.group as string;
+		if (!groupedMap.has(group)) {
+			groupedMap.set(group, []);
+		}
+		groupedMap.get(group)!.push(entry);
+	}
+	const grouped = Array.from(groupedMap.entries()).sort(([a], [b]) =>
+		a.localeCompare(b),
+	);
 
 	// Find ungrouped directory entries that have their own top-level docs section,
 	// are not nested under another product's URL path, and are not disallowed by robots.txt
@@ -89,7 +96,7 @@ export const GET: APIRoute = async ({ url }) => {
 				## ${group}
 
 				${entries
-					?.map((entry) => {
+					.map((entry) => {
 						const line = `- [${entry.data.entry.title}](${base}${entry.data.entry.url}llms.txt)`;
 						const description = entry.data.meta?.description;
 						return description ? line.concat(`: ${description}`) : line;

--- a/src/util/sidebar.ts
+++ b/src/util/sidebar.ts
@@ -109,13 +109,14 @@ export async function generateSidebar(group: Group) {
 	const product = directory.find((p) => p.id === group.label);
 	if (product && product.data.entry.group === "Developer platform") {
 		const links = [
-			["llms.txt", `${product.data.entry.url}llms.txt`],
-			["prompt.txt", "/workers/prompt.txt"],
+			[`${product.data.name} llms.txt`, `${product.data.entry.url}llms.txt`],
 			[
 				`${product.data.name} llms-full.txt`,
 				`${product.data.entry.url}llms-full.txt`,
 			],
-			["Developer Platform llms-full.txt", "/developer-platform/llms-full.txt"],
+			["Cloudflare Docs llms.txt", "/llms.txt"],
+			["Cloudflare Docs llms-full.txt", "/llms-full.txt"],
+			["Cloudflare Skills", "/style-guide/ai-tooling/#skills"],
 		];
 
 		group.entries.push({

--- a/src/util/sidebar.ts
+++ b/src/util/sidebar.ts
@@ -107,7 +107,7 @@ export async function generateSidebar(group: Group) {
 	}
 
 	const product = directory.find((p) => p.id === group.label);
-	if (product && product.data.entry.group === "Developer platform") {
+	if (product) {
 		const links = [
 			[`${product.data.name} llms.txt`, `${product.data.entry.url}llms.txt`],
 			[


### PR DESCRIPTION
## Summary

This PR improves the llms.txt documentation guidance and sidebar LLM Resources following some recent changes to `llms-full.txt` files

### Changes

1. **src/util/sidebar.ts**: Cleaned up sidebar implementation
    - **Make this section appear on all sidebars, not just Developer platform products**
    - Link to product specific `llms.txt` and `llms-full.txt`, as well as root `llms.txt` and `llms-full.txt`.
    - Don't link to workers `/workers/prompt.txt` on all directory sidebars, instead link to cloudflare skills docs.
    - Remove link to `/developer-platform/llms-full.txt`, as it doesn't exist anymore.

2. **public/_headers**: Added Content-Type header for `/*/llms.txt` files and switched `/*/llms-full.txt` files to also use `text/plain`

3. **src/content/docs/workers/get-started/prompting.mdx**: 
   - Worked on some copy here to better describe AI prompting options

4. **src/content/partials/style-guide/llms-txt.mdx**: Reordered some copy

5. **src/components/AgentDirective.astro**: Updated comment for clarity

6. **src/pages/llms.txt.ts**: Fixed some typescript errors

### Images

#### New LLM Resources Sidebar Section
<img width="291" height="234" alt="Screenshot 2026-03-30 at 11 11 58 AM" src="https://github.com/user-attachments/assets/e53dce12-fd83-47eb-9954-7475f6ed0eef" />

#### Workers prompting before
[Link](https://developers.cloudflare.com/workers/get-started/prompting/#use-docs-in-your-editor)
<img width="759" height="353" alt="Screenshot 2026-03-30 at 11 17 22 AM" src="https://github.com/user-attachments/assets/e93a3496-cace-403d-95a6-55f90133b6da" />

#### Workers prompting after
[Link](https://llms-full-side-bar-fix.preview.developers.cloudflare.com/workers/get-started/prompting/#use-docs-in-your-editor)
<img width="756" height="539" alt="Screenshot 2026-03-30 at 11 17 34 AM" src="https://github.com/user-attachments/assets/63604dda-fa28-4376-b601-145a724834e5" />
