### PR TITLE
docs(pages): Zola is preinstalled in the v2/v3 build image

### DIFF
--- a/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
+++ b/src/content/docs/pages/framework-guides/deploy-a-zola-site.mdx
@@ -81,11 +81,11 @@ Upon running `zola init`, you will prompted with three questions:
 
 <PagesBuildPreset framework="zola" />
 
-Below the configuration, make sure to set the **Environment Variables (advanced)** for specifying the `ZOLA_VERSION`.
+Zola is preinstalled in the Cloudflare Pages build environment, so no additional configuration is required. You can optionally set the `ZOLA_VERSION` environment variable under **Environment Variables (advanced)** to pin a specific version.
 
-For example, `ZOLA_VERSION`: `0.17.2`.
+For example, `ZOLA_VERSION`: `0.19.2`.
 
-After configuring your site, you can begin your first deploy. You should see Cloudflare Pages installing `zola`, your project dependencies, and building your site, before deploying it.
+After configuring your site, you can begin your first deploy. You should see Cloudflare Pages building your site with Zola, before deploying it.
 
 :::note
 

--- a/src/content/pages-build-environment/v2.yaml
+++ b/src/content/pages-build-environment/v2.yaml
@@ -62,6 +62,10 @@ tools:
     default: "3.6.3"
     supported: "Any version"
     environment_variable: "YARN_VERSION"
+  - name: Zola
+    default: "0.22.1"
+    supported: "Any version"
+    environment_variable: "ZOLA_VERSION"
 build_environment:
   operating_system: "Ubuntu `22.04.2`"
   architecture: "x86_64"

--- a/src/content/pages-build-environment/v3.yaml
+++ b/src/content/pages-build-environment/v3.yaml
@@ -62,6 +62,10 @@ tools:
     default: "4.9.1"
     supported: "Any version"
     environment_variable: "YARN_VERSION"
+  - name: Zola
+    default: "0.22.1"
+    supported: "Any version"
+    environment_variable: "ZOLA_VERSION"
 build_environment:
   operating_system: "Ubuntu `22.04.2`"
   architecture: "x86_64"


### PR DESCRIPTION
## Summary

Zola is now preinstalled in the Cloudflare Pages v2/v3 build image, so `ZOLA_VERSION` is no longer required to build a Zola site. This updates the deploy guide to reflect that.

## Changes

- Removes the instruction requiring `ZOLA_VERSION` to be set
- Notes that `ZOLA_VERSION` is still available for pinning a specific version

## Related

- Internal fix: https://gitlab.cfdata.org/cloudflare/ew/pages-infra/-/merge_requests/1167
- Public issue this resolves: https://github.com/cloudflare/pages-build-image/issues/3