### PR TITLE
[DNS] Update allow range IPs for zone transfers and NOTIFY (PCX-21353)

### DIFF
--- a/src/content/docs/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses.mdx
@@ -6,6 +6,10 @@ sidebar:
 head:
   - tag: title
     content: Cloudflare IP addresses - Access Control Lists (ACLs)
+banner:
+  content: |
+    Cloudflare is updating the source IP addresses used for DNS zone transfers (AXFR/IXFR) and NOTIFY messages. You must update your allow lists before <strong>December 1, 2026</strong> to avoid service disruption.
+  type: caution
 
 ---
 
@@ -21,7 +25,27 @@ If you are using Cloudflare for Primary DNS — meaning that you are setting up 
 
 ### Allow range
 
-Cloudflare's NOTIFY messages originate from the following IP prefixes. These ranges need to be allowed at your Secondary DNS servers.
+Cloudflare's NOTIFY messages originate from the following IP addresses. These need to be allowed at your secondary DNS servers.
+
+```txt
+104.30.167.163
+104.30.167.173
+2a09:bac0:1000:c47::/64
+```
+
+:::caution[Action required: IP address migration]
+Cloudflare is migrating the source IP addresses used for NOTIFY messages. Since April 15, 2026, Cloudflare sends from the new IP addresses listed above and temporarily falls back to the old IP addresses (listed below) if the new ones are blocked.
+
+**On December 1, 2026, the old IP addresses will stop working.** Only the new IP addresses listed above will be used.
+
+If you have an existing configuration, add the new IP addresses to your allow list first, verify that you are receiving NOTIFY messages from the new addresses, and only then remove the old IP addresses.
+:::
+
+#### Old allow range (deprecated)
+
+:::danger
+The following IP ranges are deprecated and will stop working on **December 1, 2026**. Replace them with the new IP addresses listed above.
+:::
 
 ```txt
 198.41.144.240/28
@@ -44,7 +68,27 @@ If you are using Cloudflare for Secondary DNS — meaning that you are setting u
 
 ### Allow range
 
-Cloudflare's AXFR/IXFR zone transfer requests originate from the following IP prefixes. These ranges need to be allowed at your Primary DNS servers.
+Cloudflare's AXFR/IXFR zone transfer requests originate from the following IP addresses. These need to be allowed at your primary DNS servers.
+
+```txt
+104.30.167.163
+104.30.167.173
+2a09:bac0:1000:c47::/64
+```
+
+:::caution[Action required: IP address migration]
+Cloudflare is migrating the source IP addresses used for zone transfer requests (AXFR/IXFR). Since April 15, 2026, Cloudflare sends from the new IP addresses listed above and temporarily falls back to the old IP addresses (listed below) if the new ones are blocked.
+
+**On December 1, 2026, the old IP addresses will stop working.** Only the new IP addresses listed above will be used.
+
+If you have an existing configuration, add the new IP addresses to your allow list first, verify that zone transfers are working correctly from the new addresses, and only then remove the old IP addresses.
+:::
+
+#### Old allow range (deprecated)
+
+:::danger
+The following IP ranges are deprecated and will stop working on **December 1, 2026**. Replace them with the new IP addresses listed above.
+:::
 
 ```txt
 198.41.144.240/28
@@ -64,11 +108,15 @@ Notify IPs are the IP addresses where you notify Cloudflare's Secondary DNS to i
 2606:4700:60:0:35a:4be3:4144:c5ee
 ```
 
-### Bind server configuration
+### BIND server configuration
 
 To run a BIND server as a primary, add the following statements to your zone file:
 
 ```txt
