### PR TITLE
[WAF] Document defer attribute on email obfuscation decode script

### DIFF
--- a/src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx
+++ b/src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx
@@ -8,6 +8,6 @@ date: 2026-04-14
 
 The decode script injected by [Email Address Obfuscation](/waf/tools/scrape-shield/email-address-obfuscation/) now loads with the `defer` attribute. This means the script no longer blocks page rendering — it downloads in parallel with HTML parsing and executes after the document is fully parsed, before the `DOMContentLoaded` event.
 
-This improves page loading performance, particularly Largest Contentful Paint (LCP), for all zones with Email Address Obfuscation on. No action is required.
+This improves page loading performance, contributing to better Core Web Vitals, for all zones with Email Address Obfuscation on. No action is required.
 
 If you have custom JavaScript that depends on email addresses being decoded at a specific point during page load, note that the decode script now executes after HTML parsing completes rather than inline during parsing.

--- a/src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx
+++ b/src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx
@@ -1,0 +1,13 @@
+---
+title: Email obfuscation decode script is now non-render-blocking
+description: The email-decode.min.js script injected by Email Address Obfuscation now uses the defer attribute, improving page loading performance.
+products:
+  - waf
+date: 2026-04-14
+---
+
+The decode script injected by [Email Address Obfuscation](/waf/tools/scrape-shield/email-address-obfuscation/) now loads with the `defer` attribute. This means the script no longer blocks page rendering — it downloads in parallel with HTML parsing and executes after the document is fully parsed, before the `DOMContentLoaded` event.
+
+This improves page loading performance, particularly Largest Contentful Paint (LCP), for all zones with Email Address Obfuscation turned on. No action is required.
+
+If you have custom JavaScript that depends on email addresses being decoded at a specific point during page load, note that the decode script now executes after HTML parsing completes rather than inline during parsing.

--- a/src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx
+++ b/src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx
@@ -8,6 +8,6 @@ date: 2026-04-14
 
 The decode script injected by [Email Address Obfuscation](/waf/tools/scrape-shield/email-address-obfuscation/) now loads with the `defer` attribute. This means the script no longer blocks page rendering — it downloads in parallel with HTML parsing and executes after the document is fully parsed, before the `DOMContentLoaded` event.
 
-This improves page loading performance, particularly Largest Contentful Paint (LCP), for all zones with Email Address Obfuscation turned on. No action is required.
+This improves page loading performance, particularly Largest Contentful Paint (LCP), for all zones with Email Address Obfuscation on. No action is required.
 
 If you have custom JavaScript that depends on email addresses being decoded at a specific point during page load, note that the decode script now executes after HTML parsing completes rather than inline during parsing.

--- a/src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx
+++ b/src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx
@@ -6,7 +6,7 @@ products:
 date: 2026-04-14
 ---
 
-The decode script injected by [Email Address Obfuscation](/waf/tools/scrape-shield/email-address-obfuscation/) now loads with the `defer` attribute. This means the script no longer blocks page rendering — it downloads in parallel with HTML parsing and executes after the document is fully parsed, before the `DOMContentLoaded` event.
+The decode script injected by [Email Address Obfuscation](/waf/tools/scrape-shield/email-address-obfuscation/) now loads with the `defer` attribute. This means the script no longer blocks page rendering. It downloads in parallel with HTML parsing and executes after the document is fully parsed, before the `DOMContentLoaded` event.
 
 This improves page loading performance, contributing to better Core Web Vitals, for all zones with Email Address Obfuscation on. No action is required.
 

--- a/src/content/docs/waf/tools/scrape-shield/email-address-obfuscation.mdx
+++ b/src/content/docs/waf/tools/scrape-shield/email-address-obfuscation.mdx
@@ -20,7 +20,7 @@ Web administrators have come up with clever ways to protect against this by writ
 
 When Email Address Obfuscation is enabled, Cloudflare replaces visible email addresses in your HTML with links like `[email protected]`. If a visitor sees this obfuscated format, they can click the link to reveal the actual email address. This approach prevents bots from scraping email addresses while keeping them accessible to real users.
 
-Cloudflare injects a small decode script (`email-decode.min.js`) into the page using the `defer` attribute. This means the script does not block page rendering — it downloads in parallel with HTML parsing and executes after the document is fully parsed. If you have custom JavaScript that interacts with obfuscated email elements, note that the decode script runs before the `DOMContentLoaded` event.
+Cloudflare injects a small decode script (`email-decode.min.js`) into the page using the `defer` attribute. This means the script does not block page rendering. It downloads in parallel with HTML parsing and executes after the document is fully parsed. If you have custom JavaScript that interacts with obfuscated email elements, note that the decode script runs before the `DOMContentLoaded` event.
 
 ## Change Email Address Obfuscation setting
 

--- a/src/content/docs/waf/tools/scrape-shield/email-address-obfuscation.mdx
+++ b/src/content/docs/waf/tools/scrape-shield/email-address-obfuscation.mdx
@@ -18,7 +18,9 @@ Web administrators have come up with clever ways to protect against this by writ
 
 ## How it works
 
-When Email Address Obfuscation is enabled, Cloudflare replaces visible email addresses in your HTML with links like `[email protected]`. If a visitor sees this obfuscated format, they can click the link to reveal the actual email address. This approach prevents bots from scraping email addresses while keeping them accessible to real users.
+When Email Address Obfuscation is enabled, Cloudflare replaces visible email addresses in your HTML with links like `[email protected]`. If a visitor sees this obfuscated format, they can click the link to reveal the actual email address. This approach prevents bots from scraping email addresses while keeping them accessible to real users.
+
+Cloudflare injects a small decode script (`email-decode.min.js`) into the page using the `defer` attribute. This means the script does not block page rendering — it downloads in parallel with HTML parsing and executes after the document is fully parsed. If you have custom JavaScript that interacts with obfuscated email elements, note that the decode script runs before the `DOMContentLoaded` event.
 
 ## Change Email Address Obfuscation setting
 


### PR DESCRIPTION
### Summary

Documents the `defer` attribute added to the email obfuscation decode script (`email-decode.min.js`) as part of BUGS-892. The script is now non-render-blocking, which improves Largest Contentful Paint (LCP) for all zones with Email Address Obfuscation enabled.

**Changes:**
- `src/content/docs/waf/tools/scrape-shield/email-address-obfuscation.mdx` — Added a paragraph to the "How it works" section explaining that the decode script loads with `defer`, does not block rendering, and executes before `DOMContentLoaded`. Includes a note for developers with custom JavaScript that interacts with obfuscated email elements.
- `src/content/changelog/waf/2026-04-14-email-obfuscation-defer.mdx` — New changelog entry announcing the performance improvement.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).