### PR TITLE
fix: correct changelog link for Workflows local development

### DIFF
--- a/src/content/release-notes/workflows.yaml
+++ b/src/content/release-notes/workflows.yaml
@@ -10,7 +10,7 @@ entries:
 
       All commands also accept `--port` to target a specific `wrangler dev` session (defaults to `8787`).
 
-      More information available in the [changelog](/changelog/2026-03-31-wrangler-workflows-local/).
+      More information available in the [changelog](/changelog/post/2026-04-01-wrangler-workflows-local/).
   - publish_date: "2026-03-26"
     title: "JavaScript Workflows steps can now return streamed output"
     description: |-


### PR DESCRIPTION
### Summary

Fixes broken changelog link in Workflows release notes. 

Changed `/changelog/2026-03-31-wrangler-workflows-local/` to 
`/changelog/post/2026-04-01-wrangler-workflows-local/`.

Broken link is here
https://developers.cloudflare.com/workflows/reference/changelog/
https://developers.cloudflare.com/changelog/2026-03-31-wrangler-workflows-local/


### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
