### PR TITLE
[Fundamentals] Add Cloudflare One and Gateway tags to Organizations public beta changelog

### DIFF
--- a/src/content/changelog/fundamentals/2026-04-06-organizations-public-beta.mdx
+++ b/src/content/changelog/fundamentals/2026-04-06-organizations-public-beta.mdx
@@ -3,6 +3,8 @@ title: Organizations is now in public beta for enterprises
 description: Centrally manage all of your Cloudflare accounts from a single pane of glass.
 products:
   - fundamentals
+  - cloudflare-one
+  - gateway
 date: 2026-04-06
 ---
 


### PR DESCRIPTION
## Summary

- Adds `cloudflare-one` and `gateway` product tags to the Organizations public beta changelog entry (`2026-04-06-organizations-public-beta.mdx`)
- The post references Gateway shared policies and Cloudflare One traffic policies, so these product tags ensure the changelog surfaces under those product filters as well