### PR TITLE
[Chore] Update wrangler and workers-types to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@astrojs/starlight-docsearch": "0.7.0",
 				"@astrojs/starlight-tailwind": "5.0.0",
 				"@cloudflare/vitest-pool-workers": "0.10.7",
-				"@cloudflare/workers-types": "4.20260331.1",
+				"@cloudflare/workers-types": "4.20260413.1",
 				"@expressive-code/plugin-collapsible-sections": "0.41.3",
 				"@expressive-code/plugin-line-numbers": "0.41.3",
 				"@floating-ui/react": "0.27.16",
@@ -113,7 +113,7 @@
 				"unist-util-visit": "5.0.0",
 				"vite-tsconfig-paths": "5.1.4",
 				"vitest": "3.2.4",
-				"wrangler": "4.79.0"
+				"wrangler": "4.82.1"
 			}
 		},
 		"node_modules/@actions/core": {
@@ -2150,9 +2150,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260331.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260331.1.tgz",
-			"integrity": "sha512-fsf+MWPQdQ8XPV0y3tQvqf035ETgEXfJgNTYqmiLcOHB32eH/5Kb75fyZIXS9nnBMq3x6c4+HJRTRxbovNLWiA==",
+			"version": "4.20260413.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260413.1.tgz",
+			"integrity": "sha512-4FFHIVIk645Wf20eCVfe0eM3ERsEw98DFng76QZf1C1JMgIVlfSV2gZF1EyXxNVwOG0RM/CBlu07+u/Z/0Oq9Q==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0"
 		},
@@ -18589,9 +18589,9 @@
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.79.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.79.0.tgz",
-			"integrity": "sha512-NMinIdB1pXIqdk+NLw4+RjzB7K5z4+lWMxhTxFTfZomwJu3Pm6N+kZ+a66D3nI7w0oCjsdv/umrZVmSHCBp2cg==",
+			"version": "4.82.1",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.82.1.tgz",
+			"integrity": "sha512-LXn3SJWCN0zVqvMkxPFEQxgAqdbIgpwkUpg1DodfrR5xhIUbORh56LMXPA+f5eW0wmgwz/cIA1W2q6f+tmE4LQ==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -18599,10 +18599,10 @@
 				"@cloudflare/unenv-preset": "2.16.0",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260329.0",
+				"miniflare": "4.20260410.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260329.1"
+				"workerd": "1.20260410.1"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
@@ -18615,7 +18615,7 @@
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260329.1"
+				"@cloudflare/workers-types": "^4.20260410.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -18640,9 +18640,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260329.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260329.1.tgz",
-			"integrity": "sha512-oyDXYlPBuGXKkZ85+M3jFz0/qYmvA4AEURN8USIGPDCR5q+HFSRwywSd9neTx3Wi7jhey2wuYaEpD3fEFWyWUA==",
+			"version": "1.20260410.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260410.1.tgz",
+			"integrity": "sha512-0sh6xPmCKUfv/lUklP1dfyeKxCuEZGS0HeduxnucL8ECxSgAdWTOD42h/lQTwZCIiWtyHB+ZNB9hsS2Mlf0tMQ==",
 			"cpu": [
 				"x64"
 			],
@@ -18657,9 +18657,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260329.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260329.1.tgz",
-			"integrity": "sha512-++ZxVa3ovzYeDLEG6zMqql9gzZAG8vak6ZSBQgprGKZp7akr+GKTpw9f3RrMP552NSi3gTisroLobrrkPBtYLQ==",
+			"version": "1.20260410.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260410.1.tgz",
+			"integrity": "sha512-r2On29gPvlk/eiH/OpeUT23xoB8W8D1PHr8lul5nyxElLqvh3yNxZUnJWrbcOl+ubfrvw7+jFwgopMe17xyf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -18674,9 +18674,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260329.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260329.1.tgz",
-			"integrity": "sha512-kkeywAgIHwbqHkVILqbj/YkfbrA6ARbmutjiYzZA2MwMSfNXlw6/kedAKOY8YwcymZIgepx3YTIPnBP50pOotw==",
+			"version": "1.20260410.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260410.1.tgz",
+			"integrity": "sha512-qWORRcAzPZeHJjrcYBNZTN6Y9l+iZQUz4KBdWbNrM6My4CpNrXS5kErPR373vG//5QPaDGwMXgBqyn9xfzarJQ==",
 			"cpu": [
 				"x64"
 			],
