### PR TITLE
Add product-owners team as CODEOWNERS to allow Product Leaders to approve PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Default owners if not more specific match
 
-* @cloudflare/pcx-technical-writing
+* @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # More dev-specific files
 
 /.github/ @cloudflare/content-engineering @kodster28 @mvvmm @colbywhite @ahaywood @MohamedH1998
-/.github/CODEOWNERS @cloudflare/pcx-technical-writing @kodster28
-/.github/actions/assign-pr/index.js @cloudflare/pcx-technical-writing @kodster28
+/.github/CODEOWNERS @cloudflare/pcx-technical-writing @cloudflare/product-owners @kodster28
+/.github/actions/assign-pr/index.js @cloudflare/pcx-technical-writing @cloudflare/product-owners @kodster28
 /src/components/ @cloudflare/content-engineering @kodster28
 *.js @cloudflare/content-engineering @kodster28
 *.ts @cloudflare/content-engineering @kodster28
@@ -14,240 +14,240 @@
 package.json @cloudflare/content-engineering
 /src/schemas/tags.ts @cloudflare/content-engineering @kodster28
 /src/util/api.ts @cloudflare/content-engineering @pedrosousa @kodster28
-/src/content/workers-ai-models/ @craigsdennis @cloudflare/content-engineering @cloudflare/pcx-technical-writing @kodster28
-/public/__redirects @cloudflare/content-engineering @cloudflare/pcx-technical-writing
+/src/content/workers-ai-models/ @craigsdennis @cloudflare/content-engineering @cloudflare/pcx-technical-writing @cloudflare/product-owners @kodster28
+/public/__redirects @cloudflare/content-engineering @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 
 # AI
 
-/src/content/docs/cloudflare-agent/ @dmmulroy @Brayden @cloudflare/pcx-technical-writing
-/src/content/docs/agents/ @irvinebroque @rita3ko @elithrar @thomasgauvin @threepointone @whoiskatrin @cloudflare/pcx-technical-writing @cloudflare/ai-agents @cloudflare/dev-plat-leads
-/src/content/partials/agents/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing
-/src/content/docs/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing
-/src/content/docs/workers-ai/ @rita3ko @craigsdennis @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing
-/src/content/docs/vectorize/ @elithrar @vy-ton @sejoker @mchenco @cloudflare/pcx-technical-writing
-/src/content/partials/vectorize/ @elithrar @mchenco @sejoker @cloudflare/pcx-technical-writing
-/src/content/partials/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing
-/src/content/release-notes/workers-ai.yaml @kathayl @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing
-/src/content/release-notes/ai-gateway.yaml @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing
-/src/content/release-notes/vectorize.yaml @elithrar @mchenco @sejoker @cloudflare/pcx-technical-writing
-/src/content/docs/ai-search/ @rita3ko @irvinebroque @aninibread @cloudflare/pcx-technical-writing
+/src/content/docs/cloudflare-agent/ @dmmulroy @Brayden @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/agents/ @irvinebroque @rita3ko @elithrar @thomasgauvin @threepointone @whoiskatrin @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/ai-agents @cloudflare/dev-plat-leads
+/src/content/partials/agents/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/workers-ai/ @rita3ko @craigsdennis @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/vectorize/ @elithrar @vy-ton @sejoker @mchenco @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/vectorize/ @elithrar @mchenco @sejoker @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/ai-gateway/ @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/workers-ai.yaml @kathayl @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/ai-gateway.yaml @abhishekkankani @palashgo @thebongy @roerohan @kathayl @mchenco @zeke @superhighfives @bfirsh @mattrothenberg @ethulia @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/vectorize.yaml @elithrar @mchenco @sejoker @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/ai-search/ @rita3ko @irvinebroque @aninibread @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # AI Crawl Control
-/src/content/docs/ai-crawl-control/ @cloudflare/pcx-technical-writing @CameronWhiteside
-/src/content/changelog/ai-crawl-control/ @cloudflare/pcx-technical-writing @CameronWhiteside
-/src/content/partials/ai-crawl-control/ @cloudflare/pcx-technical-writing @CameronWhiteside
+/src/content/docs/ai-crawl-control/ @cloudflare/pcx-technical-writing @cloudflare/product-owners @CameronWhiteside
+/src/content/changelog/ai-crawl-control/ @cloudflare/pcx-technical-writing @cloudflare/product-owners @CameronWhiteside
+/src/content/partials/ai-crawl-control/ @cloudflare/pcx-technical-writing @cloudflare/product-owners @CameronWhiteside
 
 # Analytics & Logs
 
