### PR TITLE
Remove notice about alert not working locally

### DIFF
--- a/src/content/docs/durable-objects/api/state.mdx
+++ b/src/content/docs/durable-objects/api/state.mdx
@@ -337,12 +337,6 @@ class MyDurableObject(DurableObject):
 
 </Tabs>
 
-:::caution[Not available in local development]
-
-`abort` is not available in local development with the `wrangler dev` CLI command.
-
-:::
-
 #### Parameters
 
 - An optional `string` .


### PR DESCRIPTION
### Summary

Confirmed that `.abort()` works locally and this notice should be removed.

