### PR TITLE
[Cloudflare Tunnel] Make Gateway proxy a hard prerequisite for private hostname routing

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-private-hostname.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-private-hostname.mdx
@@ -59,11 +59,8 @@ Your devices must also forward the following traffic to Cloudflare:
 Configuration steps vary depending on your [device on-ramp](#device-connectivity):
 
 <Details header="Cloudflare One Clients">
-	1.{" "}
-	<Render
-		file="gateway/egress-selector-split-tunnels"
-		product="cloudflare-one"
-	/>
+	1. <Render file="gateway/egress-selector-split-tunnels"
+		product="cloudflare-one"/>
 	2. In [Local Domain
 	Fallback](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/local-domains/),
 	delete the top-level domain for your private hostname. This configures WARP to

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-private-hostname.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-private-hostname.mdx
@@ -33,12 +33,12 @@ End users can connect to private hostnames using the following traffic on-ramps:
 
 Private hostname routing only works for applications connected with `cloudflared`. Other traffic off-ramps require IP-based routes.
 
-| Connector                                                                                  | Compatibility | Minimum version |
-| ------------------------------------------------------------------------------------------ | ------------- | -- |
-| [cloudflared](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/)                        | ✅            | 2025.7.0 |
-| [Peer-to-peer](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/peer-to-peer/)              | ❌             | |
-| [WARP Connector](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/) | ❌             | |
-| [Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/)                                                             | ❌             | |
+| Connector                                                                                           | Compatibility | Minimum version |
+| --------------------------------------------------------------------------------------------------- | ------------- | --------------- |
+| [cloudflared](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/)       | ✅            | 2025.7.0        |
+| [Peer-to-peer](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/peer-to-peer/)     | ❌            |                 |
+| [WARP Connector](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/) | ❌            |                 |
+| [Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/)                                    | ❌            |                 |
 
 ## Connect a private hostname
 
@@ -46,17 +46,28 @@ This section covers how to enable remote access to a private hostname applicatio
 
 ### Prerequisites
 
-To connect to private hostnames, your devices must forward the following traffic to Cloudflare:
+Before you can connect to private hostnames, you must enable the Gateway proxy.
+
+<Render file="tunnel/enable-gateway-proxy" product="cloudflare-one" />
+
+Your devices must also forward the following traffic to Cloudflare:
 
 - Initial resolved IPs:
-	<Render file="gateway/egress-selector-cgnat-ips" product="cloudflare-one"/>
+  <Render file="gateway/egress-selector-cgnat-ips" product="cloudflare-one" />
 - DNS queries for your private hostname
 
 Configuration steps vary depending on your [device on-ramp](#device-connectivity):
 
 <Details header="Cloudflare One Clients">
-1. <Render file="gateway/egress-selector-split-tunnels" product="cloudflare-one"/>
-2. In [Local Domain Fallback](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/local-domains/), delete the top-level domain for your private hostname. This configures WARP to send the DNS query to Cloudflare Gateway for resolution.
+	1.{" "}
+	<Render
+		file="gateway/egress-selector-split-tunnels"
+		product="cloudflare-one"
+	/>
+	2. In [Local Domain
+	Fallback](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/local-domains/),
+	delete the top-level domain for your private hostname. This configures WARP to
+	send the DNS query to Cloudflare Gateway for resolution.
 </Details>
 
 <Details header="WARP Connector">
@@ -75,14 +86,14 @@ Configuration steps vary depending on your [device on-ramp](#device-connectivity
 
 ### 1. Connect the application to Cloudflare
 
-<Render file="tunnel/create-tunnel" product="cloudflare-one"/>
+<Render file="tunnel/create-tunnel" product="cloudflare-one" />
 
 9. In the **Hostname routes** tab, enter the fully qualified domain name (FQDN) that represents your application (for example, `wiki.internal.local`).
 
-    <Render
-      file="tunnel/hostname-format-restrictions"
-      product="cloudflare-one"
-    />
+   <Render
+   	file="tunnel/hostname-format-restrictions"
+   	product="cloudflare-one"
+   />
 
 10. Select **Complete setup**.
 
@@ -99,28 +110,22 @@ If the machine running `cloudflared` can already resolve `wiki.internal.local` t
 #### Scenario B: Use a specific private DNS server (Advanced)
 
 <Render
-  file="tunnel/hostname-route-dns-advanced"
-  product="cloudflare-one"
-  params={{ hostname: "wiki.internal.local" }}
+	file="tunnel/hostname-route-dns-advanced"
+	product="cloudflare-one"
+	params={{ hostname: "wiki.internal.local" }}
 />
 
 ### 3. (Recommended) Filter network traffic with Gateway
 
-<Render file="tunnel/filter-network-traffic" product="cloudflare-one"/>
+<Render file="tunnel/filter-network-traffic" product="cloudflare-one" />
 
-#### Enable the Gateway proxy
+<Render file="tunnel/catch-all-policy" product="cloudflare-one" />
 
-<Render file="tunnel/enable-gateway-proxy" product="cloudflare-one"/>
-
-#### Zero Trust policies
-
-<Render file="tunnel/catch-all-policy" product="cloudflare-one"/>
-
-##### Option 1: Access application (recommended)
+#### Option 1: Access application (recommended)
 
 You can create an [Access self-hosted application](/cloudflare-one/access-controls/applications/non-http/self-hosted-private-app/) for your private hostname and configure [Access policies](/cloudflare-one/access-controls/policies/) within that application. This option allows you to manage user access alongside your SaaS and other web apps.
 
-##### Option 2: Gateway firewall policies
+#### Option 2: Gateway firewall policies
 
 If you prefer to secure the application using a traditional firewall model, you can build Gateway network policies using the [SNI](/cloudflare-one/traffic-policies/network-policies/#sni) or [SNI Domain](/cloudflare-one/traffic-policies/network-policies/#sni-domain) selector. For an additional layer of protection, add a Gateway DNS policy to allow or block the [Host](/cloudflare-one/traffic-policies/dns-policies/#host) or [Domain](/cloudflare-one/traffic-policies/dns-policies/#domain) from resolving.
 
@@ -143,10 +148,7 @@ If you prefer to secure the application using a traditional firewall model, you 
 
 :::note[SNI selector limitations]
 
-<Render
-  file="gateway/selectors/sni-443"
-  product="cloudflare-one"
-/>
+<Render file="gateway/selectors/sni-443" product="cloudflare-one" />
 
 Additionally, SNI selectors will only apply to Cloudflare One Client traffic. If your users will be connecting from other [on-ramps](#device-connectivity), you can allow or block network traffic using the [Destination IP](/cloudflare-one/traffic-policies/network-policies/#destination-ip) selector instead of SNI.
 :::
@@ -161,39 +163,41 @@ If you cannot connect, verify the following:
 
 1. **Confirm DNS resolution** - From the device, confirm that you can successfully resolve the private hostname:
 
-    ```sh
-    nslookup wiki.internal.local
-    ```
+   ```sh
+   nslookup wiki.internal.local
+   ```
 
-    ```sh output
-    Server:		127.0.2.2
-    Address:	127.0.2.2#53
+   ```sh output
+   Server:		127.0.2.2
+   Address:	127.0.2.2#53
 
-    Non-authoritative answer:
-    Name:	wiki.internal.local
-    Address: 100.80.200.48
-    ```
+   Non-authoritative answer:
+   Name:	wiki.internal.local
+   Address: 100.80.200.48
+   ```
 
-    The query should resolve using [WARP's DNS proxy](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/client-architecture/#dns-traffic) and return a Gateway <GlossaryTooltip term="initial resolved IP">initial resolved IP</GlossaryTooltip>. If the query fails to resolve or returns a different IP, check your [Local Domain Fallback](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/local-domains/) configuration and [Gateway resolver policies](/cloudflare-one/traffic-policies/resolver-policies/).
+   The query should resolve using [WARP's DNS proxy](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/client-architecture/#dns-traffic) and return a Gateway <GlossaryTooltip term="initial resolved IP">initial resolved IP</GlossaryTooltip>. If the query fails to resolve or returns a different IP, check your [Local Domain Fallback](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/local-domains/) configuration and [Gateway resolver policies](/cloudflare-one/traffic-policies/resolver-policies/).
 
 2. **Check Gateway logs** - Review your [Gateway network logs](/cloudflare-one/insights/logs/gateway-logs/) to see if the connection is being blocked by a policy.
 
 3. **Verify tunnel status** - Confirm that your tunnel is healthy and connected by checking [tunnel status](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/).
 
 4. **Test connectivity to initial resolved IP** - When you connect to the application using its private hostname, the device should make a connection to the <GlossaryTooltip term="initial resolved IP">initial resolved IP</GlossaryTooltip>:
-    ```sh
-    curl -v4 http://wiki.internal.local
-    ```
-    ```sh output
-    * Trying 100.80.200.48:80...
-    * Connected to wiki.internal.local (100.80.200.48) port 80
-    ...
-    ```
 
-    If the request fails, confirm that the initial resolved IP [routes through the WARP tunnel](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/). You can also check your [tunnel logs](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/logs/) to confirm that requests are routing to the application's private IP.
+   ```sh
+   curl -v4 http://wiki.internal.local
+   ```
+
+   ```sh output
+   * Trying 100.80.200.48:80...
+   * Connected to wiki.internal.local (100.80.200.48) port 80
+   ...
+   ```
+
+   If the request fails, confirm that the initial resolved IP [routes through the WARP tunnel](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/). You can also check your [tunnel logs](/cloudflare-one/networks/connectors/cloudflare-tunnel/monitor-tunnels/logs/) to confirm that requests are routing to the application's private IP.
 
 ## Limitations
 
 ### Google Chrome restricts access to private hostnames
 
-<Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one"/>
+<Render file="gateway/egress-selector-chrome-issue" product="cloudflare-one" />

--- a/src/content/partials/cloudflare-one/tunnel/enable-gateway-proxy.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/enable-gateway-proxy.mdx
@@ -4,31 +4,29 @@
 
 import { Tabs, TabItem } from "~/components";
 
-To start logging and filtering network traffic, turn on the Gateway proxy:
-
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
 1. Go to **Traffic policies** > **Traffic settings**.
 2. In **Proxy and inspection**, turn on **Allow Secure Web Gateway to proxy traffic**.
 3. Select **TCP**.
-4. (Recommended) To proxy traffic to internal DNS resolvers, select **UDP**.
+4. Select **UDP** (required to proxy traffic to internal DNS resolvers).
 5. (Recommended) To proxy traffic for diagnostic tools such as `ping` and `traceroute`, select **ICMP**. You may also need to [update your system](/cloudflare-one/traffic-policies/proxy/#icmp) to allow ICMP traffic through `cloudflared`.
 
 </TabItem>
 <TabItem label="Terraform (v5)">
 
 1. Add the following permission to your [`cloudflare_api_token`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/api_token):
-	- `Zero Trust Write`
+   - `Zero Trust Write`
 
 2. Turn on the TCP and/or UDP proxy using the [`cloudflare_zero_trust_device_settings`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zero_trust_device_settings) resource:
 
-	```tf
-	resource "cloudflare_zero_trust_device_settings "global_warp_settings" {
-		account_id            = var.cloudflare_account_id
-	  gateway_proxy_enabled = true
-		gateway_udp_proxy_enabled = true
-	}
-	```
+   ```tf
+   resource "cloudflare_zero_trust_device_settings "global_warp_settings" {
+   	account_id            = var.cloudflare_account_id
+     gateway_proxy_enabled = true
+   	gateway_udp_proxy_enabled = true
+   }
+   ```
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary

- Moves the "Enable the Gateway proxy" instructions from an optional Step 3 sub-section to a hard prerequisite at the top of the setup flow for private hostname routing
- Requires TCP and UDP (for DNS resolver traffic), recommends ICMP (for `ping`/`traceroute`)
- Removes the duplicate "Enable the Gateway proxy" sub-section from Step 3, which now focuses solely on recommended Zero Trust filtering policies
- Fixes heading hierarchy after removing the intermediate `#### Zero Trust policies` heading

Addresses ESCALATION-217— customer could not make private hostnames work because the Gateway proxy setting was not enabled, and the docs did not surface this as a prerequisite.