### PR TITLE
[CNI] Clarify routine maintenance notice applies to multi-homed PoPs

### DIFF
--- a/src/content/docs/network-interconnect/operational-guidance.mdx
+++ b/src/content/docs/network-interconnect/operational-guidance.mdx
@@ -19,7 +19,7 @@ Regular network maintenance may impact Cloudflare Network Interconnect (CNI) con
 
 ### Notice periods
 
-- **Routine maintenance**: Minimum two business days notice.
+- **Routine maintenance**: Minimum two business days notice in multi-homed PoPs.
 - **Emergency maintenance**: Best-effort notice, which may be less than two business days.
 
 To receive advance alerts, configure [CNI maintenance notifications](/network-interconnect/monitoring-and-alerts/).


### PR DESCRIPTION
### Summary

Clarifies that the two business day notice period for routine maintenance applies specifically to multi-homed PoPs.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).