### PR TITLE
[Docs] Add directory entries for individual SDK languages

### DIFF
--- a/src/content/directory/go-sdk.yaml
+++ b/src/content/directory/go-sdk.yaml
@@ -1,0 +1,14 @@
+id: pRXwdu
+name: Go SDK
+
+entry:
+  title: Go SDK
+  url: /fundamentals/api/reference/sdks/
+  group: Core platform
+  additional_groups: [Developer platform]
+  show: false
+
+meta:
+  title: Cloudflare Go SDK
+  description: Go software development kit (SDK) to interact with the Cloudflare API
+  author: "@cloudflare"

--- a/src/content/directory/python-sdk.yaml
+++ b/src/content/directory/python-sdk.yaml
@@ -1,0 +1,14 @@
+id: K9goVs
+name: Python SDK
+
+entry:
+  title: Python SDK
+  url: /fundamentals/api/reference/sdks/
+  group: Core platform
+  additional_groups: [Developer platform]
+  show: false
+
+meta:
+  title: Cloudflare Python SDK
+  description: Python software development kit (SDK) to interact with the Cloudflare API
+  author: "@cloudflare"

--- a/src/content/directory/sdk.yaml
+++ b/src/content/directory/sdk.yaml
@@ -3,7 +3,7 @@ name: SDK
 
 entry:
   title: SDK
-  url: /sdk/
+  url: /fundamentals/api/reference/sdks/
   group: Core platform
   additional_groups: [Developer platform]
   show: false

--- a/src/content/directory/typescript-sdk.yaml
+++ b/src/content/directory/typescript-sdk.yaml
@@ -1,0 +1,14 @@
+id: G9RhGJ
+name: TypeScript SDK
+
+entry:
+  title: TypeScript SDK
+  url: /fundamentals/api/reference/sdks/
+  group: Core platform
+  additional_groups: [Developer platform]
+  show: false
+
+meta:
+  title: Cloudflare TypeScript SDK
+  description: TypeScript software development kit (SDK) to interact with the Cloudflare API
+  author: "@cloudflare"


### PR DESCRIPTION
### Summary

Adds support for changelog entries specific to the Go/TypeScript/Python SDK.
Also fixes the URL of the "SDK" entry, which is linking to `/sdk/` and that URL returns `404`.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
