### PR TITLE
Update format of id to not contain product name in it

### DIFF
--- a/src/content/directory/mesh.yaml
+++ b/src/content/directory/mesh.yaml
@@ -1,4 +1,4 @@
-id: cMesh1
+id: 3KwtCw
 name: Cloudflare Mesh
 
 entry:


### PR DESCRIPTION
Keeping to convention of not having ids that contain some kind of reference to the item for which it is an id.