### PR TITLE
[Workers VPC] Add VPC Networks docs

### DIFF
--- a/src/content/changelog/workers-vpc/2026-04-14-vpc-networks.mdx
+++ b/src/content/changelog/workers-vpc/2026-04-14-vpc-networks.mdx
@@ -8,7 +8,7 @@ import { WranglerConfig } from "~/components";
 
 [VPC Network](/workers-vpc/configuration/vpc-networks/) bindings now give your Workers access to any service in your private network without pre-registering individual hosts or ports. This complements existing [VPC Service](/workers-vpc/configuration/vpc-services/) bindings, which scope each binding to a specific host and port.
 
-You can bind to a Cloudflare Tunnel by `tunnel_id` to access any service on the network where that tunnel is running, or bind to your Cloudflare Mesh network using `cf1:network` to reach any service accessible through any of your Mesh nodes and tunnels:
+You can bind to a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) by `tunnel_id` to reach any service on the network where that tunnel is running, or bind to your [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) network using `cf1:network` to reach any Mesh node, client device, or subnet route in your account:
 
 <WranglerConfig>
 ```jsonc

--- a/src/content/changelog/workers-vpc/2026-04-14-vpc-networks.mdx
+++ b/src/content/changelog/workers-vpc/2026-04-14-vpc-networks.mdx
@@ -1,0 +1,33 @@
+---
+title: VPC Networks and Cloudflare Mesh support now in public beta
+description: Workers can now access entire private networks through VPC Network bindings, with support for Cloudflare Tunnel and Cloudflare Mesh.
+date: 2026-04-14
+---
+
+import { WranglerConfig } from "~/components";
+
+[VPC Network](/workers-vpc/configuration/vpc-networks/) bindings now give your Workers access to any service in your private network without pre-registering individual hosts or ports. This complements existing [VPC Service](/workers-vpc/configuration/vpc-services/) bindings, which scope each binding to a specific host and port.
+
+You can bind to a Cloudflare Tunnel by `tunnel_id` to access any service on the network where that tunnel is running, or bind to your Cloudflare Mesh network using `cf1:network` to reach any service accessible through any of your Mesh nodes and tunnels:
+
+<WranglerConfig>
+```jsonc
+{
+  "vpc_networks": [
+    {
+      "binding": "MESH",
+      "network_id": "cf1:network",
+      "remote": true
+    }
+  ]
+}
+```
+</WranglerConfig>
+
+At runtime, `fetch()` routes through the network to reach the service at the IP and port you specify:
+
+```js
+const response = await env.MESH.fetch("http://10.0.1.50:8080/api/data");
+```
+
+For configuration options and examples, refer to [VPC Networks](/workers-vpc/configuration/vpc-networks/) and [Connect Workers to Cloudflare Mesh](/workers-vpc/examples/connect-to-cloudflare-mesh/).

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
@@ -113,3 +113,4 @@ Key differences:
 2. [**Connect client devices**](/cloudflare-one/networks/connectors/cloudflare-mesh/client-devices/) — Install the Cloudflare One Client on laptops and phones. They can reach each other and any Mesh node by Mesh IP.
 3. [**Add routes**](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) (optional) — Make subnets behind a Mesh node reachable from any device.
 4. [**Enable high availability**](/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability/) (optional) — Run multiple replicas of a node for failover.
+5. [**Connect from Workers**](/workers-vpc/examples/connect-to-cloudflare-mesh/) (optional) — Use VPC Network bindings to reach private services from Cloudflare Workers.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/tips.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/tips.mdx
@@ -90,6 +90,12 @@ Split Tunnels is the only supported method of running both connectors on the sam
 
 To route traffic between Cloudflare Mesh and [Cloudflare WAN](/cloudflare-wan/) (for example, reaching a Mesh node from a WAN-connected site or vice versa), your account must be on [Unified Routing mode (beta)](/cloudflare-wan/reference/traffic-steering/#unified-routing-mode-beta). Unified Routing uses a single routing fabric for all connection types (Cloudflare One Client, Cloudflare Tunnel, IPsec, GRE, CNI). Without it, Mesh and WAN connections cannot exchange traffic.
 
+## Connect Workers to Mesh
+
+Cloudflare Workers can connect to your Mesh network using [VPC Network bindings](/workers-vpc/configuration/vpc-networks/). Bind to `cf1:network` to reach any Mesh node, client device, or subnet route in your account — without specifying a particular tunnel UUID.
+
+For setup instructions and examples, refer to [Connect Workers to Cloudflare Mesh](/workers-vpc/examples/connect-to-cloudflare-mesh/).
+
 ## Source IPs for Cloudflare services
 
 When Cloudflare services (such as [Load Balancing](/load-balancing/) health checks or [Workers](/workers/)) send traffic to your private network through a Mesh node, the traffic originates from the Cloudflare source IP range (default `100.64.0.0/12`). You may need to [configure Cloudflare source IPs](/cloudflare-one/networks/connectors/cloudflare-wan/configuration/manually/how-to/configure-cloudflare-source-ips/) to avoid IP conflicts.

--- a/src/content/docs/workers-vpc/api/index.mdx
+++ b/src/content/docs/workers-vpc/api/index.mdx
@@ -20,15 +20,14 @@ Workers VPC is currently in beta. Features and APIs may change before general av
 
 ### VPC Service
 
-A VPC Service binding routes requests to a specific pre-registered host and port. The host and port configured in the VPC Service always determine the connection target — the URL passed to `fetch()` does not control routing. The `Host` header and SNI value for HTTPS requests are derived from the URL provided to `fetch()`.
+A VPC Service binding routes requests to a specific pre-registered host and port. The [VPC Service configuration](/workers-vpc/configuration/vpc-services/#vpc-service-configuration) always determines the connection target, even if a different URL or host is present in the `fetch()` call.
+
+- The **host** provided in `fetch()` does not control routing. It only populates the `Host` header and, when using `https`, the Server Name Indication (SNI) value.
+- The **port** provided in `fetch()` is ignored — the port specified in the VPC Service configuration is always used.
 
 ### VPC Network
 
-A VPC Network binding grants access to any service reachable through the bound tunnel or [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/). The URL passed to `fetch()` determines the actual destination — hostname or IP address and port.
-
-## Required roles
-
-To bind a VPC Service or VPC Network in a Worker, your user needs `Connectivity Directory Bind` (or `Connectivity Directory Admin`). For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
+A VPC Network binding grants access to any service reachable through the bound tunnel or Cloudflare Mesh. The URL passed to `fetch()` determines the actual destination — hostname or IP address and port.
 
 ## fetch()
 
@@ -123,6 +122,10 @@ export default {
 	},
 };
 ```
