### PR TITLE
[Client-side security] Document domain-based threat intelligence for all customers and deprecate code behavior analysis

### DIFF
--- a/src/content/docs/client-side-security/detection/review-malicious-scripts.mdx
+++ b/src/content/docs/client-side-security/detection/review-malicious-scripts.mdx
@@ -12,7 +12,7 @@ description:
 import { Render, Steps, Tabs, TabItem, DashButton } from "~/components";
 
 :::note
-Only available to customers with Client-Side Security Advanced.
+Domain-based threat intelligence is available to all customers. Malicious code analysis and URL-based threat intelligence require Client-Side Security Advanced.
 :::
 
 Cloudflare displays scripts and connections considered malicious at the top of the dashboard lists, so that you can quickly identify those resources, review them, and take action.
@@ -46,7 +46,6 @@ To review the scripts considered malicious:
 
 3. Select **Details** for each script considered malicious. The script details will contain:
    - **Malicious code analysis**: Scores between 1-99 classifying how malicious the current script version is, where 1 means definitely malicious and 99 means definitely not malicious.
-   - **Code behavior analysis**: Scores classifying the behavior of the current script version in terms of code obfuscation and data exfiltration. The scores vary between 1-99, where 1 means definitely malicious and 99 means definitely not malicious.
    - **Threat intelligence**: Whether the script URL and/or domain is known to be malicious according to threat intelligence feeds. If the script is considered malicious according to the feeds, the dashboard will show a list of associated threat [categories](/client-side-security/how-it-works/malicious-script-detection/#malicious-script-and-connection-categories). If threat intelligence feeds do not have any information about the script URL or domain, the dashboard will show **Not present**.
 
    The script details also include the last 10 script versions detected by Cloudflare.

--- a/src/content/docs/client-side-security/how-it-works/malicious-script-detection.mdx
+++ b/src/content/docs/client-side-security/how-it-works/malicious-script-detection.mdx
@@ -9,7 +9,7 @@ description: Cloudflare analyzes the JavaScript code of the scripts loaded by
 ---
 
 :::note
-Only available to customers with Client-Side Security Advanced.
+Domain-based threat intelligence is available to all customers. Malicious script detection and malicious URL checks require Client-Side Security Advanced.
 :::
 
 Cloudflare uses different mechanisms to determine if a script, or a connection made by a script, is malicious. These mechanisms are:

--- a/src/content/release-notes/client-side-security.yaml
+++ b/src/content/release-notes/client-side-security.yaml
@@ -10,6 +10,13 @@ entries:
       Additionally, Page Shield policies are now called content security rules. This name matches the terminology already used in the new [application security dashboard](/security/).
 
   - publish_date: "2026-03-03"
+    title: Deprecated code behavior analysis scores
+    description: |-
+      Code behavior analysis scores have been removed from the malicious script details. The updated GNN and LLM-based detection approach has proven significantly more effective at identifying true positives, making the separate behavior analysis scores redundant.
+
+      Malicious code analysis scores and threat intelligence remain available for reviewing detected scripts. For more information, refer to [Review resources considered malicious](/client-side-security/detection/review-malicious-scripts/).
+
+  - publish_date: "2026-03-03"
     title: LLM-assisted false positive reduction for malicious script detection
     description: |-
       Page Shield now includes an additional machine learning step, utilizing an LLM powered by Workers AI, to assist in analyzing the JavaScript code of scripts loaded by your website visitors. This enhancement specifically helps reduce the false positive rate of our detection engines, focusing your attention on true positives.


### PR DESCRIPTION
### Summary

Domain-based threat intelligence is now available to all Client-Side Security customers (no longer Advanced-only). This PR updates the availability notes on the detection how-to and the how-it-works concept page to reflect this. It also removes the deprecated code behavior analysis feature from both pages and adds a release note dated 2026-03-03 explaining the deprecation.

**Files changed:**
- `src/content/docs/client-side-security/detection/review-malicious-scripts.mdx` — updated top-level availability note, removed code behavior analysis bullet
- `src/content/docs/client-side-security/how-it-works/malicious-script-detection.mdx` — updated top-level availability note, removed per-section availability callouts
- `src/content/release-notes/client-side-security.yaml` — added release note for code behavior analysis deprecation (2026-03-03)

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).