### PR TITLE
[Browser Isolation] ELI5: Clarify jargon and add inline definitions across RBI setup pages

### DIFF
--- a/src/content/docs/cloudflare-one/remote-browser-isolation/setup/clientless-browser-isolation.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/setup/clientless-browser-isolation.mdx
@@ -9,7 +9,7 @@ tags:
 
 import { GlossaryTooltip, Render } from "~/components";
 
-Clientless Web Isolation allows users to securely browse high risk or sensitive websites in a remote browser without having to install the Cloudflare One Client on their device.
+Clientless Web Isolation allows users to securely browse high risk or sensitive websites in a remote browser without having to install the Cloudflare One Client on their device. Use Clientless Web Isolation when you need to provide isolated browsing to unmanaged devices (for example, contractor laptops or personal phones) where you cannot install software.
 
 ## Set up Clientless Web Isolation
 
@@ -39,13 +39,13 @@ To open links using Browser Isolation:
 
 ## Filter DNS queries
 
-Gateway filters and resolves DNS queries for isolated sessions via [DNS policies](/cloudflare-one/traffic-policies/dns-policies/). Enterprise users can resolve domains available only through private resolvers by creating [resolver policies](/cloudflare-one/traffic-policies/resolver-policies/).
+When users browse through Clientless Web Isolation, their DNS queries (the lookups that translate domain names to IP addresses) are handled by Gateway. You can use [DNS policies](/cloudflare-one/traffic-policies/dns-policies/) to control which domains the remote browser can resolve. Enterprise users can resolve domains available only through private DNS servers by creating [resolver policies](/cloudflare-one/traffic-policies/resolver-policies/).
 
 Gateway DNS and resolver policies will always apply to Clientless Web Isolation traffic, regardless of device configuration.
 
 ## Use the remote browser
 
-Clientless Web Isolation is implemented through a prefixed URL, where `<your-team-name>` is your organization's <GlossaryTooltip term="team name">team name</GlossaryTooltip>.
+Clientless Web Isolation is implemented through a prefixed URL — the target website's address is appended to a Cloudflare-hosted base URL. `<your-team-name>` is your organization's <GlossaryTooltip term="team name">team name</GlossaryTooltip>.
 
 ```txt
 https://<your-team-name>.cloudflareaccess.com/browser/<URL>
@@ -69,7 +69,7 @@ For example, if you use a third-party Secure Web Gateway to block `example.com`,
 
 ### Bypass TLS decryption
 
-If [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) is turned on, Gateway will decrypt all sites accessed through the Clientless Web Isolation URL. To connect to sites that are incompatible with TLS decryption, you will need to add a Do Not Inspect HTTP policy for the application or domain.
+[TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) allows Gateway to inspect the contents of HTTPS traffic by decrypting it, applying policies, and re-encrypting it. If TLS decryption is turned on, Gateway will decrypt all sites accessed through the Clientless Web Isolation URL. Some sites are incompatible with this process (for example, sites that use certificate pinning). To connect to those sites, add a Do Not Inspect HTTP policy for the application or domain.
 
 | Selector | Operator | Value        | Action         |
 | -------- | -------- | ------------ | -------------- |
@@ -77,7 +77,7 @@ If [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryptio
 
 :::note
 
-Clientless Web Isolation can function without TLS decryption enabled. However, TLS decryption is required to apply [HTTP policies](/cloudflare-one/traffic-policies/http-policies/) to Clientless Web Isolation traffic.
+Clientless Web Isolation can function without TLS decryption turned on. However, TLS decryption is required to apply [HTTP policies](/cloudflare-one/traffic-policies/http-policies/) to Clientless Web Isolation traffic, because Gateway must decrypt the traffic before it can inspect and filter the content.
 
 :::
 

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/setup/index.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/setup/index.mdx
@@ -16,9 +16,11 @@ Setup instructions vary depending on how you want to connect your devices to Clo
 | --------------------------------------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------- |
 | [Traffic and DNS mode](/cloudflare-one/traffic-policies/get-started/http/)                                | In-line      | Apply identity-based HTTP policies to traffic proxied through the Cloudflare One Client.                                       |
 | [Access](/cloudflare-one/access-controls/policies/isolate-application/)                                   | In-line      | Apply identity-based HTTP policies to Access applications that are rendered in a remote browser.                     |
-| [Gateway proxy endpoint](/cloudflare-one/remote-browser-isolation/setup/non-identity/)                    | In-line      | Apply non-identity HTTP policies to traffic forwarded to a proxy endpoint.                                           |
-| [Cloudflare WAN](/cloudflare-one/remote-browser-isolation/setup/non-identity/)                            | In-line      | Apply non-identity HTTP policies to traffic connected through a GRE or IPsec tunnel.                                 |
+| [Gateway proxy endpoint](/cloudflare-one/remote-browser-isolation/setup/non-identity/)                    | In-line      | Apply non-identity HTTP policies to traffic forwarded to a [proxy endpoint](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/).                                           |
+| [Cloudflare WAN](/cloudflare-one/remote-browser-isolation/setup/non-identity/)                            | In-line      | Apply non-identity HTTP policies to traffic connected through a GRE or IPsec tunnel (site-to-site encrypted connections to Cloudflare's network).                                 |
 | [Clientless remote browser](/cloudflare-one/remote-browser-isolation/setup/clientless-browser-isolation/) | Prefixed URL | Render web pages in a remote browser when users go to `https://<your-team-name>.cloudflareaccess.com/browser/<URL>`. |