-/src/content/docs/analytics/ @soheiokamoto @angelampcosta @rianvdm @cloudflare/pcx-technical-writing
-/src/content/docs/data-localization/ @soheiokamoto @angelampcosta @cloudflare/pcx-technical-writing
-/src/content/docs/logs/ @soheiokamoto @angelampcosta @rianvdm @cloudflare/pcx-technical-writing
+/src/content/docs/analytics/ @soheiokamoto @angelampcosta @rianvdm @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/data-localization/ @soheiokamoto @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/logs/ @soheiokamoto @angelampcosta @rianvdm @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # API & Zones
 
-/src/content/docs/pulumi/ @dcpena @cloudflare/pcx-technical-writing
-/src/content/docs/tenant/ @dcpena @cloudflare/pcx-technical-writing
-/src/content/docs/terraform/ @dcpena @cloudflare/pcx-technical-writing
-/src/content/docs/version-management/ @dcpena @cloudflare/pcx-technical-writing
+/src/content/docs/pulumi/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/tenant/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/terraform/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/version-management/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Browser Rendering API
 
-/src/content/docs/browser-rendering/ @mchenco @cloudflare/pcx-technical-writing @celso @kathayl @ToriLindsay
+/src/content/docs/browser-rendering/ @mchenco @cloudflare/pcx-technical-writing @cloudflare/product-owners @celso @kathayl @ToriLindsay
 
 # Changelogs
 
-/src/content/changelog/ @cloudflare/pm-changelogs @cloudflare/pcx-technical-writing
-/src/content/changelog/waf/ @cloudflare/firewall @vs-mg @fb1337 @cloudflare/pm-changelogs @cloudflare/pcx-technical-writing
-/src/assets/images/changelog/ @cloudflare/pm-changelogs @cloudflare/pcx-technical-writing
-/src/assets/images/ @cloudflare/pm-changelogs @cloudflare/pcx-technical-writing
+/src/content/changelog/ @cloudflare/pm-changelogs @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/changelog/waf/ @cloudflare/firewall @vs-mg @fb1337 @cloudflare/pm-changelogs @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/assets/images/changelog/ @cloudflare/pm-changelogs @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/assets/images/ @cloudflare/pm-changelogs @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Cloudflare One
 
-/src/content/docs/cloudflare-one/ @ranbel @Maddy-Cloudflare @codyanthony850 @cloudflare/pcx-technical-writing
-/src/content/partials/cloudflare-one/ @ranbel @Maddy-Cloudflare @codyanthony850 @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/applications/ @kennyj42 @ranbel @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/identity/ @kennyj42 @ranbel @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/access-controls/ @kennyj42 @ranbel @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/team-and-resources/devices/ @ranbel @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/ @nikitacano @ranbel @cloudflare/pcx-technical-writing
-/src/content/docs/tunnel/ @nikitacano @ranbel @cloudflare/pcx-technical-writing
-/src/content/partials/cloudflare-one/tunnel/ @nikitacano @ranbel @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/cloud-and-saas-findings/ @Maddy-Cloudflare @codyanthony850 @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/traffic-policies/ @Maddy-Cloudflare @codyanthony850@cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/remote-browser-isolation/ @codyanthony850 @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/data-loss-prevention/ @Maddy-Cloudflare @codyanthony850 @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-one/insights/dex/ @codyanthony850 @cloudflare/pcx-technical-writing
-/src/content/docs/email-security/ @Maddy-Cloudflare @cloudflare/pcx-technical-writing
+/src/content/docs/cloudflare-one/ @ranbel @Maddy-Cloudflare @codyanthony850 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/cloudflare-one/ @ranbel @Maddy-Cloudflare @codyanthony850 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/applications/ @kennyj42 @ranbel @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/identity/ @kennyj42 @ranbel @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/access-controls/ @kennyj42 @ranbel @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/team-and-resources/devices/ @ranbel @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/ @nikitacano @ranbel @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/tunnel/ @nikitacano @ranbel @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/cloudflare-one/tunnel/ @nikitacano @ranbel @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/cloud-and-saas-findings/ @Maddy-Cloudflare @codyanthony850 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/traffic-policies/ @Maddy-Cloudflare @codyanthony850@cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/remote-browser-isolation/ @codyanthony850 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/data-loss-prevention/ @Maddy-Cloudflare @codyanthony850 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-one/insights/dex/ @codyanthony850 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/email-security/ @Maddy-Cloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Consumer products
 
