### PR TITLE
Add render call for App in Agents Quick Start

### DIFF
--- a/src/content/docs/agents/getting-started/quick-start.mdx
+++ b/src/content/docs/agents/getting-started/quick-start.mdx
@@ -153,6 +153,8 @@ Update `wrangler.jsonc` to register the agent:
 Replace `src/client.tsx`:
 
 ```tsx title="src/client.tsx"
+import "./styles.css";
+import { createRoot } from "react-dom/client";
 import { useState } from "react";
 import { useAgent } from "agents/react";
 import type { CounterAgent, CounterState } from "./server";
@@ -178,6 +180,9 @@ export default function App() {
 		</div>
 	);
 }
+
+const root = createRoot(document.getElementById("root")!);
+root.render(<App />);
 ```
 
 Key points:


### PR DESCRIPTION
Without this, the app will just be a black or white screen and nothing in console. 

The `client.tsx` which is being replaced (at the direction of this doc) has these createRoot/render calls

for reference, here is the default `client.tsx` that gets generated as a result of the commands at the beginning of the quick start: 
<img width="509" height="167" alt="image" src="https://github.com/user-attachments/assets/1dcb3827-0c0c-47be-897f-194a4775c79d" />
