### PR TITLE
[Agents] Add voice agents docs and update browser tools

### DIFF
--- a/src/content/docs/agents/api-reference/browse-the-web.mdx
+++ b/src/content/docs/agents/api-reference/browse-the-web.mdx
@@ -51,14 +51,18 @@ Add the Browser Rendering and Worker Loader bindings to your wrangler configurat
 
 <WranglerConfig>
 
-```toml
-[browser]
-binding = "BROWSER"
-
-[[worker_loaders]]
-binding = "LOADER"
-
-compatibility_flags = ["nodejs_compat"]
+```jsonc
+{
+	"compatibility_flags": ["nodejs_compat"],
+	"browser": {
+		"binding": "BROWSER"
+	},
+	"worker_loaders": [
+		{
+			"binding": "LOADER"
+		}
+	]
+}
 ```
 
 </WranglerConfig>
@@ -353,12 +357,15 @@ Add the browser binding to your wrangler configuration:
 
 <WranglerConfig>
 
-```toml
-[ai]
-binding = "AI"
-
-[browser]
-binding = "MYBROWSER"
+```jsonc
+{
+	"ai": {
+		"binding": "AI"
+	},
+	"browser": {
+		"binding": "BROWSER"
+	}
+}
 ```
 
 </WranglerConfig>

--- a/src/content/docs/agents/api-reference/browse-the-web.mdx
+++ b/src/content/docs/agents/api-reference/browse-the-web.mdx
@@ -1,30 +1,315 @@
 ---
 title: Browse the web
-pcx_content_type: concept
+pcx_content_type: reference
 sidebar:
   order: 15
 ---
 
 import {
-	MetaInfo,
-	Render,
-	Type,
+	InlineBadge,
 	TypeScriptExample,
 	WranglerConfig,
 	PackageManagers,
 } from "~/components";
 
-Agents can browse the web using the [Browser Rendering](/browser-rendering/) API or your preferred headless browser service.
+Give your agents full access to the Chrome DevTools Protocol (CDP) with browser tools. <InlineBadge preset="beta" />
 
-### Browser Rendering API
+Instead of a fixed set of browser actions (click, screenshot, navigate), the LLM writes JavaScript code that runs CDP commands against a live browser session — accessing all domains, commands, events, and types in the protocol.
 
-The [Browser Rendering](/browser-rendering/) allows you to spin up headless browser instances, render web pages, and interact with websites through your Agent.
+Two tools are provided:
 
