### PR TITLE
Update /json endpoint default model and Workers AI auth docs

### DIFF
--- a/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
+++ b/src/content/docs/browser-rendering/rest-api/json-endpoint.mdx
@@ -13,7 +13,7 @@ The `/json` endpoint extracts structured data from a webpage. You can specify th
 
 :::note[Note]
 
-By default, the `/json` endpoint leverages [Workers AI](/workers-ai/) for data extraction using [`@cf/meta/llama-3.3-70b-instruct-fp8-fast`](/workers-ai/models/llama-3.3-70b-instruct-fp8-fast/). Using this endpoint incurs usage on Workers AI, which you can monitor in the [Workers AI Dashboard](https://dash.cloudflare.com/?to=/:account/ai/workers-ai). To use a different model, refer to [Using a custom model (BYO API Key)](/browser-rendering/rest-api/json-endpoint/#using-a-custom-model-byo-api-key).
+By default, the `/json` endpoint leverages [Workers AI](/workers-ai/) for data extraction using [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/). Using this endpoint incurs usage on Workers AI, which you can monitor in the [Workers AI Dashboard](https://dash.cloudflare.com/?to=/:account/ai/workers-ai). To use a different model, refer to [Using a custom model (BYO API Key)](/browser-rendering/rest-api/json-endpoint/#using-a-custom-model-byo-api-key).
 
 :::
 
@@ -306,7 +306,7 @@ Visit the [Browser Rendering API reference](/api/resources/browser_rendering/sub
 Browser Rendering can use a custom model for which you supply credentials. List the model(s) in the `custom_ai` array:
 
 - `model` should be formed as `<provider>/<model_name>` and the provider must be one of these [supported providers](/ai-gateway/usage/chat-completion/#supported-providers).
-- `authorization` is the bearer token or API key that allows Browser Rendering to call the provider on your behalf.
+- `authorization` is the bearer token or API key that allows Browser Rendering to call the provider on your behalf. For [Workers AI](/workers-ai/) models (using the `workers-ai/` prefix), `authorization` is not required — authentication is handled automatically.
 
 This example uses the `custom_ai` parameter to instruct Browser Rendering to use a Anthropic's Claude Sonnet 4 model. The prompt asks the model to extract the main `<h1>` and `<h2>` headings from the target URL and return them in a structured JSON object.
 
@@ -358,7 +358,7 @@ curl --request POST \
 
 You may specify multiple models to provide automatic failover. Browser Rendering will attempt the models in order until one succeeds. To add failover, list additional models in the `custom_ai` array.
 
-In this example, Browser Rendering first calls Anthropic's Claude Sonnet 4 model. If that request returns an error, it automatically retries with Meta Llama 3.3 70B from [Workers AI](/workers-ai/), then OpenAI's GPT-4o.
+In this example, Browser Rendering first calls Anthropic's Claude Sonnet 4 model. If that request returns an error, it automatically retries with Google Gemma 4 26B from [Workers AI](/workers-ai/), then OpenAI's GPT-4o. Note that the Workers AI model does not require an `authorization` field.
 
 ```
 "custom_ai": [
@@ -367,10 +367,9 @@ In this example, Browser Rendering first calls Anthropic's Claude Sonnet 4 model
     "authorization": "Bearer <ANTHROPIC_API_KEY>"
   },
   {
-    "model": "workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-    "authorization": "Bearer <CLOUDFLARE_AUTH_TOKEN>"
+    "model": "workers-ai/@cf/google/gemma-4-26b-a4b-it"
   },
-{
+  {
     "model": "openai/gpt-4o",
     "authorization": "Bearer <OPENAI_API_KEY>"
   }


### PR DESCRIPTION
- Update default model from @cf/meta/llama-3.3-70b-instruct-fp8-fast to @cf/google/gemma-4-26b-a4b-it
- Add note that authorization is not required for Workers AI models in custom_ai
- Update fallback example to use new default model and drop authorization for Workers AI entry

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
