### PR TITLE
[Cloudflare WAN] Add note about BGP, MD5, and Telnet

### DIFF
--- a/src/content/partials/networking-services/routing/configure-routes.mdx
+++ b/src/content/partials/networking-services/routing/configure-routes.mdx
@@ -631,7 +631,10 @@ If you are configuring BGP peering for a tunnel (GRE or IPsec) you must be aware
 - Your CPE may advertise up to 5,000 prefixes on one BGP session.
 - MD5 authentication is optional. You can use a maximum of 80 characters. Supported characters include ``a-zA-Z0-9'!@#$%^&*()+[]{}<>/.,;:_-~`= \\|``
   :::caution
-	MD5 authentication is not a security measure nor is it a valid security mechanism. The MD5 key is not treated as a secret value. This is only supported for preventing misconfiguration, not for defending against malicious attacks.
+	MD5 authentication is not a valid security mechanism. The MD5 key is not treated as a secret value. This is only supported for preventing misconfiguration, not for defending against malicious attacks.
+  :::
+  :::note
+  When MD5 is enabled, you cannot use Telnet to test BGP connectivity (Telnet does not support TCP MD5 authentication).
   :::
 
 
@@ -642,5 +645,3 @@ If you are configuring BGP peering for a tunnel (GRE or IPsec) you must be aware
   </>
 )
 }
-
-

--- a/src/content/partials/networking-services/routing/configure-routes.mdx
+++ b/src/content/partials/networking-services/routing/configure-routes.mdx
@@ -632,9 +632,8 @@ If you are configuring BGP peering for a tunnel (GRE or IPsec) you must be aware
 - MD5 authentication is optional. You can use a maximum of 80 characters. Supported characters include ``a-zA-Z0-9'!@#$%^&*()+[]{}<>/.,;:_-~`= \\|``
   :::caution
 	MD5 authentication is not a valid security mechanism. The MD5 key is not treated as a secret value. This is only supported for preventing misconfiguration, not for defending against malicious attacks.
-  :::
-  :::note
-  When MD5 is enabled, you cannot use Telnet to test BGP connectivity (Telnet does not support TCP MD5 authentication).
+
+	When MD5 is enabled, you cannot use Telnet to test BGP connectivity (Telnet does not support TCP MD5 authentication).
   :::
 
 


### PR DESCRIPTION
Adds a note calling attention to the fact that Telnet cannot be used to check BGP connectivity when MD5 is used. (Telnet is a common tool network admins will reach for to test this.)