### PR TITLE
Updating step context in Workflows docs

### DIFF
--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -94,14 +94,22 @@ let someState = await step.do(
 
 ## Access step context
 
-Workflow step callbacks receive a context object containing the current attempt number (1-indexed). This allows you to access which retry attempt is currently executing.
+Workflow step callbacks receive a [`WorkflowStepContext`](/workflows/build/workers-api/#workflowstepcontext) object containing metadata about the current step, including the current attempt number (1-indexed), the step name, how many times this step has been invoked, and the resolved step configuration.
 
 ```ts
 await step.do("my-step", async (ctx) => {
 	// ctx.attempt is 1 on first try, 2 on first retry, etc.
 	console.log(`Attempt ${ctx.attempt}`);
+	// ctx.step.name is the name passed to step.do()
+	console.log(`Step name: ${ctx.step.name}`);
+	// ctx.step.count is 1-indexed per instance
+	console.log(`Step count: ${ctx.step.count}`);
+	// ctx.config contains the resolved configuration with defaults applied
+	console.log(`Retry limit: ${ctx.config.retries.limit}`);
 });
 ```
+
+The `step.count` property is useful when running the same step in a loop to track how many times a step has been invoked within the same workflow instance.
 
 ## Force a Workflow instance to fail
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -189,6 +189,37 @@ export type WorkflowStepConfig = {
 
 Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-and-retrying/) to learn more about how Workflows are retried.
 
+## WorkflowStepContext
+
+Workflow step callbacks receive a `WorkflowStepContext` object that provides metadata about the current step and its execution state.
+
+```ts
+type WorkflowStepContext = {
+	step: {
+		name: string;
+		count: number;
+	};
+	attempt: number;
+	config: ResolvedStepConfig;
+};
+
+type ResolvedStepConfig = {
+	retries: {
+		limit: number;
+		delay: string | number;
+		backoff?: "constant" | "linear" | "exponential";
+	};
+	timeout: string | number;
+};
+```
+
+- `step.name` - the name of the step as passed to `step.do()`.
+- `step.count` - how many times a step with that name has been invoked in this instance (1-indexed). Useful when running the same step in a loop.
+- `attempt` - the current retry attempt number (1-indexed). On the first try, `attempt` is 1. On the first retry, `attempt` is 2, and so on.
+- `config` - the resolved step configuration with defaults applied, including the configured `retries` and `timeout` values.
+
+Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-and-retrying/) for examples of using the step context.
+
 ## Workflow step limits
 
 Each workflow on Workers Paid supports 10,000 steps by default. You can increase this up to 25,000 steps by configuring `steps` within the `limits` property of your Workflow definition in your Wrangler configuration:

--- a/src/content/docs/workflows/python/python-workers-api.mdx
+++ b/src/content/docs/workflows/python/python-workers-api.mdx
@@ -30,7 +30,7 @@ class MyWorkflow(WorkflowEntrypoint):
 
 Dependencies are resolved implicitly by parameter name. If a step function parameter name matches a previously declared step function, its result is injected into the step.
 
-If you define a `ctx` parameter, the step context is injected into that argument.
+If you define a `ctx` parameter, the step context is injected into that argument. The context is a dictionary containing `step` (with `name` and `count`), `attempt`, and `config`.
 
 :::note
 
@@ -156,12 +156,22 @@ from workers import WorkflowEntrypoint
 
 class CtxWorkflow(WorkflowEntrypoint):
     async def run(self, event, step):
-        @step.do()
+        @step.do("my-step")
         async def read_context(ctx):
-            return ctx["attempt"]
+            # ctx["attempt"] is 1 on first try, 2 on first retry, etc.
+            attempt = ctx["attempt"]
+            # ctx["step"]["name"] is the name passed to step.do()
+            step_name = ctx["step"]["name"]
+            # ctx["step"]["count"] is 1-indexed per instance
+            step_count = ctx["step"]["count"]
+            # ctx["config"] contains the resolved configuration
+            retry_limit = ctx["config"]["retries"]["limit"]
+            return attempt
 
         return await read_context()
 ```
+
+The `step.count` property is useful when running the same step in a loop. For the complete type definition, refer to [WorkflowStepContext](/workflows/build/workers-api/#workflowstepcontext).
 
 ### Create an instance via binding
 


### PR DESCRIPTION
### Summary

Additional step context now available from step.do()

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

