### PR TITLE
[DNSSEC] Add troubleshooting guide for deleting remaining DNSKEY records after DNSSEC is disabled

### DIFF
--- a/src/content/docs/dns/dnssec/troubleshooting.mdx
+++ b/src/content/docs/dns/dnssec/troubleshooting.mdx
@@ -201,6 +201,73 @@ In this example, DNSSEC is misconfigured if a proper DNS response is received wh
 
 ---
 
+## Delete remaining DNSKEY records after disabling DNSSEC
+
+After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records may still appear in DNS queries or zone transfers. **This is expected behavior and not a misconfiguration or error.**
+
+:::note[Expected behavior]
+
+DNSKEY records remaining in a zone after DNSSEC is disabled is normal and does not indicate a problem with your DNS configuration. DNS resolution continues to work correctly.
+
+:::
+
+However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure." This occurs because the chain of trust is broken (no DS record at the registrar), even though the zone itself functions normally. If you need to satisfy security audit requirements, you can remove the DNSKEY records using the API.
+
+### Why DNSKEY records persist
+
+When DNSSEC is disabled:
+1. The `DS` record is removed from the registrar (parent zone), breaking the chain of trust.
+2. `RRSIG` records are no longer generated for new DNS responses.
+3. However, `DNSKEY` records may remain in the zone configuration until explicitly removed.
+
+### How to remove remaining DNSKEY records
+
+:::note[Important]
+
+Only remove DNSKEY records after DNSSEC has been fully disabled and the `DS` record has been removed from your registrar. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
+
+:::
+
+:::caution
+
+DNSKEY records cannot be deleted from the Cloudflare dashboard. You must use the Cloudflare API to remove them.
+
+:::
+
+Use the [Delete DNSSEC API](/api/resources/dns/subresources/dnssec/methods/delete/) to remove the DNSSEC configuration and associated DNSKEY records:
+
+<Example>
+
+```sh
+curl --request DELETE \
+  "https://api.cloudflare.com/client/v4/zones/{zone_id}/dnssec" \
+  -H "Authorization: Bearer <API_TOKEN>"
+```
+
+</Example>
+
+This will delete the DNSSEC configuration for the zone, including all DNSKEY records. For more information on DNSSEC states, refer to [DNSSEC states](/dns/dnssec/dnssec-states/).
+
+### Verify DNSKEY removal
+
+After removing the DNSKEY records, verify they no longer appear in DNS responses:
+
+<Example>
+
+```sh
+dig DNSKEY example.com +short
+```
+
+```sh output
+# No output or NXDOMAIN response indicates no DNSKEY records
+```
+
+</Example>
+
+If DNSKEY records still appear after deletion via the API, wait for the [DNS TTL](/dns/manage-dns-records/reference/ttl/) to expire and propagate across the global DNS network. DNSKEY records typically have longer TTL values (often 3600 seconds or more), so propagation may take up to an hour or longer.
+
+---
+
 ## Next steps
 
 If a problem is discovered with DNSSEC implementation, contact the domain's registrar and confirm the `DS` record matches what the authoritative DNS provider has specified. If Cloudflare is the authoritative DNS provider, follow the instructions for [configuring DNSSEC with Cloudflare](/dns/dnssec/).

--- a/src/content/docs/dns/dnssec/troubleshooting.mdx
+++ b/src/content/docs/dns/dnssec/troubleshooting.mdx
@@ -210,7 +210,7 @@ However, some security vendors or audit tools may flag these DNSKEY records as p
 ### How to remove remaining DNSKEY records
 
 :::caution[Make sure DNSSEC is fully turned off]
