### PR TITLE
[Workers AI] Add Google Gemma 4 26B A4B model

### DIFF
--- a/src/content/changelog/workers-ai/2026-04-02-gemma-4-26b-a4b-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-04-02-gemma-4-26b-a4b-workers-ai.mdx
@@ -1,0 +1,25 @@
+---
+title: "Google Gemma 4 26B A4B now available on Workers AI"
+description: A Mixture-of-Experts model with 26B total parameters and 4B active, featuring a 256K context window, vision, thinking mode, and function calling.
+products:
+  - workers-ai
+date: 2026-04-02
+---
+
+We are partnering with Google to bring [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) to Workers AI. Gemma 4 26B A4B is a Mixture-of-Experts (MoE) model built from Gemini 3 research, with 26B total parameters and only 4B active per forward pass. By activating a small subset of parameters during inference, the model runs almost as fast as a 4B-parameter model while delivering the quality of a much larger one.
+
+Gemma 4 is Google's most capable family of open models, designed to maximize intelligence-per-parameter.
+
+## Key capabilities
+
+- **Mixture-of-Experts architecture** with 8 active experts out of 128 total (plus 1 shared expert), delivering frontier-level performance at a fraction of the compute cost of dense models
+- **256,000 token context window** for retaining full conversation history, tool definitions, and long documents across extended sessions
+- **Built-in thinking mode** that lets the model reason step-by-step before answering, improving accuracy on complex tasks
+- **Vision understanding** for object detection, document and PDF parsing, screen and UI understanding, chart comprehension, OCR (including multilingual), and handwriting recognition, with support for variable aspect ratios and resolutions
+- **Function calling** with native support for structured tool use, enabling agentic workflows and multi-step planning
+- **Multilingual** with out-of-the-box support for 35+ languages, pre-trained on 140+ languages
+- **Coding** for code generation, completion, and correction
+
+Use Gemma 4 26B A4B through the [Workers AI binding](/workers-ai/configuration/bindings/) (`env.AI.run()`), the REST API at `/run` or `/v1/chat/completions`, or the [OpenAI-compatible endpoint](/workers-ai/configuration/open-ai-compatibility/).
+
+For more information, refer to the [Gemma 4 26B A4B model page](/workers-ai/models/gemma-4-26b-a4b-it/).

--- a/src/content/changelog/workers-ai/2026-04-04-gemma-4-26b-a4b-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-04-04-gemma-4-26b-a4b-workers-ai.mdx
@@ -3,7 +3,7 @@ title: "Google Gemma 4 26B A4B now available on Workers AI"
 description: A Mixture-of-Experts model with 26B total parameters and 4B active, featuring a 256K context window, vision, thinking mode, and function calling.
 products:
   - workers-ai
-date: 2026-04-02
+date: 2026-04-04
 ---
 
 We are partnering with Google to bring [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) to Workers AI. Gemma 4 26B A4B is a Mixture-of-Experts (MoE) model built from Gemini 3 research, with 26B total parameters and only 4B active per forward pass. By activating a small subset of parameters during inference, the model runs almost as fast as a 4B-parameter model while delivering the quality of a much larger one.

--- a/src/content/docs/workers-ai/platform/pricing.mdx
+++ b/src/content/docs/workers-ai/platform/pricing.mdx
@@ -62,6 +62,7 @@ The Price in Tokens column is equivalent to the Price in Neurons column - the di
 | @cf/zai-org/glm-4.7-flash                    | $0.060 per M input tokens <br/> $0.400 per M output tokens                                        | 5500 neurons per M input tokens <br/> 36400 neurons per M output tokens                                                |
 | @cf/nvidia/nemotron-3-120b-a12b              | $0.500 per M input tokens <br/> $1.500 per M output tokens                                        | 45455 neurons per M input tokens <br/> 136364 neurons per M output tokens                                              |
 | @cf/moonshotai/kimi-k2.5                     | $0.600 per M input tokens <br/> $0.100 per M cached input tokens <br/> $3.000 per M output tokens | 54545 neurons per M input tokens <br/> 9091 neurons per M cached input tokens <br/> 272727 neurons per M output tokens |
+| @cf/google/gemma-4-26b-a4b-it                | $0.100 per M input tokens <br/> $0.300 per M output tokens                                        | 9091 neurons per M input tokens <br/> 27273 neurons per M output tokens                                                |
 
 ## Embeddings model pricing
 

