### PR TITLE
docs: add pi.dev inspiration acknowledgments to Think and Sessions

### DIFF
--- a/src/content/docs/agents/api-reference/sessions.mdx
+++ b/src/content/docs/agents/api-reference/sessions.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { TypeScriptExample, InlineBadge, LinkCard } from "~/components";
 
-The Session API provides persistent conversation storage for agents, with tree-structured messages, context blocks, compaction, full-text search, and AI-controllable tools. It runs entirely on Durable Object SQLite — no external database needed.
+The Session API provides persistent conversation storage for agents, with tree-structured messages (inspired by [Pi](https://pi.dev)), context blocks, compaction, full-text search, and AI-controllable tools. It runs entirely on Durable Object SQLite — no external database needed.
 
 :::caution[Experimental]
 
@@ -639,6 +639,12 @@ All storage is in Durable Object SQLite. Tables are created lazily on first use.
 | `assistant_sessions` | Session registry (SessionManager only) with `name`, `parent_session_id`, `model`, `source`, token/cost counters |
 | `cf_agents_context_blocks` | Persistent context block storage (`AgentContextProvider`) |
 | `cf_agents_search_entries` / `cf_agents_search_fts` | Searchable context entries and FTS5 index (`AgentSearchProvider`) |
+
+## Acknowledgments
+
+- Session's tree-structured messages are inspired by [Pi](https://pi.dev).
+- Context blocks are inspired by [Letta AI memory blocks](https://www.letta.com/blog/memory-blocks).
+- Formatting of blocks is inspired by [Hermes Agent](https://github.com/nousresearch/hermes-agent).
 
 ## Related
 

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -1360,6 +1360,10 @@ if (stable) {
 | `@cloudflare/shell`    | yes      | Workspace filesystem    |
 | `@cloudflare/codemode` | optional | For `createExecuteTool` |
 
+## Acknowledgments
+
+Think's design is inspired by [Pi](https://pi.dev).
+
 ## Related
 
 - [Sessions](/agents/api-reference/sessions/) — context blocks, compaction, search, multi-session (the storage layer Think builds on)


### PR DESCRIPTION
Adds acknowledgment sections crediting design inspirations for Think and Sessions.

## Changes

- **`think.mdx`** — new `## Acknowledgments` section: Think's design is inspired by [Pi](https://pi.dev)
- **`sessions.mdx`** — inline note in intro that tree-structured messages are inspired by [Pi](https://pi.dev), plus new `## Acknowledgments` section crediting:
  - [Pi](https://pi.dev) for tree-structured messages
  - [Letta AI memory blocks](https://www.letta.com/blog/memory-blocks) for context blocks
  - [Hermes Agent](https://github.com/nousresearch/hermes-agent) for block formatting
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/29899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