@@ -18691,9 +18691,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260329.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260329.1.tgz",
-			"integrity": "sha512-eYBN20+B7XOUSWEe0mlqkMUbfLoIKjKZnpqQiSxnLbL72JKY0D/KlfN/b7RVGLpewB7i8rTrwTNr0szCKnZzSQ==",
+			"version": "1.20260410.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260410.1.tgz",
+			"integrity": "sha512-jQfuHL4mnGDFyomSS3JNs9TpTvCu6Vzz2QSNCfJRstMzTICUFLMc4Vp/xKK+M5xkb0PoAu/G0hHx7jrxB2j+OQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -18708,9 +18708,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260329.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260329.1.tgz",
-			"integrity": "sha512-5R+/oxrDhS9nL3oA3ZWtD6ndMOqm7RfKknDNxLcmYW5DkUu7UH3J/s1t/Dz66iFePzr5BJmE7/8gbmve6TjtZQ==",
+			"version": "1.20260410.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260410.1.tgz",
+			"integrity": "sha512-h8q/nbheDqpknY7AAOz19MuQkZAR1/bnoZnKipyeUPXt5No+y6HlTtva9Bohx5Fhc1MW2CX2MQVdb55qtkkqZQ==",
 			"cpu": [
 				"x64"
 			],
@@ -19645,16 +19645,16 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/miniflare": {
-			"version": "4.20260329.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260329.0.tgz",
-			"integrity": "sha512-+G+1YFVeuEpw/gZZmUHQR7IfzJV+DDGvnSl0yXzhgvHh8Nbr8Go5uiWIwl17EyZ1Uors3FKUMDUyU6+ejeKZOw==",
+			"version": "4.20260410.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260410.0.tgz",
+			"integrity": "sha512-94LEU8d+XPVGp18eW4+bu1v7Tnq7srhqWMIsrx2jhSkdbTnGqg1I613R0GKY4eygBYl9MbqXEhzK/bczJb6uMg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "^0.34.5",
 				"undici": "7.24.4",
-				"workerd": "1.20260329.1",
+				"workerd": "1.20260410.1",
 				"ws": "8.18.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -19721,9 +19721,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/workerd": {
-			"version": "1.20260329.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260329.1.tgz",
-			"integrity": "sha512-+ifMv3uBuD33ee7pan5n8+sgVxm2u5HnbgfXzHKwMNTKw86znqBJSnJoBqtP88+2T5U2Lu11xXUt+khPYioXwQ==",
+			"version": "1.20260410.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260410.1.tgz",
+			"integrity": "sha512-T/GRD6Y5vN9g4CnGmOlfST1w7bj+1IjRFvX0K7CodZPJuPVPNPGhz8Wppah0WdT6A7I8Kad3zgZ2OkDdWtENrg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -19734,11 +19734,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260329.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260329.1",
-				"@cloudflare/workerd-linux-64": "1.20260329.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260329.1",
-				"@cloudflare/workerd-windows-64": "1.20260329.1"
+				"@cloudflare/workerd-darwin-64": "1.20260410.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260410.1",
+				"@cloudflare/workerd-linux-64": "1.20260410.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260410.1",
+				"@cloudflare/workerd-windows-64": "1.20260410.1"
 			}
 		},
 		"node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@astrojs/starlight-docsearch": "0.7.0",
 		"@astrojs/starlight-tailwind": "5.0.0",
 		"@cloudflare/vitest-pool-workers": "0.10.7",
-		"@cloudflare/workers-types": "4.20260331.1",
+		"@cloudflare/workers-types": "4.20260413.1",
 		"@expressive-code/plugin-collapsible-sections": "0.41.3",
 		"@expressive-code/plugin-line-numbers": "0.41.3",
 		"@floating-ui/react": "0.27.16",
@@ -141,7 +141,7 @@
 		"unist-util-visit": "5.0.0",
 		"vite-tsconfig-paths": "5.1.4",
 		"vitest": "3.2.4",
-		"wrangler": "4.79.0"
+		"wrangler": "4.82.1"
 	},
 	"devEngines": {
 		"runtime": {


### PR DESCRIPTION
Updates wrangler and @cloudflare/workers-types to the latest npm versions to pick up new Wrangler features and type definitions.

- `wrangler`: 4.79.0 → 4.82.1
- `@cloudflare/workers-types`: 4.20260331.1 → 4.20260413.1