--- a/src/content/release-notes/workers-ai.yaml
+++ b/src/content/release-notes/workers-ai.yaml
@@ -3,6 +3,10 @@ link: "/workers-ai/changelog/"
 productName: Workers AI
 productLink: "/workers-ai/"
 entries:
+  - publish_date: "2026-04-02"
+    title: Google Gemma 4 26B A4B now available on Workers AI
+    description: |-
+      - [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) now available on Workers AI. A Mixture-of-Experts model with 26B total parameters and 4B active, featuring a 256K context window, vision, built-in thinking mode, and function calling. Released under an Apache 2.0 license. Read [changelog](/changelog/post/2026-04-02-gemma-4-26b-a4b-workers-ai/) to get started.
   - publish_date: "2026-03-19"
     title: Moonshot AI Kimi K2.5 now available on Workers AI
     description: |-

--- a/src/content/release-notes/workers-ai.yaml
+++ b/src/content/release-notes/workers-ai.yaml
@@ -3,10 +3,10 @@ link: "/workers-ai/changelog/"
 productName: Workers AI
 productLink: "/workers-ai/"
 entries:
-  - publish_date: "2026-04-02"
+  - publish_date: "2026-04-04"
     title: Google Gemma 4 26B A4B now available on Workers AI
     description: |-
-      - [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) now available on Workers AI. A Mixture-of-Experts model with 26B total parameters and 4B active, featuring a 256K context window, vision, built-in thinking mode, and function calling. Released under an Apache 2.0 license. Read [changelog](/changelog/post/2026-04-02-gemma-4-26b-a4b-workers-ai/) to get started.
+      - [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) now available on Workers AI. A Mixture-of-Experts model with 26B total parameters and 4B active, featuring a 256K context window, vision, built-in thinking mode, and function calling. Released under an Apache 2.0 license. Read [changelog](/changelog/post/2026-04-04-gemma-4-26b-a4b-workers-ai/) to get started.
   - publish_date: "2026-03-19"
     title: Moonshot AI Kimi K2.5 now available on Workers AI
     description: |-

--- a/src/content/release-notes/workers-ai.yaml
+++ b/src/content/release-notes/workers-ai.yaml
@@ -6,7 +6,7 @@ entries:
   - publish_date: "2026-04-04"
     title: Google Gemma 4 26B A4B now available on Workers AI
     description: |-
-      - [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) now available on Workers AI. A Mixture-of-Experts model with 26B total parameters and 4B active, featuring a 256K context window, vision, built-in thinking mode, and function calling. Released under an Apache 2.0 license. Read [changelog](/changelog/post/2026-04-04-gemma-4-26b-a4b-workers-ai/) to get started.
+      - [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) now available on Workers AI. A Mixture-of-Experts model with 26B total parameters and 4B active, featuring a 256K context window, vision, built-in thinking mode, and function calling. Read [changelog](/changelog/post/2026-04-04-gemma-4-26b-a4b-workers-ai/) to get started.
   - publish_date: "2026-03-19"
     title: Moonshot AI Kimi K2.5 now available on Workers AI
     description: |-