+
+## Required roles
+
+To bind a VPC Service or VPC Network in a Worker, your user needs `Connectivity Directory Bind` (or `Connectivity Directory Admin`). For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
 
 ## Next steps
 

--- a/src/content/docs/workers-vpc/api/index.mdx
+++ b/src/content/docs/workers-vpc/api/index.mdx
@@ -1,15 +1,14 @@
 ---
 title: Workers Binding API
 pcx_content_type: reference
+description: API reference for VPC Service and VPC Network bindings in Workers.
 sidebar:
   order: 4
 ---
 
 import { Tabs, TabItem } from "~/components";
 
-VPC Service bindings provide a convenient API for accessing VPC Services from your Worker. Each binding represents a connection to a service in your private network through a Cloudflare Tunnel.
-
-Each request made on the binding will route to the specific service that was configured for the VPC Service, while restricting access to the rest of your private network.
+VPC bindings provide a `fetch()` API for accessing private services from your Worker through Cloudflare Tunnel. Both [VPC Services](/workers-vpc/configuration/vpc-services/) and [VPC Networks](/workers-vpc/configuration/vpc-networks/) expose the same `fetch()` method — the difference is in routing scope.
 
 :::note
 
@@ -17,41 +16,39 @@ Workers VPC is currently in beta. Features and APIs may change before general av
 
 :::
 
-## VPC Service binding
+## Binding types
 
-A VPC Service binding is accessed via the `env` parameter in your Worker's fetch handler. It provides a `fetch()` method for making HTTP requests to your private service.
+### VPC Service
 
