### PR TITLE
@cloudflare/playwright v1.3.0 release note and version bump

### DIFF
--- a/src/content/docs/browser-run/playwright/index.mdx
+++ b/src/content/docs/browser-run/playwright/index.mdx
@@ -23,7 +23,7 @@ Our version is open sourced and can be found in [Cloudflare's fork of Playwright
 <PackageManagers pkg="@cloudflare/playwright" dev />
 
 :::note
-The current version is [`@cloudflare/playwright` v1.2.0](https://github.com/cloudflare/playwright/releases/tag/v1.2.0), based on [Playwright v1.58.2](https://playwright.dev/docs/release-notes#version-158).
+The current version is [`@cloudflare/playwright` v1.3.0](https://github.com/cloudflare/playwright/releases/tag/v1.3.0), based on [Playwright v1.58.2](https://playwright.dev/docs/release-notes#version-158).
 :::
 
 ## Use Playwright in a Worker

--- a/src/content/release-notes/browser-run.yaml
+++ b/src/content/release-notes/browser-run.yaml
@@ -4,6 +4,10 @@ productName: Browser Run
 productLink: "/browser-run/"
 entries:
   - publish_date: "2026-04-15"
+    title: "@cloudflare/playwright v1.3.0 released"
+    description: |-
+      * Released version 1.3.0 of [`@cloudflare/playwright`](https://github.com/cloudflare/playwright/releases/tag/v1.3.0). Starting with this version, the library uses the standard CDP (Chrome DevTools Protocol) internally to communicate with Browser Run, replacing the previous chunked protocol. This aligns with Browser Run's [full CDP support](/changelog/post/2026-04-10-browser-rendering-cdp-endpoint/) and prevents compatibility issues when using the latest compatibility dates. If you encounter any issues, you can downgrade by setting a `compatibility_date` prior to `2026-03-17` or by adding the `no_websocket_standard_binary_type` flag. Refer to the [`@cloudflare/playwright` README](https://github.com/cloudflare/playwright?tab=readme-ov-file#cdp-protocol-support) for details.
+  - publish_date: "2026-04-15"
     title: "Higher concurrency limits"
     description: |-
       * Increased the default [concurrent browser limit](/browser-run/limits/#workers-paid) for Workers Paid plans from 30 to **120 per account**.


### PR DESCRIPTION
- Add release note for @cloudflare/playwright v1.3.0 (now uses standard CDP internally)
- Bump version reference from v1.2.0 to v1.3.0 on Playwright docs page

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
