### PR TITLE
[Browser Isolation] ELI5: Clarify jargon and add inline definitions across RBI root pages

### DIFF
--- a/src/content/docs/cloudflare-one/remote-browser-isolation/accessibility.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/accessibility.mdx
@@ -21,4 +21,4 @@ Alternatively, to use a keyboard shortcut, press `CTRL + ALT + Z`.
 
 ## Languages
 
-The isolated browser supports keyboard inputs in all languages. Users can use their native keyboard to type in languages that use diacritics (for example, `á` or`ç`) or character-based scripts (for example, Chinese, Japanese, or Korean).
+The isolated browser supports keyboard inputs in all languages. Users can use their native keyboard to type in languages that use diacritics (for example, `á` or `ç`) or character-based scripts (for example, Chinese, Japanese, or Korean).

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/canvas-rendering.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/canvas-rendering.mdx
@@ -6,18 +6,18 @@ sidebar: {}
 
 import { Details } from "~/components";
 
-Canvas rendering is a Browser Isolation capability that optimizes performance for web applications using the HTML5 Canvas API. It sends vector draw commands to the client instead of rasterized bitmaps, reducing bandwidth consumption and improving frame rates for productivity applications.
+Canvas rendering is a Browser Isolation capability that optimizes performance for web applications using the HTML5 Canvas API (a browser feature that allows web applications to draw graphics directly on the page). It sends vector draw commands to the client instead of rasterized bitmaps (pixel images), reducing bandwidth consumption and improving frame rates for productivity applications.
 
 ## How it works
 
-Browser Isolation uses Network Vector Rendering (NVR) to deliver efficient vector commands rather than rendered pixels. However, HTML5 Canvas content previously required server-side rasterization, sending large bitmaps for every frame.
+Browser Isolation uses Network Vector Rendering (NVR) to send lightweight drawing instructions to the user's browser, rather than streaming rendered pixels or video of the page. However, HTML5 Canvas content previously required server-side rasterization (converting draw commands into pixel images), sending large bitmaps for every frame.
 
 Canvas rendering extends NVR to Canvas-based applications by:
 
 1. Capturing draw commands made to the HTML5 Canvas element.
 2. Converting and sending those commands to the client as NVR instructions.
-3. Rendering the Canvas content on the client onto an offscreen texture.
-4. Compositing the texture into the final document output.
+3. Rendering the Canvas content on the client onto an offscreen texture (a hidden drawing surface used for intermediate rendering).
+4. Compositing (layering) the texture into the final document output.
 
 ## Supported applications
 

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/extensions.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/extensions.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 Browser Isolation supports running native Chromium Web Extensions in the remote browser.
 
-This capability allows extending tools that require DOM access (such as password managers and ad blockers) to isolated pages.
+When a page is isolated, it runs in a remote browser — not in the user's local browser. Extensions installed locally cannot interact with isolated pages because the page content exists only on the remote side. This capability allows extending tools that require DOM access (the ability to read and modify page content and structure), such as password managers and ad blockers, to isolated pages.
 
 ## Install an extension inside the remote browser
 

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/index.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/index.mdx
@@ -7,7 +7,9 @@ sidebar:
 
 import { Render } from "~/components";
 
-Cloudflare Browser Isolation complements the [Secure Web Gateway](/cloudflare-one/traffic-policies/) and [Zero Trust Network Access](/cloudflare-one/networks/connectors/cloudflare-tunnel/) solutions by executing active webpage content in a secure isolated browser. Executing active content remotely from the endpoint protects users from zero-day attacks and malware. In addition to protecting endpoints, Browser Isolation also protects users from phishing attacks by preventing user input on risky websites and controlling data transmission to sensitive web applications. You can further filter isolated traffic with Gateway [HTTP](/cloudflare-one/traffic-policies/http-policies/) and [DNS](/cloudflare-one/traffic-policies/dns-policies/) policies.
+Cloudflare Browser Isolation complements the [Secure Web Gateway](/cloudflare-one/traffic-policies/) (which inspects and filters HTTP/HTTPS traffic) and [Zero Trust Network Access](/cloudflare-one/networks/connectors/cloudflare-tunnel/) (which controls access to private applications) by executing active webpage content — executable code such as JavaScript and plugins — in a secure isolated browser. Because active content executes remotely instead of on the user's device, Browser Isolation protects users from zero-day attacks (attacks that exploit vulnerabilities with no available patch) and malware.
+
+Browser Isolation also protects users from phishing attacks by preventing user input on risky websites and controlling data transmission to sensitive web applications. You can further filter isolated traffic with Gateway [HTTP](/cloudflare-one/traffic-policies/http-policies/) and [DNS](/cloudflare-one/traffic-policies/dns-policies/) policies.
 
 Remote browsing is invisible to the user who continues to use their browser normally without changing their preferred browser and habits. Every open tab and window is automatically isolated. When the user closes the isolated browser, their session is automatically deleted.
 

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/isolation-policies.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/isolation-policies.mdx
@@ -13,7 +13,7 @@ With Browser Isolation, you can define policies to dynamically isolate websites 
 
 ## Isolate
 
