### PR TITLE
[AI Gateway] Fix incorrect log storage limits on pricing and limits pages

### DIFF
--- a/src/content/docs/ai-gateway/observability/logging/index.mdx
+++ b/src/content/docs/ai-gateway/observability/logging/index.mdx
@@ -9,7 +9,7 @@ Logging is a fundamental building block for application development. Logs provid
 
 Your AI Gateway dashboard shows logs of individual requests, including the user prompt, model response, provider, timestamp, request status, token usage, cost, and duration. When [DLP](/ai-gateway/features/dlp/) policies are configured, logs for requests that trigger a DLP match also include the DLP action taken (Flag or Block), matched policy IDs, matched profile IDs, and the specific detection entries that were triggered. These logs persist, giving you the flexibility to store them for your preferred duration and do more with valuable request data.
 
-By default, each gateway can store up to 10 million logs. You can customize this limit per gateway in your gateway settings to align with your specific requirements. If your storage limit is reached, new logs will stop being saved. To continue saving logs, you must delete older logs to free up space for new logs.
+Each gateway has a storage limit based on your plan. You can customize this limit per gateway in your gateway settings. If your storage limit is reached, new logs will stop being saved. To continue saving logs, you must delete older logs to free up space for new logs.
 To learn more about your plan limits, refer to [Limits](/ai-gateway/reference/limits/).
 
 We recommend using an authenticated gateway when storing logs to prevent unauthorized access and protects against invalid requests that can inflate log storage usage and make it harder to find the data you need. Learn more about setting up an [authenticated gateway](/ai-gateway/configuration/authentication/).
