### PR TITLE
chore: add validation for API response in schema update workflow

### DIFF
--- a/.github/workflows/update-api-schemas.yml
+++ b/.github/workflows/update-api-schemas.yml
@@ -22,6 +22,12 @@ jobs:
           LATEST_COMMIT=$(curl -s -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/cloudflare/api-schemas/commits/main | \
             jq -r '.sha')
+
+          if ! [[ "$LATEST_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Error: Unexpected value received for commit SHA: '$LATEST_COMMIT'"
+            exit 1
+          fi
+
           echo "latest_commit=$LATEST_COMMIT" >> $GITHUB_OUTPUT
 
       - name: Check current commit reference


### PR DESCRIPTION
## Summary

Adds validation for the commit SHA received from the GitHub API in the `update-api-schemas` workflow.

## Changes

- Validates that the API response is a valid 40-character hexadecimal SHA before using it in downstream steps
- Workflow exits early with a clear error message if the value is unexpected (e.g. rate limit errors returning `null`)
- Prevents downstream steps from running with malformed data