### PR TITLE
[RealtimeKit] Add Component References for Android SDK

### DIFF
--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/audio-device-selector.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/audio-device-selector.mdx
@@ -1,0 +1,40 @@
+---
+title: RtkAudioDeviceSelector
+pcx_content_type: reference
+description: API reference for RtkAudioDeviceSelector component (Android Library)
+---
+
+An audio device selector component which can be used to select audio devices.
+
+## Properties
+
+| Property       | Type     | Required | Default | Description       |
+| -------------- | -------- | -------- | ------- | ----------------- |
+| `rtk_ds_label` | `string` | ❌       | `Audio` | Custom label text |
+
+## Methods
+
+| Method              | Parameters                      | Description                               |
+| ------------------- | ------------------------------- | ----------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the selector to the meeting state    |
+| `disableLabel`      | -                               | Disable the label text above the dropdown |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming    |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkAudioDeviceSelector
+    android:id="@+id/audioSelector"
+    app:rtk_ds_label="Audio"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val audioSelector = findViewById<RtkAudioDeviceSelector>(R.id.audioSelector)
+audioSelector.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/avatar-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/avatar-view.mdx
@@ -1,0 +1,33 @@
+---
+pcx_content_type: reference
+title: RtkAvatarView
+description: API reference for RtkAvatarView component (Android Library)
+---
+
+Avatar component which renders a participant's profile picture or their initials.
+
+## Methods
+
+| Method              | Parameters                           | Description                                        |
+| ------------------- | ------------------------------------ | -------------------------------------------------- |
+| `activate`          | `participant: RtkMeetingParticipant` | Bind the avatar to a participant                   |
+| `refresh`           | -                                    | Refresh the avatar based on the participant's name |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens`      | Apply custom design tokens for theming             |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.avatarview.RtkAvatarView
+    android:id="@+id/rtk_avatar"
+    android:layout_width="48dp"
+    android:layout_height="48dp" />
+```
+
+### With Methods
+
+```kotlin
+val avatar = findViewById<RtkAvatarView>(R.id.rtk_avatar)
+avatar.activate(participant)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/button.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/button.mdx
@@ -1,0 +1,33 @@
+---
+pcx_content_type: reference
+title: RtkButton
+description: API reference for RtkButton component (Android Library)
+---
+
+A button that follows the RealtimeKit design system.
+
+## Properties
+
+| Property          | Type                             | Required | Default | Description    |
+| ----------------- | -------------------------------- | -------- | ------- | -------------- |
+| `rtk_btn_variant` | `primary \| secondary \| danger` | ❌       | -       | Button variant |
+
+## Methods
+
+| Method              | Parameters                      | Description                                 |
+| ------------------- | ------------------------------- | ------------------------------------------- |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming      |
+| `refresh`           | `uiTokens: RtkDesignTokens`     | Refresh the button with the provided tokens |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.button.RtkButton
+    android:id="@+id/btn_id"
+    android:layout_width="200dp"
+    android:layout_height="48dp"
+    android:text="Text on Button"
+    app:rtk_btn_variant="primary" />
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/camera-toggle.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/camera-toggle.mdx
@@ -1,0 +1,32 @@
+---
+pcx_content_type: reference
+title: RtkCameraToggleButton
+description: API reference for RtkCameraToggleButton component (Android Library)
+---
+
+A button which toggles the local user's camera. It automatically listens to self video events to update its state.
+
+## Methods
+
+| Method       | Parameters                   | Description                                  |
+| ------------ | ---------------------------- | -------------------------------------------- |
+| `activate`   | `meeting: RealtimeKitClient` | Bind the button to the meeting state         |
+| `deactivate` | -                            | Unbind the button and remove event listeners |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbarbuttons.RtkCameraToggleButton
+    android:id="@+id/btn_camera_toggle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val cameraToggleButton = findViewById<RtkCameraToggleButton>(R.id.btn_camera_toggle)
+cameraToggleButton.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/chat.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/chat.mdx
@@ -1,0 +1,22 @@
+---
+pcx_content_type: reference
+title: RtkChatBottomSheet
+description: API reference for RtkChatBottomSheet component (Android Library)
+---
+
+Fully featured chat screen with image and file upload and auto-scroll.
+
+## Methods
+
+| Method | Parameters                                       | Description                   |
+| ------ | ------------------------------------------------ | ----------------------------- |
+| `show` | `fragmentManager: FragmentManager, tag: String?` | Display the chat bottom sheet |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val rtkChatBottomSheet = RtkChatBottomSheet()
+rtkChatBottomSheet.show(fragmentManager, "CHAT_TAG")
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/clock-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/clock-view.mdx
@@ -1,0 +1,32 @@
+---
+title: RtkClockView
+pcx_content_type: reference
+description: API reference for RtkClockView component (Android Library)
+---
+
+A clock component which shows the elapsed time of a meeting.
+
+## Methods
+
+| Method              | Parameters                      | Description                            |
+| ------------------- | ------------------------------- | -------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the clock to the meeting state    |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkClockView
+    android:id="@+id/rtk_clock_view"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val clockView = findViewById<RtkClockView>(R.id.rtk_clock_view)
+clockView.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/control-bar-button.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/control-bar-button.mdx
@@ -1,0 +1,47 @@
+---
+pcx_content_type: reference
+title: RtkControlBarButton
+description: API reference for RtkControlBarButton component (Android Library)
+---
+
+A skeleton component used for composing custom controlbar buttons.
+
+## Properties
+
+| Property              | Type                   | Required | Default  | Description                           |
+| --------------------- | ---------------------- | -------- | -------- | ------------------------------------- |
+| `rtk_cbb_icon`        | `reference`            | ❌       | -        | Drawable resource for the button icon |
+| `rtk_cbb_variant`     | `button \| horizontal` | ❌       | `button` | Layout variant                        |
+| `rtk_cbb_showText`    | `boolean`              | ❌       | `true`   | Whether to show the label text        |
+| `rtk_cbb_iconSize`    | `dimension`            | ❌       | -        | Size of the icon                      |
+| `rtk_cbb_iconPadding` | `dimension`            | ❌       | -        | Padding between icon and label        |
+
+## Methods
+
+| Method               | Parameters                      | Description                            |
+| -------------------- | ------------------------------- | -------------------------------------- |
+| `applyDesignTokens`  | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+| `setIconDrawable`    | `drawable: Drawable?`           | Set the button icon                    |
+| `setIconTint`        | `color: Int`                    | Set the icon tint color                |
+| `setText`            | `text: String?`                 | Set the button label text              |
+| `setProcessingState` | `processing: Boolean`           | Show or hide a loading spinner         |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbarbuttons.RtkControlBarButton
+    android:id="@+id/rtk_control_bar_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:rtk_cbb_showText="true"
+    app:rtk_cbb_variant="button" />
+```
+
+### With Methods
+
+```kotlin
+val buttonView = findViewById<RtkControlBarButton>(R.id.rtk_control_bar_button)
+buttonView.setOnClickListener { }
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/control-bar-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/control-bar-view.mdx
@@ -1,0 +1,24 @@
+---
+title: RtkControlBarView
+pcx_content_type: reference
+description: API reference for RtkControlBarView component (Android Library)
+---
+
+A base container for control bar buttons. Provides design token support and background styling.
+
+## Methods
+
+| Method              | Parameters                      | Description                            |
+| ------------------- | ------------------------------- | -------------------------------------- |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbars.RtkControlBarView
+    android:id="@+id/rtk_control_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/create-poll.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/create-poll.mdx
@@ -1,0 +1,22 @@
+---
+pcx_content_type: reference
+title: RtkCreatePollBottomSheet
+description: API reference for RtkCreatePollBottomSheet component (Android Library)
+---
+
+A component that lets you create a poll.
+
+## Methods
+
+| Method | Parameters                                       | Description                          |
+| ------ | ------------------------------------------------ | ------------------------------------ |
+| `show` | `fragmentManager: FragmentManager, tag: String?` | Display the create poll bottom sheet |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val rtkCreatePollBottomSheet = RtkCreatePollBottomSheet()
+rtkCreatePollBottomSheet.show(fragmentManager, "CREATE_POLL_TAG")
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/design-tokens.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/design-tokens.mdx
@@ -1,0 +1,42 @@
+---
+pcx_content_type: reference
+title: RtkDesignTokens
+description: API reference for RtkDesignTokens component (Android Library)
+---
+
+The top-level design token container for customizing the look and feel of all UI Kit components.
+
+## Properties
+
+| Property       | Type                   | Required | Default | Description         |
+| -------------- | ---------------------- | -------- | ------- | ------------------- |
+| `colors`       | `RtkColorTokens`       | ❌       | -       | Color theme tokens  |
+| `borderWidth`  | `RtkBorderWidthToken`  | ❌       | -       | Border width token  |
+| `borderRadius` | `RtkBorderRadiusToken` | ❌       | -       | Border radius token |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val designTokens = RtkDesignTokens(
+    colors = RtkColorTokens(
+        brand = BrandColor(
+            shade300 = Color.parseColor("#497CFD"),
+            shade400 = Color.parseColor("#356EFD"),
+            shade500 = Color.parseColor("#2160FD"),
+            shade600 = Color.parseColor("#0D52FD"),
+            shade700 = Color.parseColor("#0046E5")
+        ),
+        background = BackgroundColor(
+            shade600 = Color.parseColor("#2C2C2C"),
+            shade700 = Color.parseColor("#242424"),
+            shade800 = Color.parseColor("#1C1C1C"),
+            shade900 = Color.parseColor("#141414"),
+            shade1000 = Color.parseColor("#0C0C0C")
+        )
+    ),
+    borderRadius = RtkBorderRadiusToken.Rounded,
+    borderWidth = RtkBorderWidthToken.Thin
+)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/error-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/error-view.mdx
@@ -1,0 +1,33 @@
+---
+pcx_content_type: reference
+title: RtkErrorView
+description: API reference for RtkErrorView component (Android Library)
+---
+
+A full-screen error view that displays an error message and a retry button.
+
+## Methods
+
+| Method    | Parameters                                         | Description                                     |
+| --------- | -------------------------------------------------- | ----------------------------------------------- |
+| `refresh` | `errorMessage: String, onRetryClicked: () -> Unit` | Set the error message and retry button callback |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkErrorView
+    android:id="@+id/rtk_error_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+```
+
+### With Methods
+
+```kotlin
+val errorView = findViewById<RtkErrorView>(R.id.rtk_error_view)
+errorView.refresh("Failed to connect") {
+    // Retry connection
+}
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/grid-paginator.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/grid-paginator.mdx
@@ -1,0 +1,31 @@
+---
+title: RtkGridPaginatorView
+pcx_content_type: reference
+description: API reference for RtkGridPaginatorView component (Android Library)
+---
+
+A component which allows you to change the current page of the active participants grid.
+
+## Methods
+
+| Method     | Parameters                                                       | Description                             |
+| ---------- | ---------------------------------------------------------------- | --------------------------------------- |
+| `activate` | `rtkAndroidClient: RealtimeKitClient, uiTokens: RtkDesignTokens` | Bind the paginator to the meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkGridPaginatorView
+    android:id="@+id/rtk_grid_paginator"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val paginatorView = findViewById<RtkGridPaginatorView>(R.id.rtk_grid_paginator)
+paginatorView.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/grid-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/grid-view.mdx
@@ -1,0 +1,34 @@
+---
+title: RtkGridView
+pcx_content_type: reference
+description: API reference for RtkGridView component (Android Library)
+---
+
+The main grid component which handles the participant grid layout, pagination, and focus modes.
+
+## Methods
+
+| Method              | Parameters                      | Description                                                                                                                                |
+| ------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the grid to the meeting state                                                                                                         |
+| `refresh`           | `force: Boolean`                | Force a refresh of the grid layout and participants                                                                                        |
+| `enableFocusMode`   | -                               | Enable focus mode, which hides the horizontal peer strip and full-screen toggle to keep attention on the primary speaker or shared content |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming                                                                                                     |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.grid.RtkGridView
+    android:id="@+id/rtk_grid"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+```
+
+### With Methods
+
+```kotlin
+val grid = findViewById<RtkGridView>(R.id.rtk_grid)
+grid.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/header-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/header-view.mdx
@@ -1,0 +1,32 @@
+---
+title: RtkHeaderView
+pcx_content_type: reference
+description: API reference for RtkHeaderView component (Android Library)
+---
+
+A base header view component. Provides background styling and design token support.
+
+## Methods
+
+| Method              | Parameters                      | Description                            |
+| ------------------- | ------------------------------- | -------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the header to the meeting state   |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.headers.RtkHeaderView
+    android:id="@+id/rtk_header"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val header = findViewById<RtkHeaderView>(R.id.rtk_header)
+header.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/index.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/index.mdx
@@ -1,0 +1,8 @@
+---
+pcx_content_type: reference
+title: Android
+description: Complete API reference for Android library components
+sidebar:
+  group:
+    hideIndex: true
+---

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/join-button.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/join-button.mdx
@@ -1,0 +1,33 @@
+---
+pcx_content_type: reference
+title: RtkJoinButton
+description: API reference for RtkJoinButton component (Android Library)
+---
+
+A button that performs the room join operation. Displays "Join" by default and changes to "Joining..." during the join process. Automatically disables after a successful join.
+
+## Methods
+
+| Method     | Parameters                                                  | Description                                                                                                                                                                                                                                                         |
+| ---------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `activate` | `meeting: RealtimeKitClient, localUserNameField: EditText?` | Bind the button to the meeting state. Pass an optional `EditText` reference to validate the display name before joining — if the user has `canEditDisplayName` permission and the field is blank, the button shows a "Please enter name" toast and blocks the join. |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkJoinButton
+    android:id="@+id/rtk_join_button"
+    android:layout_width="wrap_content"
+    android:layout_height="48dp"
+    app:rtk_btn_variant="primary" />
+```
+
+### With Methods
+
+```kotlin
+val joinButton = findViewById<RtkJoinButton>(R.id.rtk_join_button)
+val nameField = findViewById<EditText>(R.id.name_field)
+joinButton.activate(meeting, nameField)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/join-livestream-button.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/join-livestream-button.mdx
@@ -1,0 +1,31 @@
+---
+pcx_content_type: reference
+title: RtkJoinLivestreamButton
+description: API reference for RtkJoinLivestreamButton component (Android Library)
+---
+
+A button for joining or leaving the livestream stage.
+
+## Methods
+
+| Method     | Parameters                   | Description                          |
+| ---------- | ---------------------------- | ------------------------------------ |
+| `activate` | `meeting: RealtimeKitClient` | Bind the button to the meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkJoinLivestreamButton
+    android:id="@+id/rtk_join_livestream"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val joinLivestreamButton = findViewById<RtkJoinLivestreamButton>(R.id.rtk_join_livestream)
+joinLivestreamButton.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/join-stage-dialog.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/join-stage-dialog.mdx
@@ -1,0 +1,26 @@
+---
+pcx_content_type: reference
+title: RtkJoinStageDialog
+description: API reference for RtkJoinStageDialog component (Android Library)
+---
+
+A confirmation dialog screen shown when the user's request to join stage is approved or when the host invites the local user to join stage.
+
+## Methods
+
+| Method              | Parameters                      | Description                            |
+| ------------------- | ------------------------------- | -------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the dialog to the meeting state   |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+| `show`              | -                               | Display the dialog                     |
+| `dismiss`           | -                               | Dismiss the dialog                     |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val rtkJoinStage = RtkJoinStageDialog(requireContext())
+rtkJoinStage.show()
+rtkJoinStage.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/leave-button.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/leave-button.mdx
@@ -1,0 +1,31 @@
+---
+pcx_content_type: reference
+title: RtkLeaveButton
+description: API reference for RtkLeaveButton component (Android Library)
+---
+
+A button which toggles visibility of the leave confirmation dialog.
+
+## Methods
+
+| Method     | Parameters                   | Description                          |
+| ---------- | ---------------------------- | ------------------------------------ |
+| `activate` | `meeting: RealtimeKitClient` | Bind the button to the meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbarbuttons.RtkLeaveButton
+    android:id="@+id/rtk_leave_button"
+    android:layout_width="48dp"
+    android:layout_height="48dp" />
+```
+
+### With Methods
+
+```kotlin
+val leaveButton = findViewById<RtkLeaveButton>(R.id.rtk_leave_button)
+leaveButton.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/leave-meeting-dialog.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/leave-meeting-dialog.mdx
@@ -1,0 +1,23 @@
+---
+pcx_content_type: reference
+title: RtkLeaveMeetingView
+description: API reference for RtkLeaveMeetingView component (Android Library)
+---
+
+A component which allows you to leave a meeting or end meeting for all, if you have the permission.
+
+## Methods
+
+| Method    | Parameters | Description        |
+| --------- | ---------- | ------------------ |
+| `show`    | -          | Display the dialog |
+| `dismiss` | -          | Dismiss the dialog |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val endCallDialog = RtkLeaveMeetingView(context, meeting)
+endCallDialog.show()
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-control-bar.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-control-bar.mdx
@@ -1,0 +1,31 @@
+---
+title: RtkLivestreamControlBarView
+pcx_content_type: reference
+description: API reference for RtkLivestreamControlBarView component (Android Library)
+---
+
+A pre-built control bar for livestream meetings. Contains mic toggle, camera toggle, livestream toggle, join stage button, more toggle, and leave button.
+
+## Methods
+
+| Method     | Parameters                   | Description                               |
+| ---------- | ---------------------------- | ----------------------------------------- |
+| `activate` | `meeting: RealtimeKitClient` | Bind the control bar to the meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbars.RtkLivestreamControlBarView
+    android:id="@+id/rtk_livestream_control_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val controlBar = findViewById<RtkLivestreamControlBarView>(R.id.rtk_livestream_control_bar)
+controlBar.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-header-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-header-view.mdx
@@ -1,0 +1,31 @@
+---
+pcx_content_type: reference
+title: RtkLivestreamHeaderView
+description: API reference for RtkLivestreamHeaderView component (Android Library)
+---
+
+A pre-built header for livestream meetings. Contains the livestream indicator, viewer count, clock, and meeting title.
+
+## Methods
+
+| Method     | Parameters                   | Description                          |
+| ---------- | ---------------------------- | ------------------------------------ |
+| `activate` | `meeting: RealtimeKitClient` | Bind the header to the meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkLivestreamHeaderView
+    android:id="@+id/rtk_livestream_header"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val header = findViewById<RtkLivestreamHeaderView>(R.id.rtk_livestream_header)
+header.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-indicator.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-indicator.mdx
@@ -1,0 +1,31 @@
+---
+title: RtkLivestreamIndicator
+pcx_content_type: reference
+description: API reference for RtkLivestreamIndicator component (Android Library)
+---
+
+A visual indicator that shows when a livestream is active.
+
+## Methods
+
+| Method    | Parameters                   | Description                                                |
+| --------- | ---------------------------- | ---------------------------------------------------------- |
+| `refresh` | `meeting: RealtimeKitClient` | Update the indicator based on the current livestream state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkLivestreamIndicator
+    android:id="@+id/rtk_livestream_indicator"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val indicator = findViewById<RtkLivestreamIndicator>(R.id.rtk_livestream_indicator)
+indicator.refresh(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-toggle-button.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-toggle-button.mdx
@@ -1,0 +1,31 @@
+---
+pcx_content_type: reference
+title: RtkLivestreamToggleButton
+description: API reference for RtkLivestreamToggleButton component (Android Library)
+---
+
+A toggle button for starting or stopping a livestream.
+
+## Methods
+
+| Method     | Parameters                   | Description                          |
+| ---------- | ---------------------------- | ------------------------------------ |
+| `activate` | `meeting: RealtimeKitClient` | Bind the button to the meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkLivestreamToggleButton
+    android:id="@+id/rtk_livestream_toggle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val livestreamToggle = findViewById<RtkLivestreamToggleButton>(R.id.rtk_livestream_toggle)
+livestreamToggle.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-viewer-count.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/livestream-viewer-count.mdx
@@ -1,0 +1,31 @@
+---
+title: RtkLivestreamViewerCount
+pcx_content_type: reference
+description: API reference for RtkLivestreamViewerCount component (Android Library)
+---
+
+Displays the current viewer count for a livestream.
+
+## Methods
+
+| Method    | Parameters                   | Description                                                |
+| --------- | ---------------------------- | ---------------------------------------------------------- |
+| `refresh` | `meeting: RealtimeKitClient` | Update the viewer count based on the current meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkLivestreamViewerCount
+    android:id="@+id/rtk_viewer_count"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val viewerCount = findViewById<RtkLivestreamViewerCount>(R.id.rtk_viewer_count)
+viewerCount.refresh(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/loader-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/loader-view.mdx
@@ -1,0 +1,18 @@
+---
+pcx_content_type: reference
+title: RtkLoaderView
+description: API reference for RtkLoaderView component (Android Library)
+---
+
+A full-screen loader component that can be displayed while a connection is being established with the RealtimeKit server. You must manually control the visibility of this view based on your application's connection state.
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkLoaderView
+    android:id="@+id/clLoader"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-activity.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-activity.mdx
@@ -1,0 +1,18 @@
+---
+pcx_content_type: reference
+title: RtkMeetingActivity
+description: API reference for RtkMeetingActivity component (Android Library)
+---
+
+The main meeting activity that manages the full meeting lifecycle. Handles transitions between loading, setup, waiting room, group call, webinar, and error states. This is the activity launched by `RealtimeKitUI.startMeeting()`.
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val meetingInfo = RtkMeetingInfo(authToken = authToken, baseUrl = baseUrl)
+val realtimeKitUIInfo = RealtimeKitUIInfo(activity = this, rtkMeetingInfo = meetingInfo)
+val realtimeKitUI = RealtimeKitUIBuilder.build(realtimeKitUIInfo)
+realtimeKitUI.startMeeting()
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-control-bar.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-control-bar.mdx
@@ -1,0 +1,31 @@
+---
+title: RtkMeetingControlBarView
+pcx_content_type: reference
+description: API reference for RtkMeetingControlBarView component (Android Library)
+---
+
+A pre-built control bar for group call meetings. Contains mic toggle, camera toggle, more toggle, and leave button.
+
+## Methods
+
+| Method     | Parameters                   | Description                               |
+| ---------- | ---------------------------- | ----------------------------------------- |
+| `activate` | `meeting: RealtimeKitClient` | Bind the control bar to the meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbars.RtkMeetingControlBarView
+    android:id="@+id/rtk_meeting_control_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val controlBar = findViewById<RtkMeetingControlBarView>(R.id.rtk_meeting_control_bar)
+controlBar.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-header.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-header.mdx
@@ -1,0 +1,32 @@
+---
+title: RtkMeetingHeaderView
+pcx_content_type: reference
+description: API reference for RtkMeetingHeaderView component (Android Library)
+---
+
+A pre-built meeting header that contains meeting title, clock, recording indicator, participant count, grid paginator, and switch camera button.
+
+## Methods
+
+| Method              | Parameters                      | Description                            |
+| ------------------- | ------------------------------- | -------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the header to the meeting state   |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.headers.RtkMeetingHeaderView
+    android:id="@+id/rtk_meeting_header"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val header = findViewById<RtkMeetingHeaderView>(R.id.rtk_meeting_header)
+header.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-option-bottomsheet.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-option-bottomsheet.mdx
@@ -1,0 +1,22 @@
+---
+pcx_content_type: reference
+title: RtkMeetingOptionBottomSheet
+description: API reference for RtkMeetingOptionBottomSheet component (Android Library)
+---
+
+A bottom sheet shown when tapping the more button. Contains options for participants, chat, polls, plugins, recording, screen share, mute all, and settings.
+
+## Methods
+
+| Method | Parameters                                       | Description                              |
+| ------ | ------------------------------------------------ | ---------------------------------------- |
+| `show` | `fragmentManager: FragmentManager, tag: String?` | Display the meeting options bottom sheet |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val meetingOptions = RtkMeetingOptionBottomSheet()
+meetingOptions.show(fragmentManager, "MEETING_OPTIONS_TAG")
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-title-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/meeting-title-view.mdx
@@ -1,0 +1,32 @@
+---
+pcx_content_type: reference
+title: RtkMeetingTitleView
+description: API reference for RtkMeetingTitleView component (Android Library)
+---
+
+A text view that displays the meeting title. It automatically updates when the meeting title changes.
+
+## Methods
+
+| Method              | Parameters                      | Description                            |
+| ------------------- | ------------------------------- | -------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the view to the meeting state     |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkMeetingTitleView
+    android:id="@+id/rtk_meeting_title"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val titleView = findViewById<RtkMeetingTitleView>(R.id.rtk_meeting_title)
+titleView.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/mic-toggle.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/mic-toggle.mdx
@@ -1,0 +1,32 @@
+---
+pcx_content_type: reference
+title: RtkMicToggleButton
+description: API reference for RtkMicToggleButton component (Android Library)
+---
+
+A button which toggles the local user's microphone. It automatically listens to self audio events to update its state.
+
+## Methods
+
+| Method       | Parameters                   | Description                                  |
+| ------------ | ---------------------------- | -------------------------------------------- |
+| `activate`   | `meeting: RealtimeKitClient` | Bind the button to the meeting state         |
+| `deactivate` | -                            | Unbind the button and remove event listeners |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbarbuttons.RtkMicToggleButton
+    android:id="@+id/btn_mic_toggle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val micToggleButton = findViewById<RtkMicToggleButton>(R.id.btn_mic_toggle)
+micToggleButton.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/more-toggle-button.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/more-toggle-button.mdx
@@ -1,0 +1,31 @@
+---
+pcx_content_type: reference
+title: RtkMoreToggleButton
+description: API reference for RtkMoreToggleButton component (Android Library)
+---
+
+A button which toggles visibility of a more menu.
+
+## Methods
+
+| Method     | Parameters                   | Description                          |
+| ---------- | ---------------------------- | ------------------------------------ |
+| `activate` | `meeting: RealtimeKitClient` | Bind the button to the meeting state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbarbuttons.RtkMoreToggleButton
+    android:id="@+id/rtk_more_toggle"
+    android:layout_width="50dp"
+    android:layout_height="50dp" />
+```
+
+### With Methods
+
+```kotlin
+val moreToggleButton = findViewById<RtkMoreToggleButton>(R.id.rtk_more_toggle)
+moreToggleButton.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/name-tag-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/name-tag-view.mdx
@@ -1,0 +1,34 @@
+---
+pcx_content_type: reference
+title: RtkNameTagView
+description: API reference for RtkNameTagView component (Android Library)
+---
+
+Displays a participant's name and an audio indicator.
+
+## Methods
+
+| Method              | Parameters                                                   | Description                                   |
+| ------------------- | ------------------------------------------------------------ | --------------------------------------------- |
+| `activate`          | `participant: RtkMeetingParticipant, isScreenShare: Boolean` | Bind the name tag to a participant            |
+| `setMaxLength`      | `length: Int`                                                | Set the maximum length for the displayed name |
+| `refresh`           | -                                                            | Refresh the name and audio indicator          |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens`                              | Apply custom design tokens for theming        |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.nametagview.RtkNameTagView
+    android:id="@+id/rtk_name_tag"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val nameTag = findViewById<RtkNameTagView>(R.id.rtk_name_tag)
+nameTag.activate(participant)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participant-audio-indicator.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participant-audio-indicator.mdx
@@ -1,0 +1,32 @@
+---
+title: RtkParticipantAudioIndicator
+pcx_content_type: reference
+description: API reference for RtkParticipantAudioIndicator component (Android Library)
+---
+
+An audio visualizer component which visualizes a participant's audio.
+
+## Methods
+
+| Method     | Parameters                           | Description                                  |
+| ---------- | ------------------------------------ | -------------------------------------------- |
+| `activate` | `participant: RtkMeetingParticipant` | Bind the indicator to a participant          |
+| `refresh`  | -                                    | Force a refresh of the audio indicator state |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkParticipantAudioIndicator
+    android:id="@+id/audio_indicator"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val audioIndicator = findViewById<RtkParticipantAudioIndicator>(R.id.audio_indicator)
+audioIndicator.activate(participant)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participant-count-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participant-count-view.mdx
@@ -1,0 +1,32 @@
+---
+pcx_content_type: reference
+title: RtkParticipantCountView
+description: API reference for RtkParticipantCountView component (Android Library)
+---
+
+A text view that displays the current number of participants in a meeting. It automatically updates when the participant count changes.
+
+## Methods
+
+| Method              | Parameters                      | Description                            |
+| ------------------- | ------------------------------- | -------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the view to the meeting state     |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkParticipantCountView
+    android:id="@+id/rtk_participant_count"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val countView = findViewById<RtkParticipantCountView>(R.id.rtk_participant_count)
+countView.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participant-tile-view.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participant-tile-view.mdx
@@ -1,0 +1,43 @@
+---
+pcx_content_type: reference
+title: RtkParticipantTileView
+description: API reference for RtkParticipantTileView component (Android Library)
+---
+
+A component which plays a participant's video and allows for placement of components like name tag and avatar.
+
+## Properties
+
+| Property                  | Type                        | Required | Default       | Description                  |
+| ------------------------- | --------------------------- | -------- | ------------- | ---------------------------- |
+| `rtk_ptv_nameTagPosition` | `BOTTOM_LEFT \| TOP_CENTER` | ❌       | `BOTTOM_LEFT` | Position of the name tag     |
+| `cardBackgroundColor`     | `color`                     | ❌       | -             | Background color of the tile |
+| `cardCornerRadius`        | `dimension`                 | ❌       | -             | Corner radius of the tile    |
+
+## Methods
+
+| Method                    | Parameters                           | Description                             |
+| ------------------------- | ------------------------------------ | --------------------------------------- |
+| `activate`                | `participant: RtkMeetingParticipant` | Bind the tile to a specific participant |
+| `refreshParticipantName`  | -                                    | Refresh the name tag and avatar         |
+| `refreshParticipantVideo` | -                                    | Refresh the video view state            |
+| `applyDesignTokens`       | `designTokens: RtkDesignTokens`      | Apply custom design tokens for theming  |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.participanttile.RtkParticipantTileView
+    android:id="@+id/rtk_participant_tile"
+    android:layout_width="match_parent"
+    android:layout_height="200dp"
+    app:rtk_ptv_nameTagPosition="BOTTOM_LEFT" />
+```
+
+### With Methods
+
+```kotlin
+val tile = findViewById<RtkParticipantTileView>(R.id.rtk_participant_tile)
+tile.activate(participant)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participant-video-indicator.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participant-video-indicator.mdx
@@ -1,0 +1,31 @@
+---
+title: RtkParticipantVideoIndicator
+pcx_content_type: reference
+description: API reference for RtkParticipantVideoIndicator component (Android Library)
+---
+
+A video indicator that shows a participant's camera status.
+
+## Methods
+
+| Method     | Parameters                           | Description                         |
+| ---------- | ------------------------------------ | ----------------------------------- |
+| `activate` | `participant: RtkMeetingParticipant` | Bind the indicator to a participant |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkParticipantVideoIndicator
+    android:id="@+id/video_indicator"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val videoIndicator = findViewById<RtkParticipantVideoIndicator>(R.id.video_indicator)
+videoIndicator.activate(participant)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participants.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/participants.mdx
@@ -1,0 +1,22 @@
+---
+pcx_content_type: reference
+title: RtkParticipantsFragment
+description: API reference for RtkParticipantsFragment component (Android Library)
+---
+
+A component which lists all participants, with the ability to run privileged actions on each participant according to your permissions.
+
+## Methods
+
+| Method | Parameters                                       | Description                               |
+| ------ | ------------------------------------------------ | ----------------------------------------- |
+| `show` | `fragmentManager: FragmentManager, tag: String?` | Display the participant list bottom sheet |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val rtkParticipantsFragment = RtkParticipantsFragment()
+rtkParticipantsFragment.show(fragmentManager, "PARTICIPANTS_TAG")
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/plugins.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/plugins.mdx
@@ -1,0 +1,22 @@
+---
+pcx_content_type: reference
+title: RtkPluginsBottomSheet
+description: API reference for RtkPluginsBottomSheet component (Android Library)
+---
+
+A component which lists all available plugins from their preset, with the ability to enable or disable plugins.
+
+## Methods
+
+| Method | Parameters                                       | Description                      |
+| ------ | ------------------------------------------------ | -------------------------------- |
+| `show` | `fragmentManager: FragmentManager, tag: String?` | Display the plugins bottom sheet |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val rtkPluginsBottomSheet = RtkPluginsBottomSheet()
+rtkPluginsBottomSheet.show(fragmentManager, "PLUGINS_TAG")
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/polls.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/polls.mdx
@@ -1,0 +1,22 @@
+---
+pcx_content_type: reference
+title: RtkPollsBottomSheet
+description: API reference for RtkPollsBottomSheet component (Android Library)
+---
+
+A component which lists all available polls a user can access.
+
+## Methods
+
+| Method | Parameters                                       | Description                    |
+| ------ | ------------------------------------------------ | ------------------------------ |
+| `show` | `fragmentManager: FragmentManager, tag: String?` | Display the polls bottom sheet |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val rtkPollsBottomSheet = RtkPollsBottomSheet()
+rtkPollsBottomSheet.show(fragmentManager, "POLLS_TAG")
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/recording-indicator.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/recording-indicator.mdx
@@ -1,0 +1,32 @@
+---
+title: RtkRecordingIndicator
+pcx_content_type: reference
+description: API reference for RtkRecordingIndicator component (Android Library)
+---
+
+A component which indicates the recording status of a meeting. It does not render anything if no recording is taking place.
+
+## Methods
+
+| Method              | Parameters                      | Description                             |
+| ------------------- | ------------------------------- | --------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the indicator to the meeting state |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming  |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkRecordingIndicator
+    android:id="@+id/rtk_recording_indicator"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val recordingIndicator = findViewById<RtkRecordingIndicator>(R.id.rtk_recording_indicator)
+recordingIndicator.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/settings-bottomsheet.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/settings-bottomsheet.mdx
@@ -1,0 +1,22 @@
+---
+pcx_content_type: reference
+title: RtkSettingsBottomsheet
+description: API reference for RtkSettingsBottomsheet component (Android Library)
+---
+
+A settings bottom sheet that contains audio and video device selectors and a self-preview tile. Used in portrait orientation.
+
+## Methods
+
+| Method | Parameters                                       | Description                       |
+| ------ | ------------------------------------------------ | --------------------------------- |
+| `show` | `fragmentManager: FragmentManager, tag: String?` | Display the settings bottom sheet |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val settingsBottomSheet = RtkSettingsBottomsheet()
+settingsBottomSheet.show(fragmentManager, "SETTINGS_TAG")
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/settings-fragment.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/settings-fragment.mdx
@@ -1,0 +1,23 @@
+---
+pcx_content_type: reference
+title: RtkSettingsFragment
+description: API reference for RtkSettingsFragment component (Android Library)
+---
+
+A settings dialog that contains audio and video device selectors and a self-preview tile. Used in landscape orientation.
+
+## Methods
+
+| Method                  | Parameters                                       | Description                                        |
+| ----------------------- | ------------------------------------------------ | -------------------------------------------------- |
+| `show`                  | `fragmentManager: FragmentManager, tag: String?` | Display the settings dialog                        |
+| `setBottomSheetEnabled` | `onClick: () -> Unit`                            | Enable a button to switch to the bottom sheet view |
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val settingsFragment = RtkSettingsFragment()
+settingsFragment.show(fragmentManager, "SETTINGS_TAG")
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/setup-screen.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/setup-screen.mdx
@@ -1,0 +1,18 @@
+---
+pcx_content_type: reference
+title: RtkSetupFragment
+description: API reference for RtkSetupFragment component (Android Library)
+---
+
+A screen shown before joining the meeting, where you can edit your display name and media settings.
+
+## Usage Examples
+
+### Basic Usage
+
+```kotlin
+val rtkSetupFragment = RtkSetupFragment()
+supportFragmentManager.beginTransaction()
+    .add(R.id.fragmentContainer, rtkSetupFragment)
+    .commit()
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/tab-sync-toggle-button.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/tab-sync-toggle-button.mdx
@@ -1,0 +1,31 @@
+---
+pcx_content_type: reference
+title: RtkTabSyncToggleButton
+description: API reference for RtkTabSyncToggleButton component (Android Library)
+---
+
+A toggle button for syncing plugin tabs.
+
+## Methods
+
+| Method              | Parameters                      | Description                            |
+| ------------------- | ------------------------------- | -------------------------------------- |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkTabSyncToggleButton
+    android:id="@+id/rtk_tab_sync"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val tabSyncButton = findViewById<RtkTabSyncToggleButton>(R.id.rtk_tab_sync)
+tabSyncButton.isActivated = true
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/video-device-selector.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/video-device-selector.mdx
@@ -1,0 +1,40 @@
+---
+title: RtkVideoDeviceSelector
+pcx_content_type: reference
+description: API reference for RtkVideoDeviceSelector component (Android Library)
+---
+
+A video device selector component which can be used to select video devices.
+
+## Properties
+
+| Property       | Type     | Required | Default | Description       |
+| -------------- | -------- | -------- | ------- | ----------------- |
+| `rtk_ds_label` | `string` | ❌       | `Video` | Custom label text |
+
+## Methods
+
+| Method              | Parameters                      | Description                               |
+| ------------------- | ------------------------------- | ----------------------------------------- |
+| `activate`          | `meeting: RealtimeKitClient`    | Bind the selector to the meeting state    |
+| `disableLabel`      | -                               | Disable the label text above the dropdown |
+| `applyDesignTokens` | `designTokens: RtkDesignTokens` | Apply custom design tokens for theming    |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkVideoDeviceSelector
+    android:id="@+id/videoSelector"
+    app:rtk_ds_label="Camera"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val videoSelector = findViewById<RtkVideoDeviceSelector>(R.id.videoSelector)
+videoSelector.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/video-peer.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/video-peer.mdx
@@ -1,0 +1,31 @@
+---
+pcx_content_type: reference
+title: RtkVideoPeer
+description: API reference for RtkVideoPeer component (Android Library)
+---
+
+A view that renders a participant's video stream with an avatar fallback when video is disabled.
+
+## Methods
+
+| Method    | Parameters                                                   | Description                               |
+| --------- | ------------------------------------------------------------ | ----------------------------------------- |
+| `refresh` | `participant: RtkMeetingParticipant, isScreenShare: Boolean` | Update the view with the participant data |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.RtkVideoPeer
+    android:id="@+id/rtk_video_peer"
+    android:layout_width="match_parent"
+    android:layout_height="200dp" />
+```
+
+### With Methods
+
+```kotlin
+val videoPeer = findViewById<RtkVideoPeer>(R.id.rtk_video_peer)
+videoPeer.refresh(participant, isScreenShare = false)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/webinar-control-bar.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/webinar-control-bar.mdx
@@ -1,0 +1,33 @@
+---
+title: RtkWebinarControlBarView
+pcx_content_type: reference
+description: API reference for RtkWebinarControlBarView component (Android Library)
+---
+
+A pre-built control bar for webinar meetings. Contains mic toggle, camera toggle, webinar stage toggle, more toggle, and leave button.
+
+## Methods
+
+| Method                     | Parameters                   | Description                                       |
+| -------------------------- | ---------------------------- | ------------------------------------------------- |
+| `activate`                 | `meeting: RealtimeKitClient` | Bind the control bar to the meeting state         |
+| `deactivate`               | -                            | Unbind the control bar and remove event listeners |
+| `refreshStageToggleButton` | -                            | Force a refresh of the stage toggle button state  |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbars.RtkWebinarControlBarView
+    android:id="@+id/rtk_webinar_control_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val controlBar = findViewById<RtkWebinarControlBarView>(R.id.rtk_webinar_control_bar)
+controlBar.activate(meeting)
+```