@@ -94,7 +94,7 @@ These fields are available both in the dashboard log viewer and through the [Log
 To manage your log storage effectively, you can:
 
 - Set Storage Limits: Configure a limit on the number of logs stored per gateway in your gateway settings to ensure you only pay for what you need.
-- Enable Automatic Log Deletion: Activate the Automatic Log Deletion feature in your gateway settings to automatically delete the oldest logs once the log limit you've set or the default storage limit of 10 million logs is reached. This ensures new logs are always saved without manual intervention.
+- Enable Automatic Log Deletion: Activate the Automatic Log Deletion feature in your gateway settings to automatically delete the oldest logs once the storage limit for your account is reached. This ensures new logs are always saved without manual intervention.
 
 ## How to delete logs
 
@@ -102,7 +102,7 @@ To manage your log storage effectively and ensure continuous logging, you can de
 
 ### Automatic Log Deletion
 
-​To maintain continuous logging within your gateway's storage constraints, enable Automatic Log Deletion in your Gateway settings. This feature automatically deletes the oldest logs once the log limit you've set or the default storage limit of 10 million logs is reached, ensuring new logs are saved without manual intervention.
+​To maintain continuous logging within your gateway's storage constraints, enable Automatic Log Deletion in your Gateway settings. This feature automatically deletes the oldest logs once the storage limit for your account is reached, ensuring new logs are saved without manual intervention.
 
 ### Manual deletion
 

--- a/src/content/docs/ai-gateway/reference/limits.mdx
+++ b/src/content/docs/ai-gateway/reference/limits.mdx
@@ -18,7 +18,7 @@ The following limits apply to gateway configurations, logs, and related features
 | [Custom metadata](/ai-gateway/observability/custom-metadata/)         | 5 entries per request               |
 | [Datasets](/ai-gateway/evaluations/set-up-evaluations/)               | 10 per gateway                      |
 | Gateways free plan                                                    | 10 per account                      |
-| Gateways paid plan                                                    | 10 per account (default)            |
+| Gateways paid plan                                                    | 20 per account                      |
 | Gateway name length                                                   | 64 characters                       |
 | Log storage rate limit                                                | 500 logs per second per gateway     |
 | Logs stored [paid plan](/ai-gateway/reference/pricing/)               | 10 million per gateway <sup>1</sup> |

--- a/src/content/docs/ai-gateway/reference/limits.mdx
+++ b/src/content/docs/ai-gateway/reference/limits.mdx
@@ -22,7 +22,7 @@ The following limits apply to gateway configurations, logs, and related features
 | Gateway name length                                                   | 64 characters                       |
 | Log storage rate limit                                                | 500 logs per second per gateway     |
 | Logs stored [paid plan](/ai-gateway/reference/pricing/)               | 10 million per gateway <sup>1</sup> |
-| Logs stored [free plan](/ai-gateway/reference/pricing/)               | 100,000 total across all gateways <sup>2</sup> |
+| Logs stored [free plan](/ai-gateway/reference/pricing/)               | 100,000 per account <sup>2</sup>    |
 | [Log size stored](/ai-gateway/observability/logging/)                 | 10 MB per log <sup>3</sup>          |
 | [Logpush jobs](/ai-gateway/observability/logging/logpush/)            | 4 per account                       |
 | [Logpush size limit](/ai-gateway/observability/logging/logpush/)      | 1MB per log                         |

--- a/src/content/docs/ai-gateway/reference/limits.mdx
+++ b/src/content/docs/ai-gateway/reference/limits.mdx
@@ -22,22 +22,19 @@ The following limits apply to gateway configurations, logs, and related features
 | Gateway name length                                                   | 64 characters                       |
 | Log storage rate limit                                                | 500 logs per second per gateway     |
 | Logs stored [paid plan](/ai-gateway/reference/pricing/)               | 10 million per gateway <sup>1</sup> |
-| Logs stored [free plan](/ai-gateway/reference/pricing/)               | 100,000 per account <sup>2</sup>    |
+| Logs stored [free plan](/ai-gateway/reference/pricing/)               | 100,000 per gateway <sup>2</sup>    |
 | [Log size stored](/ai-gateway/observability/logging/)                 | 10 MB per log <sup>3</sup>          |
 | [Logpush jobs](/ai-gateway/observability/logging/logpush/)            | 4 per account                       |
 | [Logpush size limit](/ai-gateway/observability/logging/logpush/)      | 1MB per log                         |
 
-<sup>1</sup> If you have reached 10 million logs stored per gateway, new logs
-will stop being saved. To continue saving logs, you must delete older logs in
-that gateway to free up space or create a new gateway. Refer to [Auto Log
-Cleanup](/ai-gateway/observability/logging/#automatic-log-deletion) for more
-details on how to automatically delete logs.
+<sup>1</sup> When you reach the log storage limit for a gateway, you can
+configure your gateway to either automatically delete the oldest logs to make
+room for new ones, or stop saving new logs. You can also use
+[Logpush](/ai-gateway/observability/logging/logpush/) to export logs to
+external storage. Refer to [Automatic log deletion](/ai-gateway/observability/logging/#automatic-log-deletion)
+for more details.
 
-<sup>2</sup> If you have reached 100,000 logs stored per account, across all
-gateways, new logs will stop being saved. To continue saving logs, you must
-delete older logs. Refer to [Auto Log
-Cleanup](/ai-gateway/observability/logging/#automatic-log-deletion) for more
-details on how to automatically delete logs.
+<sup>2</sup> Same behavior as <sup>1</sup>.
 
 <sup>3</sup> Logs larger than 10 MB will not be stored.
 

--- a/src/content/docs/ai-gateway/reference/limits.mdx
+++ b/src/content/docs/ai-gateway/reference/limits.mdx
@@ -18,11 +18,11 @@ The following limits apply to gateway configurations, logs, and related features
 | [Custom metadata](/ai-gateway/observability/custom-metadata/)         | 5 entries per request               |
 | [Datasets](/ai-gateway/evaluations/set-up-evaluations/)               | 10 per gateway                      |
 | Gateways free plan                                                    | 10 per account                      |
-| Gateways paid plan                                                    | 20 per account                      |
+| Gateways paid plan                                                    | 10 per account (default)            |
 | Gateway name length                                                   | 64 characters                       |
 | Log storage rate limit                                                | 500 logs per second per gateway     |
 | Logs stored [paid plan](/ai-gateway/reference/pricing/)               | 10 million per gateway <sup>1</sup> |
-| Logs stored [free plan](/ai-gateway/reference/pricing/)               | 100,000 per gateway <sup>2</sup>    |
+| Logs stored [free plan](/ai-gateway/reference/pricing/)               | 100,000 total across all gateways <sup>2</sup> |
 | [Log size stored](/ai-gateway/observability/logging/)                 | 10 MB per log <sup>3</sup>          |
 | [Logpush jobs](/ai-gateway/observability/logging/logpush/)            | 4 per account                       |
 | [Logpush size limit](/ai-gateway/observability/logging/logpush/)      | 1MB per log                         |
@@ -34,7 +34,7 @@ room for new ones, or stop saving new logs. You can also use
 external storage. Refer to [Automatic log deletion](/ai-gateway/observability/logging/#automatic-log-deletion)
 for more details.
 
-<sup>2</sup> Same behavior as <sup>1</sup>.
+<sup>2</sup> On the free plan, the log storage limit applies to total logs across all gateways in your account. Same auto-delete or stop-saving behavior as <sup>1</sup>.
 
 <sup>3</sup> Logs larger than 10 MB will not be stored.
 

--- a/src/content/docs/ai-gateway/reference/pricing.mdx
+++ b/src/content/docs/ai-gateway/reference/pricing.mdx
@@ -19,12 +19,12 @@ Persistent logs are available on all plans. Log storage limits vary by plan.
 
 ### Log storage limits
 
-| Plan         | Log storage limit                    |
-| ------------ | ------------------------------------ |
+| Plan         | Log storage limit                      |
+| ------------ | -------------------------------------- |
 | Workers Free | 100,000 logs total across all gateways |
-| Workers Paid | 10,000,000 logs per gateway          |
+| Workers Paid | 10,000,000 logs per gateway            |
 
-On the Workers Free plan, the log storage limit applies to your total logs across all gateways in your account. On the Workers Paid plan, the limit applies per gateway. When you reach the storage limit, you can configure your gateway to either automatically delete the oldest logs to make room for new ones, or stop saving new logs. You can also use [Logpush](/ai-gateway/observability/logging/logpush/) to export logs to external storage. For more details, refer to [Automatic log deletion](/ai-gateway/observability/logging/#automatic-log-deletion).
+For more details on log storage behavior and automatic log deletion, refer to [Limits](/ai-gateway/reference/limits/) and [Logging](/ai-gateway/observability/logging/#automatic-log-deletion).
 
 ## Logpush
 

--- a/src/content/docs/ai-gateway/reference/pricing.mdx
+++ b/src/content/docs/ai-gateway/reference/pricing.mdx
@@ -15,16 +15,16 @@ You can monitor your usage in the AI Gateway dashboard.
 
 ## Persistent logs
 
-Persistent logs are available on all plans, with a free allocation for both free and paid plans. Charges for additional logs beyond those limits are based on the number of logs stored per month.
+Persistent logs are available on all plans. Log storage limits vary by plan.
 
-### Free allocation and overage pricing
+### Log storage limits
 
-| Plan         | Free logs stored   | Overage pricing                      |
-| ------------ | ------------------ | ------------------------------------ |
-| Workers Free | 100,000 logs total | N/A - Upgrade to Workers Paid        |
-| Workers Paid | 1,000,000 logs total | N/A |
+| Plan         | Log storage limit              |
+| ------------ | ------------------------------ |
+| Workers Free | 100,000 logs per gateway       |
+| Workers Paid | 10,000,000 logs per gateway    |
 
-Allocations are based on the total logs stored across all gateways. For guidance on managing or deleting logs, please see our [documentation](/ai-gateway/observability/logging).
+Log storage limits apply per gateway on all plans. When you reach the storage limit, you can configure your gateway to either automatically delete the oldest logs to make room for new ones, or stop saving new logs. You can also use [Logpush](/ai-gateway/observability/logging/logpush/) to export logs to external storage. For more details, refer to [Automatic log deletion](/ai-gateway/observability/logging/#automatic-log-deletion).
 
 ## Logpush
 

--- a/src/content/docs/ai-gateway/reference/pricing.mdx
+++ b/src/content/docs/ai-gateway/reference/pricing.mdx
@@ -19,12 +19,12 @@ Persistent logs are available on all plans. Log storage limits vary by plan.
 
 ### Log storage limits
 
-| Plan         | Log storage limit              |
-| ------------ | ------------------------------ |
-| Workers Free | 100,000 logs per gateway       |
-| Workers Paid | 10,000,000 logs per gateway    |
+| Plan         | Log storage limit                    |
+| ------------ | ------------------------------------ |
+| Workers Free | 100,000 logs total across all gateways |
+| Workers Paid | 10,000,000 logs per gateway          |
 
-Log storage limits apply per gateway on all plans. When you reach the storage limit, you can configure your gateway to either automatically delete the oldest logs to make room for new ones, or stop saving new logs. You can also use [Logpush](/ai-gateway/observability/logging/logpush/) to export logs to external storage. For more details, refer to [Automatic log deletion](/ai-gateway/observability/logging/#automatic-log-deletion).
+On the Workers Free plan, the log storage limit applies to your total logs across all gateways in your account. On the Workers Paid plan, the limit applies per gateway. When you reach the storage limit, you can configure your gateway to either automatically delete the oldest logs to make room for new ones, or stop saving new logs. You can also use [Logpush](/ai-gateway/observability/logging/logpush/) to export logs to external storage. For more details, refer to [Automatic log deletion](/ai-gateway/observability/logging/#automatic-log-deletion).
 
 ## Logpush
 


### PR DESCRIPTION
## Summary

- Fixed Workers Paid log storage limit on pricing page from 1M total to 10M per gateway
- Fixed free plan log storage limit from "per account" to "per gateway" on both pricing and limits pages
- Clarified that when the storage limit is reached, users can configure their gateway to either auto-delete oldest logs or stop saving new logs
- Added mention of Logpush as an option for exporting logs to external storage

Context: Internal discussion confirmed the log storage cap is per gateway on all plans (not per account for free), and the $8/100k pricing wiki is outdated.