-:::note[Required roles]
-To bind a VPC Service in a Worker, your user needs `Connectivity Directory Bind` (or `Connectivity Directory Admin`). For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
-:::
+A VPC Service binding routes requests to a specific pre-registered host and port. The host and port configured in the VPC Service always determine the connection target — the URL passed to `fetch()` does not control routing. The `Host` header and SNI value for HTTPS requests are derived from the URL provided to `fetch()`.
+
+### VPC Network
+
+A VPC Network binding grants access to any service reachable through the bound tunnel or [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/). The URL passed to `fetch()` determines the actual destination — hostname or IP address and port.
+
+## Required roles
+
+To bind a VPC Service or VPC Network in a Worker, your user needs `Connectivity Directory Bind` (or `Connectivity Directory Admin`). For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
 
 ## fetch()
 
 Makes an HTTP request to the private service through the configured tunnel.
 
 ```js
-const response = await env.VPC_SERVICE_BINDING.fetch(resource, options);
+const response = await env.MY_BINDING.fetch(resource, options);
 ```
-
-:::note
-The [VPC Service configurations](/workers-vpc/configuration/vpc-services/#vpc-service-configuration) will always be used to connect and route requests to your services in external networks, even if a different URL or host is present in the actual `fetch()` operation of the Worker code.
-
-The host provided in the `fetch()` operation is not used to route requests, and instead only populates the `Host` field for a HTTP request that can be parsed by the server and used for Server Name Indication (SNI), when the `https` scheme is specified.
-
-The port provided in the `fetch()` operation is ignored — the port specified in the VPC Service configuration will be used.
-:::
 
 ### Parameters
 
-- `resource` (string | URL | Request) - The URL to fetch. This must be an absolute URL including protocol, host, and path (for example, `http://internal-api/api/users`)
-- `options` (optional RequestInit) - Standard fetch options including:
-  - `method` - HTTP method (GET, POST, PUT, DELETE, etc.)
-  - `headers` - Request headers
-  - `body` - Request body
-  - `signal` - AbortSignal for request cancellation
+- `resource` (string | URL | Request) — The URL to fetch. Must be an absolute URL including protocol, host, and path (for example, `http://internal-api/api/users`).
+- `options` (optional RequestInit) — Standard fetch options including:
+  - `method` — HTTP method (GET, POST, PUT, DELETE, etc.)
+  - `headers` — Request headers
+  - `body` — Request body
+  - `signal` — AbortSignal for request cancellation
 
-:::note[Absolute URLs Required]
-VPC Service fetch requests must use absolute URLs including the protocol (`http`/`https`), host, and path. Relative paths are not supported.
+:::note[Absolute URLs required]
+VPC binding fetch requests must use absolute URLs including the protocol (`http`/`https`), host, and path. Relative paths are not supported.
 :::
 
 ### Return value
@@ -59,6 +56,8 @@ VPC Service fetch requests must use absolute URLs including the protocol (`http`
 Returns a `Promise<Response>` that resolves to a [standard Fetch API Response object](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
 ### Examples
+
+The following examples apply to both VPC Service and VPC Network bindings.
 
 #### Basic GET request
 
@@ -68,7 +67,7 @@ export default {
 		const privateRequest = new Request(
 			"http://internal-api.company.local/users",
 		);
-		const response = await env.VPC_SERVICE_BINDING.fetch(privateRequest);
+		const response = await env.MY_BINDING.fetch(privateRequest);
 		const users = await response.json();
 
 		return new Response(JSON.stringify(users), {
@@ -98,7 +97,7 @@ export default {
 			},
 		);
 
-		const response = await env.VPC_SERVICE_BINDING.fetch(privateRequest);
+		const response = await env.MY_BINDING.fetch(privateRequest);
 
 		if (!response.ok) {
 			return new Response("Failed to create user", { status: response.status });
@@ -118,7 +117,7 @@ export default {
 export default {
 	async fetch(request, env) {
 		const privateRequest = new Request("https://10.0.1.50/api/data");
-		const response = await env.VPC_SERVICE_BINDING.fetch(privateRequest);
+		const response = await env.MY_BINDING.fetch(privateRequest);
 
 		return response;
 	},
@@ -127,5 +126,6 @@ export default {
 
 ## Next steps
 
-- Configure [service bindings in your Wrangler configuration file](/workers-vpc/configuration/vpc-services/)
+- Configure [VPC Services](/workers-vpc/configuration/vpc-services/)
+- Configure [VPC Networks](/workers-vpc/configuration/vpc-networks/)
 - Refer to [usage examples](/workers-vpc/examples/)

--- a/src/content/docs/workers-vpc/configuration/tunnel/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/tunnel/index.mdx
@@ -2,7 +2,7 @@
 title: Cloudflare Tunnel
 pcx_content_type: concept
 sidebar:
-  order: 2
+  order: 3
 ---
 
 import { GlossaryTooltip, Tabs, TabItem, Example } from "~/components";

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -49,7 +49,7 @@ Use Cloudflare Mesh when:
 
 :::note
 
-Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/) or Mesh node that can reach the target services.
+Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) or Mesh node that can reach the target services.
 
 :::
 

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -1,0 +1,120 @@
+---
+title: VPC Networks
+pcx_content_type: concept
+sidebar:
+  order: 2
+---
+
+import { WranglerConfig } from "~/components";
+
+VPC Networks allow your Workers to access any service in your private network through a Cloudflare Tunnel without pre-registering individual hosts or ports. A single VPC Network binding grants tunnel-wide access to your private network.
+
+A VPC Network connects your Worker to an entire Cloudflare Tunnel. At runtime, your Worker can make requests to any service accessible through that tunnel using any hostname or IP address. This differs from VPC Services, which require you to create a separate service binding for each target host and port combination.
+
+:::note
+
+Workers VPC is currently in beta. Features and APIs may change before general availability. While in beta, Workers VPC is available for free to all Workers plans.
+
+:::
+
+## When to use VPC Networks
+
+Use VPC Networks when:
+
+- You need to access many services through the same tunnel
+- Your internal hostnames or IP addresses change frequently
+- You need tunnel-wide access without pre-registering individual services
+- You want dynamic hostname or IP resolution
+
+Use VPC Services when:
+
+- You have a fixed set of known targets
+- You want fine-grained per-service configuration
+- You need explicit service cataloging and access control
+
+## Bind to a tunnel
+
+Reference a specific Cloudflare Tunnel directly by its UUID:
+
+<WranglerConfig>
+```jsonc
+{
+  "vpc_networks": [
+    {
+      "binding": "MY_VPC",
+      "tunnel_id": "550e8400-e29b-41d4-a716-446655440000",
+      "remote": true
+    }
+  ]
+}
+```
+</WranglerConfig>
+
+The `remote` flag must be set to `true` to enable remote bindings during local development.
+
+## Bind to Cloudflare Mesh
+
+[Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/) enables private networking between your services, devices, and Workers through Cloudflare's global network. When you bind a Worker to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any private service accessible through your account's Mesh nodes and Cloudflare Tunnels — without specifying a particular tunnel UUID.
+
+Use Cloudflare Mesh when:
+
+- Your Workers need to reach private services across multiple tunnels or Mesh nodes
+- You want to access your entire private network from a Worker without managing individual tunnel bindings
+- Your private network topology may change (new tunnels, new nodes) and you do not want to update Worker configuration each time
+
+:::note
+
+Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/) or [Mesh node](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/) that can reach the target services.
+
+:::
+
+Bind to Cloudflare Mesh using `network_id: "cf1:network"`:
+
+<WranglerConfig>
+```jsonc
+{
+  "vpc_networks": [
+    {
+      "binding": "MY_VPC",
+      "network_id": "cf1:network",
+      "remote": true
+    }
+  ]
+}
+```
+</WranglerConfig>
+
+## Runtime usage
+
+Access any service in your network at runtime:
+
+```typescript
+export default {
+	async fetch(request: Request, env: Env) {
+		// Access any hostname or IP in your network
+		const response = await env.MY_VPC.fetch("http://internal-api.local/data");
+
+		// Or access by IP address
+		const dbResponse = await env.MY_VPC.fetch("http://10.0.5.42:5432");
+
+		return response;
+	},
+};
+```
+
+When a VPC Network cannot establish a connection to your target service, `fetch()` throws an exception.
+
+## VPC Networks vs VPC Services
+
+| Feature              | VPC Networks                                                           | VPC Services              |
+| -------------------- | ---------------------------------------------------------------------- | ------------------------- |
+| Scope                | Tunnel-wide access                                                     | Specific host + port      |
+| Configuration        | `tunnel_id` or `cf1:network`                                           | `service_id`              |
+| Service registration | Not required                                                           | Required for each target  |
+| Use when             | Dynamic discovery, tunnel-wide access, entire private network via Mesh | Fixed, cataloged services |
+
+## Next steps
+
+- Set up [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/)
+- View [examples](/workers-vpc/examples/)
+- Learn about the [Network Binding API](/workers-vpc/api/)

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -7,30 +7,15 @@ sidebar:
 
 import { WranglerConfig } from "~/components";
 
-VPC Networks allow your Workers to access any service in your private network through a Cloudflare Tunnel without pre-registering individual hosts or ports. A single VPC Network binding grants tunnel-wide access to your private network.
+VPC Networks allow your Workers to access any service in your private network without pre-registering individual hosts or ports. You can bind to a specific [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/) to reach any service behind that tunnel, or bind to Cloudflare Mesh to reach any service behind any of your tunnels and Mesh nodes.
 
-A VPC Network connects your Worker to an entire Cloudflare Tunnel. At runtime, your Worker can make requests to any service accessible through that tunnel using any hostname or IP address. This differs from VPC Services, which require you to create a separate service binding for each target host and port combination.
+At runtime, the URL you pass to `fetch()` determines the destination — any hostname or IP address reachable through the bound tunnel or Mesh network. This differs from [VPC Services](/workers-vpc/configuration/vpc-services/), which require you to create a separate binding for each target host and port combination.
 
 :::note
 
 Workers VPC is currently in beta. Features and APIs may change before general availability. While in beta, Workers VPC is available for free to all Workers plans.
 
 :::
-
-## When to use VPC Networks
-
-Use VPC Networks when:
-
-- You need to access many services through the same tunnel
-- Your internal hostnames or IP addresses change frequently
-- You need tunnel-wide access without pre-registering individual services
-- You want dynamic hostname or IP resolution
-
-Use VPC Services when:
-
-- You have a fixed set of known targets
-- You want fine-grained per-service configuration
-- You need explicit service cataloging and access control
 
 ## Bind to a tunnel
 
@@ -54,7 +39,7 @@ The `remote` flag must be set to `true` to enable remote bindings during local d
 
 ## Bind to Cloudflare Mesh
 
-[Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/) enables private networking between your services, devices, and Workers through Cloudflare's global network. When you bind a Worker to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any private service accessible through your account's Mesh nodes and Cloudflare Tunnels — without specifying a particular tunnel UUID.
+Cloudflare Mesh connects your services, devices, and Workers through Cloudflare's global network. When you bind a Worker to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any private service accessible through your account's Mesh nodes and Cloudflare Tunnels — without specifying a particular tunnel UUID.
 
 Use Cloudflare Mesh when:
 
@@ -64,7 +49,7 @@ Use Cloudflare Mesh when:
 
 :::note
 
-Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/) or [Mesh node](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/) that can reach the target services.
+Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/) or Mesh node that can reach the target services.
 
 :::
 
@@ -91,10 +76,10 @@ Access any service in your network at runtime:
 ```typescript
 export default {
 	async fetch(request: Request, env: Env) {
-		// Access any hostname or IP in your network
-		const response = await env.MY_VPC.fetch("http://internal-api.local/data");
+		// Access a service by private IP
+		const response = await env.MY_VPC.fetch("http://10.0.1.50/data");
 
-		// Or access by IP address
+		// Access another service on a different port
 		const dbResponse = await env.MY_VPC.fetch("http://10.0.5.42:5432");
 
 		return response;
@@ -106,15 +91,23 @@ When a VPC Network cannot establish a connection to your target service, `fetch(
 
 ## VPC Networks vs VPC Services
 
-| Feature              | VPC Networks                                                           | VPC Services              |
-| -------------------- | ---------------------------------------------------------------------- | ------------------------- |
-| Scope                | Tunnel-wide access                                                     | Specific host + port      |
-| Configuration        | `tunnel_id` or `cf1:network`                                           | `service_id`              |
-| Service registration | Not required                                                           | Required for each target  |
-| Use when             | Dynamic discovery, tunnel-wide access, entire private network via Mesh | Fixed, cataloged services |
+VPC Networks and [VPC Services](/workers-vpc/configuration/vpc-services/) both connect Workers to private infrastructure, but they make different trade-offs.
+
+- **Use VPC Services** when you have a known set of targets and want each binding scoped to a specific host and port.
+- **Use VPC Networks** when you need broader access — an entire tunnel or your full Mesh network — and want the URL in your `fetch()` call to control routing at runtime.
+
+The following table summarizes the differences:
+
+| Feature              | VPC Networks                                                                  | VPC Services              |
+| -------------------- | ----------------------------------------------------------------------------- | ------------------------- |
+| Scope                | Entire tunnel or full Mesh network                                            | Specific host + port      |
+| Configuration        | `tunnel_id` (single tunnel) or `cf1:network` (all tunnels and Mesh nodes)     | `service_id`              |
+| Service registration | Not required                                                                  | Required for each target  |
+| Use when             | Dynamic discovery, network-wide access, reaching services across your account | Fixed, cataloged services |
 
 ## Next steps
 
 - Set up [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/)
-- View [examples](/workers-vpc/examples/)
-- Learn about the [Network Binding API](/workers-vpc/api/)
+- Set up Cloudflare Mesh
+- Try the [Connect Workers to Cloudflare Mesh](/workers-vpc/examples/connect-to-cloudflare-mesh/) example
+- Learn about the [Workers Binding API](/workers-vpc/api/)

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { WranglerConfig } from "~/components";
 
-VPC Networks allow your Workers to access any service in your private network without pre-registering individual hosts or ports. You can bind to a specific [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/) to reach any service behind that tunnel, or bind to Cloudflare Mesh to reach any service behind any of your tunnels and Mesh nodes.
+VPC Networks allow your Workers to access any service in your private network without pre-registering individual hosts or ports. You can bind to a specific [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/) to reach any service behind that tunnel, or bind to [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) to reach any Mesh node, client device, or IP route in your account.
 
 At runtime, the URL you pass to `fetch()` determines the destination — any hostname or IP address reachable through the bound tunnel or Mesh network. This differs from [VPC Services](/workers-vpc/configuration/vpc-services/), which require you to create a separate binding for each target host and port combination.
 
@@ -39,7 +39,7 @@ The `remote` flag must be set to `true` to enable remote bindings during local d
 
 ## Bind to Cloudflare Mesh
 
-Cloudflare Mesh connects your services, devices, and Workers through Cloudflare's global network. When you bind a Worker to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any private service accessible through your account's Mesh nodes and Cloudflare Tunnels — without specifying a particular tunnel UUID.
+[Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) connects your services, devices, and Workers through Cloudflare's global network. When you bind a Worker to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any Mesh node, client device, or IP route in your account — without specifying a particular tunnel UUID.
 
 Use Cloudflare Mesh when:
 

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -49,7 +49,7 @@ Use Cloudflare Mesh when:
 
 :::note
 
-Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) or Mesh node that can reach the target services.
+Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) or [Mesh node](/cloudflare-one/networks/connectors/cloudflare-mesh/) that can reach the target services.
 
 :::
 
@@ -108,6 +108,6 @@ The following table summarizes the differences:
 ## Next steps
 
 - Set up [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/)
-- Set up Cloudflare Mesh
+- [Set up Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/get-started/)
 - Try the [Connect Workers to Cloudflare Mesh](/workers-vpc/examples/connect-to-cloudflare-mesh/) example
 - Learn about the [Workers Binding API](/workers-vpc/api/)

--- a/src/content/docs/workers-vpc/examples/connect-to-cloudflare-mesh.mdx
+++ b/src/content/docs/workers-vpc/examples/connect-to-cloudflare-mesh.mdx
@@ -5,9 +5,9 @@ pcx_content_type: example
 
 import { WranglerConfig } from "~/components";
 
-This example demonstrates how to use a VPC Network binding with Cloudflare Mesh to access any private service in your account from a Worker — without pre-registering individual hosts or specifying a tunnel UUID.
+This example demonstrates how to use a VPC Network binding with [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) to connect to any private service in your account from a Worker — without pre-registering individual hosts or specifying a tunnel UUID.
 
-When you bind to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any service accessible through your account's Mesh nodes and Cloudflare Tunnels.
+When you bind to [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) using `network_id: "cf1:network"`, your Worker can reach any Mesh node, client device, or subnet route in your account.
 
 ## Prerequisites
 

--- a/src/content/docs/workers-vpc/examples/connect-to-cloudflare-mesh.mdx
+++ b/src/content/docs/workers-vpc/examples/connect-to-cloudflare-mesh.mdx
@@ -11,7 +11,7 @@ When you bind to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker 
 
 ## Prerequisites
 
-- A Cloudflare Mesh node connected to your private network
+- A [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) node connected to your private network
 - Private services running behind your Mesh node (for example, an internal API, database, or web application)
 
 ## 1. Configure your Worker
@@ -84,5 +84,5 @@ curl https://mesh-gateway.workers.dev/api/metrics
 
 - Learn more about [VPC Networks](/workers-vpc/configuration/vpc-networks/) configuration options
 - Refer to the [Workers Binding API](/workers-vpc/api/) reference
-- Set up Cloudflare Mesh for your account
+- [Set up Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/get-started/) for your account
 - Explore [other examples](/workers-vpc/examples/)

--- a/src/content/docs/workers-vpc/examples/connect-to-cloudflare-mesh.mdx
+++ b/src/content/docs/workers-vpc/examples/connect-to-cloudflare-mesh.mdx
@@ -1,0 +1,88 @@
+---
+title: Connect Workers to Cloudflare Mesh
+pcx_content_type: example
+---
+
+import { WranglerConfig } from "~/components";
+
+This example demonstrates how to use a VPC Network binding with Cloudflare Mesh to access any private service in your account from a Worker — without pre-registering individual hosts or specifying a tunnel UUID.
+
+When you bind to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any service accessible through your account's Mesh nodes and Cloudflare Tunnels.
+
+## Prerequisites
+
+- A Cloudflare Mesh node connected to your private network
+- Private services running behind your Mesh node (for example, an internal API, database, or web application)
+
+## 1. Configure your Worker
+
+Bind your Worker to Cloudflare Mesh using `network_id: "cf1:network"` in your Wrangler configuration:
+
+<WranglerConfig>
+```jsonc
+{
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "mesh-gateway",
+	"main": "src/index.js",
+	"compatibility_date": "$today",
+	"vpc_networks": [
+		{
+			"binding": "MESH",
+			"network_id": "cf1:network",
+			"remote": true
+		}
+	]
+}
+```
+</WranglerConfig>
+
+With this single binding, your Worker can reach any service across all tunnels and Mesh nodes in your account.
+
+## 2. Implement the Worker
+
+Use the VPC Network binding to access services by private IP address. Cloudflare Mesh currently supports IP-based routing only.
+
+```js title="index.js"
+// Replace with the Mesh IP and port of your private service
+const NODE_IP = "10.0.1.50";
+const NODE_PORT = 8080;
+
+export default {
+	async fetch(request, env, ctx) {
+		try {
+			const response = await env.MESH.fetch(
+				`http://${NODE_IP}:${NODE_PORT}/api/data`,
+			);
+			return response;
+		} catch (error) {
+			// fetch() throws if the VPC Network cannot connect to the target
+			return new Response("Service unavailable", { status: 503 });
+		}
+	},
+};
+```
+
+Unlike [VPC Services](/workers-vpc/configuration/vpc-services/), the URL you pass to `fetch()` determines the actual destination. You can reach any IP and port accessible through your Mesh network without creating separate bindings for each service.
+
+## 3. Deploy and test
+
+Deploy your Worker and verify it can reach your private services:
+
+```bash
+npx wrangler deploy
+```
+
+```bash
+# Test accessing the internal user API
+curl https://mesh-gateway.workers.dev/api/users
+
+# Test accessing metrics by private IP
+curl https://mesh-gateway.workers.dev/api/metrics
+```
+
+## Next steps
+
+- Learn more about [VPC Networks](/workers-vpc/configuration/vpc-networks/) configuration options
+- Refer to the [Workers Binding API](/workers-vpc/api/) reference
+- Set up Cloudflare Mesh for your account
+- Explore [other examples](/workers-vpc/examples/)


### PR DESCRIPTION
Add VPC Networks documentation and expand the Workers Binding API reference to cover both binding types.

## Summary

**New page — `workers-vpc/configuration/vpc-networks/`:**

Concept page for VPC Networks, covering:
- Bind by tunnel ID (`tunnel_id`)
- Bind to Cloudflare Mesh (`network_id: "cf1:network"`) — what Mesh is, when to use it, prerequisites, and config example
- Runtime usage
- VPC Networks vs VPC Services comparison table

**Updated page — `workers-vpc/api/`:**

Expanded to cover both VPC Service and VPC Network bindings. Clarifies the routing behavior difference between the two types, updates the required roles note, and generalizes the `fetch()` examples to apply to both.

Co-authored-by: Ricardo Antunes <RiscadoA@users.noreply.github.com>