### PR TITLE
Portals supports code mode

### DIFF
--- a/src/content/changelog/access/2026-03-26-mcp-portal-code-mode.mdx
+++ b/src/content/changelog/access/2026-03-26-mcp-portal-code-mode.mdx
@@ -1,0 +1,19 @@
+---
+title: Code mode for MCP server portals
+description: MCP server portals support code mode, which reduces context window usage by collapsing tools into a single code execution tool.
+date: 2026-03-26
+products:
+  - access
+---
+
+[MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) support [code mode](/agents/api-reference/codemode/), a technique that reduces context window usage by replacing individual tool definitions with a single code execution tool. Code mode is available by default on all portals. To turn it off, edit the portal in **Access controls** > **AI controls** and turn off **Code mode** under **Basic information**.
+
+When code mode is active, the portal exposes a single `code` tool instead of listing every tool from every upstream MCP server. The connected AI agent writes JavaScript that calls typed `codemode.*` methods for each upstream tool. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, keeping authentication credentials and environment variables out of the model context.
+
+To use code mode, append `?codemode=search_and_execute` to your portal URL when connecting from an MCP client:
+
+```txt
+https://<subdomain>.<domain>/mcp?codemode=search_and_execute
+```
+
+For more information, refer to [Code mode](/cloudflare-one/access-controls/ai-controls/mcp-portals/#code-mode).

--- a/src/content/changelog/access/2026-03-26-mcp-portal-code-mode.mdx
+++ b/src/content/changelog/access/2026-03-26-mcp-portal-code-mode.mdx
@@ -6,9 +6,9 @@ products:
   - access
 ---
 
-[MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) support [code mode](/agents/api-reference/codemode/), a technique that reduces context window usage by replacing individual tool definitions with a single code execution tool. Code mode is available by default on all portals.
+[MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) support [code mode](/agents/api-reference/codemode/), a technique that reduces context window usage by replacing individual tool definitions with a single code execution tool. Code mode is turned on by default on all portals.
 
-To turn it off, edit the portal in **Access controls** > **AI controls** and turn off **code mode** under **Basic information**.
+To turn it off, edit the portal in **Access controls** > **AI controls** and turn off **Code mode** under **Basic information**.
 
 When code mode is active, the portal exposes a single `code` tool instead of listing every tool from every upstream MCP server. The connected AI agent writes JavaScript that calls typed `codemode.*` methods for each upstream tool. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, keeping authentication credentials and environment variables out of the model context.
 

--- a/src/content/changelog/access/2026-03-26-mcp-portal-code-mode.mdx
+++ b/src/content/changelog/access/2026-03-26-mcp-portal-code-mode.mdx
@@ -6,7 +6,9 @@ products:
   - access
 ---
 
-[MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) support [code mode](/agents/api-reference/codemode/), a technique that reduces context window usage by replacing individual tool definitions with a single code execution tool. Code mode is available by default on all portals. To turn it off, edit the portal in **Access controls** > **AI controls** and turn off **Code mode** under **Basic information**.
+[MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) support [code mode](/agents/api-reference/codemode/), a technique that reduces context window usage by replacing individual tool definitions with a single code execution tool. Code mode is available by default on all portals.
+
+To turn it off, edit the portal in **Access controls** > **AI controls** and turn off **code mode** under **Basic information**.
 
 When code mode is active, the portal exposes a single `code` tool instead of listing every tool from every upstream MCP server. The connected AI agent writes JavaScript that calls typed `codemode.*` methods for each upstream tool. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, keeping authentication credentials and environment variables out of the model context.
 
@@ -16,4 +18,4 @@ To use code mode, append `?codemode=search_and_execute` to your portal URL when 
 https://<subdomain>.<domain>/mcp?codemode=search_and_execute
 ```
 
-For more information, refer to [Code mode](/cloudflare-one/access-controls/ai-controls/mcp-portals/#code-mode).
+For more information, refer to [code mode](/cloudflare-one/access-controls/ai-controls/mcp-portals/#code-mode).

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -123,37 +123,15 @@ Cloudflare Access automatically creates an Access application for each MCP serve
 
 ## Code mode
 
-[Code mode](/agents/api-reference/codemode/) is available by default on all MCP server portals. It reduces context window usage by collapsing all tools in the portal into a single `code` tool. Instead of loading a separate tool definition for each upstream MCP server tool, the connected AI agent writes JavaScript that calls typed `codemode.*` methods. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, which keeps authentication credentials and environment variables out of the model context.
+[Code mode](/agents/api-reference/codemode/) is turned on by default on all MCP server portals. It reduces context window usage by collapsing all tools in the portal into a single `code` tool. Instead of loading a separate tool definition for each upstream MCP server tool, the connected AI agent writes JavaScript that calls typed `codemode.*` methods. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, which keeps authentication credentials and environment variables out of the model context.
 
 To use code mode, the MCP client must request it when connecting to the portal URL. Refer to [Connect with code mode](#connect-with-code-mode) for the required query parameter.
 
 Code mode is useful for portals that aggregate many MCP servers or servers that expose a large number of tools. Context window usage stays fixed regardless of how many tools are available through the portal.
 
-To turn off code mode for a portal:
-
-<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
-
-1. In [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **AI controls**.
-2. Find the portal you want to configure, then select the three dots > **Edit**.
-3. Under **Basic information**, turn off **code mode**.
-
-</TabItem> <TabItem label="API">
-
-Send a `PUT` request to the [Update a MCP Portal](/api/resources/zero_trust/subresources/access/subresources/ai_controls/subresources/mcp/subresources/portals/methods/update/) endpoint with `allow_code_mode` set to `false`:
-
-<APIRequest
-	path="/accounts/{account_id}/access/ai-controls/mcp/portals/{portal_id}"
-	method="PUT"
-	json={{
-		allow_code_mode: false,
-	}}
-/>
-
-</TabItem> </Tabs>
-
 ### Connect with code mode
 
-To use code mode, append the `?codemode=search_and_execute` query string parameter to your portal URL when connecting from an MCP client.
+To use code mode, append the `?codemode=search_and_execute` query string parameter to your portal URL when [connecting](#connect-to-a-portal) from an MCP client.
 
 For example, if your portal URL is `https://<subdomain>.<domain>/mcp`, connect to:
 
@@ -181,6 +159,37 @@ For MCP clients with server configuration files, use the portal URL with the que
 When code mode is active, the portal advertises a single `code` tool to connected MCP clients. The AI agent discovers available tools by inspecting the typed method signatures in the Dynamic Worker environment and composes multiple tool calls into a single code execution.
 
 For more information on building with code mode, refer to the [code mode SDK reference](/agents/api-reference/codemode/).
+
+### Turn off code mode
+
+To turn off code mode for a portal:
+
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+1. In [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **AI controls**.
+2. Find the portal you want to configure, then select the three dots > **Edit**.
+3. Under **Basic information**, turn off **Code mode**.
+
+</TabItem> <TabItem label="API">
+
+1. Get your existing MCP portal configuration:
+
+   <APIRequest
+   	path="/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
+   	method="GET"
+   />
+
+2. Send a `PUT` request to the [Update a MCP Portal](/api/resources/zero_trust/subresources/access/subresources/ai_controls/subresources/mcp/subresources/portals/methods/update/) endpoint with `allow_code_mode` set to `false`. To avoid overwriting your existing configuration, the `PUT` request body should contain all fields returned by the previous `GET` request.
+
+   <APIRequest
+   	path="/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
+   	method="PUT"
+   	json={{
+   		allow_code_mode: false,
+   	}}
+   />
+
+</TabItem> </Tabs>
 
 ## Route portal traffic through Gateway
 

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -10,7 +10,7 @@ sidebar:
     text: Beta
 ---
 
-import { Render, GlossaryTooltip, Tabs, TabItem, APIRequest } from "~/components";
+import { Render, Tabs, TabItem, APIRequest } from "~/components";
 
 An MCP server portal centralizes multiple [Model Context Protocol (MCP) servers](https://www.cloudflare.com/learning/ai/what-is-model-context-protocol-mcp/) onto a single HTTP endpoint.
 
@@ -22,7 +22,7 @@ Key benefits include:
 
 - **Customized tools per portal**: Admins can tailor an MCP portal to a particular use case by choosing the specific tools and prompt templates that they want to make available to users through the portal. This allows users to access a curated set of tools and prompts — the less external context exposed to the AI model, the better the AI responses tend to be.
 
-- **Code mode**: Code mode is available by default on all portals. It collapses all upstream tools into a single `code` tool. The AI agent writes JavaScript that calls typed methods for each tool, and the code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment. This keeps context window usage fixed regardless of how many tools are available. Refer to [Code mode](#code-mode) for connection instructions.
+- **Code mode**: Code mode is available by default on all portals. It collapses all upstream tools into a single `code` tool. The AI agent writes JavaScript that calls typed methods for each tool, and the code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment. This keeps context window usage fixed regardless of how many tools are available. Refer to [code mode](#code-mode) for connection instructions.
 
 - **Observability**: Once the user's AI agent is connected to the portal, Cloudflare Access logs the individual requests made using the tools in the portal. You can optionally route portal traffic through [Cloudflare Gateway](#route-portal-traffic-through-gateway) for richer HTTP logging and data loss prevention (DLP) scanning.
 
@@ -125,7 +125,7 @@ Cloudflare Access automatically creates an Access application for each MCP serve
 
 [Code mode](/agents/api-reference/codemode/) is available by default on all MCP server portals. It reduces context window usage by collapsing all tools in the portal into a single `code` tool. Instead of loading a separate tool definition for each upstream MCP server tool, the connected AI agent writes JavaScript that calls typed `codemode.*` methods. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, which keeps authentication credentials and environment variables out of the model context.
 
-To use code mode, the MCP client must include the `?codemode=search_and_execute` query parameter when connecting to the portal URL. Refer to [Connect with code mode](#connect-with-code-mode) for details.
+To use code mode, the MCP client must request it when connecting to the portal URL. Refer to [Connect with code mode](#connect-with-code-mode) for the required query parameter.
 
 Code mode is useful for portals that aggregate many MCP servers or servers that expose a large number of tools. Context window usage stays fixed regardless of how many tools are available through the portal.
 
@@ -135,8 +135,7 @@ To turn off code mode for a portal:
 
 1. In [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **AI controls**.
 2. Find the portal you want to configure, then select the three dots > **Edit**.
-3. Under **Basic information**, turn off **Code mode**.
-4. Select **Save**.
+3. Under **Basic information**, turn off **code mode**.
 
 </TabItem> <TabItem label="API">
 
@@ -181,7 +180,7 @@ For MCP clients with server configuration files, use the portal URL with the que
 
 When code mode is active, the portal advertises a single `code` tool to connected MCP clients. The AI agent discovers available tools by inspecting the typed method signatures in the Dynamic Worker environment and composes multiple tool calls into a single code execution.
 
-For more information on building with code mode, refer to the [Code mode SDK reference](/agents/api-reference/codemode/).
+For more information on building with code mode, refer to the [code mode SDK reference](/agents/api-reference/codemode/).
 
 ## Route portal traffic through Gateway
 
@@ -206,9 +205,9 @@ Gateway HTTP policies for MCP portal traffic must explicitly target the MCP serv
 
 For example, the following policy blocks traffic that contains [credentials and secrets](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/#credentials-and-secrets) or [financial information](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/#financial-information):
 
-| Selector         | Operator | Value         | Logic | Action |
-| ---------------- | -------- | ------------- | ----- | ------ |
-| Host      | in       | `example-mcp-server.example.workers.dev`  | And   | Block  |
+| Selector    | Operator | Value                                              | Logic | Action |
+| ----------- | -------- | -------------------------------------------------- | ----- | ------ |
+| Host        | in       | `example-mcp-server.example.workers.dev`           | And   | Block  |
 | DLP Profile | in       | _Credentials and Secrets_, _Financial Information_ |       |        |
 
 :::note

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -22,6 +22,8 @@ Key benefits include:
 
 - **Customized tools per portal**: Admins can tailor an MCP portal to a particular use case by choosing the specific tools and prompt templates that they want to make available to users through the portal. This allows users to access a curated set of tools and prompts — the less external context exposed to the AI model, the better the AI responses tend to be.
 
+- **Code mode**: Code mode is available by default on all portals. It collapses all upstream tools into a single `code` tool. The AI agent writes JavaScript that calls typed methods for each tool, and the code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment. This keeps context window usage fixed regardless of how many tools are available. Refer to [Code mode](#code-mode) for connection instructions.
+
 - **Observability**: Once the user's AI agent is connected to the portal, Cloudflare Access logs the individual requests made using the tools in the portal. You can optionally route portal traffic through [Cloudflare Gateway](#route-portal-traffic-through-gateway) for richer HTTP logging and data loss prevention (DLP) scanning.
 
 This guide explains how to add MCP servers to Cloudflare Access, create an MCP portal with customized tools and policies, and connect users to the portal using an MCP client.
@@ -118,6 +120,52 @@ Cloudflare Access automatically creates an Access application for each MCP serve
    1. Go to the **Experience settings** tab.
    2. <Render file="access/access-block-page" product="cloudflare-one" />
 5. Select **Save application**.
+
+## Code mode
+
+[Code mode](/agents/api-reference/codemode/) is available by default on all MCP server portals. It reduces context window usage by collapsing all tools in the portal into a single `code` tool. Instead of loading a separate tool definition for each upstream MCP server tool, the connected AI agent writes JavaScript that calls typed `codemode.*` methods. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, which keeps authentication credentials and environment variables out of the model context.
+
+To use code mode, the MCP client must include the `?codemode=search_and_execute` query parameter when connecting to the portal URL. Refer to [Connect with code mode](#connect-with-code-mode) for details.
+
+Code mode is useful for portals that aggregate many MCP servers or servers that expose a large number of tools. Context window usage stays fixed regardless of how many tools are available through the portal.
+
+To turn off code mode for a portal:
+
+1. In [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **AI controls**.
+2. Find the portal you want to configure, then select the three dots > **Edit**.
+3. Under **Basic information**, turn off **Code mode**.
+4. Select **Save**.
+
+### Connect with code mode
+
+To use code mode, append the `?codemode=search_and_execute` query string parameter to your portal URL when connecting from an MCP client.
+
+For example, if your portal URL is `https://<subdomain>.<domain>/mcp`, connect to:
+
+```txt
+https://<subdomain>.<domain>/mcp?codemode=search_and_execute
+```
+
+For MCP clients with server configuration files, use the portal URL with the query string parameter:
+
+```json title="MCP client configuration with code mode"
+{
+	"mcpServers": {
+		"example-portal": {
+			"command": "npx",
+			"args": [
+				"-y",
+				"mcp-remote@latest",
+				"https://<subdomain>.<domain>/mcp?codemode=search_and_execute"
+			]
+		}
+	}
+}
+```
+
+When code mode is active, the portal advertises a single `code` tool to connected MCP clients. The AI agent discovers available tools by inspecting the typed method signatures in the Dynamic Worker environment and composes multiple tool calls into a single code execution.
+
+For more information on building with code mode, refer to the [Code mode SDK reference](/agents/api-reference/codemode/).
 
 ## Route portal traffic through Gateway
 

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -10,7 +10,7 @@ sidebar:
     text: Beta
 ---
 
-import { Render, GlossaryTooltip } from "~/components";
+import { Render, GlossaryTooltip, Tabs, TabItem, APIRequest } from "~/components";
 
 An MCP server portal centralizes multiple [Model Context Protocol (MCP) servers](https://www.cloudflare.com/learning/ai/what-is-model-context-protocol-mcp/) onto a single HTTP endpoint.
 
@@ -131,10 +131,26 @@ Code mode is useful for portals that aggregate many MCP servers or servers that 
 
 To turn off code mode for a portal:
 
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
 1. In [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **AI controls**.
 2. Find the portal you want to configure, then select the three dots > **Edit**.
 3. Under **Basic information**, turn off **Code mode**.
 4. Select **Save**.
+
+</TabItem> <TabItem label="API">
+
+Send a `PUT` request to the [Update a MCP Portal](/api/resources/zero_trust/subresources/access/subresources/ai_controls/subresources/mcp/subresources/portals/methods/update/) endpoint with `allow_code_mode` set to `false`:
+
+<APIRequest
+	path="/accounts/{account_id}/access/ai-controls/mcp/portals/{portal_id}"
+	method="PUT"
+	json={{
+		allow_code_mode: false,
+	}}
+/>
+
+</TabItem> </Tabs>
 
 ### Connect with code mode
 

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -166,7 +166,7 @@ To turn off code mode for a portal:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **AI controls**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **AI controls**.
 2. Find the portal you want to configure, then select the three dots > **Edit**.
 3. Under **Basic information**, turn off **Code mode**.
 


### PR DESCRIPTION
### Summary

MCP server portals supports code mode for more consistent context window usage. 

### Screenshots (optional)

### Documentation checklist
- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).