### PR TITLE
[Workers VPC] Clarify Connectivity Directory Bind role permissions

### DIFF
--- a/src/content/docs/workers-vpc/api/index.mdx
+++ b/src/content/docs/workers-vpc/api/index.mdx
@@ -125,7 +125,7 @@ export default {
 
 ## Required roles
 
-To bind a VPC Service or VPC Network in a Worker, your user needs `Connectivity Directory Bind` (or `Connectivity Directory Admin`). For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
+To bind a VPC Service or VPC Network in a Worker, your user needs `Connectivity Directory Bind` (or `Connectivity Directory Admin`). Binding directly to a tunnel through a VPC Network binding requires `Connectivity Directory Admin`. For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
 
 ## Next steps
 

--- a/src/content/docs/workers-vpc/configuration/tunnel/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/tunnel/index.mdx
@@ -11,7 +11,7 @@ Cloudflare Tunnel creates secure connections from your infrastructure to Cloudfl
 
 When you create a VPC Service, you specify a tunnel ID and target service. Workers VPC then routes requests from your Worker to the specified tunnel, which establishes a connection to the specified hostname or IP address, such that the target service receives the request and returns a response back to your Worker.
 
-To allow members to create VPC Services that represent a target service reachable via a tunnel, you must assign them the **Connectivity Directory Admin** role. Members must possess **Connectivity Directory Bind** role to bind to existing VPC Services from worker.
+To allow members to create VPC Services that represent a target service reachable via a tunnel, you must assign them the **Connectivity Directory Admin** role. Members with the **Connectivity Directory Bind** role can bind to existing VPC Services from Workers. Binding directly to a tunnel through a VPC Network binding requires the **Connectivity Directory Admin** role.
 
 The tunnel maintains persistent connections to Cloudflare, eliminating the need for inbound firewall rules or public IP addresses.
 

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -19,6 +19,12 @@ Workers VPC is currently in beta. Features and APIs may change before general av
 
 ## Bind to a tunnel
 
+:::note
+
+Binding directly to a tunnel through a VPC Network binding requires the **Connectivity Directory Admin** role.
+
+:::
+
 Reference a specific Cloudflare Tunnel directly by its UUID:
 
 <WranglerConfig>

--- a/src/content/docs/workers-vpc/configuration/vpc-services/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-services/index.mdx
@@ -13,7 +13,7 @@ You can use bindings to connect to VPC Services from Workers. Every request made
 
 VPC Services enforce that requests are routed to their intended service without exposing the entire network, securing your workloads and preventing server-side request forgery (SSRF).
 
-Members must possess **Connectivity Directory Bind** role to bind to existing VPC Services from Workers. Creating VPC Services requires members to possess the **Connectivity Directory Admin** role.
+Members with the **Connectivity Directory Bind** role can bind to existing VPC Services from Workers. Creating VPC Services requires the **Connectivity Directory Admin** role.
 
 :::note
 

--- a/src/content/partials/workers-vpc/required-roles.mdx
+++ b/src/content/partials/workers-vpc/required-roles.mdx
@@ -1,8 +1,8 @@
 Workers VPC uses the following account roles:
 
 - `Connectivity Directory Read` to view Workers VPC Services and Tunnels.
-- `Connectivity Directory Bind` to list/read services and bind them in Workers.
-- `Connectivity Directory Admin` to create, update, and delete services.
+- `Connectivity Directory Bind` to list, read, and bind VPC Services in Workers.
+- `Connectivity Directory Admin` to create, update, and delete VPC Services, and bind directly to tunnels through a VPC Network binding.
 
 For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
 


### PR DESCRIPTION
Clarifies that the Connectivity Directory Bind role grants binding to VPC Services and VPC Networks, but not direct tunnel binding. Direct tunnel binding requires Connectivity Directory Admin.