### PR TITLE
[Cache] Clarify Cache Response Rule incompatibility with version management

### DIFF
--- a/src/content/docs/cache/how-to/cache-response-rules/index.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/index.mdx
@@ -21,7 +21,7 @@ Cache Response Rules can be created in the [dashboard](/cache/how-to/cache-respo
 
 :::note
 
-Cache Response Rules require that you [proxy the DNS records](/dns/proxy-status/) of your domain (or subdomain) through Cloudflare.
+Cache Response Rules require that you [proxy the DNS records](/dns/proxy-status/) of your domain (or subdomain) through Cloudflare. Cache Response Rules do not work with [Version Management](https://developers.cloudflare.com/version-management/)
 
 :::
 

--- a/src/content/docs/cache/how-to/cache-response-rules/index.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/index.mdx
@@ -20,9 +20,7 @@ Cache Response Rules apply to both cached and non-cached (dynamic) responses fro
 Cache Response Rules can be created in the [dashboard](/cache/how-to/cache-response-rules/create-dashboard/), via [API](/cache/how-to/cache-response-rules/create-api/), or [Terraform](/cache/how-to/cache-response-rules/terraform-example/).
 
 :::note
-
-Cache Response Rules require that you [proxy the DNS records](/dns/proxy-status/) of your domain (or subdomain) through Cloudflare. Cache Response Rules do not work with [Version Management](https://developers.cloudflare.com/version-management/)
-
+Cache Response Rules require that you [proxy the DNS records](/dns/proxy-status/) of your domain (or subdomain) through Cloudflare.
 :::
 
 ## Availability
@@ -61,4 +59,5 @@ In this case, the Cache Response Rule takes precedence. Cloudflare caches the as
 ## Notes
 
 - If you strip last modified then Smart Edge Revalidation will be turned off.
-- Cache Response Rules ignore HTTP Response 1xx as it is treated as informational responses.
+- Cache Response Rules ignore `1xx` HTTP response status codes as they are treated as informational responses.
+- Currently, Cache Response Rules do not work with [Version Management](/version-management/).

--- a/src/content/partials/version-management/product-limitations.mdx
+++ b/src/content/partials/version-management/product-limitations.mdx
@@ -36,7 +36,7 @@ Version Management does not currently support or have limited support for the fo
 
 <Details header="Cache Response Rules">
 
-- [Cache Response Rules](/cache/how-to/cache-response-rules/) do not work with Version Management
+- [Cache Response Rules](/cache/how-to/cache-response-rules/) do not work with Version Management.
 
 </Details>
 

--- a/src/content/partials/version-management/product-limitations.mdx
+++ b/src/content/partials/version-management/product-limitations.mdx
@@ -34,6 +34,12 @@ Version Management does not currently support or have limited support for the fo
 
 </Details>
 
+<Details header="Cache Response Rules">
+
+- [Cache Response Rules](/cache/how-to/cache-response-rules/) do not work with Version Management
+
+</Details>
+
 <Details header="Workers Cache API">
 
 - [Workers Cache API](/workers/runtime-apis/cache/) does not work with Version Management.


### PR DESCRIPTION
### Summary

Cache response rules do not work with version management. This PR updates the docs to clarify this.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