-allow-transfer {198.41.144.240/28;198.41.150.240/28;2a06:98c0:3601::/48;2a06:98c0:1401::/48;}
+allow-transfer {104.30.167.163;104.30.167.173;2a09:bac0:1000:c47::/64;}
 also-notify { 172.65.30.82;172.65.50.145;2606:4700:60:0:317:26ee:3bdf:5774;2606:4700:60:0:35a:4be3:4144:c5ee;}
 ```
+
+:::caution
+If you are updating an existing BIND configuration, first add the new IP addresses alongside the old ones in your `allow-transfer` directive. Verify that zone transfers are completing successfully from the new addresses, and only then remove the old IP addresses. The old IP addresses will stop working on **December 1, 2026**.
+:::

--- a/src/content/docs/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses.mdx
@@ -15,7 +15,7 @@ banner:
 
 import { Details } from "~/components";
 
-Depending on the setup ([Cloudflare as Primary](#cloudflare-as-primary) or [Cloudflare as Secondary](#cloudflare-as-secondary)), you need to configure slightly different Cloudflare IP addresses at your other DNS provider.
+Depending on your setup ([Cloudflare as Primary](#cloudflare-as-primary) or [Cloudflare as Secondary](#cloudflare-as-secondary)), you need to configure slightly different Cloudflare IP addresses at your other DNS provider.
 
 ## Source IP addresses
 
@@ -52,7 +52,7 @@ If you are using Cloudflare for Primary DNS — meaning that you are setting up 
 
 ### Allow range
 
-Allow the [source IP addresses](#source-ip-addresses) listed above at your secondary DNS servers.
+Cloudflare's NOTIFY messages originate from the [source IP addresses](#source-ip-addresses) listed above. Allow them at your secondary DNS servers.
 
 ### Transfer IP
 
@@ -68,7 +68,7 @@ If you are using Cloudflare for Secondary DNS — meaning that you are setting u
 
 ### Allow range
 
-Allow the [source IP addresses](#source-ip-addresses) listed above at your primary DNS servers.
+Cloudflare's AXFR/IXFR zone transfer requests originate from the [source IP addresses](#source-ip-addresses) listed above. Allow them at your primary DNS servers.
 
 ### Notify IPs
 

--- a/src/content/docs/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses.mdx
@@ -1,6 +1,7 @@
 ---
 pcx_content_type: reference
 title: Cloudflare IP addresses
+description: IP addresses used by Cloudflare for DNS zone transfers and NOTIFY messages.
 sidebar:
   order: 4
 head:
@@ -10,22 +11,15 @@ banner:
   content: |
     Cloudflare is updating the source IP addresses used for DNS zone transfers (AXFR/IXFR) and NOTIFY messages. You must update your allow lists before <strong>December 1, 2026</strong> to avoid service disruption.
   type: caution
-
 ---
 
-Access Control Lists (ACLs) define allowed source IP addresses from where servers accept incoming data or control messages.
-
-When setting up new DNS zone transfers (incoming or outgoing), you will need to update the ACLs at your other DNS provider to prevent communication from Cloudflare from being blocked.
+import { Details } from "~/components";
 
 Depending on the setup ([Cloudflare as Primary](#cloudflare-as-primary) or [Cloudflare as Secondary](#cloudflare-as-secondary)), you need to configure slightly different Cloudflare IP addresses at your other DNS provider.
 
-## Cloudflare as Primary
+## Source IP addresses
 
-If you are using Cloudflare for Primary DNS — meaning that you are setting up Cloudflare to send [outgoing zone transfers](/dns/zone-setups/zone-transfers/cloudflare-as-primary/) — you need to update the following settings at your secondary DNS provider.
-
-### Allow range
-
-Cloudflare's NOTIFY messages originate from the following IP addresses. These need to be allowed at your secondary DNS servers.
+Cloudflare's AXFR/IXFR zone transfer requests and NOTIFY messages originate from the following IP addresses. These need to be allowed at your other DNS servers.
 
 ```txt
 104.30.167.163
@@ -34,18 +28,14 @@ Cloudflare's NOTIFY messages originate from the following IP addresses. These ne
 ```
 
 :::caution[Action required: IP address migration]
-Cloudflare is migrating the source IP addresses used for NOTIFY messages. Since April 15, 2026, Cloudflare sends from the new IP addresses listed above and temporarily falls back to the old IP addresses (listed below) if the new ones are blocked.
+Since April 15, 2026, Cloudflare sends from the new IP addresses listed above and temporarily falls back to the old IP addresses if the new ones are blocked.
 
 **On December 1, 2026, the old IP addresses will stop working.** Only the new IP addresses listed above will be used.
 
-If you have an existing configuration, add the new IP addresses to your allow list first, verify that you are receiving NOTIFY messages from the new addresses, and only then remove the old IP addresses.
+If you have an existing configuration, add the new IP addresses to your allow list first, verify that transfers and notifications are working from the new addresses, and only then remove the old IP addresses.
 :::
 
-#### Old allow range (deprecated)
-
-:::danger
-The following IP ranges are deprecated and will stop working on **December 1, 2026**. Replace them with the new IP addresses listed above.
-:::
+<Details header="Old source IP addresses (deprecated — removed December 1, 2026)">
 
 ```txt
 198.41.144.240/28
