### PR TITLE
[Pages] Add Hugo to build caching frameworks

### DIFF
--- a/src/content/docs/pages/configuration/build-caching.mdx
+++ b/src/content/docs/pages/configuration/build-caching.mdx
@@ -40,9 +40,20 @@ The following frameworks support build output caching:
 | Docusaurus | `node_modules/.cache`, `.docusaurus`, `build`               |
 | Eleventy   | `.cache`                                                    |
 | Gatsby     | `.cache`, `public`                                          |
+| Hugo       | `.cache`                                                    |
 | Next.js    | `.next/cache`                                               |
 | Nuxt       | `node_modules/.cache/nuxt`                                  |
 | SvelteKit  | `node_modules/.cache/imagetools`                            |
+
+:::note[Hugo build caching]
+Hugo does not use `.cache` by default. To use build caching with Hugo, set `--cacheDir=$PWD/.cache` in your build command. For example:
+
+```sh
+hugo --minify --cacheDir=$PWD/.cache
+```
+
+Pages detects Hugo projects via the presence of a `hugo.toml`, `hugo.yaml`, `hugo.yml`, or `hugo.json` config file.
+:::
 
 ### Limits
 


### PR DESCRIPTION
## Summary

- Adds Hugo to the build caching frameworks table on the [Pages build caching docs](https://developers.cloudflare.com/pages/configuration/build-caching/#frameworks)
- Includes a note explaining that Hugo requires `--cacheDir=$PWD/.cache` in the build command, since Hugo does not use `.cache` by default
- Lists the Hugo config files used for detection (`hugo.toml`, `hugo.yaml`, `hugo.yml`, `hugo.json`)

## Context

This is a companion change to [pages-infra MR !1166](https://gitlab.cfdata.org/cloudflare/ew/pages-infra/-/merge_requests/1166) which adds Hugo build cache support to the Pages build runner. Without this docs update, users would not know how to configure their Hugo builds to benefit from caching.

Relates to https://github.com/cloudflare/workers-sdk/issues/12969