### PR TITLE
[AI Gateway] Remove deprecated label from request handling page

### DIFF
--- a/src/content/docs/ai-gateway/configuration/request-handling.mdx
+++ b/src/content/docs/ai-gateway/configuration/request-handling.mdx
@@ -9,7 +9,7 @@ import { Render, Aside } from "~/components";
 
 :::note
 
-[Dynamic Routing](/ai-gateway/features/dynamic-routing/) also offers timeouts and retries on Model nodes, along with conditional routing, rate limiting, and budget limiting through a visual interface. This page documents per-request headers that work with any provider endpoint. You can also configure retries at the [gateway level](/ai-gateway/configuration/manage-gateway/#retry-requests).
+[Dynamic Routing](/ai-gateway/features/dynamic-routing/) also offers timeouts and retries on Model nodes, along with conditional routing, rate limiting, and budget limiting through a visual interface. This page documents request-handling configuration available through Universal Endpoint provider `config` settings as well as per-request `cf-aig-*` headers that work with any provider endpoint. You can also configure retries at the [gateway level](/ai-gateway/configuration/manage-gateway/#retry-requests).
 
 :::
 

--- a/src/content/docs/ai-gateway/configuration/request-handling.mdx
+++ b/src/content/docs/ai-gateway/configuration/request-handling.mdx
@@ -9,7 +9,7 @@ import { Render, Aside } from "~/components";
 
 :::note
 
-[Dynamic Routing](/ai-gateway/features/dynamic-routing/) also offers timeouts and retries on Model nodes, along with conditional routing, rate limiting, and budget limiting through a visual interface. This page documents request-handling configuration available through Universal Endpoint provider `config` settings as well as per-request `cf-aig-*` headers that work with any provider endpoint. You can also configure retries at the [gateway level](/ai-gateway/configuration/manage-gateway/#retry-requests).
+[Dynamic Routing](/ai-gateway/features/dynamic-routing/) also offers timeouts and retries per model, along with conditional routing, rate limiting, and budget limiting through a visual interface. This page documents request-handling configuration available through Universal Endpoint provider `config` settings as well as per-request `cf-aig-*` headers that work with any provider endpoint. You can also configure retries at the [gateway level](/ai-gateway/configuration/manage-gateway/#retry-requests).
 
 :::
 

--- a/src/content/docs/ai-gateway/configuration/request-handling.mdx
+++ b/src/content/docs/ai-gateway/configuration/request-handling.mdx
@@ -7,9 +7,9 @@ sidebar:
 
 import { Render, Aside } from "~/components";
 
-:::note[Deprecated]
+:::note
 
-While the request handling features described on this page still work, [Dynamic Routing](/ai-gateway/features/dynamic-routing/) is now the preferred way to achieve advanced request handling, including timeouts, retries, and fallbacks. Dynamic Routing provides a more powerful and flexible approach with a visual interface for managing complex routing scenarios.
+[Dynamic Routing](/ai-gateway/features/dynamic-routing/) also offers timeouts and retries on Model nodes, along with conditional routing, rate limiting, and budget limiting through a visual interface. This page documents per-request headers that work with any provider endpoint. You can also configure retries at the [gateway level](/ai-gateway/configuration/manage-gateway/#retry-requests).
 
 :::
 


### PR DESCRIPTION
## Summary

Removes the misleading "Deprecated" label from the request handling page and clarifies the relationship between different configuration options.

- The page was marked deprecated, directing users to Dynamic Routing for "timeouts, retries, and fallbacks"
- However, the per-request headers on this page (`cf-aig-*`) are still valid and useful for provider endpoints
- Dynamic Routing, gateway settings, and per-request headers serve different use cases

## Changes

Updates the note to accurately explain:
- Dynamic Routing offers timeouts and retries on Model nodes, plus conditional routing and rate/budget limiting
- This page documents per-request headers for any provider endpoint
- Gateway-level retry settings are also available