### PR TITLE
chore: use jq for JSON construction in workflows

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -72,7 +72,15 @@ jobs:
           WORKFLOW_LINK: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
         run: |
           echo "Specific header links in the [Workflow Run]($WORKFLOW_LINK).\n\nGenerally, we expect you to address at least 10-15 links before closing this out." > issue_body.txt
+
+          # Use jq to safely construct JSON payload
+          BODY=$(cat issue_body.txt)
+          JSON_PAYLOAD=$(jq -n \
+            --arg title "Broken Header Links Found" \
+            --arg body "$BODY" \
+            '{title: $title, body: $body}')
+
           curl --silent -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/issues" \
-            -d "{\"title\": \"Broken Header Links Found\", \"body\": \"$(cat issue_body.txt)\"}"
+            -d "$JSON_PAYLOAD"

--- a/.github/workflows/image-audit.yml
+++ b/.github/workflows/image-audit.yml
@@ -43,10 +43,19 @@ jobs:
         if: steps.find-files.outputs.unused_files
         env:
           UNUSED_FILES: ${{ steps.find-files.outputs.unused_files }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Create the issue and reference the unused_files variable
           echo "The following files are not referenced in any markdown file:\n${UNUSED_FILES}" > unused_files.txt
-          curl --silent -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+
+          # Use jq to safely construct JSON payload
+          BODY=$(cat unused_files.txt)
+          JSON_PAYLOAD=$(jq -n \
+            --arg title "Unused Image Files Found" \
+            --arg body "$BODY" \
+            '{title: $title, body: $body}')
+
+          curl --silent -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/cloudflare/cloudflare-docs/issues" \
-            -d "{\"title\": \"Unused Image Files Found\", \"body\": \"$(cat unused_files.txt)\"}"
+            -d "$JSON_PAYLOAD"

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -63,6 +63,10 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
+          # Use jq to safely construct JSON payload
+          MESSAGE="❌ *Publish Production* workflow failed.\nActor: $ACTOR\n<https://github.com/$REPO/actions/runs/$RUN_ID|View run>"
+          JSON_PAYLOAD=$(jq -n --arg text "$MESSAGE" '{text: $text}')
+
           curl -X POST "$WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d "{\"text\": \"❌ *Publish Production* workflow failed.\nActor: $ACTOR\n<https://github.com/$REPO/actions/runs/$RUN_ID|View run>\"}"
+            -d "$JSON_PAYLOAD"


### PR DESCRIPTION
## Summary
Improves JSON payload construction in workflow files by using jq instead of manual string interpolation.

## Changes
- Update image-audit.yml to use jq for GitHub Issues API calls
- Update anchor-link-audit.yml to use jq for GitHub Issues API calls
- Update publish-production.yml to use jq for Google Chat webhook payloads
- Move GITHUB_TOKEN to env block in image-audit.yml for consistency