-/src/content/docs/1.1.1.1/ @RebeccaTamachiro @cloudflare/pcx-technical-writing
-/src/content/docs/warp-client/ @ranbel @cloudflare/pcx-technical-writing
+/src/content/docs/1.1.1.1/ @RebeccaTamachiro @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/warp-client/ @ranbel @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Core platform
 
-/src/content/docs/byoip/ @RebeccaTamachiro @cloudflare/pcx-technical-writing
-/src/content/docs/china-network/ @pedrosousa @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/ @RebeccaTamachiro @cloudflare/pcx-technical-writing
-/src/content/docs/dns/ @RebeccaTamachiro @cloudflare/pcx-technical-writing
-/src/content/docs/fundamentals/ @dcpena @cloudflare/pcx-technical-writing
-/src/content/docs/learning-paths/ @cloudflare/pcx-technical-writing
-/src/content/docs/network-error-logging/ @dcpena @cloudflare/pcx-technical-writing
-/src/content/docs/network-interconnect/ @marciocloudflare @cloudflare/pcx-technical-writing
-/src/content/docs/notifications/ @dcpena @cloudflare/pcx-technical-writing
-/src/content/docs/registrar/ @dcpena @cloudflare/pcx-technical-writing
-/src/content/docs/rules/ @pedrosousa @cloudflare/pcx-technical-writing
-/src/content/docs/ruleset-engine/ @pedrosousa @cloudflare/pcx-technical-writing
-/src/content/docs/log-explorer/ @angelampcosta @cloudflare/pcx-technical-writing
+/src/content/docs/byoip/ @RebeccaTamachiro @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/china-network/ @pedrosousa @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/ @RebeccaTamachiro @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/dns/ @RebeccaTamachiro @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/fundamentals/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/learning-paths/ @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/network-error-logging/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/network-interconnect/ @marciocloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/notifications/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/registrar/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/rules/ @pedrosousa @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/ruleset-engine/ @pedrosousa @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/log-explorer/ @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Developer Platform
 
