### PR TITLE
Document OAuth consent and token revocation features

### DIFF
--- a/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
+++ b/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
@@ -11,7 +11,6 @@ OAuth allows third-party applications to access your Cloudflare account on your 
 When authorizing an OAuth application, you can now **select specific accounts** instead of granting access to all your accounts:
 - **Account-by-account selection** — Choose exactly which accounts the application can access
 - **"All accounts" option** — Still available for trusted tools like Wrangler
-- **Clear visibility** — See which accounts allow third-party OAuth (accounts that restrict OAuth are automatically excluded)
 This gives you precise control who can access your data.
 ### Clear consent screens
 The OAuth consent screen now shows:
@@ -23,7 +22,7 @@ Manage authorized OAuth applications from your profile:
 - **See all connected apps** — View every OAuth application with access to your accounts
 - **Review permissions and scope** — Check what each application can do and which accounts it can access
 - **Revoke instantly** — Remove access with one click when you no longer need it
-To manage your OAuth applications, navigate to **Profile** > **Access Management** > **Connected Applications**.
+To manage your OAuth applications, navigate to **https://dash.cloudflare.com/profile/access-management/authorization**.
 ## Why this matters
 These updates give you:
 - **Granular control** — Authorize apps per-account instead of all-or-nothing

--- a/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
+++ b/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
@@ -22,7 +22,7 @@ Manage authorized OAuth applications from your profile:
 - **See all connected apps** — View every OAuth application with access to your accounts
 - **Review permissions and scope** — Check what each application can do and which accounts it can access
 - **Revoke instantly** — Remove access with one click when you no longer need it
-To manage your OAuth applications, navigate to **https://dash.cloudflare.com/profile/access-management/authorization**.
+To manage your OAuth applications, navigate to **Profile** > **Access Management** > **[Connected Applications](https://dash.cloudflare.com/profile/access-management/authorization)**.
 ## Why this matters
 These updates give you:
 - **Granular control** — Authorize apps per-account instead of all-or-nothing

--- a/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
+++ b/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
@@ -1,0 +1,32 @@
+---
+title: OAuth consent screen and token revocation
+description: Choose which accounts to authorize and revoke OAuth access with new granular consent and management features.
+products:
+  - fundamentals
+date: 2026-04-14
+---
+OAuth allows third-party applications to access your Cloudflare account on your behalf — like when Wrangler deploys Workers or when monitoring tools read your analytics. You now have **granular control** over which accounts these applications can access, plus the ability to revoke access anytime.
+## What's new
+### Choose which accounts to authorize
+When authorizing an OAuth application, you can now **select specific accounts** instead of granting access to all your accounts:
+- **Account-by-account selection** — Choose exactly which accounts the application can access
+- **"All accounts" option** — Still available for trusted tools like Wrangler
+- **Clear visibility** — See which accounts allow third-party OAuth (accounts that restrict OAuth are automatically excluded)
+This gives you precise control over your authorization scope.
+### Clear consent screens
+The OAuth consent screen now shows:
+- **What the application can access** — Explicit list of permissions being requested
+- **Who created the application** — Application owner and contact information  
+- **Which accounts you're authorizing** — Checkboxes for account selection
+### Revoke access anytime
+Manage authorized OAuth applications from your profile:
+- **See all connected apps** — View every OAuth application with access to your accounts
+- **Review permissions and scope** — Check what each application can do and which accounts it can access
+- **Revoke instantly** — Remove access with one click when you no longer need it
+To manage your OAuth applications, navigate to **Profile** > **Access Management** > **Connected Applications**.
+## Why this matters
+These updates give you:
+- **Granular control** — Authorize apps per-account instead of all-or-nothing
+- **Transparency** — Know exactly what you're authorizing before you consent
+- **Security** — Limit blast radius by restricting access to only necessary accounts
+- **Easy cleanup** — Revoke access when applications are no longer needed

--- a/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
+++ b/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
@@ -29,3 +29,5 @@ These updates give you:
 - **Transparency** — Know exactly what you're authorizing before you consent
 - **Security** — Limit blast radius by restricting access to only necessary accounts
 - **Easy cleanup** — Revoke access when applications are no longer needed
+## Learn more
+Read more about these improvements in our blog post: [Improving the OAuth consent experience](https://blog.cloudflare.com/improved-developer-security/#improving-the-oauth-consent-experience).

--- a/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
+++ b/src/content/changelog/fundamentals/2026-04-14-oauth-consent-and-revoke.mdx
@@ -1,5 +1,5 @@
 ---
-title: OAuth consent screen and token revocation
+title: Improved OAuth experience for consent and management
 description: Choose which accounts to authorize and revoke OAuth access with new granular consent and management features.
 products:
   - fundamentals
@@ -12,7 +12,7 @@ When authorizing an OAuth application, you can now **select specific accounts** 
 - **Account-by-account selection** — Choose exactly which accounts the application can access
 - **"All accounts" option** — Still available for trusted tools like Wrangler
 - **Clear visibility** — See which accounts allow third-party OAuth (accounts that restrict OAuth are automatically excluded)
-This gives you precise control over your authorization scope.
+This gives you precise control who can access your data.
 ### Clear consent screens
 The OAuth consent screen now shows:
 - **What the application can access** — Explicit list of permissions being requested


### PR DESCRIPTION
Added details about OAuth consent screen enhancements, including granular account selection and revocation features.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

 Adding changelog for OAuth consent and revocation features 
   
   This changelog covers:
   - Account-by-account OAuth consent
   - Self-service token revocation
   - New consent screen improvements