### PR TITLE
[RealtimeKit] Fix incorrect API reference URLs and text

### DIFF
--- a/src/content/docs/realtime/realtimekit/ai/summary.mdx
+++ b/src/content/docs/realtime/realtimekit/ai/summary.mdx
@@ -76,7 +76,7 @@ Configure `meeting.summary` event in [webhooks](/api/resources/realtime_kit/subr
 
 #### Fetch summary
 
-Refer to [Fetch summary of transcripts for a session](/api/resources/realtime_kit/subresources/sessions/#fetch-summary-of-transcripts-for-a-session).
+Refer to [Fetch summary of transcripts for a session](/api/resources/realtime_kit/subresources/sessions/methods/get_session_summary/).
 
 ```bash
 curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/realtime/kit/{app_id}/sessions/{session_id}/summary" \
@@ -85,7 +85,7 @@ curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/realtime
 
 #### Trigger manually
 
-Generate a summary after the meeting if `summarize_on_end` was not set. Refer to [Generate summary of transcripts for the session](/api/resources/realtime_kit/subresources/sessions/#generate-summary-of-transcripts-for-the-session).
+Generate a summary after the meeting if `summarize_on_end` was not set. Refer to [Generate summary of transcripts for the session](/api/resources/realtime_kit/subresources/sessions/methods/generate_summary_of_transcripts/).
 
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/realtime/kit/{app_id}/sessions/{session_id}/summary" \

--- a/src/content/docs/realtime/realtimekit/ai/transcription.mdx
+++ b/src/content/docs/realtime/realtimekit/ai/transcription.mdx
@@ -169,7 +169,7 @@ Configure `meeting.transcript` event in [webhooks](/api/resources/realtime_kit/s
 
 #### REST API
 
-Refer to [Fetch the complete transcript for a session](/api/resources/realtime_kit/subresources/sessions/#fetch-the-complete-transcript-for-a-session).
+Refer to [Fetch the complete transcript for a session](/api/resources/realtime_kit/subresources/sessions/methods/get_session_transcripts/).
 
 ```bash
 curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/realtime/kit/{app_id}/sessions/{session_id}/transcript" \

--- a/src/content/docs/realtime/realtimekit/concepts/index.mdx
+++ b/src/content/docs/realtime/realtimekit/concepts/index.mdx
@@ -32,7 +32,7 @@ Example - A recurring “Weekly Standup” **meeting will generate a new session
 
 ### Participant
 
-A **Participant** is created when you add a user to a meeting via the [REST API](/api/resources/realtime_kit/subresources/meetings/methods/create/). This API call returns a unique `authToken` that the client-side SDK uses to join the session and authenticate the user.
+A **Participant** is created when you add a user to a meeting via the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/). This API call returns a unique `authToken` that the client-side SDK uses to join the session and authenticate the user.
 
 > **Note:** Please do not re-use auth tokens for participants.
 

--- a/src/content/docs/realtime/realtimekit/core/index.mdx
+++ b/src/content/docs/realtime/realtimekit/core/index.mdx
@@ -12,7 +12,7 @@ import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnipp
 
 ### Initialize Core SDK
 
-To integrate the Core SDK, you will need to initialize it with a [participant's auth token](/api/resources/realtime_kit/#create-a-participant), and then use the provided SDK APIs to control the peer in the session.
+To integrate the Core SDK, you will need to initialize it with a [participant's auth token](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/), and then use the provided SDK APIs to control the peer in the session.
 
 Initialization might differ slightly based on your tech stack. Please choose your preferred tech stack below.
 
@@ -54,7 +54,7 @@ export default function App() {
 
 ```
 
-Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 
@@ -89,7 +89,7 @@ You can initialise the SDK using `RealtimeKitClient.init`.
 	});
 ```
 
-Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 
@@ -120,7 +120,7 @@ class AppComponent {
 }
 ```
 
-Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 
@@ -131,7 +131,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
     val meeting = RealtimeKitMeetingBuilder.build(activity)
     ```
 
-    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/resources/realtime_kit/#create-a-participant).
+    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/).
 
     ```kotlin
     val meetingInfo =
@@ -169,7 +169,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
     meeting.addSelfEventListener(selfEventListener: self)
     ```
 
-    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/resources/realtime_kit/#create-a-participant).
+    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/).
 
     ```swift
     let meetingInfo = RtkMeetingInfo(authToken: authToken,
@@ -192,7 +192,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
     final meeting = RealtimeKitClient();
     ```
 
-    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Create Participant API](/api/resources/realtime_kit/#create-a-participant).
+    Configure the meeting properties in the `RtkMeetingInfo` class with a valid participant `authToken` from the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/).
 
     ```dart
     final meetingInfo = RtkMeetingInfo(
@@ -257,7 +257,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
     }
     ```
 
-    Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 

--- a/src/content/docs/realtime/realtimekit/recording-guide/index.mdx
+++ b/src/content/docs/realtime/realtimekit/recording-guide/index.mdx
@@ -28,7 +28,7 @@ we currently support the
 1. When the recording is finished, it is stored in RealtimeKit's Cloudflare R2 bucket.
 2. RealtimeKit generates a downloadable link from which the recording can be
    downloaded. You can get the download URL using the
-   [Fetch details of a recording API](/api/resources/realtime_kit/subresources/recordings/)
+   [Fetch details of a recording API](/api/resources/realtime_kit/subresources/recordings/methods/get_one_recording/)
    or from the Developer Portal.
 
    You can receive notifications of recording status in any of the following
@@ -42,7 +42,7 @@ we currently support the
    deleted.
 
    You can get the download URL using the
-   [Fetch active recording API](/api/resources/realtime_kit/subresources/recordings/methods/start_recordings/) or
+   [Fetch active recording API](/api/resources/realtime_kit/subresources/recordings/methods/get_active_recordings/) or
    from the Developer Portal.
 
    We support transferring recordings to AWS, Azure, and DigitalOcean storage
@@ -55,5 +55,5 @@ we currently support the
 A typical workflow for recording a meeting involves the following steps:
 
 1. Start a recording using the [Start Recording API](/api/resources/realtime_kit/subresources/recordings/methods/start_recordings/) or client side SDK.
-2. Stop the recording using the [Stop Recording API](/api/resources/realtime_kit/subresources/recordings/) or client side SDK.
-3. Fetch the download URL for downloading the recording using the [Fetch Recording Details API](/api/resources/realtime_kit/subresources/recordings/methods/get_one_recording/), webhook, or from the Developer Portal.
+2. Stop the recording using the [Pause, resume, or stop recording API](/api/resources/realtime_kit/subresources/recordings/methods/pause_resume_stop_recording/) or client side SDK.
+3. Fetch the download URL for downloading the recording using the [Fetch details of a recording API](/api/resources/realtime_kit/subresources/recordings/methods/get_one_recording/), webhook, or from the Developer Portal.

--- a/src/content/docs/realtime/realtimekit/recording-guide/index.mdx
+++ b/src/content/docs/realtime/realtimekit/recording-guide/index.mdx
@@ -55,5 +55,5 @@ we currently support the
 A typical workflow for recording a meeting involves the following steps:
 
 1. Start a recording using the [Start Recording API](/api/resources/realtime_kit/subresources/recordings/methods/start_recordings/) or client side SDK.
-2. Stop the recording using the [Pause, resume, or stop recording API](/api/resources/realtime_kit/subresources/recordings/methods/pause_resume_stop_recording/) or client side SDK.
+2. Manage the recording using the [Pause, resume, or stop recording API](/api/resources/realtime_kit/subresources/recordings/methods/pause_resume_stop_recording/) or client side SDK.
 3. Fetch the download URL for downloading the recording using the [Fetch details of a recording API](/api/resources/realtime_kit/subresources/recordings/methods/get_one_recording/), webhook, or from the Developer Portal.

--- a/src/content/docs/realtime/realtimekit/sdk-selection.mdx
+++ b/src/content/docs/realtime/realtimekit/sdk-selection.mdx
@@ -24,7 +24,7 @@ RealtimeKit provides two ways to build real-time media applications:
 When you use our UI Kit, you also get access to the core SDK with it, which can be used to build additional features based on your needs.
 :::
 
-### Select you framework
+### Select your framework
 
 RealtimeKit support all the popular frameworks for web and mobile platforms. Please select the Platform and Framework that you are building on.
 

--- a/src/content/docs/realtime/realtimekit/ui-kit/index.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/index.mdx
@@ -33,7 +33,7 @@ export default function App() {
 }
 ```
 
-Use the [Create Participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 ## Create a meeting component
 
@@ -112,7 +112,7 @@ Use the `rtk-meeting` component to render the meeting UI:
 
 Pass the `authToken` and connect the meeting object to the UI component:
 
-Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 ```html
 <script>
@@ -186,7 +186,7 @@ class AppComponent {
 }
 ```
 
-Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participant/) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 </RTKCodeSnippet>
 
@@ -196,7 +196,7 @@ Use the [Create Participant API](/api/resources/realtime_kit/#create-a-participa
 
 Create a `RealtimeKitUI` instance with your auth token, then call `startMeeting(completion:)` to get a view controller. Present it to display the full meeting UI.
 
-Use the [Create Participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 ```swift
 import RealtimeKit
@@ -226,7 +226,7 @@ present(controller, animated: true)
 
 Create an `RtkMeetingInfo` with your auth token, wrap it in `RealtimeKitUIInfo`, build the UI Kit, and call `startMeeting()`.
 
-Use the [Create Participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 ```kotlin
 import com.cloudflare.realtimekit.models.RtkMeetingInfo
@@ -250,7 +250,7 @@ rtkUIKit.startMeeting()
 
 Create an `RtkMeetingInfo` with your auth token, wrap it in `RealtimeKitUIInfo`, and build the UI Kit. The returned `RealtimeKitUI` object is a Flutter widget — place it directly in your widget tree.
 
-Use the [Create Participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 ```dart
 import 'package:flutter/material.dart';
@@ -277,7 +277,7 @@ Call `RealtimeKitUIBuilder.dispose()` when you no longer need the meeting UI.
 
 Use the `useRealtimeKitClient` hook from the core React Native package to create a meeting instance:
 
-Use the [Create Participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
+Use the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/) to fetch the `authToken`.
 
 ```typescript
 import {

--- a/src/content/partials/realtime/realtimekit/web/breakout-room-preface.mdx
+++ b/src/content/partials/realtime/realtimekit/web/breakout-room-preface.mdx
@@ -1,7 +1,7 @@
 ---
 {}
-
 ---
+
 :::note
 The breakout rooms feature, also known as connected meetings, is currently in beta, which means it is still being tested and evaluated, and may undergo some changes.
 :::
@@ -88,8 +88,8 @@ You can choose to provide the following permissions to participants:
 
 ### Create a meeting
 
-Create a RealtimeKit meeting using the [Create Meeting API](/api/resources/realtime_kit/subresources/meetings/). This API returns a unique identifier for your meeting.
+Create a RealtimeKit meeting using the [Create meeting API](/api/resources/realtime_kit/subresources/meetings/methods/create/). This API returns a unique identifier for your meeting.
 
 ### Add participants
 
-After creating the meeting, add each participant using the [Add Participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/). The `presetName` created earlier must be passed in the body of the Add Participant API request.
+After creating the meeting, add each participant using the [Add participant API](/api/resources/realtime_kit/subresources/meetings/methods/add_participant/). The `presetName` created earlier must be passed in the body of the Add Participant API request.


### PR DESCRIPTION
### Summary

Corrects URLs and link text across the RealtimeKit SDK documentation that were pointing to wrong API reference pages or using non-descriptive, inconsistent link text.