### PR TITLE
Update changelog for API Shield for zombie endpoint detection

### DIFF
--- a/src/content/changelog/api-shield/2025-11-25-zombie-endpoint-risk-label.mdx
+++ b/src/content/changelog/api-shield/2025-11-25-zombie-endpoint-risk-label.mdx
@@ -1,0 +1,11 @@
+---
+title: New Zombie API detection for API Shield
+description: API Shield now automatically labels inactive saved endpoints with the cf-risk-zombie risk label.
+date: 2025-11-25
+---
+
+API Shield now automatically detects zombie endpoints — saved endpoints that have not received traffic for an extended period. When detected, the `cf-risk-zombie` [risk label](/api-shield/management-and-monitoring/endpoint-labels/#risk-labels) is applied.
+
+The scan runs daily alongside existing risk scans. Endpoints are labeled after 32 days without traffic.
+
+Zombie endpoints may indicate deprecated or forgotten API surface area that could pose a security risk. Review these endpoints and consider removing them from Endpoint Management if they are no longer in use. Also consider using a [fallthrough rule](/api-shield/security/schema-validation/#add-validation-by-adding-a-fallthrough-rule) to prevent communication with endpoints removed from Endpoint Management.

--- a/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
+++ b/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
@@ -7,7 +7,14 @@ sidebar:
   label: Labeling service
 ---
 
-import { Render, Steps, Tabs, TabItem, DashButton, GlossaryTooltip } from "~/components";
+import {
+	Render,
+	Steps,
+	Tabs,
+	TabItem,
+	DashButton,
+	GlossaryTooltip,
+} from "~/components";
 
 API Shield's labeling service will help you organize your endpoints and address vulnerabilities in your API. The labeling service comes with managed and user-defined labels.
 
@@ -112,7 +119,7 @@ How you address risks to your endpoints will depend on its label(s). The followi
 
    Speak with your developers or application owners in your organization to understand whether or not all requests to these endpoints should be authenticated. Modify your application to consistently enforce the authentication requirement for all traffic accessing these endpoints.
 
-	Refer to [Authentication Posture](/api-shield/security/authentication-posture/) for more information.
+   Refer to [Authentication Posture](/api-shield/security/authentication-posture/) for more information.
 
 </Steps>
 

--- a/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
+++ b/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
@@ -77,6 +77,8 @@ Cloudflare automatically runs risk scans every 24 hours on your saved endpoints.
 
 `cf-risk-bola-pollution`: Automatically added when an endpoint experiences successful responses where parameters are found in multiple places in the request, as opposed to what is expected from the API's schema.
 
+`cf-risk-zombie`: Automatically added when a saved endpoint has not received traffic in 32 days.
+
 :::note
 Cloudflare will only add authentication labels to endpoints with successful response codes. Refer to the below table for more details.
 :::


### PR DESCRIPTION
### Summary
Adds documentation for the new `cf-risk-zombie` risk label in API Shield. This label is automatically applied to saved endpoints that have not received traffic in 32 days, helping customers identify deprecated or forgotten API surface area.
**Changes:**
- New changelog entry for Zombie API detection (backdated to 2025-11-25 when the feature first became visible to customers)
- Added `cf-risk-zombie` to the risk labels section on the endpoint labeling service page
- Fixed a pre-existing `<Steps>` component rendering error on the endpoint labels page (missing indentation in step 1 content)
### Documentation checklist
- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).