### PR TITLE
[DLP] Improve clarity across DLP policies pages

### DIFF
--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/common-policies.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/common-policies.mdx
@@ -33,7 +33,7 @@ For more information on what file formats DLP can scan, refer to [Supported file
 
 ## Block uploads/downloads for specific users
 
-You can configure access on a per-user or group basis by adding [identity-based conditions](/cloudflare-one/traffic-policies/identity-selectors/) to your policies. These selectors match against user attributes from your configured [identity provider](/cloudflare-one/identity-providers/).
+You can configure access on a per-user or group basis by adding [identity-based conditions](/cloudflare-one/traffic-policies/identity-selectors/) to your policies. These selectors match against user attributes from your configured identity provider.
 
 The following example blocks only contractors from uploading/downloading Financial Information to file sharing apps. Users who are not in the _Contractors_ group are not affected by this policy.
 

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/common-policies.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/common-policies.mdx
@@ -10,11 +10,15 @@ head:
 
 import { GlossaryTooltip, Render } from "~/components";
 
-The following in-line DLP policies are commonly used to secure data in uploaded and downloaded files.
+The following DLP policies are commonly used to secure sensitive data in uploaded and downloaded files. They are built as [Gateway HTTP policies](/cloudflare-one/traffic-policies/http-policies/) using the [DLP Profile](/cloudflare-one/traffic-policies/http-policies/#dlp-profile) selector.
+
+Before using these policies, complete the [prerequisites for scanning HTTP traffic](/cloudflare-one/data-loss-prevention/dlp-policies/#prerequisites).
 
 ## Log uploads/downloads
 
-The **Allow** action functions as an implicit logger, providing visibility into where your sensitive data is going without impacting the end user experience. The following example scans for your enabled Financial Information profile entries when users upload or download data to file sharing apps.
+When you want to monitor where sensitive data is going before enforcing blocks, use the **Allow** action. In a Gateway HTTP policy, all matches — including Allow — are recorded in your [HTTP request logs](/cloudflare-one/data-loss-prevention/dlp-policies/#4-view-dlp-logs). This gives you visibility into sensitive data transfers without disrupting users.
+
+The following example logs any upload or download that matches your enabled [Financial Information](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/#financial-information) DLP profile entries when users interact with file sharing applications.
 
 | Selector           | Operator | Value                   | Logic | Action |
 | ------------------ | -------- | ----------------------- | ----- | ------ |
@@ -29,7 +33,9 @@ For more information on what file formats DLP can scan, refer to [Supported file
 
 ## Block uploads/downloads for specific users
 
-You can configure access on a per-user or group basis by adding [identity-based conditions](/cloudflare-one/traffic-policies/identity-selectors/) to your policies. The following example blocks only contractors from uploading/downloading Financial Information to file sharing apps.
+You can configure access on a per-user or group basis by adding [identity-based conditions](/cloudflare-one/traffic-policies/identity-selectors/) to your policies. These selectors match against user attributes from your configured [identity provider](/cloudflare-one/identity-providers/).
+
+The following example blocks only contractors from uploading/downloading Financial Information to file sharing apps. Users who are not in the _Contractors_ group are not affected by this policy.
 
 | Selector           | Operator | Value                   | Logic | Action |
 | ------------------ | -------- | ----------------------- | ----- | ------ |
@@ -39,7 +45,7 @@ You can configure access on a per-user or group basis by adding [identity-based 
 
 ## Exclude Android applications
 
-Many Android applications (such as Google Drive) use <GlossaryTooltip term="certificate pinning" link="/ssl/reference/certificate-pinning/">certificate pinning</GlossaryTooltip>, which is incompatible with Gateway inspection. If needed, you can create a [Do Not Inspect policy](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) so that the app can continue to function on Android:
+Many Android applications (such as Google Drive) use <GlossaryTooltip term="certificate pinning" link="/ssl/reference/certificate-pinning/">certificate pinning</GlossaryTooltip>, which is incompatible with Gateway TLS decryption. These applications verify they are connecting directly to their own servers and will reject Gateway's inspection certificate. If needed, you can create a [Do Not Inspect policy](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) so that the app can continue to function on Android:
 
 1. Set up an [OS version device posture check](/cloudflare-one/reusable-components/posture-checks/client-checks/os-version/) that checks for the Android operating system.
 
@@ -50,15 +56,15 @@ Many Android applications (such as Google Drive) use <GlossaryTooltip term="cert
    | Application                  | in       | _Google Drive_       | And   | Do Not Inspect |
    | Passed Device Posture Checks | in       | _OS Version Android_ |       |                |
 
-Android users can now use the app, but the app traffic will bypass DLP scanning.
+Android users can now use the app, but the app traffic will bypass Gateway inspection entirely — including DLP scanning, HTTP logging, and antivirus scanning.
 
 ## Exclude specific sites
 
-In your [DLP logs](/cloudflare-one/data-loss-prevention/dlp-policies/#4-view-dlp-logs), you may find that certain sites are a common source of noise. To exempt these sites from DLP scanning:
+In your [DLP logs](/cloudflare-one/data-loss-prevention/dlp-policies/#4-view-dlp-logs), you may find that certain sites routinely trigger DLP detections that do not represent actual data loss (false positives). To exempt these sites from DLP scanning:
 
 1. [Create a list](/cloudflare-one/reusable-components/lists/) of hostnames or URLs.
 
-2. Exclude the list from your DLP policy as shown in the example below:
+2. Exclude the list from your DLP policy using the `not in list` operator, which references the list you created in step 1:
 
    | Selector    | Operator    | Value                   | Logic | Action |
    | ----------- | ----------- | ----------------------- | ----- | ------ |

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/index.mdx
@@ -6,7 +6,9 @@ sidebar:
   label: Create DLP policies
 ---
 
-You can scan HTTP traffic for sensitive data through Secure Web Gateway policies. To perform DLP filtering, first configure a DLP profile with the data patterns you want to detect, and then build a Gateway HTTP policy to allow or block the sensitive data from leaving your organization. Gateway will parse and scan your HTTP traffic for strings matching the keywords or regular expressions (regexes) specified in the DLP profile.
+import { GlossaryTooltip } from "~/components";
+
+You can scan HTTP traffic for sensitive data through [Secure Web Gateway](/cloudflare-one/traffic-policies/) policies. Setting up <GlossaryTooltip term="Cloudflare Data Loss Prevention (DLP)">DLP</GlossaryTooltip> is a two-step process: first, configure a **DLP profile** that defines what sensitive data patterns to detect, and then build a **Gateway HTTP policy** that defines what action to take (allow, block, or log) when Gateway finds matching data. Gateway will parse and scan your HTTP traffic for strings matching the keywords or regular expressions (regexes) specified in the DLP profile.
 
 :::note
 To scan AI prompts and responses without Gateway HTTP filtering, you can also enable DLP directly on an [AI Gateway](/ai-gateway/features/dlp/).
@@ -14,17 +16,17 @@ To scan AI prompts and responses without Gateway HTTP filtering, you can also en
 
 ## Prerequisites
 
-- Set up [Gateway HTTP filtering](/cloudflare-one/traffic-policies/get-started/http/).
+- Set up [Gateway HTTP filtering](/cloudflare-one/traffic-policies/get-started/http/). This routes your users' web traffic through Cloudflare Gateway so it can be inspected.
   - HTTP filtering requires turning on the [Gateway proxy](/cloudflare-one/traffic-policies/proxy/#turn-on-the-gateway-proxy) for TCP traffic.
-- Turn on [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#turn-on-tls-decryption).
+- Turn on [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#turn-on-tls-decryption). Because most web traffic is encrypted with HTTPS, Gateway must decrypt it before DLP can scan the request body for sensitive data.
 
 ## 1. Configure a DLP profile
 
-Refer to [Configure a DLP profile](/cloudflare-one/data-loss-prevention/dlp-profiles/). We recommend getting started with a predefined profile.
+A DLP profile defines the sensitive data patterns you want to detect — for example, social security number formats, credit card numbers, or custom patterns specific to your organization. Refer to [Configure a DLP profile](/cloudflare-one/data-loss-prevention/dlp-profiles/). We recommend getting started with a predefined profile.
 
 :::caution[Important]
 
-DLP scans will not start until you [create a DLP policy](#2-create-a-dlp-policy).
+A DLP profile only defines detection patterns. DLP scans will not start until you [create a DLP policy](#2-create-a-dlp-policy).
 :::
 
 ## 2. Create a DLP policy
@@ -35,21 +37,21 @@ DLP Profiles may be used alongside other Cloudflare One rules in a [Gateway HTTP
 
 2. Select **Add a policy**.
 
-3. Build an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) using the [DLP Profile](/cloudflare-one/traffic-policies/http-policies/#dlp-profile) selector. For example, the following policy prevents users from uploading sensitive data to any location other than an approved corporate application:
+3. Build an [HTTP policy](/cloudflare-one/traffic-policies/http-policies/) using the [DLP Profile](/cloudflare-one/traffic-policies/http-policies/#dlp-profile) selector. For example, the following policy blocks users from uploading sensitive data to any location other than an approved corporate application. It combines three conditions: the request content matches a DLP profile, the HTTP method is `POST`, and the destination is not an approved application:
 
-   | Selector    | Operator | Value                                                    | Logic | Action |
-   | ----------- | -------- | -------------------------------------------------------- | ----- | ------ |
-   | DLP Profile | in       | _Social Security, Insurance, Tax, and Identifer Numbers_ | And   | Block  |
-   | HTTP Method | in       | _POST_                                                   | And   |        |
-   | Application | not in   | _Workday_                                                |       |        |
+   | Selector    | Operator | Value                                                     | Logic | Action |
+   | ----------- | -------- | --------------------------------------------------------- | ----- | ------ |
+   | DLP Profile | in       | _Social Security, Insurance, Tax, and Identifier Numbers_ | And   | Block  |
+   | HTTP Method | in       | _POST_                                                    | And   |        |
+   | Application | not in   | _Workday_                                                 |       |        |
 
 4. Select **Create policy**.
 
-DLP scanning is now turned on.
+DLP scanning is now turned on for HTTP traffic matching this policy.
 
 ## 3. Test DLP policy
 
-You can test your DLP policy on any device connected to your Zero Trust organization. To perform a basic test:
+You can test your DLP policy on any device connected to your [Zero Trust organization](/cloudflare-one/). To perform a basic test:
 
 1. Go to [dlptest.com](http://dlptest.com/http-post/).
 2. Enter a text message or upload a file containing the sensitive data.
@@ -67,9 +69,11 @@ Different sites will send requests in different ways. For example, some sites wi
    - **DLP Profiles** shows the requests which matched a specific DLP profile.
    - **Policy** shows the requests which matched a specific DLP policy.
 
-You can expand an individual row to view details about the request. To see the data that triggered the DLP policy, [configure logging options](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/).
+You can expand an individual row to view details about the request. By default, logs show that a match occurred but do not include the actual matched content. To see the data that triggered the DLP policy, [configure logging options](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/).
 
 ### Report false positives
+
+If DLP flags a request that does not actually contain sensitive data (a false positive), you can report it to Cloudflare:
 
 1. Select the log you want to report.
 2. Select **Report DLP false positive** under **DLP details**.

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/logging-options.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/logging-options.mdx
@@ -7,17 +7,27 @@ sidebar:
   order: 2
 ---
 
-Data Loss Prevention allows you to capture, store, and view the data that triggered a specific DLP policy for use as forensic evidence. Users on all plans can log the [payload](#log-the-payload-of-matched-rules) or [generative AI prompt content](#log-generative-ai-prompt-content) of matched HTTP requests in their Cloudflare logs. Additionally, Enterprise users can [configure a Logpush job](#send-http-requests-to-logpush-destination) to send copies of entire matched HTTP requests to storage destinations.
+Data Loss Prevention allows you to capture, store, and view the data that triggered a specific DLP policy for use as forensic evidence. DLP offers three logging approaches, each suited to different needs:
 
-The data that triggers a DLP policy is stored in the portion of the HTTP request known as the payload. Payload logging is especially useful when diagnosing the behavior of DLP policies. Since the values that triggered a rule may contain sensitive data, they are encrypted with a customer-provided public key so that only you can examine them later. The stored data will include a redacted version of the match, plus 75 bytes of additional context on both sides of the match.
+| Approach                                                                    | What it captures                                            | Encryption                      | Availability |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------- | ------------ |
+| [Payload logging](#log-the-payload-of-matched-rules)                        | Redacted match + 75 bytes of surrounding context            | Encrypted with your public key  | All plans    |
+| [AI prompt logging](#log-generative-ai-prompt-content)                      | Generative AI prompt topic, user prompt, and model response | Encrypted with your public key  | All plans    |
+| [Logpush forensic copies](#send-dlp-forensic-copies-to-logpush-destination) | Complete HTTP request (headers + body)                      | Encrypted in transit only (TLS) | Enterprise   |
+
+Users on all plans can log the [payload](#log-the-payload-of-matched-rules) or [generative AI prompt content](#log-generative-ai-prompt-content) of matched HTTP requests in their Cloudflare logs. Additionally, Enterprise users can [configure a Logpush job](#send-dlp-forensic-copies-to-logpush-destination) to send copies of entire matched HTTP requests to storage destinations.
+
+The data that triggers a DLP policy is stored in the body of the HTTP request — the part that carries content such as file uploads, form submissions, and chat messages. This body is referred to as the payload. Payload logging is especially useful when diagnosing the behavior of DLP policies. Since the values that triggered a rule may contain sensitive data, they are encrypted with a customer-provided public key so that only you can examine them later. The stored data will include a redacted version of the match, plus 75 bytes of additional context on both sides of the match.
 
 ## Set a DLP payload encryption public key
 
-Before you begin logging DLP payloads, you will need to set a DLP payload encryption public key.
+Before you begin logging DLP payloads, you will need to set a DLP payload encryption public key. DLP uses public-key encryption so that matched sensitive data is readable only by you — Cloudflare does not have access to your private key and cannot decrypt your logs.
 
 ### Generate a key pair
 
-To generate a public/private key pair in the command line, refer to [these instructions](/waf/managed-rules/payload-logging/command-line/generate-key-pair/).
+You will generate two keys: a public key (uploaded to Cloudflare to encrypt log data) and a private key (kept by you to decrypt log data later).
+
+To generate a public/private key pair in the command line, refer to [Generate a key pair](/waf/managed-rules/payload-logging/command-line/generate-key-pair/).
 
 ### Upload the public key to Cloudflare
 
@@ -27,16 +37,16 @@ To generate a public/private key pair in the command line, refer to [these instr
 4. Select **Save**.
 
 :::note
-The matching private key is required to view logs. If you lose your private key, you will need to [generate](#1-generate-a-key-pair) and [upload](#2-upload-the-public-key-to-cloudflare) a new public key. The payload of new requests will be encrypted with the new public key.
+The matching private key is required to view logs. If you lose your private key, you will need to [generate](#generate-a-key-pair) and [upload](#upload-the-public-key-to-cloudflare) a new public key. The payload of new requests will be encrypted with the new public key. Previously logged data encrypted with the old key will be permanently unreadable.
 :::
 
 ## Log the payload of matched rules
 
-DLP can log the payload of matched HTTP requests in your Cloudflare logs.
+DLP can log the payload of matched HTTP requests in your Cloudflare logs. Use payload logging to verify what content triggered a DLP detection — for example, to confirm whether a match was a real finding or a false positive.
 
 ### Turn on payload logging for a DLP policy
 
-You can enable payload logging for any Allow or Block HTTP policy that uses the [_DLP Profile_](/cloudflare-one/traffic-policies/http-policies/#dlp-profile) selector.
+You can enable payload logging for any Allow or Block HTTP policy that uses the [_DLP Profile_](/cloudflare-one/traffic-policies/http-policies/#dlp-profile) selector — the filter condition that matches traffic against your DLP detection profiles.
 
 1. Go to **Traffic policies** > **Firewall policies** > **HTTP**.
 2. Edit an existing Allow or Block DLP policy, or [create a new policy](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy).
@@ -62,11 +72,11 @@ Cloudflare does not store the key or the decrypted payload.
 
 ### Report false and true positives to AI context analysis
 
-When you have [AI context analysis](/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings/#ai-context-analysis) turned on for a DLP profile, you can train the AI model to adjust its confident threshold by reporting false and true positives.
+When you have [AI context analysis](/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings/#ai-context-analysis) turned on for a DLP profile, you can improve detection accuracy over time by reporting false and true positives. A false positive is a match that DLP flagged incorrectly (the content was not actually sensitive). A true positive confirms that DLP correctly identified sensitive data. These reports train the AI model to adjust its confidence threshold.
 
 To report a DLP match payload as a false or true positive:
 
-1. [Find and decrypt](#4-view-payload-logs) the payload log you want to report.
+1. [Find and decrypt](#view-payload-logs) the payload log you want to report.
 2. In **Log details**, choose a detected context match.
 3. In **Context**, select the redacted match data.
 4. In **Match details**, choose whether you want to report the match as a false positive or a true positive.
@@ -75,9 +85,9 @@ Based on your report, DLP's machine learning will adjust its confidence in futur
 
 ### Data privacy
 
-- All Cloudflare logs are encrypted at rest. Encrypting the payload content adds a second layer of encryption for the matched values that triggered a DLP rule.
+- All Cloudflare logs are encrypted at rest (encrypted while stored on disk). Encrypting the payload content adds a second layer of encryption for the matched values that triggered a DLP rule.
 - Cloudflare cannot decrypt encrypted payloads, since this operation requires your private key. Cloudflare staff will never ask for the private key.
-- DLP will redact all predefined alphanumeric characters in the log. For example, `123-45-6789` will become `XXX-XX-XXXX`.
+- DLP will redact alphanumeric characters in the matched pattern, replacing them with `X` while preserving the format. For example, `123-45-6789` will become `XXX-XX-XXXX`.
   - You can define sensitive data with [Exact Data Match (EDM)](/cloudflare-one/data-loss-prevention/detection-entries/#exact-data-match). EDM match logs will redact your defined strings.
 
 ## Log generative AI prompt content
@@ -86,7 +96,7 @@ DLP can detect and log the prompt topic sent to an AI tool.
 
 ### Turn on AI prompt content logging for a DLP policy
 
-You can enable payload logging for any Allow or Block HTTP policy that uses the [_Application_](/cloudflare-one/traffic-policies/http-policies/#application) selector with a supported [Application Granular Controls](/cloudflare-one/traffic-policies/http-policies/#granular-controls) application.
+You can enable AI prompt content logging for any Allow or Block HTTP policy that uses the [_Application_](/cloudflare-one/traffic-policies/http-policies/#application) selector with a supported [Application Granular Controls](/cloudflare-one/traffic-policies/http-policies/#granular-controls) application. This means your policy must target a specific AI application (such as ChatGPT) that Gateway can inspect at a granular level.
 
 1. Go to **Traffic policies** > **Firewall policies** > **HTTP**.
 2. Edit an existing Allow or Block DLP policy, or [create a new policy](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy).
@@ -113,7 +123,9 @@ Gateway logs will provide a summary of the conversation, including the topic and
 Only available on Enterprise plans.
 :::
 
-Gateway allows you to send copies of entire HTTP requests matched in HTTP Allow and Block policies to storage destinations configured in [Logpush](/logs/logpush/), including third-party destinations. Forensic copies include unaltered payloads and headers which may include sensitive data. Logpush logs are encrypted in transit only, such as when sent as TLS traffic. Further encryption depends on your storage destination's policies.
+Unlike payload logging (which stores encrypted excerpts of matched content), forensic copies send the complete, unaltered HTTP request — including all headers and the full body — to an external storage destination.
+
+Gateway allows you to send copies of entire HTTP requests matched in HTTP Allow and Block policies to storage destinations configured in [Logpush](/logs/logpush/) (Cloudflare's log delivery service), including third-party destinations. Forensic copies include unaltered payloads and headers which may include sensitive data. Logpush logs are encrypted in transit only, such as when sent as TLS traffic. Once the data reaches your storage destination, it is stored according to that destination's encryption policies — not encrypted by Cloudflare.
 
 To set up the DLP Forensic Copy Logpush job:
 
@@ -122,7 +134,7 @@ To set up the DLP Forensic Copy Logpush job:
 3. Choose a [Logpush destination](/logs/logpush/logpush-job/enable-destinations/).
 4. In **Configure logpush job**, choose the _DLP forensic copies_ dataset. Select **Create Logpush job**.
 5. Return to Cloudflare One and go to **Traffic policies** > **Firewall policies** > **HTTP**.
-6. Edit an existing Allow or Block policy, or [create a new policy](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy). Your policy does not need to include a DLP profile.
+6. Edit an existing Allow or Block policy, or [create a new policy](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy). Your policy does not need to include a DLP profile — any Gateway HTTP policy can send forensic copies.
 7. In the policy builder, scroll down to **Configure policy settings** and turn on **Send DLP forensic copies to storage**.
 8. Select a storage destination. Gateway will list any configured Logpush jobs or integrations that can receive HTTP requests.
 9. Select **Save policy**.


### PR DESCRIPTION
Improves clarity, fixes bugs, and adds missing context across all three pages in `src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/` based on an ELI5 analysis. All new claims were adversarially reviewed against source documentation.

**Changes across all three pages:**

- **index.mdx (Scan HTTP traffic)**
  - Add `GlossaryTooltip` for DLP on first use and cross-link Secure Web Gateway
  - Clarify the profile-vs-policy distinction inline ("a DLP profile defines what to detect; a Gateway HTTP policy defines what action to take")
  - Add 1-sentence "why" to each prerequisite (HTTP filtering routes traffic through Gateway; TLS decryption allows reading encrypted content)
  - Expand the caution note to explain why a profile alone does not start scanning
  - Narrate the example policy's combined-condition logic so readers can parse the table
  - Fix typo in example table: "Identifer" → "Identifier"
  - Add cross-link for "Zero Trust organization"
  - Note that logs show match metadata by default, not matched content
  - Define "false positive" inline in the reporting section

- **common-policies.mdx (Common DLP policies)**
  - Replace undefined "in-line DLP policies" with clear terminology and add prerequisite reminder
  - Explain the Allow-as-logger mechanism ("all matches — including Allow — are recorded in your HTTP request logs")
  - Link _Financial Information_ to predefined profiles on first use
  - Add identity provider cross-link and clarify that non-matching users are unaffected
  - Explain certificate pinning consequence and expand Do Not Inspect trade-off to include HTTP logging and AV scanning (per `http-policies/index.mdx:233`)
  - Replace vague "noise" with "false positives"
  - Connect the List creation step to the `not in list` operator usage

- **logging-options.mdx (Logging options)**
  - Add comparison table of three logging approaches (payload / AI prompt / Logpush) with encryption model and plan availability
  - Define "payload" explicitly as the HTTP request body on first use
  - Explain why DLP uses customer-managed encryption (Cloudflare cannot read your data)
  - Describe the two keys (public for encryption, private for decryption) before the generation step
  - Fix broken anchor `#1-generate-a-key-pair` → `#generate-a-key-pair`
  - Fix broken anchor `#4-view-payload-logs` → `#view-payload-logs`
  - Fix broken anchor `#send-http-requests-to-logpush-destination` → `#send-dlp-forensic-copies-to-logpush-destination`
  - Fix link text "these instructions" → descriptive text per style guide
  - Fix typo: "confident threshold" → "confidence threshold"
  - Define "false positive" and "true positive" inline
  - Fix terminology: "enable payload logging" → "enable AI prompt content logging" in the AI section
  - Add inline definition of "encrypted at rest"
  - Clarify that redaction replaces characters with X while preserving format
  - Add inline gloss for Logpush and explain the DLP Profile selector
  - Clarify Logpush security model: data encrypted in transit only, stored per destination policies
  - Note that any Gateway HTTP policy (not just DLP) can send forensic copies
  - Add consequence of losing private key: previously logged data becomes permanently unreadable