### PR TITLE
fix: Use safe shell loop pattern for file iteration

### DIFF
--- a/.github/workflows/potential-redirects-or-partials.yml
+++ b/.github/workflows/potential-redirects-or-partials.yml
@@ -85,11 +85,12 @@ jobs:
 
             ### Redirects
             This PR changes current filenames or deletes current files. Make sure you have [redirects](https://developers.cloudflare.com/pages/configuration/redirects/) set up to cover the following paths:"
-              for path in $CHANGED_FILES; do
+              while IFS= read -r path; do
+                [ -z "$path" ] && continue
                 clean_path=$(echo "$path" | sed 's/"//g') # Remove quotation marks
                 comment_body="$comment_body
             - [ ] \`$clean_path\`"
-              done
+              done <<< "$CHANGED_FILES"
             fi
 
             # Conditional bit for PARTIAL_FILES
@@ -98,11 +99,12 @@ jobs:
 
             ### Partials
             This PR updates partial files, which are pieces of content used across multiple files in our [Render component](https://developers.cloudflare.com/style-guide/components/render/)."
-              for path in $PARTIAL_FILES; do
+              while IFS= read -r path; do
+                [ -z "$path" ] && continue
                 updated_path=$(echo "$path" | sed -e 's/"//g' -e 's/^\///' -e 's/\/$//')
                 comment_body="$comment_body
             - [ ] \`$updated_path\` - [view affected files](https://developers.cloudflare.com/style-guide/components/render/?partial=$updated_path)"
-              done
+              done <<< "$PARTIAL_FILES"
             fi
 
             # Check if a comment already exists


### PR DESCRIPTION
## Summary

Updates shell loops in the potential-redirects-or-partials workflow to use a more robust iteration pattern for processing filenames.

## Changes

Replaced `for` loops with `while read` pattern:
- `for path in $CHANGED_FILES` → `while IFS= read -r path; do ... done <<< "$CHANGED_FILES"`
- `for path in $PARTIAL_FILES` → `while IFS= read -r path; do ... done <<< "$PARTIAL_FILES"`
- Added empty line checks to skip blank lines

## Why

The new pattern handles filenames with spaces and special characters more reliably. It processes each line exactly as returned from the GitHub API and follows shell scripting best practices for iterating over multi-line variables.