-/src/content/docs/containers/ @mikenomitch @th0m @cloudflare/pcx-technical-writing @cloudflare/cloudchamber
-/src/content/partials/containers/ @mikenomitch @th0m @cloudflare/pcx-technical-writing @cloudflare/cloudchamber
-/src/content/docs/d1/ @elithrar @rozenmd @vy-ton @joshthoward @oxyjun @harshil1712 @cloudflare/pcx-technical-writing
-/src/content/release-notes/d1.yaml @elithrar @rozenmd @vy-ton @joshthoward @oxyjun @cloudflare/pcx-technical-writing
-/src/content/partials/d1/ @elithrar @rozenmd @vy-ton @joshthoward @oxyjun @harshil1712 @cloudflare/pcx-technical-writing
-/src/content/docs/ai-crawl-control/ @oxyjun @cloudflare/pcx-technical-writing
-/src/content/docs/durable-objects/ @elithrar @vy-ton @joshthoward @oxyjun @lambrospetrou @mikenomitch @cloudflare/pcx-technical-writing
-/src/content/partials/durable-objects/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing
-/src/content/release-notes/durable-objects.yaml @elithrar @rozenmd @vy-ton @joshthoward @oxyjun @cloudflare/pcx-technical-writing
-/src/content/docs/email-routing/ @cloudflare/pcx-technical-writing
-/src/content/docs/hyperdrive/ @elithrar @thomasgauvin @sejoker @oxyjun @cloudflare/pcx-technical-writing
-/src/content/release-notes/hyperdrive.yaml @elithrar @thomasgauvin @sejoker @oxyjun @cloudflare/pcx-technical-writing
-/src/content/partials/hyperdrive/ @elithrar @thomasgauvin @sejoker @oxyjun @cloudflare/pcx-technical-writing
-/src/content/release-notes/durable-objects.yaml @elithrar @vy-ton @joshthoward @oxyjun @cloudflare/pcx-technical-writing
-/src/content/docs/images/ @ToriLindsay @cloudflare/pcx-technical-writing @renandincer @third774
-/src/content/docs/pages/ @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @irvinebroque @cloudflare/pcx-technical-writing
-/src/content/partials/pages/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing
-/src/assets/images/pages/ @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @cloudflare/pcx-technical-writing
-/src/content/release-notes/pages.yaml @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @cloudflare/pcx-technical-writing
-/src/content/docs/kv/ @elithrar @thomasgauvin @oxyjun @cloudflare/pcx-technical-writing
-/src/content/release-notes/kv.yaml @elithrar @thomasgauvin @oxyjun @cloudflare/pcx-technical-writing
-/src/content/partials/kv/ @elithrar @thomasgauvin @oxyjun @cloudflare/pcx-technical-writing
-/src/content/docs/queues/ @elithrar @jonesphillip @harshil1712 @mia303 @cloudflare/pcx-technical-writing
-/src/content/partials/queues/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing
-/src/content/release-notes/queues.yaml @elithrar @jonesphillip @cloudflare/pcx-technical-writing
-/src/content/docs/r2/ @oxyjun @elithrar @jonesphillip @aninibread @harshil1712 @cloudflare/workers-docs @cloudflare/pcx-technical-writing
-/src/content/partials/r2/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing
-/src/content/release-notes/r2.yaml @oxyjun @elithrar @aninibread @cloudflare/workers-docs @cloudflare/pcx-technical-writing
-/src/content/docs/realtime/ @cloudflare/pcx-technical-writing @cloudflare/realtime @cloudflare/RealtimeKit @roerohan @ravindra-cloudflare
-/src/assets/images/realtime/ @cloudflare/pcx-technical-writing @cloudflare/realtime @cloudflare/RealtimeKit @roerohan @ravindra-cloudflare
-/src/content/partials/realtime/ @cloudflare/realtime @cloudflare/RealtimeKit @roerohan @ravindra-cloudflare @cloudflare/pcx-technical-writing
-/public/realtime/ @cloudflare/pcx-technical-writing @cloudflare/realtime @cloudflare/RealtimeKit @roerohan @ravindra-cloudflare
-/src/content/docs/stream/ @tsmith512 @ToriLindsay @cloudflare/pcx-technical-writing @renandincer @third774
-/src/content/release-notes/stream.yaml @tsmith512 @ToriLindsay @cloudflare/pcx-technical-writing
-/src/content/docs/workers/ @cloudflare/workers-docs @GregBrimble @irvinebroque @mikenomitch @korinne @WalshyDev @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/wrangler @mattietk @cloudflare/dev-plat-leads
-/src/content/partials/workers/ @cloudflare/workers-docs @GregBrimble @irvinebroque @mikenomitch @WalshyDev @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/wrangler @mattietk
-/src/assets/images/workers/ @cloudflare/workers-docs @GregBrimble @irvinebroque @WalshyDev @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/wrangler @mattietk
-/src/content/release-notes/workers.yaml @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @cloudflare/deploy-config @cloudflare/pcx-technical-writing @irvinebroque @mikenomitch @mattietk
-/src/content/docs/zaraz/ @ToriLindsay @kathayl @jonnyparris @simonabadoiu @cloudflare/pcx-technical-writing
-/src/content/release-notes/zaraz.yaml @jonnyparris @simonabadoiu @cloudflare/pcx-technical-writing
-/src/content/docs/workers/ci-cd/ @irvinebroque @aninibread @GregBrimble @cloudflare/pcx-technical-writing @yomna-shousha
-/src/content/compatibility-flags/ @irvinebroque @mikenomitch @GregBrimble @cloudflare/pcx-technical-writing
-/src/content/docs/workers/wrangler/ @cloudflare/wrangler @irvinebroque @cloudflare/pcx-technical-writing
-/src/content/docs/pages/framework-guides/ @cloudflare/wrangler @aninibread @GregBrimble @cloudflare/pcx-technical-writing
-/src/content/docs/analytics/analytics-engine/ @irvinebroque @elithrar @nevikashah @WalshyDev @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-for-platforms/ @irvinebroque @dinasaur404 @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-for-platforms/workers-for-platforms/ @irvinebroque @dinasaur404 @cloudflare/deploy-config @cloudflare/pcx-technical-writing
-/src/content/docs/workers/observability/ @irvinebroque @mikenomitch @nevikashah @cloudflare/pcx-technical-writing
-/src/content/docs/workers/static-assets @irvinebroque @GregBrimble @WalshyDev @cloudflare/deploy-config @cloudflare/pcx-technical-writing
-/src/content/docs/workflows/ @elithrar @celso @mia303 @jonesphillip @cloudflare/pcx-technical-writing
-/src/content/partials/workflows/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing
-/src/content/docs/sandbox/ @whoiskatrin @ghostwriternr @cloudflare/pcx-technical-writing @cloudflare/ai-agents
-/src/content/docs/pipelines/ @Marcinthecloud @cmackenzie1 @oliy @garvit-gupta @sejoker @jonesphillip @elithrar @cloudflare/pcx-technical-writing
-/src/content/docs/r2-sql/  @Marcinthecloud @netgusto @sesteves @sejoker @laplab @jonesphillip @elithrar @jonathanc-n @cloudflare/pcx-technical-writing
-/src/content/docs/r2/data-catalog/ @Marcinthecloud @sejoker @jonesphillip @elithrar @laplab @vovacf201 @nagraham @cloudflare/pcx-technical-writing
+/src/content/docs/containers/ @mikenomitch @th0m @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/cloudchamber
+/src/content/partials/containers/ @mikenomitch @th0m @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/cloudchamber
+/src/content/docs/d1/ @elithrar @rozenmd @vy-ton @joshthoward @oxyjun @harshil1712 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/d1.yaml @elithrar @rozenmd @vy-ton @joshthoward @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/d1/ @elithrar @rozenmd @vy-ton @joshthoward @oxyjun @harshil1712 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/ai-crawl-control/ @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/durable-objects/ @elithrar @vy-ton @joshthoward @oxyjun @lambrospetrou @mikenomitch @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/durable-objects/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/durable-objects.yaml @elithrar @rozenmd @vy-ton @joshthoward @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/email-routing/ @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/hyperdrive/ @elithrar @thomasgauvin @sejoker @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/hyperdrive.yaml @elithrar @thomasgauvin @sejoker @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/hyperdrive/ @elithrar @thomasgauvin @sejoker @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/durable-objects.yaml @elithrar @vy-ton @joshthoward @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/images/ @ToriLindsay @cloudflare/pcx-technical-writing @cloudflare/product-owners @renandincer @third774
+/src/content/docs/pages/ @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @irvinebroque @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/pages/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/assets/images/pages/ @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/pages.yaml @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/kv/ @elithrar @thomasgauvin @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/kv.yaml @elithrar @thomasgauvin @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/kv/ @elithrar @thomasgauvin @oxyjun @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/queues/ @elithrar @jonesphillip @harshil1712 @mia303 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/queues/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/queues.yaml @elithrar @jonesphillip @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/r2/ @oxyjun @elithrar @jonesphillip @aninibread @harshil1712 @cloudflare/workers-docs @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/r2/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/r2.yaml @oxyjun @elithrar @aninibread @cloudflare/workers-docs @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/realtime/ @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/realtime @cloudflare/RealtimeKit @roerohan @ravindra-cloudflare
+/src/assets/images/realtime/ @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/realtime @cloudflare/RealtimeKit @roerohan @ravindra-cloudflare
+/src/content/partials/realtime/ @cloudflare/realtime @cloudflare/RealtimeKit @roerohan @ravindra-cloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/public/realtime/ @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/realtime @cloudflare/RealtimeKit @roerohan @ravindra-cloudflare
+/src/content/docs/stream/ @tsmith512 @ToriLindsay @cloudflare/pcx-technical-writing @cloudflare/product-owners @renandincer @third774
+/src/content/release-notes/stream.yaml @tsmith512 @ToriLindsay @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/workers/ @cloudflare/workers-docs @GregBrimble @irvinebroque @mikenomitch @korinne @WalshyDev @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/wrangler @mattietk @cloudflare/dev-plat-leads
+/src/content/partials/workers/ @cloudflare/workers-docs @GregBrimble @irvinebroque @mikenomitch @WalshyDev @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/wrangler @mattietk
+/src/assets/images/workers/ @cloudflare/workers-docs @GregBrimble @irvinebroque @WalshyDev @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/wrangler @mattietk
+/src/content/release-notes/workers.yaml @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/product-owners @irvinebroque @mikenomitch @mattietk
+/src/content/docs/zaraz/ @ToriLindsay @kathayl @jonnyparris @simonabadoiu @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/zaraz.yaml @jonnyparris @simonabadoiu @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/workers/ci-cd/ @irvinebroque @aninibread @GregBrimble @cloudflare/pcx-technical-writing @cloudflare/product-owners @yomna-shousha
+/src/content/compatibility-flags/ @irvinebroque @mikenomitch @GregBrimble @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/workers/wrangler/ @cloudflare/wrangler @irvinebroque @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/pages/framework-guides/ @cloudflare/wrangler @aninibread @GregBrimble @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/analytics/analytics-engine/ @irvinebroque @elithrar @nevikashah @WalshyDev @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-for-platforms/ @irvinebroque @dinasaur404 @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-for-platforms/workers-for-platforms/ @irvinebroque @dinasaur404 @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/workers/observability/ @irvinebroque @mikenomitch @nevikashah @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/workers/static-assets @irvinebroque @GregBrimble @WalshyDev @cloudflare/deploy-config @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/workflows/ @elithrar @celso @mia303 @jonesphillip @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/partials/workflows/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/sandbox/ @whoiskatrin @ghostwriternr @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/ai-agents
+/src/content/docs/pipelines/ @Marcinthecloud @cmackenzie1 @oliy @garvit-gupta @sejoker @jonesphillip @elithrar @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/r2-sql/  @Marcinthecloud @netgusto @sesteves @sejoker @laplab @jonesphillip @elithrar @jonathanc-n @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/r2/data-catalog/ @Marcinthecloud @sejoker @jonesphillip @elithrar @laplab @vovacf201 @nagraham @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # DDoS Protection
 
