### PR TITLE
[Browser Rendering] Add Wrangler CLI commands documentation

### DIFF
--- a/src/content/changelog/browser-rendering/2026-04-06-browser-wrangler-commands.mdx
+++ b/src/content/changelog/browser-rendering/2026-04-06-browser-wrangler-commands.mdx
@@ -1,18 +1,18 @@
 ---
 title: Manage Browser Rendering sessions with Wrangler CLI
-description: Use the wrangler browser command namespace to manage Browser Rendering sessions from the CLI.
+description: Use wrangler browser commands to manage Browser Rendering sessions from the CLI.
 products:
   - browser-rendering
 date: 2026-04-06
 ---
 
-[Browser Rendering](/browser-rendering/) now supports a `wrangler browser` command namespace. Use it to manage live browser sessions directly from the command line.
+[Browser Rendering](/browser-rendering/) now supports `wrangler browser` commands, letting you create, manage, and view browser sessions directly from your terminal, streamlining your workflow.
 
 The following commands are available:
 
 | Command                   | Description                            |
 | ------------------------- | -------------------------------------- |
-| `wrangler browser create` | Create a new live browser session      |
+| `wrangler browser create` | Create a new browser session           |
 | `wrangler browser close`  | Close a session                        |
 | `wrangler browser list`   | List active sessions                   |
 | `wrangler browser view`   | View a live browser session            |
@@ -23,10 +23,10 @@ The `create` command launches a new browser session and opens it in your default
 wrangler browser create
 ```
 
-Use `--lab` to enable lab browser features, or `--keepAlive` to set the session keep-alive duration (60-600 seconds):
+Use `--keepAlive` to set the session keep-alive duration (60-600 seconds):
 
 ```sh
-wrangler browser create --lab --keepAlive 300
+wrangler browser create --keepAlive 300
 ```
 
 The `view` command auto-selects when only one session exists, or prompts for selection when multiple sessions are available.

--- a/src/content/changelog/browser-rendering/2026-04-06-browser-wrangler-commands.mdx
+++ b/src/content/changelog/browser-rendering/2026-04-06-browser-wrangler-commands.mdx
@@ -1,0 +1,36 @@
+---
+title: Manage Browser Rendering sessions with Wrangler CLI
+description: Use the wrangler browser command namespace to manage Browser Rendering sessions from the CLI.
+products:
+  - browser-rendering
+date: 2026-04-06
+---
+
+[Browser Rendering](/browser-rendering/) now supports a `wrangler browser` command namespace. Use it to manage live browser sessions directly from the command line.
+
+The following commands are available:
+
+| Command                   | Description                            |
+| ------------------------- | -------------------------------------- |
+| `wrangler browser create` | Create a new live browser session      |
+| `wrangler browser close`  | Close a session                        |
+| `wrangler browser list`   | List active sessions                   |
+| `wrangler browser view`   | View a live browser session            |
+
+The `create` command launches a new browser session and opens it in your default browser:
+
+```sh
+wrangler browser create
+```
+
+Use `--lab` to enable lab browser features, or `--keepAlive` to set the session keep-alive duration (60-600 seconds):
+
+```sh
+wrangler browser create --lab --keepAlive 300
+```
+
+The `view` command auto-selects when only one session exists, or prompts for selection when multiple sessions are available.
+
+All commands support `--json` for structured output that scripts and AI agents can parse directly.
+
+For full usage details, refer to the [Wrangler commands documentation](/browser-rendering/reference/wrangler-commands/).

--- a/src/content/changelog/browser-rendering/2026-04-14-browser-wrangler-commands.mdx
+++ b/src/content/changelog/browser-rendering/2026-04-14-browser-wrangler-commands.mdx
@@ -3,7 +3,7 @@ title: Manage Browser Rendering sessions with Wrangler CLI
 description: Use wrangler browser commands to manage Browser Rendering sessions from the CLI.
 products:
   - browser-rendering
-date: 2026-04-06
+date: 2026-04-14
 ---
 
 [Browser Rendering](/browser-rendering/) now supports `wrangler browser` commands, letting you create, manage, and view browser sessions directly from your terminal, streamlining your workflow.

--- a/src/content/changelog/browser-rendering/2026-04-14-browser-wrangler-commands.mdx
+++ b/src/content/changelog/browser-rendering/2026-04-14-browser-wrangler-commands.mdx
@@ -6,7 +6,7 @@ products:
 date: 2026-04-14
 ---
 
-[Browser Rendering](/browser-rendering/) now supports `wrangler browser` commands, letting you create, manage, and view browser sessions directly from your terminal, streamlining your workflow.
+[Browser Rendering](/browser-rendering/) now supports `wrangler browser` commands, letting you create, manage, and view browser sessions directly from your terminal, streamlining your workflow. Since Wrangler handles authentication, you do not need to pass API tokens in your commands.
 
 The following commands are available:
 
@@ -17,7 +17,7 @@ The following commands are available:
 | `wrangler browser list`   | List active sessions                   |
 | `wrangler browser view`   | View a live browser session            |
 
-The `create` command launches a new browser session and opens it in your default browser:
+The `create` command spins up a browser instance on Cloudflare's network and returns a session URL. Once created, you can connect to the session using any [CDP](/browser-rendering/cdp/)-compatible client like [Puppeteer](/browser-rendering/cdp/puppeteer/), [Playwright](/browser-rendering/cdp/playwright/), or [MCP clients](/browser-rendering/cdp/mcp-clients/) to automate browsing, scrape content, or debug remotely.
 
 ```sh
 wrangler browser create
