### PR TITLE
Match husky pre-commit CRLF file check to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Text files that Git should normalize to LF line endings.
+# The pre-commit hook (.husky/pre-commit) uses the same extension list
+# to skip binary files. Keep both in sync when adding new file types.
 *.astro text eol=lf
 *.css text eol=lf
 *.go text eol=lf

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -16,6 +16,16 @@ while IFS= read -r file; do
     continue
   fi
 
+  # Only process known text files (matches .gitattributes).
+  # Skip binary files (images, fonts, etc.) to avoid corruption.
+  case "${file##*/}" in
+    __redirects|.editorconfig|.gitattributes|.prettierignore) ;;
+    *) case "$file" in
+         *.astro|*.css|*.go|*.html|*.ini|*.js|*.jsx|*.json|*.md|*.mdx|*.mjs|*.svg|*.toml|*.ts|*.tsx|*.txt|*.vue|*.xml|*.yaml|*.yml) ;;
+         *) continue ;;
+       esac ;;
+  esac
+
   # Check for carriage returns
   if grep -qU $'\r' "$file"; then
     # perl -pi works cross-platform (macOS BSD and Linux GNU)


### PR DESCRIPTION
### Summary

Match husky CRLF pre-commit file check to .gitattributes. The husky pre-commit was matching on binary files like images, causing them to become corrupt. 

The CI step that checks this already has the `-I` flag to skip binary files.