-You can define a method that uses Puppeteer to pull the content of a web page, parse the DOM, and extract relevant information by calling a model via [Workers AI](/workers-ai/):
+| Tool | Description |
+| --- | --- |
+| `browser_search` | Query the CDP spec to discover commands, events, and types. The spec is fetched dynamically from the browser's CDP endpoint and cached. |
+| `browser_execute` | Run CDP commands against a live browser via a `cdp` helper. Each call opens a fresh browser session, executes the code, and closes it. |
+
+## When to use browser tools
+
+Browser tools are useful when your agent needs to:
+
+- **Inspect web pages** — DOM structure, computed styles, accessibility tree
+- **Debug frontend issues** — network waterfalls, console errors, performance traces
+- **Scrape structured data** — extract content from rendered pages
+- **Capture screenshots or PDFs** — visual snapshots of web content
+- **Profile performance** — Core Web Vitals, JavaScript profiling, memory analysis
+
+For basic page fetches that do not need a rendered DOM, use `fetch()` instead.
+
+## Install
+
+Browser tools require the Agents SDK and `@cloudflare/codemode`:
+
+```sh
+npm install agents @cloudflare/codemode ai zod
+```
+
+## Quick start
+
+### 1. Configure bindings
+
+Add the Browser Rendering and Worker Loader bindings to your wrangler configuration:
+
+<WranglerConfig>
+
+```toml
+[browser]
+binding = "BROWSER"
+
+[[worker_loaders]]
+binding = "LOADER"
+
+compatibility_flags = ["nodejs_compat"]
+```
+
+</WranglerConfig>
+
+### 2. Create browser tools
 
 <TypeScriptExample>
 
 ```ts
+import { createBrowserTools } from "agents/browser/ai";
+
+const browserTools = createBrowserTools({
+	browser: env.BROWSER,
+	loader: env.LOADER,
+});
+```
+
+</TypeScriptExample>
+
+To connect to a custom CDP endpoint instead of the Browser Rendering binding, pass `cdpUrl`.
+
+### 3. Use with streamText
+
+Pass browser tools alongside your other tools. The `model` can be any AI SDK provider — here using Workers AI:
+
+<TypeScriptExample>
+
+```ts
+import { streamText } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
+
+const workersai = createWorkersAI({ binding: env.AI });
+
+const result = streamText({
+	model: workersai("@cf/zai-org/glm-4.7-flash"),
+	system: "You are a helpful assistant that can inspect web pages.",
+	messages,
+	tools: {
+		...browserTools,
+		...otherTools,
+	},
+});
+```
+
+</TypeScriptExample>
+
+Both tools accept a `code` parameter containing a JavaScript async arrow function. The sandbox injects globals depending on the tool — `spec` for `browser_search` and `cdp` for `browser_execute`.
+
+When the LLM uses `browser_search`, the code queries the CDP spec via the injected `spec` object:
+
+```js
+async () => {
+	const s = await spec.get();
+	return s.domains
+		.find((d) => d.name === "Network")
+		.commands.map((c) => ({ method: c.method, description: c.description }));
+};
+```
+
+When the LLM uses `browser_execute`, the code runs CDP commands via the injected `cdp` helper:
+
+```js
+async () => {
+	const { targetId } = await cdp.send("Target.createTarget", {
+		url: "https://example.com",
+	});
+	const sessionId = await cdp.attachToTarget(targetId);
+	const { root } = await cdp.send("DOM.getDocument", {}, { sessionId });
+	const { outerHTML } = await cdp.send(
+		"DOM.getOuterHTML",
+		{ nodeId: root.nodeId },
+		{ sessionId },
+	);
+	await cdp.send("Target.closeTarget", { targetId });
+	return outerHTML;
+};
+```
+
+## Use with an Agent
+
+The typical pattern is to create browser tools inside an [`AIChatAgent`](/agents/api-reference/chat-agents/) message handler, which gives you message persistence and streaming:
+
+<TypeScriptExample>
+
+```ts
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { createBrowserTools } from "agents/browser/ai";
+import { createWorkersAI } from "workers-ai-provider";
+import { streamText, convertToModelMessages, stepCountIs } from "ai";
+
+export class MyAgent extends AIChatAgent<Env> {
+	async onChatMessage() {
+		const workersai = createWorkersAI({ binding: this.env.AI });
+		const browserTools = createBrowserTools({
+			browser: this.env.BROWSER,
+			loader: this.env.LOADER,
+		});
+
+		const result = streamText({
+			model: workersai("@cf/zai-org/glm-4.7-flash"),
+			system: "You can browse the web and inspect pages.",
+			messages: await convertToModelMessages(this.messages),
+			tools: {
+				...browserTools,
+			},
+			stopWhen: stepCountIs(10),
+		});
+
+		return result.toUIMessageStreamResponse();
+	}
+}
+```
+
+</TypeScriptExample>
+
+## TanStack AI
+
+For TanStack AI, use the `/tanstack-ai` export:
+
+<TypeScriptExample>
+
+```ts
+import { createBrowserTools } from "agents/browser/tanstack-ai";
+import { chat, workersAIText } from "@tanstack/ai";
+
+const browserTools = createBrowserTools({
+	browser: env.BROWSER,
+	loader: env.LOADER,
+});
+
+const stream = chat({
+	adapter: workersAIText(env.AI, "@cf/zai-org/glm-4.7-flash"),
+	tools: [...browserTools, ...otherTools],
+	messages,
+});
+```
+
+</TypeScriptExample>
+
+## Execution model
+
+- `browser_search` fetches the live CDP protocol from the browser's `/json/protocol` endpoint and caches it briefly.
+- `browser_execute` opens a fresh browser session for each call, exposes a small `cdp` helper API to sandboxed code, and closes the session when execution finishes.
+- LLM-generated code runs in a Worker sandbox. CDP traffic stays in the host Worker.
+
+## CDP helper API
+
+Inside `browser_execute`, the following functions are available to the sandboxed code.
+
+### `cdp.send(method, params?, options?)`
+
+Send a CDP command and wait for the response.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `method` | `string` | CDP method, for example `"DOM.getDocument"` or `"Network.enable"` |
+| `params` | `unknown` | Method parameters |
+| `options.timeoutMs` | `number` | Per-command timeout (default: 10 seconds) |
+| `options.sessionId` | `string` | Target session ID (required for page-scoped commands) |
+
+### `cdp.attachToTarget(targetId, options?)`
+
+Attach to a target and get a session ID. Uses `Target.attachToTarget` with `flatten: true`.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `targetId` | `string` | The target to attach to |
+| `options.timeoutMs` | `number` | Timeout for the attach command |
+
+Returns the `sessionId` string.
+
+### `cdp.getDebugLog(limit?)`
+
+Get recent CDP debug log entries (sends, receives, errors). Defaults to the last 50 entries, max 400.
+
+### `cdp.clearDebugLog()`
+
+Clear the debug log buffer.
+
+## Configuration
+
+### `createBrowserTools(options)`
+
+Returns AI SDK tools (`browser_search` and `browser_execute`).
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `browser` | `Fetcher` | — | Browser Rendering binding |
+| `cdpUrl` | `string` | — | Optional override for a custom CDP endpoint |
+| `cdpHeaders` | `Record<string, string>` | — | Headers for CDP URL discovery (for example, Cloudflare Access) |
+| `loader` | `WorkerLoader` | required | Worker Loader binding for sandboxed execution |
+| `timeout` | `number` | `30000` | Execution timeout in milliseconds |
+
+Either `browser` or `cdpUrl` must be provided. When both are set, `cdpUrl` takes priority.
+
+### Raw access
+
+For custom integrations, import the building blocks directly:
+
+<TypeScriptExample>
+
+```ts
+import {
+	CdpSession,
+	connectBrowser,
+	connectUrl,
+	createBrowserToolHandlers,
+} from "agents/browser";
+
+// Connect to a custom CDP endpoint
+const session = await connectUrl("http://localhost:9222");
+const version = await session.send("Browser.getVersion");
+session.close();
+```
+
+</TypeScriptExample>
+
+## Local development
+
+Recent Wrangler releases support Browser Rendering in local development. `npx wrangler dev` provisions the browser automatically, so the same `browser: env.BROWSER` setup works locally and when deployed.
+
+Use `cdpUrl` only when you intentionally want to connect to some other CDP-compatible browser endpoint, such as a tunnel or a manually managed Chrome instance.
+
+## Security considerations
+
+- LLM-generated code runs in **isolated Worker sandboxes** — each execution gets its own Worker instance
+- External network access (`fetch`, `connect`) is **blocked** in the sandbox at the runtime level
+- CDP commands are dispatched via Workers RPC — the WebSocket lives in the host, not the sandbox
+- The CDP spec stays on the server — only query results flow to the LLM
+- Responses are truncated to approximately 6,000 tokens to prevent context window overflow
+
+## Current limitations
+
+- **One session per execute call** — each `browser_execute` invocation opens a fresh browser session. Multi-step workflows must be completed within a single code block.
+- **No authenticated sessions** — the browser starts without any cookies or login state.
+- Requires `@cloudflare/codemode` as a peer dependency.
+- Limited to JavaScript execution in the sandbox (no TypeScript syntax).
+
+---
+
+## Using Puppeteer directly
+
+If you prefer to control the browser programmatically without LLM-generated code, you can use Puppeteer with the [Browser Rendering](/browser-rendering/) API directly.
+
+<PackageManagers pkg="@cloudflare/puppeteer" dev />
+
+<TypeScriptExample>
+
+```ts
+import puppeteer from "@cloudflare/puppeteer";
+
 interface Env {
 	BROWSER: Fetcher;
 	AI: Ai;
@@ -48,7 +333,7 @@ export class MyAgent extends Agent<Env> {
 				messages: [
 					{
 						role: "user",
-						content: `Return a JSON object with the product names, prices and URLs with the following format: { "name": "Product Name", "price": "Price", "url": "URL" } from the website content below. <content>${bodyContent}</content>`,
+						content: `Return a JSON object with the product names, prices and URLs from the website content below. <content>${bodyContent}</content>`,
 					},
 				],
 			});
@@ -64,28 +349,21 @@ export class MyAgent extends Agent<Env> {
 
 </TypeScriptExample>
 
-You'll also need to add install the `@cloudflare/puppeteer` package and add the following to the wrangler configuration of your Agent:
-
-<PackageManagers pkg="@cloudflare/puppeteer" dev />
+Add the browser binding to your wrangler configuration:
 
 <WranglerConfig>
 
-```jsonc
-{
-	// ...
-	"ai": {
-		"binding": "AI",
-	},
-	"browser": {
-		"binding": "MYBROWSER",
-	},
-	// ...
-}
+```toml
+[ai]
+binding = "AI"
+
+[browser]
+binding = "MYBROWSER"
 ```
 
 </WranglerConfig>
 
