### PR TITLE
Add experimental headful mode docs and Chrome 126 local dev upgrade

### DIFF
--- a/src/content/docs/browser-rendering/faq.mdx
+++ b/src/content/docs/browser-rendering/faq.mdx
@@ -84,6 +84,12 @@ Not yet. Local development currently has the following limitation(s):
 
 - Requests larger than 1 MB are not supported.
 
+You can also run Chrome in visible (headful) mode during local development to visually debug your automation scripts (experimental). Set the `X_BROWSER_HEADFUL` environment variable before starting your dev server:
+
+```sh
+X_BROWSER_HEADFUL=true npx wrangler dev
+```
+
 <Render file="remote-binding-note" product="workers" />
 
 ### How do I render authenticated pages using the REST API?

--- a/src/content/docs/browser-rendering/playwright/index.mdx
+++ b/src/content/docs/browser-rendering/playwright/index.mdx
@@ -301,6 +301,26 @@ The `userAgent` parameter does not bypass bot protection. Requests from Browser 
 :::
 
 
+## Local debugging with headful mode (experimental)
+
+When developing locally with `wrangler dev` or `vite dev`, Chrome runs in headless mode by default. To launch Chrome in visible (headful) mode, set the `X_BROWSER_HEADFUL` environment variable:
+
+```sh
+X_BROWSER_HEADFUL=true npx wrangler dev
+```
+
+Or with the [Cloudflare Vite plugin](/workers/vite-plugin/):
+
+```sh
+X_BROWSER_HEADFUL=true npx vite dev
+```
+
+This opens a browser window so you can watch your Playwright automation in real time, making it easier to debug navigation, element selection, and page interactions.
+
+:::note
+When using `@cloudflare/playwright` in headful mode, two Chrome windows may appear. This is expected behavior due to how Playwright handles browser contexts via CDP.
+:::
+
 ## Session management
 
 In order to facilitate browser session management, we have extended the Playwright API with new methods:

--- a/src/content/docs/browser-rendering/puppeteer.mdx
+++ b/src/content/docs/browser-rendering/puppeteer.mdx
@@ -79,6 +79,22 @@ await page.setUserAgent(
 The `userAgent` parameter does not bypass bot protection. Requests from Browser Rendering will always be identified as a bot.
 :::
 
+## Local debugging with headful mode (experimental)
+
+When developing locally with `wrangler dev` or `vite dev`, Chrome runs in headless mode by default. To launch Chrome in visible (headful) mode, set the `X_BROWSER_HEADFUL` environment variable:
+
+```sh
+X_BROWSER_HEADFUL=true npx wrangler dev
+```
+
+Or with the [Cloudflare Vite plugin](/workers/vite-plugin/):
+
+```sh
+X_BROWSER_HEADFUL=true npx vite dev
+```
+
+This opens a browser window so you can watch your Puppeteer automation in real time, making it easier to debug navigation, element selection, and page interactions.
+
 ## Element selection
 
 Puppeteer provides multiple methods for selecting elements on a page. While CSS selectors work as expected, XPath selectors are not supported due to security constraints in the Workers runtime.

--- a/src/content/docs/browser-rendering/reference/wrangler.mdx
+++ b/src/content/docs/browser-rendering/reference/wrangler.mdx
@@ -52,4 +52,18 @@ const browser = await puppeteer.launch(env.MYBROWSER);
 
 Run `npx wrangler dev` to test your Worker locally.
 
+### Headful mode (experimental)
+
+By default, local development runs Chrome in headless mode. To launch Chrome in visible (headful) mode for debugging, set the `X_BROWSER_HEADFUL` environment variable:
+
+```sh
+X_BROWSER_HEADFUL=true npx wrangler dev
+```
+
+This opens a browser window on screen so you can watch navigations, interactions, and rendering in real time. Headful mode is for local development only and does not affect deployed Workers. This feature is experimental and may change without notice.
+
+:::note
+When using [`@cloudflare/playwright`](/browser-rendering/playwright/), two Chrome windows may appear. This is expected behavior due to how Playwright handles browser contexts via CDP.
+:::
+
 <Render file="remote-binding-note" product="workers" />

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,6 +3,10 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
+  - publish_date: "2026-04-06"
+    title: "Local development: headful mode (experimental)"
+    description: |-
+      * You can now run Chrome in visible (headful) mode during local development by setting `X_BROWSER_HEADFUL=true` before running `wrangler dev` or `vite dev`. This makes it easier to visually debug your browser automation scripts. This feature is experimental and may change without notice.
   - publish_date: "2026-03-23"
     title: "@cloudflare/playwright v1.2.0 released"
     description: |-


### PR DESCRIPTION
- Add release note for headful mode (X_BROWSER_HEADFUL=true) and local Chrome 124→126 upgrade
- Add headful mode (experimental) section to Playwright, Puppeteer, and Wrangler reference pages
- Add headful mode mention to FAQ local development section
- Note Playwright two-window behavior on Playwright and Wrangler pages

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
