### PR TITLE
[Agents] Close documentation gaps vs upstream SDK

### DIFF
--- a/src/content/docs/agents/api-reference/callable-methods.mdx
+++ b/src/content/docs/agents/api-reference/callable-methods.mdx
@@ -710,15 +710,27 @@ for (const [name, meta] of methods) {
 
 ### `SyntaxError: Invalid or unexpected token`
 
-If your dev server fails with `SyntaxError: Invalid or unexpected token` when using `@callable()`, set `"target": "ES2021"` in your `tsconfig.json`. This ensures that Vite's esbuild transpiler downlevels TC39 decorators instead of passing them through as native syntax.
+If your dev server fails with `SyntaxError: Invalid or unexpected token` when using `@callable()`, you need two things:
 
-```json
+**1. Add the `agents/vite` plugin** — Vite 8 uses Oxc for transpilation, which does not yet support TC39 decorators. The plugin adds the required transform:
+
+```ts title="vite.config.ts"
+import agents from "agents/vite";
+
+export default defineConfig({
+	plugins: [agents(), react(), cloudflare()],
+});
+```
+
+**2. Extend `agents/tsconfig`** — this sets `"target": "ES2021"` and all other recommended compiler options:
+
+```json title="tsconfig.json"
 {
-	"compilerOptions": {
-		"target": "ES2021"
-	}
+	"extends": "agents/tsconfig"
 }
 ```
+
+If you cannot extend the shared config, set `"target": "ES2021"` manually in your `tsconfig.json`.
 
 :::caution
 Do not set `"experimentalDecorators": true` in your `tsconfig.json`. The Agents SDK uses [TC39 standard decorators](https://github.com/tc39/proposal-decorators), not TypeScript legacy decorators. Enabling `experimentalDecorators` applies an incompatible transform that silently breaks `@callable()` at runtime.

--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -277,12 +277,12 @@ export class ChatAgent extends AIChatAgent {
 
 Controls whether `AIChatAgent` waits for MCP server connections to settle before calling `onChatMessage`. This ensures `this.mcp.getAITools()` returns the full set of tools, especially after Durable Object hibernation when connections are being restored in the background.
 
-| Value                  | Behavior                                      |
-| ---------------------- | --------------------------------------------- |
+| Value                 | Behavior                                      |
+| --------------------- | --------------------------------------------- |
 | `{ timeout: 10_000 }` | Wait up to 10 seconds (default)               |
 | `{ timeout: N }`      | Wait up to `N` milliseconds                   |
-| `true`                 | Wait indefinitely until all connections ready  |
-| `false`                | Do not wait (old behavior before 0.2.0)        |
+| `true`                | Wait indefinitely until all connections ready |
+| `false`               | Do not wait (old behavior before 0.2.0)       |
 
 <TypeScriptExample>
 
@@ -303,21 +303,181 @@ export class ChatAgent extends AIChatAgent {
 
 For lower-level control, call `this.mcp.waitForConnections()` directly inside your `onChatMessage` instead.
 
-### `persistMessages` and `saveMessages`
+### `messageConcurrency`
 
-For advanced cases, you can manually persist messages:
+Controls how overlapping user submissions behave when a chat turn is already active or queued.
 
 <TypeScriptExample>
 
 ```ts
-// Persist messages without triggering a new response
-await this.persistMessages(messages);
-
-// Persist messages AND trigger onChatMessage (e.g., programmatic messages)
-await this.saveMessages(messages);
+export class ChatAgent extends AIChatAgent {
+	messageConcurrency = "queue";
+}
 ```
 
 </TypeScriptExample>
+
+| Strategy                                        | Behavior                                                                                                                            |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `"queue"` (default)                             | Queue every submission and process in order                                                                                         |
+| `"latest"`                                      | Keep only the latest overlapping submission; superseded submissions still persist their user messages but do not start a model turn |
+| `"merge"`                                       | Queue overlapping submissions, then collapse their trailing user messages into one combined turn before the latest queued turn runs |
+| `"drop"`                                        | Ignore overlapping submissions entirely                                                                                             |
+| `{ strategy: "debounce", debounceMs?: number }` | Trailing-edge latest with a quiet window (default 750ms)                                                                            |
+
+This setting only applies to `sendMessage()` submissions. Regenerations, tool continuations, approvals, clears, and programmatic `saveMessages()` calls keep their existing serialized behavior.
+
+### `persistMessages` and `saveMessages`
+
+`persistMessages` stores messages in SQLite and broadcasts the update to all connected clients, but does **not** trigger a model turn. Use it when you want to inject messages into the conversation without starting a new response.
+
+`saveMessages` persists messages **and** triggers `onChatMessage()` for a new response. It waits for any active chat turn to finish before starting, so scheduled or programmatic messages never overlap an in-flight stream.
+
+<TypeScriptExample>
+
+```ts
+// Store messages without triggering a response
+await this.persistMessages(messages);
+
+// Store messages AND trigger onChatMessage
+const { requestId, status } = await this.saveMessages(messages);
+```
+
+</TypeScriptExample>
+
+`saveMessages` accepts either an array of messages or a function that derives the next message list from the latest persisted `this.messages`. Use the function form to avoid stale baselines when multiple calls queue up:
+
+<TypeScriptExample>
+
+```ts
+await this.saveMessages((messages) => [
+	...messages,
+	{
+		id: crypto.randomUUID(),
+		role: "user",
+		parts: [{ type: "text", text: "Summarize the latest data" }],
+		createdAt: new Date(),
+	},
+]);
+```
+
+</TypeScriptExample>
+
+`saveMessages` returns `{ requestId, status }` where `status` is `"completed"` if the turn ran, or `"skipped"` if the chat was cleared before it started.
+
+### `onChatResponse`
+
+Called after a chat turn completes and the assistant message has been persisted. The turn lock is released before this hook runs, so it is safe to call `saveMessages` from inside. Fires for all turn completion paths: WebSocket chat requests, `saveMessages`, and auto-continuation.
+
+<TypeScriptExample>
+
+```ts
+import type { ChatResponseResult } from "@cloudflare/ai-chat";
+
+export class ChatAgent extends AIChatAgent {
+	protected async onChatResponse(result: ChatResponseResult) {
+		if (result.status === "completed") {
+			console.log("Turn completed:", result.requestId);
+		}
+		if (result.status === "error") {
+			console.error("Turn failed:", result.error);
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+The `ChatResponseResult` contains:
+
+| Field          | Type                                  | Description                                                       |
+| -------------- | ------------------------------------- | ----------------------------------------------------------------- |
+| `message`      | `UIMessage`                           | The finalized assistant message from this turn                    |
+| `requestId`    | `string`                              | The request ID associated with this turn                          |
+| `continuation` | `boolean`                             | Whether this turn was a continuation of a previous assistant turn |
+| `status`       | `"completed" \| "error" \| "aborted"` | How the turn ended                                                |
+| `error`        | `string \| undefined`                 | Error message when `status` is `"error"`                          |
+
+:::note
+Responses triggered from inside `onChatResponse` (for example, via `saveMessages`) do not fire `onChatResponse` recursively.
+:::
+
+### `sanitizeMessageForPersistence`
+
+Override this method to apply custom transformations to messages before they are persisted to storage. This hook runs **after** the built-in sanitization (OpenAI metadata stripping, Anthropic provider-executed tool payload truncation, empty reasoning part filtering).
+
+<TypeScriptExample>
+
+```ts
+export class ChatAgent extends AIChatAgent {
+	protected sanitizeMessageForPersistence(message: UIMessage): UIMessage {
+		return {
+			...message,
+			parts: message.parts.map((part) => {
+				if (
+					"output" in part &&
+					typeof part.output === "string" &&
+					part.output.length > 1000
+				) {
+					return { ...part, output: "[redacted]" };
+				}
+				return part;
+			}),
+		};
+	}
+}
+```
+
+</TypeScriptExample>
+
+### Turn lifecycle helpers
+
+These methods help you coordinate programmatic turns and wait for pending interactions.
+
+#### `hasPendingInteraction()`
+
+Returns `true` when an assistant message is waiting on a client tool result or approval.
+
+<TypeScriptExample>
+
+```ts
+if (this.hasPendingInteraction()) {
+	console.log("Waiting for user to approve or provide tool output");
+}
+```
+
+</TypeScriptExample>
+
+#### `waitUntilStable()`
+
+Waits until the conversation is fully stable — no active stream, no pending client-tool interactions, and no queued continuation turns. Returns `true` when stable, or `false` if the timeout expires before a pending interaction resolves.
+
+<TypeScriptExample>
+
+```ts
+const stable = await this.waitUntilStable({ timeout: 30_000 });
+if (stable) {
+	console.log("All turns complete, safe to proceed");
+}
+```
+
+</TypeScriptExample>
+
+This is especially useful with `saveMessages` for server-driven flows:
+
+<TypeScriptExample>
+
+```ts
+await this.saveMessages((messages) => [...messages, syntheticUserMessage]);
+await this.waitUntilStable({ timeout: 60_000 });
+// The assistant has finished responding
+```
+
+</TypeScriptExample>
+
+#### `resetTurnState()`
+
+Aborts the active turn and invalidates queued continuations. The built-in `CF_AGENT_CHAT_CLEAR` handler calls this automatically, but you can call it manually if needed.
 
 ### Lifecycle hooks
 

--- a/src/content/docs/agents/api-reference/client-sdk.mdx
+++ b/src/content/docs/agents/api-reference/client-sdk.mdx
@@ -187,6 +187,23 @@ When the WebSocket connection closes — whether due to network issues, server r
 
 Agents can maintain state that syncs bidirectionally with all connected clients.
 
+### Reading current state
+
+Both `useAgent` and `AgentClient` expose a `state` property that reflects the current agent state. It starts as `undefined` until the first state message is received from the server.
+
+<TypeScriptExample>
+
+```ts
+const agent = useAgent({ agent: "GameAgent", name: "game-123" });
+
+// Read the current state at any time
+console.log("Current score:", agent.state?.score);
+```
+
+</TypeScriptExample>
+
+With `useAgent`, state updates trigger a React re-render, so `agent.state` always reflects the latest value in your JSX. With `AgentClient`, the `state` field is updated synchronously on each incoming server broadcast or `setState` call.
+
 ### Receiving state updates
 
 <TypeScriptExample>

--- a/src/content/docs/agents/api-reference/configuration.mdx
+++ b/src/content/docs/agents/api-reference/configuration.mdx
@@ -250,6 +250,81 @@ const response = await this.env.AI.run("@cf/meta/llama-3-8b-instruct", {
 
 </TypeScriptExample>
 
+## TypeScript configuration
+
+The Agents SDK ships a shared `tsconfig.json` that sets all the compiler options needed for agents projects — including the `ES2021` target required for `@callable()` decorators, strict mode, bundler module resolution, and Workers types.
+
+Extend it in your `tsconfig.json`:
+
+```json
+{
+	"extends": "agents/tsconfig"
+}
+```
+
+This is equivalent to:
+
+```json
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"jsx": "react-jsx",
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"types": ["node", "@cloudflare/workers-types", "vite/client"],
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true
+	}
+}
+```
+
+You can override individual options as needed:
+
+```json
+{
+	"extends": "agents/tsconfig",
+	"compilerOptions": {
+		"jsx": "preserve"
+	}
+}
+```
+
+:::caution
+Do not set `"experimentalDecorators": true`. The Agents SDK uses [TC39 standard decorators](https://github.com/tc39/proposal-decorators), not TypeScript legacy decorators. Enabling `experimentalDecorators` applies an incompatible transform that silently breaks `@callable()` at runtime.
+:::
+
+## Vite configuration
+
+The Agents SDK provides a Vite plugin that handles TC39 decorator transforms. Vite 8 uses Oxc for transpilation, which does not yet support TC39 decorators — without this plugin, `@callable()` and other decorators will fail at runtime.
+
+Add the plugin to your `vite.config.ts`:
+
+<TypeScriptExample>
+
+```ts title="vite.config.ts"
+import { cloudflare } from "@cloudflare/vite-plugin";
+import react from "@vitejs/plugin-react";
+import agents from "agents/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [agents(), react(), cloudflare()],
+});
+```
+
+</TypeScriptExample>
+
+The `agents()` plugin is safe to include even if your project does not use decorators. It only runs the transform on files that contain `@` syntax.
+
+The starter template and all examples include this plugin by default. If you encounter `SyntaxError: Invalid or unexpected token` with decorators, refer to [Callable methods — Troubleshooting](/agents/api-reference/callable-methods/#troubleshooting).
+
 ## Generating types
 
 Wrangler can generate TypeScript types for your bindings.

--- a/src/content/docs/agents/api-reference/mcp-client-api.mdx
+++ b/src/content/docs/agents/api-reference/mcp-client-api.mdx
@@ -69,7 +69,8 @@ Use `addMcpServer()` to connect to an MCP server. For non-OAuth servers, no opti
 // Non-OAuth server — no options required
 await this.addMcpServer("notion", "https://mcp.notion.so/mcp");
 
-// OAuth server — provide callbackHost for the OAuth redirect flow
+// OAuth server — callbackHost is auto-derived from the incoming request,
+// but you can set it explicitly if needed (e.g. custom domains)
 await this.addMcpServer("github", "https://mcp.github.com/mcp", {
 	callbackHost: "https://my-worker.workers.dev",
 });
@@ -124,11 +125,15 @@ await this.addMcpServer("internal", "https://internal-mcp.example.com/mcp", {
 MCP server URLs are validated before connection to prevent Server-Side Request Forgery (SSRF). The following URL targets are blocked:
 
 - Private/internal IP ranges (RFC 1918: `10.x`, `172.16-31.x`, `192.168.x`)
-- Loopback addresses (`127.x`, `::1`)
+- Unspecified addresses (`0.0.0.0`, `[::]`)
 - Link-local addresses (`169.254.x`, `fe80::`)
-- Cloud metadata endpoints (`169.254.169.254`)
+- IPv6 unique-local addresses (`fc00::/7`)
+- IPv4-mapped IPv6 addresses that resolve to private ranges (for example, `[::ffff:10.0.0.1]`)
+- Cloud metadata endpoints (`metadata.google.internal`)
 
-If you need to connect to an internal MCP server, use the [RPC transport](/agents/model-context-protocol/transport/) with a Durable Object binding instead of HTTP.
+Loopback addresses (`localhost`, `127.x.x.x`, `[::1]`) are **allowed** for local development.
+
+For production connections to internal services, use the [RPC transport](/agents/model-context-protocol/transport/) with a Durable Object binding instead of HTTP.
 
 ### Return value
 
@@ -502,7 +507,7 @@ async addMcpServer(
 - `serverName` (string, required) — Display name for the MCP server
 - `url` (string, required) — URL of the MCP server endpoint
 - `options` (object, optional) — Connection configuration:
-  - `callbackHost` — Host for OAuth callback URL. Only needed for OAuth-authenticated servers. If omitted, automatically derived from the incoming request
+  - `callbackHost` — Host for OAuth callback URL. Only needed for OAuth-authenticated servers. If omitted, automatically derived from the incoming request or WebSocket connection URI — you typically do not need to set this unless you are using a custom domain that differs from the Worker's hostname
   - `callbackPath` — Custom callback URL path that bypasses the default `/agents/{class}/{name}/callback` construction. **Required when `sendIdentityOnConnect` is `false`** to prevent leaking the instance name. When set, the callback URL becomes `{callbackHost}/{callbackPath}`. You must route this path to the agent instance via `getAgentByName`
   - `agentsPrefix` — URL prefix for OAuth callback path. Default: `"agents"`. Ignored when `callbackPath` is provided
   - `client` — MCP client configuration options (passed to `@modelcontextprotocol/sdk` Client constructor). By default, includes `CfWorkerJsonSchemaValidator` for validating tool parameters against JSON schemas
@@ -866,10 +871,44 @@ async closeAllConnections(): Promise<void>
 Get all discovered MCP tools in a format compatible with the AI SDK.
 
 ```ts
-getAITools(): ToolSet
+getAITools(filter?: MCPServerFilter): ToolSet
 ```
 
 Tools are automatically namespaced by server ID to prevent conflicts when multiple MCP servers expose tools with the same name.
+
+Pass an `MCPServerFilter` to scope the returned tools to a subset of connected servers:
+
+<TypeScriptExample>
+
+```ts
+// Tools from a specific server only
+const githubTools = this.mcp.getAITools({ serverId: "github" });
+
+// Tools from multiple servers
+const tools = this.mcp.getAITools({ serverId: ["github", "notion"] });
+
+// Tools from servers matching a name
+const tools = this.mcp.getAITools({ serverName: "GitHub" });
+
+// Only tools from servers that are ready
+const tools = this.mcp.getAITools({ state: "ready" });
+```
+
+</TypeScriptExample>
+
+The filter type is available from `agents/mcp/client`:
+
+```ts
+import type { MCPServerFilter } from "agents/mcp/client";
+
+type MCPServerFilter = {
+	serverId?: string | string[];
+	serverName?: string | string[];
+	state?: MCPConnectionState | MCPConnectionState[];
+};
+```
+
+All specified filter criteria are AND'd together. The same filter parameter is accepted by `listTools()`, `listPrompts()`, `listResources()`, and `listResourceTemplates()`.
 
 ## Error handling
 

--- a/src/content/docs/agents/api-reference/queue-tasks.mdx
+++ b/src/content/docs/agents/api-reference/queue-tasks.mdx
@@ -21,6 +21,7 @@ type QueueItem<T> = {
 	payload: T; // Data to pass to the callback function
 	callback: keyof Agent; // Name of the method to call
 	created_at: number; // Timestamp when the task was created
+	retry?: RetryOptions; // Retry options for this task
 };
 ```
 
@@ -31,13 +32,19 @@ type QueueItem<T> = {
 Adds a task to the queue for future execution.
 
 ```ts
-async queue<T>(callback: keyof this, payload: T): Promise<string>
+async queue<T>(
+  callback: keyof this,
+  payload: T,
+  options?: { retry?: RetryOptions }
+): Promise<string>
 ```
 
 **Parameters:**
 
 - `callback` - The name of the method to call when processing the task
 - `payload` - Data to pass to the callback method
+- `options` - Optional configuration:
+  - `retry` - Retry options for the callback execution. If the callback throws, it is retried with exponential backoff. Refer to [Retries](/agents/api-reference/retries/) for details on `RetryOptions`
 
 **Returns:** The unique ID of the queued task
 
@@ -296,29 +303,39 @@ class BatchProcessor extends Agent {
 
 ## Error handling
 
+Use the built-in `retry` option instead of manual re-queue logic. When a callback throws, the task is automatically retried with exponential backoff:
+
 <TypeScriptExample>
 
 ```ts
 class RobustAgent extends Agent {
-	async reliableTask(payload: any, queueItem: QueueItem) {
-		try {
-			await this.doSomethingRisky(payload);
-		} catch (error) {
-			console.error(`Task ${queueItem.id} failed:`, error);
-
-			// Optionally re-queue with retry logic
-			if (payload.retryCount < 3) {
-				await this.queue("reliableTask", {
-					...payload,
-					retryCount: (payload.retryCount || 0) + 1,
-				});
-			}
+	async reliableTask(payload: { url: string }, queueItem: QueueItem) {
+		console.log(`Processing task ${queueItem.id}`);
+		const response = await fetch(payload.url);
+		if (!response.ok) {
+			throw new Error(`Request failed: ${response.status}`);
 		}
+	}
+
+	async onMessage(connection: Connection, message: WSMessage) {
+		await this.queue(
+			"reliableTask",
+			{ url: "https://api.example.com/data" },
+			{
+				retry: {
+					maxAttempts: 5,
+					baseDelayMs: 500,
+					maxDelayMs: 10_000,
+				},
+			},
+		);
 	}
 }
 ```
 
 </TypeScriptExample>
+
+If no `retry` option is provided, the class-level defaults from `static options.retry` are used (3 attempts, 100ms base delay, 3s max delay). Refer to [Retries](/agents/api-reference/retries/) for full details.
 
 ## Best practices
 
@@ -343,9 +360,6 @@ The queue system works with other Agent SDK features:
 - No priority system (FIFO only).
 - Queue processing happens during agent execution, not as separate background jobs.
 
-:::note
-Queue tasks support built-in retries with exponential backoff. Pass `{ retry: { maxAttempts, baseDelayMs, maxDelayMs } }` as the third argument to `queue()`. Refer to [Retries](/agents/api-reference/retries/) for details.
-:::
 
 ## Queue vs Schedule
 

--- a/src/content/docs/agents/api-reference/schedule-tasks.mdx
+++ b/src/content/docs/agents/api-reference/schedule-tasks.mdx
@@ -186,6 +186,8 @@ await this.schedule("0 0 1 * *", "monthlyCleanup", {});
 - Health checks
 - Subscription renewals
 
+Cron schedules are idempotent by default — calling `schedule()` with the same cron expression, callback, and payload multiple times returns the existing schedule instead of creating a duplicate. This makes cron schedules safe to set up in `onStart()`.
+
 ### Interval
 
 Use `scheduleEvery()` to run a task at fixed intervals (in seconds). Unlike cron, intervals support sub-minute precision and arbitrary durations:
@@ -213,6 +215,25 @@ await this.scheduleEvery(90, "syncData", { destination: "warehouse" });
 | Arbitrary intervals | No (must fit cron pattern)            | Yes                    |
 | Fixed schedule      | Yes (for example, "every day at 8am") | No (relative to start) |
 | Overlap prevention  | No                                    | Yes (built-in)         |
+
+**Idempotency:**
+
+`scheduleEvery()` is idempotent on the combination of callback name, interval, and payload — calling it multiple times with the same arguments does not create duplicate schedules. This makes it safe to call in `onStart()`, which runs on every Durable Object wake:
+
+<TypeScriptExample>
+
+```ts
+class MyAgent extends Agent {
+	async onStart() {
+		// Safe to call on every wake — only one schedule is created
+		await this.scheduleEvery(30, "poll", { source: "api" });
+	}
+}
+```
+
+</TypeScriptExample>
+
+A different interval or payload creates a new, independent schedule.
 
 **Overlap prevention:**
 
@@ -669,7 +690,7 @@ async schedule<T>(
   when: Date | string | number,
   callback: keyof this,
   payload?: T,
-  options?: { retry?: RetryOptions }
+  options?: { retry?: RetryOptions; idempotent?: boolean }
 ): Promise<Schedule<T>>
 ```
 
@@ -680,9 +701,29 @@ Schedule a task for future execution.
 - `when` - When to execute: `number` (seconds delay), `Date` (specific time), or `string` (cron expression)
 - `callback` - Name of the method to call
 - `payload` - Data to pass to the callback (must be JSON-serializable)
-- `options.retry` - Optional retry configuration. Refer to [Retries](/agents/api-reference/retries/) for details.
+- `options.retry` - Optional retry configuration. Refer to [Retries](/agents/api-reference/retries/) for details
+- `options.idempotent` - Deduplicate by callback + payload. Defaults to `true` for cron schedules, `false` for delayed and Date-based schedules
 
 **Returns:** A `Schedule` object with the task details
+
+**Idempotency:**
+
+Cron schedules are idempotent by default — calling `schedule("0 * * * *", "tick")` multiple times with the same callback, cron expression, and payload returns the existing schedule instead of creating a duplicate. Set `idempotent: false` to override this.
+
+For delayed and Date-based schedules, set `idempotent: true` to opt in to the same dedup behavior (matched on callback + payload). This is especially useful when calling `schedule()` in `onStart()` to avoid accumulating duplicate rows across Durable Object restarts:
+
+<TypeScriptExample>
+
+```ts
+class MyAgent extends Agent {
+	async onStart() {
+		// Without idempotent: true, this creates a new row on every DO restart
+		await this.schedule(3600, "hourlyCleanup", {}, { idempotent: true });
+	}
+}
+```
+
+</TypeScriptExample>
 
 :::caution
 
@@ -854,6 +895,12 @@ dispose2(); // Now the agent can go idle
 - **Interval jobs:** After execution, rescheduled for `now + intervalSeconds`; skipped if still running
 
 ## Next steps
+
+<LinkCard
+	title="Push notifications"
+	href="/agents/guides/push-notifications/"
+	description="Send browser push notifications using scheduling and web-push."
+/>
 
 <LinkCard
 	title="Queue tasks"

--- a/src/content/docs/agents/api-reference/websockets.mdx
+++ b/src/content/docs/agents/api-reference/websockets.mdx
@@ -13,14 +13,16 @@ Agents support WebSocket connections for real-time, bi-directional communication
 
 Agents have several lifecycle hooks that fire at different points:
 
-| Hook                                          | When called                                               |
-| --------------------------------------------- | --------------------------------------------------------- |
-| `onStart(props?)`                             | Once when the agent first starts (before any connections) |
-| `onRequest(request)`                          | When an HTTP request is received (non-WebSocket)          |
-| `onConnect(connection, ctx)`                  | When a new WebSocket connection is established            |
-| `onMessage(connection, message)`              | When a WebSocket message is received                      |
-| `onClose(connection, code, reason, wasClean)` | When a WebSocket connection closes                        |
-| `onError(connection, error)`                  | When a WebSocket error occurs                             |
+| Hook                                          | When called                                                          |
+| --------------------------------------------- | -------------------------------------------------------------------- |
+| `onStart(props?)`                             | Once when the agent first starts (before any connections)            |
+| `onRequest(request)`                          | When an HTTP request is received (non-WebSocket)                     |
+| `onConnect(connection, ctx)`                  | When a new WebSocket connection is established                       |
+| `onMessage(connection, message)`              | When a WebSocket message is received                                 |
+| `onClose(connection, code, reason, wasClean)` | When a WebSocket connection closes                                   |
+| `onError(connection, error)`                  | When a WebSocket error occurs on a connection                        |
+| `onError(error)`                              | When a server-level error occurs (not tied to a specific connection) |
+| `shouldSendProtocolMessages(connection, ctx)` | Whether to send protocol messages (identity, state, MCP) to this connection. Default: `true` |
 
 ### `onStart`
 
@@ -90,13 +92,16 @@ export class ChatAgent extends Agent {
 
 Each connected client has a unique `Connection` object:
 
-| Property/Method         | Type     | Description                           |
-| ----------------------- | -------- | ------------------------------------- |
-| `id`                    | `string` | Unique identifier for this connection |
-| `state`                 | `State`  | Per-connection state object           |
-| `setState(state)`       | `void`   | Update connection state               |
-| `send(message)`         | `void`   | Send message to this client           |
-| `close(code?, reason?)` | `void`   | Close the connection                  |
+| Property/Method         | Type              | Description                                                      |
+| ----------------------- | ----------------- | ---------------------------------------------------------------- |
+| `id`                    | `string`          | Unique identifier for this connection                            |
+| `uri`                   | `string \| null`  | URL of the original WebSocket upgrade request. Persists across hibernation |
+| `state`                 | `State`           | Per-connection state object                                      |
+| `setState(state)`       | `void`            | Update connection state                                          |
+| `send(message)`         | `void`            | Send message to this client                                      |
+| `close(code?, reason?)` | `void`            | Close the connection                                             |
+| `tags`                  | `readonly string[]` | Tags assigned via `getConnectionTags`. Always includes the connection ID as the first tag |
+| `server`                | `string`          | The agent instance name (same as `this.name` on the Agent)       |
 
 ### Per-connection state
 
@@ -210,12 +215,14 @@ export class ChatAgent extends Agent {
 
 ### Connection management methods
 
-| Method              | Signature                                 | Description                            |
-| ------------------- | ----------------------------------------- | -------------------------------------- |
-| `getConnections`    | `(tag?: string) => Iterable<Connection>`  | Get all connections, optionally by tag |
-| `getConnection`     | `(id: string) => Connection \| undefined` | Get connection by ID                   |
-| `getConnectionTags` | `(connection, ctx) => string[]`           | Override to tag connections            |
-| `broadcast`         | `(message, without?: string[]) => void`   | Send to all connections                |
+| Method                         | Signature                                 | Description                                                                        |
+| ------------------------------ | ----------------------------------------- | ---------------------------------------------------------------------------------- |
+| `getConnections`               | `(tag?: string) => Iterable<Connection>`  | Get all connections, optionally by tag                                             |
+| `getConnection`                | `(id: string) => Connection \| undefined` | Get connection by ID                                                               |
+| `getConnectionTags`            | `(connection, ctx) => string[]`           | Override to tag connections                                                        |
+| `broadcast`                    | `(message, without?: string[]) => void`   | Send to all connections                                                            |
+| `isConnectionReadonly`         | `(connection) => boolean`                 | Check if a connection is [readonly](/agents/api-reference/readonly-connections/)    |
+| `isConnectionProtocolEnabled`  | `(connection) => boolean`                 | Check if protocol messages are enabled for this connection                         |
 
 ## Handling binary data
 
@@ -250,15 +257,25 @@ Agents automatically send JSON text frames (identity, state, MCP servers) to eve
 
 ## Error and close handling
 
-Handle connection errors and disconnections:
+Handle connection errors and disconnections. The `onError` method has two overloads — one for WebSocket connection errors and one for server-level errors:
 
 <TypeScriptExample>
 
 ```ts
 export class ChatAgent extends Agent {
-	async onError(connection: Connection, error: unknown) {
-		console.error(`Connection ${connection.id} error:`, error);
-		// Clean up any resources for this connection
+	// WebSocket connection error
+	onError(connection: Connection, error: unknown): void;
+	// Server-level error (not tied to a specific connection)
+	onError(error: unknown): void;
+	onError(connectionOrError: Connection | unknown, error?: unknown) {
+		if (error) {
+			console.error(
+				`Connection ${(connectionOrError as Connection).id} error:`,
+				error,
+			);
+		} else {
+			console.error("Server error:", connectionOrError);
+		}
 	}
 
 	async onClose(
@@ -269,7 +286,6 @@ export class ChatAgent extends Agent {
 	) {
 		console.log(`Connection ${connection.id} closed: ${code} ${reason}`);
 
-		// Notify other clients
 		this.broadcast(
 			JSON.stringify({
 				event: "user-left",
@@ -281,6 +297,8 @@ export class ChatAgent extends Agent {
 ```
 
 </TypeScriptExample>
+
+The default `onError` implementation logs the error and rethrows it. Override it to add custom error handling, reporting, or recovery logic.
 
 ## Message types
 
@@ -488,6 +506,43 @@ export class ChatRoom extends Agent {
 ```
 
 </TypeScriptExample>
+
+## Suppressing protocol messages
+
+By default, agents send JSON text frames (identity, state sync, MCP server lists) to every connection. Override `shouldSendProtocolMessages` to suppress them for specific connections — for example, binary-only clients that cannot handle JSON text frames:
+
+<TypeScriptExample>
+
+```ts
+export class IoTAgent extends Agent {
+	shouldSendProtocolMessages(
+		connection: Connection,
+		ctx: ConnectionContext,
+	): boolean {
+		const url = new URL(ctx.request.url);
+		return url.searchParams.get("protocol") !== "binary";
+	}
+}
+```
+
+</TypeScriptExample>
+
+When this returns `false`, the connection does not receive identity, state, or MCP server list frames — neither on connect nor via broadcasts. The connection can still send and receive regular messages, use RPC, and participate in all non-protocol communication.
+
+Use `isConnectionProtocolEnabled(connection)` to check the status of any connection at runtime.
+
+## Agent properties
+
+These properties are available on `this` inside any Agent method:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `this.name` | `string` | The instance name of this agent |
+| `this.state` | `State` | The current agent state (lazy-loaded from SQLite) |
+| `this.env` | `Env` | Worker environment bindings |
+| `this.ctx` | `DurableObjectState` | Durable Object context (storage, alarms, etc.) |
+| `this.sql` | template tag | SQL template tag for executing queries against the agent's SQLite storage |
+| `this.mcp` | `MCPClientManager` | MCP client manager for connecting to external MCP servers |
 
 ## Connecting from clients
 

--- a/src/content/docs/agents/concepts/agent-class.mdx
+++ b/src/content/docs/agents/concepts/agent-class.mdx
@@ -457,6 +457,55 @@ You can safely call `this.destroy()` from within a scheduled task callback. The 
 
 :::
 
+### `static options`
+
+Configure agent behavior by overriding `static options` on your class. All fields are optional — defaults are applied at runtime.
+
+```ts
+export class MyAgent extends Agent {
+	static options = {
+		hibernate: true,
+		sendIdentityOnConnect: false,
+		retry: { maxAttempts: 5, baseDelayMs: 200, maxDelayMs: 5000 },
+	};
+}
+```
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `hibernate` | `boolean` | `true` | Whether the agent hibernates when inactive. WebSocket connections stay open while the DO sleeps |
+| `sendIdentityOnConnect` | `boolean` | `true` | Send identity (agent name, instance name) to clients on WebSocket connect. Set to `false` to hide sensitive instance names |
+| `hungScheduleTimeoutSeconds` | `number` | `30` | Timeout before a running interval schedule is considered hung and force-reset. Increase for long-running callbacks |
+| `keepAliveIntervalMs` | `number` | `30000` | Interval in milliseconds for `keepAlive()` alarm heartbeats. Lower values mean faster recovery but more frequent alarms |
+| `retry` | `RetryOptions` | `{ maxAttempts: 3, baseDelayMs: 100, maxDelayMs: 3000 }` | Default retry options for `schedule()`, `queue()`, and `this.retry()`. Per-task options override these defaults |
+
+### `this.keepAlive()` and `this.keepAliveWhile()`
+
+Durable Objects are evicted after a period of inactivity (typically 70–140 seconds with no incoming requests, WebSocket messages, or alarms). During long-running operations — streaming LLM responses, waiting on external APIs, running multi-step computations — the agent can be evicted mid-flight.
+
+`keepAlive()` creates an alarm heartbeat that prevents eviction. `keepAliveWhile()` wraps an async function and guarantees cleanup.
+
+```ts
+class MyAgent extends Agent {
+	async handleLongTask() {
+		// Option 1: manual dispose
+		const dispose = await this.keepAlive();
+		try {
+			await longRunningComputation();
+		} finally {
+			dispose();
+		}
+
+		// Option 2: automatic cleanup (recommended)
+		const result = await this.keepAliveWhile(async () => {
+			return await longRunningComputation();
+		});
+	}
+}
+```
+
+`AIChatAgent` uses `keepAliveWhile` internally to keep the agent alive during streaming LLM responses. For more details, refer to [Schedule tasks — Keeping the agent alive](/agents/api-reference/schedule-tasks/#keeping-the-agent-alive).
+
 ### Routing
 
 The `Agent` class re-exports the [addressing helpers](#addressing) as `getAgentByName` and `routeAgentRequest`.

--- a/src/content/docs/agents/concepts/human-in-the-loop.mdx
+++ b/src/content/docs/agents/concepts/human-in-the-loop.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 ---
 
-import { LinkCard } from "~/components";
+import { TypeScriptExample, LinkCard } from "~/components";
 
 Human-in-the-Loop (HITL) workflows integrate human judgment and oversight into automated processes. These workflows pause at critical points for human review, validation, or decision-making before proceeding.
 
@@ -26,29 +26,185 @@ Human-in-the-Loop (HITL) workflows integrate human judgment and oversight into a
 | AI tool execution   | Confirming tool calls before running |
 | Access control      | Granting permissions, role changes   |
 
-## Patterns for human-in-the-loop
+## Choosing an approach
 
-Cloudflare provides two main patterns for implementing human-in-the-loop:
+The Agents SDK provides five patterns for human-in-the-loop. Choose based on your architecture:
 
-### Workflow approval
+| Use Case | Pattern | Best For |
+| --- | --- | --- |
+| Long-running workflows | Workflow Approval | Multi-step processes, durable approval gates that can wait hours or weeks |
+| AIChatAgent tools | `needsApproval` | Chat-based tool calls with server-side approval before execution |
+| Client-side tools | `onToolCall` | Tools that need browser APIs or user interaction before execution |
+| MCP servers | Elicitation | MCP tools requesting structured user input during execution |
+| Simple confirmations | State + WebSocket | Lightweight approval flows without AI chat or workflows |
+
+### Decision tree
+
+```
+Is this part of a multi-step workflow?
+├── Yes → Use Workflow Approval (waitForApproval)
+└── No → Are you building an MCP server?
+         ├── Yes → Use MCP Elicitation (elicitInput)
+         └── No → Is this an AI chat interaction?
+                  ├── Yes → Does the tool need browser APIs?
+                  │        ├── Yes → Use onToolCall (client-side execution)
+                  │        └── No → Use needsApproval (server-side with approval)
+                  └── No → Use State + WebSocket for simple confirmations
+```
+
+## Pattern 1: Workflow approval
 
 For durable, multi-step processes with approval gates that can wait hours, days, or weeks. Use [Cloudflare Workflows](/workflows/) with the `waitForApproval()` method.
 
 **Key APIs:**
 
 - `waitForApproval(step, { timeout })` — Pause workflow until approved
-- `approveWorkflow(instanceId, options)` — Approve a waiting workflow
-- `rejectWorkflow(instanceId, options)` — Reject a waiting workflow
+- `approveWorkflow(workflowId, { reason?, metadata? })` — Approve a waiting workflow
+- `rejectWorkflow(workflowId, { reason? })` — Reject a waiting workflow
 
 **Best for:** Expense approvals, content publishing pipelines, data export requests
 
-### MCP elicitation
+## Pattern 2: `needsApproval` (AI chat tools)
 
-For MCP servers that need to request additional structured input from users during tool execution. The MCP client renders a form based on your JSON Schema.
+For `AIChatAgent` tools that should pause for user confirmation before executing. Define `needsApproval` on the tool — it can be a boolean or an async predicate based on the tool arguments:
 
-**Key API:**
+<TypeScriptExample>
 
-- `elicitInput(options, context)` — Request structured input from the user
+```ts
+tools: {
+	processPayment: tool({
+		description: "Process a payment",
+		inputSchema: z.object({
+			amount: z.number(),
+			recipient: z.string(),
+		}),
+		needsApproval: async ({ amount }) => amount > 100,
+		execute: async ({ amount, recipient }) => charge(amount, recipient),
+	});
+}
+```
+
+</TypeScriptExample>
+
+On the client, render pending approvals from message parts and call `addToolApprovalResponse`:
+
+<TypeScriptExample>
+
+```ts
+const { messages, addToolApprovalResponse } = useAgentChat({ agent });
+
+{
+	messages.map((msg) =>
+		msg.parts
+			.filter(
+				(part) => part.type === "tool" && part.state === "approval-required",
+			)
+			.map((part) => (
+				<div key={part.toolCallId}>
+					<p>
+						Approve {part.toolName}?
+					</p>
+					<button
+						onClick={() =>
+							addToolApprovalResponse({ id: part.toolCallId, approved: true })
+						}
+					>
+						Approve
+					</button>
+					<button
+						onClick={() =>
+							addToolApprovalResponse({
+								id: part.toolCallId,
+								approved: false,
+							})
+						}
+					>
+						Reject
+					</button>
+				</div>
+			)),
+	);
+}
+```
+
+</TypeScriptExample>
+
+For custom denial messages, use `addToolOutput` with `state: "output-error"` instead of `addToolApprovalResponse`:
+
+<TypeScriptExample>
+
+```ts
+addToolOutput({
+	toolCallId: part.toolCallId,
+	state: "output-error",
+	errorText: "User declined: insufficient budget for this quarter",
+});
+```
+
+</TypeScriptExample>
+
+## Pattern 3: `onToolCall` (client-side execution)
+
+For tools that need browser APIs (geolocation, clipboard, camera) or user interaction before returning a result. Define the tool on the server without `execute`, then handle it on the client:
+
+<TypeScriptExample>
+
+```ts
+const { messages, sendMessage } = useAgentChat({
+	agent,
+	onToolCall: async ({ toolCall, addToolOutput }) => {
+		if (toolCall.toolName === "getLocation") {
+			const pos = await new Promise((resolve, reject) =>
+				navigator.geolocation.getCurrentPosition(resolve, reject),
+			);
+			addToolOutput({
+				toolCallId: toolCall.toolCallId,
+				output: { lat: pos.coords.latitude, lng: pos.coords.longitude },
+			});
+		}
+	},
+});
+```
+
+</TypeScriptExample>
+
+When `autoContinueAfterToolResult` is `true` (the default), the conversation automatically continues after the client provides the tool output.
+
+## Pattern 4: MCP elicitation
+
+For MCP servers that need to request additional structured input from users during tool execution. The MCP client renders a form based on your JSON Schema:
+
+<TypeScriptExample>
+
+```ts
+export class MyMcpAgent extends McpAgent {
+	async init() {
+		this.server.server.setRequestHandler(
+			CallToolRequestSchema,
+			async (request, extra) => {
+				const result = await this.server.server.elicitInput({
+					message: "Please confirm the transfer details",
+					requestedSchema: {
+						type: "object",
+						properties: {
+							confirmed: { type: "boolean", description: "Confirm transfer?" },
+							notes: { type: "string", description: "Optional notes" },
+						},
+						required: ["confirmed"],
+					},
+				});
+
+				if (result.action === "accept" && result.content?.confirmed) {
+					return { content: [{ type: "text", text: "Transfer confirmed" }] };
+				}
+				return { content: [{ type: "text", text: "Transfer cancelled" }] };
+			},
+		);
+	}
+}
+```
+
+</TypeScriptExample>
 
 **Best for:** Interactive tool confirmations, gathering additional parameters mid-execution
 
@@ -65,28 +221,33 @@ In a workflow-based approval:
 5. When approved, the workflow resumes with the approval metadata
 6. If rejected or timed out, the workflow handles the rejection appropriately
 
+## Timeouts and escalation
+
+Set timeouts to prevent workflows from waiting indefinitely:
+
+<TypeScriptExample>
+
+```ts
+const approval = await this.waitForApproval(step, {
+	timeout: "7 days",
+});
+```
+
+</TypeScriptExample>
+
+Use [scheduling](/agents/api-reference/schedule-tasks/) for escalation:
+
+<TypeScriptExample>
+
+```ts
+await this.schedule(86400, "sendApprovalReminder", { workflowId });
+
+await this.schedule(604800, "escalateToManager", { workflowId });
+```
+
+</TypeScriptExample>
+
 ## Best practices
-
-### Long-term state persistence
-
-Human review processes do not operate on predictable timelines. A reviewer might need days or weeks to make a decision, especially for complex cases requiring additional investigation or multiple approvals. Your system needs to maintain perfect state consistency throughout this period, including:
-
-- The original request and context
-- All intermediate decisions and actions
-- Any partial progress or temporary states
-- Review history and feedback
-
-:::note[Tip]
-[Durable Objects](/durable-objects/) provide an ideal solution for managing state in Human-in-the-Loop workflows, offering persistent compute instances that maintain state for hours, weeks, or months.
-:::
-
-### Timeouts and escalation
-
-Set timeouts to prevent workflows from waiting indefinitely. Use [scheduling](/agents/api-reference/schedule-tasks/) to:
-
-- Send reminders after a period of inactivity
-- Escalate to managers or alternative approvers
-- Auto-reject or auto-approve based on business rules
 
 ### Audit trails
 
@@ -97,9 +258,17 @@ Maintain immutable audit logs of all approval decisions using the [SQL API](/age
 - The reason or justification
 - Any relevant metadata
 
+### Long-term state persistence
+
+Human review processes do not operate on predictable timelines. A reviewer might need days or weeks to make a decision. Your system needs to maintain state consistency throughout this period — the original request, intermediate decisions, partial progress, and review history.
+
+:::note[Tip]
+[Durable Objects](/durable-objects/) provide persistent compute instances that maintain state for hours, weeks, or months — ideal for long-lived approval flows.
+:::
+
 ### Continuous improvement
 
-Human reviewers play a crucial role in evaluating and improving LLM performance. Implement a systematic evaluation process where human feedback is collected not just on the final output, but on the LLM's decision-making process:
+Human reviewers play a crucial role in evaluating and improving LLM performance:
 
 - **Decision quality assessment**: Have reviewers evaluate the LLM's reasoning process and decision points.
 - **Edge case identification**: Use human expertise to identify scenarios where performance could be improved.
@@ -107,21 +276,20 @@ Human reviewers play a crucial role in evaluating and improving LLM performance.
 
 ### Error handling and recovery
 
-Robust error handling is essential for maintaining workflow integrity. Your system should gracefully handle:
-
-- Reviewer unavailability
-- System outages
-- Conflicting reviews
-- Timeout expiration
-
-Implement clear escalation paths for exceptional cases and automatic checkpointing that allows workflows to resume from the last stable state after any interruption.
+Your system should gracefully handle reviewer unavailability, system outages, conflicting reviews, and timeout expiration. Implement clear escalation paths for exceptional cases and automatic checkpointing that allows workflows to resume from the last stable state after any interruption.
 
 ## Next steps
 
 <LinkCard
 	title="Human-in-the-loop patterns"
 	href="/agents/guides/human-in-the-loop/"
-	description="Implementation examples for approval flows."
+	description="Full implementation examples with workflows and chat tools."
+/>
+
+<LinkCard
+	title="Chat agents — Tool approval"
+	href="/agents/api-reference/chat-agents/#tool-approval-human-in-the-loop"
+	description="needsApproval and addToolApprovalResponse reference."
 />
 
 <LinkCard

--- a/src/content/docs/agents/getting-started/add-to-existing-project.mdx
+++ b/src/content/docs/agents/getting-started/add-to-existing-project.mdx
@@ -101,7 +101,51 @@ Add the Durable Object binding and migration:
 - `new_sqlite_classes` enables SQLite storage for state persistence
 - `nodejs_compat` flag is required for the agents package
 
-## 4. Export the Agent class
+## 4. Configure TypeScript and Vite
+
+If you use `@callable()` decorators (as in the example above), you need two build configurations.
+
+**tsconfig.json** — extend `agents/tsconfig` (or set `"target": "ES2021"` manually):
+
+```json
+{
+	"extends": "agents/tsconfig"
+}
+```
+
+If you have an existing `tsconfig.json` with custom settings, you can extend and override:
+
+```json
+{
+	"extends": "agents/tsconfig",
+	"compilerOptions": {
+		"paths": { "~/*": ["./src/*"] }
+	}
+}
+```
+
+**vite.config.ts** — add the `agents()` plugin (handles TC39 decorator transforms for Vite 8):
+
+<TypeScriptExample>
+
+```ts
+import agents from "agents/vite";
+
+export default defineConfig({
+	plugins: [
+		agents(),
+		// ... your existing plugins
+	],
+});
+```
+
+</TypeScriptExample>
+
+If your project does not use Vite, the `tsconfig.json` change alone is sufficient — your bundler must support TC39 decorators (stage 3, version `2023-11`).
+
+For more details, refer to the [TypeScript configuration](/agents/api-reference/configuration/#typescript-configuration) and [Vite configuration](/agents/api-reference/configuration/#vite-configuration) reference.
+
+## 5. Export the Agent class
 
 Your agent class must be exported from your main entry point. Update your `src/index.ts`:
 
@@ -119,7 +163,7 @@ export default {
 
 </TypeScriptExample>
 
-## 5. Wire up routing
+## 6. Wire up routing
 
 Choose the approach that matches your project structure:
 
@@ -212,7 +256,7 @@ Configure assets in the Wrangler configuration file:
 
 </WranglerConfig>
 
-## 6. Generate TypeScript types
+## 7. Generate TypeScript types
 
 Do not hand-write your `Env` interface. Run [`wrangler types`](/workers/wrangler/commands/general/#types) to generate a type definition file that matches your Wrangler configuration. This catches mismatches between your config and code at compile time instead of at deploy time.
 
@@ -226,7 +270,7 @@ This creates a type definition file with all your bindings typed, including your
 
 Refer to [Configuration](/agents/api-reference/configuration/#generating-types) for more details on type generation.
 
-## 7. Connect from the frontend
+## 8. Connect from the frontend
 
 ### React
 

--- a/src/content/docs/agents/getting-started/quick-start.mdx
+++ b/src/content/docs/agents/getting-started/quick-start.mdx
@@ -40,6 +40,31 @@ This creates a project with:
 - `src/server.ts` — Your agent code
 - `src/client.tsx` — React frontend
 - `wrangler.jsonc` — Cloudflare configuration
+- `tsconfig.json` — Extends `agents/tsconfig` for correct decorator and module settings
+- `vite.config.ts` — Includes the `agents/vite` plugin for decorator support
+
+The starter template includes two important SDK integrations. If you are setting up a project manually, add both:
+
+**tsconfig.json** — extends `agents/tsconfig`, which sets `target: "ES2021"` and other recommended options:
+
+```json
+{
+	"extends": "agents/tsconfig"
+}
+```
+
+**vite.config.ts** — includes the `agents()` plugin, which handles TC39 decorator transforms (required for `@callable()` in Vite 8):
+
+```ts
+import { cloudflare } from "@cloudflare/vite-plugin";
+import react from "@vitejs/plugin-react";
+import agents from "agents/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+	plugins: [agents(), react(), cloudflare()],
+});
+```
 
 Open [http://localhost:5173](http://localhost:5173) to see your agent in action.
 

--- a/src/content/docs/agents/guides/push-notifications.mdx
+++ b/src/content/docs/agents/guides/push-notifications.mdx
@@ -1,0 +1,418 @@
+---
+title: Push notifications
+pcx_content_type: how-to
+sidebar:
+  order: 7
+---
+
+import { TypeScriptExample, LinkCard } from "~/components";
+
+Send browser push notifications from your agent — even when the user has closed the tab. By combining the agent's persistent state (for storing push subscriptions), scheduling (for timed delivery), and the [Web Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API), you can reach users who are completely offline.
+
+## How it works
+
+```
+Browser                              Agent (Durable Object)
+───────                              ──────────────────────
+1. Register service worker
+2. Subscribe to push (VAPID key)
+3. Send subscription to agent ──────► Store in this.state
+4. Create reminder ─────────────────► this.schedule(delay, "sendReminder", payload)
+
+   ... user closes tab ...
+
+5.                                    Alarm fires → sendReminder()
+                                      web-push sends encrypted payload
+                                              │
+6. Service worker receives push ◄─────────────┘
+7. showNotification()
+```
+
+The agent stores push subscriptions durably in its state and uses `this.schedule()` to fire notifications at the right time. When the alarm triggers, the agent calls the push service endpoint using the [`web-push`](https://www.npmjs.com/package/web-push) library. The browser's service worker receives the push event and displays a native notification.
+
+## Prerequisites
+
+### Generate VAPID keys
+
+Web Push requires a VAPID (Voluntary Application Server Identification) key pair. Generate one:
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Store the keys in a `.env` file for local development:
+
+```
+VAPID_PUBLIC_KEY=BGxK...
+VAPID_PRIVATE_KEY=abc1...
+VAPID_SUBJECT=mailto:you@example.com
+```
+
+For production, use `wrangler secret put`:
+
+```bash
+wrangler secret put VAPID_PUBLIC_KEY
+wrangler secret put VAPID_PRIVATE_KEY
+wrangler secret put VAPID_SUBJECT
+```
+
+## Create the agent
+
+The agent has three responsibilities: store push subscriptions, schedule reminders, and send notifications when alarms fire.
+
+<TypeScriptExample>
+
+```ts
+import { Agent, callable, routeAgentRequest } from "agents";
+import webpush from "web-push";
+
+type Subscription = {
+	endpoint: string;
+	expirationTime: number | null;
+	keys: {
+		p256dh: string;
+		auth: string;
+	};
+};
+
+type Reminder = {
+	id: string;
+	message: string;
+	scheduledAt: number;
+	sent: boolean;
+};
+
+type ReminderAgentState = {
+	subscriptions: Subscription[];
+	reminders: Reminder[];
+};
+
+export class ReminderAgent extends Agent<Env, ReminderAgentState> {
+	initialState: ReminderAgentState = {
+		subscriptions: [],
+		reminders: [],
+	};
+
+	@callable()
+	getVapidPublicKey(): string {
+		return this.env.VAPID_PUBLIC_KEY;
+	}
+
+	@callable()
+	async subscribe(subscription: Subscription): Promise<{ ok: boolean }> {
+		const exists = this.state.subscriptions.some(
+			(s) => s.endpoint === subscription.endpoint,
+		);
+		if (!exists) {
+			this.setState({
+				...this.state,
+				subscriptions: [...this.state.subscriptions, subscription],
+			});
+		}
+		return { ok: true };
+	}
+
+	@callable()
+	async unsubscribe(endpoint: string): Promise<{ ok: boolean }> {
+		this.setState({
+			...this.state,
+			subscriptions: this.state.subscriptions.filter(
+				(s) => s.endpoint !== endpoint,
+			),
+		});
+		return { ok: true };
+	}
+
+	@callable()
+	async createReminder(
+		message: string,
+		delaySeconds: number,
+	): Promise<Reminder> {
+		const id = crypto.randomUUID();
+		const scheduledAt = Date.now() + delaySeconds * 1000;
+		const reminder: Reminder = { id, message, scheduledAt, sent: false };
+
+		this.setState({
+			...this.state,
+			reminders: [...this.state.reminders, reminder],
+		});
+
+		await this.schedule(delaySeconds, "sendReminder", { id, message });
+		return reminder;
+	}
+
+	async sendReminder(payload: { id: string; message: string }) {
+		webpush.setVapidDetails(
+			this.env.VAPID_SUBJECT,
+			this.env.VAPID_PUBLIC_KEY,
+			this.env.VAPID_PRIVATE_KEY,
+		);
+
+		const deadEndpoints: string[] = [];
+
+		await Promise.all(
+			this.state.subscriptions.map(async (sub) => {
+				try {
+					await webpush.sendNotification(
+						sub,
+						JSON.stringify({
+							title: "Reminder",
+							body: payload.message,
+							tag: `reminder-${payload.id}`,
+						}),
+					);
+				} catch (err: unknown) {
+					const statusCode =
+						err instanceof webpush.WebPushError ? err.statusCode : 0;
+					if (statusCode === 404 || statusCode === 410) {
+						deadEndpoints.push(sub.endpoint);
+					}
+				}
+			}),
+		);
+
+		if (deadEndpoints.length > 0) {
+			this.setState({
+				...this.state,
+				subscriptions: this.state.subscriptions.filter(
+					(s) => !deadEndpoints.includes(s.endpoint),
+				),
+			});
+		}
+
+		this.setState({
+			...this.state,
+			reminders: this.state.reminders.map((r) =>
+				r.id === payload.id ? { ...r, sent: true } : r,
+			),
+		});
+
+		this.broadcast(
+			JSON.stringify({
+				type: "reminder_sent",
+				id: payload.id,
+				timestamp: Date.now(),
+			}),
+		);
+	}
+}
+
+export default {
+	async fetch(request: Request, env: Env) {
+		return (
+			(await routeAgentRequest(request, env)) ??
+			new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+The `sendReminder` callback handles three things: delivering the push notification via the `web-push` library, cleaning up dead subscriptions (the push service returns 404 or 410 when a subscription is no longer valid), and broadcasting to any connected clients so the UI updates in real time.
+
+## Set up the service worker
+
+The service worker runs in the browser and receives push events even when no tabs are open. Place this file at `public/sw.js` so it is served from the root of your domain:
+
+```js
+self.addEventListener("push", (event) => {
+	if (!event.data) return;
+
+	const data = event.data.json();
+
+	event.waitUntil(
+		self.registration.showNotification(data.title || "Notification", {
+			body: data.body || "",
+			icon: data.icon || "/favicon.ico",
+			tag: data.tag,
+			data: data.data,
+		}),
+	);
+});
+
+self.addEventListener("notificationclick", (event) => {
+	event.notification.close();
+
+	event.waitUntil(
+		self.clients.matchAll({ type: "window" }).then((windowClients) => {
+			for (const client of windowClients) {
+				if (
+					client.url.includes(self.location.origin) &&
+					"focus" in client
+				) {
+					return client.focus();
+				}
+			}
+			return self.clients.openWindow("/");
+		}),
+	);
+});
+```
+
+The `push` event handler parses the JSON payload and displays a native notification. The `notificationclick` handler focuses an existing tab or opens a new one when the user taps the notification.
+
+## Build the client
+
+The client needs to: register the service worker, request notification permission, subscribe to push using the VAPID public key, and send the subscription to the agent.
+
+### Register the service worker
+
+<TypeScriptExample>
+
+```ts
+useEffect(() => {
+	if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+		return;
+	}
+	navigator.serviceWorker.register("/sw.js");
+}, []);
+```
+
+</TypeScriptExample>
+
+### Subscribe to push
+
+Fetch the VAPID public key from the agent, then subscribe through the Push API:
+
+<TypeScriptExample>
+
+```ts
+function base64urlToUint8Array(base64url: string): Uint8Array {
+	const padded = base64url + "=".repeat((4 - (base64url.length % 4)) % 4);
+	const binary = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+	return bytes;
+}
+
+async function subscribeToPush(
+	agent: ReturnType<typeof useAgent>,
+) {
+	const permission = await Notification.requestPermission();
+	if (permission !== "granted") return;
+
+	const vapidPublicKey = await agent.call("getVapidPublicKey");
+	const reg = await navigator.serviceWorker.ready;
+	const subscription = await reg.pushManager.subscribe({
+		userVisibleOnly: true,
+		applicationServerKey: base64urlToUint8Array(vapidPublicKey).buffer,
+	});
+
+	const subJson = subscription.toJSON();
+	await agent.call("subscribe", [
+		{
+			endpoint: subJson.endpoint,
+			expirationTime: subJson.expirationTime ?? null,
+			keys: subJson.keys,
+		},
+	]);
+}
+```
+
+</TypeScriptExample>
+
+### Create reminders
+
+With the subscription stored, creating a reminder is a single RPC call. The agent handles scheduling and delivery:
+
+<TypeScriptExample>
+
+```ts
+await agent.call("createReminder", ["Check the oven", 300]);
+```
+
+</TypeScriptExample>
+
+The agent schedules an alarm for 300 seconds (5 minutes). When it fires, the push notification arrives — even if the user closed the tab minutes ago.
+
+## Configuration
+
+### wrangler.jsonc
+
+```jsonc
+{
+	"name": "push-notifications",
+	"compatibility_date": "2026-01-28",
+	"compatibility_flags": ["nodejs_compat"],
+	"main": "src/server.ts",
+	"durable_objects": {
+		"bindings": [
+			{ "name": "ReminderAgent", "class_name": "ReminderAgent" },
+		],
+	},
+	"migrations": [{ "tag": "v1", "new_sqlite_classes": ["ReminderAgent"] }],
+	"assets": {
+		"not_found_handling": "single-page-application",
+	},
+}
+```
+
+The `nodejs_compat` compatibility flag is required for the `web-push` library.
+
+### Dependencies
+
+```bash
+npm install agents web-push
+```
+
+## Production considerations
+
+### Subscription expiry
+
+Push subscriptions can expire or be revoked by the user. Always handle 404 and 410 responses from the push service by removing the dead subscription from state, as shown in the `sendReminder` example above.
+
+### Per-user vs shared agents
+
+For most applications, use one agent per user (using the user ID as the agent name). This isolates each user's subscriptions and reminders. For broadcast-style notifications (same message to many users), a shared agent can store all subscriptions, but be aware of the state size as the subscription list grows.
+
+### Combining push with WebSocket broadcast
+
+Use `this.broadcast()` for clients that are currently connected (instant, no push service roundtrip) and Web Push for clients that are offline. The `sendReminder` example above does both — connected clients get a real-time WebSocket message, and offline clients get a push notification.
+
+### Multiple devices
+
+A single user may subscribe from multiple browsers or devices. The agent stores each subscription separately, and `sendReminder` iterates over all of them. Each device receives its own push notification.
+
+### Retry on failure
+
+If the push service returns a 5xx error (temporary failure), you can retry using `this.schedule()` with a short delay:
+
+<TypeScriptExample>
+
+```ts
+try {
+	await webpush.sendNotification(sub, payload);
+} catch (err: unknown) {
+	const statusCode =
+		err instanceof webpush.WebPushError ? err.statusCode : 0;
+	if (statusCode >= 500) {
+		await this.schedule(60, "retrySendNotification", {
+			endpoint: sub.endpoint,
+			payload,
+		});
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Next steps
+
+<LinkCard
+	title="Schedule tasks"
+	href="/agents/api-reference/schedule-tasks/"
+	description="Learn about scheduling and keepAlive for long-running operations."
+/>
+
+<LinkCard
+	title="Store and sync state"
+	href="/agents/api-reference/store-and-sync-state/"
+	description="Manage agent state for storing subscriptions."
+/>
+
+<LinkCard
+	title="Callable methods"
+	href="/agents/api-reference/callable-methods/"
+	description="Expose agent methods as RPC endpoints."
+/>


### PR DESCRIPTION
## Summary

Comprehensive documentation update to close gaps between the upstream `cloudflare/agents` SDK and the public-facing docs. Audited all commits from the last ~2 months and updated 12 pages.

Thanks to @whoiskatrin for the groundwork in #29219 — several of the fixes here (queue retry signature, SSRF blocklist correction, HITL expansion, websocket additions) were identified in that PR and are incorporated into this one.

### New pages

- **`guides/push-notifications.mdx`** — Full guide: VAPID keys, agent with subscription management, service worker, client subscribe flow, production considerations

### Updated pages

| File | What changed |
|------|-------------|
| `chat-agents.mdx` | Added `messageConcurrency`, `onChatResponse`, `sanitizeMessageForPersistence`, `saveMessages`/`persistMessages` (properly documented), turn lifecycle helpers (`waitUntilStable`, `hasPendingInteraction`, `resetTurnState`) |
| `schedule-tasks.mdx` | Added `schedule()` `idempotent` option, `scheduleEvery()` idempotency section, cron idempotency note, push-notifications cross-link |
| `queue-tasks.mdx` | Fixed `queue()` signature to include `options.retry`, added `retry` to `QueueItem` type, replaced manual re-queue example with built-in retry |
| `mcp-client-api.mdx` | Fixed SSRF blocklist (loopback **allowed** for local dev), added `MCPServerFilter` to `getAITools()`, documented `callbackHost` auto-derivation |
| `client-sdk.mdx` | Added readable `state` property on `useAgent`/`AgentClient` |
| `websockets.mdx` | Added `onError(error)` server-level overload, `shouldSendProtocolMessages` to lifecycle table, `Connection.uri`/`tags`/`server` properties, `isConnectionReadonly`/`isConnectionProtocolEnabled` to management table, "Suppressing protocol messages" section, "Agent properties" table |
| `agent-class.mdx` | Added `static options` table (`hibernate`, `sendIdentityOnConnect`, `hungScheduleTimeoutSeconds`, `keepAliveIntervalMs`, `retry`), `keepAlive()`/`keepAliveWhile()` section |
| `human-in-the-loop.mdx` | Expanded from 2 patterns to 5 with decision table + decision tree, added `needsApproval` server+client examples, `onToolCall` client-side pattern, MCP elicitation example, timeouts/escalation with code |
| `configuration.mdx` | Added "TypeScript configuration" (`agents/tsconfig`) and "Vite configuration" (`agents/vite`) sections |
| `callable-methods.mdx` | Updated troubleshooting: recommend `agents/vite` plugin + `agents/tsconfig` instead of manual `target` setting |
| `quick-start.mdx` | Added `tsconfig.json` and `vite.config.ts` to project file list with setup instructions |
| `add-to-existing-project.mdx` | Inserted step 4 "Configure TypeScript and Vite" with `agents/tsconfig` and `agents/vite` plugin |

## Test plan

- [ ] Verify all internal links resolve (especially new cross-links between configuration, callable-methods, and schedule-tasks)
- [ ] Verify code examples render correctly in preview
- [ ] Spot-check API signatures against current `agents` and `@cloudflare/ai-chat` source


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/29764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
