### PR TITLE
Fix BYIOP spectrum link and add example snippet

### DIFF
--- a/src/content/docs/byoip/address-maps/index.mdx
+++ b/src/content/docs/byoip/address-maps/index.mdx
@@ -52,4 +52,11 @@ To specify different addresses for certain zones, [create a new address map](/by
 
 You can use address maps to set up [non-SNI support](/byoip/address-maps/setup/#spectrum-https-applications) for Spectrum HTTPS applications.
 
-However, to control what IP address Cloudflare will use when responding to requests for your Spectrum applications, you should first refer to their respective configuration and set the `edge_ips` field as `static`. For details, refer to the [Spectrum API](/api/resources/spectrum/models/edge_ips/).
+However, to control what IP address Cloudflare will use when responding to requests for your Spectrum applications, you should first refer to their respective configuration and set the `edge_ips` field as `static`, e.g.:
+```json
+"edge_ips": {
+  "type": "static",
+  "ips": ["1.2.3.4"]
+}
+```
+For details, refer to the [Spectrum API](/api/resources/spectrum#%28resource%29%20spectrum%20%3E%20%28model%29%20edge_ips%20%3E%20%28schema%29%20%3E%20%28variant%29%201).


### PR DESCRIPTION
### Summary

the current link is broken (see https://developers.cloudflare.com/byoip/address-maps/).

To be honest, I imagine this kind of links is simply prone to breaking. But at least this will fix it for now

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog). **ANSWER**: it's just a link fix
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
