### PR TITLE
chore: cache-assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
         with:
           path: |
             node_modules/.astro/assets
-          key: static
+          key: astro-assets-${{ hashFiles('src/assets/**') }}
+          restore-keys: |
+            astro-assets-
 
       # The starlight-links-validator plugin runs in astro:build:done, which fires
       # AFTER all pages have been written to dist/. If link validation fails, the


### PR DESCRIPTION
### Summary

The Astro assets cache is configured with a static, immutable key: key: static

GitHub Actions caches are immutable, once created, a cache entry with a given key is never updated. This means the cache was created once and never refreshed, so changed or new assets are reprocessed on every build. This also caused the deploy preview to re-upload +6,000 assets per run instead of only changed files.

## Fix
Replace the static cache key with a content-based key and restore-keys fallback:
```
key: astro-assets-${{ hashFiles('src/assets/**') }}
restore-keys: |
  astro-assets-
```
- No asset changes (most PRs): exact cache hit, zero reprocessing
- Assets added/changed: partial restore via restore-keys, only new/changed assets processed, updated cache saved

