### PR TITLE
More accuractely identify failed builds in check builds results workflow step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,28 +130,47 @@ jobs:
       # AFTER all pages have been written to dist/. If link validation fails, the
       # build exits non-zero but dist/ is complete. We use continue-on-error so the
       # job succeeds (allowing deploy + post-build to run), then check the outcome below.
-      - run: npm run build
+      # We capture build output with tee so we can grep it to distinguish link-check
+      # failures from real build failures.
+      - name: Build
         id: build_step
-        name: Build
         continue-on-error: true
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_LINK_CHECK: true
+        run: |
+          set -o pipefail
+          npm run build 2>&1 | tee /tmp/build-output.log
 
-      # Distinguish between "link check failed" (dist/ exists) and "real build failure" (no dist/).
-      # If the build produced no output, we must fail the job immediately.
+      # Distinguish between "link check failed" and "real build failure" by grepping
+      # the captured build output for the link validator's specific error message.
+      # A non-empty dist/ alone is NOT sufficient — a partial build failure can leave
+      # pages in dist/ without the build completing.
       - name: Check build result
         id: check_link_result
+        shell: bash
         run: |
+          if [ "${{ steps.build_step.outcome }}" = "success" ]; then
+            echo "failed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Build failed — determine why.
+          # If dist/ is missing or empty, the build failed before producing any output.
           if [ ! -d dist ] || [ -z "$(ls -A dist)" ]; then
-            echo "Build failed before producing output. Check the Build job logs for the error."
+            echo "::error::Build failed before producing output. Check the Build step logs."
             exit 1
           fi
-          if [ "${{ steps.build_step.outcome }}" = "failure" ]; then
+
+          # dist/ has content, but the build still failed. Check if the ONLY failure
+          # was the link validator (which throws after all pages are written).
+          if grep -q "Links validation failed" /tmp/build-output.log; then
             echo "failed=true" >> "$GITHUB_OUTPUT"
             echo "::warning::Build succeeded but link validation failed. Preview will still be deployed."
           else
-            echo "failed=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Build failed for a reason other than link validation. Check the Build step logs."
+            exit 1
           fi
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,10 @@ jobs:
 
       # Distinguish between "link check failed" and "real build failure" by grepping
       # the captured build output for the link validator's specific error message.
-      # A non-empty dist/ alone is NOT sufficient — a partial build failure can leave
-      # pages in dist/ without the build completing.
+      # The link validator runs in astro:build:done (after all pages are written to
+      # dist/), so its error string can only appear when the build itself completed.
+      # Any other failure — including partial builds with a non-empty dist/ — will
+      # not contain that string and will correctly fail here.
       - name: Check build result
         id: check_link_result
         shell: bash
@@ -156,15 +158,7 @@ jobs:
             exit 0
           fi
 
-          # Build failed — determine why.
-          # If dist/ is missing or empty, the build failed before producing any output.
-          if [ ! -d dist ] || [ -z "$(ls -A dist)" ]; then
-            echo "::error::Build failed before producing output. Check the Build step logs."
-            exit 1
-          fi
-
-          # dist/ has content, but the build still failed. Check if the ONLY failure
-          # was the link validator (which throws after all pages are written).
+          # Build failed. Was it only the link validator?
           if grep -q "Links validation failed" /tmp/build-output.log; then
             echo "failed=true" >> "$GITHUB_OUTPUT"
             echo "::warning::Build succeeded but link validation failed. Preview will still be deployed."


### PR DESCRIPTION
## Summary

We're currently performing a work around in our build due to the starlight link validator plugin throwing errors on failure, and being unable to be config'ed to just warn. We still want to build preview deploys when the link validator fails, so we need to not fail the build pipeline in that scenario. 

### Previous Solution
The previous solution to this problem was to always succeed the build step via `continue-on-error: true`, and check after the fact in a separate `check build result` job to see if that build actually failed or if it was just a link validation issue based on if the `dist/` directory existed or not. 

### The problem
As it turns out, the `dist/` directory can exist even if the build legitimately fails. #29333

### This PR's solution
This PR's solution to this is to just adjust our work around to more accurately identify which failures are link validation vs real build failures. Instead of check for the existence of the `dist/` directory, we'll instead `grep` for the line "Links validation failed" outputted from the starlight link validator plugin. If this line exists, the link validation caused the job failure, else the actual build did.

### The future solution

I've opened a [PR](https://github.com/HiDeoo/starlight-links-validator/pull/147) to the starlight-links-validator library to add native support for non-blocking link validation and structured error output

Once that PR is merged and released, we can simplify our CI significantly:

1. **Update `astro.config.ts`** to set `failOnError: false` and `writeErrorsToFile: true` on the plugin config.
2. **Remove the `tee` + `grep` workaround** from the build step — the build will always succeed (no more `continue-on-error`, no more output capture).
3. **Replace the "Check build result" step** with a simple file existence check:
   ```yaml
   - name: Check for broken links
     run: |
       if [ -f .starlight-links-validator/errors.json ]; then
         echo "::error::Broken links found"
         exit 1
       fi
   ```

This eliminates the fragile output-parsing workaround entirely and gives us a clean separation between "build succeeded" and "link validation found errors."