### PR TITLE
chore: anchor agents/ gitignore pattern to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist/
 distmd/
 distllms/
+
 # generated types
 .astro/
 
@@ -30,6 +31,7 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
 /test-results/
 /playwright-report/
 /blob-report/
@@ -50,4 +52,4 @@ CLAUDE.md
 .cursor/
 .github/prompts/
 .github/agents/
-agents/
+/agents/


### PR DESCRIPTION
### Summary

The `agents/` pattern in `.gitignore` was matching any directory named `agents/` at any depth in the repo, including `src/content/docs/agents/`. This was blocking edits to the Agents documentation pages.

Changed `agents/` to `/agents/` to anchor the pattern to the repo root, so it only ignores a top-level `agents/` directory (the intended rulesync output target) and no longer affects `src/content/docs/agents/`.

(Also added 2 unrelated newlines)