### PR TITLE
Update agents browse-the-web: rename Browser Rendering to Browser Run

### DIFF
--- a/src/content/docs/agents/api-reference/browse-the-web.mdx
+++ b/src/content/docs/agents/api-reference/browse-the-web.mdx
@@ -12,7 +12,7 @@ import {
 	PackageManagers,
 } from "~/components";
 
-Give your agents full access to the Chrome DevTools Protocol (CDP) with browser tools. <InlineBadge preset="beta" />
+Give your agents full access to the [Chrome DevTools Protocol (CDP)](/browser-run/cdp/) with [Browser Run](/browser-run/) tools. <InlineBadge preset="beta" />
 
 Instead of a fixed set of browser actions (click, screenshot, navigate), the LLM writes JavaScript code that runs CDP commands against a live browser session — accessing all domains, commands, events, and types in the protocol.
 


### PR DESCRIPTION
- Rename all 'Browser Rendering' references to 'Browser Run'
- Add link to Browser Run docs (/browser-rendering/) in intro
- Add link to CDP docs (/browser-rendering/cdp/) on Chrome DevTools Protocol mention

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