-/src/content/docs/ddos-protection/ @patriciasantaana @cloudflare/pcx-technical-writing
-/src/content/docs/ddos-protection/change-log/ @patriciasantaana @cloudflare/pcx-technical-writing
-/src/content/release-notes/ddos-http.yaml @patriciasantaana @cloudflare/pcx-technical-writing
-/src/content/release-notes/ddos-network.yaml @patriciasantaana @cloudflare/pcx-technical-writing
+/src/content/docs/ddos-protection/ @patriciasantaana @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/ddos-protection/change-log/ @patriciasantaana @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/ddos-http.yaml @patriciasantaana @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/ddos-network.yaml @patriciasantaana @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Docs team areas
 
-/src/content/docs/style-guide/ @dcpena @cloudflare/pcx-technical-writing
+/src/content/docs/style-guide/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Google tag gateway
-/src/content/docs/google-tag-gateway/ @ToriLindsay @kathayl @simonabadoiu @jonnyparris @cloudflare/pcx-technical-writing
+/src/content/docs/google-tag-gateway/ @ToriLindsay @kathayl @simonabadoiu @jonnyparris @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Magic products
 
-/src/content/docs/magic-transit/ @marciocloudflare @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-network-firewall/ @Maddy-Cloudflare @cloudflare/pcx-technical-writing
-/src/content/docs/network-flow/ @marciocloudflare @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-wan/ @marciocloudflare @cloudflare/pcx-technical-writing
-/src/content/docs/multi-cloud-networking/ @marciocloudflare @cloudflare/pcx-technical-writing
+/src/content/docs/magic-transit/ @marciocloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-network-firewall/ @Maddy-Cloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/network-flow/ @marciocloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-wan/ @marciocloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/multi-cloud-networking/ @marciocloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Migration guides
 
