### PR TITLE
fix: link validation failures for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,9 +202,7 @@ jobs:
           path: .starlight-links-validator
 
       - name: Link validation
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx tsx bin/post-link-validation-comment/index.ts
+        run: npx tsx bin/check-link-validation/index.ts
 
   notify:
     name: Notify
@@ -243,6 +241,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx tsx bin/post-pr-ci-failure-comment/index.ts
+
+      - name: Download link validation report
+        if: needs.build.outputs.link_validation_failed == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: link-validation-report
+          path: .starlight-links-validator
+
+      - name: Post link validation comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx tsx bin/post-link-validation-comment/index.ts
 
   publish-preview:
     name: Deploy Preview

--- a/bin/check-link-validation/index.ts
+++ b/bin/check-link-validation/index.ts
@@ -22,7 +22,6 @@ async function run(): Promise<void> {
 	} catch {
 		core.setFailed(`Could not read report at ${reportPath}`);
 		process.exit();
-		return;
 	}
 
 	core.setFailed(

--- a/bin/check-link-validation/index.ts
+++ b/bin/check-link-validation/index.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import * as core from "@actions/core";
+
+interface LinkValidationReport {
+	errorCount: number;
+	errorFileCount: number;
+}
+
+async function run(): Promise<void> {
+	const reportPath =
+		process.env.REPORT_PATH ?? ".starlight-links-validator/errors.json";
+
+	if (!existsSync(reportPath)) {
+		core.info("No broken links found.");
+		return;
+	}
+
+	let report: LinkValidationReport;
+	try {
+		report = JSON.parse(readFileSync(reportPath, "utf8"));
+	} catch {
+		core.setFailed(`Could not read report at ${reportPath}`);
+		process.exit();
+		return;
+	}
+
+	core.setFailed(
+		`Found ${report.errorCount} broken link(s) across ${report.errorFileCount} file(s).`,
+	);
+}
+
+run();

--- a/bin/post-link-validation-comment/index.ts
+++ b/bin/post-link-validation-comment/index.ts
@@ -137,10 +137,6 @@ async function run(): Promise<void> {
 				body: comment,
 			});
 		}
-
-		core.setFailed(
-			`Found ${report.errorCount} broken link(s) across ${report.errorFileCount} file(s).`,
-		);
 	} catch (error) {
 		if (error instanceof Error) {
 			core.setFailed(error.message);


### PR DESCRIPTION
### Summary

The "Link validation" step in the `post-build` job was failing for fork PRs with "Resource not accessible by integration". This is a GitHub security restriction: fork PRs receive a read-only `GITHUB_TOKEN` that cannot write PR comments — this cannot be overridden by maintainer approval.

The original script mixed two concerns: failing the job on broken links, and posting a PR comment with the report. This PR separates them:

**`bin/check-link-validation/index.ts`** (new) — reads the report file from disk and calls `core.setFailed` if broken links exist. No GitHub API calls, no token required. Runs for all PRs including forks.

**`bin/post-link-validation-comment/index.ts`** (mostly unchanged) — posts/updates/deletes the PR comment.

**CI changes:**
- `post-build` retains "Link validation" using the new script — always runs, always fails on broken links, works for forks
- "Download link validation report" and "Post link validation comment" move into the `notify` job, both guarded with `if: ... full_name == github.repository` so they are skipped for forks. The comment step has `continue-on-error: true`.