### PR TITLE
Standardize "PAYGO" / "PayGo" to "Pay-as-you-go"

### DIFF
--- a/src/content/changelog/dex/2025-08-29-dex-mcp-server.mdx
+++ b/src/content/changelog/dex/2025-08-29-dex-mcp-server.mdx
@@ -10,6 +10,6 @@ We've released an MCP server [(Model Context Protocol)](https://cloudflare.com/l
 
 The DEX MCP server is an AI tool that allows customers to ask a question like, "Show me the connectivity and performance metrics for the device used by carly&#8204;@acme.com", and receive an answer that contains data from the DEX API.
 
-Any Cloudflare One customer using a Free, PayGo, or Enterprise account can access the DEX MCP Server. This feature is available to everyone.
+Any Cloudflare One customer using a Free, Pay-as-you-go, or Enterprise account can access the DEX MCP Server. This feature is available to everyone.
 
 Customers can test the new DEX MCP server in less than one minute. To learn more, read the [DEX MCP server documentation](/cloudflare-one/insights/dex/dex-mcp-server/).

--- a/src/content/changelog/gateway/2025-05-27-Protocol-Detection-availability.mdx
+++ b/src/content/changelog/gateway/2025-05-27-Protocol-Detection-availability.mdx
@@ -1,5 +1,5 @@
 ---
-title: Gateway Protocol Detection Now Available for PAYGO and Free Plans
+title: Gateway Protocol Detection Now Available for Pay-as-you-go and Free Plans
 description: Gateway protocol detection is now available on customer plan types!
 products:
   - gateway

--- a/src/content/changelog/ssl/2025-05-19-paygo-updates.mdx
+++ b/src/content/changelog/ssl/2025-05-19-paygo-updates.mdx
@@ -1,6 +1,6 @@
 ---
