### PR TITLE
Add documentation for the Cloudflare Sandbox SDK bridge

### DIFF
--- a/src/content/docs/sandbox/api/file-watching.mdx
+++ b/src/content/docs/sandbox/api/file-watching.mdx
@@ -1,5 +1,5 @@
 ---
-title: File Watching
+title: File watching
 pcx_content_type: concept
 sidebar:
   order: 4

--- a/src/content/docs/sandbox/api/index.mdx
+++ b/src/content/docs/sandbox/api/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: API Reference
+title: API reference
 pcx_content_type: navigation
 sidebar:
   order: 4
@@ -27,7 +27,7 @@ The Sandbox SDK provides a comprehensive API for executing code, managing files,
 </LinkTitleCard>
 
 <LinkTitleCard
-	title="File Watching"
+	title="File watching"
 	href="/sandbox/api/file-watching/"
 	icon="seti:eye"
 >
@@ -36,7 +36,7 @@ The Sandbox SDK provides a comprehensive API for executing code, managing files,
 </LinkTitleCard>
 
 <LinkTitleCard
-	title="Code Interpreter"
+	title="Code interpreter"
 	href="/sandbox/api/interpreter/"
 	icon="laptop"
 >

--- a/src/content/docs/sandbox/api/interpreter.mdx
+++ b/src/content/docs/sandbox/api/interpreter.mdx
@@ -1,5 +1,5 @@
 ---
-title: Code Interpreter
+title: Code interpreter
 pcx_content_type: concept
 sidebar:
   order: 4

