### PR TITLE
[Agents] Add stream recovery docs to chat agents, update Think chatRecovery default

### DIFF
--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -530,6 +530,130 @@ export class ChatAgent extends AIChatAgent {
 If you do not pass `abortSignal` to `streamText`, the LLM call will continue running in the background even after the user cancels. Always forward it when possible.
 :::
 
+### Stream recovery
+
+When a Durable Object is evicted mid-stream (code update, inactivity timeout, resource limit), the LLM connection is severed permanently and the in-memory streaming state is lost. `chatRecovery` wraps each chat turn in a [`runFiber()`](/agents/api-reference/durable-execution/), providing automatic `keepAlive` during streaming and a recovery hook on restart.
+
+<TypeScriptExample>
+
+```ts
+export class ChatAgent extends AIChatAgent {
+	override chatRecovery = true;
+}
+```
+
+</TypeScriptExample>
+
+When enabled, every `onChatMessage` call runs inside a fiber. If the agent is evicted mid-stream, the fiber row survives in SQLite. On the next activation, the framework detects the interrupted fiber, reconstructs the partial response from buffered stream chunks, and calls `onChatRecovery`.
+
+#### `onChatRecovery`
+
+Override to implement provider-specific recovery. The default behavior persists the partial response and schedules a continuation via `continueLastTurn()`.
+
+<TypeScriptExample>
+
+```ts
+import type { ChatRecoveryContext, ChatRecoveryOptions } from "@cloudflare/ai-chat";
+
+export class ChatAgent extends AIChatAgent {
+	override chatRecovery = true;
+
+	override async onChatRecovery(
+		ctx: ChatRecoveryContext,
+	): Promise<ChatRecoveryOptions> {
+		console.log(`Recovered ${ctx.partialText.length} chars of partial text`);
+
+		// Default: persist partial + schedule continuation
+		return {};
+	}
+}
+```
+
+</TypeScriptExample>
+
+**`ChatRecoveryContext`:**
+
+| Field             | Type                                   | Description                                                           |
+| ----------------- | -------------------------------------- | --------------------------------------------------------------------- |
+| `streamId`        | `string`                               | ID of the interrupted stream                                          |
+| `requestId`       | `string`                               | ID of the original chat request                                       |
+| `partialText`     | `string`                               | Text generated before eviction                                        |
+| `partialParts`    | `MessagePart[]`                        | Message parts (text, reasoning, tool calls) generated before eviction |
+| `recoveryData`    | `unknown \| null`                      | Data from `this.stash()` — entirely user-controlled                   |
+| `messages`        | `ChatMessage[]`                        | Full conversation history                                             |
+| `lastBody`        | `Record<string, unknown> \| undefined` | The original request body                                             |
+| `lastClientTools` | `ClientToolSchema[] \| undefined`      | Client tool schemas from the original request                         |
+
+**`ChatRecoveryOptions`:**
+
+| Field      | Default | Description                                       |
+| ---------- | ------- | ------------------------------------------------- |
+| `persist`  | `true`  | Save the partial response as an assistant message |
+| `continue` | `true`  | Schedule a continuation via `continueLastTurn()`  |
+
+Common return values:
+
+- `{}` — persist partial + auto-continue (default, works with providers that support assistant prefill)
+- `{ continue: false }` — persist partial but do not auto-continue (handle continuation yourself)
+- `{ persist: false, continue: false }` — handle everything yourself (for example, retrieve a completed response from the provider)
+
+#### `continueLastTurn`
+
+Appends to the last assistant message by re-calling `onChatMessage` with the saved request body. The response is streamed as a continuation — appended to the existing assistant message, not a new one. No synthetic user message is created.
+
+```ts
+protected continueLastTurn(body?: Record<string, unknown>): Promise<SaveMessagesResult>;
+```
+
+Called automatically by the default recovery path. Can also be called manually from scheduled callbacks or other entry points. The optional `body` parameter merges with the saved `_lastBody`.
+
+#### Stashing recovery data
+
+Use `this.stash()` inside `onChatMessage` to persist provider-specific data for recovery. The stash is stored in the fiber's SQLite row, separate from agent state, and available as `ctx.recoveryData` in `onChatRecovery`.
+
+<TypeScriptExample>
+
+```ts
+export class ChatAgent extends AIChatAgent {
+	override chatRecovery = true;
+
+	async onChatMessage(_onFinish, options) {
+		const result = streamText({
+			model: openai("gpt-5.4"),
+			messages: await convertToModelMessages(this.messages),
+			providerOptions: { openai: { store: true } },
+			includeRawChunks: true,
+			onChunk: ({ chunk }) => {
+				if (chunk.type === "raw") {
+					const raw = chunk.rawValue as {
+						type?: string;
+						response?: { id?: string };
+					};
+					if (raw?.type === "response.created" && raw.response?.id) {
+						this.stash({ responseId: raw.response.id });
+					}
+				}
+			},
+		});
+		return result.toUIMessageStreamResponse();
+	}
+}
+```
+
+</TypeScriptExample>
+
+#### Recovery strategies by provider
+
+The right strategy depends on whether the provider supports assistant prefill and whether the response continues server-side after disconnection:
+
+| Provider               | Strategy                                                     | Token cost |
+| ---------------------- | ------------------------------------------------------------ | ---------- |
+| Workers AI             | `continueLastTurn()` — model continues via assistant prefill | Low        |
+| OpenAI (Responses API) | Retrieve completed response by ID — zero wasted tokens       | Zero       |
+| Anthropic              | Persist partial, send a synthetic user message to continue   | Medium     |
+
+For how chat recovery fits into the broader long-running agents story, refer to [Long-running agents: Recovering interrupted LLM streams](/agents/concepts/long-running-agents/#recovering-interrupted-llm-streams). For the underlying fiber API, refer to [Durable Execution](/agents/api-reference/durable-execution/).
+
 ## Client API
 
 ### `useAgentChat`
@@ -1366,7 +1490,7 @@ The originating client receives the streaming response. All other clients receiv
 
 | Import path                 | Exports                                             |
 | --------------------------- | --------------------------------------------------- |
-| `@cloudflare/ai-chat`       | `AIChatAgent`, `createToolsFromClientSchemas`       |
+| `@cloudflare/ai-chat`       | `AIChatAgent`, `createToolsFromClientSchemas`, `ChatRecoveryContext`, `ChatRecoveryOptions` |
 | `@cloudflare/ai-chat/react` | `useAgentChat`                                      |
 | `@cloudflare/ai-chat/types` | `MessageType`, `OutgoingMessage`, `IncomingMessage` |
 
@@ -1420,4 +1544,16 @@ If you are upgrading from an earlier version, replace deprecated calls with thei
 	title="Build a chat agent"
 	href="/agents/getting-started/build-a-chat-agent/"
 	description="Step-by-step tutorial for building your first chat agent."
+/>
+
+<LinkCard
+	title="Durable execution"
+	href="/agents/api-reference/durable-execution/"
+	description="runFiber(), stash(), and crash recovery for long-running work."
+/>
+
+<LinkCard
+	title="Long-running agents"
+	href="/agents/concepts/long-running-agents/"
+	description="Lifecycle, recovery patterns, and provider-specific strategies."
 />

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -168,7 +168,7 @@ Both Think and [`AIChatAgent`](/agents/api-reference/chat-agents/) extend `Agent
 | `configureSession()`    | identity                         | Add context blocks, compaction, search, skills — refer to [Sessions](/agents/api-reference/sessions/) |
 | `messageConcurrency`    | `"queue"`                        | How overlapping submits behave — refer to [Message concurrency](#message-concurrency)                 |
 | `waitForMcpConnections` | `false`                          | Wait for MCP servers before inference                                                                 |
-| `chatRecovery`          | `false`                          | Wrap turns in `runFiber` for durable execution                                                        |
+| `chatRecovery`          | `true`                           | Wrap turns in `runFiber` for durable execution                                                        |
 
 ## Dynamic configuration
 


### PR DESCRIPTION
### Summary

Adds the missing stream recovery (`chatRecovery`) section to the chat agents API reference page, and updates the Think API reference to reflect that `chatRecovery` now defaults to `true`.

The chat agents page was missing documentation for `chatRecovery`, `onChatRecovery`, `continueLastTurn()`, stashing recovery data, and per-provider recovery strategies. The durable-execution and long-running-agents pages already cross-referenced this content, but the chat-agents page had nothing to land on.

Changes:
- **`chat-agents.mdx`**: New "Stream recovery" section with `chatRecovery`, `onChatRecovery` hook, `ChatRecoveryContext`/`ChatRecoveryOptions` types, `continueLastTurn()`, stash example, and provider strategy table. Updated exports table to include `ChatRecoveryContext` and `ChatRecoveryOptions`. Added link cards for durable-execution and long-running-agents.
- **`think.mdx`**: Updated `chatRecovery` default from `false` to `true` in the configuration table.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

Made with [Cursor](https://cursor.com)