### PR TITLE
Add changelog entries for L4 transport telemetry fields

### DIFF
--- a/src/content/changelog/rules/2026-04-01-l4-transport-telemetry-fields.mdx
+++ b/src/content/changelog/rules/2026-04-01-l4-transport-telemetry-fields.mdx
@@ -1,0 +1,40 @@
+---
+title: New QUIC RTT and delivery rate fields
+description: Two new fields expose QUIC round-trip time and connection delivery rate, completing the set of L4 transport telemetry available in rule expressions.
+date: 2026-04-01
+---
+
+Two new fields are now available in rule expressions that surface Layer 4 transport telemetry from the client connection. Together with the existing [`cf.timings.client_tcp_rtt_msec`](/ruleset-engine/rules-language/fields/reference/) field, these fields give you a complete picture of connection quality for both TCP and QUIC traffic — enabling transport-aware rules without requiring any client-side changes.
+
+Previously, QUIC RTT and delivery rate data was only available via the `Server-Timing: cfL4` response header. These new fields make the same data available directly in rule expressions, so you can use them in Transform Rules, WAF Custom Rules, and other phases that support dynamic fields.
+
+### New fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `cf.timings.client_quic_rtt_msec` | Integer | The smoothed QUIC round-trip time (RTT) between Cloudflare and the client in milliseconds. Only populated for QUIC (HTTP/3) connections. Returns `0` for TCP connections. |
+| `cf.edge.l4.delivery_rate` | Integer | The most recent data delivery rate estimate for the client connection, in bytes per second. Returns `0` when L4 statistics are not available for the request. |
+
+### Example: Route slow connections to a lightweight origin
+
+Use a request header transform rule to tag requests from high-latency connections, so your origin can serve a lighter page variant:
+
+**Rule expression:**
+
+```txt
+cf.timings.client_tcp_rtt_msec > 200 or cf.timings.client_quic_rtt_msec > 200
+```
+
+**Header modifications:**
+
+| Operation | Header name | Value |
+| --- | --- | --- |
+| Set | `X-High-Latency` | `true` |
+
+### Example: Match low-bandwidth connections
+
+```txt
+cf.edge.l4.delivery_rate > 0 and cf.edge.l4.delivery_rate < 100000
+```
+
+For more information, refer to [Request Header Transform Rules](/rules/transform/request-header-modification/) and the [fields reference](/ruleset-engine/rules-language/fields/reference/).

--- a/src/content/changelog/workers/2026-04-01-l4-transport-telemetry-fields.mdx
+++ b/src/content/changelog/workers/2026-04-01-l4-transport-telemetry-fields.mdx
@@ -1,0 +1,41 @@
+---
+title: New L4 transport telemetry fields in Workers
+description: Three new properties on request.cf expose client connection RTT and delivery rate, enabling transport-aware logic in Workers without client-side changes.
+date: 2026-04-01
+---
+
+Three new properties are now available on `request.cf` in Workers that expose Layer 4 transport telemetry from the client connection. These properties let your Worker make decisions based on real-time connection quality signals — such as round-trip time and data delivery rate — without requiring any client-side changes.
+
+Previously, this telemetry was only available via the `Server-Timing: cfL4` response header. These new properties surface the same data directly in the Workers runtime, so you can use it for routing, logging, or response customization.
+
+### New properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `clientTcpRtt` | number \| undefined | The smoothed TCP round-trip time (RTT) between Cloudflare and the client in milliseconds. Only present for TCP connections (HTTP/1, HTTP/2). For example, `22`. |
+| `clientQuicRtt` | number \| undefined | The smoothed QUIC round-trip time (RTT) between Cloudflare and the client in milliseconds. Only present for QUIC connections (HTTP/3). For example, `42`. |
+| `edgeL4` | Object \| undefined | Layer 4 transport statistics. Contains `deliveryRate` (number) — the most recent data delivery rate estimate for the connection, in bytes per second. For example, `123456`. |
+
+### Example: Log connection quality metrics
+
+```js
+export default {
+  async fetch(request) {
+    const cf = request.cf;
+
+    const rtt = cf.clientTcpRtt ?? cf.clientQuicRtt ?? 0;
+    const deliveryRate = cf.edgeL4?.deliveryRate ?? 0;
+    const transport = cf.clientTcpRtt ? "TCP" : "QUIC";
+
+    console.log(`Transport: ${transport}, RTT: ${rtt}ms, Delivery rate: ${deliveryRate} B/s`);
+
+    const headers = new Headers(request.headers);
+    headers.set("X-Client-RTT", String(rtt));
+    headers.set("X-Delivery-Rate", String(deliveryRate));
+
+    return fetch(new Request(request, { headers }));
+  },
+};
+```
+
+For more information, refer to [Workers Runtime APIs: Request](/workers/runtime-apis/request/).


### PR DESCRIPTION
## Summary

- Adds **Rules changelog** for two new Rulesets fields: `cf.timings.client_quic_rtt_msec` and `cf.edge.l4.delivery_rate`
- Adds **Workers changelog** for three new `request.cf` properties: `clientTcpRtt`, `clientQuicRtt`, and `edgeL4.deliveryRate`

## Context

The underlying docs (field definitions in `index.yaml` and Workers `request.mdx`) were already merged in [#29163](https://github.com/cloudflare/cloudflare-docs/pull/29163). These changelog entries announce the fields to customers.

Note: `cf.timings.client_tcp_rtt_msec` was previously announced in the [October 2025 Rules changelog](https://developers.cloudflare.com/changelog/post/2025-10-30-tcp-rtt-and-tcp-fields/), so the Rules entry only covers the two genuinely new fields. All three Workers properties are new and included.

## Files

| File | Product |
| --- | --- |
| `src/content/changelog/rules/2026-04-01-l4-transport-telemetry-fields.mdx` | Rules |
| `src/content/changelog/workers/2026-04-01-l4-transport-telemetry-fields.mdx` | Workers |

Related: SHIP-13879