### PR TITLE
[DLS] Clarify that regional hostnames do not apply to Spectrum applications

### DIFF
--- a/src/content/docs/data-localization/compatibility.mdx
+++ b/src/content/docs/data-localization/compatibility.mdx
@@ -201,7 +201,7 @@ The tables below show whether each Cloudflare product is compatible with each DL
 
 [^41]: Logs / Analytics not available outside US region when using Customer Metadata Boundary. Use Logpush instead.
 
-[^42]: Only applies to HTTP/S Spectrum applications.
+[^42]: Only applies to HTTP/S Spectrum applications. Spectrum applications use a separate regionalization mechanism from the Regional Hostnames API. Configuring a regional hostname does not regionalize a Spectrum application on the same hostname. Contact your [Account Team](/support/contacting-cloudflare-support/) for Spectrum-specific regionalization.
 
 [^43]: Web Analytics collects the [minimum amount of information](/web-analytics/data-metrics/data-origin-and-collection/). Alternatively, you can [exclude EU Visitors from RUM](/speed/observatory/rum-beacon/#rum-excluding-eeaeu).
 

--- a/src/content/docs/data-localization/limitations.mdx
+++ b/src/content/docs/data-localization/limitations.mdx
@@ -40,6 +40,12 @@ The following features and protocols are not supported by Regional Services and 
 
 Since Regional Services leverages Spectrum (Cloudflare's Layer 4 proxy service) in the background, [Spectrum limitations](/spectrum/reference/limitations/) apply.
 
+### Regional hostnames and Spectrum applications
+
+Regional hostnames configured through the dashboard or the Regional Hostnames API only apply to hostnames [proxied](/dns/proxy-status/) through Cloudflare. They do not regionalize [Spectrum](/spectrum/) applications.
+
+If a hostname has both a regional hostname configuration and an active Spectrum application, these are independent systems. The Spectrum application may override the regional hostname's IP steering with its own IP assignment. As a result, traffic may not be processed in the region configured via the Regional Hostnames API. If you need to regionalize a Spectrum application, contact your [Account Team](/support/contacting-cloudflare-support/) about Spectrum-specific regionalization options. Spectrum-specific regionalization only applies to HTTP and HTTPS [application types](/spectrum/reference/configuration-options/#application-type).
+
 Regional Services does not apply to [subrequests](/workers/platform/limits/#subrequests) (secondary HTTP requests that your Cloudflare Workers make to other services). Regional Services operates on your hostname's IPs. We recommend using [DNSSEC](/learning-paths/application-security/default-traffic-security/dnssec/) (which cryptographically signs DNS records to prevent tampering) and/or [DNS over HTTPS](/1.1.1.1/encryption/dns-over-https/) (which encrypts DNS queries) to ensure that DNS responses are secure and correct.
 
 ## Customer Metadata Boundary


### PR DESCRIPTION
Clarifies that regional hostnames configured via the dashboard or Regional Hostnames API only regionalize hostnames proxied through Cloudflare. Spectrum applications use a separate regionalization mechanism and are not affected by regional hostname configurations.