--- a/src/content/docs/sandbox/bridge/http-api.mdx
+++ b/src/content/docs/sandbox/bridge/http-api.mdx
@@ -1,0 +1,190 @@
+---
+title: HTTP API reference
+pcx_content_type: reference
+sidebar:
+  order: 1
+description: Complete HTTP API reference for the sandbox bridge Worker.
+reviewed: 2026-04-13
+---
+
+import { WranglerConfig } from "~/components";
+
+This page documents every route exposed by the [sandbox bridge](/sandbox/bridge/).
+
+## Authentication
+
+All routes under `/v1/sandbox/*` and `/v1/openapi.*` require a Bearer token:
+
+```txt
+Authorization: Bearer <SANDBOX_API_KEY>
+```
+
+When `SANDBOX_API_KEY` is not configured, authentication is skipped for local development convenience. Always set the secret before deploying to production.
+
+## OpenAPI schema
+
+The bridge serves its own API documentation:
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/v1/openapi.json` | Machine-readable OpenAPI 3.1 schema. |
+| `GET` | `/v1/openapi` | Interactive HTML documentation. |
+
+Both routes accept authentication via Bearer header or `?token=` query parameter.
+
+When running locally with `npm run dev`, open `http://localhost:8787/v1/openapi` in your browser to explore every endpoint interactively.
+
+## Sandbox lifecycle
+
+| Method | Route | Description |
+|---|---|---|
+| `POST` | `/v1/sandbox` | Create a new sandbox. Returns `{"id": "<sandbox-id>"}`. |
+| `DELETE` | `/v1/sandbox/:id` | Destroy the sandbox container. Returns `204`. |
+| `GET` | `/v1/sandbox/:id/running` | Check container liveness. Returns `{"running": true\|false}`. |
+
+## Command execution
+
+| Method | Route | Description |
+|---|---|---|
+| `POST` | `/v1/sandbox/:id/exec` | Run a command. Response is an SSE stream (see below). |
+
+The `/exec` endpoint accepts a JSON body:
+
+```json
+{
+  "argv": ["sh", "-lc", "echo hello"],
+  "timeout_ms": 10000,
+  "cwd": "/workspace"
+}
+```
+
+### Argv escaping
+
+Each element of the `argv` array is escaped using ANSI-C `$'...'` quoting before being joined into a shell command. Tokens that contain only safe characters (`A-Za-z0-9@%+=:,./-`) are passed through unchanged. All other tokens are wrapped in `$'...'` with backslashes, single quotes, newlines, carriage returns, and tabs escaped. This prevents shell injection while preserving arguments that contain spaces, quotes, or special characters.
+
+### SSE response format
+
+The response is a `text/event-stream` with the following event types:
+
+| Event | Data | Description |
+|---|---|---|
+| `stdout` | Base64-encoded chunk | Standard output from the command. |
+| `stderr` | Base64-encoded chunk | Standard error from the command. |
+| `exit` | `{"exit_code": N}` | Command completed. Terminal event. |
+| `error` | `{"error": "…", "code": "…"}` | Command failed. Terminal event. |
+
+## File operations
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/v1/sandbox/:id/file/*` | Read a file. Returns raw bytes (`application/octet-stream`). |
+| `PUT` | `/v1/sandbox/:id/file/*` | Write a file. Request body is raw bytes. Returns `{"ok": true}`. Max 32 MiB. |
+
+The file path is encoded in the URL after `/file/`. All paths must resolve within `/workspace`. Path traversal attempts (for example, `../../etc/passwd`) are rejected.
+
+## Workspace persistence
+
+| Method | Route | Description |
+|---|---|---|
+| `POST` | `/v1/sandbox/:id/persist` | Serialize `/workspace` to a tar archive. Returns raw tar bytes. |
+| `POST` | `/v1/sandbox/:id/hydrate` | Populate `/workspace` from a tar archive sent as the request body. |
+
+The `/persist` endpoint accepts an optional `excludes` query parameter — a comma-separated list of relative paths to exclude from the archive.
+
+The `/hydrate` endpoint accepts a raw tar payload up to 32 MiB.
+
+## Bucket mounts
+
+| Method | Route | Description |
+|---|---|---|
+| `POST` | `/v1/sandbox/:id/mount` | Mount an S3-compatible bucket as a local directory. |
+| `POST` | `/v1/sandbox/:id/unmount` | Unmount a previously mounted bucket. |
+
+The `/mount` endpoint accepts a JSON body:
+
+```json
+{
+  "bucket": "my-bucket",
+  "mountPath": "/mnt/data",
+  "options": {
+    "endpoint": "https://ACCOUNT_ID.r2.cloudflarestorage.com",
+    "readOnly": false,
+    "prefix": "subdir/",
+    "credentials": {
+      "accessKeyId": "...",
+      "secretAccessKey": "..."
+    }
+  }
+}
+```
+
+Credentials are optional — the bridge auto-detects from Worker secrets (`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) when omitted.
+
+## Sessions
+
+| Method | Route | Description |
+|---|---|---|
+| `POST` | `/v1/sandbox/:id/session` | Create a session. Returns `{"id": "<session-id>"}`. |
+| `DELETE` | `/v1/sandbox/:id/session/:sid` | Delete a session. Returns `204`. |
+
+Sessions isolate working directory, environment variables, and command execution state within a sandbox. Pass the `Session-Id` header on `/exec`, `/file/*`, and `/pty` requests to scope them to a session.
+
+When no `Session-Id` header is provided, requests use the sandbox default session.
+
+## Terminal (PTY)
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/v1/sandbox/:id/pty` | Upgrade to a WebSocket PTY session. |
+
+Query parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `cols` | number | `80` | Terminal width in columns. |
+| `rows` | number | `24` | Terminal height in rows. |
+| `shell` | string | — | Shell binary (for example, `/bin/bash`). |
+| `session` | string | — | Session ID for session-scoped PTY. |
+
+The WebSocket carries binary frames for terminal I/O and JSON text frames for control messages:
+
+| Direction | Frame type | Content |
+|---|---|---|
+| Client to server | Binary | UTF-8 encoded keystrokes. |
+| Server to client | Binary | Terminal output including ANSI escape sequences. |
+| Client to server | Text (JSON) | Control messages (for example, `{"type": "resize", "cols": 120, "rows": 30}`). |
+| Server to client | Text (JSON) | Status messages (`ready`, `exit`, `error`). |
+
+## Warm pool
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/v1/pool/stats` | Current pool statistics. |
+| `POST` | `/v1/pool/prime` | Start the warm pool alarm loop. |
+| `POST` | `/v1/pool/shutdown-prewarmed` | Stop all idle warm containers. |
+
+The warm pool pre-starts sandbox containers so new sessions boot instantly. Configure it with environment variables in `wrangler.jsonc`:
+
+<WranglerConfig>
+
+```toml
+[vars]
+WARM_POOL_TARGET = "3"           # Number of idle containers to keep warm (0 = disabled)
+WARM_POOL_REFRESH_INTERVAL = "10000"  # Health-check interval in milliseconds
+```
+
+</WranglerConfig>
+
+A cron trigger (`* * * * *`) primes the pool automatically after deployment. Set `WARM_POOL_TARGET` to `"0"` (the default) to disable the pool and avoid unexpected costs.
+
+## Health check
+
+| Method | Route | Description |
+|---|---|---|
+| `GET` | `/health` | Unauthenticated liveness probe. Returns `{"ok": true}`. |
+
+## Related resources
+
+- [Bridge overview](/sandbox/bridge/) — What the bridge is, deployment, and usage examples.
+- [Sandbox API reference](/sandbox/api/) — Complete Sandbox SDK method reference.
+- [Bridge source on GitHub](https://github.com/cloudflare/sandbox-sdk/tree/main/bridge) — Worker, Dockerfile, and OpenAPI schema.

--- a/src/content/docs/sandbox/bridge/index.mdx
+++ b/src/content/docs/sandbox/bridge/index.mdx
@@ -1,0 +1,310 @@
+---
+title: Sandbox bridge
+pcx_content_type: reference
+sidebar:
+  order: 8
+description: Deploy the sandbox bridge Worker to control Cloudflare Sandboxes over HTTP from any language or platform.
+tags:
+  - Python
+  - Node.js
+  - Docker
+reviewed: 2026-04-13
+---
+
+import { Details, Tabs, TabItem } from "~/components";
+
+The sandbox bridge is a reference-implementation Cloudflare Worker that exposes the [Sandbox SDK](/sandbox/api/) as an HTTP API. Any HTTP client — Python script, Node.js service, CI pipeline — can create and control sandboxes without writing a Worker.
+
+## Why use the bridge
+
+The Sandbox SDK is designed for use within Cloudflare Workers. If your application runs outside of the Workers ecosystem, it cannot interact with sandboxes directly.
+
+The bridge exposes the Sandbox SDK as a standard HTTP API so you can create and control sandboxes from any language or platform.
+
+Key [Sandbox SDK methods](/sandbox/api/) map to individual HTTP endpoints. The bridge adds authentication, input validation, workspace path containment, and an optional [warm pool](/sandbox/bridge/http-api/#warm-pool) for instant container boot.
+
+## Deploy
+
+Deploy the bridge Worker to your Cloudflare account:
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/sandbox-sdk/bridge/worker)
+
+The button deploys the Worker and generates a `SANDBOX_API_KEY` secret for authentication. When deployment finishes, note your Worker URL and API key — every example on this page uses them.
+
+<Details header="Manual deployment">
+
+If you prefer to deploy step by step, scaffold the project and deploy manually.
+
+**Prerequisites:**
+
+- A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) with the Containers / Sandbox beta enabled.
+- [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) and npm.
+- [Docker](https://www.docker.com/) running locally — `wrangler deploy` builds a container image from the bridge `Dockerfile`.
+
+**Steps:**
+
+1. Scaffold the bridge project:
+
+	```sh
+	npm create cloudflare sandbox-bridge --template=cloudflare/sandbox-sdk/bridge/worker
+	cd sandbox-bridge
+	```
+
+2. Authenticate with Cloudflare:
+
+	```sh
+	npx wrangler login
+	```
+
+3. Set the API key secret. Choose any strong token value — clients must send this as a Bearer token:
+
+	```sh
+	openssl rand -hex 32 | tee /dev/stderr | npx wrangler secret put SANDBOX_API_KEY
+	```
+
+	The key is printed to your terminal and piped to Wrangler. Save it — you will need it to authenticate API requests.
+
+4. Deploy the Worker:
+
+	```sh
+	npx wrangler deploy
+	```
+
+5. Verify the deployment:
+
+	```sh
+	curl https://cloudflare-sandbox-bridge.<your-subdomain>.workers.dev/health
+	```
+
+	You should see `{"ok":true}`.
+
+</Details>
+
+### Container image
+
+The bridge `Dockerfile` extends the [`cloudflare/sandbox`](https://hub.docker.com/r/cloudflare/sandbox) base image and pre-installs common agent tooling:
+
+- **Languages**: Python 3.13, Node.js, Bun
+- **Tools**: git, ripgrep, curl, wget, jq, tar, sed, gawk, procps
+
+Customize the `Dockerfile` to add languages, system packages, or tools your workloads need.
+
+## Usage
+
+All examples assume the following environment variables are set:
+
+```sh
+export SANDBOX_API_URL=https://cloudflare-sandbox-bridge.<your-subdomain>.workers.dev
+export SANDBOX_API_KEY=<your-token>
+```
+
+### Create a sandbox and run a command
+
+<Tabs>
+<TabItem label="curl">
+
+```sh
+# Create a sandbox
+SANDBOX_ID=$(curl -s -X POST "$SANDBOX_API_URL/v1/sandbox" \
+  -H "Authorization: Bearer $SANDBOX_API_KEY" | jq -r '.id')
+
+echo "Sandbox ID: $SANDBOX_ID"
+
+# Run a command
+curl -s -X POST "$SANDBOX_API_URL/v1/sandbox/$SANDBOX_ID/exec" \
+  -H "Authorization: Bearer $SANDBOX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"argv": ["sh", "-lc", "echo hello from the sandbox"], "timeout_ms": 10000}'
+
+# Destroy the sandbox when done
+curl -s -X DELETE "$SANDBOX_API_URL/v1/sandbox/$SANDBOX_ID" \
+  -H "Authorization: Bearer $SANDBOX_API_KEY"
+```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```js
+const API_URL = process.env.SANDBOX_API_URL;
+const API_KEY = process.env.SANDBOX_API_KEY;
+
+const headers = {
+  Authorization: `Bearer ${API_KEY}`,
+  "Content-Type": "application/json",
+};
+
+// Create a sandbox
+const { id } = await fetch(`${API_URL}/v1/sandbox`, {
+  method: "POST",
+  headers,
+}).then((r) => r.json());
+
+console.log(`Sandbox ID: ${id}`);
+
+// Run a command
+// Response is a text/event-stream with the following SSE events:
+//   event: stdout  — data is a base64-encoded output chunk
+//   event: stderr  — data is a base64-encoded error chunk
+//   event: exit    — data is JSON: {"exit_code": 0}
+//   event: error   — data is JSON: {"error": "...", "code": "..."}
+const execRes = await fetch(`${API_URL}/v1/sandbox/${id}/exec`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({
+    argv: ["sh", "-lc", "echo hello from the sandbox"],
+    timeout_ms: 10000,
+  }),
+});
+
+console.log(await execRes.text());
+
+// Destroy the sandbox when done
+await fetch(`${API_URL}/v1/sandbox/${id}`, {
+  method: "DELETE",
+  headers,
+});
+```
+
+</TabItem>
+<TabItem label="Python">
+
+```python
+# /// script
+# dependencies = ["httpx"]
+# ///
+import os
+import httpx
+
+API_URL = os.environ["SANDBOX_API_URL"]
+API_KEY = os.environ["SANDBOX_API_KEY"]
+
+headers = {"Authorization": f"Bearer {API_KEY}"}
+
+# Create a sandbox
+resp = httpx.post(f"{API_URL}/v1/sandbox", headers=headers)
+sandbox_id = resp.json()["id"]
+print(f"Sandbox ID: {sandbox_id}")
+
+# Run a command
+# Response is a text/event-stream with the following SSE events:
+#   event: stdout  — data is a base64-encoded output chunk
+#   event: stderr  — data is a base64-encoded error chunk
+#   event: exit    — data is JSON: {"exit_code": 0}
+#   event: error   — data is JSON: {"error": "...", "code": "..."}
+exec_resp = httpx.post(
+    f"{API_URL}/v1/sandbox/{sandbox_id}/exec",
+    headers=headers,
+    json={
+        "argv": ["sh", "-lc", "echo hello from the sandbox"],
+        "timeout_ms": 10000,
+    },
+)
+print(exec_resp.text)
+
+# Destroy the sandbox when done
+httpx.delete(f"{API_URL}/v1/sandbox/{sandbox_id}", headers=headers)
+```
+
+</TabItem>
+</Tabs>
+
+### Write and read files
+
+<Tabs>
+<TabItem label="curl">
+
+```sh
+# Write a file
+curl -s -X PUT "$SANDBOX_API_URL/v1/sandbox/$SANDBOX_ID/file/workspace/hello.py" \
+  -H "Authorization: Bearer $SANDBOX_API_KEY" \
+  --data-binary 'print("hello world")'
+
+# Read a file
+curl -s "$SANDBOX_API_URL/v1/sandbox/$SANDBOX_ID/file/workspace/hello.py" \
+  -H "Authorization: Bearer $SANDBOX_API_KEY"
+```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```js
+// Write a file
+await fetch(`${API_URL}/v1/sandbox/${id}/file/workspace/hello.py`, {
+  method: "PUT",
+  headers,
+  body: 'print("hello world")',
+});
+
+// Read a file
+const content = await fetch(
+  `${API_URL}/v1/sandbox/${id}/file/workspace/hello.py`,
+  { headers },
+).then((r) => r.text());
+
+console.log(content);
+```
+
+</TabItem>
+<TabItem label="Python">
+
+```python
+# /// script
+# dependencies = ["httpx"]
+# ///
+import os
+import httpx
+
+API_URL = os.environ["SANDBOX_API_URL"]
+API_KEY = os.environ["SANDBOX_API_KEY"]
+SANDBOX_ID = os.environ["SANDBOX_ID"]  # from the "Create a sandbox" step
+headers = {"Authorization": f"Bearer {API_KEY}"}
+
+# Write a file
+httpx.put(
+    f"{API_URL}/v1/sandbox/{SANDBOX_ID}/file/workspace/hello.py",
+    headers=headers,
+    content=b'print("hello world")',
+)
+
+# Read a file
+content = httpx.get(
+    f"{API_URL}/v1/sandbox/{SANDBOX_ID}/file/workspace/hello.py",
+    headers=headers,
+).text
+print(content)
+```
+
+</TabItem>
+</Tabs>
+
+## Keep the bridge updated
+
+The bulk of the bridge logic is in the `@cloudflare/sandbox` package. To pull in the latest improvements:
+
+1. Update the SDK dependency:
+
+	```sh
+	npm update @cloudflare/sandbox
+	```
+
+2. Redeploy:
+
+	```sh
+	npx wrangler deploy
+	```
+
+Check the [sandbox-sdk releases](https://github.com/cloudflare/sandbox-sdk/releases) for changes to the `Dockerfile` or bridge configuration that may require manual updates.
+
+## Source code and examples
+
+The bridge source code and examples are available on GitHub:
+
+- [Bridge source](https://github.com/cloudflare/sandbox-sdk/tree/main/bridge) — Worker, Dockerfile, deploy script, and OpenAPI schema.
+- [Workspace chat example](https://github.com/cloudflare/sandbox-sdk/tree/main/bridge/examples/workspace-chat) — Full-stack chat application with a file browser sidebar.
+
+## Related resources
+
+- [HTTP API reference](/sandbox/bridge/http-api/) — Complete route reference for the bridge API.
+- [Getting started](/sandbox/get-started/) — Build your first sandbox application directly on Workers.
+- [Architecture](/sandbox/concepts/architecture/) — How the Sandbox SDK layers Workers, Durable Objects, and Containers.
+- [API reference](/sandbox/api/) — Complete Sandbox SDK method reference.

--- a/src/content/docs/sandbox/guides/production-deployment.mdx
+++ b/src/content/docs/sandbox/guides/production-deployment.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy to Production
+title: Deploy to production
 pcx_content_type: how-to
 sidebar:
   order: 10

--- a/src/content/docs/sandbox/guides/websocket-connections.mdx
+++ b/src/content/docs/sandbox/guides/websocket-connections.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebSocket Connections
+title: WebSocket connections
 pcx_content_type: how-to
 sidebar:
   order: 5

--- a/src/content/docs/sandbox/index.mdx
+++ b/src/content/docs/sandbox/index.mdx
@@ -59,7 +59,7 @@ With Sandbox, you can execute Python scripts, run Node.js applications, analyze 
 
   </TabItem>
 
-    <TabItem label="Code Interpreter">
+    <TabItem label="Code interpreter">
     ```typescript
     import { getSandbox } from '@cloudflare/sandbox';
 
@@ -117,7 +117,7 @@ With Sandbox, you can execute Python scripts, run Node.js applications, analyze 
     	```
     </TabItem>
 
-    <TabItem label="File Watching">
+    <TabItem label="File watching">
     	```typescript
     	import { getSandbox } from '@cloudflare/sandbox';
 
@@ -175,7 +175,7 @@ With Sandbox, you can execute Python scripts, run Node.js applications, analyze 
     	Connect browser terminals directly to sandbox shells via WebSocket. Learn more: [Browser terminals](/sandbox/guides/browser-terminals/).
     </TabItem>
 
-    <TabItem label="WebSocket Connections">
+    <TabItem label="WebSocket connections">
     	```typescript
     	import { getSandbox } from '@cloudflare/sandbox';
 
@@ -322,7 +322,7 @@ Stateful coordination layer that enables Sandbox to maintain persistent environm
 	SDK.
 </LinkTitleCard>
 
-<LinkTitleCard title="API Reference" href="/sandbox/api/" icon="seti:json">
+<LinkTitleCard title="API reference" href="/sandbox/api/" icon="seti:json">
 	Explore the complete API documentation for the Sandbox SDK.
 </LinkTitleCard>
 


### PR DESCRIPTION
### Summary

Two commits:

1. **Title casing fix** — Normalizes page titles to sentence case across four existing Sandbox pages (`API Reference` → `API reference`, `File Watching` → `File watching`, etc.).
2. **Bridge reference docs** — Adds two new pages:
   - `src/content/docs/sandbox/bridge/index.mdx` — Overview of the sandbox bridge Worker (what it is, deploy instructions, usage examples in curl/Node.js/Python).
   - `src/content/docs/sandbox/bridge/http-api.mdx` — Complete HTTP API reference for the bridge (lifecycle, exec, files, sessions, PTY, warm pool, bucket mounts).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
