### PR TITLE
Document schedule property for Workflow bindings

### DIFF
--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1127,6 +1127,9 @@ To bind Workflows to your Worker, assign an array of the below object to the `wo
 - `script_name` <Type text="string" /> <MetaInfo text="optional" />
   - The name of the Worker script where the Workflow class is defined. Only required if the Workflow is defined in a different Worker than the one the binding is configured on.
 
+- `schedule` <Type text="string | string[]" /> <MetaInfo text="optional" />
+  - A cron expression, or array of cron expressions, that automatically triggers new Workflow instances on the given schedule. For example, `"0 9 * * 1"` triggers every Monday at 9am UTC. Cannot be set on a Workflow that references an external `script_name`.
+
 Example:
 
 <WranglerConfig>
@@ -1138,6 +1141,8 @@ Example:
 			"binding": "<BINDING_NAME>",
 			"name": "<WORKFLOW_NAME>",
 			"class_name": "<CLASS_NAME>",
+			// optional: trigger on a cron schedule
+			"schedule": "0 9 * * 1",
 		},
 	],
 }

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -211,6 +211,49 @@ steps = 25_000
 
 Note that Workflows on Workers Free have a limit of 1,024 steps. Refer to [Workflow limits](/workflows/reference/limits/) for more information.
 
+## Workflow schedules
+
+You can automatically trigger new Workflow instances on a cron schedule by setting the `schedule` property in your Wrangler configuration. It accepts a single cron expression or an array of cron expressions.
+
+<WranglerConfig>
+
+```jsonc
+{
+	"workflows": [
+		{
+			"name": "my-workflow",
+			"binding": "MY_WORKFLOW",
+			"class_name": "MyWorkflow",
+			// trigger every day at 9am UTC
+			"schedule": "0 9 * * *",
+		},
+	],
+}
+```
+
+</WranglerConfig>
+
+To trigger on multiple schedules, provide an array:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"workflows": [
+		{
+			"name": "my-workflow",
+			"binding": "MY_WORKFLOW",
+			"class_name": "MyWorkflow",
+			"schedule": ["0 9 * * 1", "0 17 * * 5"],
+		},
+	],
+}
+```
+
+</WranglerConfig>
+
+The `schedule` property cannot be set on a Workflow that references an external `script_name`. Configure the schedule on the Worker that defines the Workflow.
+
 ## NonRetryableError
 
 - <code>throw new NonRetryableError(message: <Type text="string" />, name <Type text="string" /> <MetaInfo text="optional" />)</code>: <Type text="NonRetryableError" />


### PR DESCRIPTION
Adds documentation for the new `schedule` field on Workflow bindings, introduced in cloudflare/workers-sdk#13467.

#### Changes

- `workers/wrangler/configuration.mdx` — added `schedule` field entry alongside the other workflow binding properties
- `workflows/build/workers-api.mdx` — added a new "Workflow schedules" section with single and array cron expression examples

Related: WOR-1221