-/src/content/docs/migration-guides/ @kimj15 @cloudflare/pcx-technical-writing
+/src/content/docs/migration-guides/ @kimj15 @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # MoQ
 
-/src/content/docs/moq/ @renandincer @nils-ohlmeier @cloudflare/pcx-technical-writing
-/src/content/products/moq.yml @renandincer @nils-ohlmeier @cloudflare/pcx-technical-writing
+/src/content/docs/moq/ @renandincer @nils-ohlmeier @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/products/moq.yml @renandincer @nils-ohlmeier @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Performance products
 
-/src/content/docs/argo-smart-routing/ @dcpena @cloudflare/pcx-technical-writing
-/src/content/docs/automatic-platform-optimization/ @cloudflare/pcx-technical-writing
-/src/content/docs/cache/ @angelampcosta @cloudflare/pcx-technical-writing
-/src/content/docs/health-checks/ @angelampcosta @cloudflare/pcx-technical-writing
-/src/content/docs/load-balancing/ @angelampcosta @cloudflare/pcx-technical-writing
-src/content/docs/smart-shield/ @RebeccaTamachiro @cloudflare/pcx-technical-writing
-/src/content/docs/spectrum/ @angelampcosta @cloudflare/pcx-technical-writing
-/src/content/docs/speed/ @angelampcosta @cloudflare/pcx-technical-writing
-/src/content/docs/web3/ @cloudflare/pcx-technical-writing
+/src/content/docs/argo-smart-routing/ @dcpena @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/automatic-platform-optimization/ @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cache/ @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/health-checks/ @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/load-balancing/ @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
+src/content/docs/smart-shield/ @RebeccaTamachiro @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/spectrum/ @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/speed/ @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/web3/ @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Privacy
 
