### PR TITLE
Clarify difference between sets of Tunnel documentation

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/index.mdx
@@ -10,6 +10,8 @@ tags:
 
 import { Render, Stream } from "~/components";
 
+:::note[Looking to expose public applications?] This documentation covers Cloudflare Tunnel use cases for private networking and Zero Trust, like VPN replacement and private network access. For publishing public web applications, APIs, and services to the Internet through Cloudflare refer to the [Cloudflare Tunnel documentation](/tunnel). :::
+
 Cloudflare Tunnel provides you with a secure way to connect your resources to Cloudflare without a publicly routable IP address. With Tunnel, you do not send traffic to an external IP — instead, a lightweight daemon in your infrastructure (`cloudflared`) creates [outbound-only connections](#outbound-only-connections) to Cloudflare's global network. Cloudflare Tunnel can connect HTTP web servers, [SSH servers](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/), [remote desktops](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/rdp/), and other protocols safely to Cloudflare. This way, your origins can serve traffic through Cloudflare without being vulnerable to attacks that bypass Cloudflare.
 
 Refer to our [reference architecture](/reference-architecture/architectures/sase/) for details on how to implement Cloudflare Tunnel into your existing infrastructure.

--- a/src/content/docs/tunnel/index.mdx
+++ b/src/content/docs/tunnel/index.mdx
@@ -21,6 +21,10 @@ import {
 
 <Plan type="all" />
 
+:::note[Looking for private networking or Zero Trust?]
+This documentation covers Cloudflare Tunnel use cases for public applications. For VPN replacement, private network access, and network traffic filtering, refer to the [Cloudflare One Tunnel documentation](/cloudflare-one/networks/connectors/cloudflare-tunnel/).
+:::
+
 Cloudflare Tunnel connects your infrastructure to Cloudflare through an outbound-only, [post-quantum encrypted](/ssl/post-quantum-cryptography/) connection. Instead of exposing a public IP, you install a lightweight daemon called `cloudflared` on your server. It creates a persistent tunnel to Cloudflare's global network, so all traffic to your origins flows through Cloudflare — where CDN caching, WAF, Bot Management, and DDoS protection are applied automatically.
 
 No open inbound ports. No public IPs. No attack surface.
@@ -48,10 +52,6 @@ Each tunnel maintains four long-lived connections to two Cloudflare data centers
 - **Public ingress routing** — Publish internal applications to the internet by mapping public hostnames to local services. Supports HTTP, HTTPS, TCP, SSH, RDP, and [more](/tunnel/routing/#supported-protocols).
 - **Workers VPC** — Enable [Cloudflare Workers](/workers-vpc/) to securely access private databases, APIs, and services through your tunnel.
 - **Load Balancing** — Use tunnels as origin endpoints in [Cloudflare Load Balancer](/load-balancing/) pools for high availability and intelligent traffic steering.
-
-:::note[Looking for Zero Trust and private networking?]
-For VPN replacement, private network access, and network traffic filtering, refer to the [Cloudflare One Tunnel documentation](/cloudflare-one/networks/connectors/cloudflare-tunnel/).
-:::
 
 ## Get started
 


### PR DESCRIPTION
### Summary

Customer cited they were confused as to which Tunnel docs to refer to. We also want to make sure any bots crawling understand which set of docs to reference. 
