### PR TITLE
Update @cloudflare/playwright to v1.2.0

### DIFF
--- a/src/content/docs/browser-rendering/playwright/index.mdx
+++ b/src/content/docs/browser-rendering/playwright/index.mdx
@@ -23,7 +23,7 @@ Our version is open sourced and can be found in [Cloudflare's fork of Playwright
 <PackageManagers pkg="@cloudflare/playwright" dev />
 
 :::note
-The current version is [`@cloudflare/playwright` v1.1.0](https://github.com/cloudflare/playwright/releases/tag/v1.1.0), based on [Playwright v1.57.0](https://playwright.dev/docs/release-notes#version-157).
+The current version is [`@cloudflare/playwright` v1.2.0](https://github.com/cloudflare/playwright/releases/tag/v1.2.0), based on [Playwright v1.58.2](https://playwright.dev/docs/release-notes#version-158).
 :::
 
 ## Use Playwright in a Worker

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,6 +3,10 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
+  - publish_date: "2026-03-23"
+    title: "@cloudflare/playwright v1.2.0 released"
+    description: |-
+      * Released version 1.2.0 of [`@cloudflare/playwright`](https://github.com/cloudflare/playwright/releases/tag/v1.2.0), now upgraded to [Playwright v1.58.2](https://playwright.dev/docs/release-notes#version-158).
   - publish_date: "2026-03-17"
     title: "Separate bot detection IDs for Browser Rendering methods"
     description: |-


### PR DESCRIPTION
- Add release note for @cloudflare/playwright v1.2.0 (upgraded to Playwright v1.58.2)
- Update version note on Playwright docs page from v1.1.0/v1.57.0 to v1.2.0/v1.58.2

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
