### PR TITLE
Remove beta badge from Preview URLs and Placement docs

### DIFF
--- a/src/content/docs/workers/configuration/placement.mdx
+++ b/src/content/docs/workers/configuration/placement.mdx
@@ -3,9 +3,6 @@ pcx_content_type: concept
 title: Placement
 head: []
 description: Control where your Worker runs to reduce latency.
-sidebar:
-  badge:
-    text: Beta
 ---
 
 import { WranglerConfig, DashButton, Tabs, TabItem } from "~/components";

--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -2,9 +2,6 @@
 pcx_content_type: configuration
 title: Preview URLs
 head: []
-sidebar:
-  badge:
-    text: Beta
 description: Preview URLs allow you to preview new versions of your project without deploying it to production.
 ---
 


### PR DESCRIPTION
## Summary
- Removes the `Beta` sidebar badge from the **Preview URLs** (`/workers/configuration/previews`) page.
- Removes the `Beta` sidebar badge from the **Placement** (`/workers/configuration/placement`) page.