### PR TITLE
CASB - Removing Queued Status from manage-findings manage-findings

### DIFF
--- a/src/content/docs/cloudflare-one/cloud-and-saas-findings/manage-findings.mdx
+++ b/src/content/docs/cloudflare-one/cloud-and-saas-findings/manage-findings.mdx
@@ -165,7 +165,6 @@ Remediated findings will appear in **Cloud & SaaS findings** > **Posture Finding
 | Status     | Description                                                                                                     |
 | ---------- | --------------------------------------------------------------------------------------------------------------- |
 | Pending    | CASB has set the finding to be remediated.                                                                      |
-| Queued     | CASB has queued the finding for remediation.                                                                    |
 | Processing | CASB is currently remediating the finding.                                                                      |
 | Validating | CASB successfully completed the remediation and is waiting for confirmation that the finding has been resolved. |
 | Completed  | CASB successfully remediated the finding and validated that the finding has been resolved.                      |


### PR DESCRIPTION
Removing CASB Remediation Status "Queued" which was never implemented.

### Summary

- Updating CASB Remediation status documentation to reflect implementation

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
