### PR TITLE
Clarify rejectResourceTypes and render parameter behavior on /crawl

### DIFF
--- a/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/crawl-endpoint.mdx
@@ -193,7 +193,9 @@ A successful cancellation will return a `200 OK` status code. The job status wil
 
 ## Optional parameters
 
-The following optional parameters can be used in your crawl request, in addition to the required `url` parameter. For the full list, refer to the [API docs](/api/resources/browser_rendering/).
+The following optional parameters can be used in your crawl request, in addition to the required `url` parameter. These are parameters specific to the `/crawl` endpoint.
+
+When `render` is `true` (the default), crawl jobs also support all standard Browser Rendering parameters such as `rejectResourceTypes`, `rejectRequestPattern`, `cookies`, and `setExtraHTTPHeaders`. When `render` is `false`, only the crawl-specific parameters listed in the table below are supported. For the full list, refer to the [API reference](/api/resources/browser_rendering/subresources/crawl/methods/create/).
 
 | Optional parameter | Type | Description |
 | --- | --- | --- |
@@ -406,7 +408,7 @@ curl -X POST 'https://api.cloudflare.com/client/v4/accounts/{account_id}/browser
 
 ### Block unnecessary resources
 
-Speed up crawling by blocking images and media:
+Speed up crawling by blocking images and media. `rejectResourceTypes` is only available when `render` is `true` (the default).
 
 ```bash
 curl -X POST 'https://api.cloudflare.com/client/v4/accounts/{account_id}/browser-rendering/crawl' \


### PR DESCRIPTION
- Explain that the optional parameters table lists crawl-specific params
- Note that render: true crawls also support all standard BR params
- Note that render: false crawls only support the listed crawl-specific params
- Link to the more specific crawl create API reference
- Clarify rejectResourceTypes requires render: true in the example section

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
