### PR TITLE
chore: update htmltest installation method

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -38,8 +38,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
-        run: curl https://htmltest.wjdp.uk | bash
+      - name: Install htmltest
+        run: |
+          HTMLTEST_VERSION="0.17.0"
+          HTMLTEST_ARCHIVE="htmltest_${HTMLTEST_VERSION}_linux_amd64.tar.gz"
+          HTMLTEST_URL="https://github.com/wjdp/htmltest/releases/download/v${HTMLTEST_VERSION}/${HTMLTEST_ARCHIVE}"
+          # Checksum from https://github.com/wjdp/htmltest/releases/download/v0.17.0/htmltest_0.17.0_checksums.txt
+          HTMLTEST_CHECKSUM="775c597ee74899d6002cd2d93076f897f4ba68686bceabe2e5d72e84c57bc0fb"
+
+          curl -sL -o "${HTMLTEST_ARCHIVE}" "${HTMLTEST_URL}"
+          echo "${HTMLTEST_CHECKSUM}  ${HTMLTEST_ARCHIVE}" | sha256sum --check
+          tar -xzf "${HTMLTEST_ARCHIVE}"
+          chmod +x htmltest
+          mv htmltest ./bin/htmltest
 
       - name: Check - Broken header links
         id: header-link-check


### PR DESCRIPTION
## Summary
Updates the htmltest installation approach in the anchor link audit workflow.

## Changes
- Switch to direct download from GitHub releases
- Add version pinning to v0.17.0
- Include checksum verification for integrity

## Testing
- Anchor link audit run can be seen here: https://github.com/cloudflare/cloudflare-docs/actions/runs/23912554737/job/69738032431