### PR TITLE
lint: prevent logging in runtime scripts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,4 +44,15 @@ export default [
 			],
 		},
 	},
+	{
+		files: ["src/scripts/**/*.{js,ts}"],
+		rules: {
+			"no-console": [
+				"error",
+				{
+					allow: ["warn", "error"],
+				},
+			],
+		},
+	},
 ];

--- a/src/scripts/explain-code.ts
+++ b/src/scripts/explain-code.ts
@@ -10,7 +10,6 @@ function getCodeBlockPosition(button: HTMLElement): number {
 	while (currentBlock) {
 		if (currentBlock.tagName === "PRE") {
 			currentBlock = currentBlock.querySelector(codeSelector);
-			console.log(currentBlock);
 			break;
 		}
 		currentBlock = currentBlock.previousElementSibling;


### PR DESCRIPTION
Prevents known runtime dirs only since it's not a big deal to `console.log` during build time.