### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-04-15)

### DIFF
--- a/src/content/changelog/logs/2026-04-15-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-04-15-log-fields-updated.mdx
@@ -1,0 +1,13 @@
+---
+title: Updated fields in HTTP requests Logpush dataset in Cloudflare Logs
+description: Fields have been updated in the HTTP requests Logpush dataset in Cloudflare Logs.
+date: 2026-04-15
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### Updated fields in existing datasets
+
+- **HTTP requests** (removed): `BotDetectionIDs`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -9,12 +9,6 @@ sidebar:
 
 The descriptions below detail the fields available for `http_requests`.
 
-## BotDetectionIDs
-
-Type: `array[int]`
-
-List of IDs that correlate to the Bot Management Heuristic detections made on a request. Available only for Bot Management customers. To enable this feature, contact your account team.
-
 ## BotDetectionTags
 
 Type: `array[string]`


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Updated fields in existing datasets

- **HTTP requests** (removed): `BotDetectionIDs`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/{account,zone}/` — dataset pages
- `src/content/changelog/logs/2026-04-15-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
