### PR TITLE
chore: Upgrade custom actions to Node 24

### DIFF
--- a/.github/actions/assign-pr/action.yml
+++ b/.github/actions/assign-pr/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: true
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "index.js"

--- a/.github/actions/issue-label-assign/action.yml
+++ b/.github/actions/issue-label-assign/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: true
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "index.js"

--- a/.github/actions/issue-label-assign/action.yml
+++ b/.github/actions/issue-label-assign/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: true
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "index.js"


### PR DESCRIPTION
## Summary

Upgrades our custom action from Node 16 to Node 24

## Changes

- Updated `issue-label-assign` action from `node16` to `node24`
- Updated `assign-pr` action from `node20` to `node24`