@@ -31,6 +31,6 @@ wrangler browser create --keepAlive 300
 
 The `view` command auto-selects when only one session exists, or prompts for selection when multiple sessions are available.
 
-All commands support `--json` for structured output that scripts and AI agents can parse directly.
+All commands support `--json` for structured output, and because these are CLI commands, you can incorporate them into scripts to automate session management.
 
 For full usage details, refer to the [Wrangler commands documentation](/browser-rendering/reference/wrangler-commands/).

--- a/src/content/docs/browser-rendering/reference/wrangler-commands.mdx
+++ b/src/content/docs/browser-rendering/reference/wrangler-commands.mdx
@@ -8,6 +8,6 @@ description: Manage Browser Rendering sessions from the command line using Wrang
 
 import { Render } from "~/components";
 
-Use the `wrangler browser` command namespace to manage Browser Rendering sessions from the command line.
+Use `wrangler browser` commands to manage Browser Rendering sessions from the command line.
 
 <Render file="wrangler-commands/browser" product="workers" />

--- a/src/content/docs/browser-rendering/reference/wrangler-commands.mdx
+++ b/src/content/docs/browser-rendering/reference/wrangler-commands.mdx
@@ -1,0 +1,13 @@
+---
+pcx_content_type: reference
+title: Wrangler commands
+sidebar:
+  order: 21
+description: Manage Browser Rendering sessions from the command line using Wrangler.
+---
+
+import { Render } from "~/components";
+
+Use the `wrangler browser` command namespace to manage Browser Rendering sessions from the command line.
+
+<Render file="wrangler-commands/browser" product="workers" />

--- a/src/content/docs/workers/wrangler/commands/browser.mdx
+++ b/src/content/docs/workers/wrangler/commands/browser.mdx
@@ -6,6 +6,6 @@ description: Wrangler commands for interacting with Cloudflare Browser Rendering
 
 import { WranglerNamespace } from "~/components";
 
-Interact with [Browser Rendering](/browser/) service using Wrangler.
+Interact with the [Browser Rendering](/browser-rendering/) service using Wrangler.
 
 <WranglerNamespace namespace="browser" />

--- a/src/content/docs/workers/wrangler/commands/browser.mdx
+++ b/src/content/docs/workers/wrangler/commands/browser.mdx
@@ -1,0 +1,11 @@
+---
+pcx_content_type: reference
+title: Browser
+description: Wrangler commands for interacting with Cloudflare Browser Rendering.
+---
+
+import { WranglerNamespace } from "~/components";
+
+Interact with [Browser Rendering](/browser/) service using Wrangler.
+
+<WranglerNamespace namespace="browser" />

--- a/src/content/partials/workers/wrangler-commands/browser.mdx
+++ b/src/content/partials/workers/wrangler-commands/browser.mdx
@@ -1,0 +1,7 @@
+---
+{}
+---
+
+import { WranglerNamespace } from "~/components";
+
+<WranglerNamespace namespace="browser" />

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,6 +3,10 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
+  - publish_date: "2026-04-14"
+    title: "Wrangler CLI commands for Browser Rendering"
+    description: |-
+      * Added `wrangler browser` commands to create, manage, and view browser sessions directly from the terminal. Available commands: `create`, `close`, `list`, and `view`. For full usage details, refer to [Wrangler commands](/browser-rendering/reference/wrangler-commands/).
   - publish_date: "2026-04-13"
     title: "@cloudflare/puppeteer v1.1.0 released"
     description: |-


### PR DESCRIPTION
### Summary

Adds documentation for the new `wrangler browser` command namespace, which allows users to manage Browser Rendering DevTools sessions from the CLI.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