@@ -53,6 +43,16 @@ The following IP ranges are deprecated and will stop working on **December 1, 20
 2a06:98c0:3601::/48
 2a06:98c0:1401::/48
 ```
+
+</Details>
+
+## Cloudflare as Primary
+
+If you are using Cloudflare for Primary DNS — meaning that you are setting up Cloudflare to send [outgoing zone transfers](/dns/zone-setups/zone-transfers/cloudflare-as-primary/) — you need to update the following settings at your secondary DNS provider.
+
+### Allow range
+
+Allow the [source IP addresses](#source-ip-addresses) listed above at your secondary DNS servers.
 
 ### Transfer IP
 
@@ -68,34 +68,7 @@ If you are using Cloudflare for Secondary DNS — meaning that you are setting u
 
 ### Allow range
 
-Cloudflare's AXFR/IXFR zone transfer requests originate from the following IP addresses. These need to be allowed at your primary DNS servers.
-
-```txt
-104.30.167.163
-104.30.167.173
-2a09:bac0:1000:c47::/64
-```
-
-:::caution[Action required: IP address migration]
-Cloudflare is migrating the source IP addresses used for zone transfer requests (AXFR/IXFR). Since April 15, 2026, Cloudflare sends from the new IP addresses listed above and temporarily falls back to the old IP addresses (listed below) if the new ones are blocked.
-
-**On December 1, 2026, the old IP addresses will stop working.** Only the new IP addresses listed above will be used.
-
-If you have an existing configuration, add the new IP addresses to your allow list first, verify that zone transfers are working correctly from the new addresses, and only then remove the old IP addresses.
-:::
-
-#### Old allow range (deprecated)
-
-:::danger
-The following IP ranges are deprecated and will stop working on **December 1, 2026**. Replace them with the new IP addresses listed above.
-:::
-
-```txt
-198.41.144.240/28
-198.41.150.240/28
-2a06:98c0:3601::/48
-2a06:98c0:1401::/48
-```
+Allow the [source IP addresses](#source-ip-addresses) listed above at your primary DNS servers.
 
 ### Notify IPs
 

--- a/src/content/docs/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/access-control-lists/cloudflare-ip-addresses.mdx
@@ -32,7 +32,7 @@ Since April 15, 2026, Cloudflare sends from the new IP addresses listed above an
 
 **On December 1, 2026, the old IP addresses will stop working.** Only the new IP addresses listed above will be used.
 
-If you have an existing configuration, add the new IP addresses to your allow list first, verify that transfers and notifications are working from the new addresses, and only then remove the old IP addresses.
+If you have an existing configuration, add the new IP addresses to your allow list first, verify that transfers and NOTIFY messages are working from the new addresses, and only then remove the old IP addresses.
 :::
 
 <Details header="Old source IP addresses (deprecated — removed December 1, 2026)">


### PR DESCRIPTION
## Summary
- Adds new source IP addresses for DNS zone transfers (AXFR/IXFR) and NOTIFY messages
- Marks old IP ranges as deprecated with a **December 1, 2026** end-of-life date
- Adds a page-level caution banner about the migration
- Updates BIND server configuration example to use new IPs, with migration guidance for existing setups
## Context
Cloudflare is upgrading the Secondary DNS system for higher availability, which includes new egress IPs for:
- **Cloudflare as Secondary**: AXFR/IXFR zone transfer requests to primary servers
- **Cloudflare as Primary**: NOTIFY messages to secondary servers
During the transition (starting April 15, 2026), Cloudflare uses the new IPs and falls back to the old IPs if the new ones are blocked. On December 1, 2026, fallback stops and only the new IPs will be used.
**New IPs:**
- `104.30.167.163`
- `104.30.167.173`
- `2a09:bac0:1000:c47::/64`
**Old IPs (deprecated):**
- `198.41.144.240/28`
- `198.41.150.240/28`
- `2a06:98c0:3601::/48`
- `2a06:98c0:1401::/48`
Relates to: [PCX-21353](https://jira.cfdata.org/browse/PCX-21353), DNS-12492
> **Note:** This is Phase 1 of the migration. In Phase 2 (after December 1, 2026), the old IPs, deprecation notices, and fallback explanation should be removed from this page.