### PR TITLE
[Gateway] Remove beta labels from ICMP proxy, protocol detection, and inspect on all ports

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/tls-decryption.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/tls-decryption.mdx
@@ -13,7 +13,6 @@ import {
 	Render,
 	TabItem,
 	Tabs,
-	Badge,
 } from "~/components";
 
 Cloudflare Gateway can perform [SSL/TLS decryption](https://www.cloudflare.com/learning/security/what-is-https-inspection/) to inspect HTTPS traffic for malware and other security risks. TLS decryption is required for HTTP policies to inspect HTTPS traffic. Without it, information contained within HTTPS encryption, such as the full URL, headers, and request body, [will not be visible to Gateway](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect).
@@ -44,7 +43,7 @@ Gateway does not support TLS decryption for applications which use:
 - [ESNI and ECH handshake encryption](#esni-and-ech)
 - [Automatic HTTPS upgrades](#google-chrome-automatic-https-upgrades)
 
-### Inspect on all ports <Badge text="Beta" variant="caution" size="small" />
+### Inspect on all ports
 
 <Render
 	file="gateway/inspect-on-all-ports"

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-import { Badge, Render } from "~/components";
+import { Render } from "~/components";
 
 Gateway supports the detection, logging, and filtering of network protocols using packet attributes.
 
@@ -20,7 +20,7 @@ To turn on protocol detection:
 
 You can now use _Detected Protocol_ as a selector in a [Network policy](/cloudflare-one/traffic-policies/network-policies/#detected-protocol).
 
-### Inspect on all ports <Badge text="Beta" variant="caution" size="small" />
+### Inspect on all ports
 
 <Render
 	file="gateway/inspect-on-all-ports"
@@ -54,13 +54,13 @@ Gateway supports detection and filtering of the following protocols:
 | DCERPC                                                            | Distributed Computing Environment / Remote Procedure Call.                                   |
 | MQTT                                                              | Message Queuing Telemetry Transport — lightweight IoT messaging protocol.                    |
 | TPKT                                                              | TPKT commonly initiates RDP sessions, so you can use it to identify and filter RDP traffic.  |
-| IMAP <Badge text="Beta" variant="caution" size="small" />         | Internet Message Access Protocol — email retrieval.                                          |
-| POP3 <Badge text="Beta" variant="caution" size="small" />         | Post Office Protocol v3 — email retrieval.                                                   |
-| SMTP <Badge text="Beta" variant="caution" size="small" />         | Simple Mail Transfer Protocol — email sending.                                               |
-| MYSQL <Badge text="Beta" variant="caution" size="small" />        | MySQL database wire protocol.                                                                |
-| RSYNC-DAEMON <Badge text="Beta" variant="caution" size="small" /> | rsync daemon protocol.                                                                       |
-| LDAP <Badge text="Beta" variant="caution" size="small" />         | Lightweight Directory Access Protocol.                                                       |
-| NTP <Badge text="Beta" variant="caution" size="small" />          | Network Time Protocol.                                                                       |
+| IMAP         | Internet Message Access Protocol — email retrieval.                                          |
+| POP3         | Post Office Protocol v3 — email retrieval.                                                   |
+| SMTP         | Simple Mail Transfer Protocol — email sending.                                               |
+| MYSQL        | MySQL database wire protocol.                                                                |
+| RSYNC-DAEMON | rsync daemon protocol.                                                                       |
+| LDAP         | Lightweight Directory Access Protocol.                                                       |
+| NTP          | Network Time Protocol.                                                                       |
 
 ## Example network policy
 

--- a/src/content/docs/cloudflare-one/traffic-policies/proxy.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/proxy.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 12
 ---
 
-import { Badge, Tabs, TabItem, Render } from "~/components";
+import { Tabs, TabItem, Render } from "~/components";
 
 You can forward [HTTP](/cloudflare-one/traffic-policies/get-started/http/) and [network](/cloudflare-one/traffic-policies/get-started/network/) traffic to Gateway for logging and filtering. Gateway can proxy both outbound traffic and traffic directed to resources connected via a Cloudflare Tunnel, Generic Routing Encapsulation (GRE) tunnel, or IPsec tunnel. When a user connects to the Gateway proxy, Gateway will accept the connection and establish a new, separate connection to the origin server.
 
@@ -39,7 +39,7 @@ The UDP proxy forwards UDP traffic such as VoIP, [internal DNS requests](/cloudf
 
 HTTP/3 uses the QUIC protocol over UDP. To inspect HTTP/3 traffic, turn on both TLS decryption and the UDP proxy. Gateway will then intercept the HTTP/3 connection and connect to the origin server over HTTP/2. Otherwise, HTTP/3 traffic will bypass inspection. For more information on browser-specific behavior, refer to [HTTP/3 inspection](/cloudflare-one/traffic-policies/http-policies/http3/).
 
-### ICMP (Internet Control Message Protocol) <Badge text="Beta" variant="caution" size="small" />
+### ICMP (Internet Control Message Protocol)
 
 The ICMP proxy allows ICMP traffic to reach your private network through Gateway. For example, this would allow a Cloudflare One Client user to run diagnostic commands such as `ping` and `traceroute` to an internal server IP.
 


### PR DESCRIPTION
## Summary

- Remove beta badges from **ICMP proxy**, **new protocol detection protocols** (IMAP, POP3, SMTP, MYSQL, RSYNC-DAEMON, LDAP, NTP), and **inspect on all ports** to mark these Gateway features as GA
- Clean up unused `Badge` component imports from affected files
- Update changelog entries to remove beta references

## Files changed

| File | Change |
|------|--------|
| `traffic-policies/proxy.mdx` | Remove beta badge from ICMP proxy heading |
| `traffic-policies/network-policies/protocol-detection.mdx` | Remove beta badges from "Inspect on all ports" heading and 7 protocol rows |
| `traffic-policies/http-policies/tls-decryption.mdx` | Remove beta badge from "Inspect on all ports" heading |
| `changelog/gateway/2026-02-27-new-protocol-detection-protocols.mdx` | Remove "(Beta)" from title and "in beta" from body |
| `changelog/gateway/2025-07-24-HTTP-Inspection-on-all-ports.mdx` | Remove "(Beta)" from link text |

Ref: PCX-21510