### PR TITLE
[SSL] Add Java 27 to pqc-support.mdx

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -24,6 +24,7 @@ The list below is for reference only. Responsibility for third-party software li
 - Default for [Tor Browser 15.0+](https://www.torproject.org/)
 - Cloudflare's [fork of Go](https://github.com/cloudflare/go)
 - Default for [Go 1.24+](https://go.dev/doc/go1.24#cryptotlspkgcryptotls)
+- Default for [Java 27+](https://www.java.com/)
 - Default for [OpenSSL 3.5.0+](https://www.openssl.org/)
 - Default for [Node 24.5.0+](https://nodejs.org/) and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352))
 - [BoringSSL](https://boringssl.googlesource.com/boringssl/)

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -24,7 +24,7 @@ The list below is for reference only. Responsibility for third-party software li
 - Default for [Tor Browser 15.0+](https://www.torproject.org/)
 - Cloudflare's [fork of Go](https://github.com/cloudflare/go)
 - Default for [Go 1.24+](https://go.dev/doc/go1.24#cryptotlspkgcryptotls)
-- Default for [Java 27+](https://www.java.com/)
+- Default for [Java 27+](https://openjdk.org/jeps/527)
 - Default for [OpenSSL 3.5.0+](https://www.openssl.org/)
 - Default for [Node 24.5.0+](https://nodejs.org/) and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352))
 - [BoringSSL](https://boringssl.googlesource.com/boringssl/)


### PR DESCRIPTION
### Summary

Java 27 will support X25519MLKEM768.

Source: https://openjdk.org/jeps/527

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