+
+**In-line** mode means traffic is inspected as it flows through Gateway — users browse to websites using normal URLs, not a special Cloudflare prefix. Some in-line methods require device or network configuration, such as installing the Cloudflare One Client or configuring a PAC file. **Prefixed URL** mode requires users to visit a Cloudflare-hosted URL that wraps the target website.
 
 ## 2. Build an Isolation policy
 
@@ -42,7 +44,7 @@ Users can see if a webpage is isolated by using one of the following methods:
 
 ### Normal browsing
 
-- A non-Cloudflare root certificate indicates that Cloudflare did not proxy this web page.
+- A non-Cloudflare root certificate indicates that Cloudflare did not proxy this web page. The root certificate is the certificate authority (CA) that your browser trusts to verify the site's identity.
 
   ![Website does not present a Cloudflare root certificate](~/assets/images/cloudflare-one/rbi/non-cloudflare-root-ca.png)
 

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/setup/non-identity.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/setup/non-identity.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 ---
 
-With Cloudflare One, you can isolate HTTP traffic from on-ramps such as [proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/) or [Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/) (formerly Magic WAN). Since these on-ramps do not require users to log in to the Cloudflare One Client, [identity-based policies](/cloudflare-one/traffic-policies/identity-selectors/) are not supported.
+On-ramps are the methods used to route traffic from your network to Cloudflare for inspection. With Cloudflare One, you can isolate HTTP traffic from on-ramps such as [proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/) (which your browser connects to via PAC files to send traffic through Gateway) or [Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/) (formerly Magic WAN, which connects your network to Cloudflare through GRE or IPsec tunnels). Since these on-ramps do not require users to log in to the Cloudflare One Client, [identity-based policies](/cloudflare-one/traffic-policies/identity-selectors/) are not supported.
 
 :::note
 
@@ -16,8 +16,8 @@ If you want to apply Isolate policies based on user identity, you will need to e
 
 1. [Install a Cloudflare certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/) on your devices.
 2. Connect your infrastructure to Gateway using one of the following on-ramps:
-   - Configure your browser to forward traffic to a Gateway proxy endpoint with [PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/).
-   - Connect your enterprise site router to Gateway with the [anycast GRE or IPsec tunnel on-ramp to Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/).
+   - Configure your browser to forward traffic to a Gateway proxy endpoint with [PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/) (Proxy Auto-Configuration files that tell the browser which traffic to route through the proxy).
+   - Connect your enterprise site router to Gateway with the [anycast GRE or IPsec tunnel on-ramp to Cloudflare WAN](/cloudflare-wan/zero-trust/cloudflare-gateway/) (site-to-site encrypted tunnels between your network and Cloudflare).
 3. Enable non-identity browser isolation:
    1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Browser isolation** > **Browser isolation settings**.
    2. Turn on **Allow isolated HTTP traffic when user identity is unknown**.


### PR DESCRIPTION
### Summary

Adds inline definitions and context for technical terms across the 3 pages in the Browser Isolation setup folder. These pages serve IT admins and security teams who may not be familiar with terms like "on-ramps," "PAC files," "TLS decryption," "prefixed URL," or "in-line mode."

Changes were generated using the ELI5 skill and verified through an adversarial review that checked all 18 net-new claims against existing documentation (16 verified, 2 medium/low misleading findings corrected before commit).

Key changes by page:
- **setup/index.mdx** — Added a cross-link for "proxy endpoint." Defined "GRE or IPsec tunnel" inline. Added a paragraph explaining what "In-line" and "Prefixed URL" modes mean in the deployment table, with a qualifier that some in-line methods require device configuration. Defined "root certificate" at first mention.
- **setup/clientless-browser-isolation.mdx** — Added use-case context (unmanaged devices). Defined "DNS queries" and "prefixed URL" inline. Added a one-sentence explanation of what TLS decryption does and why it is required for HTTP policies. Replaced "private resolvers" with "private DNS servers." Added certificate pinning as an example of TLS decryption incompatibility.
- **setup/non-identity.mdx** — Defined "on-ramps," "proxy endpoints," "PAC files," and "GRE or IPsec tunnels" inline on first use.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).