### PR TITLE
chore: add .opencode/package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ CLAUDE.md
 .github/prompts/
 .github/agents/
 /agents/
+
+# certain versions of opencode mistakenly commit package-lock.json
+.opencode/package-lock.json


### PR DESCRIPTION
### Summary

Adds `.opencode/package-lock.json` to `.gitignore` to prevent it from being accidentally committed.