### PR TITLE
[Agents] Add Sub-agents, Sessions, and Think reference docs

### DIFF
--- a/src/content/docs/agents/api-reference/agents-api.mdx
+++ b/src/content/docs/agents/api-reference/agents-api.mdx
@@ -91,6 +91,9 @@ flowchart TD
 | **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`                      | [Protocol messages](/agents/api-reference/protocol-messages/)       |
 | **Context**           | `getCurrentAgent()`                                                                  | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
 | **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                    | [Observability](/agents/api-reference/observability/)               |
+| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                                  | [Sub-agents](/agents/api-reference/sub-agents/)                    |
+| **Sessions**          | `Session.create()`, context blocks, compaction, search                               | [Sessions](/agents/api-reference/sessions/)                        |
+| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions                     | [Think](/agents/api-reference/think/)                              |
 
 ## SQL API
 

--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -1245,6 +1245,12 @@ export class ChatAgent extends AIChatAgent {
 
 ### Subagent delegation
 
+:::note
+
+This section covers **in-process** subagents using the AI SDK's `ToolLoopAgent`. For **Durable Object sub-agents** with their own isolated storage and typed RPC, refer to [Sub-agents](/agents/api-reference/sub-agents/). For streaming full LLM turns through a child agent, refer to [Think: Sub-agent RPC](/agents/api-reference/think/#sub-agent-rpc-and-programmatic-turns).
+
+:::
+
 Tools can delegate work to focused sub-calls with their own context. Use [`ToolLoopAgent`](https://ai-sdk.dev/docs/reference/ai-sdk-core/tool-loop-agent) to define a reusable agent, then call it from a tool's `execute`:
 
 <TypeScriptExample>

--- a/src/content/docs/agents/api-reference/durable-execution.mdx
+++ b/src/content/docs/agents/api-reference/durable-execution.mdx
@@ -283,7 +283,7 @@ Key points:
 
 ### Chat recovery
 
-`AIChatAgent` builds on fibers for LLM streaming recovery. When `unstable_chatRecovery` is enabled, each chat turn is wrapped in a fiber automatically. The framework handles the internal recovery path and exposes `onChatRecovery` for provider-specific strategies. Refer to [Long-running agents: Recovering interrupted LLM streams](/agents/concepts/long-running-agents/#recovering-interrupted-llm-streams) for details.
+`AIChatAgent` builds on fibers for LLM streaming recovery. When `chatRecovery` is enabled, each chat turn is wrapped in a fiber automatically. The framework handles the internal recovery path and exposes `onChatRecovery` for provider-specific strategies. Refer to [Long-running agents: Recovering interrupted LLM streams](/agents/concepts/long-running-agents/#recovering-interrupted-llm-streams) for details.
 
 ## Concurrent fibers
 
@@ -344,4 +344,4 @@ Run an async function while keeping the DO alive. Heartbeat starts before `fn` a
 - [Long-running agents](/agents/concepts/long-running-agents/) — how fibers compose with schedules, plans, and async operations
 - [Schedule tasks](/agents/api-reference/schedule-tasks/) — `keepAlive` details and the alarm system
 - [Workflows](/agents/concepts/workflows/) — durable multi-step execution outside the agent
-- [Chat agents](/agents/api-reference/chat-agents/) — `unstable_chatRecovery` and `onChatRecovery`
+- [Chat agents](/agents/api-reference/chat-agents/) — `chatRecovery` and `onChatRecovery`

--- a/src/content/docs/agents/api-reference/sessions.mdx
+++ b/src/content/docs/agents/api-reference/sessions.mdx
@@ -1,0 +1,647 @@
+---
+title: Sessions
+pcx_content_type: reference
+description: Persistent conversation storage with tree-structured messages, context blocks, compaction, full-text search, and AI-controllable tools.
+tags:
+  - AI
+sidebar:
+  order: 6
+---
+
+import { TypeScriptExample, InlineBadge, LinkCard } from "~/components";
+
+The Session API provides persistent conversation storage for agents, with tree-structured messages, context blocks, compaction, full-text search, and AI-controllable tools. It runs entirely on Durable Object SQLite — no external database needed.
+
+:::caution[Experimental]
+
+The Session API is under `agents/experimental/memory/session`. The API surface is stable but may evolve before graduating to the main package.
+
+:::
+
+## Quick start
+
+<TypeScriptExample>
+
+```ts
+import { Agent } from "agents";
+import { Session } from "agents/experimental/memory/session";
+
+class MyAgent extends Agent {
+	session = Session.create(this)
+		.withContext("soul", {
+			provider: { get: async () => "You are a helpful assistant." },
+		})
+		.withContext("memory", {
+			description: "Learned facts about the user",
+			maxTokens: 1100,
+		})
+		.withCachedPrompt();
+
+	async onMessage(message: unknown) {
+		await this.session.appendMessage(message);
+		const history = this.session.getHistory();
+		const system = await this.session.freezeSystemPrompt();
+		const tools = await this.session.tools();
+		// Pass history, system prompt, and tools to your LLM
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Creating a session
+
+### Builder API (recommended)
+
+Use `Session.create(agent)` with a chainable builder. Context providers without an explicit `provider` option are auto-wired to SQLite.
+
+<TypeScriptExample>
+
+```ts
+const session = Session.create(this)
+	.withContext("soul", { provider: { get: async () => "You are helpful." } })
+	.withContext("memory", { description: "Learned facts", maxTokens: 1100 })
+	.withCachedPrompt()
+	.onCompaction(myCompactFn)
+	.compactAfter(100_000);
+```
+
+</TypeScriptExample>
+
+### Direct constructor
+
+For full control over providers:
+
+<TypeScriptExample>
+
+```ts
+import {
+	Session,
+	AgentSessionProvider,
+	AgentContextProvider,
+} from "agents/experimental/memory/session";
+
+const session = new Session(new AgentSessionProvider(this), {
+	context: [
+		{
+			label: "memory",
+			description: "Notes",
+			maxTokens: 500,
+			provider: new AgentContextProvider(this, "memory"),
+		},
+		{ label: "soul", provider: { get: async () => "You are helpful." } },
+	],
+});
+```
+
+</TypeScriptExample>
+
+### Builder methods
+
+All builder methods return `this` for chaining. Order does not matter — providers are resolved lazily on first use.
+
+| Method | Description |
+| ------ | ----------- |
+| `Session.create(agent)` | Static factory. `agent` is any object with a `sql` tagged template method (your Agent or Durable Object). |
+| `.forSession(sessionId)` | Namespace this session by ID. Required for multi-session isolation when not using `SessionManager`. |
+| `.withContext(label, options?)` | Add a context block. Refer to [Context blocks](#context-blocks). |
+| `.withCachedPrompt(provider?)` | Enable system prompt persistence. The prompt is frozen on first use and survives hibernation and eviction. |
+| `.onCompaction(fn)` | Register a compaction function. Refer to [Compaction](#compaction). |
+| `.compactAfter(tokenThreshold)` | Auto-compact when estimated token count exceeds the threshold. Requires `.onCompaction()`. |
+
+## Messages
+
+Messages use the `SessionMessage` type — a minimal shape with `id`, `role`, `parts`, and optional `createdAt`. The Vercel AI SDK's `UIMessage` is structurally compatible and can be passed directly. The session stores messages in a tree structure via `parent_id`, enabling branching conversations.
+
+<TypeScriptExample>
+
+```ts
+// Append — auto-parents to the latest leaf unless parentId is specified
+await session.appendMessage(message);
+await session.appendMessage(message, parentId);
+
+// Update an existing message (matched by message.id)
+session.updateMessage(message);
+
+// Delete specific messages
+session.deleteMessages(["msg-1", "msg-2"]);
+
+// Clear all messages and skill state
+session.clearMessages();
+```
+
+</TypeScriptExample>
+
+:::note
+
+`appendMessage()` is `async` because it may trigger auto-compaction. The underlying SQLite write is synchronous. All other write methods (`updateMessage`, `deleteMessages`, `clearMessages`) are synchronous.
+
+:::
+
+### Reading history
+
+<TypeScriptExample>
+
+```ts
+// Linear history from root to the latest leaf
+const messages = session.getHistory();
+
+// History to a specific leaf (for branching)
+const branch = session.getHistory(leafId);
+
+// Get a single message
+const msg = session.getMessage("msg-1");
+
+// Get the newest message
+const latest = session.getLatestLeaf();
+
+// Count messages in path
+const count = session.getPathLength();
+```
+
+</TypeScriptExample>
+
+### Branching
+
+Messages form a tree. When you `appendMessage` with a `parentId` that already has children, you create a branch. Use `getBranches()` to get all child messages branching from a given point:
+
+<TypeScriptExample>
+
+```ts
+// Get all child messages that branch from messageId
+const branches = session.getBranches(messageId);
+```
+
+</TypeScriptExample>
+
+This powers features like response regeneration — pass the user message ID to get both the original and regenerated responses. `getHistory(leafId)` walks the chosen path.
+
+## Search
+
+Full-text search over the conversation history using SQLite FTS5:
+
+<TypeScriptExample>
+
+```ts
+const results = session.search("deployment Friday", { limit: 10 });
+// Returns: Array<{ id, role, content, createdAt? }>
+```
+
+</TypeScriptExample>
+
+Uses porter stemming and unicode tokenization. The search covers all messages in the session.
+
+## Context blocks
+
+Context blocks are persistent key-value sections injected into the system prompt. Each block has a **label**, optional **description**, and a **provider** that determines its behavior.
+
+### Provider types
+
+There are four provider types, detected by duck-typing:
+
+| Provider | Interface | Behavior | AI tool |
+| -------- | --------- | -------- | ------- |
+| **ContextProvider** | `get()` | Read-only block in system prompt | — |
+| **WritableContextProvider** | `get()` + `set()` | Writable via AI | `set_context` |
+| **SkillProvider** | `get()` + `load()` + `set?()` | On-demand keyed documents. `get()` returns a metadata listing; `load(key)` fetches full content. | `load_context`, `unload_context`, `set_context` |
+| **SearchProvider** | `get()` + `search()` + `set?()` | Full-text searchable entries. `get()` returns a summary; `search(query)` runs FTS5. | `search_context`, `set_context` |
+
+### Built-in providers
+
+**`AgentContextProvider`** — SQLite-backed writable context. This is the default when using the builder without an explicit provider.
+
+<TypeScriptExample>
+
+```ts
+import { AgentContextProvider } from "agents/experimental/memory/session";
+
+new AgentContextProvider(this, "memory");
+```
+
+</TypeScriptExample>
+
+**`R2SkillProvider`** — Cloudflare R2 bucket for on-demand document loading. Skills are listed in the system prompt as metadata; the model loads full content on demand via `load_context`.
+
+<TypeScriptExample>
+
+```ts
+import { R2SkillProvider } from "agents/experimental/memory/session";
+
+Session.create(this).withContext("skills", {
+	provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" }),
+});
+```
+
+</TypeScriptExample>
+
+**`AgentSearchProvider`** — SQLite FTS5 searchable context. Entries are indexed and searchable by the model via `search_context`.
+
+<TypeScriptExample>
+
+```ts
+import { AgentSearchProvider } from "agents/experimental/memory/session";
+
+Session.create(this).withContext("knowledge", {
+	description: "Searchable knowledge base",
+	provider: new AgentSearchProvider(this),
+});
+```
+
+</TypeScriptExample>
+
+### Adding and removing context at runtime
+
+Blocks can be added and removed dynamically after initialization:
+
+<TypeScriptExample>
+
+```ts
+// Add a new block (auto-wires to SQLite if no provider given)
+await session.addContext("extension-notes", {
+	description: "From extension X",
+	maxTokens: 500,
+});
+
+// Remove it
+session.removeContext("extension-notes");
+
+// Rebuild the system prompt to reflect changes
+await session.refreshSystemPrompt();
+```
+
+</TypeScriptExample>
+
+:::note
+
+`addContext` and `removeContext` do not automatically update the frozen system prompt. Call `refreshSystemPrompt()` afterward.
+
+:::
+
+### Reading and writing context
+
+<TypeScriptExample>
+
+```ts
+// Read a single block
+const block = session.getContextBlock("memory");
+// { label, description?, content, tokens, maxTokens?, writable, isSkill, isSearchable }
+
+// Read all blocks
+const blocks = session.getContextBlocks();
+
+// Replace content entirely
+await session.replaceContextBlock("memory", "User likes coffee.");
+
+// Append content
+await session.appendContextBlock("memory", "\nUser prefers dark roast.");
+```
+
+</TypeScriptExample>
+
+### System prompt
+
+The system prompt is built from all context blocks with headers and metadata:
+
+```txt
+══════════════════════════════════════════════
+SOUL (Identity) [readonly]
+══════════════════════════════════════════════
+You are a helpful assistant.
+
+══════════════════════════════════════════════
+MEMORY (Learned facts) [45% — 495/1100 tokens]
+══════════════════════════════════════════════
+User likes coffee.
+User prefers dark roast.
+```
+
+<TypeScriptExample>
+
+```ts
+// Freeze — first call renders and persists; subsequent calls return cached value
+const prompt = await session.freezeSystemPrompt();
+
+// Refresh — re-render from current block state and persist
+const updated = await session.refreshSystemPrompt();
+```
+
+</TypeScriptExample>
+
+The frozen prompt survives Durable Object hibernation and eviction when `withCachedPrompt()` is enabled.
+
+## AI tools
+
+Session automatically generates tools based on the provider types of your context blocks. Pass these to your LLM alongside your own tools.
+
+<TypeScriptExample>
+
+```ts
+const tools = await session.tools();
+const allTools = { ...tools, ...myTools };
+```
+
+</TypeScriptExample>
+
+### set_context
+
+Generated when any writable block exists. Writes to regular blocks, skill blocks (keyed), or search blocks (keyed). Enforces `maxTokens` limits.
+
+### load_context
+
+Generated when any skill block exists. Loads full content by key from a `SkillProvider`.
+
+### unload_context
+
+Generated alongside `load_context`. Frees context space by unloading a previously loaded skill. The skill remains available for re-loading.
+
+### search_context
+
+Generated when any search block exists. Full-text search within a searchable context block. Returns top 10 results by FTS5 rank.
+
+### session_search
+
+Available on `SessionManager` only. Searches across all sessions.
+
+## Compaction
+
+Compaction summarizes older messages to keep conversations within token limits. Original messages are preserved in SQLite — the summary is a non-destructive overlay applied at read time.
+
+### Setup
+
+<TypeScriptExample>
+
+```ts
+import { createCompactFunction } from "agents/experimental/memory/utils/compaction-helpers";
+
+const session = Session.create(this)
+	.withContext("memory", { maxTokens: 1100 })
+	.onCompaction(
+		createCompactFunction({
+			summarize: (prompt) =>
+				generateText({ model: myModel, prompt }).then((r) => r.text),
+			protectHead: 3,
+			tailTokenBudget: 20000,
+			minTailMessages: 2,
+		}),
+	)
+	.compactAfter(100_000);
+```
+
+</TypeScriptExample>
+
+### How compaction works
+
+1. **Protect head** — first N messages are never compacted (default 3)
+2. **Protect tail** — walk backward from the end, accumulating tokens up to a budget (default 20K tokens)
+3. **Align boundaries** — shift boundaries to avoid splitting tool call/result pairs
+4. **Summarize middle** — send the middle section to an LLM with a structured format (Topic, Key Points, Current State, Open Items)
+5. **Store overlay** — saved in the `assistant_compactions` table, keyed by `fromMessageId` and `toMessageId`
+6. **Iterative** — on subsequent compactions, the existing summary is passed to the LLM to update rather than replace
+
+When `getHistory()` is called, compaction overlays are applied transparently — the compacted range is replaced by a synthetic summary message.
+
+### Manual compaction
+
+<TypeScriptExample>
+
+```ts
+const result = await session.compact();
+
+// Or manage overlays directly
+session.addCompaction("Summary of messages 1-50", "msg-1", "msg-50");
+const overlays = session.getCompactions();
+```
+
+</TypeScriptExample>
+
+### Auto-compaction
+
+When `.compactAfter(threshold)` is set, `appendMessage()` checks the estimated token count after each write. If it exceeds the threshold, `compact()` is called automatically. Auto-compaction failure is non-fatal — the message is already saved.
+
+:::note
+
+Token estimation is heuristic (not tiktoken). It uses `max(chars/4, words*1.3)` with 4 tokens per-message overhead. Tiktoken would add 80–120 MB heap overhead, which exceeds Cloudflare Workers' 128 MB limit.
+
+:::
+
+## SessionManager
+
+`SessionManager` is a registry for multiple named sessions within a single Durable Object. It provides lifecycle management, convenience methods, and cross-session search.
+
+### Creating a SessionManager
+
+<TypeScriptExample>
+
+```ts
+import { SessionManager } from "agents/experimental/memory/session";
+
+const manager = SessionManager.create(this)
+	.withContext("soul", { provider: { get: async () => "You are helpful." } })
+	.withContext("memory", { description: "Learned facts", maxTokens: 1100 })
+	.withCachedPrompt()
+	.onCompaction(myCompactFn)
+	.compactAfter(100_000)
+	.withSearchableHistory("history");
+```
+
+</TypeScriptExample>
+
+Context blocks, prompt caching, and compaction settings are propagated to all sessions created through the manager. Provider keys are automatically namespaced by session ID.
+
+### Builder methods
+
+| Method | Description |
+| ------ | ----------- |
+| `SessionManager.create(agent)` | Static factory. |
+| `.withContext(label, options?)` | Add context block template for all sessions. |
+| `.withCachedPrompt(provider?)` | Enable prompt persistence for all sessions. |
+| `.onCompaction(fn)` | Register compaction function for all sessions. |
+| `.compactAfter(tokenThreshold)` | Auto-compact threshold for all sessions. |
+| `.withSearchableHistory(label)` | Add a cross-session searchable history block. The model can search past conversations from any session. |
+
+### Session lifecycle
+
+<TypeScriptExample>
+
+```ts
+// Create a new session
+const info = manager.create("My Chat");
+
+// Create with metadata
+const info2 = manager.create("My Chat", {
+	parentSessionId: "parent-id",
+	model: "claude-sonnet-4-20250514",
+	source: "web",
+});
+
+// Get session metadata (null if not found)
+const session = manager.get(sessionId);
+
+// List all sessions (ordered by updated_at DESC)
+const sessions = manager.list();
+
+// Rename
+manager.rename(sessionId, "New Name");
+
+// Delete (clears messages too)
+manager.delete(sessionId);
+```
+
+</TypeScriptExample>
+
+### Accessing sessions
+
+<TypeScriptExample>
+
+```ts
+// Get or create the Session instance for an ID
+// Lazy — creates on first access, caches for subsequent calls
+const session = manager.getSession(sessionId);
+```
+
+</TypeScriptExample>
+
+### Message convenience methods
+
+These delegate to the underlying Session and update the session's `updated_at` timestamp:
+
+<TypeScriptExample>
+
+```ts
+// Append a single message
+await manager.append(sessionId, message, parentId);
+
+// Add or update (upsert)
+await manager.upsert(sessionId, message, parentId);
+
+// Batch append (auto-chains parent IDs)
+await manager.appendAll(sessionId, messages, parentId);
+
+// Read history
+const history = manager.getHistory(sessionId, leafId);
+
+// Message count
+const count = manager.getMessageCount(sessionId);
+
+// Clear messages
+manager.clearMessages(sessionId);
+
+// Delete specific messages
+manager.deleteMessages(sessionId, ["msg-1"]);
+```
+
+</TypeScriptExample>
+
+### Forking
+
+Fork a session at a specific message — copies history up to that point into a new session:
+
+<TypeScriptExample>
+
+```ts
+const forked = await manager.fork(sessionId, atMessageId, "Forked Chat");
+// forked.parent_session_id === sessionId
+```
+
+</TypeScriptExample>
+
+### Usage tracking
+
+<TypeScriptExample>
+
+```ts
+manager.addUsage(sessionId, inputTokens, outputTokens, cost);
+```
+
+</TypeScriptExample>
+
+### Cross-session search
+
+<TypeScriptExample>
+
+```ts
+// Search across all sessions (FTS5)
+const results = manager.search("deployment Friday", { limit: 20 });
+
+// Get tools for the model (includes session_search)
+const tools = manager.tools();
+```
+
+</TypeScriptExample>
+
+## Custom providers
+
+Implement any of the four provider interfaces to plug in your own storage:
+
+<TypeScriptExample>
+
+```ts
+// Read-only context
+const myProvider: ContextProvider = {
+	get: async () => "Static content here",
+};
+
+// Writable context (enables set_context tool)
+const myWritable: WritableContextProvider = {
+	get: async () => fetchFromMyDB(),
+	set: async (content) => saveToMyDB(content),
+};
+
+// Skill provider (enables load_context tool)
+const mySkills: SkillProvider = {
+	get: async () => "- api-ref: API Reference\n- guide: User Guide",
+	load: async (key) => fetchDocument(key),
+	set: async (key, content, description) => saveDocument(key, content, description),
+};
+
+// Search provider (enables search_context tool)
+const mySearch: SearchProvider = {
+	get: async () => "42 entries indexed",
+	search: async (query) => searchMyIndex(query),
+	set: async (key, content) => indexContent(key, content),
+};
+```
+
+</TypeScriptExample>
+
+You can also implement `SessionProvider` to replace the SQLite storage entirely:
+
+<TypeScriptExample>
+
+```ts
+const myStorage: SessionProvider = {
+	getMessage(id) { /* ... */ },
+	getHistory(leafId?) { /* ... */ },
+	getLatestLeaf() { /* ... */ },
+	getBranches(messageId) { /* ... */ },
+	getPathLength(leafId?) { /* ... */ },
+	appendMessage(message, parentId?) { /* ... */ },
+	updateMessage(message) { /* ... */ },
+	deleteMessages(messageIds) { /* ... */ },
+	clearMessages() { /* ... */ },
+	addCompaction(summary, fromId, toId) { /* ... */ },
+	getCompactions() { /* ... */ },
+	searchMessages(query, limit) { /* ... */ },
+};
+```
+
+</TypeScriptExample>
+
+## Storage tables
+
+All storage is in Durable Object SQLite. Tables are created lazily on first use.
+
+| Table | Purpose |
+| ----- | ------- |
+| `assistant_messages` | Tree-structured messages with `id`, `session_id`, `parent_id`, `role`, `content` (JSON), `created_at` |
+| `assistant_compactions` | Compaction overlays with `summary`, `from_message_id`, `to_message_id` |
+| `assistant_fts` | FTS5 virtual table for message search (porter stemming, unicode tokenization) |
+| `assistant_sessions` | Session registry (SessionManager only) with `name`, `parent_session_id`, `model`, `source`, token/cost counters |
+| `cf_agents_context_blocks` | Persistent context block storage (`AgentContextProvider`) |
+| `cf_agents_search_entries` / `cf_agents_search_fts` | Searchable context entries and FTS5 index (`AgentSearchProvider`) |
+
+## Related
+
+- [Think](/agents/api-reference/think/) — opinionated chat agent that uses Session for conversation storage via `configureSession()`
+- [Chat agents](/agents/api-reference/chat-agents/) — `AIChatAgent` with its own message persistence layer
+- [Store and sync state](/agents/api-reference/store-and-sync-state/) — `setState()` for simpler key-value persistence

--- a/src/content/docs/agents/api-reference/sub-agents.mdx
+++ b/src/content/docs/agents/api-reference/sub-agents.mdx
@@ -1,0 +1,337 @@
+---
+title: Sub-agents
+pcx_content_type: reference
+description: Spawn child agents with isolated storage and typed RPC using subAgent(), abortSubAgent(), and deleteSubAgent().
+tags:
+  - AI
+sidebar:
+  order: 5
+---
+
+import {
+	TypeScriptExample,
+	WranglerConfig,
+	InlineBadge,
+	LinkCard,
+} from "~/components";
+
+Spawn child agents as co-located Durable Objects with their own isolated SQLite storage. The parent gets a typed RPC stub for calling methods on the child — every public method on the child class is callable as a remote procedure call with Promise-wrapped return types.
+
+## Quick start
+
+<TypeScriptExample>
+
+```ts
+import { Agent } from "agents";
+
+export class Orchestrator extends Agent {
+	async delegateWork() {
+		const researcher = await this.subAgent(Researcher, "research-1");
+		const findings = await researcher.search("cloudflare agents sdk");
+		return findings;
+	}
+}
+
+export class Researcher extends Agent {
+	async search(query: string) {
+		const results = await fetch(`https://api.example.com/search?q=${query}`);
+		return results.json();
+	}
+}
+```
+
+</TypeScriptExample>
+
+Both classes must be exported from the worker entry point. No separate Durable Object bindings are needed — child classes are discovered automatically via `ctx.exports`.
+
+<WranglerConfig>
+
+```toml
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat", "experimental"]
+
+[[durable_objects.bindings]]
+class_name = "Orchestrator"
+name = "Orchestrator"
+
+[[migrations]]
+new_sqlite_classes = ["Orchestrator"]
+tag = "v1"
+```
+
+</WranglerConfig>
+
+Only the parent agent needs a Durable Object binding and migration. Child agents are created as facets of the parent — they share the same machine but have fully isolated SQLite storage.
+
+## subAgent
+
+Get or create a named sub-agent. The first call for a given name triggers the child's `onStart()`. Subsequent calls return the existing instance.
+
+<TypeScriptExample>
+
+```ts
+class Agent {
+	async subAgent<T extends Agent>(
+		cls: SubAgentClass<T>,
+		name: string,
+	): Promise<SubAgentStub<T>>;
+}
+```
+
+</TypeScriptExample>
+
+| Parameter | Type               | Description                                                                                                      |
+| --------- | ------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `cls`     | `SubAgentClass<T>` | The Agent subclass. Must be exported from the worker entry point, and the export name must match the class name. |
+| `name`    | `string`           | Unique name for this child instance. The same name always returns the same child.                                |
+
+Returns a `SubAgentStub<T>` — a typed RPC stub where every user-defined method on `T` is available as a Promise-returning remote call.
+
+### SubAgentStub
+
+The stub exposes all public instance methods you define on the child class. Methods inherited from `Agent` (lifecycle hooks, `setState`, `broadcast`, `sql`, and so on) are excluded — only your custom methods appear on the stub.
+
+Return types are automatically wrapped in `Promise` if they are not already:
+
+<TypeScriptExample>
+
+```ts
+class MyChild extends Agent {
+	greet(name: string): string {
+		return `Hello, ${name}`;
+	}
+	async fetchData(url: string): Promise<unknown> {
+		return fetch(url).then((r) => r.json());
+	}
+}
+
+// On the stub:
+// greet(name: string) => Promise<string>       (sync → wrapped)
+// fetchData(url: string) => Promise<unknown>   (already async → unchanged)
+```
+
+</TypeScriptExample>
+
+### Requirements
+
+- The child class must extend `Agent`
+- The child class must be exported from the worker entry point (`export class MyChild extends Agent`)
+- The export name must match the class name — `export { Foo as Bar }` is not supported
+
+## abortSubAgent
+
+Forcefully stop a running sub-agent. The child stops executing immediately and restarts on the next `subAgent()` call. Storage is preserved — only the running instance is killed.
+
+<TypeScriptExample>
+
+```ts
+class Agent {
+	abortSubAgent(cls: SubAgentClass, name: string, reason?: unknown): void;
+}
+```
+
+</TypeScriptExample>
+
+| Parameter | Type            | Description                                       |
+| --------- | --------------- | ------------------------------------------------- |
+| `cls`     | `SubAgentClass` | The Agent subclass used when creating the child   |
+| `name`    | `string`        | Name of the child to abort                        |
+| `reason`  | `unknown`       | Error thrown to any pending or future RPC callers |
+
+Abort is transitive — if the child has its own sub-agents, they are also aborted.
+
+## deleteSubAgent
+
+Abort the child (if running) and permanently wipe its storage. The next `subAgent()` call creates a fresh instance with empty SQLite.
+
+<TypeScriptExample>
+
+```ts
+class Agent {
+	deleteSubAgent(cls: SubAgentClass, name: string): void;
+}
+```
+
+</TypeScriptExample>
+
+| Parameter | Type            | Description                                     |
+| --------- | --------------- | ----------------------------------------------- |
+| `cls`     | `SubAgentClass` | The Agent subclass used when creating the child |
+| `name`    | `string`        | Name of the child to delete                     |
+
+Deletion is transitive — the child's own sub-agents are also deleted.
+
+## Storage isolation
+
+Each sub-agent has its own SQLite database, completely isolated from the parent and from other sub-agents. A parent writing to `this.sql` and a child writing to `this.sql` operate on different databases:
+
+<TypeScriptExample>
+
+```ts
+export class Parent extends Agent {
+	async demonstrate() {
+		this.sql`INSERT INTO parent_data (key, value) VALUES ('color', 'blue')`;
+
+		const child = await this.subAgent(Child, "child-1");
+		await child.increment("clicks");
+
+		// Parent's SQL and child's SQL are completely separate
+	}
+}
+
+export class Child extends Agent {
+	async increment(key: string): Promise<number> {
+		this
+			.sql`CREATE TABLE IF NOT EXISTS counters (key TEXT PRIMARY KEY, value INTEGER DEFAULT 0)`;
+		this
+			.sql`INSERT INTO counters (key, value) VALUES (${key}, 1) ON CONFLICT(key) DO UPDATE SET value = value + 1`;
+		const row = this.sql<{
+			value: number;
+		}>`SELECT value FROM counters WHERE key = ${key}`.one();
+		return row?.value ?? 0;
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Naming and identity
+
+Two different classes can share the same user-facing name — they are resolved independently. The internal key is a composite of class name and facet name:
+
+<TypeScriptExample>
+
+```ts
+const counter = await this.subAgent(Counter, "shared-name");
+const logger = await this.subAgent(Logger, "shared-name");
+// These are two separate sub-agents with separate storage
+```
+
+</TypeScriptExample>
+
+The child's `this.name` property returns the facet name (not the parent's name):
+
+<TypeScriptExample>
+
+```ts
+export class Child extends Agent {
+	getName(): string {
+		return this.name; // Returns "shared-name", not the parent's ID
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Patterns
+
+### Parallel sub-agents
+
+Run multiple sub-agents concurrently:
+
+<TypeScriptExample>
+
+```ts
+export class Orchestrator extends Agent {
+	async runAll(queries: string[]) {
+		const results = await Promise.all(
+			queries.map(async (query, i) => {
+				const worker = await this.subAgent(Researcher, `research-${i}`);
+				return worker.search(query);
+			}),
+		);
+		return results;
+	}
+}
+```
+
+</TypeScriptExample>
+
+### Nested sub-agents
+
+Sub-agents can spawn their own sub-agents, forming a tree:
+
+<TypeScriptExample>
+
+```ts
+export class Manager extends Agent {
+	async delegate(task: string) {
+		const team = await this.subAgent(TeamLead, "team-a");
+		return team.assign(task);
+	}
+}
+
+export class TeamLead extends Agent {
+	async assign(task: string) {
+		const worker = await this.subAgent(Worker, "worker-1");
+		return worker.execute(task);
+	}
+}
+
+export class Worker extends Agent {
+	async execute(task: string) {
+		return { completed: task };
+	}
+}
+```
+
+</TypeScriptExample>
+
+### Callback streaming
+
+Pass an `RpcTarget` callback to stream results from a sub-agent back to the parent:
+
+<TypeScriptExample>
+
+```ts
+import { RpcTarget } from "cloudflare:workers";
+
+class StreamCollector extends RpcTarget {
+	chunks: string[] = [];
+	onChunk(text: string) {
+		this.chunks.push(text);
+	}
+}
+
+export class Parent extends Agent {
+	async streamFromChild() {
+		const child = await this.subAgent(Streamer, "streamer-1");
+		const collector = new StreamCollector();
+		await child.generate("Write a poem", collector);
+		return collector.chunks;
+	}
+}
+
+export class Streamer extends Agent {
+	async generate(prompt: string, callback: StreamCollector) {
+		const chunks = ["Once ", "upon ", "a ", "time..."];
+		for (const chunk of chunks) {
+			callback.onChunk(chunk);
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Limitations
+
+Sub-agents run as facets of the parent Durable Object. Some `Agent` methods are not available in sub-agents:
+
+| Method             | Behavior in sub-agent                              |
+| ------------------ | -------------------------------------------------- |
+| `schedule()`       | Throws `"not supported in sub-agents"`             |
+| `cancelSchedule()` | Throws `"not supported in sub-agents"`             |
+| `keepAlive()`      | Throws `"not supported in sub-agents"`             |
+| `setState()`       | Works normally (writes to the child's own storage) |
+| `this.sql`         | Works normally (child's own SQLite)                |
+| `subAgent()`       | Works — sub-agents can spawn their own children    |
+
+For scheduled work, have the parent schedule the task and delegate to the sub-agent when the schedule fires.
+
+## Related
+
+- [Think](/agents/api-reference/think/) — `chat()` method for streaming AI turns through sub-agents
+- [Long-running agents](/agents/concepts/long-running-agents/) — sub-agent delegation in the context of multi-week agent lifetimes
+- [Callable methods](/agents/api-reference/callable-methods/) — RPC via `@callable` and service bindings
+- [Chat agents](/agents/api-reference/chat-agents/) — `ToolLoopAgent` for in-process AI SDK sub-calls

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -1,0 +1,1370 @@
+---
+title: Think
+pcx_content_type: reference
+description: Opinionated chat agent framework with built-in tools, persistent memory, lifecycle hooks, streaming, and sub-agent RPC.
+tags:
+  - AI
+sidebar:
+  order: 7
+---
+
+import {
+	TypeScriptExample,
+	WranglerConfig,
+	InlineBadge,
+	LinkCard,
+} from "~/components";
+
+`@cloudflare/think` is an opinionated chat agent base class for Cloudflare Workers. It handles the full chat lifecycle — agentic loop, message persistence, streaming, tool execution, client tools, stream resumption, and extensions — all backed by Durable Object SQLite.
+
+Think works as both a **top-level agent** (WebSocket chat to browser clients via `useAgentChat`) and a **sub-agent** (RPC streaming from a parent agent via `chat()`).
+
+## Quick start
+
+### Install
+
+```sh
+npm install @cloudflare/think @cloudflare/ai-chat agents ai @cloudflare/shell zod workers-ai-provider
+```
+
+### Server
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+import { createWorkersAI } from "workers-ai-provider";
+import { routeAgentRequest } from "agents";
+
+export class MyAgent extends Think<Env> {
+	getModel() {
+		return createWorkersAI({ binding: this.env.AI })(
+			"@cf/moonshotai/kimi-k2.5",
+		);
+	}
+}
+
+export default {
+	async fetch(request: Request, env: Env) {
+		return (
+			(await routeAgentRequest(request, env)) ||
+			new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+That is it. Think handles the WebSocket chat protocol, message persistence, the agentic loop, message sanitization, stream resumption, client tool support, and workspace file tools.
+
+### Client
+
+<TypeScriptExample>
+
+```ts
+import { useAgent } from "agents/react";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
+
+function Chat() {
+	const agent = useAgent({ agent: "MyAgent" });
+	const { messages, sendMessage, status } = useAgentChat({ agent });
+
+	return (
+		<div>
+			{messages.map((msg) => (
+				<div key={msg.id}>
+					<strong>{msg.role}:</strong>
+					{msg.parts.map((part, i) =>
+						part.type === "text" ? <span key={i}>{part.text}</span> : null,
+					)}
+				</div>
+			))}
+
+			<form
+				onSubmit={(e) => {
+					e.preventDefault();
+					const input = e.currentTarget.elements.namedItem(
+						"input",
+					) as HTMLInputElement;
+					sendMessage({ text: input.value });
+					input.value = "";
+				}}
+			>
+				<input name="input" placeholder="Send a message..." />
+				<button type="submit">Send</button>
+			</form>
+		</div>
+	);
+}
+```
+
+</TypeScriptExample>
+
+### Configuration
+
+<WranglerConfig>
+
+```toml
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat", "experimental"]
+
+[ai]
+binding = "AI"
+
+[[durable_objects.bindings]]
+class_name = "MyAgent"
+name = "MyAgent"
+
+[[migrations]]
+new_sqlite_classes = ["MyAgent"]
+tag = "v1"
+```
+
+</WranglerConfig>
+
+## Think vs AIChatAgent
+
+Both Think and [`AIChatAgent`](/agents/api-reference/chat-agents/) extend `Agent` and speak the same `cf_agent_chat_*` WebSocket protocol. They serve different goals.
+
+**AIChatAgent** is a protocol adapter. You override `onChatMessage` and are responsible for calling `streamText`, wiring tools, converting messages, and returning a `Response`. AIChatAgent handles the plumbing — message persistence, streaming, abort, resume — but the LLM call is entirely your concern.
+
+**Think** is an opinionated framework. It makes decisions for you: `getModel()` returns the model, `getSystemPrompt()` or `configureSession()` sets the prompt, `getTools()` returns tools. The default `onChatMessage` runs the complete agentic loop. You override individual pieces, not the whole pipeline.
+
+| Concern                | AIChatAgent                                                      | Think                                                               |
+| ---------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **Minimal subclass**   | ~15 lines (wire `streamText` + tools + system prompt + response) | 3 lines (`getModel()` only)                                         |
+| **Storage**            | Flat SQL table                                                   | Session: tree-structured messages, context blocks, compaction, FTS5 |
+| **Regeneration**       | Destructive (old response deleted)                               | Non-destructive branching (old responses preserved)                 |
+| **Context management** | Manual                                                           | Context blocks with LLM-writable persistent memory                  |
+| **Sub-agent RPC**      | Not built in                                                     | `chat()` with `StreamCallback`                                      |
+| **Programmatic turns** | `saveMessages()`                                                 | `saveMessages()` + `continueLastTurn()`                             |
+| **Compaction**         | `maxPersistedMessages` (deletes oldest)                          | Non-destructive summaries via overlays                              |
+| **Search**             | Not available                                                    | FTS5 full-text search per-session and cross-session                 |
+
+### When to use AIChatAgent
+
+- You need full control over the LLM call (RAG, multi-model, custom streaming)
+- You want the `Response` return type for HTTP middleware or testing
+- You are building a simple chatbot with no memory requirements
+
+### When to use Think
+
+- You want to ship fast (3-line subclass with everything wired)
+- You need persistent memory (context blocks the model can read and write)
+- You need long conversations (non-destructive compaction)
+- You need conversation search (FTS5)
+- You are building a sub-agent system (parent-child RPC with streaming)
+- You need proactive agents (programmatic turns from scheduled tasks or webhooks)
+
+## Configuration overrides
+
+| Method / Property       | Default                          | Description                                                                                           |
+| ----------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `getModel()`            | throws                           | Return the `LanguageModel` to use                                                                     |
+| `getSystemPrompt()`     | `"You are a helpful assistant."` | System prompt (fallback when no context blocks)                                                       |
+| `getTools()`            | `{}`                             | AI SDK `ToolSet` for the agentic loop                                                                 |
+| `maxSteps`              | `10`                             | Max tool-call rounds per turn                                                                         |
+| `configureSession()`    | identity                         | Add context blocks, compaction, search, skills — refer to [Sessions](/agents/api-reference/sessions/) |
+| `messageConcurrency`    | `"queue"`                        | How overlapping submits behave — refer to [Message concurrency](#message-concurrency)                 |
+| `waitForMcpConnections` | `false`                          | Wait for MCP servers before inference                                                                 |
+| `chatRecovery` | `false`                          | Wrap turns in `runFiber` for durable execution                                                        |
+
+## Dynamic configuration
+
+Think accepts a `Config` type parameter for per-instance typed configuration. Configuration is persisted in SQLite and survives hibernation and restarts.
+
+<TypeScriptExample>
+
+```ts
+type MyConfig = { modelTier: "fast" | "capable"; theme: string };
+
+export class MyAgent extends Think<Env, MyConfig> {
+	getModel() {
+		const tier = this.getConfig()?.modelTier ?? "fast";
+		const models = {
+			fast: "@cf/moonshotai/kimi-k2.5",
+			capable: "@cf/meta/llama-4-scout-17b-16e-instruct",
+		};
+		return createWorkersAI({ binding: this.env.AI })(models[tier]);
+	}
+}
+```
+
+</TypeScriptExample>
+
+| Method                        | Description                                                   |
+| ----------------------------- | ------------------------------------------------------------- |
+| `configure(config: Config)`   | Persist a typed configuration object                          |
+| `getConfig(): Config \| null` | Read the persisted configuration, or null if never configured |
+
+Expose configuration to the client via `@callable`:
+
+<TypeScriptExample>
+
+```ts
+import { callable } from "agents";
+
+export class MyAgent extends Think<Env, MyConfig> {
+	getModel() {
+		/* ... */
+	}
+
+	@callable()
+	updateConfig(config: MyConfig) {
+		this.configure(config);
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Session integration
+
+Think uses [Session](/agents/api-reference/sessions/) for conversation storage. Override `configureSession` to add persistent memory, compaction, search, and skills:
+
+<TypeScriptExample>
+
+```ts
+import { Think, Session } from "@cloudflare/think";
+
+export class MyAgent extends Think<Env> {
+	getModel() {
+		/* ... */
+	}
+
+	configureSession(session: Session) {
+		return session
+			.withContext("soul", {
+				provider: { get: async () => "You are a helpful coding assistant." },
+			})
+			.withContext("memory", {
+				description: "Important facts learned during conversation.",
+				maxTokens: 2000,
+			})
+			.withCachedPrompt();
+	}
+}
+```
+
+</TypeScriptExample>
+
+When `configureSession` adds context blocks, Think builds the system prompt from those blocks instead of using `getSystemPrompt()`. Think's `this.messages` getter reads directly from Session's tree-structured storage.
+
+For the full Session API — context blocks, compaction, search, skills, and multi-session support — refer to the [Sessions documentation](/agents/api-reference/sessions/).
+
+## Tools
+
+Think provides built-in workspace file tools on every turn, plus integration points for custom tools, code execution, and dynamic extensions.
+
+### Tool merge order
+
+On every turn, Think merges tools from multiple sources. Later sources override earlier ones if names collide:
+
+1. **Workspace tools** — `read`, `write`, `edit`, `list`, `find`, `grep`, `delete` (built-in)
+2. **`getTools()`** — your custom server-side tools
+3. **Session tools** — `set_context`, `load_context`, `search_context` (from `configureSession`)
+4. **Extension tools** — tools from loaded extensions (prefixed by extension name)
+5. **MCP tools** — from connected MCP servers
+6. **Client tools** — from the browser (refer to [Client tools](#client-tools))
+7. **Caller tools** — from `chat()` options when used as a sub-agent
+
+### Built-in workspace tools
+
+Every Think agent gets `this.workspace` — a virtual filesystem backed by Durable Object SQLite. Workspace tools are automatically available to the model with no configuration.
+
+| Tool     | Description                                                                 |
+| -------- | --------------------------------------------------------------------------- |
+| `read`   | Read a file's content                                                       |
+| `write`  | Write content to a file (creates parent directories)                        |
+| `edit`   | Apply a find-and-replace edit to an existing file (supports fuzzy matching) |
+| `list`   | List files and directories in a path                                        |
+| `find`   | Find files matching a glob pattern                                          |
+| `grep`   | Search file contents by regex or fixed string                               |
+| `delete` | Delete a file or directory                                                  |
+
+#### R2 spillover
+
+By default, the workspace stores everything in SQLite. For large files, override `workspace` to add R2 spillover:
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+import { Workspace } from "@cloudflare/shell";
+
+export class MyAgent extends Think<Env> {
+	override workspace = new Workspace({
+		sql: this.ctx.storage.sql,
+		r2: this.env.R2,
+		name: () => this.name,
+	});
+
+	getModel() {
+		/* ... */
+	}
+}
+```
+
+</TypeScriptExample>
+
+This requires an R2 bucket binding:
+
+<WranglerConfig>
+
+```toml
+[[r2_buckets]]
+binding = "R2"
+bucket_name = "agent-files"
+```
+
+</WranglerConfig>
+
+### Custom tools
+
+Override `getTools()` to add your own tools. These are standard AI SDK `tool()` definitions with Zod schemas:
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+import { tool } from "ai";
+import type { ToolSet } from "ai";
+import { z } from "zod";
+
+export class MyAgent extends Think<Env> {
+	getModel() {
+		/* ... */
+	}
+
+	getTools(): ToolSet {
+		return {
+			getWeather: tool({
+				description: "Get the current weather for a city",
+				inputSchema: z.object({
+					city: z.string().describe("City name"),
+				}),
+				execute: async ({ city }) => {
+					const res = await fetch(
+						`https://api.weather.com/v1/current?q=${city}&key=${this.env.WEATHER_KEY}`,
+					);
+					return res.json();
+				},
+			}),
+		};
+	}
+}
+```
+
+</TypeScriptExample>
+
+Custom tools are merged with workspace tools automatically. If a custom tool has the same name as a workspace tool, the custom tool wins.
+
+### Tool approval
+
+Tools can require user approval before execution using the `needsApproval` option:
+
+```ts
+getTools(): ToolSet {
+	return {
+		deleteFile: tool({
+			description: "Delete a file from the system",
+			inputSchema: z.object({ path: z.string() }),
+			needsApproval: async ({ path }) => path.startsWith("/important/"),
+			execute: async ({ path }) => {
+				await this.workspace.rm(path);
+				return { deleted: path };
+			},
+		}),
+	};
+}
+```
+
+When `needsApproval` returns `true`, the tool call is sent to the client for approval. The conversation pauses until the client responds with `CF_AGENT_TOOL_APPROVAL`.
+
+### Per-turn tool overrides
+
+The `beforeTurn` hook can restrict or add tools for a specific turn:
+
+```ts
+beforeTurn(ctx: TurnContext) {
+	return {
+		activeTools: ["read", "write", "getWeather"],
+		tools: { emergencyTool: this.createEmergencyTool() },
+	};
+}
+```
+
+`activeTools` limits which tools the model can call. `tools` adds extra tools for this turn only (merged on top of existing tools).
+
+### MCP tools
+
+Think inherits MCP client support from the `Agent` base class. MCP tools from connected servers are automatically merged into every turn.
+
+Set `waitForMcpConnections` to ensure MCP servers are connected before inference runs:
+
+<TypeScriptExample>
+
+```ts
+export class MyAgent extends Think<Env> {
+	waitForMcpConnections = true; // default 10s timeout
+	// or: waitForMcpConnections = { timeout: 5000 };
+
+	getModel() {
+		/* ... */
+	}
+}
+```
+
+</TypeScriptExample>
+
+Add MCP servers programmatically or via `@callable` methods:
+
+<TypeScriptExample>
+
+```ts
+import { callable } from "agents";
+
+export class MyAgent extends Think<Env> {
+	getModel() {
+		/* ... */
+	}
+
+	@callable()
+	async addServer(name: string, url: string) {
+		return await this.addMcpServer(name, url);
+	}
+
+	@callable()
+	async removeServer(serverId: string) {
+		await this.removeMcpServer(serverId);
+	}
+}
+```
+
+</TypeScriptExample>
+
+### Code execution tool
+
+Let the LLM write and run JavaScript in a sandboxed Worker. Requires `@cloudflare/codemode` and a `worker_loaders` binding.
+
+```sh
+npm install @cloudflare/codemode
+```
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+import { createExecuteTool } from "@cloudflare/think/tools/execute";
+import { createWorkspaceTools } from "@cloudflare/think/tools/workspace";
+
+export class MyAgent extends Think<Env> {
+	getModel() {
+		/* ... */
+	}
+
+	getTools() {
+		return {
+			execute: createExecuteTool({
+				tools: createWorkspaceTools(this.workspace),
+				loader: this.env.LOADER,
+			}),
+		};
+	}
+}
+```
+
+</TypeScriptExample>
+
+<WranglerConfig>
+
+```toml
+[[worker_loaders]]
+binding = "LOADER"
+```
+
+</WranglerConfig>
+
+For richer filesystem access, pass a `state` backend:
+
+<TypeScriptExample>
+
+```ts
+import { createWorkspaceStateBackend } from "@cloudflare/shell";
+
+createExecuteTool({
+	tools: myDomainTools,
+	state: createWorkspaceStateBackend(this.workspace),
+	loader: this.env.LOADER,
+});
+```
+
+</TypeScriptExample>
+
+### Browser tools
+
+Give your agent access to the Chrome DevTools Protocol (CDP) for web page inspection, scraping, screenshots, and debugging. Requires `@cloudflare/codemode` and a Browser Rendering binding.
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+import { createBrowserTools } from "@cloudflare/think/tools/browser";
+
+export class MyAgent extends Think<Env> {
+	getModel() {
+		/* ... */
+	}
+
+	getTools() {
+		return {
+			...createBrowserTools({
+				browser: this.env.BROWSER,
+				loader: this.env.LOADER,
+			}),
+		};
+	}
+}
+```
+
+</TypeScriptExample>
+
+<WranglerConfig>
+
+```toml
+[browser]
+binding = "BROWSER"
+
+[[worker_loaders]]
+binding = "LOADER"
+```
+
+</WranglerConfig>
+
+This adds two tools:
+
+| Tool              | Description                                                                             |
+| ----------------- | --------------------------------------------------------------------------------------- |
+| `browser_search`  | Query the CDP protocol spec to discover commands, events, and types                     |
+| `browser_execute` | Run CDP commands against a live browser session (screenshots, DOM reads, JS evaluation) |
+
+For a custom Chrome endpoint, pass `cdpUrl` instead of `browser`:
+
+<TypeScriptExample>
+
+```ts
+createBrowserTools({
+	cdpUrl: "http://localhost:9222",
+	loader: this.env.LOADER,
+});
+```
+
+</TypeScriptExample>
+
+For the full CDP helper API, refer to [Browse the web](/agents/api-reference/browse-the-web/).
+
+### Extensions
+
+Extensions are dynamically loaded sandboxed Workers that add tools at runtime. The LLM can write extension source code, load it, and use the new tools on the next turn.
+
+Extensions require a `worker_loaders` binding:
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+
+export class MyAgent extends Think<Env> {
+	extensionLoader = this.env.LOADER;
+
+	getModel() {
+		/* ... */
+	}
+}
+```
+
+</TypeScriptExample>
+
+#### Static extensions
+
+Define extensions that load at startup:
+
+<TypeScriptExample>
+
+```ts
+export class MyAgent extends Think<Env> {
+	extensionLoader = this.env.LOADER;
+
+	getModel() {
+		/* ... */
+	}
+
+	getExtensions() {
+		return [
+			{
+				manifest: {
+					name: "math",
+					version: "1.0.0",
+					permissions: { network: false },
+				},
+				source: `({
+					tools: {
+						add: {
+							description: "Add two numbers",
+							parameters: { a: { type: "number" }, b: { type: "number" } },
+							execute: async ({ a, b }) => ({ result: a + b })
+						}
+					}
+				})`,
+			},
+		];
+	}
+}
+```
+
+</TypeScriptExample>
+
+Extension tools are namespaced — a `math` extension with an `add` tool becomes `math_add` in the model's tool set.
+
+#### LLM-driven extensions
+
+Give the model `createExtensionTools` so it can load extensions dynamically:
+
+<TypeScriptExample>
+
+```ts
+import { createExtensionTools } from "@cloudflare/think/tools/extensions";
+
+export class MyAgent extends Think<Env> {
+	extensionLoader = this.env.LOADER;
+
+	getModel() {
+		/* ... */
+	}
+
+	getTools() {
+		return {
+			...createExtensionTools({ manager: this.extensionManager! }),
+			...this.extensionManager!.getTools(),
+		};
+	}
+}
+```
+
+</TypeScriptExample>
+
+This gives the model two tools:
+
+- `load_extension` — load a new extension from JavaScript source
+- `list_extensions` — list currently loaded extensions
+
+#### Extension context blocks
+
+Extensions can declare context blocks in their manifest. These are automatically registered with the Session:
+
+```ts
+getExtensions() {
+	return [{
+		manifest: {
+			name: "notes",
+			version: "1.0.0",
+			permissions: { network: false },
+			context: [
+				{ label: "scratchpad", description: "Extension scratch space", maxTokens: 500 },
+			],
+		},
+		source: `({ tools: { /* ... */ } })`,
+	}];
+}
+```
+
+The context block is registered as `notes_scratchpad` (namespaced by extension name).
+
+### Custom workspace backends
+
+The individual tool factories are exported for use with custom storage backends:
+
+<TypeScriptExample>
+
+```ts
+import {
+	createReadTool,
+	createWriteTool,
+	createEditTool,
+	createListTool,
+	createFindTool,
+	createGrepTool,
+	createDeleteTool,
+	createWorkspaceTools,
+} from "@cloudflare/think/tools/workspace";
+```
+
+</TypeScriptExample>
+
+Implement the operations interface for your storage backend:
+
+<TypeScriptExample>
+
+```ts
+import type { ReadOperations } from "@cloudflare/think/tools/workspace";
+
+const myReadOps: ReadOperations = {
+	readFile: async (path) => fetchFromMyStorage(path),
+	stat: async (path) => getFileInfo(path),
+};
+
+const readTool = createReadTool({ ops: myReadOps });
+```
+
+</TypeScriptExample>
+
+## Lifecycle hooks
+
+Think owns the `streamText` call and provides hooks at each stage of the chat turn. Hooks fire on every turn regardless of entry path — WebSocket chat, sub-agent `chat()`, `saveMessages`, and auto-continuation after tool results.
+
+### Hook summary
+
+| Hook                        | When it fires                                 | Return                     | Async |
+| --------------------------- | --------------------------------------------- | -------------------------- | ----- |
+| `configureSession(session)` | Once during `onStart`                         | `Session`                  | yes   |
+| `beforeTurn(ctx)`           | Before `streamText`                           | `TurnConfig` or void       | yes   |
+| `beforeToolCall(ctx)`       | When model calls a tool                       | `ToolCallDecision` or void | yes   |
+| `afterToolCall(ctx)`        | After tool execution                          | void                       | yes   |
+| `onStepFinish(ctx)`         | After each step completes                     | void                       | yes   |
+| `onChunk(ctx)`              | Per streaming chunk                           | void                       | yes   |
+| `onChatResponse(result)`    | After turn completes and message is persisted | void                       | yes   |
+| `onChatError(error)`        | On error during a turn                        | error to propagate         | no    |
+
+### Execution order
+
+For a turn with two tool calls:
+
+```txt
+configureSession()          ← once at startup, not per-turn
+      │
+beforeTurn()                ← inspect assembled context, override model/tools/prompt
+      │
+  ┌── streamText ───────────────────────────────────┐
+  │   onChunk()  onChunk()  onChunk()  ...          │
+  │       │                                         │
+  │   beforeToolCall()  →  tool executes            │
+  │                        afterToolCall()           │
+  │       │                                         │
+  │   onStepFinish()                                │
+  │       │                                         │
+  │   onChunk()  onChunk()  ...                     │
+  │       │                                         │
+  │   beforeToolCall()  →  tool executes            │
+  │                        afterToolCall()           │
+  │       │                                         │
+  │   onStepFinish()                                │
+  └─────────────────────────────────────────────────┘
+      │
+onChatResponse()            ← message persisted, turn lock released
+```
+
+### beforeTurn
+
+Called before `streamText`. Receives the fully assembled context — system prompt, converted messages, merged tools, and model. Return a `TurnConfig` to override any part, or void to accept defaults.
+
+```ts
+beforeTurn(ctx: TurnContext): TurnConfig | void | Promise<TurnConfig | void>
+```
+
+#### TurnContext
+
+| Field          | Type                      | Description                                                              |
+| -------------- | ------------------------- | ------------------------------------------------------------------------ |
+| `system`       | `string`                  | Assembled system prompt (from context blocks or `getSystemPrompt()`)     |
+| `messages`     | `ModelMessage[]`          | Assembled model messages (truncated, pruned)                             |
+| `tools`        | `ToolSet`                 | Merged tool set (workspace + getTools + session + MCP + client + caller) |
+| `model`        | `LanguageModel`           | The model from `getModel()`                                              |
+| `continuation` | `boolean`                 | Whether this is a continuation turn (auto-continue after tool result)    |
+| `body`         | `Record<string, unknown>` | Custom body fields from the client request                               |
+
+#### TurnConfig
+
+All fields are optional. Return only what you want to change.
+
+| Field             | Type                      | Description                          |
+| ----------------- | ------------------------- | ------------------------------------ |
+| `model`           | `LanguageModel`           | Override the model for this turn     |
+| `system`          | `string`                  | Override the system prompt           |
+| `messages`        | `ModelMessage[]`          | Override the assembled messages      |
+| `tools`           | `ToolSet`                 | Extra tools to merge (additive)      |
+| `activeTools`     | `string[]`                | Limit which tools the model can call |
+| `toolChoice`      | `ToolChoice`              | Force a specific tool call           |
+| `maxSteps`        | `number`                  | Override `maxSteps` for this turn    |
+| `providerOptions` | `Record<string, unknown>` | Provider-specific options            |
+
+#### Examples
+
+Switch to a cheaper model for continuation turns:
+
+```ts
+beforeTurn(ctx: TurnContext) {
+	if (ctx.continuation) {
+		return { model: this.cheapModel };
+	}
+}
+```
+
+Restrict which tools the model can call:
+
+```ts
+beforeTurn(ctx: TurnContext) {
+	return { activeTools: ["read", "write", "getWeather"] };
+}
+```
+
+Add per-turn context from the client body:
+
+```ts
+beforeTurn(ctx: TurnContext) {
+	if (ctx.body?.selectedFile) {
+		return {
+			system: ctx.system + `\n\nUser is editing: ${ctx.body.selectedFile}`,
+		};
+	}
+}
+```
+
+### beforeToolCall
+
+Called when the model produces a tool call. Only fires for server-side tools (tools with `execute`).
+
+:::note
+
+`beforeToolCall` currently fires as an observation hook — after tool execution, via `onStepFinish` data. The `block` and `substitute` actions in `ToolCallDecision` are defined in the types but are not yet functional. For now, use this hook for logging and analytics.
+
+:::
+
+```ts
+beforeToolCall(ctx: ToolCallContext) {
+	console.log(`Tool called: ${ctx.toolName}`, ctx.args);
+}
+```
+
+| Field      | Type                      | Description                   |
+| ---------- | ------------------------- | ----------------------------- |
+| `toolName` | `string`                  | Name of the tool being called |
+| `args`     | `Record<string, unknown>` | Arguments the model provided  |
+
+### afterToolCall
+
+Called after a tool executes.
+
+```ts
+afterToolCall(ctx: ToolCallResultContext) {
+	this.env.ANALYTICS.writeDataPoint({
+		blobs: [ctx.toolName],
+		doubles: [JSON.stringify(ctx.result).length],
+	});
+}
+```
+
+| Field      | Type                      | Description                        |
+| ---------- | ------------------------- | ---------------------------------- |
+| `toolName` | `string`                  | Name of the tool that was called   |
+| `args`     | `Record<string, unknown>` | Arguments the tool was called with |
+| `result`   | `unknown`                 | The result returned by the tool    |
+
+### onStepFinish
+
+Called after each step completes in the agentic loop. A step is one `streamText` iteration — the model generates text, optionally calls tools, and the step ends.
+
+```ts
+onStepFinish(ctx: StepContext) {
+	console.log(
+		`Step ${ctx.stepType}: ${ctx.usage.inputTokens}in/${ctx.usage.outputTokens}out`,
+	);
+}
+```
+
+| Field          | Type                                       | Description                 |
+| -------------- | ------------------------------------------ | --------------------------- |
+| `stepType`     | `"initial" \| "continue" \| "tool-result"` | Why the step ran            |
+| `text`         | `string`                                   | Text generated in this step |
+| `toolCalls`    | `unknown[]`                                | Tool calls made             |
+| `toolResults`  | `unknown[]`                                | Tool results received       |
+| `finishReason` | `string`                                   | Why the step ended          |
+| `usage`        | `{ inputTokens, outputTokens }`            | Token usage for this step   |
+
+### onChunk
+
+Called for each streaming chunk. High-frequency — fires per token. Use for streaming analytics, progress indicators, or token counting. Observational only.
+
+### onChatResponse
+
+Called after a chat turn completes and the assistant message has been persisted. The turn lock is released before this hook runs, so it is safe to call `saveMessages` or other methods from inside.
+
+Fires for all turn completion paths: WebSocket, sub-agent RPC, `saveMessages`, and auto-continuation.
+
+```ts
+onChatResponse(result: ChatResponseResult) {
+	if (result.status === "completed") {
+		console.log(`Turn ${result.requestId}: ${result.message.parts.length} parts`);
+	}
+}
+```
+
+| Field          | Type                                  | Description                                |
+| -------------- | ------------------------------------- | ------------------------------------------ |
+| `message`      | `UIMessage`                           | The persisted assistant message            |
+| `requestId`    | `string`                              | Unique ID for this turn                    |
+| `continuation` | `boolean`                             | Whether this was a continuation turn       |
+| `status`       | `"completed" \| "error" \| "aborted"` | How the turn ended                         |
+| `error`        | `string?`                             | Error message (when `status` is `"error"`) |
+
+### onChatError
+
+Called when an error occurs during a chat turn. Return the error to propagate it, or return a different error. The partial assistant message (if any) is persisted before this hook fires.
+
+```ts
+onChatError(error: unknown) {
+	console.error("Chat turn failed:", error);
+	return new Error("Something went wrong. Please try again.");
+}
+```
+
+## Client tools
+
+Think supports tools that execute in the browser. The client sends tool schemas in the chat request body, Think merges them with server tools, and when the LLM calls a client tool, the call is routed to the client for execution.
+
+### Defining client tools
+
+On the client, pass `clientTools` to `useAgentChat`:
+
+<TypeScriptExample>
+
+```ts
+const { messages, sendMessage } = useAgentChat({
+	agent,
+	clientTools: {
+		getUserTimezone: {
+			description: "Get the user's timezone from their browser",
+			parameters: {},
+			execute: async () => {
+				return Intl.DateTimeFormat().resolvedOptions().timeZone;
+			},
+		},
+		getClipboard: {
+			description: "Read text from the user's clipboard",
+			parameters: {},
+			execute: async () => {
+				return navigator.clipboard.readText();
+			},
+		},
+	},
+});
+```
+
+</TypeScriptExample>
+
+Client tools are tools without an `execute` function on the server — they only have a schema. When the LLM produces a tool call for one, Think routes it to the client.
+
+### Approval flow
+
+Handle approvals on the client with `onToolCall`:
+
+<TypeScriptExample>
+
+```ts
+const { messages, sendMessage, addToolResult } = useAgentChat({
+	agent,
+	onToolCall: ({ toolCall }) => {
+		if (toolCall.toolName === "read") {
+			return { approve: true };
+		}
+		// Others go through the UI approval flow
+	},
+});
+```
+
+</TypeScriptExample>
+
+### Auto-continuation
+
+After a client tool result is received, Think automatically continues the conversation without a new user message. The continuation turn has `continuation: true` in the `TurnContext`, which you can use in `beforeTurn` to adjust model or tool selection.
+
+### Message concurrency
+
+The `messageConcurrency` property controls how overlapping user submits behave when a chat turn is already active.
+
+| Strategy                                        | Behavior                                                                              |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `"queue"`                                       | Queue every submit and process them in order. Default.                                |
+| `"latest"`                                      | Keep only the latest overlapping submit.                                              |
+| `"merge"`                                       | All overlapping user messages remain in history; the model sees them all in one turn. |
+| `"drop"`                                        | Ignore overlapping submits entirely. Messages are not persisted.                      |
+| `{ strategy: "debounce", debounceMs?: number }` | Trailing-edge latest with a quiet window (default 750ms).                             |
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+import type { MessageConcurrency } from "@cloudflare/think";
+
+export class SearchAgent extends Think<Env> {
+	override messageConcurrency: MessageConcurrency = "latest";
+	getModel() {
+		/* ... */
+	}
+}
+```
+
+</TypeScriptExample>
+
+### Multi-tab broadcast
+
+Think broadcasts streaming responses to all connected WebSocket clients. When multiple browser tabs are connected to the same agent, all tabs see the streamed response in real time. Tool call states (pending, result, approval) are broadcast to all tabs.
+
+## Sub-agent RPC and programmatic turns
+
+Think works as both a top-level agent and a sub-agent. When used as a sub-agent, the `chat()` method runs a full turn and streams events via a callback.
+
+### chat
+
+```ts
+async chat(
+	userMessage: string | UIMessage,
+	callback: StreamCallback,
+	options?: ChatOptions,
+): Promise<void>
+```
+
+#### StreamCallback
+
+| Method           | When it fires                                                   |
+| ---------------- | --------------------------------------------------------------- |
+| `onEvent(json)`  | For each streaming chunk (JSON-serialized `UIMessageChunk`)     |
+| `onDone()`       | After the turn completes and the assistant message is persisted |
+| `onError(error)` | On error during the turn (if not provided, the error is thrown) |
+
+#### ChatOptions
+
+| Field    | Description                                                 |
+| -------- | ----------------------------------------------------------- |
+| `signal` | `AbortSignal` to cancel the turn mid-stream                 |
+| `tools`  | Extra tools to merge for this turn (highest merge priority) |
+
+#### Example: parent calling a child
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+
+export class ParentAgent extends Think<Env> {
+	getModel() {
+		/* ... */
+	}
+
+	async delegateToChild(task: string) {
+		const child = await this.subAgent(ChildAgent, "child-1");
+
+		const chunks: string[] = [];
+		await child.chat(task, {
+			onEvent: (json) => {
+				chunks.push(json);
+			},
+			onDone: () => {
+				console.log("Child completed");
+			},
+			onError: (error) => {
+				console.error("Child failed:", error);
+			},
+		});
+
+		return chunks;
+	}
+}
+
+export class ChildAgent extends Think<Env> {
+	getModel() {
+		/* ... */
+	}
+
+	getSystemPrompt() {
+		return "You are a research assistant. Analyze data and report findings.";
+	}
+}
+```
+
+</TypeScriptExample>
+
+#### Passing extra tools
+
+The `tools` option adds tools for this turn only, with the highest merge priority:
+
+<TypeScriptExample>
+
+```ts
+import { tool } from "ai";
+import { z } from "zod";
+
+await child.chat("Summarize the report", callback, {
+	tools: {
+		fetchReport: tool({
+			description: "Fetch the report data",
+			inputSchema: z.object({}),
+			execute: async () => this.getReportData(),
+		}),
+	},
+});
+```
+
+</TypeScriptExample>
+
+#### Aborting a sub-agent turn
+
+Pass an `AbortSignal` to cancel mid-stream. When aborted, the partial assistant message is still persisted.
+
+<TypeScriptExample>
+
+```ts
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 30_000);
+
+await child.chat("Long analysis task", callback, {
+	signal: controller.signal,
+});
+```
+
+</TypeScriptExample>
+
+### saveMessages
+
+Inject messages and trigger a model turn without a WebSocket connection. Use for scheduled responses, webhook-triggered turns, proactive agents, or chaining from `onChatResponse`.
+
+```ts
+async saveMessages(
+	messages:
+		| UIMessage[]
+		| ((current: UIMessage[]) => UIMessage[] | Promise<UIMessage[]>),
+): Promise<SaveMessagesResult>
+```
+
+Returns `{ requestId, status }` where `status` is `"completed"` or `"skipped"`.
+
+#### Static messages
+
+<TypeScriptExample>
+
+```ts
+await this.saveMessages([
+	{
+		id: crypto.randomUUID(),
+		role: "user",
+		parts: [{ type: "text", text: "Time for your daily summary." }],
+	},
+]);
+```
+
+</TypeScriptExample>
+
+#### Function form
+
+When multiple `saveMessages` calls queue up, the function form runs with the latest messages when the turn actually starts:
+
+<TypeScriptExample>
+
+```ts
+await this.saveMessages((current) => [
+	...current,
+	{
+		id: crypto.randomUUID(),
+		role: "user",
+		parts: [{ type: "text", text: "Continue your analysis." }],
+	},
+]);
+```
+
+</TypeScriptExample>
+
+#### Scheduled responses
+
+Trigger a turn from a cron schedule:
+
+<TypeScriptExample>
+
+```ts
+export class MyAgent extends Think<Env> {
+	getModel() {
+		/* ... */
+	}
+
+	async onScheduled() {
+		await this.saveMessages([
+			{
+				id: crypto.randomUUID(),
+				role: "user",
+				parts: [{ type: "text", text: "Generate the daily report." }],
+			},
+		]);
+	}
+}
+```
+
+</TypeScriptExample>
+
+#### Chaining from onChatResponse
+
+Start a follow-up turn after the current one completes:
+
+```ts
+async onChatResponse(result: ChatResponseResult) {
+	if (result.status === "completed" && this.needsFollowUp(result.message)) {
+		await this.saveMessages([{
+			id: crypto.randomUUID(),
+			role: "user",
+			parts: [{ type: "text", text: "Now summarize what you found." }],
+		}]);
+	}
+}
+```
+
+### continueLastTurn
+
+Resume the last assistant turn without injecting a new user message. Useful after tool results are received or after recovery from an interruption.
+
+```ts
+protected async continueLastTurn(
+	body?: Record<string, unknown>,
+): Promise<SaveMessagesResult>
+```
+
+Returns `{ requestId, status: "skipped" }` if the last message is not an assistant message. The optional `body` parameter overrides the stored body for this continuation.
+
+### Chat recovery
+
+Think can wrap chat turns in Durable Object fibers for durable execution. When a DO is evicted mid-turn, the turn can be recovered on restart.
+
+<TypeScriptExample>
+
+```ts
+export class MyAgent extends Think<Env> {
+	chatRecovery = true;
+
+	getModel() {
+		/* ... */
+	}
+}
+```
+
+</TypeScriptExample>
+
+When `chatRecovery` is `true`, all four turn paths (WebSocket, auto-continuation, `saveMessages`, `continueLastTurn`) are wrapped in `runFiber`.
+
+#### onChatRecovery
+
+When an interrupted chat fiber is detected after DO restart, Think calls `onChatRecovery`:
+
+<TypeScriptExample>
+
+```ts
+export class MyAgent extends Think<Env> {
+	chatRecovery = true;
+
+	getModel() {
+		/* ... */
+	}
+
+	onChatRecovery(ctx: ChatRecoveryContext) {
+		console.log(
+			`Recovering turn ${ctx.requestId}, partial: ${ctx.partialText.length} chars`,
+		);
+		return {
+			persist: true,
+			continue: true,
+		};
+	}
+}
+```
+
+</TypeScriptExample>
+
+#### ChatRecoveryContext
+
+| Field             | Type                       | Description                               |
+| ----------------- | -------------------------- | ----------------------------------------- |
+| `streamId`        | `string`                   | The stream ID of the interrupted turn     |
+| `requestId`       | `string`                   | The request ID of the interrupted turn    |
+| `partialText`     | `string`                   | Text generated before the interruption    |
+| `partialParts`    | `MessagePart[]`            | Parts accumulated before the interruption |
+| `recoveryData`    | `unknown \| null`          | Data from `this.stash()` during the turn  |
+| `messages`        | `UIMessage[]`              | Current conversation history              |
+| `lastBody`        | `Record<string, unknown>?` | Body from the interrupted turn            |
+| `lastClientTools` | `ClientToolSchema[]?`      | Client tools from the interrupted turn    |
+
+#### ChatRecoveryOptions
+
+| Field      | Type       | Description                                      |
+| ---------- | ---------- | ------------------------------------------------ |
+| `persist`  | `boolean?` | Whether to persist the partial assistant message |
+| `continue` | `boolean?` | Whether to auto-continue with a new turn         |
+
+With `persist: true`, the partial message is saved. With `continue: true`, Think calls `continueLastTurn()` after the agent reaches a stable state.
+
+### Stability detection
+
+Think provides methods to check if the agent is in a stable state — no pending tool results, no pending approvals, no active turns.
+
+#### hasPendingInteraction
+
+Returns `true` if any assistant message has pending tool calls (tools without results or pending approvals).
+
+```ts
+protected hasPendingInteraction(): boolean
+```
+
+#### waitUntilStable
+
+Returns a promise that resolves to `true` when the agent reaches a stable state, or `false` if the timeout is exceeded.
+
+<TypeScriptExample>
+
+```ts
+const stable = await this.waitUntilStable({ timeout: 30_000 });
+if (stable) {
+	await this.saveMessages([
+		{
+			id: crypto.randomUUID(),
+			role: "user",
+			parts: [{ type: "text", text: "Now that you are done, summarize." }],
+		},
+	]);
+}
+```
+
+</TypeScriptExample>
+
+## Package exports
+
+| Export                               | Description                                                   |
+| ------------------------------------ | ------------------------------------------------------------- |
+| `@cloudflare/think`                  | `Think`, `Session`, `Workspace` — main class and re-exports   |
+| `@cloudflare/think/tools/workspace`  | `createWorkspaceTools()` — for custom storage backends        |
+| `@cloudflare/think/tools/execute`    | `createExecuteTool()` — sandboxed code execution via codemode |
+| `@cloudflare/think/tools/extensions` | `createExtensionTools()` — LLM-driven extension loading       |
+| `@cloudflare/think/extensions`       | `ExtensionManager`, `HostBridgeLoopback` — extension runtime  |
+
+## Peer dependencies
+
+| Package                | Required | Notes                   |
+| ---------------------- | -------- | ----------------------- |
+| `agents`               | yes      | Cloudflare Agents SDK   |
+| `ai`                   | yes      | Vercel AI SDK v6        |
+| `zod`                  | yes      | Schema validation (v4)  |
+| `@cloudflare/shell`    | yes      | Workspace filesystem    |
+| `@cloudflare/codemode` | optional | For `createExecuteTool` |
+
+## Related
+
+- [Sessions](/agents/api-reference/sessions/) — context blocks, compaction, search, multi-session (the storage layer Think builds on)
+- [Sub-agents](/agents/api-reference/sub-agents/) — `subAgent()`, `abortSubAgent()`, `deleteSubAgent()` (the base Agent methods for spawning children)
+- [Chat agents](/agents/api-reference/chat-agents/) — `AIChatAgent` for when you need full control over the LLM call
+- [Long-running agents](/agents/concepts/long-running-agents/) — sub-agent delegation patterns for multi-week agent lifetimes
+- [Durable execution](/agents/api-reference/durable-execution/) — `runFiber()` and crash recovery (used by `chatRecovery`)
+- [Browse the web](/agents/api-reference/browse-the-web/) — full CDP helper API reference

--- a/src/content/docs/agents/concepts/long-running-agents.mdx
+++ b/src/content/docs/agents/concepts/long-running-agents.mdx
@@ -520,11 +520,13 @@ export class ProjectManager extends Agent<ProjectState> {
 
 Sub-agents are independent Durable Objects. They have their own state, their own schedules, and their own lifecycle. The parent does not need to stay alive while the sub-agent works — it can start the work, hibernate, and be woken by a callback or scheduled check.
 
+For the full `subAgent()` API — typed RPC stubs, abort, delete, storage isolation, and limitations — refer to [Sub-agents](/agents/api-reference/sub-agents/). For AI-specific sub-agent streaming (running full LLM turns through a child agent), refer to [Think: Sub-agent RPC](/agents/api-reference/think/#sub-agent-rpc-and-programmatic-turns).
+
 ## Recovering interrupted LLM streams
 
 The patterns above handle the project manager's coordination work — scheduling, delegating, polling. But the project manager also uses an LLM directly: generating plans, summarizing progress, drafting status emails. Those LLM calls stream tokens over a connection that cannot be resumed if the agent is evicted mid-response.
 
-For chat-oriented agents built on `AIChatAgent`, this is an even sharper problem — the user is watching the response stream in real time and sees it stop mid-sentence. `unstable_chatRecovery` wraps each chat turn in a `runFiber`, providing automatic `keepAlive` during streaming and a recovery hook when the agent restarts:
+For chat-oriented agents built on `AIChatAgent`, this is an even sharper problem — the user is watching the response stream in real time and sees it stop mid-sentence. `chatRecovery` wraps each chat turn in a `runFiber`, providing automatic `keepAlive` during streaming and a recovery hook when the agent restarts:
 
 ```ts
 import { AIChatAgent } from "@cloudflare/ai-chat";
@@ -534,7 +536,7 @@ import type {
 } from "@cloudflare/ai-chat";
 
 class ProjectChat extends AIChatAgent<Env> {
-  override unstable_chatRecovery = true;
+  override chatRecovery = true;
 
   override async onChatRecovery(
     ctx: ChatRecoveryContext
@@ -653,7 +655,7 @@ Long-running agents on Cloudflare are not long-running processes. They are durab
 | **`schedule()` / `scheduleEvery()`**   | Wake the agent at future times                |
 | **`keepAlive()` / `keepAliveWhile()`** | Prevent eviction during active work           |
 | **`runFiber()` / `stash()`**           | Checkpoint and recover long tasks             |
-| **`unstable_chatRecovery`**            | Recover interrupted LLM streams               |
+| **`chatRecovery`**            | Recover interrupted LLM streams               |
 | **`onRequest()` / `onEmail()` / RPC**  | Wake on external events                       |
 | **`runWorkflow()`**                    | Delegate heavyweight multi-step work          |
 | **`subAgent()`**                       | Delegate specialized work to child agents     |


### PR DESCRIPTION
### Summary

Adds three new API reference pages for the Agents SDK, covering experimental features that were previously undocumented in cloudflare-docs:

- **[Sub-agents](/agents/api-reference/sub-agents/)** — Documents `Agent.subAgent()`, `abortSubAgent()`, `deleteSubAgent()`, `SubAgentStub<T>` typing, storage isolation, naming, patterns (parallel, nested, callback streaming), and limitations.
- **[Sessions](/agents/api-reference/sessions/)** — Documents the experimental `Session` API: builder pattern, tree-structured messages, branching, context blocks (4 provider types), AI tools, compaction, `SessionManager`, forking, cross-session search, storage tables, and custom providers.
- **[Think](/agents/api-reference/think/)** — Comprehensive reference for `@cloudflare/think`: quick start, Think vs AIChatAgent comparison, configuration, session integration, tools (7-layer merge order, workspace, code execution, browser/CDP, extensions), all 8 lifecycle hooks, client tools, message concurrency, sub-agent RPC via `chat()`, programmatic turns, chat recovery, and stability detection.

Also updates three existing pages with cross-links:
- `agents-api.mdx` — added Sub-agents, Sessions, Think rows to the API reference table
- `long-running-agents.mdx` — added link from "Delegating to sub-agents" to the new API reference
- `chat-agents.mdx` — added note in "Subagent delegation" distinguishing in-process AI SDK subagents from Durable Object sub-agents

Source material adapted from the [agents-repo](https://github.com/cloudflare/agents) internal docs (`docs/think/`, `docs/sessions.md`).

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/29882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
