### PR TITLE
[Chore] Remove sync from post-install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"format:core:fix": "npm run format:core -- --write",
 		"format:content": "npx prettier --write \"**/*.{md,mdx,astro}\"",
 		"format:data": "npx prettier --write \"**/*.{json,yaml,yml}\"",
-		"postinstall": "npx patch-package && npm run sync",
+		"postinstall": "npx patch-package",
 		"preview": "npx astro preview",
 		"script:optimize-svgs": "npx tsx scripts/optimize-svgs.ts",
 		"start": "npx astro dev",


### PR DESCRIPTION
### Summary

This is already included in dev and build by default, so we don't need on install. Saves ~30 sec when we miss the node_modules cache.

<img width="740" height="285" alt="Screenshot 2026-04-03 at 3 03 27 PM" src="https://github.com/user-attachments/assets/0603e1b6-2bfd-43ff-9eac-157c2b42a525" />


https://docs.astro.build/en/reference/cli-reference/#astro-sync