### PR TITLE
[Gateway] Add tiered policies docs and restructure MSP page

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -1080,6 +1080,8 @@
 /magic-firewall/reference/magic-firewall-functions/ /cloudflare-network-firewall/reference/network-firewall-functions/ 301
 # CF1 changelog page
 /cloudflare-one/changelog/magic-firewall/ /cloudflare-one/changelog/cloudflare-network-firewall/ 301
+# CF1 MSP page moved under tiered-policies
+/cloudflare-one/traffic-policies/managed-service-providers/ /cloudflare-one/traffic-policies/tiered-policies/managed-service-providers/ 301
 # CF1 packet filtering overview rename
 /cloudflare-one/traffic-policies/packet-filtering/magic-firewall-overview/ /cloudflare-one/traffic-policies/packet-filtering/network-firewall-overview/ 301
 # cross-product magic-firewall slug renames

--- a/src/content/docs/cloudflare-one/traffic-policies/tiered-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/tiered-policies/index.mdx
@@ -1,0 +1,182 @@
+---
+pcx_content_type: how-to
+title: Tiered policies
+sidebar:
+  order: 15
+---
+
+:::note[Beta]
+Tiered policies with Cloudflare Organizations is currently in beta and available on Enterprise plans. To get started, refer to [Get started](#get-started).
+:::
+
+Gateway supports using [Cloudflare Organizations](/fundamentals/organizations/) to share configurations between and apply specific policies to accounts within an Organization. Tiered Gateway policies with Organizations support [DNS](/cloudflare-one/traffic-policies/dns-policies/), [network](/cloudflare-one/traffic-policies/network-policies/), [HTTP](/cloudflare-one/traffic-policies/http-policies/), and [resolver](/cloudflare-one/traffic-policies/resolver-policies/) policies.
+
+For a DNS-only deployment using the Tenant API, refer to [Managed service providers (MSPs)](/cloudflare-one/traffic-policies/tiered-policies/managed-service-providers/).
+
+## Get started
+
+To set up Cloudflare Organizations, refer to [Create an Organization](/fundamentals/organizations/#create-an-organization). Once you have provisioned and configured your Organization's accounts, you can create [Gateway policies](/cloudflare-one/traffic-policies/).
+
+For more information about Cloudflare Organizations, refer to the [Organizations](/fundamentals/organizations/) documentation.
+
+## Account types
+
+Zero Trust accounts in Cloudflare Organizations include source accounts and recipient accounts.
+
+In a tiered policy configuration, a top-level source account can share Gateway policies with its recipient accounts. Recipient accounts can add policies as needed while still being managed by the source account. Organization owners can also configure a [custom block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) for recipient accounts independently from the source account. Gateway will automatically [generate a unique root CA](/cloudflare-one/team-and-resources/devices/user-side-certificates/#generate-a-cloudflare-root-certificate) for each recipient account in an Organization.
+
+Each recipient account is subject to the default Zero Trust [account limits](/cloudflare-one/account-limits/).
+
+Gateway evaluates source account policies before any recipient account policies. Shared policies always take priority in recipient accounts — recipient accounts cannot bypass, modify, or reorder shared policies, and cannot move any of their own policies above shared ones. If you update the relative priority of shared policies in the source account, the change will be reflected in recipient accounts within approximately two minutes.
+
+All traffic and corresponding policies, logs, and configurations for a recipient account will be contained to that recipient account. Organization owners can view logs for recipient accounts on a per-account basis, and [Logpush jobs](/logs/logpush/) must be configured separately. When using DLP policies with [payload logging](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#log-the-payload-of-matched-rules), each recipient account must configure its own [encryption public key](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#set-a-dlp-payload-encryption-public-key).
+
+```mermaid
+flowchart TD
+%% Accessibility
+ accTitle: How Gateway policies work in a tiered account configuration
+ accDescr: Flowchart describing the order of precedence Gateway applies policies in a tiered account configuration using Cloudflare Organizations.
+
+%% Flowchart
+ subgraph s1["Source account"]
+        n1["Block malware"]
+        n2["Block spyware"]
+        n3["Block DNS tunnel"]
+  end
+ subgraph s2["Recipient account A"]
+        n5["Block malware"]
+        n6["Block spyware"]
+        n4["Block social media"]
+  end
+ subgraph s3["Recipient account B"]
+        n8["Block malware"]
+        n9["Block spyware"]
+        n10["Block DNS tunnel"]
+        n7["Block instant messaging"]
+  end
+    n1 ~~~ n2
+    n2 ~~~ n3
+    s1 -- Share policies with --> s2 & s3
+
+    n1@{ shape: rect}
+    n2@{ shape: rect}
+    n3@{ shape: rect}
+    n4@{ shape: rect}
+    n5@{ shape: rect}
+    n6@{ shape: rect}
+    n7@{ shape: rect}
+    n8@{ shape: rect}
+    n9@{ shape: rect}
+    n10@{ shape: rect}
+     n1:::Sky
+     n2:::Sky
+     n3:::Peach
+     n4:::Forest
+     n5:::Sky
+     n6:::Sky
+     n7:::Forest
+     n8:::Sky
+     n9:::Sky
+     n10:::Peach
+    classDef Sky stroke-width:1px, stroke-dasharray:none, stroke:#374D7C, fill:#E2EBFF, color:#374D7C
+    classDef Peach stroke-width:1px, stroke-dasharray:none, stroke:#FBB35A, fill:#FFEFDB, color:#8F632D
+    classDef Forest stroke-width:1px, stroke-dasharray:none, stroke:#2D6A4F, fill:#D8F3DC, color:#2D6A4F
+```
+
+In the diagram above, blue policies are shared from the source account, orange policies are not shared, and green policies are created locally in recipient accounts.
+
+### Limitations
+
+Tiered policies have the following limitations:
+
+- [Egress policies](/cloudflare-one/traffic-policies/egress-policies/) cannot be shared between accounts.
+- Source accounts cannot share policies that use [device posture](/cloudflare-one/reusable-components/posture-checks/) selectors, the detected protocol selector, or the quarantine action. Source and recipient accounts can still create and apply policies with these selectors and actions separately from the Organization share.
+- Policies can only be shared within an Organization. Sharing to sub-organizations is not supported.
+
+:::caution
+If a shared policy contains identity-based selectors, ensure that both the source account and recipient accounts have matching identity provider (IdP) configurations. If there is a mismatch in IdPs between the source account and a recipient account, the shared policy will never apply to traffic in that recipient account.
+:::
+
+## Manage policies
+
+You can create, configure, and share your tiered policies in the source account for your Cloudflare Organization.
+
+### Share policy
+
+To share a Gateway policy from a source account to a recipient account:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+2. Choose the policy type you want to share. If you want to share a resolver policy, go to **Traffic policies** > **Resolver policies**.
+3. Find the policy you want to share from the list. In the three-dot menu, select **Share**. Alternatively, to bulk share multiple policies, you can select each policy you want to share, then select **Actions** > **Share**.
+4. In **Select account**, choose the accounts you want to share the policy with. To share the policy with all existing and future recipient accounts in your Organization, choose *Select all accounts in org*.
+5. Select **Continue**, then select **Share**.
+
+A sharing icon will appear next to the policy's name. When sharing is complete, the policy will appear in and apply to the recipient accounts. Shared policies will appear grayed out in the recipient account's list of Gateway policies.
+
+:::note
+After sharing a policy, it may take up to two minutes before the policy appears in recipient accounts.
+:::
+
+If a policy fails to share to recipient accounts, Gateway will retry deploying the policy automatically unless the error is unrecoverable.
+
+### Edit share recipients
+
+To change or remove recipients for a Gateway policy:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+2. Choose the policy type you want to edit. If you want to edit a resolver policy, go to **Traffic policies** > **Resolver policies**.
+3. Find the policy you want to edit from the list.
+4. In the three-dot menu, select **Edit shared configuration recipients**.
+5. In **Select account**, choose the accounts you want to share the policy with. To remove a recipient, select **Remove** next to the recipient account's name.
+6. Select **Continue**, then select **Save**.
+
+When sharing is complete, the policy sharing will update across the configured recipient accounts.
+
+:::note
+If you selected *Select all accounts in org* when sharing the policy, you will need to [unshare the policy](#unshare-policy) before you can edit its recipient accounts.
+:::
+
+### Unshare policy
+
+To stop sharing a policy with all recipient accounts:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+2. Choose the policy type you want to remove. If you want to remove a resolver policy, go to **Traffic policies** > **Resolver policies**.
+3. Find the policy you want to remove from the list. In the three-dot menu, select **Unshare**. Alternatively, to bulk remove multiple policies, you can select each policy you want to remove, then select **Actions** > **Unshare**.
+4. Select **Unshare**.
+
+When sharing is complete, Gateway will stop sharing the policy with all recipient accounts and only apply the policy to the source account.
+
+### Edit shared policy
+
+When you edit or delete a shared policy in a source account, Gateway will require confirmation before making any changes. Changes made to shared policies will apply to all recipient accounts. Deleting a shared policy will delete the policy from both the source account and all recipient accounts.
+
+## Manage settings
+
+You can share Zero Trust settings from your source account to recipient accounts in your Cloudflare Organization, including the Gateway block page and extended email address matching. Other Gateway settings configured in a source account, such as [AV scanning](/cloudflare-one/traffic-policies/http-policies/antivirus-scanning/) and [file sandboxing](/cloudflare-one/traffic-policies/http-policies/file-sandboxing/), will not affect recipient account configurations.
+
+### Share Gateway block page
+
+To share your [Gateway block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) settings from a source account to a recipient account:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Reusable components** > **Custom pages**.
+2. In **Account Gateway block page**, select the three-dot menu and choose **Share**.
+3. In **Select account**, choose the accounts you want to share the settings with. To share the settings with all existing and future recipient accounts in your Organization, choose *Select all accounts in org*.
+4. Select **Continue**, then select **Share**.
+
+A sharing icon will appear next to the setting. When sharing is complete, the setting will appear in and apply to the recipient accounts.
+
+To modify share recipients or unshare the setting, select the three-dot menu and choose **Edit shared configuration recipients** or **Unshare**.
+
+### Share extended email address matching
+
+To share your [extended email address matching](/cloudflare-one/traffic-policies/identity-selectors/#extended-email-addresses) settings from a source account to a recipient account:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings**.
+2. In **Firewall** > **Matched extended email address**, select the three-dot menu and choose **Share**.
+3. In **Select account**, choose the accounts you want to share the settings with. To share the settings with all existing and future recipient accounts in your Organization, choose *Select all accounts in org*.
+4. Select **Continue**, then select **Share**.
+
+A sharing icon will appear next to the setting. When sharing is complete, the setting will appear in and apply to the recipient accounts.
+
+To modify share recipients or unshare the setting, select the three-dot menu and choose **Edit shared configuration recipients** or **Unshare**.

--- a/src/content/docs/cloudflare-one/traffic-policies/tiered-policies/managed-service-providers.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/tiered-policies/managed-service-providers.mdx
@@ -1,12 +1,12 @@
 ---
 pcx_content_type: how-to
 title: Managed service providers (MSPs)
-sidebar:
-  order: 15
 ---
 
-:::note
-Only available on Enterprise plans. For more information, contact your account team.
+:::note[Tiered policies with Organizations]
+Only available for [Cloudflare Partners](https://www.cloudflare.com/partners/) on Enterprise plans. Cloudflare recommends Enterprise customers configure a [Cloudflare Organization](/fundamentals/organizations/) for use with [tiered policies](/cloudflare-one/traffic-policies/tiered-policies/). Tiered policies with Organizations supports DNS, network, HTTP, and resolver policies, shared block pages, extended email matching, and per-account logging — capabilities not available through the Tenant API.
+
+For more information, contact your account team.
 :::
 
 Gateway supports the [Cloudflare Tenant API](/tenant/), which allows Cloudflare-partnered managed service providers (MSPs) to set up and manage Cloudflare accounts and services for their customers. With the Tenant API, MSPs can create Zero Trust deployments with global Gateway policy control. Policies can be customized or overridden at a group or individual account level.
@@ -17,9 +17,17 @@ The Tenant platform only supports [DNS policies](/cloudflare-one/traffic-policie
 
 For more information, refer to the [Cloudflare Zero Trust for managed service providers](https://blog.cloudflare.com/gateway-managed-service-provider/) blog post.
 
-## Get started
+## Organizations vs. Tenant API
 
-{/* Don't need to surface much of the policy creation flow here */}
+| Feature | Organizations ([Tiered policies](/cloudflare-one/traffic-policies/tiered-policies/)) | Tenant API (MSP) |
+|---|---|---|
+| **Supported policy types** | DNS, Network, HTTP, Resolver | DNS only |
+| **Account model** | Source / Recipient accounts | Parent / Child accounts |
+| **Shareable settings** | Block pages, extended email matching | Block pages |
+| **Setup** | Dashboard (self-serve) | API-only |
+| **Availability** | Enterprise (beta) | Enterprise (GA) |
+
+## Get started
 
 To set up the Tenant API, refer to [Get started](/tenant/get-started/). Once you have provisioned and configured your customer's Cloudflare accounts, you can create [DNS policies](/cloudflare-one/traffic-policies/dns-policies/).
 
@@ -32,7 +40,9 @@ The Gateway Tenant platform supports tiered and siloed account configurations.
 In a tiered account configuration, a top-level parent account enforces global security policies that apply to all of its child accounts. Child accounts can override or add policies as needed while still being managed by the parent account. MSPs can also configure child accounts independently from the parent account, including:
 
 - Configuring a [custom block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/)
+  - Child accounts will use the block page setting used by the parent account unless you configure separate block settings for the child account. This applies to both redirects and custom block pages. The block page uses the account certificate for each child account.
 - Generating or uploading [root certificates](/cloudflare-one/team-and-resources/devices/user-side-certificates/)
+  - If Gateway cannot attribute an incoming DNS query to a child account, it will use the parent account's certificate. This happens when the source IP address of the DNS query does not match a child account or if a custom DNS resolver endpoint is not configured.
 - Mapping [DNS locations](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/)
 - Creating [lists](/cloudflare-one/reusable-components/lists/)
 


### PR DESCRIPTION
## Summary

- Adds new **Tiered policies** page (`/cloudflare-one/traffic-policies/tiered-policies/`) documenting Organizations-based Gateway policy sharing (DNS, network, HTTP, resolver)
- Moves existing MSP/Tenant API docs as a subpage under tiered-policies, with a comparison table and sharpened callout recommending Organizations
- Adds 301 redirect from old `/managed-service-providers/` URL to new path

## Key additions to tiered-policies page
- Beta callout
- Source/recipient account model with mermaid diagram
- Policy sharing procedures (share, edit recipients, unshare, edit)
- Settings sharing (block page, extended email matching)
- Limitations (egress, device posture, detected protocol, quarantine action, sub-org sharing)
- IdP mismatch warning
- ~2 minute propagation delay note
- Policy priority enforcement details

## Key additions to MSP subpage
- Organizations vs. Tenant API comparison table
- Detailed callout recommending Organizations over Tenant API

Related: SHIP-6306