### PR TITLE
docs: remove account and zone limits from Organizations page

### DIFF
--- a/src/content/changelog/fundamentals/2026-04-06-organizations-public-beta.mdx
+++ b/src/content/changelog/fundamentals/2026-04-06-organizations-public-beta.mdx
@@ -12,7 +12,7 @@ We're announcing the public beta of **Organizations** for enterprise customers, 
 
 **What's New**
 
-**Organizations [BETA]**: [Organizations](/fundamentals/organizations/) are a new top-level container for centrally managing multiple accounts. Each Organization supports up to 500 accounts and 500 zones, giving larger teams a single place to administer resources at scale.
+**Organizations [BETA]**: [Organizations](/fundamentals/organizations/) are a new top-level container for centrally managing multiple accounts. Each Organization supports up to 500 accounts and 5000 zones, giving larger teams a single place to administer resources at scale.
 
 **Self-serve onboarding**: Enterprise customers can [create an Organization](/fundamentals/organizations/setup/) in the dashboard and assign accounts where they are already Super Administrators.
 

--- a/src/content/docs/fundamentals/organizations/index.mdx
+++ b/src/content/docs/fundamentals/organizations/index.mdx
@@ -13,7 +13,7 @@ import { DirectoryListing, Plan } from "~/components";
 
 An organization is a top-level container in Cloudflare for managing multiple accounts. It allows administrators to govern accounts, members, and resources from a single location rather than managing each account individually. Organization Super Administrators have implicit access to all accounts within the organization. This means they do not need explicit membership on each account.
 
-Each user can create one organization, and each organization supports up to 500 accounts and 500 zones.
+Each user can create one organization.
 
 :::note
 


### PR DESCRIPTION
This PR updates the Organizations documentation with two changes:

**Changes:**

1. **Organizations overview page** (`src/content/docs/fundamentals/organizations/index.mdx`)
   - Removed the account and zone limits from the overview
   - Changed from: "Each user can create one organization, and each organization supports up to 500 accounts and 500 zones."
   - Changed to: "Each user can create one organization."

2. **Organizations changelog** (`src/content/changelog/fundamentals/2026-04-06-organizations-public-beta.mdx`)
   - Updated zone limit from 500 to 5000
   - Changed from: "Each Organization supports up to 500 accounts and 500 zones"
   - Changed to: "Each Organization supports up to 500 accounts and 5000 zones"