-/src/content/docs/key-transparency/ @cloudflare/pcx-technical-writing
-/src/content/docs/privacy-gateway/ @cloudflare/pcx-technical-writing
+/src/content/docs/key-transparency/ @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/privacy-gateway/ @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Radar
 
-/src/content/docs/radar/ @andre-j3sus @cloudflare/pcx-technical-writing
-/src/content/release-notes/radar.yaml @andre-j3sus @cloudflare/pcx-technical-writing
+/src/content/docs/radar/ @andre-j3sus @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/release-notes/radar.yaml @andre-j3sus @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Reference architecture
 
-/src/content/docs/reference-architecture/ @securitypedant @cloudflare/pcx-technical-writing
-/src/assets/images/reference-architecture/ @securitypedant @cloudflare/pcx-technical-writing
+/src/content/docs/reference-architecture/ @securitypedant @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/assets/images/reference-architecture/ @securitypedant @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Security products
 
-/src/content/docs/api-shield/ @patriciasantaana @cloudflare/pcx-technical-writing
-/src/content/docs/bots/ @patriciasantaana @cloudflare/pcx-technical-writing
-/src/content/docs/dmarc-management/ @Maddy-Cloudflare @cloudflare/pcx-technical-writing
-/src/content/docs/firewall/ @pedrosousa @cloudflare/firewall @cloudflare/pcx-technical-writing
-/src/content/docs/client-side-security/ @pedrosousa @cloudflare/pcx-technical-writing
-/src/content/docs/secrets-store/ @RebeccaTamachiro @cloudflare/pcx-technical-writing
-/src/content/docs/security-center/ @cloudflare/pcx-technical-writing
-/src/content/docs/ssl/ @RebeccaTamachiro @cloudflare/pcx-technical-writing
-/src/content/docs/waf/ @pedrosousa @cloudflare/firewall @cloudflare/pcx-technical-writing
-/src/content/docs/waf/change-log/ @pedrosousa @cloudflare/firewall @vs-mg @cloudflare/pcx-technical-writing
-/src/content/docs/cloudflare-challenges/ @patriciasantaana @cloudflare/pcx-technical-writing
+/src/content/docs/api-shield/ @patriciasantaana @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/bots/ @patriciasantaana @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/dmarc-management/ @Maddy-Cloudflare @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/firewall/ @pedrosousa @cloudflare/firewall @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/client-side-security/ @pedrosousa @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/secrets-store/ @RebeccaTamachiro @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/security-center/ @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/ssl/ @RebeccaTamachiro @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/waf/ @pedrosousa @cloudflare/firewall @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/waf/change-log/ @pedrosousa @cloudflare/firewall @vs-mg @cloudflare/pcx-technical-writing @cloudflare/product-owners
+/src/content/docs/cloudflare-challenges/ @patriciasantaana @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Support
 
