### PR TITLE
[SUPPORT] Fix 2FA enable step to reflect new dashboard UI

### DIFF
--- a/src/content/partials/support/2fa-enable.mdx
+++ b/src/content/partials/support/2fa-enable.mdx
@@ -17,8 +17,7 @@ To enable two-factor authentication for your Cloudflare login:
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login).
 2. Under the **My Profile** dropdown, select **My Profile**.
 3. Select **Authentication**. 
-4. Select **Manage** in the Two-Factor Authentication card.
-5. Configure either a [TOTP mobile app](/fundamentals/user-profiles/2fa/#configure-totp-mobile-application-authentication), [security key](/fundamentals/user-profiles/2fa/#configure-security-key-authentication-for-two-factor-cloudflare-login), or [email 2FA](/fundamentals/user-profiles/2fa/#configure-email-two-factor-authentication).
+4. Select **Add** next to [Mobile App Authentication](/fundamentals/user-profiles/2fa/#configure-totp-mobile-application-authentication) or [Security Key Authentication](/fundamentals/user-profiles/2fa/#configure-security-key-authentication-for-two-factor-cloudflare-login), or **Enable** next to [Email Authentication](/fundamentals/user-profiles/2fa/#configure-email-two-factor-authentication).
 
 :::note
 


### PR DESCRIPTION
### Summary

Updates the 2FA enable steps in the shared `2fa-enable` partial to reflect the current dashboard UI. The step previously instructed users to select **Manage** in the Two-Factor Authentication card, but the current dashboard shows **Set up** or **Learn more** for users who have not yet configured 2FA. Updated to reflect both possible labels.

Triggering ticket: `02069923`

### Screenshots (optional)

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).