### PR TITLE
[Workers] Mark Deploy Hooks as available in compatibility matrix

### DIFF
--- a/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
+++ b/src/content/docs/workers/static-assets/migration-guides/migrate-from-pages.mdx
@@ -457,7 +457,7 @@ This compatibility matrix compares the features of Workers and Pages. Unless oth
 | [Monorepos](/workers/ci-cd/builds/advanced-setups/)                                                         | ✅      | ✅      |
 | [Build Watch Paths](/workers/ci-cd/builds/build-watch-paths/)                                               | ✅      | ✅      |
 | [Build Caching](/workers/ci-cd/builds/build-caching/)                                                       | ✅      | ✅      |
-| [Deploy Hooks](/pages/configuration/deploy-hooks/)                                                          | ⏳      | ✅      |
+| [Deploy Hooks](/workers/ci-cd/builds/deploy-hooks/)                                                         | ✅      | ✅      |
 | [Branch Deploy Controls](/pages/configuration/branch-build-controls/)                                       | 🟡 [^3] | ✅      |
 | [Custom Branch Aliases](/pages/how-to/custom-branch-aliases/)                                               | ⏳      | ✅      |
 | **Pages Functions**                                                                                         |         |         |


### PR DESCRIPTION
## Summary

- Updates the Pages-to-Workers compatibility matrix to mark Deploy Hooks as ✅ (supported) for Workers, replacing the previous ⏳ (coming soon)
- Updates the link to point to the Workers Deploy Hooks docs instead of the Pages docs