### PR TITLE
[API Shield] Add cf-contains-ads managed label

### DIFF
--- a/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
+++ b/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
@@ -49,6 +49,8 @@ Use managed labels to identify endpoints by use case. Cloudflare may automatical
 
 `cf-web-page`: Add this label to endpoints that serve HTML pages.
 
+`cf-contains-ads`: Add this label to endpoints that serve web pages containing advertisements.
+
 :::note
 [Bot Fight Mode](/bots/get-started/bot-fight-mode/) will not block requests to endpoints labeled as `cf-rss-feed`.
 


### PR DESCRIPTION
### Summary

- Adds `cf-contains-ads` to the managed labels list in the endpoint labeling docs, documenting it as the label for endpoints that serve web pages containing advertisements.
- Placement follows `cf-web-page` since ad-serving pages are a subset of web pages, and matches the writing style of all other managed label entries.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).