-As a rule of thumb, after removing the DS record from your registrar, wait 1.5 times its [TTL](/dns/manage-dns-records/reference/ttl/) - if the DS TTL is 24 hours, wait 36 hours. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
+As a rule of thumb, after removing the DS record from your registrar, wait at least 1.5 times its [TTL](/dns/manage-dns-records/reference/ttl/) - if the DS TTL is 24 hours, wait 36 hours. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
 :::
 
 Use the [Delete DNSSEC API](/api/resources/dns/subresources/dnssec/methods/delete/) to transition the zone to the `deleted` state. This stops all zone signing and removes all DNSSEC record types (RRSIG, NSEC, DNSKEY, CDS, and CDNSKEY):

--- a/src/content/docs/dns/dnssec/troubleshooting.mdx
+++ b/src/content/docs/dns/dnssec/troubleshooting.mdx
@@ -203,7 +203,7 @@ In this example, DNSSEC is misconfigured if a proper DNS response is received wh
 
 ## Delete remaining DNSKEY records after disabling DNSSEC
 
-After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records may still appear in DNS queries or zone transfers. This is expected behavior and **not a misconfiguration or error**. Refer to [DNSSEC states](/dns/dnssec/dnssec-states/) and [RFC 8078](https://www.rfc-editor.org/rfc/rfc8078.html#section-4) for details.
+After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records continue to appear in DNS queries and zone transfers. In the `disabled` state, Cloudflare still signs the zone and serves RRSIG, NSEC, and DNSKEY records. This is expected behavior and **not a misconfiguration or error**. Refer to [DNSSEC states](/dns/dnssec/dnssec-states/) and [RFC 8078](https://www.rfc-editor.org/rfc/rfc8078.html#section-4) for details.
 
 However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure.". You can remove the DNSKEY records using the API.
 
@@ -213,14 +213,11 @@ However, some security vendors or audit tools may flag these DNSKEY records as p
 Only remove DNSKEY records after DNSSEC has been fully disabled and the `DS` record has been removed from your registrar. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
 :::
 
-Use the [Delete DNSSEC API](/api/resources/dns/subresources/dnssec/methods/delete/) to remove the DNSSEC configuration and associated DNSKEY records:
+Use the [Delete DNSSEC API](/api/resources/dns/subresources/dnssec/methods/delete/) to transition the zone to the `deleted` state. This stops all zone signing and removes all DNSSEC record types (RRSIG, NSEC, DNSKEY, CDS, and CDNSKEY):
 
-<APIRequest
-	path="/zones/{zone_id}/dnssec"
-	method="DELETE"
-/>
+<APIRequest path="/zones/{zone_id}/dnssec" method="DELETE" />
 
-This deletes the DNSSEC configuration for the zone, including all DNSKEY records. For more information on DNSSEC states, refer to [DNSSEC states](/dns/dnssec/dnssec-states/).
+For more information on DNSSEC states, refer to [DNSSEC states](/dns/dnssec/dnssec-states/).
 
 ### Verify DNSKEY removal
 

--- a/src/content/docs/dns/dnssec/troubleshooting.mdx
+++ b/src/content/docs/dns/dnssec/troubleshooting.mdx
@@ -10,7 +10,7 @@ head:
     content: Troubleshooting DNSSEC
 ---
 
-import { Example } from "~/components";
+import { Example, APIRequest } from "~/components";
 
 Learn more about how to troubleshoot issues with DNSSEC.
 
@@ -147,7 +147,7 @@ dig +short DS cloudflare.com
 2371 13 2 32996839A6D808AFE3EB4A795A0E6A7A39A76FC52FF228B22B76F6D6 3826F2B9
 ```
 
-When using the `+trace` option, `dig` confirms whether an answer is returned by the nameserver for `cloudflare.com` or the nameserver for `.com`.  In this example, the `DS` record for `cloudflare.com` is returned by `e.gtld-servers.net`:
+When using the `+trace` option, `dig` confirms whether an answer is returned by the nameserver for `cloudflare.com` or the nameserver for `.com`. In this example, the `DS` record for `cloudflare.com` is returned by `e.gtld-servers.net`:
 
 ```sh
 dig DS cloudflare.com +trace
@@ -203,22 +203,19 @@ In this example, DNSSEC is misconfigured if a proper DNS response is received wh
 
 ## Delete remaining DNSKEY records after disabling DNSSEC
 
-After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records may still appear in DNS queries or zone transfers. This is expected behavior and not a misconfiguration or error.
+After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records may still appear in DNS queries or zone transfers. This is expected behavior and **not a misconfiguration or error**. Refer to [DNSSEC states](/dns/dnssec/dnssec-states/) and [RFC 8078](https://www.rfc-editor.org/rfc/rfc8078.html#section-4) for details.
 
-:::note[Expected behavior]
+However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure." This occurs because the chain of trust is broken (no DS record at the registrar), even though the zone itself functions normally.
 
-DNSKEY records remaining in a zone after DNSSEC is disabled is normal and does not indicate a problem with your DNS configuration. DNS resolution continues to work correctly.
+If you need to satisfy security audit requirements, you can remove the DNSKEY records using the API.
 
-:::
-
-However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure." This occurs because the chain of trust is broken (no DS record at the registrar), even though the zone itself functions normally. If you need to satisfy security audit requirements, you can remove the DNSKEY records using the API.
-
-### Why DNSKEY records persist
+### Understand DNSKEY record persistence
 
 When DNSSEC is disabled:
+
 1. The `DS` record is removed from the registrar (parent zone), breaking the chain of trust.
 2. `RRSIG` records are no longer generated for new DNS responses.
-3. However, `DNSKEY` records may remain in the zone configuration until explicitly removed. This operation is available via API only, as explained below.
+3. `DNSKEY` records may remain in the zone configuration until explicitly removed. You can remove remaining DNSKEY records via API.
 
 ### How to remove remaining DNSKEY records
 
@@ -228,35 +225,22 @@ Only remove DNSKEY records after DNSSEC has been fully disabled and the `DS` rec
 
 Use the [Delete DNSSEC API](/api/resources/dns/subresources/dnssec/methods/delete/) to remove the DNSSEC configuration and associated DNSKEY records:
 
-<Example>
+<APIRequest
+	path="/zones/{zone_id}/dnssec"
+	method="DELETE"
+/>
 
-```sh
-curl --request DELETE \
-  "https://api.cloudflare.com/client/v4/zones/{zone_id}/dnssec" \
-  -H "Authorization: Bearer <API_TOKEN>"
-```
-
-</Example>
-
-This will delete the DNSSEC configuration for the zone, including all DNSKEY records. For more information on DNSSEC states, refer to [DNSSEC states](/dns/dnssec/dnssec-states/).
+This deletes the DNSSEC configuration for the zone, including all DNSKEY records. For more information on DNSSEC states, refer to [DNSSEC states](/dns/dnssec/dnssec-states/).
 
 ### Verify DNSKEY removal
 
-After removing the DNSKEY records, verify they no longer appear in DNS responses:
-
-<Example>
+After removing the DNSKEY records, verify they no longer appear in DNS responses. An empty response confirms removal.
 
 ```sh
 dig DNSKEY example.com +short
 ```
 
-```sh output
-# No output or NXDOMAIN response indicates no DNSKEY records
-```
-
-</Example>
-
-If DNSKEY records still appear after deletion via the API, wait for the [DNS TTL](/dns/manage-dns-records/reference/ttl/) to expire and propagate across the global DNS network. DNSKEY records typically have longer TTL values (often 3600 seconds or more), so propagation may take up to an hour or longer.
+If DNSKEY records still appear, wait for the [time-to-live (TTL)](/dns/manage-dns-records/reference/ttl/) to expire. DNSKEY records typically have longer TTL values (often 3600 seconds or more), so propagation may take one hour or longer.
 
 ---
 

--- a/src/content/docs/dns/dnssec/troubleshooting.mdx
+++ b/src/content/docs/dns/dnssec/troubleshooting.mdx
@@ -203,14 +203,16 @@ In this example, DNSSEC is misconfigured if a proper DNS response is received wh
 
 ## Delete remaining DNSKEY records after disabling DNSSEC
 
-After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records continue to appear in DNS queries and zone transfers. In the `disabled` state, Cloudflare still signs the zone and serves RRSIG, NSEC, and DNSKEY records. This is expected behavior and **not a misconfiguration or error**. Refer to [DNSSEC states](/dns/dnssec/dnssec-states/) and [RFC 8078](https://www.rfc-editor.org/rfc/rfc8078.html#section-4) for details.
+After disabling DNSSEC, DNSKEY records continue to appear in DNS queries and zone transfers. In the `disabled` state, Cloudflare still signs the zone and serves RRSIG, NSEC, and DNSKEY records. This is expected behavior and **not a misconfiguration or error**. Refer to [DNSSEC states](/dns/dnssec/dnssec-states/) and [RFC 8078](https://www.rfc-editor.org/rfc/rfc8078.html#section-4) for details.
 
 However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure". You can remove the DNSKEY records using the API.
 
 ### How to remove remaining DNSKEY records
 
 :::caution[Make sure DNSSEC is fully turned off]
-As a rule of thumb, after removing the DS record from your registrar, wait at least 1.5 times its [TTL](/dns/manage-dns-records/reference/ttl/) - if the DS TTL is 24 hours, wait 36 hours. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
+As a rule of thumb, after removing the DS record from your registrar, wait at least 1.5 times its [TTL](/dns/manage-dns-records/reference/ttl/) before removing the DNSKEY records. If the DS TTL is 24 hours, wait 36 hours.
+
+Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
 :::
 
 Use the [Delete DNSSEC API](/api/resources/dns/subresources/dnssec/methods/delete/) to transition the zone to the `deleted` state. This stops all zone signing and removes all DNSSEC record types (RRSIG, NSEC, DNSKEY, CDS, and CDNSKEY):

--- a/src/content/docs/dns/dnssec/troubleshooting.mdx
+++ b/src/content/docs/dns/dnssec/troubleshooting.mdx
@@ -203,7 +203,7 @@ In this example, DNSSEC is misconfigured if a proper DNS response is received wh
 
 ## Delete remaining DNSKEY records after disabling DNSSEC
 
-After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records may still appear in DNS queries or zone transfers. **This is expected behavior and not a misconfiguration or error.**
+After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records may still appear in DNS queries or zone transfers. This is expected behavior and not a misconfiguration or error.
 
 :::note[Expected behavior]
 
@@ -218,20 +218,12 @@ However, some security vendors or audit tools may flag these DNSKEY records as p
 When DNSSEC is disabled:
 1. The `DS` record is removed from the registrar (parent zone), breaking the chain of trust.
 2. `RRSIG` records are no longer generated for new DNS responses.
-3. However, `DNSKEY` records may remain in the zone configuration until explicitly removed.
+3. However, `DNSKEY` records may remain in the zone configuration until explicitly removed. This operation is available via API only, as explained below.
 
 ### How to remove remaining DNSKEY records
 
-:::note[Important]
-
-Only remove DNSKEY records after DNSSEC has been fully disabled and the `DS` record has been removed from your registrar. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
-
-:::
-
 :::caution
-
-DNSKEY records cannot be deleted from the Cloudflare dashboard. You must use the Cloudflare API to remove them.
-
+Only remove DNSKEY records after DNSSEC has been fully disabled and the `DS` record has been removed from your registrar. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
 :::
 
 Use the [Delete DNSSEC API](/api/resources/dns/subresources/dnssec/methods/delete/) to remove the DNSSEC configuration and associated DNSKEY records:

--- a/src/content/docs/dns/dnssec/troubleshooting.mdx
+++ b/src/content/docs/dns/dnssec/troubleshooting.mdx
@@ -205,17 +205,7 @@ In this example, DNSSEC is misconfigured if a proper DNS response is received wh
 
 After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records may still appear in DNS queries or zone transfers. This is expected behavior and **not a misconfiguration or error**. Refer to [DNSSEC states](/dns/dnssec/dnssec-states/) and [RFC 8078](https://www.rfc-editor.org/rfc/rfc8078.html#section-4) for details.
 
-However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure." This occurs because the chain of trust is broken (no DS record at the registrar), even though the zone itself functions normally.
-
-If you need to satisfy security audit requirements, you can remove the DNSKEY records using the API.
-
-### Understand DNSKEY record persistence
-
-When DNSSEC is disabled:
-
-1. The `DS` record is removed from the registrar (parent zone), breaking the chain of trust.
-2. `RRSIG` records are no longer generated for new DNS responses.
-3. `DNSKEY` records may remain in the zone configuration until explicitly removed. You can remove remaining DNSKEY records via API.
+However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure.". You can remove the DNSKEY records using the API.
 
 ### How to remove remaining DNSKEY records
 

--- a/src/content/docs/dns/dnssec/troubleshooting.mdx
+++ b/src/content/docs/dns/dnssec/troubleshooting.mdx
@@ -205,12 +205,12 @@ In this example, DNSSEC is misconfigured if a proper DNS response is received wh
 
 After [disabling DNSSEC](/dns/dnssec/#disable-dnssec), DNSKEY records continue to appear in DNS queries and zone transfers. In the `disabled` state, Cloudflare still signs the zone and serves RRSIG, NSEC, and DNSKEY records. This is expected behavior and **not a misconfiguration or error**. Refer to [DNSSEC states](/dns/dnssec/dnssec-states/) and [RFC 8078](https://www.rfc-editor.org/rfc/rfc8078.html#section-4) for details.
 
-However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure.". You can remove the DNSKEY records using the API.
+However, some security vendors or audit tools may flag these DNSKEY records as problematic, reporting "DNSKEY record found but no DS record found" with a security outcome of "Provably Insecure". You can remove the DNSKEY records using the API.
 
 ### How to remove remaining DNSKEY records
 
-:::caution
-Only remove DNSKEY records after DNSSEC has been fully disabled and the `DS` record has been removed from your registrar. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
+:::caution[Make sure DNSSEC is fully turned off]
+As a rule of thumb, after removing the DS record from your registrar, wait 1.5 times its [TTL](/dns/manage-dns-records/reference/ttl/) - if the DS TTL is 24 hours, wait 36 hours. Removing DNSKEY records while DNSSEC is still enabled will break DNS resolution.
 :::
 
 Use the [Delete DNSSEC API](/api/resources/dns/subresources/dnssec/methods/delete/) to transition the zone to the `deleted` state. This stops all zone signing and removes all DNSSEC record types (RRSIG, NSEC, DNSKEY, CDS, and CDNSKEY):
@@ -233,4 +233,4 @@ If DNSKEY records still appear, wait for the [time-to-live (TTL)](/dns/manage-dn
 
 ## Next steps
 
-If a problem is discovered with DNSSEC implementation, contact the domain's registrar and confirm the `DS` record matches what the authoritative DNS provider has specified. If Cloudflare is the authoritative DNS provider, follow the instructions for [configuring DNSSEC with Cloudflare](/dns/dnssec/).
+If a problem is discovered with DNSSEC implementation, contact the domain's registrar and confirm the DS record matches what the authoritative DNS provider has specified. If Cloudflare is the authoritative DNS provider, follow the instructions for [configuring DNSSEC with Cloudflare](/dns/dnssec/).


### PR DESCRIPTION


Adds a new section to the DNSSEC troubleshooting page explaining:
- DNSKEY records remaining after disabling DNSSEC is expected behavior
- Security vendors may flag these as 'Provably Insecure' due to broken chain of trust
- How to use the Delete DNSSEC API to remove DNSSEC configuration and DNSKEY records
- Verification using dig

Addresses ESCALATION-1035 and SPM-3369

