### PR TITLE
AI Search: add new Workers AI models

### DIFF
--- a/src/content/changelog/ai-search/2026-04-09-new-workers-ai-models.mdx
+++ b/src/content/changelog/ai-search/2026-04-09-new-workers-ai-models.mdx
@@ -1,0 +1,31 @@
+---
+title: New Workers AI models for text generation and embedding in AI Search
+description: AI Search adds four new Workers AI models including GLM, Qwen, and EmbeddingGemma.
+products:
+  - ai-search
+date: 2026-04-08
+---
+
+[AI Search](/ai-search/) now supports four additional [Workers AI](/workers-ai/) models across text generation and embedding.
+
+### Text generation
+
+| Model                        | Context window (tokens) |
+| ---------------------------- | ----------------------- |
+| `@cf/zai-org/glm-4.7-flash`  | 131,072                 |
+| `@cf/qwen/qwen3-30b-a3b-fp8` | 32,000                  |
+
+GLM-4.7-Flash is a lightweight model from Zhipu AI with a 131,072 token context window, suitable for long-document summarization and retrieval tasks. Qwen3-30B-A3B is a mixture-of-experts model from Alibaba that activates only 3 billion parameters per forward pass, keeping inference fast while maintaining strong response quality.
+
+### Embedding
+
+| Model                            | Vector dims | Input tokens | Metric |
+| -------------------------------- | ----------- | ------------ | ------ |
+| `@cf/qwen/qwen3-embedding-0.6b`  | 1,024       | 4,096        | cosine |
+| `@cf/google/embeddinggemma-300m` | 768         | 512          | cosine |
+
+Qwen3-Embedding-0.6B supports up to 4,096 input tokens, making it a good fit for indexing longer text chunks. EmbeddingGemma-300M from Google produces 768-dimension vectors and is optimized for low-latency embedding workloads.
+
+All four models are available without additional provider keys since they run on Workers AI. Select them when creating or updating an AI Search instance in the dashboard or through the API.
+
+For the full list of supported models, refer to [Supported models](/ai-search/configuration/models/supported-models/).