-### Browserbase
+## Using Browserbase
 
 You can also use [Browserbase](https://docs.browserbase.com/integrations/cloudflare/typescript) by using the Browserbase API directly from within your Agent.
 
@@ -96,12 +374,6 @@ cd your-agent-project-folder
 npx wrangler@latest secret put BROWSERBASE_API_KEY
 ```
 
-```sh output
-Enter a secret value: ******
-Creating the secret for the Worker "agents-example"
-Success! Uploaded secret BROWSERBASE_API_KEY
-```
-
 Install the `@cloudflare/puppeteer` package and use it from within your Agent to call the Browserbase API:
 
 <PackageManagers pkg="@cloudflare/puppeteer" />
@@ -109,13 +381,22 @@ Install the `@cloudflare/puppeteer` package and use it from within your Agent to
 <TypeScriptExample>
 
 ```ts
+import puppeteer from "@cloudflare/puppeteer";
+
 interface Env {
 	BROWSERBASE_API_KEY: string;
 }
 
-export class MyAgent extends Agent {
-	constructor(env: Env) {
-		super(env);
+export class MyAgent extends Agent<Env> {
+	async browse(url: string) {
+		const browser = await puppeteer.connect({
+			browserWSEndpoint: `wss://connect.browserbase.com?apiKey=${this.env.BROWSERBASE_API_KEY}`,
+		});
+		const page = await browser.newPage();
+		await page.goto(url);
+		const content = await page.content();
+		await browser.close();
+		return content;
 	}
 }
 ```

--- a/src/content/docs/agents/api-reference/voice.mdx
+++ b/src/content/docs/agents/api-reference/voice.mdx
@@ -1,0 +1,730 @@
+---
+title: Voice agents
+pcx_content_type: reference
+sidebar:
+  order: 16
+---
+
+import {
+	InlineBadge,
+	TypeScriptExample,
+	WranglerConfig,
+	PackageManagers,
+} from "~/components";
+
+Build real-time voice agents with speech-to-text, text-to-speech, and conversation persistence. Audio streams over WebSocket — no SFU or meeting infrastructure required. <InlineBadge preset="beta" />
+
+## Overview
+
+`@cloudflare/voice` provides two server-side mixins and matching client libraries:
+
+| Export | Import | Purpose |
+| --- | --- | --- |
+| `withVoice` | `@cloudflare/voice` | Full voice agent: STT, LLM, TTS, persistence |
+| `withVoiceInput` | `@cloudflare/voice` | STT-only: transcription without response |
+| `useVoiceAgent` | `@cloudflare/voice/react` | React hook for `withVoice` agents |
+| `useVoiceInput` | `@cloudflare/voice/react` | React hook for `withVoiceInput` agents |
+| `VoiceClient` | `@cloudflare/voice/client` | Framework-agnostic client |
+
+Built on Cloudflare Durable Objects, you get:
+
+- **Real-time audio** — mic audio streams as binary WebSocket frames, TTS audio streams back
+- **Automatic conversation persistence** — messages stored in SQLite, survive restarts
+- **Streaming TTS** — LLM tokens are sentence-chunked and synthesized concurrently
+- **Interruption handling** — user speech during playback cancels the current response
+- **Continuous STT** — per-call transcriber session, model handles turn detection
+- **Pipeline hooks** — intercept and transform text at every stage
+
+## Quick start
+
+### Install
+
+```sh
+npm install @cloudflare/voice agents
+```
+
+### Server
+
+<TypeScriptExample>
+
+```ts
+import { Agent } from "agents";
+import {
+	withVoice,
+	WorkersAIFluxSTT,
+	WorkersAITTS,
+	type VoiceTurnContext,
+} from "@cloudflare/voice";
+
+const VoiceAgent = withVoice(Agent);
+
+export class MyAgent extends VoiceAgent<Env> {
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new WorkersAITTS(this.env.AI);
+
+	async onTurn(transcript: string, context: VoiceTurnContext) {
+		return "Hello! I heard you say: " + transcript;
+	}
+}
+```
+
+</TypeScriptExample>
+
+### Client (React)
+
+```tsx
+import { useVoiceAgent } from "@cloudflare/voice/react";
+
+function VoiceUI() {
+	const {
+		status,
+		transcript,
+		interimTranscript,
+		audioLevel,
+		isMuted,
+		startCall,
+		endCall,
+		toggleMute,
+	} = useVoiceAgent({ agent: "MyAgent" });
+
+	return (
+		<div>
+			<p>Status: {status}</p>
+
+			<button onClick={status === "idle" ? startCall : endCall}>
+				{status === "idle" ? "Start Call" : "End Call"}
+			</button>
+
+			<button onClick={toggleMute}>{isMuted ? "Unmute" : "Mute"}</button>
+
+			{interimTranscript && (
+				<p>
+					<em>{interimTranscript}</em>
+				</p>
+			)}
+
+			{transcript.map((msg, i) => (
+				<p key={i}>
+					<strong>{msg.role}:</strong> {msg.text}
+				</p>
+			))}
+		</div>
+	);
+}
+```
+
+### Wrangler configuration
+
+<WranglerConfig>
+
+```toml
+[ai]
+binding = "AI"
+
+[[durable_objects.bindings]]
+name = "MyAgent"
+class_name = "MyAgent"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyAgent"]
+```
+
+</WranglerConfig>
+
+## How it works
+
+```txt
+Browser                              Durable Object (withVoice)
+┌──────────┐                         ┌──────────────────────────┐
+│ Mic      │   binary PCM (16kHz)    │ Transcriber session      │
+│          │ ──────────────────────► │ (per-call, continuous)   │
+│          │                         │   ↓ model detects turn   │
+│          │   JSON: transcript      │ onTurn() → your LLM code │
+│          │ ◄────────────────────── │   ↓ (sentence chunking)  │
+│          │   binary: audio         │ TTS                      │
+│ Speaker  │ ◄────────────────────── │                          │
+└──────────┘                         └──────────────────────────┘
+```
+
+1. The client captures mic audio and sends it as binary WebSocket frames (16kHz mono 16-bit PCM).
+2. Audio streams continuously to the transcriber session (created at `start_call`, lives for the entire call).
+3. The STT model detects when the user finishes an utterance and fires `onUtterance`. All providers use **model-driven turn detection** — the client does not need to signal end-of-speech for STT.
+4. Your `onTurn()` method runs — typically an LLM call.
+5. The response is sentence-chunked and synthesized via TTS.
+6. Audio streams back to the client for playback.
+
+The client receives `transcript_interim` messages with partial results as the user speaks, so you can show real-time feedback in the UI.
+
+## Server API: `withVoice`
+
+`withVoice(Agent)` adds the full voice pipeline to an Agent class.
+
+### Providers
+
+Set providers as class properties. Class field initializers run after `super()`, so `this.env` is available.
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `transcriber` | `Transcriber` | Yes | Continuous per-call STT provider |
+| `tts` | `TTSProvider` | Yes | Text-to-speech |
+
+<TypeScriptExample>
+
+```ts
+import { withVoice, WorkersAIFluxSTT, WorkersAITTS } from "@cloudflare/voice";
+
+const VoiceAgent = withVoice(Agent);
+
+export class MyAgent extends VoiceAgent<Env> {
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new WorkersAITTS(this.env.AI);
+}
+```
+
+</TypeScriptExample>
+
+For runtime model switching (for example, a Flux vs Nova 3 dropdown), override `createTranscriber`:
+
+<TypeScriptExample>
+
+```ts
+export class MyAgent extends VoiceAgent<Env> {
+	tts = new WorkersAITTS(this.env.AI);
+
+	createTranscriber(connection: Connection): Transcriber {
+		return new WorkersAIFluxSTT(this.env.AI);
+	}
+}
+```
+
+</TypeScriptExample>
+
+### `onTurn(transcript, context)`
+
+**Required.** Called when the user finishes speaking and the transcript is ready.
+
+Return a `string`, `AsyncIterable<string>`, or `ReadableStream` for streaming responses.
+
+**Simple response:**
+
+<TypeScriptExample>
+
+```ts
+export class MyAgent extends VoiceAgent<Env> {
+  transcriber = new WorkersAIFluxSTT(this.env.AI);
+  tts = new WorkersAITTS(this.env.AI);
+
+  async onTurn(transcript: string, context: VoiceTurnContext) {
+    return "You said: " + transcript;
+  }
+}
+```
+
+</TypeScriptExample>
+
+**Streaming response (recommended for LLM):**
+
+<TypeScriptExample>
+
+```ts
+import { streamText } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
+
+export class MyAgent extends VoiceAgent<Env> {
+  transcriber = new WorkersAIFluxSTT(this.env.AI);
+  tts = new WorkersAITTS(this.env.AI);
+
+  async onTurn(transcript: string, context: VoiceTurnContext) {
+    const workersai = createWorkersAI({ binding: this.env.AI });
+
+    const result = streamText({
+      model: workersai("@cf/moonshotai/kimi-k2.5"),
+      system: "You are a helpful voice assistant. Keep responses concise.",
+      messages: [
+        ...context.messages.map(m => ({
+          role: m.role as "user" | "assistant",
+          content: m.content,
+        })),
+        { role: "user", content: transcript },
+      ],
+      abortSignal: context.signal,
+    });
+
+    return result.textStream;
+  }
+}
+```
+
+</TypeScriptExample>
+
+The `context` object provides:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `connection` | `Connection` | The WebSocket connection |
+| `messages` | `Array<{ role: string; content: string }>` | Conversation history from SQLite |
+| `signal` | `AbortSignal` | Aborted on interrupt or disconnect |
+
+### Lifecycle hooks
+
+| Method | Description |
+| --- | --- |
+| `beforeCallStart(connection)` | Return `false` to reject the call |
+| `onCallStart(connection)` | Called after a call is accepted |
+| `onCallEnd(connection)` | Called when a call ends |
+| `onInterrupt(connection)` | Called when user interrupts during playback |
+
+### Pipeline hooks
+
+Intercept and transform data at each pipeline stage. Return `null` to skip the current utterance.
+
+| Method | Receives | Can skip? |
+| --- | --- | --- |
+| `afterTranscribe(transcript, connection)` | STT text | Yes |
+| `beforeSynthesize(text, connection)` | Text before TTS | Yes |
+| `afterSynthesize(audio, text, connection)` | Audio after TTS | Yes |
+
+<TypeScriptExample>
+
+```ts
+import { type Connection } from "agents";
+
+export class MyAgent extends VoiceAgent<Env> {
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new WorkersAITTS(this.env.AI);
+
+	afterTranscribe(transcript: string, connection: Connection) {
+		if (transcript.length < 3) return null;
+		return transcript;
+	}
+
+	beforeSynthesize(text: string, connection: Connection) {
+		return text.replace(/\bAI\b/g, "A.I.");
+	}
+
+	async onTurn(transcript: string, context: VoiceTurnContext) {
+		return transcript;
+	}
+}
+```
+
+</TypeScriptExample>
+
+### Convenience methods
+
+| Method | Description |
+| --- | --- |
+| `speak(connection, text)` | Synthesize and send audio to one connection |
+| `speakAll(text)` | Synthesize and send audio to all connections |
+| `forceEndCall(connection)` | Programmatically end a call |
+| `saveMessage(role, text)` | Persist a message to conversation history |
+| `getConversationHistory()` | Retrieve conversation history from SQLite |
+
+### Configuration options
+
+Pass options to `withVoice()` as the second argument:
+
+<TypeScriptExample>
+
+```ts
+const VoiceAgent = withVoice(Agent, {
+	historyLimit: 20,
+	audioFormat: "mp3",
+	maxMessageCount: 1000,
+});
+```
+
+</TypeScriptExample>
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `historyLimit` | `number` | `20` | Max messages loaded for context |
+| `audioFormat` | `string` | `"mp3"` | Audio format sent to client |
+| `maxMessageCount` | `number` | `1000` | Max messages stored in SQLite |
+
+## Server API: `withVoiceInput`
+
+`withVoiceInput(Agent)` adds STT-only voice input — no TTS, no LLM, no response generation. Use this for dictation, search-by-voice, or any UI where you need speech-to-text without a conversational agent.
+
+<TypeScriptExample>
+
+```ts
+import { Agent } from "agents";
+import { withVoiceInput, WorkersAINova3STT } from "@cloudflare/voice";
+
+const InputAgent = withVoiceInput(Agent);
+
+export class DictationAgent extends InputAgent<Env> {
+	transcriber = new WorkersAINova3STT(this.env.AI);
+
+	onTranscript(text: string, connection: Connection) {
+		console.log("User said:", text);
+	}
+}
+```
+
+</TypeScriptExample>
+
+### `onTranscript(text, connection)`
+
+Called after each utterance is transcribed. Override this to process the transcript.
+
+### Hooks
+
+`withVoiceInput` supports the same lifecycle hooks as `withVoice`:
+
+- `beforeCallStart(connection)` — return `false` to reject
+- `onCallStart(connection)`, `onCallEnd(connection)`, `onInterrupt(connection)`
+- `createTranscriber(connection)` — override for runtime model switching
+- `afterTranscribe(transcript, connection)` — filter or transform transcripts
+
+It does **not** have TTS hooks (`beforeSynthesize`, `afterSynthesize`) or `onTurn`.
+
+## Client API: React hooks
+
+### `useVoiceAgent`
+
+Wraps `VoiceClient` for `withVoice` agents. Manages connection, mic capture, playback, silence detection, and interrupt detection.
+
+```tsx
+import { useVoiceAgent } from "@cloudflare/voice/react";
+
+const {
+	status, // "idle" | "listening" | "thinking" | "speaking"
+	transcript, // TranscriptMessage[] — conversation history
+	interimTranscript, // string | null — real-time partial transcript
+	metrics, // VoicePipelineMetrics | null
+	audioLevel, // number (0–1) — current mic RMS level
+	isMuted, // boolean
+	connected, // boolean — WebSocket connected
+	error, // string | null
+	startCall, // () => Promise<void>
+	endCall, // () => void
+	toggleMute, // () => void
+	sendText, // (text: string) => void — bypass STT
+	sendJSON, // (data: Record<string, unknown>) => void
+	lastCustomMessage, // unknown — last non-voice message from server
+} = useVoiceAgent({
+	agent: "MyAgent",
+	name: "default",
+	host: window.location.host,
+});
+```
+
+#### Tuning options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `silenceThreshold` | `number` | `0.04` | RMS below this is silence |
+| `silenceDurationMs` | `number` | `500` | Silence duration before `end_of_speech` (ms) |
+| `interruptThreshold` | `number` | `0.05` | RMS to detect speech during playback |
+| `interruptChunks` | `number` | `2` | Consecutive high-RMS chunks to trigger interrupt |
+
+Changing tuning options triggers a client reconnect (the connection key includes them).
+
+### `useVoiceInput`
+
+Lightweight hook for dictation and voice-to-text. Accumulates user transcripts into a single string.
+
+```tsx
+import { useVoiceInput } from "@cloudflare/voice/react";
+
+function Dictation() {
+	const {
+		transcript, // string — accumulated text from all utterances
+		interimTranscript, // string | null — current partial transcript
+		isListening, // boolean
+		audioLevel, // number (0–1)
+		isMuted, // boolean
+		error, // string | null
+		start, // () => Promise<void>
+		stop, // () => void
+		toggleMute, // () => void
+		clear, // () => void — clear accumulated transcript
+	} = useVoiceInput({ agent: "DictationAgent" });
+
+	return (
+		<div>
+			<textarea
+				value={
+					transcript + (interimTranscript ? " " + interimTranscript : "")
+				}
+				readOnly
+			/>
+			<button onClick={isListening ? stop : start}>
+				{isListening ? "Stop" : "Dictate"}
+			</button>
+		</div>
+	);
+}
+```
+
+## Client API: `VoiceClient`
+
+Framework-agnostic client for environments without React.
+
+<TypeScriptExample>
+
+```ts
+import { VoiceClient } from "@cloudflare/voice/client";
+
+const client = new VoiceClient({ agent: "MyAgent" });
+
+client.addEventListener("statuschange", (status) => {
+	console.log("Status:", status);
+});
+
+client.addEventListener("transcriptchange", (messages) => {
+	console.log("Transcript:", messages);
+});
+
+client.addEventListener("error", (err) => {
+	console.error("Error:", err);
+});
+
+client.connect();
+await client.startCall();
+
+// Later:
+client.endCall();
+client.disconnect();
+```
+
+</TypeScriptExample>
+
+### Events
+
+| Event | Data type | Description |
+| --- | --- | --- |
+| `statuschange` | `VoiceStatus` | Pipeline state changed |
+| `transcriptchange` | `TranscriptMessage[]` | Transcript updated |
+| `interimtranscript` | `string \| null` | Interim transcript from streaming STT |
+| `metricschange` | `VoicePipelineMetrics` | Pipeline timing metrics |
+| `audiolevelchange` | `number` | Mic audio level (0–1) |
+| `connectionchange` | `boolean` | WebSocket connected/disconnected |
+| `mutechange` | `boolean` | Mute state changed |
+| `error` | `string \| null` | Error occurred |
+| `custommessage` | `unknown` | Non-voice message from server |
+
+### Advanced options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `transport` | `VoiceTransport` | Custom transport (default: WebSocket via PartySocket) |
+| `audioInput` | `VoiceAudioInput` | Custom mic capture (default: built-in AudioWorklet) |
+| `preferredFormat` | `VoiceAudioFormat` | Hint for server audio format (advisory only) |
+
+## Providers
+
+### Built-in (Workers AI)
+
+No API keys required — use your Workers AI binding:
+
+| Class | Type | Default model | Recommended for |
+| --- | --- | --- | --- |
+| `WorkersAIFluxSTT` | Continuous STT | `@cf/deepgram/flux` | `withVoice` |
+| `WorkersAINova3STT` | Continuous STT | `@cf/deepgram/nova-3` | `withVoiceInput` |
+| `WorkersAITTS` | TTS | `@cf/deepgram/aura-1` | Both |
+
+<TypeScriptExample>
+
+```ts
+import { Agent } from "agents";
+import {
+	withVoice,
+	WorkersAIFluxSTT,
+	WorkersAINova3STT,
+	WorkersAITTS,
+} from "@cloudflare/voice";
+
+const VoiceAgent = withVoice(Agent);
+
+// Default usage
+export class MyAgent extends VoiceAgent<Env> {
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new WorkersAITTS(this.env.AI);
+}
+
+// Custom options
+export class CustomAgent extends VoiceAgent<Env> {
+	transcriber = new WorkersAIFluxSTT(this.env.AI, {
+		eotThreshold: 0.8,
+		keyterms: ["Cloudflare", "Workers"],
+	});
+	tts = new WorkersAITTS(this.env.AI, {
+		model: "@cf/deepgram/aura-1",
+		speaker: "asteria",
+	});
+}
+```
+
+</TypeScriptExample>
+
+### Third-party providers
+
+| Package | Class | Description |
+| --- | --- | --- |
+| `@cloudflare/voice-deepgram` | `DeepgramSTT` | Continuous STT |
+| `@cloudflare/voice-elevenlabs` | `ElevenLabsTTS` | High-quality TTS |
+| `@cloudflare/voice-twilio` | `TwilioAdapter` | Telephony (phone calls) |
+
+**ElevenLabs TTS:**
+
+<TypeScriptExample>
+
+```ts
+import { ElevenLabsTTS } from "@cloudflare/voice-elevenlabs";
+
+export class MyAgent extends VoiceAgent<Env> {
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new ElevenLabsTTS({
+		apiKey: this.env.ELEVENLABS_API_KEY,
+		voiceId: "21m00Tcm4TlvDq8ikWAM",
+	});
+}
+```
+
+</TypeScriptExample>
+
+**Deepgram STT:**
+
+<TypeScriptExample>
+
+```ts
+import { DeepgramSTT } from "@cloudflare/voice-deepgram";
+
+export class MyAgent extends VoiceAgent<Env> {
+	transcriber = new DeepgramSTT({
+		apiKey: this.env.DEEPGRAM_API_KEY,
+	});
+	tts = new WorkersAITTS(this.env.AI);
+}
+```
+
+</TypeScriptExample>
+
+## Telephony (Twilio)
+
+Connect phone calls to your voice agent using the Twilio adapter:
+
+```sh
+npm install @cloudflare/voice-twilio
+```
+
+The adapter bridges Twilio Media Streams to your VoiceAgent:
+
+```txt
+Phone → Twilio → WebSocket → TwilioAdapter → WebSocket → VoiceAgent
+```
+
+`WorkersAITTS` returns MP3, which cannot be decoded to PCM in the Workers runtime. When using the Twilio adapter, use a TTS provider that outputs raw PCM (for example, ElevenLabs with `outputFormat: "pcm_16000"`).
+
+## Text messages
+
+`withVoice` agents can also receive text messages, bypassing STT entirely. This is useful for chat-style input alongside voice.
+
+```tsx
+const { sendText } = useVoiceAgent({ agent: "MyAgent" });
+
+// Send text — goes straight to onTurn() without STT
+sendText("What is the weather like today?");
+```
+
+Text messages work both during and outside of active calls. During a call, the response is spoken aloud via TTS. Outside a call, the response is sent as text-only transcript messages.
+
+## Custom messages
+
+Send and receive application-level JSON messages alongside voice protocol messages. Non-voice messages pass through to your `onMessage` handler on the server and emit `custommessage` events on the client.
+
+**Server:**
+
+<TypeScriptExample>
+
+```ts
+export class MyAgent extends VoiceAgent<Env> {
+	onMessage(connection: Connection, message: WSMessage) {
+		const data = JSON.parse(message as string);
+		if (data.type === "kick_speaker") {
+			this.forceEndCall(connection);
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+**Client:**
+
+```tsx
+const { sendJSON, lastCustomMessage } = useVoiceAgent({ agent: "MyAgent" });
+
+sendJSON({ type: "kick_speaker" });
+
+useEffect(() => {
+	if (lastCustomMessage) {
+		console.log("Custom message:", lastCustomMessage);
+	}
+}, [lastCustomMessage]);
+```
+
+## Single-speaker enforcement
+
+Use `beforeCallStart` to restrict who can start a call. This example enforces single-speaker — only one connection can be the active speaker at a time:
+
+<TypeScriptExample>
+
+```ts
+import { type Connection } from "agents";
+
+export class MyAgent extends VoiceAgent<Env> {
+	#speakerId: string | null = null;
+
+	beforeCallStart(connection: Connection) {
+		if (this.#speakerId !== null) {
+			return false;
+		}
+		this.#speakerId = connection.id;
+		return true;
+	}
+
+	onCallEnd(connection: Connection) {
+		if (this.#speakerId === connection.id) {
+			this.#speakerId = null;
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Pipeline metrics
+
+`withVoice` agents emit timing metrics after each turn:
+
+```tsx
+const { metrics } = useVoiceAgent({ agent: "MyAgent" });
+
+// metrics: {
+//   llm_ms: 850,
+//   tts_ms: 200,
+//   first_audio_ms: 950,
+//   total_ms: 1200,
+// }
+```
+
+## Conversation history
+
+`withVoice` automatically persists conversation messages to SQLite. Access history in your `onTurn` via `context.messages`, or directly:
+
+<TypeScriptExample>
+
+```ts
+const history = this.getConversationHistory(20);
+
+this.saveMessage("assistant", "Welcome! How can I help?");
+```
+
+</TypeScriptExample>
+
+History survives Durable Object restarts and client reconnections. Voice agents use `keepAlive` to prevent eviction during active calls.

--- a/src/content/docs/agents/api-reference/voice.mdx
+++ b/src/content/docs/agents/api-reference/voice.mdx
@@ -117,17 +117,26 @@ function VoiceUI() {
 
 <WranglerConfig>
 
-```toml
-[ai]
-binding = "AI"
-
-[[durable_objects.bindings]]
-name = "MyAgent"
-class_name = "MyAgent"
-
-[[migrations]]
-tag = "v1"
-new_sqlite_classes = ["MyAgent"]
+```jsonc
+{
+	"ai": {
+		"binding": "AI"
+	},
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "MyAgent",
+				"class_name": "MyAgent"
+			}
+		]
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["MyAgent"]
+		}
+	]
+}
 ```
 
 </WranglerConfig>

--- a/src/content/docs/agents/guides/build-a-voice-agent.mdx
+++ b/src/content/docs/agents/guides/build-a-voice-agent.mdx
@@ -48,22 +48,30 @@ Update `wrangler.jsonc` to include a Workers AI binding and a Durable Object for
 
 <WranglerConfig>
 
-```toml
-name = "voice-agent"
-compatibility_date = "$today"
-compatibility_flags = ["nodejs_compat"]
-main = "src/server.ts"
-
-[ai]
-binding = "AI"
-
-[[durable_objects.bindings]]
-name = "MyVoiceAgent"
-class_name = "MyVoiceAgent"
-
-[[migrations]]
-tag = "v1"
-new_sqlite_classes = ["MyVoiceAgent"]
+```jsonc
+{
+	"name": "voice-agent",
+	"compatibility_date": "$today",
+	"compatibility_flags": ["nodejs_compat"],
+	"main": "src/server.ts",
+	"ai": {
+		"binding": "AI"
+	},
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "MyVoiceAgent",
+				"class_name": "MyVoiceAgent"
+			}
+		]
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["MyVoiceAgent"]
+		}
+	]
+}
 ```
 
 </WranglerConfig>

--- a/src/content/docs/agents/guides/build-a-voice-agent.mdx
+++ b/src/content/docs/agents/guides/build-a-voice-agent.mdx
@@ -1,0 +1,299 @@
+---
+title: Build a voice agent
+pcx_content_type: tutorial
+sidebar:
+  order: 15
+products:
+  - workers
+difficulty: Intermediate
+---
+
+import {
+	InlineBadge,
+	TypeScriptExample,
+	WranglerConfig,
+	PackageManagers,
+	LinkCard,
+} from "~/components";
+
+Build a voice agent that listens to users, thinks with an LLM, and speaks back — all in real-time over WebSocket. <InlineBadge preset="beta" />
+
+By the end of this guide you will have:
+
+- A server-side voice agent with speech-to-text and text-to-speech
+- An LLM-powered `onTurn` handler that streams responses
+- Tools that the agent can call during conversation
+- A React client with a push-to-talk style UI
+
+## Prerequisites
+
+- A Cloudflare account with [Workers AI](/workers-ai/) access
+- Node.js 18+
+
+## 1. Create the project
+
+Scaffold a new Workers project with Vite and React, then add the voice dependencies:
+
+```sh
+npm create cloudflare@latest voice-agent -- --template cloudflare/agents-starter
+cd voice-agent
+npm install @cloudflare/voice
+```
+
+The starter gives you a working Vite + React + Cloudflare Workers setup. You will replace the server and client code in the following steps.
+
+## 2. Configure wrangler
+
+Update `wrangler.jsonc` to include a Workers AI binding and a Durable Object for your voice agent:
+
+<WranglerConfig>
+
+```toml
+name = "voice-agent"
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+main = "src/server.ts"
+
+[ai]
+binding = "AI"
+
+[[durable_objects.bindings]]
+name = "MyVoiceAgent"
+class_name = "MyVoiceAgent"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyVoiceAgent"]
+```
+
+</WranglerConfig>
+
+## 3. Build the server
+
+Replace `src/server.ts` with the following. The `withVoice` mixin adds the full voice pipeline — STT, sentence chunking, TTS, and conversation persistence — to a standard `Agent` class.
+
+<TypeScriptExample>
+
+```ts
+import { Agent, routeAgentRequest, type Connection } from "agents";
+import {
+	withVoice,
+	WorkersAIFluxSTT,
+	WorkersAITTS,
+	type VoiceTurnContext,
+} from "@cloudflare/voice";
+import { streamText, tool, stepCountIs } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
+import { z } from "zod";
+
+const VoiceAgent = withVoice(Agent);
+
+export class MyVoiceAgent extends VoiceAgent<Env> {
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new WorkersAITTS(this.env.AI);
+
+	async onTurn(transcript: string, context: VoiceTurnContext) {
+		const workersAi = createWorkersAI({ binding: this.env.AI });
+
+		const result = streamText({
+			model: workersAi("@cf/moonshotai/kimi-k2.5"),
+			system:
+				"You are a helpful voice assistant. Keep responses concise — you are being spoken aloud.",
+			messages: [
+				...context.messages.map((m) => ({
+					role: m.role as "user" | "assistant",
+					content: m.content,
+				})),
+				{ role: "user" as const, content: transcript },
+			],
+			tools: {
+				get_current_time: tool({
+					description: "Get the current date and time.",
+					inputSchema: z.object({}),
+					execute: async () => ({
+						time: new Date().toLocaleTimeString("en-US", {
+							hour: "2-digit",
+							minute: "2-digit",
+						}),
+					}),
+				}),
+			},
+			stopWhen: stepCountIs(3),
+			abortSignal: context.signal,
+		});
+
+		return result.textStream;
+	}
+
+	async onCallStart(connection: Connection) {
+		await this.speak(connection, "Hi there! How can I help you today?");
+	}
+}
+
+export default {
+	async fetch(request: Request, env: Env) {
+		return (
+			(await routeAgentRequest(request, env)) ??
+			new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+Key points:
+
+- `WorkersAIFluxSTT` handles continuous speech-to-text — the model detects when the user finishes speaking.
+- `WorkersAITTS` converts the LLM response to audio, sentence by sentence.
+- `onTurn` receives the transcript and returns a stream. The mixin handles chunking the stream into sentences and synthesizing each one.
+- `onCallStart` sends a greeting when the user connects.
+- `context.messages` contains the full conversation history from SQLite.
+- `context.signal` is aborted if the user interrupts or disconnects.
+
+## 4. Build the client
+
+Replace `src/client.tsx` with a React component using the `useVoiceAgent` hook. The hook manages the WebSocket connection, mic capture, audio playback, and interrupt detection.
+
+```tsx
+import { useVoiceAgent } from "@cloudflare/voice/react";
+
+function App() {
+	const {
+		status,
+		transcript,
+		interimTranscript,
+		metrics,
+		audioLevel,
+		isMuted,
+		startCall,
+		endCall,
+		toggleMute,
+	} = useVoiceAgent({ agent: "MyVoiceAgent" });
+
+	return (
+		<div>
+			<h1>Voice Agent</h1>
+			<p>Status: {status}</p>
+
+			<div>
+				<button onClick={status === "idle" ? startCall : endCall}>
+					{status === "idle" ? "Start Call" : "End Call"}
+				</button>
+				{status !== "idle" && (
+					<button onClick={toggleMute}>
+						{isMuted ? "Unmute" : "Mute"}
+					</button>
+				)}
+			</div>
+
+			{interimTranscript && (
+				<p>
+					<em>{interimTranscript}</em>
+				</p>
+			)}
+
+			{transcript.map((msg, i) => (
+				<p key={i}>
+					<strong>{msg.role}:</strong> {msg.text}
+				</p>
+			))}
+
+			{metrics && (
+				<p>
+					LLM: {metrics.llm_ms}ms | TTS: {metrics.tts_ms}ms | First
+					audio: {metrics.first_audio_ms}ms
+				</p>
+			)}
+		</div>
+	);
+}
+```
+
+The `status` field cycles through `"idle"` → `"listening"` → `"thinking"` → `"speaking"` → `"listening"`, giving you everything you need to build a responsive UI.
+
+## 5. Run it
+
+```sh
+npm run dev
+```
+
+Open the app in your browser, select **Start Call**, and speak. You will see the transcript appear in real time, and the agent's response will play through your speakers.
+
+## Adding pipeline hooks
+
+You can intercept and transform data at each stage of the pipeline. For example, filter out short transcripts (noise) and adjust pronunciation before TTS:
+
+<TypeScriptExample>
+
+```ts
+export class MyVoiceAgent extends VoiceAgent<Env> {
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new WorkersAITTS(this.env.AI);
+
+	afterTranscribe(transcript: string, connection: Connection) {
+		if (transcript.length < 3) return null;
+		return transcript;
+	}
+
+	beforeSynthesize(text: string, connection: Connection) {
+		return text.replace(/\bAI\b/g, "A.I.");
+	}
+
+	async onTurn(transcript: string, context: VoiceTurnContext) {
+		return "You said: " + transcript;
+	}
+}
+```
+
+</TypeScriptExample>
+
+Returning `null` from `afterTranscribe` drops the utterance entirely — useful for filtering noise or very short transcripts.
+
+## Using third-party providers
+
+Swap in third-party STT or TTS providers without changing your agent logic:
+
+<TypeScriptExample>
+
+```ts
+import { ElevenLabsTTS } from "@cloudflare/voice-elevenlabs";
+import { DeepgramSTT } from "@cloudflare/voice-deepgram";
+
+export class MyVoiceAgent extends VoiceAgent<Env> {
+	transcriber = new DeepgramSTT({
+		apiKey: this.env.DEEPGRAM_API_KEY,
+	});
+
+	tts = new ElevenLabsTTS({
+		apiKey: this.env.ELEVENLABS_API_KEY,
+		voiceId: "21m00Tcm4TlvDq8ikWAM",
+	});
+
+	async onTurn(transcript: string, context: VoiceTurnContext) {
+		return "You said: " + transcript;
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Next steps
+
+<LinkCard
+	title="Voice agents API reference"
+	href="/agents/api-reference/voice/"
+	description="Full reference for withVoice, withVoiceInput, React hooks, VoiceClient, and all providers."
+/>
+
+<LinkCard
+	title="Chat agents"
+	href="/agents/api-reference/chat-agents/"
+	description="Build text-based AI chat with AIChatAgent and useAgentChat."
+/>
+
+<LinkCard
+	title="Using AI models"
+	href="/agents/api-reference/using-ai-models/"
+	description="Use Workers AI, OpenAI, Anthropic, Gemini, or any provider with your agents."
+/>

--- a/src/content/docs/agents/index.mdx
+++ b/src/content/docs/agents/index.mdx
@@ -63,7 +63,8 @@ The starter includes streaming AI chat, server-side and client-side tools, human
 - **Think with any model** — Call [any AI model](/agents/api-reference/using-ai-models/) — Workers AI, OpenAI, Anthropic, Gemini — and stream responses over [WebSockets](/agents/api-reference/websockets/) or [Server-Sent Events](/agents/api-reference/http-sse/). Long-running reasoning models that take minutes to respond work out of the box.
 - **Use and serve tools** — Define server-side tools, client-side tools that run in the browser, and [human-in-the-loop](/agents/concepts/human-in-the-loop/) approval flows. Expose your agent's tools to other agents and LLMs via [MCP](/agents/api-reference/mcp-agent-api/).
 - **Act on their own** — [Schedule tasks](/agents/api-reference/schedule-tasks/) on a delay, at a specific time, or on a cron. Agents can wake themselves up, do work, and go back to sleep — without a user present.
-- **Browse the web** — Spin up [headless browsers](/agents/api-reference/browse-the-web/) to scrape, screenshot, and interact with web pages.
+- **Browse the web** — Give your agents [browser tools](/agents/api-reference/browse-the-web/) powered by the Chrome DevTools Protocol to scrape, screenshot, debug, and interact with web pages.
+- **Talk to users** — Build real-time [voice agents](/agents/api-reference/voice/) with speech-to-text, text-to-speech, and conversation persistence — audio streams over WebSocket.
 - **Orchestrate work** — Run multi-step [workflows](/agents/api-reference/run-workflows/) with automatic retries, or coordinate across multiple agents.
 - **React to events** — Handle [inbound email](/agents/api-reference/email/), HTTP requests, WebSocket messages, and state changes — all from the same class.
 


### PR DESCRIPTION
### Summary

Adds documentation for two recently shipped Agents SDK features: **voice agents** (`@cloudflare/voice`) and **browser tools** (`agents/browser`).

**New pages:**
- `api-reference/voice.mdx` — Full reference for `withVoice`, `withVoiceInput`, React hooks (`useVoiceAgent`, `useVoiceInput`), `VoiceClient`, Workers AI and third-party providers, telephony (Twilio), pipeline hooks, conversation persistence.
- `guides/build-a-voice-agent.mdx` — Step-by-step tutorial: scaffold a project, wire up STT + LLM + TTS, build a React client, add pipeline hooks and third-party providers.

**Updated pages:**
- `api-reference/browse-the-web.mdx` — Rewritten to lead with the new CDP-based `agents/browser` tools (`createBrowserTools` for AI SDK and TanStack AI), CDP helper API reference, configuration, security model, and limitations. Puppeteer and Browserbase kept as alternatives below the fold.
- `index.mdx` — Updated "Browse the web" bullet and added "Talk to users" bullet for voice agents.

Source content synced from the agents repo (`docs/browse-the-web.md` and `docs/voice.md`).

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.


Made with [Cursor](https://cursor.com)