### PR TITLE
docs(kv): clarify that cached reads are billable

### DIFF
--- a/src/content/partials/workers/kv_pricing.mdx
+++ b/src/content/partials/workers/kv_pricing.mdx
@@ -23,4 +23,6 @@ operations of that type will fail with an error.
 Workers KV pricing for read, write and delete operations is on a per-key basis. Bulk read operations
 are billed by the amount of keys read in a bulk read operation.
 
+All keys read are billed whether values are served from Cloudflare's Cache (a hot read) or fetched from central storage (a cold read). KV caches data to improve read latency, but both cached and uncached reads count toward your billable read usage.
+
 :::


### PR DESCRIPTION
Add a note to the KV pricing partial clarifying that all read operations are billed regardless of whether the value is served from edge cache (hot read) or fetched from central storage (cold read).

This is a common source of confusion, the existing documentation does not explicitly state whether KV's internal caching layer affects billing.

Customers reasonably wonder if only cold reads that hit the central stores are metered, or if cache hits at the POP level also count.

The answer is that all reads are billed equally. This note makes that explicit using the hot/cold read terminology already defined on the "How KV works" page (https://developers.cloudflare.com/kv/concepts/how-kv-works/)

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