--- a/src/content/docs/ai-search/configuration/models/supported-models.mdx
+++ b/src/content/docs/ai-search/configuration/models/supported-models.mdx
@@ -11,49 +11,56 @@ This page lists all models supported by AI Search and their lifecycle status.
 If you would like to use a model that is not currently supported, reach out to us on [Discord](https://discord.gg/cloudflaredev) to request it.
 :::
 
-
 ## Production models
+
 Production models are the actively supported and recommended models that are stable, fully available.
 
 ### Text generation
-| Provider | Alias | Context window (tokens) |
-|---|---|---|
-| **Anthropic** | `anthropic/claude-3-7-sonnet` | 200,000 |
-|  | `anthropic/claude-sonnet-4` | 200,000 |
-|  | `anthropic/claude-opus-4` | 200,000 |
-|  | `anthropic/claude-3-5-haiku` | 200,000 |
-| **Cerebras** | `cerebras/qwen-3-235b-a22b-instruct` | 64,000 |
-|  | `cerebras/qwen-3-235b-a22b-thinking` | 65,000 |
-|  | `cerebras/llama-3.3-70b` | 65,000 |
-|  | `cerebras/llama-4-maverick-17b-128e-instruct` | 8,000 |
-|  | `cerebras/llama-4-scout-17b-16e-instruct` | 8,000 |
-|  | `cerebras/gpt-oss-120b` | 64,000 |
-| **Google AI Studio** | `google-ai-studio/gemini-2.5-flash` | 1,048,576 |
-|  | `google-ai-studio/gemini-2.5-pro` | 1,048,576 |
-| **Grok (x.ai)** | `grok/grok-4` | 256,000 |
-| **Groq** | `groq/llama-3.3-70b-versatile` | 131,072 |
-|  | `groq/llama-3.1-8b-instant` | 131,072 |
-| **OpenAI** | `openai/gpt-5` | 400,000 |
-|  | `openai/gpt-5-mini` | 400,000 |
-|  | `openai/gpt-5-nano` | 400,000 |
-| **Workers AI** | `@cf/meta/llama-3.3-70b-instruct-fp8-fast` | 24,000 |
-|  | `@cf/meta/llama-3.1-8b-instruct-fast` | 60,000 |
-|  | `@cf/meta/llama-3.1-8b-instruct-fp8` | 32,000 |
-|  | `@cf/meta/llama-4-scout-17b-16e-instruct` | 131,000 |
+
+| Provider             | Alias                                         | Context window (tokens) |
+| -------------------- | --------------------------------------------- | ----------------------- |
+| **Anthropic**        | `anthropic/claude-3-7-sonnet`                 | 200,000                 |
+|                      | `anthropic/claude-sonnet-4`                   | 200,000                 |
+|                      | `anthropic/claude-opus-4`                     | 200,000                 |
+|                      | `anthropic/claude-3-5-haiku`                  | 200,000                 |
+| **Cerebras**         | `cerebras/qwen-3-235b-a22b-instruct`          | 64,000                  |
+|                      | `cerebras/qwen-3-235b-a22b-thinking`          | 65,000                  |
+|                      | `cerebras/llama-3.3-70b`                      | 65,000                  |
+|                      | `cerebras/llama-4-maverick-17b-128e-instruct` | 8,000                   |
+|                      | `cerebras/llama-4-scout-17b-16e-instruct`     | 8,000                   |
+|                      | `cerebras/gpt-oss-120b`                       | 64,000                  |
+| **Google AI Studio** | `google-ai-studio/gemini-2.5-flash`           | 1,048,576               |
+|                      | `google-ai-studio/gemini-2.5-pro`             | 1,048,576               |
+| **Grok (x.ai)**      | `grok/grok-4`                                 | 256,000                 |
+| **Groq**             | `groq/llama-3.3-70b-versatile`                | 131,072                 |
+|                      | `groq/llama-3.1-8b-instant`                   | 131,072                 |
+| **OpenAI**           | `openai/gpt-5`                                | 400,000                 |
+|                      | `openai/gpt-5-mini`                           | 400,000                 |
+|                      | `openai/gpt-5-nano`                           | 400,000                 |
+| **Workers AI**       | `@cf/meta/llama-3.3-70b-instruct-fp8-fast`    | 24,000                  |
+|                      | `@cf/meta/llama-3.1-8b-instruct-fast`         | 60,000                  |
+|                      | `@cf/meta/llama-3.1-8b-instruct-fp8`          | 32,000                  |
+|                      | `@cf/meta/llama-4-scout-17b-16e-instruct`     | 131,000                 |
+|                      | `@cf/zai-org/glm-4.7-flash`                   | 131,072                 |
+|                      | `@cf/qwen/qwen3-30b-a3b-fp8`                  | 32,000                  |
 
 ### Embedding
-| Provider | Alias | Vector dims | Input tokens | Metric |
-|---|---|---|---|---|
-| **Google AI Studio** | `google-ai-studio/gemini-embedding-001` | 1,536 | 2048 | cosine |
-| **OpenAI** | `openai/text-embedding-3-small` | 1,536 | 8192 | cosine |
-|  | `openai/text-embedding-3-large` | 1,536 | 8192 | cosine |
-| **Workers AI** | `@cf/baai/bge-m3` | 1,024 | 512 | cosine |
-|  | `@cf/baai/bge-large-en-v1.5` | 1,024 | 512 | cosine |
+
+| Provider             | Alias                                   | Vector dims | Input tokens | Metric |
+| -------------------- | --------------------------------------- | ----------- | ------------ | ------ |
+| **Google AI Studio** | `google-ai-studio/gemini-embedding-001` | 1,536       | 2048         | cosine |
+| **OpenAI**           | `openai/text-embedding-3-small`         | 1,536       | 8192         | cosine |
+|                      | `openai/text-embedding-3-large`         | 1,536       | 8192         | cosine |
+| **Workers AI**       | `@cf/baai/bge-m3`                       | 1,024       | 512          | cosine |
+|                      | `@cf/baai/bge-large-en-v1.5`            | 1,024       | 512          | cosine |
+|                      | `@cf/qwen/qwen3-embedding-0.6b`         | 1,024       | 4,096        | cosine |
+|                      | `@cf/google/embeddinggemma-300m`        | 768         | 512          | cosine |
 
 ### Reranking
-| Provider | Alias | Input tokens | 
-|---|---|---|
-| **Workers AI** | `@cf/baai/bge-reranker-base` | 512 | 
+
+| Provider       | Alias                        | Input tokens |
+| -------------- | ---------------------------- | ------------ |
+| **Workers AI** | `@cf/baai/bge-reranker-base` | 512          |
 
 ## Transition models
 


### PR DESCRIPTION
Adds four new Workers AI models to the AI Search supported models page and creates a changelog entry for the additions.

- Add GLM-4.7-Flash and Qwen3-30B-A3B text generation models
- Add Qwen3-Embedding-0.6B and EmbeddingGemma-300M embedding models
- Add changelog entry for 2026-04-08
- Fix table formatting in supported models page