-title: Increased limits for Cloudflare for SaaS and Secrets Store free and pay-as-you-go plans
-description: With upgraded limits to [all free and paid plans](https://www.cloudflare.com/plans/), you can now extend the benefits of Cloudflare to more end customers via [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/) and deploy more account level variables through [Cloudflare Secrets Store](https://developers.cloudflare.com/secrets-store/). 
+title: Increased limits for Cloudflare for SaaS and Secrets Store free and Pay-as-you-go plans
+description: With upgraded limits to [all free and paid plans](https://www.cloudflare.com/plans/), you can now extend the benefits of Cloudflare to more end customers via [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/) and deploy more account level variables through [Cloudflare Secrets Store](https://developers.cloudflare.com/secrets-store/).
 date: 2025-05-27T11:00:00Z
 products:
   - ssl
@@ -12,7 +12,7 @@ import { Card, Render, Details } from "~/components";
 
 With upgraded limits to [all free and paid plans](https://www.cloudflare.com/plans/), you can now scale more easily with [Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/) and [Secrets Store](https://developers.cloudflare.com/secrets-store/).
 
-[Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/) allows you to extend the benefits of Cloudflare to your customers via their own custom or vanity domains. Now, the [limit for custom hostnames](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/plans/) on a Cloudflare for SaaS pay-as-you-go plan has been **raised from 5,000 custom hostnames to 50,000 custom hostnames.**
+[Cloudflare for SaaS](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/) allows you to extend the benefits of Cloudflare to your customers via their own custom or vanity domains. Now, the [limit for custom hostnames](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/plans/) on a Cloudflare for SaaS Pay-as-you-go plan has been **raised from 5,000 custom hostnames to 50,000 custom hostnames.**
 
 With custom origin server -- previously an enterprise-only feature -- you can route traffic from one or more custom hostnames somewhere other than your default proxy fallback. [Custom origin server](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/) is now available to Cloudflare for SaaS customers on Free, Pro, and Business plans.
 

--- a/src/content/docs/billing/sales-tax.mdx
+++ b/src/content/docs/billing/sales-tax.mdx
@@ -15,17 +15,17 @@ Cloudflare customers in a sponsorship program (i.e. [Project Athenian](https://w
 
 ## US State sales tax
 
-In the US, sales tax requirements are computed based on the 9-digit postal code of the address on file for your Cloudflare account. 
+In the US, sales tax requirements are computed based on the 9-digit postal code of the address on file for your Cloudflare account.
 Note to customers in Maryland: On July 1, 2025, Maryland began charging a tax on some technology services, including some provided by Cloudflare.
 
 ### Filing for US sales tax exemption
 
 Cloudflare is required by law to maintain documentation of tax-exempt sales. If you or your company are exempt from paying sales tax, email [exemptioncertificates@cloudflare.com](mailto:exemptioncertificates@cloudflare.com) from an email address associated with your Cloudflare account and provide one of the following forms of tax-exempt documentation:
 
-* Resale certificate
-* Multi-state tax exemption certificate
-* State sales tax exemption certificate
-* Partial sales tax exemption certificate
+- Resale certificate
+- Multi-state tax exemption certificate
+- State sales tax exemption certificate
+- Partial sales tax exemption certificate
 
 After your exemption is validated, tax-exempt status is added to your Cloudflare account information. Cloudflare invoices do not contain sales tax for the duration your exemption is valid.
 
@@ -47,12 +47,11 @@ Contact [billing@cloudflare.com](mailto:billing@cloudflare.com) with any questio
 
 ## Taiwan (VAT)
 
-Cloudflare collects VAT on all pay-as-you-go customers in Taiwan. The eGUI Invoice ID and eGUI Code are shown in the Cloudflare dashboard and are required to retrieve an invoice from the Taiwan government.
+Cloudflare collects VAT on all Pay-as-you-go customers in Taiwan. The eGUI Invoice ID and eGUI Code are shown in the Cloudflare dashboard and are required to retrieve an invoice from the Taiwan government.
 
 ## Japan (CT)
 
-Cloudflare Inc. is currently registered in Japan as of October 1st, 2023. Due to some constraints, Cloudflare will be only able to start collecting tax from PAYGO customers on April 1st, 2024.
-
+Cloudflare Inc. is currently registered in Japan as of October 1st, 2023. Due to some constraints, Cloudflare will be only able to start collecting tax from Pay-as-you-go customers on April 1st, 2024.
 
 ## Canada
 

--- a/src/content/docs/cache/how-to/cache-rules/settings.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/settings.mdx
@@ -178,9 +178,8 @@ Define the request components used to define a [custom Cache Key](/cache/how-to/
 
 Enterprise customers have these additional options for custom Cache Keys:
 
-- In the **Query string** section, you can select **All query string parameters**, **All query string parameters except** and enter an exception, **No query parameters except** and enter the parameters, or **Ignore query string** (also available for pay-as-you-go customers).
+- In the **Query string** section, you can select **All query string parameters**, **All query string parameters except** and enter an exception, **No query parameters except** and enter the parameters, or **Ignore query string** (also available for Pay-as-you-go customers).
 - In the **Headers** section, you can specify header names along with their values. For custom headers, values are optional; however, for the following restricted headers, you must include one to three specific values:
-
   - `accept`
   - `accept-charset`
   - `accept-encoding`

--- a/src/content/docs/cloudflare-one/insights/dex/dex-mcp-server.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/dex-mcp-server.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 The MCP server [(Model Context Protocol)](https://cloudflare.com/learning/ai/what-is-model-context-protocol-mcp/) for Digital Experience Monitoring (DEX) is an AI tool that allows customers to ask a question like, "Show me the connectivity and performance metrics for the device used by carly&#8204;@acme.com", and receive an answer that contains data from the DEX API.
 
-Any Cloudflare One customer using a Free, PayGo, or Enterprise account can access the DEX MCP Server. This feature is available to everyone.
+Any Cloudflare One customer using a Free, Pay-as-you-go, or Enterprise account can access the DEX MCP Server. This feature is available to everyone.
 
 There are two primary options for connecting to the DEX MCP server:
 

--- a/src/content/docs/reference-architecture/design-guides/zero-trust-for-saas.mdx
+++ b/src/content/docs/reference-architecture/design-guides/zero-trust-for-saas.mdx
@@ -58,7 +58,7 @@ This guide assumes you have an Enterprise contract with Cloudflare that includes
 - Cloudflare Zero Trust licenses for the number of users you plan to onboard
 - Cloudflare Cloud Email security licenses for the number of users whose cloud inbox emails will be filtered
 
-:::note[Free and PayGo capabilities]
+:::note[Free and Pay-as-you-go capabilities]
 A lot of the capabilities described in this document [are also available in our free and Pay-as-you-go plans](https://www.cloudflare.com/en-gb/plans/zero-trust-services/).
 :::
 

--- a/src/content/docs/support/contacting-cloudflare-support.mdx
+++ b/src/content/docs/support/contacting-cloudflare-support.mdx
@@ -61,7 +61,12 @@ For account security, you must verify your identity and account ownership in the
 
 1. In the Cloudflare dashboard, go to the **Support** page and select the account you are calling about.
 
-<LinkButton href="https://dash.cloudflare.com/?to=/:account/support" icon="external">Go to Support</LinkButton>
+<LinkButton
+	href="https://dash.cloudflare.com/?to=/:account/support"
+	icon="external"
+>
+	Go to Support
+</LinkButton>
 
 2. Click on the **Technical Support** tile and then the **Emergency Phone Line** tile.
 
@@ -81,7 +86,12 @@ To submit a support case, follow these steps:
 
 1. In the Cloudflare dashboard, go to the **Support** page and select the account you require assistance for.
 
-<LinkButton href="https://dash.cloudflare.com/?to=/:account/support" icon="external">Go to Support</LinkButton>
+<LinkButton
+	href="https://dash.cloudflare.com/?to=/:account/support"
+	icon="external"
+>
+	Go to Support
+</LinkButton>
 
 2. Click on the **Technical Support** tile, or for billing issues click **Billing** and then click **Create a Case** at the bottom of the following screen.
 
@@ -92,21 +102,21 @@ To submit a support case, follow these steps:
 5. Enter a detailed summary of the issue you’re experiencing.
 
 6. Complete the case submission fields as completely as possible with the following information. _(**Please note** that missing information will increase the time it takes to resolve your issue and our team may not be able to investigate without enough information. Please review [Gathering information for troubleshooting sites](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/) and make sure you include all needed information.)_
-    \- A detailed description of the issue with the following information:
-    - Timestamp (UTC)
-    - ZoneName/ZoneID
-    - Problem frequency
-    - Steps to reproduce the issue, with actual results vs expected results
-      \- Any necessary information for a technical investigation
-    - A description of the actual results vs expected results
-    - Steps to reproduce the issue, with example URLs 
-    - Exact error messages
-    - [HAR files](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/#generate-a-har-file)
-    - Screenshots
-    - Relevant logs from the origin web server
-    - Output from [test tools](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/) such as MTR, traceroute, dig/nslookup, and cURL
-      \- Priority level, impact to service / production
-      \- Any collaborators whom you wish to be cc'd on the case
+   \- A detailed description of the issue with the following information:
+   - Timestamp (UTC)
+   - ZoneName/ZoneID
+   - Problem frequency
+   - Steps to reproduce the issue, with actual results vs expected results
+     \- Any necessary information for a technical investigation
+   - A description of the actual results vs expected results
+   - Steps to reproduce the issue, with example URLs 
+   - Exact error messages
+   - [HAR files](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/#generate-a-har-file)
+   - Screenshots
+   - Relevant logs from the origin web server
+   - Output from [test tools](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/) such as MTR, traceroute, dig/nslookup, and cURL
+     \- Priority level, impact to service / production
+     \- Any collaborators whom you wish to be cc'd on the case
 7. Click **Submit Case**
 
 \*\* Available to certain plan types only. Refer to chart above for details.
@@ -147,7 +157,12 @@ When sending Cloudflare Support packet captures, please do the following:
 
 1. In the Cloudflare dashboard, go to the **Support** page.
 
-<LinkButton href="https://dash.cloudflare.com/?to=/:account/support" icon="external">Go to Support</LinkButton>
+<LinkButton
+	href="https://dash.cloudflare.com/?to=/:account/support"
+	icon="external"
+>
+	Go to Support
+</LinkButton>
 
 2. Click on **Get help**
 
@@ -161,7 +176,12 @@ When sending Cloudflare Support packet captures, please do the following:
 
 1. In the Cloudflare dashboard, go to the **Support** page and select the account you require assistance for.
 
-<LinkButton href="https://dash.cloudflare.com/?to=/:account/support" icon="external">Go to Support</LinkButton>
+<LinkButton
+	href="https://dash.cloudflare.com/?to=/:account/support"
+	icon="external"
+>
+	Go to Support
+</LinkButton>
 
 2. Click on the **Technical Support** tile followed by **View My Cases**.
 
@@ -179,11 +199,16 @@ Available for Business and Enterprise plans only. Use **live chat** for quick qu
 
 1. In the Cloudflare dashboard, go to the **Support** page and select the account you require assistance for.
 
-<LinkButton href="https://dash.cloudflare.com/?to=/:account/support" icon="external">Go to Support</LinkButton>
+<LinkButton
+	href="https://dash.cloudflare.com/?to=/:account/support"
+	icon="external"
+>
+	Go to Support
+</LinkButton>
 
 2. Select **Technical Support** tile > **Chat with an agent**.
-	* **Business plans**: Complete the support form and select **Start Live Chat**. The widget will open automatically, pre-filled with your details.
-	* **Enterprise plans**: The chat widget will open immediately. Enter a brief description of your problem to begin.
+   - **Business plans**: Complete the support form and select **Start Live Chat**. The widget will open automatically, pre-filled with your details.
+   - **Enterprise plans**: The chat widget will open immediately. Enter a brief description of your problem to begin.
 
 3. Wait for an agent to join the conversation. Response times may vary based on current chat volume.
 
@@ -213,7 +238,7 @@ Below are definitions of the priority levels Cloudflare assigns to cases and the
 - P2 High - High Business Impact: Significant but localized service or security disruption. While not a full outage, this issue affects business operations and requires urgent resolution.
   - _Example_: A recurring or persistent issue is affecting a portion of your users, such as degraded performance, intermittent outages, or limited accessibility.
   - _Example_: A past, confirmed security attack has resulted in measurable impact, requiring investigation and mitigation to prevent recurrence.
-- P3 Normal -  Moderate Business Impact: Limited service impact or suspected security concerns. The issue does not pose an immediate risk but requires attention for continued reliability.
+- P3 Normal - Moderate Business Impact: Limited service impact or suspected security concerns. The issue does not pose an immediate risk but requires attention for continued reliability.
   - _Example_: Your service is operational, but you are experiencing minor disruptions, such as performance fluctuations, unexpected behavior, or non-critical bugs.
   - _Example_: A suspected security threat has been detected but is currently mitigated (e.g., an attack that Cloudflare successfully blocked).
 - P4 Low - Low Business Impact: General inquiries and non-urgent requests. The issue does not impact your service availability or business operations.
@@ -236,7 +261,7 @@ Below are definitions of the priority levels Cloudflare assigns to cases and the
 
 ### SLOs for other plans
 
-- PAYGO and Free customers - No SLAs are offered, but customers are responded to in the order in which their request is received. For a quicker answer, we highly recommend searching or posting on our [Community forums](https://community.cloudflare.com/).
+- Pay-as-you-go and Free customers - No SLAs are offered, but customers are responded to in the order in which their request is received. For a quicker answer, we highly recommend searching or posting on our [Community forums](https://community.cloudflare.com/).
 
 ## Supported languages
 

--- a/src/content/docs/support/contacting-cloudflare-support.mdx
+++ b/src/content/docs/support/contacting-cloudflare-support.mdx
@@ -102,12 +102,12 @@ To submit a support case, follow these steps:
 5. Enter a detailed summary of the issue you’re experiencing.
 
 6. Complete the case submission fields as completely as possible with the following information. _(**Please note** that missing information will increase the time it takes to resolve your issue and our team may not be able to investigate without enough information. Please review [Gathering information for troubleshooting sites](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/) and make sure you include all needed information.)_
-   \- A detailed description of the issue with the following information:
+   - A detailed description of the issue with the following information:
    - Timestamp (UTC)
    - ZoneName/ZoneID
    - Problem frequency
    - Steps to reproduce the issue, with actual results vs expected results
-     \- Any necessary information for a technical investigation
+     - Any necessary information for a technical investigation
    - A description of the actual results vs expected results
    - Steps to reproduce the issue, with example URLs 
    - Exact error messages
@@ -115,8 +115,8 @@ To submit a support case, follow these steps:
    - Screenshots
    - Relevant logs from the origin web server
    - Output from [test tools](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/) such as MTR, traceroute, dig/nslookup, and cURL
-     \- Priority level, impact to service / production
-     \- Any collaborators whom you wish to be cc'd on the case
+     - Priority level, impact to service / production
+     - Any collaborators whom you wish to be cc'd on the case
 7. Click **Submit Case**
 
 \*\* Available to certain plan types only. Refer to chart above for details.

--- a/src/content/release-notes/workers-for-platforms.yaml
+++ b/src/content/release-notes/workers-for-platforms.yaml
@@ -6,7 +6,7 @@ entries:
   - publish_date: "2024-04-16"
     title: Workers for Platforms available to all users
     description: |-
-      Workers for Platforms will be available for all users through the new pay-as-you-go plan. For more information, refer to the [blog post](https://blog.cloudflare.com/browser-rendering-api-ga-rolling-out-cloudflare-snippets-swr-and-bringing-workers-for-platforms-to-our-paygo-plans/).
+      Workers for Platforms will be available for all users through the new Pay-as-you-go plan. For more information, refer to the [blog post](https://blog.cloudflare.com/browser-rendering-api-ga-rolling-out-cloudflare-snippets-swr-and-bringing-workers-for-platforms-to-our-paygo-plans/).
   - publish_date: "2023-05-18"
     title: Outbound Workers, Custom Limits and Tail Workers
     description: |-


### PR DESCRIPTION
Replaces informal abbreviations (PAYGO, PayGo) with the proper plan name "Pay-as-you-go" across 6 files.

- **contacting-cloudflare-support.mdx** — "PAYGO and Free customers" → "Pay-as-you-go and Free customers"
- **zero-trust-for-saas.mdx** — aside title "Free and PayGo capabilities" → "Free and Pay-as-you-go capabilities"
- **dex-mcp-server.mdx** (docs) — "Free, PayGo, or Enterprise" → "Free, Pay-as-you-go, or Enterprise"
- **dex-mcp-server.mdx** (changelog) — same change as above
- **sales-tax.mdx** — "PAYGO customers" → "Pay-as-you-go customers"
- **Protocol-Detection-availability.mdx** (changelog title) — "PAYGO and Free Plans" → "Pay-as-you-go and Free Plans"

One additional match in `release-notes/workers-for-platforms.yaml` was intentionally left unchanged because "paygo" appears inside an external blog post URL.