### PR TITLE
[Logs] Add dashboard setup instructions for BigQuery Logpush destination

### DIFF
--- a/src/content/changelog/logs/2026-04-14-bigquery-dashboard-support.mdx
+++ b/src/content/changelog/logs/2026-04-14-bigquery-dashboard-support.mdx
@@ -1,0 +1,13 @@
+---
+title: Logpush to BigQuery — Cloudflare dashboard support
+description: Configure Logpush to Google BigQuery directly from the Cloudflare dashboard.
+products:
+  - logpush
+date: 2026-04-14
+---
+
+You can now configure Logpush jobs to Google BigQuery directly from the Cloudflare dashboard, in addition to the existing API-based setup.
+
+Previously, setting up a BigQuery Logpush destination required using the Logpush API. Now you can create and manage BigQuery Logpush jobs from the **Logpush** page in the Cloudflare dashboard by selecting **Google BigQuery** as the destination and entering your Google Cloud project ID, dataset ID, table ID, and service account credentials.
+
+For more information, refer to [Enable Logpush to Google BigQuery](/logs/logpush/logpush-job/enable-destinations/bigquery/).

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/aws-s3.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/aws-s3.mdx
@@ -39,7 +39,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 9. In **Advanced Options**, you can:
-    - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+    - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
     - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
     - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/azure.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/azure.mdx
@@ -37,7 +37,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/bigquery.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/bigquery.mdx
@@ -10,7 +10,7 @@ head:
 
 import { Render, APIRequest } from "~/components";
 
-Cloudflare Logpush supports pushing logs directly to Google BigQuery (using Legacy Streaming API) via the Cloudflare API.
+Cloudflare Logpush supports pushing logs directly to Google BigQuery (using Legacy Streaming API) via the Cloudflare dashboard or via API.
 
 ## Create and get access to a BigQuery table
 
@@ -38,6 +38,34 @@ TABLE_ID=<TABLE_ID>
 
 bq mk --table "${PROJECT_ID}:${DATASET_ID}.${TABLE_ID}" schema.json
 ```
+
+## Manage via the Cloudflare dashboard
+
+<Render file="enable-logpush-job" product="logs" />
+
+4. In **Select a destination**, choose **Google BigQuery**.
+
+5. Enter the following destination details:
+   - **Project ID** - your Google Cloud project ID
+   - **Dataset ID** - the BigQuery dataset containing your table
+   - **Table ID** - the BigQuery table to push logs to
+   - **Service Account Credentials** - paste your Google service account key JSON. This credential is stored encrypted and will not be displayed again.
+
+When you are done entering the destination details, select **Continue**.
+
+6. Select the dataset to push to the storage service.
+
+7. In the next step, you need to configure your logpush job:
+   - Enter the **Job name**.
+   - Under **If logs match**, you can select the events to include and/or remove from your logs. Refer to [Filters](/logs/logpush/logpush-job/filters/) for more information. Not all datasets have this option available.
+   - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
+
+8. In **Advanced Options**, you can:
+    - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
+    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
+    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
+
+9. Select **Submit** once you are done configuring your logpush job.
 
 ## Manage via API
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/datadog.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/datadog.mdx
@@ -45,7 +45,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/google-cloud-storage.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/google-cloud-storage.mdx
@@ -36,7 +36,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 9. In **Advanced Options**, you can:
-    - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+    - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
     - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
     - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/http.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/http.mdx
@@ -31,7 +31,7 @@ Cloudflare expects that the endpoint is available over HTTPS, using a trusted ce
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/ibm-cloud-logs.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/ibm-cloud-logs.mdx
@@ -33,7 +33,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/new-relic.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/new-relic.mdx
@@ -42,7 +42,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/r2.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/r2.mdx
@@ -72,7 +72,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/s3-compatible-endpoints.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/s3-compatible-endpoints.mdx
@@ -48,7 +48,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/sentinelone.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/sentinelone.mdx
@@ -33,7 +33,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/splunk.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/splunk.mdx
@@ -35,7 +35,7 @@ When you are done entering the destination details, select **Continue**.
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/sumo-logic.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/sumo-logic.mdx
@@ -28,7 +28,7 @@ Cloudflare Logpush supports pushing logs directly to Sumo Logic via the Cloudfla
    - In **Send the following fields**, you can choose to either push all logs to your storage destination or selectively choose which logs you want to push.
 
 8. In **Advanced Options**, you can:
-   - Choose the format of timestamp fields in your logs (`RFC3339`(default),`Unix`, or `UnixNano`).
+   - Choose the format of timestamp fields in your logs (`RFC3339` (default), `Unix`, or `UnixNano`).
    - Select a [sampling rate](/logs/logpush/logpush-job/api-configuration/#sampling-rate) for your logs or push a randomly-sampled percentage of logs.
    - Enable redaction for `CVE-2021-44228`. This option will replace every occurrence of `${` with `x{`.
 


### PR DESCRIPTION


### Summary

Documents how to configure a BigQuery Logpush job via the Cloudflare
dashboard, matching the UI changes shipped.

Adds a changelog entry for the new dashboard support.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

