### PR TITLE
feat: custom prettier plugin to correctly format inline MDX components

### DIFF
--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,13 +1,24 @@
 // @ts-check
 /** @type {import("prettier").Config} */
 export default {
-	plugins: ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
+	plugins: [
+		"prettier-plugin-astro",
+		"prettier-plugin-tailwindcss",
+		"./plugins/prettier-plugin-mdx-inline/index.mjs",
+	],
 	useTabs: true,
 	overrides: [
 		{
 			files: "*.astro",
 			options: {
 				parser: "astro",
+			},
+		},
+		{
+			files: "*.mdx",
+			options: {
+				parser: "mdx-inline",
+				mdxInlineElements: "code,GlossaryTooltip",
 			},
 		},
 	],

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -14,6 +14,12 @@ export default {
 				parser: "astro",
 			},
 		},
+		// Prettier's MDX formatter wraps inline JSX elements (like <code> and
+		// <GlossaryTooltip>) onto new lines, which causes MDX v2+ to inject <p>
+		// tags inside them — breaking the rendered HTML. This custom plugin
+		// prevents that by keeping configured elements on a single line.
+		// This may become unnecessary once prettier adds MDX v3 support:
+		// https://github.com/prettier/prettier/issues/12209
 		{
 			files: "*.mdx",
 			options: {

--- a/plugins/prettier-plugin-mdx-inline/index.mjs
+++ b/plugins/prettier-plugin-mdx-inline/index.mjs
@@ -35,12 +35,22 @@
  */
 
 /**
+ * Extract the element name from the start of a JSX string.
+ * e.g., "<code>" → "code", "<GlossaryTooltip term="x">" → "GlossaryTooltip"
+ */
+function getElementName(value) {
+	const match = value.trim().match(/^<([a-zA-Z][a-zA-Z0-9]*)/);
+	return match ? match[1] : null;
+}
+
+/**
  * Collapse a multi-line JSX element value onto a single line.
  *
  * Handles:
  * - {" "} spacer expressions inserted by prettier
  * - Newlines with surrounding whitespace from indentation
  * - Multiple consecutive spaces from collapsing
+ * - Trailing content after the closing tag (e.g., in list items)
  *
  * Preserves:
  * - Attribute values (strings in the opening tag)
@@ -49,6 +59,9 @@
 function collapseInlineJsx(value) {
 	// Remove {" "} spacers — these are prettier artifacts for preserving spaces
 	let result = value.replace(/\{" "\}/g, " ");
+
+	const elementName = getElementName(result);
+	if (!elementName) return result;
 
 	// Find the end of the opening tag by tracking string context.
 	// We need to skip over attribute values that may contain '>' characters.
@@ -73,14 +86,16 @@ function collapseInlineJsx(value) {
 
 	if (openTagEnd === -1) return result;
 
-	// Find the closing tag at the end of the value
-	const closeTagMatch = result.match(/<\/[a-zA-Z][a-zA-Z0-9]*>\s*$/);
-	if (!closeTagMatch) return result;
+	// Find the matching closing tag — it may not be at the very end of the
+	// value if there is trailing content (e.g., in a list item where the
+	// description text follows the </code> within the same JSX node).
+	const closeTag = `</${elementName}>`;
+	const closeTagIndex = result.indexOf(closeTag, openTagEnd);
+	if (closeTagIndex === -1) return result;
 
-	const closeTagStart = closeTagMatch.index;
 	const openTag = result.substring(0, openTagEnd + 1);
-	const content = result.substring(openTagEnd + 1, closeTagStart);
-	const closeTag = closeTagMatch[0].trim();
+	const content = result.substring(openTagEnd + 1, closeTagIndex);
+	const trailing = result.substring(closeTagIndex + closeTag.length);
 
 	// Collapse whitespace in the content between tags
 	const collapsed = content
@@ -88,7 +103,7 @@ function collapseInlineJsx(value) {
 		.replace(/\s{2,}/g, " ") // multiple spaces → single space
 		.trim();
 
-	return openTag + collapsed + closeTag;
+	return openTag + collapsed + closeTag + trailing;
 }
 
 /**

--- a/plugins/prettier-plugin-mdx-inline/index.mjs
+++ b/plugins/prettier-plugin-mdx-inline/index.mjs
@@ -1,0 +1,173 @@
+/**
+ * prettier-plugin-mdx-inline
+ *
+ * Prevents prettier from reformatting specific JSX elements in MDX files.
+ *
+ * Problem: Prettier's MDX formatter treats standalone JSX elements (like
+ * `<code>`) as block-level and wraps their children
+ * onto new lines when they exceed printWidth. MDX v2+ then interprets those
+ * newlines as markdown paragraph boundaries, injecting <p> tags inside inline
+ * elements — producing broken HTML like `<code><p>...</p></code>`.
+ *
+ * Solution: This plugin intercepts the parsed MDX AST and converts matching
+ * JSX nodes to opaque HTML nodes that prettier outputs verbatim. It also
+ * collapses any existing multi-line formatting back to a single line.
+ *
+ * Configuration (.prettierrc.mjs):
+ *
+ *   export default {
+ *     plugins: ["./prettier-plugin-mdx-inline/index.mjs"],
+ *     overrides: [{
+ *       files: "*.mdx",
+ *       options: { parser: "mdx-inline" },
+ *     }],
+ *   };
+ *
+ * You must specify which elements to protect via `mdxInlineElements`:
+ *
+ *   overrides: [{
+ *     files: "*.mdx",
+ *     options: {
+ *       parser: "mdx-inline",
+ *       mdxInlineElements: "code,GlossaryTooltip",
+ *     },
+ *   }],
+ */
+
+/**
+ * Collapse a multi-line JSX element value onto a single line.
+ *
+ * Handles:
+ * - {" "} spacer expressions inserted by prettier
+ * - Newlines with surrounding whitespace from indentation
+ * - Multiple consecutive spaces from collapsing
+ *
+ * Preserves:
+ * - Attribute values (strings in the opening tag)
+ * - Self-closing tags within content (e.g., <Type text="..." />)
+ */
+function collapseInlineJsx(value) {
+	// Remove {" "} spacers — these are prettier artifacts for preserving spaces
+	let result = value.replace(/\{" "\}/g, " ");
+
+	// Find the end of the opening tag by tracking string context.
+	// We need to skip over attribute values that may contain '>' characters.
+	let inString = false;
+	let stringChar = "";
+	let openTagEnd = -1;
+
+	for (let i = 0; i < result.length; i++) {
+		const ch = result[i];
+		if (inString) {
+			if (ch === stringChar && result[i - 1] !== "\\") {
+				inString = false;
+			}
+		} else if (ch === '"' || ch === "'") {
+			inString = true;
+			stringChar = ch;
+		} else if (ch === ">") {
+			openTagEnd = i;
+			break;
+		}
+	}
+
+	if (openTagEnd === -1) return result;
+
+	// Find the closing tag at the end of the value
+	const closeTagMatch = result.match(/<\/[a-zA-Z][a-zA-Z0-9]*>\s*$/);
+	if (!closeTagMatch) return result;
+
+	const closeTagStart = closeTagMatch.index;
+	const openTag = result.substring(0, openTagEnd + 1);
+	const content = result.substring(openTagEnd + 1, closeTagStart);
+	const closeTag = closeTagMatch[0].trim();
+
+	// Collapse whitespace in the content between tags
+	const collapsed = content
+		.replace(/\n\s*/g, " ") // newlines + indentation → single space
+		.replace(/\s{2,}/g, " ") // multiple spaces → single space
+		.trim();
+
+	return openTag + collapsed + closeTag;
+}
+
+/**
+ * Parse the configured element list from the options.
+ */
+function getInlineElements(options) {
+	const configured = options.mdxInlineElements;
+	if (!configured || typeof configured !== "string") {
+		return [];
+	}
+	return configured
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+/**
+ * Check if a JSX node value starts with one of the inline element names.
+ */
+function isInlineElement(value, elements) {
+	const trimmed = value.trim();
+	for (const el of elements) {
+		if (trimmed.startsWith(`<${el}>`) || trimmed.startsWith(`<${el} `)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Walk the AST and convert matching JSX nodes to HTML nodes.
+ */
+function transformAst(ast, elements) {
+	function walk(node) {
+		if (node.type === "jsx" && isInlineElement(node.value, elements)) {
+			// Convert to HTML type so prettier outputs it verbatim
+			node.type = "html";
+			// Collapse multi-line content back to a single line
+			node.value = collapseInlineJsx(node.value);
+		}
+		if (node.children) {
+			node.children.forEach(walk);
+		}
+	}
+	walk(ast);
+	return ast;
+}
+
+/** @type {import("prettier").Plugin} */
+const plugin = {
+	options: {
+		mdxInlineElements: {
+			type: "string",
+			category: "MDX",
+			default: "",
+			description:
+				"Comma-separated list of JSX element names that should not be reformatted.",
+		},
+	},
+
+	parsers: {
+		"mdx-inline": {
+			async parse(text, options) {
+				// Delegate to the built-in MDX parser via prettier's stable plugin export
+				const { parsers } = await import("prettier/plugins/markdown");
+				const ast = await parsers.mdx.parse(text, options);
+
+				// Transform matching JSX nodes to prevent reformatting
+				const elements = getInlineElements(options);
+				transformAst(ast, elements);
+
+				return ast;
+			},
+			// Use the built-in mdast printer — we only modify the AST
+			astFormat: "mdast",
+			locStart: (node) => node.position?.start?.offset ?? 0,
+			locEnd: (node) => node.position?.end?.offset ?? 0,
+		},
+	},
+};
+
+export default plugin;

--- a/src/content/docs/api-shield/security/jwt-validation/index.mdx
+++ b/src/content/docs/api-shield/security/jwt-validation/index.mdx
@@ -14,7 +14,6 @@ import {
 	DashButton,
 } from "~/components";
 
-{/* prettier-ignore */}
 <GlossaryTooltip term="JSON web token (JWT)">JSON web tokens (JWT)</GlossaryTooltip> are often used as part of an authentication component on many web applications today. Since JWTs are crucial to identifying users and their access, ensuring the token’s integrity is important.
 
 API Shield’s JWT validation stops JWT replay attacks and JWT tampering by cryptographically verifying incoming JWTs before they are passed to your API origin. JWT validation will also stop requests with expired tokens or tokens that are not yet valid.
@@ -126,7 +125,7 @@ API Shield will verify JSON Web Tokens regardless of whether or not they have th
 
 ### Ignore `OPTIONS` pre-flight CORS requests
 
-Due to cross-origin resource sharing (CORS) security, web browsers will send "pre-flight" requests using the `OPTIONS` verb to API endpoints before sending a `GET` (or other verb) request. By definition, `OPTIONS` requests do not include headers or cookies and are anonymous. 
+Due to cross-origin resource sharing (CORS) security, web browsers will send "pre-flight" requests using the `OPTIONS` verb to API endpoints before sending a `GET` (or other verb) request. By definition, `OPTIONS` requests do not include headers or cookies and are anonymous.
 
 If you expect web browsers to be valid clients of your API, and to prevent blocking `OPTIONS` requests from those browsers, Cloudflare recommends adding `or http.request.method eq "OPTIONS"` to your JWT validation rules.
 
@@ -137,6 +136,7 @@ If you expect web browsers to be valid clients of your API, and to prevent block
 JWT validation is available for all API Shield customers. Enterprise customers who have not purchased API Shield can preview [API Shield as a non-contract service](https://dash.cloudflare.com/?to=/:account/:zone/security/api-shield) in the Cloudflare dashboard or by contacting your account team.
 
 ---
+
 ## Limitations
 
 Currently, the following known limitations exist:

--- a/src/content/docs/api-shield/security/schema-validation/index.mdx
+++ b/src/content/docs/api-shield/security/schema-validation/index.mdx
@@ -29,7 +29,6 @@ You can migrate to Schema validation 2.0 manually by uploading your schemas to t
 
 ## Process
 
-{/* prettier-ignore */}
 <GlossaryTooltip term="API endpoint">Endpoints</GlossaryTooltip> must be added to [Endpoint Management](/api-shield/management-and-monitoring/endpoint-management/) for Schema validation to protect them. Uploading a schema via the Cloudflare dashboard will automatically add endpoints, or you can manually add them from [API Discovery](/api-shield/security/api-discovery/).
 
 If you are uploading a schema via the API or Terraform, you must parse the schema and add your endpoints manually.
@@ -434,12 +433,12 @@ Schema validation inspects request bodies up to a maximum size that depends on y
 
 The default body size limits are:
 
-| Plan | Default body size limit |
-| --- | --- |
-| Free | 1 KB |
-| Pro | 8 KB |
-| Business | 8 KB |
-| Enterprise | 128 KB |
+| Plan       | Default body size limit |
+| ---------- | ----------------------- |
+| Free       | 1 KB                    |
+| Pro        | 8 KB                    |
+| Business   | 8 KB                    |
+| Enterprise | 128 KB                  |
 
 :::note
 This limit is separate from the [WAF maximum body inspection size](/waf/managed-rules/#maximum-body-size), which controls how much of the request payload the WAF scans. Increasing one does not affect the other.

--- a/src/content/docs/durable-objects/api/base.mdx
+++ b/src/content/docs/durable-objects/api/base.mdx
@@ -56,9 +56,7 @@ class MyDurableObject(DurableObject):
 
 ### `fetch`
 
-- <code>
-  	fetch(request <Type text="Request" />)
-  </code>
+- <code>fetch(request <Type text="Request" />)</code>
   : <Type text="Response" /> | <Type text="Promise<Response>" />- Takes an HTTP
   [Request](https://developers.cloudflare.com/workers/runtime-apis/request/) and
   returns an HTTP
@@ -93,16 +91,11 @@ export class MyDurableObject extends DurableObject<Env> {
 
 ### `alarm`
 
-- <code>
-  	alarm(alarmInfo? <Type text="AlarmInvocationInfo" />)
-  </code>
+- <code>alarm(alarmInfo? <Type text="AlarmInvocationInfo" />)</code>
   : <Type text="void" /> | <Type text="Promise<void>" />
   - Called by the system when a scheduled alarm time is reached.
-
   - The `alarm()` handler has guaranteed at-least-once execution and will be retried upon failure using exponential backoff, starting at two second delays for up to six retries. Retries will be performed if the method fails with an uncaught exception.
-
   - This method can be `async`.
-
   - Refer to [Alarms](/durable-objects/api/alarms/) for more information.
 
 #### Parameters
@@ -132,10 +125,7 @@ export class MyDurableObject extends DurableObject<Env> {
 
 ### `webSocketMessage`
 
-- <code>
-  	webSocketMessage(ws <Type text="WebSocket" />, message{" "}
-  	<Type text="string | ArrayBuffer" />)
-  </code>
+- <code>webSocketMessage(ws <Type text="WebSocket" />, message <Type text="string | ArrayBuffer" />)</code>
   : <Type text="void" /> | <Type text="Promise<void>" />- Called by the system
   when an accepted WebSocket receives a message. - This method is not called for
   WebSocket control frames. The system will respond to an incoming [WebSocket
@@ -170,10 +160,7 @@ export class MyDurableObject extends DurableObject<Env> {
 
 ### `webSocketClose`
 
-- <code>
-  	webSocketClose(ws <Type text="WebSocket" />, code <Type text="number" />,
-  	reason <Type text="string" />, wasClean <Type text="boolean" />)
-  </code>
+- <code>webSocketClose(ws <Type text="WebSocket" />, code <Type text="number" />, reason <Type text="string" />, wasClean <Type text="boolean" />)</code>
   : <Type text="void" /> | <Type text="Promise<void>" />- Called by the system
   when a WebSocket connection is closed.
   - With the [`web_socket_auto_reply_to_close`](/workers/configuration/compatibility-flags/#websocket-auto-reply-to-close) compatibility flag (enabled by default on compatibility dates on or after `2026-04-07`), the runtime automatically sends a reciprocal Close frame and transitions `readyState` to `CLOSED` before this handler is called. You do not need to call `ws.close()` — but doing so is safe (the call is silently ignored).
@@ -209,9 +196,7 @@ export class MyDurableObject extends DurableObject<Env> {
 
 ### `webSocketError`
 
-- <code>
-  	webSocketError(ws <Type text="WebSocket" />, error <Type text="unknown" />)
-  </code>
+- <code>webSocketError(ws <Type text="WebSocket" />, error <Type text="unknown" />)</code>
   : <Type text="void" /> | <Type text="Promise<void>" />- Called by the system
   when a non-disconnection error occurs on a WebSocket connection. - This method
   can be `async`.

--- a/src/content/docs/durable-objects/best-practices/websockets.mdx
+++ b/src/content/docs/durable-objects/best-practices/websockets.mdx
@@ -321,9 +321,7 @@ The following methods are available on the Hibernation WebSocket API. Use them t
 
 #### `WebSocket.serializeAttachment`
 
-- <code>
-  	serializeAttachment(value <Type text="any" />)
-  </code>
+- <code>serializeAttachment(value <Type text="any" />)</code>
   : <Type text="void" />
 
 Keeps a copy of `value` associated with the WebSocket connection.
@@ -362,34 +360,35 @@ export class WebSocketServer extends DurableObject<Env> {
 		const url = new URL(request.url);
 		const orderId = url.searchParams.get("orderId") ?? "anonymous";
 
-		const webSocketPair = new WebSocketPair();
-		const [client, server] = Object.values(webSocketPair);
+    	const webSocketPair = new WebSocketPair();
+    	const [client, server] = Object.values(webSocketPair);
 
-		this.ctx.acceptWebSocket(server);
+    	this.ctx.acceptWebSocket(server);
 
-		// Persist per-connection state that survives hibernation
-		const state: ConnectionState = {
-			orderId,
-			joinedAt: Date.now(),
-		};
-		server.serializeAttachment(state);
+    	// Persist per-connection state that survives hibernation
+    	const state: ConnectionState = {
+    		orderId,
+    		joinedAt: Date.now(),
+    	};
+    	server.serializeAttachment(state);
 
-		return new Response(null, { status: 101, webSocket: client });
-	}
+    	return new Response(null, { status: 101, webSocket: client });
+    }
 
-	async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
-		// Restore state after potential hibernation
-		const state = ws.deserializeAttachment() as ConnectionState;
-		ws.send(`Hello ${state.orderId}, you joined at ${state.joinedAt}`);
-	}
+    async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
+    	// Restore state after potential hibernation
+    	const state = ws.deserializeAttachment() as ConnectionState;
+    	ws.send(`Hello ${state.orderId}, you joined at ${state.joinedAt}`);
+    }
 
-	async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
-		const state = ws.deserializeAttachment() as ConnectionState;
-		console.log(`${state.orderId} disconnected`);
-		// With web_socket_auto_reply_to_close (compat date >= 2026-04-07), the runtime
-		// auto-replies to Close frames. Calling close() is safe but no longer required.
-		ws.close(code, reason);
-	}
+    async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
+    	const state = ws.deserializeAttachment() as ConnectionState;
+    	console.log(`${state.orderId} disconnected`);
+    	// With web_socket_auto_reply_to_close (compat date >= 2026-04-07), the runtime
+    	// auto-replies to Close frames. Calling close() is safe but no longer required.
+    	ws.close(code, reason);
+    }
+
 }
 
 ````

--- a/src/content/docs/ruleset-engine/rules-language/functions.mdx
+++ b/src/content/docs/ruleset-engine/rules-language/functions.mdx
@@ -33,7 +33,6 @@ The Rules language supports these transformation functions:
 
 ### `any`
 
-{/* prettier-ignore */}
 <code>any(<Type text="Array<Boolean>" />)</code>: <Type text="Boolean" />
 
 Returns `true` when the comparison operator in the argument returns `true` for _any_ of the values in the argument array. Returns `false` otherwise.
@@ -46,7 +45,6 @@ any(url_decode(http.request.body.form.values[*])[*] contains "an xss attack")
 
 ### `all`
 
-{/* prettier-ignore */}
 <code>all(<Type text="Array<Boolean>" />)</code>: <Type text="Boolean" />
 
 Returns `true` when the comparison operator in the argument returns `true` for _all_ values in the argument array. Returns `false` otherwise.
@@ -59,7 +57,6 @@ all(http.request.headers["content-type"][*] == "application/json")
 
 ### `encode_base64`
 
-{/* prettier-ignore */}
 <code>encode_base64(input <Type text="String | Bytes" /> [, flags <Type text="String" />])</code>: <Type text="String" />
 
 Encodes an `input` string or byte array to Base64 format.
@@ -92,7 +89,6 @@ You can only use the `encode_base64()` function in [request/response header tran
 
 ### `cidr`
 
-{/* prettier-ignore */}
 <code>cidr(address <Type text="IP address" />, ipv4_network_bits <Type text="Integer" />, ipv6_network_bits <Type text="Integer" />)</code>: <Type text="IP address" />
 
 Returns the network address corresponding to an IP address (IPv4 or IPv6), given the provided IPv4 and IPv6 network bits (which determine the corresponding netmasks).
@@ -112,7 +108,6 @@ You can only use the `cidr()` function in [custom rules](/waf/custom-rules/) and
 
 ### `cidr6`
 
-{/* prettier-ignore */}
 <code>cidr6(address <Type text="IP address" />, ipv6_network_bits <Type text='Integer' />)</code>: <Type text="IP address" />
 
 Returns the IPv6 network address corresponding to an IPv6 address, given the provided network bits (which determine the netmask). If you provide an IPv4 address in the first parameter, it will be returned unchanged.
@@ -134,7 +129,6 @@ You can only use the `cidr6()` function in [custom rules](/waf/custom-rules/) an
 
 ### `concat`
 
-{/* prettier-ignore */}
 <code>concat(<Type text="String | Bytes | Array" />)</code>: <Type text="String | Array" />
 
 Takes a comma-separated list of values. Concatenates the argument values into a single String or array.
@@ -145,7 +139,6 @@ For example, `concat("String1", " ", "String", "2")` will return `"String1 Strin
 
 ### `decode_base64`
 
-{/* prettier-ignore */}
 <code>decode_base64(source <Type text="String" />)</code>: <Type text="String" />
 
 Decodes a Base64-encoded String specified in `source`.
@@ -160,7 +153,6 @@ You can only use the `decode_base64()` function in [Transform Rules](/rules/tran
 
 ### `ends_with`
 
-{/* prettier-ignore */}
 <code>ends_with(source <Type text="String" />, substring <Type text="String" />)</code>: <Type text="Boolean" />
 
 Returns `true` when the source ends with a given substring. Returns `false` otherwise. The source cannot be a literal value (like `"foo"`).
@@ -169,7 +161,6 @@ For example, if `http.request.uri.path` is `"/welcome.html"`, then `ends_with(ht
 
 ### `join`
 
-{/* prettier-ignore */}
 <code>join(items <Type text="Array<String>" />, separator <Type text="String" />)</code>: <Type text="String" />
 
 Returns a string which is the concatenation of the strings in `items` with the `separator` between each item.
@@ -193,7 +184,6 @@ The `join()` function is only available in [Transform Rules](/rules/transform/),
 
 ### `has_key`
 
-{/* prettier-ignore */}
 <code>has_key(map: <Type text="Map<T>" />, key: <Type text="String" />)</code>: <Type text="Boolean" />
 
 Returns true if the `key` specified in the second argument, which can be a literal or a dynamic string, is an existing key in the `map` provided as first argument; returns false otherwise.
@@ -214,7 +204,6 @@ has_key(http.request.headers, lower(http.request.uri.args.names[0]))
 
 ### `has_value`
 
-{/* prettier-ignore */}
 <code>has_value(collection: <Type text="Map<T> | Array<T>" />, value: <Type text="T" />)</code>: <Type text="Boolean" />
 
 Returns true if the `value` specified in the second argument, which can be a literal or a dynamic value, is found in the `collection` provided as first argument; returns false otherwise.
@@ -235,7 +224,6 @@ has_value(http.request.headers.names, http.request.uri.args.names[0])
 
 ### `len`
 
-{/* prettier-ignore */}
 <code>len(<Type text="String | Bytes | Array" />)</code>: <Type text="Integer" />
 
 Returns the byte length of a String or Bytes value, or the number of elements in an array.
@@ -244,7 +232,6 @@ For example, if the value of `http.host` is `"example.com"`, then `len(http.host
 
 ### `lookup_json_integer`
 
-{/* prettier-ignore */}
 <code>lookup_json_integer(field <Type text="String" />, key <Type text="String | Integer" />, key <Type text="String | Integer" /> <MetaInfo text='optional' />, ...)</code>: <Type text="Integer" />
 
 Returns the integer value associated with the supplied `key` in `field`.
@@ -279,7 +266,6 @@ Examples:
 
 ### `lookup_json_string`
 
-{/* prettier-ignore */}
 <code>lookup_json_string(field <Type text="String" />, key <Type text="String | Integer" />, key <Type text="String | Integer" /> <MetaInfo text='optional' />, ...)</code>: <Type text="String" />
 
 Returns the string value associated with the supplied `key` in `field`.
@@ -312,7 +298,6 @@ Examples:
 
 ### `lower`
 
-{/* prettier-ignore */}
 <code>lower(<Type text="String" />)</code>: <Type text="String" />
 
 Converts a string field to lowercase. Only uppercase ASCII bytes are converted. All other bytes are unaffected.
@@ -321,7 +306,6 @@ For example, if `http.host` is `"WWW.cloudflare.com"`, then `lower(http.host) ==
 
 ### `regex_replace`
 
-{/* prettier-ignore */}
 <code>regex_replace(source <Type text="String" />, regular_expression <Type text="String" />, replacement <Type text="String" />)</code>: <Type text="String" />
 
 Replaces a part of a source string matched by a regular expression with a replacement string, returning the result. The replacement string can contain references to regular expression capture groups (for example, `${1}` and `${2}`), up to eight replacement references.
@@ -356,7 +340,6 @@ Currently, the `regex_replace()` function is only available in rewrite expressio
 
 ### `remove_bytes`
 
-{/* prettier-ignore */}
 <code>remove_bytes(<Type text="Bytes" />)</code>: <Type text="Bytes" />
 
 Returns a new byte array with all the occurrences of the given bytes removed.
@@ -365,7 +348,6 @@ For example, if `http.host` is `"www.cloudflare.com"`, then `remove_bytes(http.h
 
 ### `remove_query_args`
 
-{/* prettier-ignore */}
 <code>remove_query_args(field <Type text="String" />, query_param1 <Type text="String" />, query_param2 <Type text="String" />, ...)</code>: <Type text="String" />
 
 Removes one or more query string parameters from a URI query string. Returns a string without the specified parameters.
@@ -402,7 +384,6 @@ You can only use the `remove_query_args()` function in [rewrite expressions of T
 
 ### `sha256`
 
-{/* prettier-ignore */}
 <code>sha256(input <Type text="String | Bytes" />)</code>: <Type text="Bytes" />
 
 Computes the SHA-256 cryptographic hash of the `input` string or byte array. Returns a 32-byte hash value.
@@ -439,7 +420,6 @@ You can only use the `sha256()` function in rewrite expressions of [Transform Ru
 
 ### `split`
 
-{/* prettier-ignore */}
 <code>split(input <Type text="String" />, separator <Type text="String" />, limit <Type text="Integer" />)</code>: <Type text="Array<String>" />
 
 Splits the `input` string into an array of strings by breaking the initial string at every occurrence of the `separator` string. The returned array will contain at most `limit` number of elements.
@@ -477,7 +457,6 @@ The `split()` function is only available in [response header transform rules](/r
 
 ### `starts_with`
 
-{/* prettier-ignore */}
 <code>starts_with(source <Type text="String" />, substring <Type text="String" />)</code>: <Type text="Boolean" />
 
 Returns `true` when the source starts with a given substring. Returns `false` otherwise. The source cannot be a literal value (like `"foo"`).
@@ -486,7 +465,6 @@ For example, if `http.request.uri.path` is `"/blog/first-post"`, then `starts_wi
 
 ### `substring`
 
-{/* prettier-ignore */}
 <code>substring(field <Type text="String | Bytes" />, start <Type text="Integer" />, end <Type text="Integer" /> <MetaInfo text='optional' />)</code>: <Type text="String" />
 
 Returns part of the `field` value (the value of a String or Bytes [field](/ruleset-engine/rules-language/fields/reference/)) from the `start` byte index up to (but excluding) the `end` byte index. The first byte in `field` has index `0`. If you do not provide the optional `end` index, the function returns the part of the string from `start` index to the end of the string.
@@ -506,7 +484,6 @@ substring(http.request.body.raw, 0, -2)  will return "asdfgh"
 
 ### `to_string`
 
-{/* prettier-ignore */}
 <code>to_string(<Type text="Integer | Boolean | IP address" />)</code>: <Type text="String" />
 
 Returns the string representation of an Integer, Boolean, or IP address value.
@@ -527,7 +504,6 @@ You can only use the `to_string()` function in rewrite expressions of [Transform
 
 ### `upper`
 
-{/* prettier-ignore */}
 <code>upper(<Type text="String" />)</code>: <Type text="String" />
 
 Converts a string field to uppercase. Only lowercase ASCII bytes are converted. All other bytes are unaffected.
@@ -536,7 +512,6 @@ For example, if `http.host` is`"www.cloudflare.com"`, then `upper(http.host)` wi
 
 ### `url_decode`
 
-{/* prettier-ignore */}
 <code>url_decode(source <Type text="String" />, options <Type text="String" /> <MetaInfo text='optional' />)</code>: <Type text="String" />
 
 Decodes a URL-formatted string defined in `source`, as in the following:
@@ -569,7 +544,6 @@ url_decode(http.request.uri.path) matches "(?u)\p{Hangul}+"
 
 ### `uuidv4`
 
-{/* prettier-ignore */}
 <code>uuidv4(source <Type text="Bytes" />)</code>: <Type text="String" />
 
 Generates a random UUIDv4 (Universally Unique Identifier, version 4) based on the given argument (a source of randomness). To obtain an array of random bytes, use the [`cf.random_seed`](/ruleset-engine/rules-language/fields/reference/cf.random_seed/) field.
@@ -582,7 +556,6 @@ You can only use the `uuidv4()` function in [rewrite expressions of Transform Ru
 
 ### `wildcard_replace`
 
-{/* prettier-ignore */}
 <code>wildcard_replace(source <Type text="Bytes" />, wildcard_pattern <Type text="Bytes" />, replacement <Type text="Bytes" />, flags <Type text="Bytes" /> <MetaInfo text='optional' />)</code>: <Type text="String" />
 
 Replaces a `source` string, matched by a literal with zero or more `*` wildcard metacharacters, with a replacement string, returning the result. The replacement string can contain references to wildcard capture groups (for example, `${1}` and `${2}`), up to eight replacement references.
@@ -631,7 +604,6 @@ Currently, you can only use the `wildcard_replace()` function in rewrite express
 
 ### `bit_slice`
 
-{/* prettier-ignore */}
 <code>bit_slice(protocol <Type text="String" />, offset_start <Type text="Number" />, offset_end <Type text="Number" />)</code>: <Type text="Number" />
 
 This function looks for matches on a given slice of bits.

--- a/src/content/docs/workers/runtime-apis/bindings/worker-loader.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/worker-loader.mdx
@@ -105,11 +105,7 @@ To add a dynamic worker loader binding to your worker, add it to your Wrangler c
 
 ### `get`
 
-<code>
-	get(id <Type text="string" />, getCodeCallback{" "}
-	<Type text="() => Promise<WorkerCode>" />
-	): <Type text="WorkerStub" />
-</code>
+<code>get(id <Type text="string" />, getCodeCallback <Type text="() => Promise<WorkerCode>" /> ): <Type text="WorkerStub" /></code>
 
 Loads a Worker with the given ID, returning a `WorkerStub` which may be used to invoke the Worker.
 

--- a/src/content/docs/workers/runtime-apis/nodejs/asynclocalstorage.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/asynclocalstorage.mdx
@@ -192,9 +192,7 @@ console.log(myResource.doSomething()); // prints 123
 - <code>asyncResource.bind(fnfunction, thisArgany)</code>
   - Binds the given function to the async context associated with this `AsyncResource`.
 
-- <code>
-  	asyncResource.runInAsyncScope(fnfunction, thisArgany, ...argsarguments)
-  </code>
+- <code>asyncResource.runInAsyncScope(fnfunction, thisArgany, ...argsarguments)</code>
   - Call the provided function with the given arguments in the async context associated with this `AsyncResource`.
 
 ## Caveats

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -29,7 +29,6 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 
 ### run
 
-{/* prettier-ignore */}
 - <code>run(event: WorkflowEvent&lt;T&gt;, step: WorkflowStep): Promise&lt;T&gt;</code>
   - `event` - the event passed to the Workflow, including an optional `payload` containing data (parameters)
   - `step` - the `WorkflowStep` type that provides the step methods for your Workflow
@@ -75,10 +74,9 @@ Refer to the [events and parameters](/workflows/build/events-and-parameters/) do
 
 ### step
 
-{/* prettier-ignore */}
 - <code>step.do(name: string, callback: (): RpcSerializable): Promise&lt;T&gt;</code>
 - <code>step.do(name: string, config?: WorkflowStepConfig, callback: ():
-	RpcSerializable): Promise&lt;T&gt;</code>
+  RpcSerializable): Promise&lt;T&gt;</code>
   - `name` - the name of the step, up to 256 characters.
   - `config` (optional) - an optional `WorkflowStepConfig` for configuring [step specific retry behaviour](/workflows/build/sleeping-and-retrying/).
   - `callback` - an asynchronous function that optionally returns serializable state for the Workflow to persist. In JavaScript Workflows, this includes a fresh, unlocked `ReadableStream<Uint8Array>` for large binary output.
@@ -130,13 +128,11 @@ export class MyWorkflow extends WorkflowEntrypoint<Env> {
 
 </TypeScriptExample>
 
-{/* prettier-ignore */}
 - <code>step.sleep(name: string, duration: WorkflowDuration): Promise&lt;void&gt;</code>
   - `name` - the name of the step.
   - `duration` - the duration to sleep until, in either seconds or as a `WorkflowDuration` compatible string.
   - Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-and-retrying/) to learn more about how Workflows are retried.
 
-{/* prettier-ignore */}
 - <code>step.sleepUntil(name: string, timestamp: Date | number): Promise&lt;void&gt;</code>
   - `name` - the name of the step.
   - `timestamp` - a JavaScript `Date` object or milliseconds from the Unix epoch to sleep the Workflow instance until.
@@ -217,7 +213,6 @@ Note that Workflows on Workers Free have a limit of 1,024 steps. Refer to [Workf
 
 ## NonRetryableError
 
-{/* prettier-ignore */}
 - <code>throw new NonRetryableError(message: <Type text="string" />, name <Type text="string" /> <MetaInfo text="optional" />)</code>: <Type text="NonRetryableError" />
   - When thrown inside [`step.do()`](/workflows/build/workers-api/#step), this error stops step retries, propagating the error to the top level (the [run](/workflows/build/workers-api/#run) function). Any error not handled at this top level will cause the Workflow instance to fail.
   - Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-and-retrying/) to learn more about how Workflows steps are retried.
@@ -317,7 +312,6 @@ The `Workflow` type exports the following methods:
 
 Create (trigger) a new instance of the given Workflow.
 
-{/* prettier-ignore */}
 - <code>create(options?: WorkflowInstanceCreateOptions): Promise&lt;WorkflowInstance&gt;</code>
   - `options` - optional properties to pass when creating an instance, including a user-provided ID and payload parameters.
 
@@ -381,7 +375,6 @@ Create (trigger) a batch of new instance of the given Workflow, up to 100 instan
 
 This is useful when you are scheduling multiple instances at once. A call to `createBatch` is treated the same as a call to `create` (for a single instance) and allows you to work within the [instance creation limit](/workflows/reference/limits/).
 
-{/* prettier-ignore */}
 - <code>createBatch(batch: WorkflowInstanceCreateOptions[]): Promise&lt;WorkflowInstance[]&gt;</code>
   - `batch` - list of Options to pass when creating an instance, including a user-provided ID and payload parameters.
 

--- a/src/content/docs/workflows/python/python-workers-api.mdx
+++ b/src/content/docs/workflows/python/python-workers-api.mdx
@@ -21,7 +21,6 @@ class MyWorkflow(WorkflowEntrypoint):
 
 ## WorkflowStep
 
-{/* prettier-ignore */}
 - <code>step.do(name=None, *, concurrent=False, config=None)</code> — a decorator that allows you to define a step in a workflow.
   - `name` — an optional name for the step. If omitted, the function name (`func.__name__`) is used.
   - `concurrent` — an optional boolean that indicates whether dependencies for this step can run concurrently.
@@ -57,7 +56,6 @@ Note that the decorator doesn't make the call to the step, it just returns a cal
 When returning state from a step, you must make sure that the returned value is serializable. Since steps run through an FFI layer, the returned value gets type translated via [FFI.](https://pyodide.org/en/stable/usage/api/python-api/ffi.html#pyodide.ffi.to_js)
 Refer to [Pyodide's documentation](https://pyodide.org/en/stable/usage/type-conversions.html#type-translations-pyproxy-to-js) regarding type conversions for more information.
 
-{/* prettier-ignore */}
 - <code>step.sleep(name, duration)</code>
   - `name` — the name of the step.
   - `duration` — the duration to sleep until, in either seconds or as a `WorkflowDuration` compatible string.
@@ -67,7 +65,6 @@ async def run(self, event, step):
     await step.sleep("my-sleep-step", "10 seconds")
 ```
 
-{/* prettier-ignore */}
 - <code>step.sleep_until(name, timestamp)</code>
   - `name` — the name of the step.
   - `timestamp` — a `datetime.datetime` object or seconds from the Unix epoch to sleep the workflow instance until.
@@ -79,7 +76,6 @@ async def run(self, event, step):
     await step.sleep_until("my-sleep-step", datetime.datetime.now() + datetime.timedelta(seconds=10))
 ```
 
-{/* prettier-ignore */}
 - <code>step.wait_for_event(name, event_type, timeout="24 hours")</code>
   - `name` — the name of the step.
   - `event_type` — the type of event to wait for.


### PR DESCRIPTION
## Summary

Adds a custom prettier plugin (`prettier-plugin-mdx-inline`) that prevents prettier from wrapping `<code>` and `<GlossaryTooltip>` children onto new lines in MDX files.

**The problem:** Prettier's MDX formatter treats standalone JSX elements as block-level and wraps their children onto new lines when they exceed `printWidth`. MDX v2+ interprets those newlines as markdown paragraph boundaries, injecting `<p>` tags inside inline elements — producing broken HTML like `<code><p>...</p></code>`. This is a known MDX behavior ([mdx-js/mdx#1798](https://github.com/mdx-js/mdx/issues/1798)) and prettier's MDX parser does not yet account for it ([prettier/prettier#12209](https://github.com/prettier/prettier/issues/12209) tracks MDX v3 support which may eventually resolve this). The codebase relied on 41 `prettier-ignore` comments to work around it.

**The fix:** The plugin wraps prettier's built-in MDX parser and converts matching JSX AST nodes to opaque HTML nodes that prettier outputs verbatim. It also collapses any existing multi-line formatting (from previous prettier runs) back to a single line. The element list is configurable via `mdxInlineElements` in `.prettierrc.mjs`.

**What changed in content files:**
- Removed all 41 `prettier-ignore` comments that were guarding `<code>` and `<GlossaryTooltip>` elements
- Collapsed 7 already-broken multi-line `<code>` blocks back to single lines (these had been reformatted by prettier in the past without `prettier-ignore` protection)
- No content changes — only formatting and comment removal

**Performance:** Negligible overhead (~60ms across 231 files, within run-to-run noise).

## Images
Here are just two examples...

#### Before 
https://developers.cloudflare.com/durable-objects/best-practices/websockets/

<img width="775" height="347" alt="Screenshot 2026-04-11 at 6 47 00 PM" src="https://github.com/user-attachments/assets/d7f56c39-dc45-4dca-b137-1bad3398ccd5" />

https://developers.cloudflare.com/durable-objects/api/base/

<img width="759" height="399" alt="Screenshot 2026-04-11 at 6 52 48 PM" src="https://github.com/user-attachments/assets/9baf3cbf-6a12-4f60-a2b3-b48da47fd53f" />



#### After
https://mdx-formatting.preview.developers.cloudflare.com/durable-objects/best-practices/websockets/

<img width="791" height="301" alt="Screenshot 2026-04-11 at 6 47 05 PM" src="https://github.com/user-attachments/assets/dd29e583-2622-4983-ab07-857713a9b6b3" />

https://mdx-formatting.preview.developers.cloudflare.com/durable-objects/api/base/

<img width="770" height="368" alt="Screenshot 2026-04-11 at 6 52 53 PM" src="https://github.com/user-attachments/assets/966d2318-8e01-4031-b913-6afc9588cf7c" />