-When an HTTP policy applies the Isolate action, the user's web browser is transparently served an HTML compatible remote browser client. Isolation policies can be applied to requests that include `Accept: text/html*`. This allows Browser Isolation policies to co-exist with API traffic.
+When an HTTP policy applies the Isolate action, the user's web browser is transparently served an HTML compatible remote browser client. Isolation policies can be applied to requests that include `Accept: text/html*` (requests for web pages). This allows Browser Isolation policies to co-exist with API traffic.
 
 The following example enables isolation for all web traffic:
 
@@ -45,7 +45,7 @@ You can choose to disable isolation for certain destinations or categories. The 
 
 ## Policy settings
 
-The following optional settings appear in the Gateway HTTP policy builder when you select the _Isolate_ action. Configure these settings to [prevent data loss](https://blog.cloudflare.com/data-protection-browser/) when users interact with untrusted websites in the remote browser.
+When you isolate a website, you can also restrict what users do on that site. The following optional settings appear in the Gateway HTTP policy builder when you select the _Isolate_ action. Configure these settings to [prevent data loss](https://blog.cloudflare.com/data-protection-browser/) when users interact with untrusted websites in the remote browser — for example, to stop a user from copying confidential data out of an isolated internal application.
 
 ### Copy (from remote to client)
 

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/known-limitations.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/known-limitations.mdx
@@ -16,12 +16,12 @@ Below, you will find information regarding the current limitations for Browser I
 
 ## Website compatibility
 
-Our Network Vector Rendering (NVR) technology allows us to deliver a secure remote computing experience without the bandwidth limitations of video streams. While we expect most websites to work perfectly, some browser features and web technologies are unsupported and will be implemented in the future:
+Our Network Vector Rendering (NVR) technology sends drawing instructions to the user's browser instead of streaming video of the page. This allows us to deliver a secure remote computing experience without the bandwidth limitations of video streams. While we expect most websites to work perfectly, some browser features and web technologies are unsupported and will be implemented in the future:
 
 - Webcam and microphone support is unavailable.
-- Websites that use WebGL may not function. To turn off WebGL in the browser, refer to [WebGL Rendering Error](/cloudflare-one/remote-browser-isolation/troubleshooting/#webgl-rendering-error).
+- Websites that use WebGL (a browser technology for rendering 3D graphics) may not function. To turn off WebGL in the browser, refer to [WebGL Rendering Error](/cloudflare-one/remote-browser-isolation/troubleshooting/#webgl-rendering-error).
 - Netflix and Spotify Web Player are unavailable.
-- H.265/HEVC is not a supported video format at this time.
+- H.265/HEVC (a video compression format) is not a supported video format at this time.
 
 ## Browser compatibility
 
@@ -36,7 +36,7 @@ Our Network Vector Rendering (NVR) technology allows us to deliver a secure remo
 
 ### Brave
 
-Brave's WebRTC IP Handling Policy can impact how Cloudflare RBI loads and functions. If the WebRTC IP Handling Policy is configured to **Disable Non-Proxied UDP**, RBI may fail to load correctly.
+Browser Isolation uses [WebRTC](/cloudflare-one/remote-browser-isolation/network-dependencies/#webrtc-channel) for low-latency communication between the local and remote browser. Brave's WebRTC IP Handling Policy can impact how Cloudflare RBI loads and functions. If the WebRTC IP Handling Policy is configured to **Disable Non-Proxied UDP**, RBI may fail to load correctly because Brave blocks the UDP connections that WebRTC requires.
 
 To ensure RBI loads correctly, go to `brave://settings/privacy` in your Brave browser window, find **WebRTC IP Handling Policy**, and change the setting from **Disable Non-Proxied UDP** to one of the following:
 
@@ -46,7 +46,7 @@ To ensure RBI loads correctly, go to `brave://settings/privacy` in your Brave br
 
 ## Protocol support
 
-Browser Isolation does not support HTTP.
+Browser Isolation requires HTTPS. Websites served over unencrypted HTTP cannot be isolated.
 
 ## Virtual machines
 
@@ -68,11 +68,11 @@ When a user downloads a file within the remote browser, the file is held in memo
 
 ## Multifactor authentication
 
-[Clientless Web Isolation](/cloudflare-one/remote-browser-isolation/setup/clientless-browser-isolation/) does not support Yubikey or WebAuthN. These authentication technologies require the isolated website to use the same domain name as the non-isolated website. Therefore, they will not work with prefixed Clientless Web Isolation URLs but will work normally for [in-line deployments](/cloudflare-one/remote-browser-isolation/setup/) such as [isolated Access applications](/cloudflare-one/access-controls/policies/isolate-application/).
+[Clientless Web Isolation](/cloudflare-one/remote-browser-isolation/setup/clientless-browser-isolation/) does not support Yubikey or WebAuthN (hardware security key authentication). These authentication technologies require the isolated website to use the same domain name as the non-isolated website. Clientless Web Isolation changes the URL by adding a prefix, which breaks this requirement. Therefore, Yubikey and WebAuthN will not work with prefixed Clientless Web Isolation URLs but will work normally for [in-line deployments](/cloudflare-one/remote-browser-isolation/setup/) such as [isolated Access applications](/cloudflare-one/access-controls/policies/isolate-application/).
 
 ## SAML applications
 
-Cloudflare Remote Browser Isolation now [supports SAML applications that use HTTP-POST bindings](/cloudflare-one/changelog/browser-isolation/#2025-05-13). This resolves previous issues such as `405` errors and login loops during SSO authentication flows.
+Cloudflare Remote Browser Isolation now [supports SAML applications that use HTTP-POST bindings](/cloudflare-one/changelog/browser-isolation/#2025-05-13). SAML is a protocol used for single sign-on (SSO), and some SAML implementations send login data via an HTTP POST request (HTTP-POST bindings). This resolves previous issues such as `405` errors and login loops during SSO authentication flows.
 
 You no longer need to isolate both the Identity Provider (IdP) and Service Provider (SP), or switch to HTTP-Redirect bindings, to use Browser Isolation with POST-based SSO. Users can log in to internal or SaaS applications in the isolated browser securely and seamlessly.
 

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/network-dependencies.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/network-dependencies.mdx
@@ -11,7 +11,7 @@ If your organization uses a firewall or other policies to restrict Internet traf
 
 ## Remoting client
 
-Isolated pages are served by the remoting client. This client communicates to Cloudflare's network via HTTPS and WebRTC.
+Isolated pages are served by the remoting client — the software component in the user's browser that loads, displays, and communicates with the remote browser session. This client communicates to Cloudflare's network via HTTPS and WebRTC.
 
 ### Remoting Client (Services)
 
@@ -27,7 +27,7 @@ Users connecting through Clientless Web Isolation also require connectivity to C
 
 ### WebRTC channel
 
-Browser Isolation uses WebRTC for low-latency communication between the local browser and the remote browser.
+Browser Isolation uses WebRTC (a real-time communication protocol) for low-latency communication between the local browser and the remote browser. WebRTC uses UDP rather than TCP, which means this traffic does not flow through standard HTTP/HTTPS proxy settings. The connecting device must have direct UDP connectivity to the IP ranges listed below.
 
 In order to pass WebRTC traffic, the remoting client must be able to connect to the following IP addresses:
 


### PR DESCRIPTION
### Summary

Adds inline definitions and context for technical terms across all 7 root-level pages in the Remote Browser Isolation section. These pages serve a mixed audience (IT admins, security teams, decision-makers) and used several terms — NVR, WebRTC, rasterization, WebGL, SAML HTTP-POST bindings, DOM access — without explanation.

Changes were generated using the ELI5 skill and verified through an adversarial review that checked every net-new claim against existing documentation.

Key changes by page:
- **index.mdx** — Inline definitions for "active webpage content," "zero-day attacks," "Secure Web Gateway," and "Zero Trust Network Access." Broke the dense opening paragraph into two for readability.
- **canvas-rendering.mdx** — Defined "HTML5 Canvas API," "rasterized bitmaps," "NVR," "offscreen texture," and "compositing" inline on first use.
- **extensions.mdx** — Added context explaining *why* local extensions cannot interact with isolated pages. Defined "DOM access."
- **isolation-policies.mdx** — Added parenthetical for `Accept: text/html*`. Added introductory sentence to Policy Settings explaining the data-loss-prevention purpose.
- **known-limitations.mdx** — Defined NVR, WebGL, H.265/HEVC, Yubikey/WebAuthN, SAML/HTTP-POST bindings inline. Clarified "Browser Isolation does not support HTTP" → "Browser Isolation requires HTTPS." Added WebRTC context to Brave section.
- **network-dependencies.mdx** — Defined "remoting client" and "WebRTC" inline. Added explanation that WebRTC uses UDP and does not flow through HTTP proxies.
- **accessibility.mdx** — Fixed missing space typo.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).