### PR TITLE
fix: count all types of code blocks for explanations

### DIFF
--- a/src/plugins/expressive-code/explain-code.js
+++ b/src/plugins/expressive-code/explain-code.js
@@ -157,14 +157,12 @@ export default () => {
 					context.renderData.blockAst
 				);
 
+				// Expressive Code frames plugin is required for explain button to work correctly. Ignore if it's not present.
 				if (
 					blockAst.tagName !== "figure" ||
 					!Array.isArray(blockAst.properties?.className) ||
 					!blockAst.properties.className.includes("frame")
 				) {
-					console.warn(
-						"Expressive Code frames plugin is required for explain button to work correctly",
-					);
 					return;
 				}
 

--- a/src/scripts/explain-code.ts
+++ b/src/scripts/explain-code.ts
@@ -1,8 +1,20 @@
 import "../components/explain-code-sheet/explain-code-sheet";
 
 function getCodeBlockPosition(button: HTMLElement): number {
-	const codeBlocks = document.querySelectorAll(".expressive-code");
-	const currentBlock = button.closest(".expressive-code");
+	const wrapperSelector = ".explain";
+	const codeSelector = "pre code";
+	const codeBlocks = document.querySelectorAll(codeSelector);
+	const wrapper = button.closest(wrapperSelector);
+
+	let currentBlock = wrapper?.previousElementSibling;
+	while (currentBlock) {
+		if (currentBlock.tagName === "PRE") {
+			currentBlock = currentBlock.querySelector(codeSelector);
+			console.log(currentBlock);
+			break;
+		}
+		currentBlock = currentBlock.previousElementSibling;
+	}
 	if (!currentBlock) return 1;
 	return Array.from(codeBlocks).indexOf(currentBlock) + 1;
 }


### PR DESCRIPTION
### Summary

The previous code block counting logic only accounted for blocks from expressive code. The count would be off for blocks put in via the package manager component or the just natural use of ```` ``` ````. 

This logic counts instances of `<pre><code>`, which results in code fences when converted back into markdown (via Markdown for Agents).

All of this means the code block explain button will explain the appropriate code block.