### PR TITLE
[Workers] Update simultaneous open connections docs for slot-release-on-headers

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.3.17"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.17.tgz",
+      "integrity": "sha512-N5lckFtYvEu2R8K1um//MIOTHsJHniF2kHoPIWPCrxKG5Jpismt1ISGzIiU3aKI2ht/9VgcqKPC5oZFLdmpxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.17",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.96",
+        "@opentui/solid": ">=0.1.96"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.17.tgz",
+      "integrity": "sha512-2+MGgu7wynqTBwxezR01VAGhILXlpcHDY/pF7SWB87WOgLt3kD55HjKHNj6PWxyY8n575AZolR95VUC3gtwfmA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/src/assets/images/workers/platform/limits/connection-cancel-after.svg
+++ b/src/assets/images/workers/platform/limits/connection-cancel-after.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 230" fill="none">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+    .label { font-size: 12px; font-weight: 600; fill: #1a1a1a; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .phase { font-size: 11px; font-weight: 600; fill: #fff; }
+    .phase-body { font-size: 11px; fill: #0369a1; }
+    .annotation { font-size: 10px; fill: #6b7280; }
+  </style>
+  <defs>
+    <marker id="time-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#d1d5db"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="820" height="230" fill="#fafafa" rx="8"/>
+
+  <!-- Time axis -->
+  <line x1="40" y1="30" x2="720" y2="30" stroke="#d1d5db" stroke-width="1.5" marker-end="url(#time-arrow)"/>
+  <text x="735" y="34" class="sublabel">time</text>
+
+  <!-- Connection bar: headers phase -->
+  <path d="M44,52 h76 v36 h-76 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <text x="80" y="75" text-anchor="middle" class="phase">headers</text>
+
+  <!-- "Freed" marker at end of headers -->
+  <line x1="120" y1="42" x2="120" y2="112" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="128" y="115" class="sublabel" style="fill: #16a34a;">freed</text>
+
+  <!-- Body: same alternating read/gap/read/gap pattern, but in blue (no longer counted) -->
+  <!-- read 1 -->
+  <rect x="120" y="52" width="60" height="36" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="150" y="75" text-anchor="middle" class="phase-body">body</text>
+  <!-- gap 1 -->
+  <rect x="180" y="52" width="30" height="36" fill="#f0f9ff" stroke="#bae6fd" stroke-width="1" stroke-dasharray="3 2"/>
+  <!-- read 2 -->
+  <rect x="210" y="52" width="70" height="36" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="245" y="75" text-anchor="middle" class="phase-body">body</text>
+  <!-- gap 2 -->
+  <rect x="280" y="52" width="30" height="36" fill="#f0f9ff" stroke="#bae6fd" stroke-width="1" stroke-dasharray="3 2"/>
+  <!-- read 3 -->
+  <rect x="310" y="52" width="60" height="36" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="340" y="75" text-anchor="middle" class="phase-body">body</text>
+  <!-- gap 3 -->
+  <rect x="370" y="52" width="30" height="36" fill="#f0f9ff" stroke="#bae6fd" stroke-width="1" stroke-dasharray="3 2"/>
+  <!-- read 4 -->
+  <rect x="400" y="52" width="70" height="36" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="435" y="75" text-anchor="middle" class="phase-body">body</text>
+  <!-- gap 5 — no longer a problem -->
+  <rect x="470" y="52" width="30" height="36" fill="#f0f9ff" stroke="#bae6fd" stroke-width="1" stroke-dasharray="3 2"/>
+  <!-- read 5 — completes normally -->
+  <path d="M500,52 h76 q4,0 4,4 v28 q0,4 -4,4 h-76 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="538" y="75" text-anchor="middle" class="phase-body">body</text>
+
+  <!-- Completed marker -->
+  <text x="595" y="68" class="label" style="fill: #16a34a;">✓</text>
+  <text x="613" y="68" class="sublabel" style="fill: #16a34a;">completes</text>
+
+  <!-- Explanation -->
+  <text x="40" y="148" class="sublabel">The body phase is no longer counted against the connection limit.</text>
+  <text x="40" y="163" class="sublabel">Gaps from decompression or buffering cannot trigger cancellation.</text>
+
+  <!-- Legend -->
+  <rect x="40" y="185" width="740" height="32" rx="6" fill="#f9fafb" stroke="#e5e7eb" stroke-width="1"/>
+  <rect x="58" y="194" width="24" height="14" rx="3" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="89" y="205" class="sublabel">Bytes flowing (not counted)</text>
+  <rect x="270" y="194" width="24" height="14" rx="3" fill="#f0f9ff" stroke="#bae6fd" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="301" y="205" class="sublabel">Brief pause (not counted)</text>
+</svg>

--- a/src/assets/images/workers/platform/limits/connection-cancel-before.svg
+++ b/src/assets/images/workers/platform/limits/connection-cancel-before.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 260" fill="none">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+    .label { font-size: 12px; font-weight: 600; fill: #1a1a1a; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .phase { font-size: 11px; font-weight: 600; fill: #fff; }
+    .phase-body { font-size: 11px; fill: #6b7280; }
+    .annotation { font-size: 10px; fill: #6b7280; }
+  </style>
+  <defs>
+    <marker id="time-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#d1d5db"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="820" height="260" fill="#fafafa" rx="8"/>
+
+  <!-- Time axis -->
+  <line x1="40" y1="30" x2="720" y2="30" stroke="#d1d5db" stroke-width="1.5" marker-end="url(#time-arrow)"/>
+  <text x="735" y="34" class="sublabel">time</text>
+
+  <!-- Connection bar: headers phase -->
+  <path d="M44,52 h76 v36 h-76 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <text x="80" y="75" text-anchor="middle" class="phase">headers</text>
+
+  <!-- Body: alternating read/gap/read/gap pattern -->
+  <!-- read 1 -->
+  <rect x="120" y="52" width="60" height="36" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="150" y="75" text-anchor="middle" class="phase-body">body</text>
+  <!-- gap 1 -->
+  <rect x="180" y="52" width="30" height="36" fill="#f3f4f6" stroke="#d1d5db" stroke-width="1" stroke-dasharray="3 2"/>
+  <!-- read 2 -->
+  <rect x="210" y="52" width="70" height="36" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="245" y="75" text-anchor="middle" class="phase-body">body</text>
+  <!-- gap 2 -->
+  <rect x="280" y="52" width="30" height="36" fill="#f3f4f6" stroke="#d1d5db" stroke-width="1" stroke-dasharray="3 2"/>
+  <!-- read 3 -->
+  <rect x="310" y="52" width="60" height="36" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="340" y="75" text-anchor="middle" class="phase-body">body</text>
+  <!-- gap 3 -->
+  <rect x="370" y="52" width="30" height="36" fill="#f3f4f6" stroke="#d1d5db" stroke-width="1" stroke-dasharray="3 2"/>
+  <!-- read 4 -->
+  <rect x="400" y="52" width="70" height="36" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="435" y="75" text-anchor="middle" class="phase-body">body</text>
+  <!-- gap 4 — this is where cancellation happens -->
+  <rect x="470" y="52" width="30" height="36" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="3 2"/>
+
+  <!-- Canceled marker -->
+  <text x="520" y="68" class="label" style="fill: #dc2626;">✗</text>
+  <text x="538" y="68" class="sublabel" style="fill: #dc2626;">canceled</text>
+
+  <!-- Annotation arrow pointing to a gap -->
+  <line x1="295" y1="100" x2="295" y2="90" stroke="#9ca3af" stroke-width="1"/>
+  <text x="295" y="115" text-anchor="middle" class="annotation">brief gaps from gzip decompression</text>
+  <text x="295" y="128" text-anchor="middle" class="annotation">or internal buffering</text>
+
+  <!-- Explanation -->
+  <text x="40" y="165" class="sublabel">When a 7th connection is opened, a brief gap where there is no I/O makes</text>
+  <text x="40" y="180" class="sublabel">the connection appear idle — so it gets canceled, even though the Worker</text>
+  <text x="40" y="195" class="sublabel">is still using it.</text>
+
+  <!-- Legend -->
+  <rect x="40" y="215" width="740" height="32" rx="6" fill="#f9fafb" stroke="#e5e7eb" stroke-width="1"/>
+  <rect x="58" y="224" width="24" height="14" rx="3" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="89" y="235" class="sublabel">Bytes flowing</text>
+  <rect x="200" y="224" width="24" height="14" rx="3" fill="#f3f4f6" stroke="#d1d5db" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="231" y="235" class="sublabel">Brief pause (appears idle)</text>
+  <rect x="420" y="224" width="24" height="14" rx="3" fill="#fef2f2" stroke="#dc2626" stroke-width="1" stroke-dasharray="3 2"/>
+  <text x="451" y="235" class="sublabel">Canceled by runtime</text>
+</svg>

--- a/src/assets/images/workers/platform/limits/connection-limit-after.svg
+++ b/src/assets/images/workers/platform/limits/connection-limit-after.svg
@@ -25,14 +25,14 @@
   <path d="M164,72 h106 v36 h-106 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M270,72 h276 q4,0 4,4 v28 q0,4 -4,4 h-276 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
   <text x="215" y="95" text-anchor="middle" class="phase">headers</text>
-  <text x="410" y="95" text-anchor="middle" class="phase-body">reading body (no longer counted)</text>
+  <text x="410" y="95" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #2: start=175, headers=70 → 245, body=210 → 455 (earliest headers) -->
   <text x="40" y="142" class="label">fetch #2</text>
   <path d="M179,122 h66 v36 h-66 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M245,122 h206 q4,0 4,4 v28 q0,4 -4,4 h-206 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
   <text x="210" y="145" text-anchor="middle" class="phase">headers</text>
-  <text x="350" y="145" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="350" y="145" text-anchor="middle" class="phase-body">body</text>
 
 
 
@@ -41,35 +41,35 @@
   <path d="M199,172 h126 v36 h-126 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M325,172 h246 q4,0 4,4 v28 q0,4 -4,4 h-246 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
   <text x="260" y="195" text-anchor="middle" class="phase">headers</text>
-  <text x="450" y="195" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="450" y="195" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #4: start=210, headers=65 → 275, body=150 → 425 -->
   <text x="40" y="242" class="label">fetch #4</text>
   <path d="M214,222 h61 v36 h-61 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M275,222 h146 q4,0 4,4 v28 q0,4 -4,4 h-146 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
   <text x="244" y="245" text-anchor="middle" class="phase">headers</text>
-  <text x="350" y="245" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="350" y="245" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #5: start=230, headers=90 → 320, body=300 → 620 -->
   <text x="40" y="292" class="label">fetch #5</text>
   <path d="M234,272 h86 v36 h-86 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M320,272 h296 q4,0 4,4 v28 q0,4 -4,4 h-296 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
   <text x="276" y="295" text-anchor="middle" class="phase">headers</text>
-  <text x="470" y="295" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="470" y="295" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #6: start=250, headers=105 → 355, body=320 → 675 -->
   <text x="40" y="342" class="label">fetch #6</text>
   <path d="M254,322 h101 v36 h-101 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M355,322 h316 q4,0 4,4 v28 q0,4 -4,4 h-316 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
   <text x="304" y="345" text-anchor="middle" class="phase">headers</text>
-  <text x="515" y="345" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="515" y="345" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #7: issued at t=310, starts immediately (connection already free since t=245) -->
   <text x="40" y="392" class="label">fetch #7</text>
   <path d="M318,372 h76 v36 h-76 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#16a34a" stroke="#15803d" stroke-width="1"/>
   <path d="M394,372 h201 q4,0 4,4 v28 q0,4 -4,4 h-201 v-36z" fill="#f0fdf4" stroke="#86efac" stroke-width="1"/>
   <text x="356" y="395" text-anchor="middle" class="phase">headers</text>
-  <text x="496" y="395" text-anchor="middle" style="font-size: 11px; fill: #16a34a;">reading body</text>
+  <text x="496" y="395" text-anchor="middle" style="font-size: 11px; fill: #16a34a;">body</text>
 
   <!-- Annotation below #7 -->
   <text x="314" y="425" class="annotation">no queuing — a connection was already free</text>

--- a/src/assets/images/workers/platform/limits/connection-limit-after.svg
+++ b/src/assets/images/workers/platform/limits/connection-limit-after.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 500" fill="none">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+    .label { font-size: 12px; font-weight: 600; fill: #1a1a1a; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .phase { font-size: 11px; font-weight: 600; fill: #fff; }
+    .phase-body { font-size: 11px; fill: #0369a1; }
+    .annotation { font-size: 10px; fill: #6b7280; }
+  </style>
+  <defs>
+    <marker id="time-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#d1d5db"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="820" height="500" fill="#fafafa" rx="8"/>
+
+  <!-- Time axis -->
+  <line x1="130" y1="48" x2="720" y2="48" stroke="#d1d5db" stroke-width="1.5" marker-end="url(#time-arrow)"/>
+  <text x="735" y="52" class="sublabel">time</text>
+
+  <!-- fetch #1: start=160, headers=110 → 270, body=280 → 550 -->
+  <text x="40" y="92" class="label">fetch #1</text>
+  <path d="M164,72 h106 v36 h-106 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M270,72 h276 q4,0 4,4 v28 q0,4 -4,4 h-276 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="215" y="95" text-anchor="middle" class="phase">headers</text>
+  <text x="410" y="95" text-anchor="middle" class="phase-body">reading body (no longer counted)</text>
+
+  <!-- fetch #2: start=175, headers=70 → 245, body=210 → 455 (earliest headers) -->
+  <text x="40" y="142" class="label">fetch #2</text>
+  <path d="M179,122 h66 v36 h-66 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M245,122 h206 q4,0 4,4 v28 q0,4 -4,4 h-206 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="210" y="145" text-anchor="middle" class="phase">headers</text>
+  <text x="350" y="145" text-anchor="middle" class="phase-body">reading body</text>
+
+
+
+  <!-- fetch #3: start=195, headers=130 → 325, body=250 → 575 -->
+  <text x="40" y="192" class="label">fetch #3</text>
+  <path d="M199,172 h126 v36 h-126 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M325,172 h246 q4,0 4,4 v28 q0,4 -4,4 h-246 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="260" y="195" text-anchor="middle" class="phase">headers</text>
+  <text x="450" y="195" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #4: start=210, headers=65 → 275, body=150 → 425 -->
+  <text x="40" y="242" class="label">fetch #4</text>
+  <path d="M214,222 h61 v36 h-61 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M275,222 h146 q4,0 4,4 v28 q0,4 -4,4 h-146 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="244" y="245" text-anchor="middle" class="phase">headers</text>
+  <text x="350" y="245" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #5: start=230, headers=90 → 320, body=300 → 620 -->
+  <text x="40" y="292" class="label">fetch #5</text>
+  <path d="M234,272 h86 v36 h-86 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M320,272 h296 q4,0 4,4 v28 q0,4 -4,4 h-296 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="276" y="295" text-anchor="middle" class="phase">headers</text>
+  <text x="470" y="295" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #6: start=250, headers=105 → 355, body=320 → 675 -->
+  <text x="40" y="342" class="label">fetch #6</text>
+  <path d="M254,322 h101 v36 h-101 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M355,322 h316 q4,0 4,4 v28 q0,4 -4,4 h-316 v-36z" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="304" y="345" text-anchor="middle" class="phase">headers</text>
+  <text x="515" y="345" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #7: issued at t=310, starts immediately (connection already free since t=245) -->
+  <text x="40" y="392" class="label">fetch #7</text>
+  <path d="M318,372 h76 v36 h-76 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#16a34a" stroke="#15803d" stroke-width="1"/>
+  <path d="M394,372 h201 q4,0 4,4 v28 q0,4 -4,4 h-201 v-36z" fill="#f0fdf4" stroke="#86efac" stroke-width="1"/>
+  <text x="356" y="395" text-anchor="middle" class="phase">headers</text>
+  <text x="496" y="395" text-anchor="middle" style="font-size: 11px; fill: #16a34a;">reading body</text>
+
+  <!-- Annotation below #7 -->
+  <text x="314" y="425" class="annotation">no queuing — a connection was already free</text>
+
+  <!-- Legend -->
+  <rect x="40" y="450" width="740" height="32" rx="6" fill="#f9fafb" stroke="#e5e7eb" stroke-width="1"/>
+  <rect x="58" y="459" width="24" height="14" rx="3" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <text x="89" y="470" class="sublabel">Waiting for headers (counted)</text>
+  <rect x="290" y="459" width="24" height="14" rx="3" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
+  <text x="321" y="470" class="sublabel">Reading body (no longer counted)</text>
+  <rect x="520" y="459" width="24" height="14" rx="3" fill="#16a34a" stroke="#15803d" stroke-width="1"/>
+  <text x="551" y="470" class="sublabel">New connection (started earlier)</text>
+</svg>

--- a/src/assets/images/workers/platform/limits/connection-limit-before.svg
+++ b/src/assets/images/workers/platform/limits/connection-limit-before.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 500" fill="none">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+    .label { font-size: 12px; font-weight: 600; fill: #1a1a1a; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .phase { font-size: 11px; font-weight: 600; fill: #fff; }
+    .phase-body { font-size: 11px; fill: #6b7280; }
+    .phase-queued { font-size: 11px; font-weight: 600; fill: #dc2626; }
+    .annotation { font-size: 10px; fill: #6b7280; }
+  </style>
+  <defs>
+    <marker id="time-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#d1d5db"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="820" height="500" fill="#fafafa" rx="8"/>
+
+  <!-- Time axis -->
+  <line x1="130" y1="48" x2="720" y2="48" stroke="#d1d5db" stroke-width="1.5" marker-end="url(#time-arrow)"/>
+  <text x="735" y="52" class="sublabel">time</text>
+
+  <!-- fetch #1: start=160, headers=110 → 270, body=280 → 550 -->
+  <text x="40" y="92" class="label">fetch #1</text>
+  <path d="M164,72 h106 v36 h-106 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M270,72 h276 q4,0 4,4 v28 q0,4 -4,4 h-276 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="215" y="95" text-anchor="middle" class="phase">headers</text>
+  <text x="410" y="95" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #2: start=175, headers=70 → 245, body=210 → 455 -->
+  <text x="40" y="142" class="label">fetch #2</text>
+  <path d="M179,122 h66 v36 h-66 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M245,122 h206 q4,0 4,4 v28 q0,4 -4,4 h-206 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="210" y="145" text-anchor="middle" class="phase">headers</text>
+  <text x="350" y="145" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #3: start=195, headers=130 → 325, body=250 → 575 -->
+  <text x="40" y="192" class="label">fetch #3</text>
+  <path d="M199,172 h126 v36 h-126 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M325,172 h246 q4,0 4,4 v28 q0,4 -4,4 h-246 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="260" y="195" text-anchor="middle" class="phase">headers</text>
+  <text x="450" y="195" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #4: start=210, headers=65 → 275, body=150 → 425 (shortest total) -->
+  <text x="40" y="242" class="label">fetch #4</text>
+  <path d="M214,222 h61 v36 h-61 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M275,222 h146 q4,0 4,4 v28 q0,4 -4,4 h-146 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="244" y="245" text-anchor="middle" class="phase">headers</text>
+  <text x="350" y="245" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- Done marker — vertical dashed line from end of #4 down to #7 -->
+  <line x1="425" y1="222" x2="425" y2="380" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="435" y="237" class="sublabel" fill="#16a34a">done</text>
+
+  <!-- fetch #5: start=230, headers=90 → 320, body=300 → 620 -->
+  <text x="40" y="292" class="label">fetch #5</text>
+  <path d="M234,272 h86 v36 h-86 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M320,272 h296 q4,0 4,4 v28 q0,4 -4,4 h-296 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="276" y="295" text-anchor="middle" class="phase">headers</text>
+  <text x="470" y="295" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #6: start=250, headers=105 → 355, body=320 → 675 -->
+  <text x="40" y="342" class="label">fetch #6</text>
+  <path d="M254,322 h101 v36 h-101 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <path d="M355,322 h316 q4,0 4,4 v28 q0,4 -4,4 h-316 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="304" y="345" text-anchor="middle" class="phase">headers</text>
+  <text x="515" y="345" text-anchor="middle" class="phase-body">reading body</text>
+
+  <!-- fetch #7: issued at t=310, queued until #4 ends at 425 -->
+  <text x="40" y="392" class="label">fetch #7</text>
+  <!-- Queued bar (rounded left, flat right): 310 → 425 -->
+  <path d="M314,372 h111 v36 h-111 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#fef2f2" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="368" y="395" text-anchor="middle" class="phase-queued">queued</text>
+  <!-- Headers (flat left, flat right): 425 → 495 -->
+  <rect x="425" y="372" width="70" height="36" fill="#16a34a" stroke="#15803d" stroke-width="1"/>
+  <!-- Body (flat left, rounded right): 495 → 640 -->
+  <path d="M495,372 h141 q4,0 4,4 v28 q0,4 -4,4 h-141 v-36z" fill="#f0fdf4" stroke="#86efac" stroke-width="1"/>
+  <text x="460" y="395" text-anchor="middle" class="phase">headers</text>
+  <text x="567" y="395" text-anchor="middle" style="font-size: 11px; fill: #16a34a;">body</text>
+
+  <!-- Annotation below #7 -->
+  <text x="310" y="425" class="annotation">waits for the first connection to fully complete (headers + body)</text>
+
+  <!-- Legend -->
+  <rect x="40" y="450" width="740" height="32" rx="6" fill="#f9fafb" stroke="#e5e7eb" stroke-width="1"/>
+  <rect x="58" y="459" width="24" height="14" rx="3" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
+  <text x="89" y="470" class="sublabel">Waiting for headers (counted)</text>
+  <rect x="278" y="459" width="24" height="14" rx="3" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
+  <text x="309" y="470" class="sublabel">Reading body (counted)</text>
+  <rect x="468" y="459" width="24" height="14" rx="3" fill="#fef2f2" stroke="#dc2626" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="499" y="470" class="sublabel">Queued (no free connections)</text>
+</svg>

--- a/src/assets/images/workers/platform/limits/connection-limit-before.svg
+++ b/src/assets/images/workers/platform/limits/connection-limit-before.svg
@@ -26,28 +26,28 @@
   <path d="M164,72 h106 v36 h-106 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M270,72 h276 q4,0 4,4 v28 q0,4 -4,4 h-276 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
   <text x="215" y="95" text-anchor="middle" class="phase">headers</text>
-  <text x="410" y="95" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="410" y="95" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #2: start=175, headers=70 → 245, body=210 → 455 -->
   <text x="40" y="142" class="label">fetch #2</text>
   <path d="M179,122 h66 v36 h-66 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M245,122 h206 q4,0 4,4 v28 q0,4 -4,4 h-206 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
   <text x="210" y="145" text-anchor="middle" class="phase">headers</text>
-  <text x="350" y="145" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="350" y="145" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #3: start=195, headers=130 → 325, body=250 → 575 -->
   <text x="40" y="192" class="label">fetch #3</text>
   <path d="M199,172 h126 v36 h-126 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M325,172 h246 q4,0 4,4 v28 q0,4 -4,4 h-246 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
   <text x="260" y="195" text-anchor="middle" class="phase">headers</text>
-  <text x="450" y="195" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="450" y="195" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #4: start=210, headers=65 → 275, body=150 → 425 (shortest total) -->
   <text x="40" y="242" class="label">fetch #4</text>
   <path d="M214,222 h61 v36 h-61 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M275,222 h146 q4,0 4,4 v28 q0,4 -4,4 h-146 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
   <text x="244" y="245" text-anchor="middle" class="phase">headers</text>
-  <text x="350" y="245" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="350" y="245" text-anchor="middle" class="phase-body">body</text>
 
   <!-- Done marker — vertical dashed line from end of #4 down to #7 -->
   <line x1="425" y1="222" x2="425" y2="380" stroke="#16a34a" stroke-width="1.5" stroke-dasharray="4 3"/>
@@ -58,14 +58,14 @@
   <path d="M234,272 h86 v36 h-86 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M320,272 h296 q4,0 4,4 v28 q0,4 -4,4 h-296 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
   <text x="276" y="295" text-anchor="middle" class="phase">headers</text>
-  <text x="470" y="295" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="470" y="295" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #6: start=250, headers=105 → 355, body=320 → 675 -->
   <text x="40" y="342" class="label">fetch #6</text>
   <path d="M254,322 h101 v36 h-101 q-4,0 -4,-4 v-28 q0,-4 4,-4z" fill="#f97316" stroke="#ea580c" stroke-width="1"/>
   <path d="M355,322 h316 q4,0 4,4 v28 q0,4 -4,4 h-316 v-36z" fill="#fff7ed" stroke="#fdba74" stroke-width="1"/>
   <text x="304" y="345" text-anchor="middle" class="phase">headers</text>
-  <text x="515" y="345" text-anchor="middle" class="phase-body">reading body</text>
+  <text x="515" y="345" text-anchor="middle" class="phase-body">body</text>
 
   <!-- fetch #7: issued at t=310, queued until #4 ends at 425 -->
   <text x="40" y="392" class="label">fetch #7</text>

--- a/src/content/changelog/workers/2026-04-09-relaxed-connection-limiting.mdx
+++ b/src/content/changelog/workers/2026-04-09-relaxed-connection-limiting.mdx
@@ -4,6 +4,14 @@ description: The six-connection limit now only applies while waiting for respons
 date: 2026-04-09
 ---
 
-The [simultaneous open connections limit](/workers/platform/limits/#simultaneous-open-connections) has been relaxed. Previously, each Worker invocation was limited to six open connections at a time for the entire lifetime of each connection, including while reading the response body. Now, a connection slot is freed as soon as response headers arrive, so the six-connection limit only constrains how many connections can be in the initial "waiting for headers" phase simultaneously.
+The [simultaneous open connections limit](/workers/platform/limits/#simultaneous-open-connections) has been relaxed. Previously, each Worker invocation was limited to six open connections at a time for the entire lifetime of each connection, including while reading the response body. Now, a connection is freed as soon as response headers arrive, so the six-connection limit only constrains how many connections can be in the initial "waiting for headers" phase simultaneously.
+
+### Before: Connection counts against limit for its entire lifetime
+
+![A 7th fetch is queued until an earlier connection fully completes, including reading its entire response body](~/assets/images/workers/platform/limits/connection-limit-before.svg)
+
+### After: Connection only counts against limit while waiting for headers
+
+![A 7th fetch starts as soon as any earlier connection receives its response headers](~/assets/images/workers/platform/limits/connection-limit-after.svg)
 
 This means Workers can now have many more connections open at the same time without queueing, as long as no more than six are waiting for their initial response. This eliminates the `Response closed due to connection limit` exception that could previously occur when the runtime canceled stalled connections to prevent deadlocks.

--- a/src/content/changelog/workers/2026-04-09-relaxed-connection-limiting.mdx
+++ b/src/content/changelog/workers/2026-04-09-relaxed-connection-limiting.mdx
@@ -1,17 +1,27 @@
 ---
-title: Relaxed simultaneous connection limiting
+title: Relaxed simultaneous connection limiting for Workers
 description: The six-connection limit now only applies while waiting for response headers, allowing Workers to maintain more open connections simultaneously.
 date: 2026-04-09
 ---
 
 The [simultaneous open connections limit](/workers/platform/limits/#simultaneous-open-connections) has been relaxed. Previously, each Worker invocation was limited to six open connections at a time for the entire lifetime of each connection, including while reading the response body. Now, a connection is freed as soon as response headers arrive, so the six-connection limit only constrains how many connections can be in the initial "waiting for headers" phase simultaneously.
 
-### Before: Connection counts against limit for its entire lifetime
+### Before: New connections are blocked until an earlier connection fully completes
 
 ![A 7th fetch is queued until an earlier connection fully completes, including reading its entire response body](~/assets/images/workers/platform/limits/connection-limit-before.svg)
 
-### After: Connection only counts against limit while waiting for headers
+### After: New connections can start as soon as response headers arrive
 
 ![A 7th fetch starts as soon as any earlier connection receives its response headers](~/assets/images/workers/platform/limits/connection-limit-after.svg)
 
 This means Workers can now have many more connections open at the same time without queueing, as long as no more than six are waiting for their initial response. This eliminates the `Response closed due to connection limit` exception that could previously occur when the runtime canceled stalled connections to prevent deadlocks.
+
+Previously, the runtime used a deadlock avoidance algorithm that watched each open connection for I/O activity. If all six connections appeared idle — even momentarily — the runtime would cancel the least-recently-used connection to make room for new requests. In practice, this heuristic was fragile. For example, when a response used `Content-Encoding: gzip`, the runtime's internal decompression created brief gaps between read and write operations. During these gaps, the connection appeared stalled despite being actively read by the Worker. If multiple connections hit these gaps at the same time, the runtime could spuriously cancel a connection that was working correctly. By only counting connections during the waiting-for-headers phase — where the runtime is fully in control and there is no ambiguity about whether the connection is active — this class of bug is eliminated entirely.
+
+### Before: Connections could be canceled during brief internal pauses
+
+![A connection with gaps from gzip decompression appears idle and is canceled by the runtime](~/assets/images/workers/platform/limits/connection-cancel-before.svg)
+
+### After: Connections complete normally regardless of internal pauses
+
+![The same connection completes normally because the body phase is no longer counted against the limit](~/assets/images/workers/platform/limits/connection-cancel-after.svg)

--- a/src/content/changelog/workers/2026-04-09-relaxed-connection-limiting.mdx
+++ b/src/content/changelog/workers/2026-04-09-relaxed-connection-limiting.mdx
@@ -1,0 +1,9 @@
+---
+title: Relaxed simultaneous connection limiting
+description: The six-connection limit now only applies while waiting for response headers, allowing Workers to maintain more open connections simultaneously.
+date: 2026-04-09
+---
+
+The [simultaneous open connections limit](/workers/platform/limits/#simultaneous-open-connections) has been relaxed. Previously, each Worker invocation was limited to six open connections at a time for the entire lifetime of each connection, including while reading the response body. Now, a connection slot is freed as soon as response headers arrive, so the six-connection limit only constrains how many connections can be in the initial "waiting for headers" phase simultaneously.
+
+This means Workers can now have many more connections open at the same time without queueing, as long as no more than six are waiting for their initial response. This eliminates the `Response closed due to connection limit` exception that could previously occur when the runtime canceled stalled connections to prevent deadlocks.

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -200,7 +200,7 @@ Using global [`fetch()`](/workers/runtime-apis/fetch/) to call another Worker on
 
 ## Simultaneous open connections
 
-Each Worker invocation can open up to six simultaneous connections. The following API calls count toward this limit:
+Each Worker invocation can have up to six connections simultaneously waiting for response headers. The following API calls count toward this limit while the initial connection is being established and the server has not yet responded:
 
 - `fetch()` method of the [Fetch API](/workers/runtime-apis/fetch/)
 - `get()`, `put()`, `list()`, and `delete()` methods of [Workers KV namespace objects](/kv/api/)
@@ -211,9 +211,9 @@ Each Worker invocation can open up to six simultaneous connections. The followin
 
 Outbound WebSocket connections also count toward this limit.
 
-Once six connections are open, the runtime queues additional attempts until an existing connection closes. The runtime may close stalled connections (those not actively reading or writing) with a `Response closed due to connection limit` exception.
+Once response headers arrive for a connection, it no longer counts toward the six-connection limit. This means a Worker can have many connections open simultaneously, as long as no more than six are in the initial "waiting for headers" phase at the same time. If a seventh connection is attempted while six are already waiting for headers, it is queued until one of the existing connections receives its response headers.
 
-If you use `fetch()` but do not need the response body, call `response.body.cancel()` to free the connection:
+If you use `fetch()` but do not need the response body, calling `response.body.cancel()` is still good practice to free memory:
 
 ```ts
 const response = await fetch(url);
@@ -226,8 +226,6 @@ if (response.statusCode <= 299) {
 	response.body.cancel();
 }
 ```
-
-If the system detects a deadlock (pending connection attempts with no in-progress reads or writes), it cancels the least-recently-used connection to unblock the Worker.
 
 :::note
 

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -7,7 +7,7 @@ head: []
 description: Cloudflare Workers plan and platform limits.
 ---
 
-import { Render, WranglerConfig, DashButton } from "~/components";
+import { Render, WranglerConfig, DashButton, TypeScriptExample } from "~/components";
 
 ## Account plan limits
 
@@ -215,17 +215,21 @@ Once response headers arrive for a connection, it no longer counts toward the si
 
 If you use `fetch()` but do not need the response body, calling `response.body.cancel()` is still good practice to free memory:
 
+<TypeScriptExample filename="src/index.ts">
+
 ```ts
 const response = await fetch(url);
 
 // Only read the response body for successful responses
-if (response.statusCode <= 299) {
+if (response.status <= 299) {
 	// Call response.json(), response.text() or otherwise process the body
 } else {
 	// Explicitly cancel it
 	response.body.cancel();
 }
 ```
+
+</TypeScriptExample>
 
 :::note
 


### PR DESCRIPTION
### Summary

The Workers runtime now releases connection slots when response headers arrive, rather than when the response body is fully consumed. This means the 6-connection limit only constrains how many connections can be in the 'waiting for headers' phase simultaneously.

Remove documentation of stall detection and forced connection cancellation (Response closed due to connection limit), as this behavior is no longer observable with the new slot release timing. Keep the response.body.cancel() advice for memory management.

Add a changelog entry for the change.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
