### PR TITLE
fix: clarify Save button location in Versions & Deployments docs

### DIFF
--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -58,7 +58,7 @@ Wrangler versions before 3.73.0 require you to specify a `--x-versions` flag.
 
 :::
 
-To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command or create a new version via the Online Editor in the Cloudflare dashboard by clicking **Edit Code**, then selecting the **Save** option under the down arrow beside the "Deploy" button.
+To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command or create a new version via the online code editor in the Cloudflare dashboard by selecting **Edit code**, then selecting the **Save** option under the down arrow beside the "Deploy" button.
 
 Versions created in this way can then be deployed all at once or gradually deployed using the [`wrangler versions deploy`](/workers/wrangler/commands/general/#versions-deploy) command or via the Cloudflare dashboard under the **Deployments** tab.
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -58,7 +58,21 @@ Wrangler versions before 3.73.0 require you to specify a `--x-versions` flag.
 
 :::
 
-To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command or create a new version via the online code editor in the Cloudflare dashboard by selecting **Edit code**, then selecting the **Save** option under the down arrow beside the "Deploy" button.
+To create a new version of your Worker that is not deployed immediately:
+
+<Tabs> <TabItem label="Wrangler CLI">
+
+Run the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command.
+
+</TabItem> <TabItem label="Dashboard">
+
+1. In the Cloudflare dashboard, go to your Worker.
+2. Select **Edit code**.
+3. Make your changes, then select the down arrow beside the **Deploy** button.
+4. Select **Save**.
+
+</TabItem>
+</Tabs>
 
 Versions created in this way can then be deployed all at once or gradually deployed using the [`wrangler versions deploy`](/workers/wrangler/commands/general/#versions-deploy) command or via the Cloudflare dashboard under the **Deployments** tab.
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -58,21 +58,7 @@ Wrangler versions before 3.73.0 require you to specify a `--x-versions` flag.
 
 :::
 
-To create a new version of your Worker that is not deployed immediately:
-
-<Tabs> <TabItem label="Wrangler CLI">
-
-Run the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command.
-
-</TabItem> <TabItem label="Dashboard">
-
-1. In the Cloudflare dashboard, go to your Worker.
-2. Select **Edit code**.
-3. Make your changes, then select the down arrow beside the **Deploy** button.
-4. Select **Save**.
-
-</TabItem>
-</Tabs>
+To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command or create a new version via the online code editor in the Cloudflare dashboard by selecting **Edit code**, then selecting the **Save** option under the down arrow beside the "Deploy" button.
 
 Versions created in this way can then be deployed all at once or gradually deployed using the [`wrangler versions deploy`](/workers/wrangler/commands/general/#versions-deploy) command or via the Cloudflare dashboard under the **Deployments** tab.
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -58,7 +58,7 @@ Wrangler versions before 3.73.0 require you to specify a `--x-versions` flag.
 
 :::
 
-To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command or create a new version via the Cloudflare dashboard using the **Save** button. You can find the **Save** option under the down arrow beside the "Deploy" button.
+To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command or create a new version via the Online Editor in the Cloudflare dashboard by clicking **Edit Code**, then selecting the **Save** option under the down arrow beside the "Deploy" button.
 
 Versions created in this way can then be deployed all at once or gradually deployed using the [`wrangler versions deploy`](/workers/wrangler/commands/general/#versions-deploy) command or via the Cloudflare dashboard under the **Deployments** tab.
 


### PR DESCRIPTION
## Description

Clarifies the location of the **Save** button for creating new Worker versions in the Versions & Deployments documentation.

The **Save** button is only visible within the Online Editor (Edit Code) interface, not on the main Worker dashboard or Deployments tab. The previous instructions did not specify this, making it difficult for users to find the button.

## Changes

- Updated the "Upload a new version to be gradually deployed or deployed at a later time" section to specify navigating to the Online Editor via **Edit Code** first.

## Related

Closes #28812