### PR TITLE
[CNI] Add Dataplane v2 qualifier to maintenance notice periods

### DIFF
--- a/src/content/docs/network-interconnect/operational-guidance.mdx
+++ b/src/content/docs/network-interconnect/operational-guidance.mdx
@@ -21,7 +21,7 @@ Regular network maintenance may impact Cloudflare Network Interconnect (CNI) con
 
 For Dataplane v2 connectivity in multi-homed PoPs only:
 
-- **Routine maintenance**: Minimum two business days notice in multi-homed PoPs.
+- **Routine maintenance**: Minimum two business days notice.
 - **Emergency maintenance**: Best-effort notice, which may be less than two business days.
 
 To receive advance alerts, configure [CNI maintenance notifications](/network-interconnect/monitoring-and-alerts/).

--- a/src/content/docs/network-interconnect/operational-guidance.mdx
+++ b/src/content/docs/network-interconnect/operational-guidance.mdx
@@ -19,6 +19,8 @@ Regular network maintenance may impact Cloudflare Network Interconnect (CNI) con
 
 ### Notice periods
 
+For Dataplane v2 connectivity in multi-homed PoPs only:
+
 - **Routine maintenance**: Minimum two business days notice in multi-homed PoPs.
 - **Emergency maintenance**: Best-effort notice, which may be less than two business days.
 


### PR DESCRIPTION
### Summary

Clarifies that the maintenance notice periods apply specifically to Dataplane v2 connectivity in multi-homed PoPs.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).