### PR TITLE
chore: add validation for API response in schema update workflow

### DIFF
--- a/.github/workflows/update-api-schemas.yml
+++ b/.github/workflows/update-api-schemas.yml
@@ -22,6 +22,13 @@ jobs:
           LATEST_COMMIT=$(curl -s -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/cloudflare/api-schemas/commits/main | \
             jq -r '.sha')
+
+          # Validate that we got a valid git SHA (40 hex characters)
+          if ! [[ "$LATEST_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Error: Invalid commit SHA received from API: '$LATEST_COMMIT'"
+            exit 1
+          fi
+
           echo "latest_commit=$LATEST_COMMIT" >> $GITHUB_OUTPUT
 
       - name: Check current commit reference


### PR DESCRIPTION
## Summary
Adds validation for the commit SHA received from the GitHub API in the update-api-schemas workflow.

## Changes
- Add regex validation to ensure the API returns a valid 40-character hexadecimal SHA
- Workflow now fails early with a clear error message if the API response is malformed
- Prevents downstream issues in git operations and file modifications

## Benefits
- Guards against malformed API responses (e.g., rate limit errors, null values)
- Provides clearer error messages when API calls fail
- Improves workflow reliability