### PR TITLE
Browser Rendering: CDP + WebMCP changelog entries

### DIFF
--- a/src/content/changelog/browser-rendering/2026-04-09-browser-rendering-cdp-endpoints.mdx
+++ b/src/content/changelog/browser-rendering/2026-04-09-browser-rendering-cdp-endpoints.mdx
@@ -1,0 +1,47 @@
+---
+title: Browser Rendering CDP endpoints now accessible from any environment
+description: Connect to Browser Rendering from any environment using Chrome DevTools Protocol endpoints for session management, browser automation, and live debugging.
+products:
+  - browser-rendering
+date: 2026-04-09
+---
+
+import { CURL } from "~/components";
+
+Browser Rendering now supports the [Chrome DevTools Protocol (CDP)](/browser-rendering/cdp/) via the `/devtools` endpoints. You can create persistent browser sessions, manage multiple tabs, and control browsers using CDP commands from any environment that supports WebSocket connections. This includes local development machines, CI/CD pipelines, and external servers.
+
+With CDP support, you can:
+
+- **Create and manage browser sessions** - Launch browser instances that remain active for extended periods using `POST /devtools/browser`
+- **Manage tabs programmatically** - List, create, and close tabs via HTTP endpoints like `GET /devtools/browser/{session_id}/json/list`
+- **Automate with Puppeteer** - Connect Puppeteer scripts directly to Browser Rendering for browser automation
+- **Use AI agents with MCP** - Configure AI coding agents to control browsers via the Model Context Protocol
+- **Debug live sessions** - Open Chrome DevTools UI to inspect and debug remote browser sessions in real time
+
+The CDP endpoints complement the existing Quick Actions by providing lower-level browser control. While Quick Actions offer high-level operations like screenshots and PDFs, CDP enables fine-grained control over browser behavior, network monitoring, and JavaScript execution.
+
+For example, to create a browser session and open a tab:
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/ACCOUNT_ID/browser-rendering/devtools/browser"
+	method="POST"
+	headers={{
+		Authorization: "Bearer {api_token}",
+	}}
+	query={{
+		keep_alive: "600000",
+	}}
+/>
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/ACCOUNT_ID/browser-rendering/devtools/browser/SESSION_ID/json/new"
+	method="PUT"
+	headers={{
+		Authorization: "Bearer {api_token}",
+	}}
+	query={{
+		url: "https://example.com",
+	}}
+/>
+
+To learn more, refer to the [CDP documentation](/browser-rendering/cdp/).

--- a/src/content/changelog/browser-rendering/2026-04-09-browser-rendering-webmcp.mdx
+++ b/src/content/changelog/browser-rendering/2026-04-09-browser-rendering-webmcp.mdx
@@ -1,0 +1,24 @@
+---
+title: "WebMCP support now available"
+description: "AI agents can now discover and execute website tools directly using WebMCP, enabling faster and more reliable browser automation."
+products:
+  - browser-rendering
+date: 2026-04-09
+---
+
+Browser Rendering now supports [WebMCP](/browser-rendering/features/webmcp/) (Web Model Context Protocol), a browser API that lets websites expose structured tools for AI agents to discover and execute directly. Instead of slow screenshot-analyze-click loops, agents can call website functions like `searchFlights()` or `bookTicket()` with typed parameters, making browser automation faster, more reliable, and less fragile.
+
+With WebMCP, you can:
+
+- **Discover website tools** - Use `navigator.modelContextTesting.listTools()` to see available actions on any WebMCP-enabled site
+- **Execute tools directly** - Call `navigator.modelContextTesting.executeTool()` with typed parameters
+- **Handle human-in-the-loop interactions** - Some tools pause for user confirmation before completing sensitive actions
+
+WebMCP is currently available through Lab sessions, which use Chrome beta with experimental features enabled. To start a WebMCP session, add `lab=true` to your `/devtools/browser` request:
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/browser-rendering/devtools/browser?lab=true&keep_alive=300000" \
+  -H "Authorization: Bearer {api_token}"
+```
+
+For a step-by-step guide, refer to the [WebMCP documentation](/browser-rendering/features/webmcp/).

--- a/src/content/release-notes/browser-rendering.yaml
+++ b/src/content/release-notes/browser-rendering.yaml
@@ -3,6 +3,14 @@ link: "/browser-rendering/changelog/"
 productName: Browser Rendering
 productLink: "/browser-rendering/"
 entries:
+  - publish_date: "2026-04-09"
+    title: "CDP endpoints now accessible from any environment (Beta)"
+    description: |-
+      * Browser Rendering now supports the [Chrome DevTools Protocol (CDP)](/browser-rendering/cdp/) via the `/devtools` endpoints. Create persistent browser sessions, manage tabs, and control browsers using CDP commands from any environment that supports WebSocket connections, including local machines, CI/CD pipelines, and external servers. Connect with [Puppeteer](/browser-rendering/cdp/puppeteer/), [MCP clients](/browser-rendering/cdp/mcp-clients/), or any CDP-compatible client.
+  - publish_date: "2026-04-09"
+    title: "WebMCP support now available (Beta)"
+    description: |-
+      * Added support for [WebMCP](/browser-rendering/features/webmcp/) (Web Model Context Protocol), a browser API that lets websites expose structured tools for AI agents to discover and execute directly. Available through Lab sessions using Chrome beta. Start a WebMCP session by adding `lab=true` to your `/devtools/browser` request.
   - publish_date: "2026-03-23"
     title: "@cloudflare/playwright v1.2.0 released"
     description: |-


### PR DESCRIPTION
Changelog entries for CDP endpoints and WebMCP support, both launching as Beta.

**Files added:**
- `2026-04-09-browser-rendering-cdp-endpoints.mdx` - Cloudflare changelog for CDP
- `2026-04-09-browser-rendering-webmcp.mdx` - Cloudflare changelog for WebMCP

**Files modified:**
- `browser-rendering.yaml` - Two new BR-specific release note entries (CDP + WebMCP, both Beta)

**Notes:**
- Date is tentatively 4/9, may change
- Copy not finalized yet, will review before merging
- Changelog entries were removed from the feature PRs (#29508, #29514) and consolidated here