### PR TITLE
chore(realtimekit): updating 31 Mar release notes for realtimekit product

### DIFF
--- a/src/content/release-notes/realtimekit-web-core.yaml
+++ b/src/content/release-notes/realtimekit-web-core.yaml
@@ -8,7 +8,7 @@ entries:
     description: |-
       **Features**
 
-      - Simulcast support is now available to all RealtimeKit clients. Configure it per participant in Preset via the [RealtimeKit dashboard](https://dash.cloudflare.com/?to=/:account/realtime/kit), [Preset API](https://developers.cloudflare.com/api/resources/realtime_kit/subresources/presets/methods/create) at `config.media.video.simulcast`, or while [initializing the SDK](/realtime/realtimekit/core/).
+      - Simulcast support is now available to all RealtimeKit clients. Configure it per participant in Preset via the [RealtimeKit dashboard](https://dash.cloudflare.com/?to=/:account/realtime/kit), [Preset API](https://developers.cloudflare.com/api/resources/realtime_kit/subresources/presets/methods/create) using the `config.media.video.simulcast` field, or while [initializing the SDK](/realtime/realtimekit/core/).
       - Added 4K UHD video support in media production (configurable in Preset and API). Falls back to the maximum supported resolution if the camera does not support 4K.
   - publish_date: "2026-03-10"
     title: RealtimeKit Web Core 1.2.5

--- a/src/content/release-notes/realtimekit-web-core.yaml
+++ b/src/content/release-notes/realtimekit-web-core.yaml
@@ -3,6 +3,13 @@ link: "/realtime/realtimekit/release-notes/"
 productName: RealtimeKit Web Core
 productLink: "/realtime/realtimekit/"
 entries:
+  - publish_date: "2026-03-31"
+    title: RealtimeKit Web Core 1.3.0
+    description: |-
+      **Features**
+
+      - Simulcast support is now available to all RealtimeKit clients. Configure it per participant in Preset via the [RealtimeKit dashboard](https://dash.cloudflare.com/?to=/:account/realtime/kit), [Preset API](https://developers.cloudflare.com/api/resources/realtime_kit/subresources/presets/methods/create) at `config.media.video.simulcast`, or while [initializing the SDK](/realtime/realtimekit/core/).
+      - Added 4K UHD video support in media production (configurable in Preset and API). Falls back to the maximum supported resolution if the camera does not support 4K.
   - publish_date: "2026-03-10"
     title: RealtimeKit Web Core 1.2.5
     description: |-

--- a/src/content/release-notes/realtimekit-web-ui-kit.yaml
+++ b/src/content/release-notes/realtimekit-web-ui-kit.yaml
@@ -3,6 +3,12 @@ link: "/realtime/realtimekit/release-notes/"
 productName: RealtimeKit Web UI Kit
 productLink: "/realtime/realtimekit/"
 entries:
+  - publish_date: "2026-03-31"
+    title: RealtimeKit Web UI Kit 1.1.2
+    description: |-
+      **Enhancements**
+
+      - AI sidebar component now uses `activeSidebar` state instead of `activeAI` state, streamlining all sidebar components under a single state.
   - publish_date: "2026-03-10"
     title: RealtimeKit Web UI Kit 1.1.1
     description: |-


### PR DESCRIPTION
### Summary

Adding release notes for Web SDK release that happened on March 31st, 2026, for RealtimeKit product

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
