### PR TITLE
Gateway policy expressions

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
@@ -3,9 +3,6 @@ pcx_content_type: concept
 title: Gateway policy expressions
 sidebar:
   order: 14
-head:
-  - tag: title
-    content: Gateway policy expressions
 description: Learn about the expression syntax used to build Gateway DNS, HTTP, Network, Egress, and Resolver policies.
 ---
 

--- a/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
@@ -1,0 +1,176 @@
+---
+pcx_content_type: concept
+title: Gateway policy expressions
+sidebar:
+  order: 1
+head:
+  - tag: title
+    content: Gateway policy expressions
+description: Learn about the expression syntax used to build Gateway DNS, HTTP, Network, Egress, and Resolver policies.
+---
+
+import { Render } from "~/components";
+
+Gateway policies use a wirefilter-based expression language to match traffic against selectors (criteria). This syntax is similar to, but distinct from, the [Rules language](/ruleset-engine/rules-language/) used by WAF, Page Rules, and other application security products.
+
+:::caution[Important]
+
+The [Ruleset Engine documentation](/ruleset-engine/rules-language/) does not apply to Gateway policies. Gateway has its own set of selectors and fields specific to Zero Trust traffic filtering. For available selectors, refer to the documentation for each policy type:
+
+- [DNS policy selectors](/cloudflare-one/traffic-policies/dns-policies/#selectors)
+- [HTTP policy selectors](/cloudflare-one/traffic-policies/http-policies/#selectors)
+- [Network policy selectors](/cloudflare-one/traffic-policies/network-policies/#selectors)
+- [Egress policy selectors](/cloudflare-one/traffic-policies/egress-policies/#selectors)
+- [Resolver policy selectors](/cloudflare-one/traffic-policies/resolver-policies/#selectors)
+
+:::
+
+## Expression syntax
+
+Gateway expressions follow this pattern:
+
+```txt
+<field> <operator> <value>
+```
+
+For example:
+
+```txt
+dns.fqdn == "example.com"
+http.request.host == "api.example.com"
+identity.email == "user@company.com"
+```
+
+### Operators
+
+Gateway supports the following operators:
+
+| Operator | Name | Example |
+| --- | --- | --- |
+| `==` | Equals | `dns.fqdn == "example.com"` |
+| `!=` | Does not equal | `http.request.host != "blocked.com"` |
+| `in` | Value is in set | `net.dst.port in {80 443}` |
+| `matches` | Matches regular expression | `http.request.host matches ".*\\.example\\.com"` |
+| `>` | Greater than | `http.upload.file.size > 10` |
+| `>=` | Greater than or equal to | `http.download.file.size >= 100` |
+| `<` | Less than | `http.upload.file.size < 50` |
+| `<=` | Less than or equal to | `http.download.file.size <= 200` |
+
+### Logical operators
+
+Combine multiple conditions using logical operators:
+
+| Operator | Name | Example |
+| --- | --- | --- |
+| `and` | Logical AND | `dns.fqdn == "example.com" and identity.email == "admin@company.com"` |
+| `or` | Logical OR | `net.dst.port == 80 or net.dst.port == 443` |
+| `not` | Logical NOT | `not(identity.email == "guest@company.com")` |
+
+You can also use symbols instead of words:
+
+- `&&` instead of `and`
+- `||` instead of `or`
+
+## Working with arrays
+
+Some Gateway fields return arrays (multiple values). Use the `any()` function to match if any element in the array meets the condition:
+
+```txt
+any(http.request.uri.content_category[*] in {17 85 102})
+```
+
+```txt
+any(identity.groups[*].name in {"Engineering" "Security"})
+```
+
+```txt
+any(http.request.domains[*] == "example.com")
+```
+
+The `[*]` notation indicates that the function should evaluate all elements in the array.
+
+## Working with lists
+
+You can reference [lists](/cloudflare-one/reusable-components/lists/) in your expressions using the list UUID:
+
+```txt
+http.request.host in $<LIST_UUID>
+```
+
+```txt
+any(http.request.domains[*] in $<LIST_UUID>)
+```
+
+To find a list's UUID, go to **My Team** > **Lists** in Zero Trust and select the list. The UUID appears in the browser URL.
+
+## Common field patterns
+
+Each Gateway policy type has its own set of available fields. The table below shows the field prefixes used by each policy type:
+
+| Policy type | Field prefix | Example fields |
+| --- | --- | --- |
+| DNS | `dns.` | `dns.fqdn`, `dns.content_category`, `dns.src_ip` |
+| HTTP | `http.` | `http.request.host`, `http.request.uri`, `http.request.domains` |
+| Network | `net.` | `net.dst.ip`, `net.dst.port`, `net.src.ip` |
+| Identity | `identity.` | `identity.email`, `identity.groups`, `identity.name` |
+| Device posture | `device_posture.` | `device_posture.checks.passed` |
+
+For a complete list of available fields for each policy type, refer to the selectors documentation linked at the top of this page.
+
+## Example expressions
+
+### Block a domain in a DNS policy
+
+```txt
+dns.fqdn == "example.com"
+```
+
+### Block multiple content categories in an HTTP policy
+
+```txt
+any(http.request.uri.content_category[*] in {17 85 102})
+```
+
+### Allow traffic from a specific user group
+
+```txt
+any(identity.groups[*].name in {"Engineering"})
+```
+
+### Block traffic to a destination IP range in a Network policy
+
+```txt
+net.dst.ip in {10.0.0.0/8}
+```
+
+### Combine identity and traffic conditions
+
+```txt
+http.request.host == "internal.example.com" and identity.email matches ".*@company.com"
+```
+
+## Gateway vs Ruleset Engine
+
+If you are familiar with [Cloudflare Rules language](/ruleset-engine/rules-language/), note that Gateway uses a different set of fields. The following table summarizes the key differences:
+
+| | Ruleset Engine | Gateway |
+| --- | --- | --- |
+| **Products** | WAF, Transform Rules, Cache Rules, Configuration Rules | DNS, HTTP, Network, Egress, Resolver policies |
+| **Field examples** | `http.request.uri.path`, `cf.bot_management.score`, `ip.src` | `dns.fqdn`, `http.request.host`, `identity.email` |
+| **Identity fields** | Not available | Available (`identity.email`, `identity.groups`, etc.) |
+| **DNS fields** | Not available | Available (`dns.fqdn`, `dns.content_category`, etc.) |
+| **Documentation** | [Rules language](/ruleset-engine/rules-language/) | [Traffic policies](/cloudflare-one/traffic-policies/) |
+
+:::note
+
+Do not reference the [Ruleset Engine fields reference](/ruleset-engine/rules-language/fields/) when building Gateway policies. Gateway has its own field set documented on each policy type page.
+
+:::
+
+## Related resources
+
+- [DNS policies](/cloudflare-one/traffic-policies/dns-policies/)
+- [HTTP policies](/cloudflare-one/traffic-policies/http-policies/)
+- [Network policies](/cloudflare-one/traffic-policies/network-policies/)
+- [Identity-based policies](/cloudflare-one/traffic-policies/identity-selectors/)
+- [Lists](/cloudflare-one/reusable-components/lists/)

--- a/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
@@ -11,7 +11,7 @@ description: Learn about the expression syntax used to build Gateway DNS, HTTP, 
 
 import { Render } from "~/components";
 
-Gateway policies use a wirefilter-based expression language to match traffic against selectors (criteria). This syntax is similar to, but distinct from, the [Rules language](/ruleset-engine/rules-language/) used by WAF, Page Rules, and other application security products.
+Gateway policies use a wirefilter-based expression language to match traffic against selectors (criteria). This syntax is similar to, but distinct from, the [Rules language](/ruleset-engine/rules-language/) used by WAF, Rules, and other Cloudflare products. Refer to [Gateway versus Ruleset Engine](#gateway-versus-ruleset-engine) for details on the differences.
 
 :::caution[Important]
 
@@ -71,7 +71,7 @@ You can also use symbols instead of words:
 - `&&` instead of `and`
 - `||` instead of `or`
 
-## Working with arrays
+## Array handling
 
 Some Gateway fields return arrays (multiple values). Use the `any()` function to match if any element in the array meets the condition:
 
@@ -89,7 +89,7 @@ any(http.request.domains[*] == "example.com")
 
 The `[*]` notation indicates that the function should evaluate all elements in the array.
 
-## Working with lists
+## List handling
 
 You can reference [lists](/cloudflare-one/reusable-components/lists/) in your expressions using the list UUID:
 
@@ -105,7 +105,7 @@ To find a list's UUID, go to **My Team** > **Lists** in Zero Trust and select th
 
 ## Common field patterns
 
-Each Gateway policy type has its own set of available fields. The table below shows the field prefixes used by each policy type:
+Each Gateway policy type has its own set of available fields. The following table shows the field prefixes used by each policy type:
 
 | Policy type | Field prefix | Example fields |
 | --- | --- | --- |
@@ -149,7 +149,7 @@ net.dst.ip in {10.0.0.0/8}
 http.request.host == "internal.example.com" and identity.email matches ".*@company.com"
 ```
 
-## Gateway vs Ruleset Engine
+## Gateway versus Ruleset Engine
 
 If you are familiar with [Cloudflare Rules language](/ruleset-engine/rules-language/), note that Gateway uses a different set of fields. The following table summarizes the key differences:
 
@@ -157,8 +157,8 @@ If you are familiar with [Cloudflare Rules language](/ruleset-engine/rules-langu
 | --- | --- | --- |
 | **Products** | WAF, Transform Rules, Cache Rules, Configuration Rules | DNS, HTTP, Network, Egress, Resolver policies |
 | **Field examples** | `http.request.uri.path`, `cf.bot_management.score`, `ip.src` | `dns.fqdn`, `http.request.host`, `identity.email` |
-| **Identity fields** | Not available | Available (`identity.email`, `identity.groups`, etc.) |
-| **DNS fields** | Not available | Available (`dns.fqdn`, `dns.content_category`, etc.) |
+| **Identity fields** | Not available | Available (for example, `identity.email`, `identity.groups`) |
+| **DNS fields** | Not available | Available (for example, `dns.fqdn`, `dns.content_category`) |
 | **Documentation** | [Rules language](/ruleset-engine/rules-language/) | [Traffic policies](/cloudflare-one/traffic-policies/) |
 
 :::note

--- a/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
@@ -42,25 +42,25 @@ identity.email == "user@company.com"
 
 Gateway supports the following operators:
 
-| Operator | Name | Example |
-| --- | --- | --- |
-| `==` | Equals | `dns.fqdn == "example.com"` |
-| `!=` | Does not equal | `http.request.host != "blocked.com"` |
-| `in` | Value is in set | `net.dst.port in {80 443}` |
+| Operator  | Name                       | Example                                          |
+| --------- | -------------------------- | ------------------------------------------------ |
+| `==`      | Equals                     | `dns.fqdn == "example.com"`                      |
+| `!=`      | Does not equal             | `http.request.host != "blocked.com"`             |
+| `in`      | Value is in set            | `net.dst.port in {80 443}`                       |
 | `matches` | Matches regular expression | `http.request.host matches ".*\\.example\\.com"` |
-| `>` | Greater than | `http.upload.file.size > 10` |
-| `>=` | Greater than or equal to | `http.download.file.size >= 100` |
-| `<` | Less than | `http.upload.file.size < 50` |
-| `<=` | Less than or equal to | `http.download.file.size <= 200` |
+| `>`       | Greater than               | `http.upload.file.size > 10`                     |
+| `>=`      | Greater than or equal to   | `http.download.file.size >= 100`                 |
+| `<`       | Less than                  | `http.upload.file.size < 50`                     |
+| `<=`      | Less than or equal to      | `http.download.file.size <= 200`                 |
 
 ### Logical operators
 
 Combine multiple conditions using logical operators:
 
-| Operator | Name | Example |
-| --- | --- | --- |
-| `and` | Logical AND | `dns.fqdn == "example.com" and identity.email == "admin@company.com"` |
-| `or` | Logical OR | `net.dst.port == 80 or net.dst.port == 443` |
+| Operator | Name        | Example                                                               |
+| -------- | ----------- | --------------------------------------------------------------------- |
+| `and`    | Logical AND | `dns.fqdn == "example.com" and identity.email == "admin@company.com"` |
+| `or`     | Logical OR  | `net.dst.port == 80 or net.dst.port == 443`                           |
 
 You can also use symbols instead of words:
 
@@ -103,13 +103,13 @@ To find a list's UUID, go to **My Team** > **Lists** in Zero Trust and select th
 
 Each Gateway policy type has its own set of available fields. The following table shows the field prefixes used by each policy type:
 
-| Policy type | Field prefix | Example fields |
-| --- | --- | --- |
-| DNS | `dns.` | `dns.fqdn`, `dns.content_category`, `dns.src_ip` |
-| HTTP | `http.` | `http.request.host`, `http.request.uri`, `http.request.domains` |
-| Network | `net.` | `net.dst.ip`, `net.dst.port`, `net.src.ip` |
-| Identity | `identity.` | `identity.email`, `identity.groups`, `identity.name` |
-| Device posture | `device_posture.` | `device_posture.checks.passed` |
+| Policy type    | Field prefix      | Example fields                                                  |
+| -------------- | ----------------- | --------------------------------------------------------------- |
+| DNS            | `dns.`            | `dns.fqdn`, `dns.content_category`, `dns.src_ip`                |
+| HTTP           | `http.`           | `http.request.host`, `http.request.uri`, `http.request.domains` |
+| Network        | `net.`            | `net.dst.ip`, `net.dst.port`, `net.src.ip`                      |
+| Identity       | `identity.`       | `identity.email`, `identity.groups`, `identity.name`            |
+| Device posture | `device_posture.` | `device_posture.checks.passed`                                  |
 
 For a complete list of available fields for each policy type, refer to the selectors documentation linked at the top of this page.
 
@@ -149,13 +149,13 @@ http.request.host == "internal.example.com" and identity.email matches ".*@compa
 
 The following table summarizes the key differences between the Rules language](/ruleset-engine/rules-language/) (supported by the Ruleset Engine) and Gateway policy expressions:
 
-| | Ruleset Engine | Gateway |
-| --- | --- | --- |
-| **Products** | WAF, Transform Rules, Cache Rules, Configuration Rules | DNS, HTTP, Network, Egress, Resolver policies |
-| **Field examples** | `http.request.uri.path`, `cf.bot_management.score`, `ip.src` | `dns.fqdn`, `http.request.host`, `identity.email` |
-| **Identity fields** | Not available | Available (for example, `identity.email`, `identity.groups`) |
-| **DNS fields** | Not available | Available (for example, `dns.fqdn`, `dns.content_category`) |
-| **Documentation** | [Rules language](/ruleset-engine/rules-language/) | [Traffic policies](/cloudflare-one/traffic-policies/) |
+|                     | Ruleset Engine                                               | Gateway                                                      |
+| ------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| **Products**        | WAF, Transform Rules, Cache Rules, Configuration Rules       | DNS, HTTP, Network, Egress, Resolver policies                |
+| **Field examples**  | `http.request.uri.path`, `cf.bot_management.score`, `ip.src` | `dns.fqdn`, `http.request.host`, `identity.email`            |
+| **Identity fields** | Not available                                                | Available (for example, `identity.email`, `identity.groups`) |
+| **DNS fields**      | Not available                                                | Available (for example, `dns.fqdn`, `dns.content_category`)  |
+| **Documentation**   | [Rules language](/ruleset-engine/rules-language/)            | [Traffic policies](/cloudflare-one/traffic-policies/)        |
 
 :::note
 

--- a/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: concept
 title: Gateway policy expressions
 sidebar:
-  order: 1
+  order: 14
 head:
   - tag: title
     content: Gateway policy expressions

--- a/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/expression-syntax.mdx
@@ -61,7 +61,6 @@ Combine multiple conditions using logical operators:
 | --- | --- | --- |
 | `and` | Logical AND | `dns.fqdn == "example.com" and identity.email == "admin@company.com"` |
 | `or` | Logical OR | `net.dst.port == 80 or net.dst.port == 443` |
-| `not` | Logical NOT | `not(identity.email == "guest@company.com")` |
 
 You can also use symbols instead of words:
 
@@ -148,7 +147,7 @@ http.request.host == "internal.example.com" and identity.email matches ".*@compa
 
 ## Gateway versus Ruleset Engine
 
-If you are familiar with [Cloudflare Rules language](/ruleset-engine/rules-language/), note that Gateway uses a different set of fields. The following table summarizes the key differences:
+The following table summarizes the key differences between the Rules language](/ruleset-engine/rules-language/) (supported by the Ruleset Engine) and Gateway policy expressions:
 
 | | Ruleset Engine | Gateway |
 | --- | --- | --- |


### PR DESCRIPTION
Learn about the expression syntax used to build Gateway DNS, HTTP, Network, Egress, and Resolver policies.

Related Jira: PCX-19977

### Summary

Clarifies the expression syntax used to build Gateway DNS, HTTP, Network, Egress, and Resolver policies.  This syntax is similar to, but distinct from, the Ruleset Engine syntax.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