-/src/content/docs/support/ @cloudflare/pcx-technical-writing @cloudflare/customer-support
-/src/assets/images/support/ @cloudflare/pcx-technical-writing @cloudflare/customer-support
-/src/content/docs/billing/ @cloudflare/customer-support @cloudflare/pcx-technical-writing
+/src/content/docs/support/ @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/customer-support
+/src/assets/images/support/ @cloudflare/pcx-technical-writing @cloudflare/product-owners @cloudflare/customer-support
+/src/content/docs/billing/ @cloudflare/customer-support @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Turnstile
 
-/src/content/docs/turnstile/ @migueldemoura @punkeel @patriciasantaana @cloudflare/pcx-technical-writing
+/src/content/docs/turnstile/ @migueldemoura @punkeel @patriciasantaana @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Waiting Room
 
-/src/content/docs/waiting-room/ @angelampcosta @cloudflare/pcx-technical-writing
+/src/content/docs/waiting-room/ @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # Web Analytics
 
-/src/content/docs/web-analytics/ @angelampcosta @cloudflare/pcx-technical-writing
+/src/content/docs/web-analytics/ @angelampcosta @cloudflare/pcx-technical-writing @cloudflare/product-owners
 
 # AI Prompts for Cloudflare Workers development
-/public/workers/prompts/ @jahands @Maximo-Guk @cloudflare/pcx-technical-writing
+/public/workers/prompts/ @jahands @Maximo-Guk @cloudflare/pcx-technical-writing @cloudflare/product-owners


### PR DESCRIPTION
## Summary

- Adds `@cloudflare/product-owners` to every rule in `.github/CODEOWNERS`, mirroring the existing `@cloudflare/pcx-technical-writing` coverage.

## Why

Today, only members of `@cloudflare/pcx-technical-writing` (and the per-path individual owners) can provide the code owner approval required by the branch protection rule on `production`. This change widens the set of people who can approve PRs to include Product Leaders, allowing them to stamp changes in situations where a full technical writing review isn't necessary — without requiring rubber-stamp approvals from the docs team.

## How it works

The `production` branch protection rule has "Require review from Code Owners" enabled. By adding `@cloudflare/product-owners` to every CODEOWNERS rule, any member of that team can now provide a satisfying code owner approval on any PR.

## Follow-up action required

Because CODEOWNERS conflates "who can approve" with "who gets notified," adding a team to every rule means that team will receive review requests on every PR. To avoid notification spam for product-owners members:

1. Go to https://github.com/orgs/cloudflare/teams/product-owners/settings
2. Under "Code review" > "Auto assignment," ensure auto-assignment is either disabled or configured to avoid broadcasting review requests to the entire team

This way, product-owners members can proactively approve PRs when needed without being pinged on every PR opened against this repo.