### PR TITLE
Update transfer-domain-to-cloudflare.mdx

### DIFF
--- a/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
+++ b/src/content/docs/registrar/get-started/transfer-domain-to-cloudflare.mdx
@@ -16,7 +16,7 @@ Transferring a domain moves your registration from your current registrar to Clo
 - **Cost:** Cloudflare domains are at-cost with no markup fees. Most transfers include a one-year extension from your current expiration date. Some country-code domains (such as `.uk`) have no transfer fee.
 
 :::note
-Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare). You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, Squarespace, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
+Before you can transfer, you must first [add your domain to Cloudflare](#1-add-your-domain-to-cloudflare). You cannot [enter an authorization code](/registrar/troubleshooting/#cannot-find-where-to-enter-your-authorization-code) until your domain is active on Cloudflare. If your domain is registered with a website builder platform (such as Block, Shopify, or Wix), you may not be able to change nameservers while the domain is registered there. Refer to [Transfer from website builders](#transfer-from-website-builders) for the recommended workaround, or [Troubleshoot failed domain transfers](/registrar/troubleshooting/) if you are running into issues.
 :::
 
 :::note
@@ -163,7 +163,7 @@ Registrants transferring a `.us` domain will always receive a FOA email.
 
 ## Transfer from website builders
 
-Some website builder platforms (such as Block, Shopify, Squarespace, and Wix) act as both your hosting provider and domain registrar. These platforms typically do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer is not possible.
+Some website builder platforms (such as Block, Shopify, and Wix) act as both your hosting provider and domain registrar. These platforms typically do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer is not possible.
 
 The workaround is to transfer your domain to another registrar first, wait 60 days, then transfer to Cloudflare:
 

--- a/src/content/docs/registrar/troubleshooting.mdx
+++ b/src/content/docs/registrar/troubleshooting.mdx
@@ -101,7 +101,7 @@ Your domain may not appear on the [Transfer Domains](https://dash.cloudflare.com
 
 ## Cannot update nameservers at your current registrar
 
-Some website builder platforms (such as Block, Shopify, Squarespace, and Wix) do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer from these platforms is not possible. For the recommended workaround, refer to [Transfer from website builders](/registrar/get-started/transfer-domain-to-cloudflare/#transfer-from-website-builders).
+Some website builder platforms (such as Block, Shopify, and Wix) do not allow you to change nameservers while the domain is registered with them. Because Cloudflare requires your nameservers to point to Cloudflare before a transfer can begin, a direct transfer from these platforms is not possible. For the recommended workaround, refer to [Transfer from website builders](/registrar/get-started/transfer-domain-to-cloudflare/#transfer-from-website-builders).
 
 ## Email verification required
 


### PR DESCRIPTION
Removed squarespace from the list of registrar/hosts that do not allow nameserver changes since they do

### Summary

Removed squarespace text from the list of registrar/hosts that do not allow nameserver changes since they do. No other changes to links, etc. There is still a link to squarespace nameserver change KB.