### PR TITLE
AI Explain Code button matches the Copy Code button behavior

### DIFF
--- a/src/plugins/expressive-code/explain-code.js
+++ b/src/plugins/expressive-code/explain-code.js
@@ -93,6 +93,17 @@ export default () => {
 				opacity: var(--ec-frm-inlBtnBgHoverOrFocusOpa);
 			}
 
+			@media (hover: hover) {
+				.expressive-code .explain button {
+					opacity: 0;
+				}
+			}
+
+			.expressive-code .frame:hover .explain button:not(:hover),
+			.expressive-code .frame:focus-within :focus-visible ~ .explain button:not(:hover) {
+				opacity: 0.75;
+			}
+
 			.expressive-code .explain button:active, .expressive-code .explain button:hover {
 				opacity: 1;
 			}


### PR DESCRIPTION
### Summary

This update modifies the behavior of the "AI Explain" button to ensure consistency with the "Copy Code" button (which only appears on hover). Currently, the "AI Explain" button is always visible, but this update hides it until the user hovers over the code block. This change aligns the interaction patterns of both buttons.

Related to feedback in #29740

### Screenshots (optional)

Before:
<img width="1408" height="650" alt="CleanShot 2026-04-15 at 14 53 21@2x" src="https://github.com/user-attachments/assets/47fb0eb3-9d70-47b6-944a-d5a6b7600ff4" />

After:
<img width="1418" height="642" alt="CleanShot 2026-04-15 at 14 53 02@2x" src="https://github.com/user-attachments/assets/9bbcd997-b0be-4ba1-8499-a84be992f5ae" />

Hovering over the code block:
<img width="1418" height="642" alt="CleanShot 2026-04-15 at 14 53 08@2x" src="https://github.com/user-attachments/assets/b5948483-6d72-4865-a4a1-bdac60ca5332" />