--- a/src/content/workers-ai-models/gemma-4-26b-a4b-it.json
+++ b/src/content/workers-ai-models/gemma-4-26b-a4b-it.json
@@ -1,0 +1,4772 @@
+{
+    "id": "328adb49-4a7d-43e3-a2d5-802ae8100fe7",
+    "source": 1,
+    "name": "@cf/google/gemma-4-26b-a4b-it",
+    "description": "Gemma 4 is Google's most intelligent family of open models, built from Gemini 3 research to maximize intelligence-per-parameter.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "created_at": "2026-04-02 15:05:22.642",
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "context_window",
+            "value": "256000"
+        },
+        {
+            "property_id": "price",
+            "value": [
+                {
+                    "unit": "per M input tokens",
+                    "price": 0.1,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M output tokens",
+                    "price": 0.3,
+                    "currency": "USD"
+                }
+            ]
+        },
+        {
+            "property_id": "function_calling",
+            "value": "true"
+        },
+        {
+            "property_id": "reasoning",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://ai.google.dev/gemma/docs/gemma_4_license"
+        },
+        {
+            "property_id": "vision",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "title": "Prompt",
+                            "properties": {
+                                "prompt": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "description": "The input text prompt for the model to generate a response."
+                                },
+                                "skip_special_tokens": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enable_thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "prompt"
+                            ]
+                        },
+                        {
+                            "title": "Messages",
+                            "properties": {
+                                "messages": {
+                                    "type": "array",
+                                    "description": "A list of messages comprising the conversation so far.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "developer"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "system"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "user"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "image_url",
+                                                                                "input_audio",
+                                                                                "file"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "image_url": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "detail": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "auto",
+                                                                                        "low",
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "default": "auto"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "input_audio": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "format": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "wav",
+                                                                                        "mp3"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "file": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "file_data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "file_id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "filename": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                },
+                                                                "minItems": 1
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "assistant"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "refusal"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "refusal": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "refusal": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "audio": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_calls": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        "function": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string",
+                                                                                    "description": "JSON-encoded arguments string."
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "custom"
+                                                                            ]
+                                                                        },
+                                                                        "custom": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "input": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "input"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "custom"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "function_call": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "arguments": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name",
+                                                                    "arguments"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "tool"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_call_id": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "tool_call_id"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "name"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "minItems": 1
+                                },
+                                "skip_special_tokens": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "enable_thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "messages"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "title": "Prompt",
+                                        "properties": {
+                                            "merge": {
+                                                "source": {
+                                                    "prompt": {
+                                                        "type": "string",
+                                                        "minLength": 1,
+                                                        "description": "The input text prompt for the model to generate a response."
+                                                    },
+                                                    "skip_special_tokens": {
+                                                        "type": "boolean",
+                                                        "default": false
+                                                    }
+                                                },
+                                                "with": {
+                                                    "model": {
+                                                        "type": "string",
+                                                        "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                                    },
+                                                    "audio": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                                "properties": {
+                                                                    "voice": {
+                                                                        "oneOf": [
+                                                                            {
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "format": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "wav",
+                                                                            "aac",
+                                                                            "mp3",
+                                                                            "flac",
+                                                                            "opus",
+                                                                            "pcm16"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "voice",
+                                                                    "format"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "frequency_penalty": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number",
+                                                                "minimum": -2,
+                                                                "maximum": 2
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": 0,
+                                                        "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                                    },
+                                                    "logit_bias": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                                    },
+                                                    "logprobs": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "boolean"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": false,
+                                                        "description": "Whether to return log probabilities of the output tokens."
+                                                    },
+                                                    "top_logprobs": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "integer",
+                                                                "minimum": 0,
+                                                                "maximum": 20
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                                    },
+                                                    "max_tokens": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "integer"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                                    },
+                                                    "max_completion_tokens": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "integer"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                                    },
+                                                    "metadata": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Set of 16 key-value pairs that can be attached to the object."
+                                                    },
+                                                    "modalities": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "text",
+                                                                        "audio"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                                    },
+                                                    "n": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "integer",
+                                                                "minimum": 1,
+                                                                "maximum": 128
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": 1,
+                                                        "description": "How many chat completion choices to generate for each input message."
+                                                    },
+                                                    "parallel_tool_calls": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable parallel function calling during tool use."
+                                                    },
+                                                    "prediction": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "content"
+                                                                        ]
+                                                                    },
+                                                                    "content": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "string"
+                                                                            },
+                                                                            {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        },
+                                                                                        "text": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "text"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "content"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "presence_penalty": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number",
+                                                                "minimum": -2,
+                                                                "maximum": 2
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": 0,
+                                                        "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                                    },
+                                                    "reasoning_effort": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                                    },
+                                                    "chat_template_kwargs": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "enable_thinking": {
+                                                                "type": "boolean",
+                                                                "default": true,
+                                                                "description": "Whether to enable reasoning, enabled by default."
+                                                            },
+                                                            "clear_thinking": {
+                                                                "type": "boolean",
+                                                                "default": false,
+                                                                "description": "If false, preserves reasoning context between turns."
+                                                            }
+                                                        }
+                                                    },
+                                                    "response_format": {
+                                                        "anyOf": [
+                                                            {
+                                                                "description": "Specifies the format the model must output.",
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "json_object"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "json_schema"
+                                                                                ]
+                                                                            },
+                                                                            "json_schema": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "name": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "description": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "schema": {
+                                                                                        "type": "object"
+                                                                                    },
+                                                                                    "strict": {
+                                                                                        "anyOf": [
+                                                                                            {
+                                                                                                "type": "boolean"
+                                                                                            },
+                                                                                            {
+                                                                                                "type": "null"
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "name"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "json_schema"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "seed": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "integer"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "description": "If specified, the system will make a best effort to sample deterministically."
+                                                    },
+                                                    "service_tier": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "auto",
+                                                                    "default",
+                                                                    "flex",
+                                                                    "scale",
+                                                                    "priority"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": "auto",
+                                                        "description": "Specifies the processing type used for serving the request."
+                                                    },
+                                                    "stop": {
+                                                        "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "null"
+                                                            },
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "minItems": 1,
+                                                                "maxItems": 4
+                                                            }
+                                                        ]
+                                                    },
+                                                    "store": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "boolean"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": false,
+                                                        "description": "Whether to store the output for model distillation / evals."
+                                                    },
+                                                    "stream": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "boolean"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": false,
+                                                        "description": "If true, partial message deltas will be sent as server-sent events."
+                                                    },
+                                                    "stream_options": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "include_usage": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "include_obfuscation": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "temperature": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number",
+                                                                "minimum": 0,
+                                                                "maximum": 2
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": 1,
+                                                        "description": "Sampling temperature between 0 and 2."
+                                                    },
+                                                    "tool_choice": {
+                                                        "anyOf": [
+                                                            {
+                                                                "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "none",
+                                                                            "auto",
+                                                                            "required"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "description": "Force a specific function tool.",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "function"
+                                                                                ]
+                                                                            },
+                                                                            "function": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "name": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "name"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "description": "Force a specific custom tool.",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "custom"
+                                                                                ]
+                                                                            },
+                                                                            "custom": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "name": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "name"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "description": "Constrain to an allowed subset of tools.",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "allowed_tools"
+                                                                                ]
+                                                                            },
+                                                                            "allowed_tools": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "mode": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "auto",
+                                                                                            "required"
+                                                                                        ]
+                                                                                    },
+                                                                                    "tools": {
+                                                                                        "type": "array",
+                                                                                        "items": {
+                                                                                            "type": "object"
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "mode",
+                                                                                    "tools"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tools": {
+                                                        "type": "array",
+                                                        "description": "A list of tools the model may call.",
+                                                        "items": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        "function": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string",
+                                                                                    "description": "The name of the function to be called."
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "description": "A description of what the function does."
+                                                                                },
+                                                                                "parameters": {
+                                                                                    "type": "object",
+                                                                                    "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                                },
+                                                                                "strict": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ],
+                                                                                    "default": false,
+                                                                                    "description": "Whether to enable strict schema adherence."
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "custom"
+                                                                            ]
+                                                                        },
+                                                                        "custom": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "format": {
+                                                                                    "oneOf": [
+                                                                                        {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "type": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "text"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "type"
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "type": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "grammar"
+                                                                                                    ]
+                                                                                                },
+                                                                                                "grammar": {
+                                                                                                    "type": "object",
+                                                                                                    "properties": {
+                                                                                                        "definition": {
+                                                                                                            "type": "string"
+                                                                                                        },
+                                                                                                        "syntax": {
+                                                                                                            "type": "string",
+                                                                                                            "enum": [
+                                                                                                                "lark",
+                                                                                                                "regex"
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    },
+                                                                                                    "required": [
+                                                                                                        "definition",
+                                                                                                        "syntax"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "type",
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "custom"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "top_p": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "number",
+                                                                "minimum": 0,
+                                                                "maximum": 1
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ],
+                                                        "default": 1,
+                                                        "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                                    },
+                                                    "user": {
+                                                        "type": "string",
+                                                        "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                                    },
+                                                    "web_search_options": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Options for the web search tool (when using built-in web search).",
+                                                                "properties": {
+                                                                    "search_context_size": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "low",
+                                                                            "medium",
+                                                                            "high"
+                                                                        ],
+                                                                        "default": "medium"
+                                                                    },
+                                                                    "user_location": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "approximate"
+                                                                                ]
+                                                                            },
+                                                                            "approximate": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "city": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "country": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "region": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "timezone": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "approximate"
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "function_call": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "functions": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string",
+                                                                    "description": "The name of the function to be called."
+                                                                },
+                                                                "description": {
+                                                                    "type": "string",
+                                                                    "description": "A description of what the function does."
+                                                                },
+                                                                "parameters": {
+                                                                    "type": "object",
+                                                                    "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ],
+                                                                    "default": false,
+                                                                    "description": "Whether to enable strict schema adherence."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 128
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "prompt"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Messages",
+                                        "properties": {
+                                            "messages": {
+                                                "type": "array",
+                                                "description": "A list of messages comprising the conversation so far.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "developer"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "system"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "user"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "image_url",
+                                                                                            "input_audio",
+                                                                                            "file"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "image_url": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "url": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "detail": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "auto",
+                                                                                                    "low",
+                                                                                                    "high"
+                                                                                                ],
+                                                                                                "default": "auto"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "input_audio": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "format": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "wav",
+                                                                                                    "mp3"
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "file": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "file_data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "file_id": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "filename": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            },
+                                                                            "minItems": 1
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "assistant"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "refusal"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "refusal": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "refusal": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "audio": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_calls": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "oneOf": [
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "function"
+                                                                                        ]
+                                                                                    },
+                                                                                    "function": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "arguments": {
+                                                                                                "type": "string",
+                                                                                                "description": "JSON-encoded arguments string."
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "arguments"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "function"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "custom"
+                                                                                        ]
+                                                                                    },
+                                                                                    "custom": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "input": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "input"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "custom"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "function_call": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "tool"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_call_id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "tool_call_id"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 1
+                                            },
+                                            "skip_special_tokens": {
+                                                "type": "boolean",
+                                                "default": false
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "enable_thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "messages"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "A unique identifier for the chat completion."
+                        },
+                        "object": {
+                            "type": "string"
+                        },
+                        "created": {
+                            "type": "integer",
+                            "description": "Unix timestamp (seconds) of when the completion was created."
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "The model used for the chat completion."
+                        },
+                        "choices": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "index": {
+                                                "type": "integer"
+                                            },
+                                            "message": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "role": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "assistant"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "annotations": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "url_citation"
+                                                                            ]
+                                                                        },
+                                                                        "url_citation": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "title": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "start_index": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "end_index": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "url",
+                                                                                "title",
+                                                                                "start_index",
+                                                                                "end_index"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "url_citation"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "audio": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "data": {
+                                                                                "type": "string",
+                                                                                "description": "Base64 encoded audio bytes."
+                                                                            },
+                                                                            "expires_at": {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "transcript": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id",
+                                                                            "data",
+                                                                            "expires_at",
+                                                                            "transcript"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "tool_calls": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "function"
+                                                                                    ]
+                                                                                },
+                                                                                "function": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "arguments": {
+                                                                                            "type": "string",
+                                                                                            "description": "JSON-encoded arguments string."
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "arguments"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "custom"
+                                                                                    ]
+                                                                                },
+                                                                                "custom": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "input": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "input"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "custom"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "function_call": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "arguments": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name",
+                                                                            "arguments"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "role",
+                                                            "content",
+                                                            "refusal"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "finish_reason": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "stop",
+                                                    "length",
+                                                    "tool_calls",
+                                                    "content_filter",
+                                                    "function_call"
+                                                ]
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "index",
+                                            "message",
+                                            "finish_reason",
+                                            "logprobs"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "minItems": 1
+                        },
+                        "usage": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "prompt_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "completion_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "total_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "prompt_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "cached_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "completion_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "reasoning_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "accepted_prediction_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "rejected_prediction_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "prompt_tokens",
+                                        "completion_tokens",
+                                        "total_tokens"
+                                    ]
+                                }
+                            ]
+                        },
+                        "system_fingerprint": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "service_tier": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        "auto",
+                                        "default",
+                                        "flex",
+                                        "scale",
+                                        "priority"
+                                    ]
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "object",
+                        "created",
+                        "model",
+                        "choices"
+                    ]
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add documentation for the new `@cf/google/gemma-4-26b-a4b-it` model on Workers AI (partner with Google)
- Add model JSON with schema, pricing, and properties (vision, function calling, reasoning, 256K context window)
- Add changelog entry, release notes entry, and pricing row ($0.10/M input, $0.30/M output)