--- a/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/webinar-stage-toggle.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/api-reference/android/webinar-stage-toggle.mdx
@@ -1,0 +1,33 @@
+---
+pcx_content_type: reference
+title: RtkWebinarStageToggleButton
+description: API reference for RtkWebinarStageToggleButton component (Android Library)
+---
+
+Component that lets you add provision for the local user to join the webinar stage.
+
+## Methods
+
+| Method       | Parameters                   | Description                                  |
+| ------------ | ---------------------------- | -------------------------------------------- |
+| `activate`   | `meeting: RealtimeKitClient` | Bind the button to the meeting state         |
+| `deactivate` | -                            | Unbind the button and remove event listeners |
+| `refresh`    | -                            | Force a refresh of the button state          |
+
+## Usage Examples
+
+### Basic Usage
+
+```xml
+<com.cloudflare.realtimekit.ui.view.controlbarbuttons.webinarstagetogglebutton.RtkWebinarStageToggleButton
+    android:id="@+id/rtk_webinar_stage_toggle"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" />
+```
+
+### With Methods
+
+```kotlin
+val stageToggleButton = findViewById<RtkWebinarStageToggleButton>(R.id.rtk_webinar_stage_toggle)
+stageToggleButton.activate(meeting)
+```


### PR DESCRIPTION
### Summary

Added component references for RealtimeKit Android SDK.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
