### PR TITLE
[Billing] Add request-journey page, optimization tips, and cross-linking

### DIFF
--- a/src/content/docs/billing/get-started/create-billing-profile.mdx
+++ b/src/content/docs/billing/get-started/create-billing-profile.mdx
@@ -93,3 +93,9 @@ Log in to your PayPal account and send your payment to ar@cloudflare.com. The pa
 :::note
 US banks do not participate in International Bank Account Numbers (IBAN).
 :::
+
+## Related resources
+
+- [Update billing information](/billing/get-started/update-billing-info/) — Change payment methods, billing address, or email
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — Billing lifecycle and charge types
+- [Billing policy](/billing/understand/billing-policy/) — Refund policy and subscription terms

--- a/src/content/docs/billing/get-started/update-billing-info.mdx
+++ b/src/content/docs/billing/get-started/update-billing-info.mdx
@@ -101,3 +101,9 @@ You cannot remove a VAT or GST number from past invoices. Removing a VAT or GST 
 3. From **Billing Address**, select **Edit**.
 4. In the **VAT/GST** field, delete the VAT or GST number.
 5. Select **Confirm**.
+
+## Related resources
+
+- [Create billing profile](/billing/get-started/create-billing-profile/) — Set up your initial payment method
+- [Invoices](/billing/manage/invoices/) — View and download invoices
+- [Sales tax](/billing/understand/sales-tax/) — How tax is calculated based on your billing address

--- a/src/content/docs/billing/index.mdx
+++ b/src/content/docs/billing/index.mdx
@@ -83,6 +83,10 @@ Understand refund policies, payment methods, and subscription terms.
 Learn how usage-based charges work for products like Workers and other metered services.
 </LinkTitleCard>
 
+<LinkTitleCard title="How charges accrue" href="/billing/understand/how-charges-accrue/">
+Follow a request through Cloudflare and see which products generate charges at each stage.
+</LinkTitleCard>
+
 <LinkTitleCard title="Sales tax" href="/billing/understand/sales-tax/">
 Understand how Cloudflare collects sales tax based on your billing address.
 </LinkTitleCard>

--- a/src/content/docs/billing/manage/billable-usage.mdx
+++ b/src/content/docs/billing/manage/billable-usage.mdx
@@ -65,3 +65,9 @@ The dashboard reads from the same data source that generates your monthly invoic
 
 To get notified when your spend crosses a dollar threshold, you can create budget alerts directly from the dashboard. For detailed instructions, refer to [Budget alerts](/billing/manage/budget-alerts/).
 
+## Related resources
+
+- [Budget alerts](/billing/manage/budget-alerts/) — Get notified when spend crosses a threshold
+- [Usage-based billing](/billing/understand/usage-based-billing/) — Which products use metered billing
+- [How charges accrue](/billing/understand/how-charges-accrue/) — How a request generates charges across products
+

--- a/src/content/docs/billing/manage/budget-alerts.mdx
+++ b/src/content/docs/billing/manage/budget-alerts.mdx
@@ -59,3 +59,9 @@ Cloudflare offers two types of spend monitoring:
 | **Best for** | Overall cost management | Monitoring a single product |
 
 For per-product usage notifications, refer to [Usage-based billing](/billing/understand/usage-based-billing/#usage-based-billing-notifications).
+
+## Related resources
+
+- [Monitor billable usage](/billing/manage/billable-usage/) — Track daily usage-based costs
+- [Usage-based billing](/billing/understand/usage-based-billing/) — Which products use metered billing
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — Billing lifecycle and charge types

--- a/src/content/docs/billing/manage/cancel-subscription.mdx
+++ b/src/content/docs/billing/manage/cancel-subscription.mdx
@@ -54,3 +54,9 @@ To change your plan instead of cancelling, select **Change** under **Active Subs
 :::caution
 Fees are non-refundable. You are billed for the full billing period in which you cancel and no refunds are issued for unused time. After cancellation, you retain access to paid services through the end of the current billing period. For full terms, refer to the [Cloudflare Terms of Use](https://www.cloudflare.com/terms/).
 :::
+
+## Related resources
+
+- [Change domain plan](/billing/manage/change-plan/) — Upgrade or downgrade instead of cancelling
+- [Billing policy](/billing/understand/billing-policy/) — Refund policy and subscription terms
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — When downgrades and cancellations take effect

--- a/src/content/docs/billing/manage/change-plan.mdx
+++ b/src/content/docs/billing/manage/change-plan.mdx
@@ -82,3 +82,9 @@ To change the duration of your Cloudflare plan in the dashboard:
 To change the duration of a Cloudflare plan for a domain using the API, send a [`PUT`](/api/resources/zones/subresources/subscriptions/methods/update/) request with an updated value for the `frequency` parameter.
 
 </TabItem> </Tabs>
+
+## Related resources
+
+- [Cancel subscriptions](/billing/manage/cancel-subscription/) — Cancel plans and add-ons
+- [Billing policy](/billing/understand/billing-policy/) — Refund policy and subscription terms
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — When upgrades and downgrades take effect

--- a/src/content/docs/billing/manage/invoices.mdx
+++ b/src/content/docs/billing/manage/invoices.mdx
@@ -57,3 +57,9 @@ Monthly and annual billing subscriptions run on different billing cycles.
 The first monthly purchase on a Cloudflare account sets the billing date for the following monthly subscriptions. The same behaviour occurs for annual subscriptions.
 
 You can have two different billing cycles on your account, one for a monthly subscription and another for an annual subscription.
+
+## Related resources
+
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — How to read your invoice
+- [Pay an outstanding balance](/billing/manage/pay-invoices-overdue-balances/) — Resolve unpaid invoices
+- [Update billing information](/billing/get-started/update-billing-info/) — Change your billing email for invoice delivery

--- a/src/content/docs/billing/manage/pay-invoices-overdue-balances.mdx
+++ b/src/content/docs/billing/manage/pay-invoices-overdue-balances.mdx
@@ -56,3 +56,9 @@ If an automatic subscription renewal payment fails, Cloudflare automatically ret
 3. Select **Pay now** next to the invoice you want to pay.
 
 You will be redirected to our payment system to proceed.
+
+## Related resources
+
+- [Resolve a payment failure](/billing/troubleshoot/troubleshoot-failed-payments/) — Fix errors when paying
+- [Invoices](/billing/manage/invoices/) — View and download invoices
+- [Error reference](/billing/troubleshoot/error-reference/) — Look up billing error messages

--- a/src/content/docs/billing/troubleshoot/error-reference.mdx
+++ b/src/content/docs/billing/troubleshoot/error-reference.mdx
@@ -30,3 +30,9 @@ Use the table below to find common billing error messages, understand what they 
 ## Still stuck?
 
 If your error message is not listed above or the suggested solution does not resolve the issue, [contact Cloudflare support](/support/contacting-cloudflare-support/).
+
+## Related resources
+
+- [Resolve a payment failure](/billing/troubleshoot/troubleshoot-failed-payments/) — Fix payment errors
+- [Pay an outstanding balance](/billing/manage/pay-invoices-overdue-balances/) — Resolve unpaid invoices
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — Billing lifecycle and charge types

--- a/src/content/docs/billing/troubleshoot/resolve-cannot-remove-payment-method.mdx
+++ b/src/content/docs/billing/troubleshoot/resolve-cannot-remove-payment-method.mdx
@@ -64,3 +64,9 @@ If you have any domains with auto-renew enabled that are expiring in 31 days or 
 ### If none of the above apply
 
 If none of the above apply and you still receive an error, [contact Cloudflare support](/support/contacting-cloudflare-support/).
+
+## Related resources
+
+- [Update billing information](/billing/get-started/update-billing-info/) — Add a replacement payment method
+- [Cancel subscriptions](/billing/manage/cancel-subscription/) — Cancel subscriptions before removing a payment method
+- [Error reference](/billing/troubleshoot/error-reference/) — Look up other billing error messages

--- a/src/content/docs/billing/troubleshoot/resolve-you-cannot-modify-this-subscription.mdx
+++ b/src/content/docs/billing/troubleshoot/resolve-you-cannot-modify-this-subscription.mdx
@@ -47,3 +47,9 @@ If the cancellation hasn’t taken effect yet, you can click **Cancel Downgrade*
 3. Go to **Subscriptions**.
 4. Locate the **Product** you have cancelled
 5. Under the **Action** column, click **Cancel Downgrade**
+
+## Related resources
+
+- [Cancel subscriptions](/billing/manage/cancel-subscription/) — How cancellations work
+- [Billing policy](/billing/understand/billing-policy/) — Refund policy and billing terms
+- [Error reference](/billing/troubleshoot/error-reference/) — Look up other billing error messages

--- a/src/content/docs/billing/troubleshoot/resolve-zone-cannot-be-upgraded.mdx
+++ b/src/content/docs/billing/troubleshoot/resolve-zone-cannot-be-upgraded.mdx
@@ -28,3 +28,9 @@ As a reference, the full error messages you may see are:
 
 - "Due to a Billing related issue, the zone cannot be upgraded at this time. Please visit the Billing section to ensure there is no outstanding balance."
 - "Refer to https://cfl.re/3VUQyyL for assistance. For security reasons, there is a problem with your billing profile."
+
+## Related resources
+
+- [Pay an outstanding balance](/billing/manage/pay-invoices-overdue-balances/) — Resolve unpaid balances
+- [Change domain plan](/billing/manage/change-plan/) — Upgrade or downgrade your plan
+- [Error reference](/billing/troubleshoot/error-reference/) — Look up other billing error messages

--- a/src/content/docs/billing/troubleshoot/troubleshoot-failed-payments.mdx
+++ b/src/content/docs/billing/troubleshoot/troubleshoot-failed-payments.mdx
@@ -67,3 +67,9 @@ After checking the items above, retry your transaction in the Cloudflare dashboa
 ### Try a new payment method
 
 If you cannot resolve this using your current payment method, you may wish to try an alternative payment method. Cloudflare accepts credit and debit cards (Visa, Mastercard, American Express, Discover), PayPal, Apple Pay, Google Pay, and Stripe Link. To try this, refer to [update your payment methods](/billing/get-started/update-billing-info/#update-payment-methods).
+
+## Related resources
+
+- [Pay an outstanding balance](/billing/manage/pay-invoices-overdue-balances/) — Resolve unpaid invoices
+- [Update billing information](/billing/get-started/update-billing-info/) — Change your payment method
+- [Error reference](/billing/troubleshoot/error-reference/) — Look up other billing error messages

--- a/src/content/docs/billing/troubleshoot/troubleshoot-invoices.mdx
+++ b/src/content/docs/billing/troubleshoot/troubleshoot-invoices.mdx
@@ -26,3 +26,9 @@ If your Cloudflare payment is past due and you order additional services, the pa
 :::note
 You may have to wait up to one billing period for updates to appear in your Cloudflare invoice.
 :::
+
+## Related resources
+
+- [Invoices](/billing/manage/invoices/) — Download and manage invoices
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — How to read your invoice
+- [Update billing information](/billing/get-started/update-billing-info/) — Change your billing email

--- a/src/content/docs/billing/understand/how-charges-accrue.mdx
+++ b/src/content/docs/billing/understand/how-charges-accrue.mdx
@@ -1,0 +1,128 @@
+---
+title: How charges accrue
+pcx_content_type: concept
+sidebar:
+  order: 1
+description: How a request generates billable usage across Cloudflare products.
+---
+
+import { Details } from "~/components";
+
+Every request to a Cloudflare-proxied domain can touch multiple products, each with its own billing dimension. This page walks through a realistic request lifecycle and shows which products generate charges at each stage.
+
+Understanding this flow helps you predict costs, identify optimization opportunities, and make sense of your invoice.
+
+## A request through a Pro zone
+
+Consider a visitor loading a page on a Pro domain that uses Workers, R2, Argo Smart Routing, and Cache Reserve. Here is what happens at each stage and which billable resources are involved.
+
+### 1. DNS resolution
+
+The visitor's browser resolves the domain. This DNS query is handled by Cloudflare's authoritative DNS.
+
+| Resource | Billing impact |
+|---|---|
+| DNS queries | Included in all plans at no extra charge. If you use Load Balancing, DNS queries to load-balanced hostnames are metered (first 500K included). |
+
+### 2. Edge request and TLS
+
+The request arrives at the nearest Cloudflare data center. Cloudflare terminates TLS and processes the request.
+
+| Resource | Billing impact |
+|---|---|
+| TLS/SSL | Included in all plans. Advanced Certificate Manager and SSL for SaaS have separate pricing. |
+
+### 3. Cache lookup
+
+Cloudflare checks whether a cached response exists for this request.
+
+**Cache hit** — the response is served directly from the edge. No origin fetch occurs. This is the cheapest path.
+
+| Resource | Billing impact |
+|---|---|
+| Bandwidth | Included in all plans. Cloudflare does not charge for bandwidth. |
+| Cache Reserve reads | If Cache Reserve is enabled and the asset is served from tiered cache storage, reads are metered at $0.36 per million. |
+
+**Cache miss** — the request must be forwarded to the origin. Continue to step 4.
+
+### 4. Argo Smart Routing (if enabled)
+
+If Argo is enabled, Cloudflare routes the request through the fastest path across its network to your origin.
+
+| Resource | Billing impact |
+|---|---|
+| Argo data transfer | Metered per GB transferred between Cloudflare and your origin. First 1 GB included, then $0.10 per GB. |
+
+### 5. Workers execution (if configured)
+
+If a Worker is bound to the route, it executes before or instead of fetching from the origin.
+
+| Resource | Billing impact |
+|---|---|
+| Worker requests | Metered per invocation. Workers Paid plan includes 10 million requests, then $0.30 per million. |
+| Worker CPU time | Metered per millisecond of CPU time. 30 million CPU-ms included, then $0.02 per million CPU-ms. |
+| Workers KV reads/writes | If the Worker reads from or writes to KV, each operation is metered separately. |
+
+### 6. Origin fetch and response
+
+If the Worker or cache miss triggers an origin fetch, Cloudflare retrieves the response from your origin server.
+
+| Resource | Billing impact |
+|---|---|
+| Bandwidth | No charge for data transfer between Cloudflare and your origin (no egress fees). |
+
+### 7. R2 storage operations (if used)
+
+If the Worker or origin logic reads from or writes to R2, each operation is metered.
+
+| Resource | Billing impact |
+|---|---|
+| R2 Class A operations (writes) | First 1 million included, then $4.50 per million. |
+| R2 Class B operations (reads) | First 10 million included, then $0.36 per million. |
+| R2 storage | First 10 GB-month included, then $0.015 per GB-month. |
+| R2 data egress | Free. Cloudflare does not charge for R2 egress. |
+
+### 8. Cache write (miss path)
+
+After fetching from the origin, Cloudflare caches the response at the edge for future requests.
+
+| Resource | Billing impact |
+|---|---|
+| Cache Reserve writes | If Cache Reserve is enabled, writes are metered at $4.50 per million. |
+
+### 9. Image Resizing (if configured)
+
+If the request triggers Image Resizing (via URL parameters or a Worker), the transformation is metered.
+
+| Resource | Billing impact |
+|---|---|
+| Image transformations | First 50,000 included on the Business plan, then metered per request. |
+
+### 10. Response delivered
+
+The final response is sent to the visitor. No additional charges apply at this stage.
+
+## What this means for your invoice
+
+A single page load can generate dozens of requests. Each request may touch a different combination of the products above. Your monthly invoice aggregates all of these individual operations across all requests, all domains, and the full billing period.
+
+The key takeaway: **cached responses are the cheapest path**. Every cache hit avoids origin fetch costs, Argo routing charges, Workers execution, and R2 operations. Optimizing your cache hit ratio is the single most effective way to reduce usage-based charges.
+
+## Cost optimization strategies
+
+| Strategy | Products affected | Impact |
+|---|---|---|
+| Maximize cache hit ratio with appropriate Cache-Control headers | Argo, Workers, origin bandwidth | High — every cache hit eliminates origin-side costs |
+| Use Cache Reserve for long-tail content | Cache, origin | Medium — reduces origin fetches for infrequently accessed content |
+| Set appropriate TTLs to avoid unnecessary revalidation | Cache, Argo | Medium — reduces origin round-trips |
+| Use Workers Smart Placement to run Workers closer to your data | Workers CPU time | Medium — reduces execution time for data-dependent Workers |
+| Use R2 lifecycle rules to move infrequently accessed data to Infrequent Access tier | R2 storage | Medium — reduces storage costs for archival data |
+| Monitor usage with the [billable usage dashboard](/billing/manage/billable-usage/) | All usage-based products | High — visibility is the first step to optimization |
+| Set up [budget alerts](/billing/manage/budget-alerts/) to catch unexpected spikes | All usage-based products | High — prevents surprise invoices |
+
+## Related resources
+
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — Billing lifecycle, charge types, and invoice structure
+- [Usage-based billing](/billing/understand/usage-based-billing/) — Which products use metered billing
+- [Monitor billable usage](/billing/manage/billable-usage/) — Track daily usage-based costs
+- [Budget alerts](/billing/manage/budget-alerts/) — Get notified when spend crosses a threshold

--- a/src/content/docs/billing/understand/preview-services.mdx
+++ b/src/content/docs/billing/understand/preview-services.mdx
@@ -38,3 +38,8 @@ Since these services are not yet part of your contract, we recommend that you us
 ## View enabled products
 
 To view which products you have previously enabled, go to your [Account Subscriptions](https://dash.cloudflare.com/?to=/:account/billing/subscriptions) page and look for items that with **Terms** of **NOT IN CONTRACT**.
+
+## Related resources
+
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — Billing lifecycle and charge types
+- [Usage-based billing](/billing/understand/usage-based-billing/) — Which products use metered billing

--- a/src/content/docs/billing/understand/sales-tax.mdx
+++ b/src/content/docs/billing/understand/sales-tax.mdx
@@ -88,3 +88,9 @@ Cloudflare will issue tax invoices and add VAT at the 16% standard rate on top o
 You may update your VAT registration number in your account profile.
 
 Reach out to Cloudflare via email [indirect_tax@cloudflare.com](mailto:indirect_tax@cloudflare.com) if you have any tax related concerns or questions.
+
+## Related resources
+
+- [Update billing information](/billing/get-started/update-billing-info/) — Change your billing address or VAT number
+- [Invoices](/billing/manage/invoices/) — View tax details on your invoices
+- [Billing policy](/billing/understand/billing-policy/) — General billing terms

--- a/src/content/docs/billing/understand/usage-based-billing.mdx
+++ b/src/content/docs/billing/understand/usage-based-billing.mdx
@@ -15,6 +15,38 @@ For example, if your billing date is on the 15th of the month and you turn on Cl
 The pricing structure varies based on the service being used.
 :::
 
+## Products with usage-based billing
+
+The following products bill based on consumption. Each product includes a free tier — you are only charged for usage that exceeds the included amount.
+
+| Product | Billable metric | Free tier (included) | Overage rate |
+|---|---|---|---|
+| [Workers](/workers/platform/pricing/) | Requests, CPU time | 10M requests, 30M CPU-ms | $0.30/M requests, $0.02/M CPU-ms |
+| [R2](/r2/pricing/) | Storage, operations | 10 GB storage, 1M Class A, 10M Class B | $0.015/GB, $4.50/M Class A, $0.36/M Class B |
+| [Argo Smart Routing](/argo-smart-routing/) | Data transfer (GB) | First 1 GB | $0.10/GB |
+| [Cache Reserve](/cache/how-to/cache-reserve/) | Reads, writes, storage | None | $0.36/M reads, $4.50/M writes, $0.015/GB |
+| [Load Balancing](/load-balancing/pricing/) | DNS queries | First 500K | $0.50/500K |
+| [Stream](/stream/pricing/) | Minutes stored, minutes viewed | Varies by plan | Varies |
+| [Images](/images/pricing/) | Transformations, storage | Varies by plan | Varies |
+| [Spectrum](/spectrum/pricing/) | Data transfer (GB) | None | $1.00/GB |
+
+For the full pricing details of each product, refer to the product-specific pricing page linked above.
+
+## Optimize usage-based costs
+
+Reducing usage-based charges starts with understanding where your consumption comes from. Use the [billable usage dashboard](/billing/manage/billable-usage/) to identify which products are driving costs, then apply the strategies below.
+
+| Strategy | What it reduces |
+|---|---|
+| Increase cache hit ratio with longer TTLs and appropriate `Cache-Control` headers | Argo data transfer, Workers invocations, origin load |
+| Use [Cache Reserve](/cache/how-to/cache-reserve/) for long-tail content | Origin fetches for infrequently accessed assets |
+| Set up [R2 lifecycle rules](/r2/buckets/object-lifecycles/) to transition cold data to Infrequent Access | R2 storage costs |
+| Use [Workers Smart Placement](/workers/configuration/smart-placement/) for data-heavy Workers | Workers CPU time |
+| Batch R2 operations where possible instead of per-object reads | R2 Class B operation count |
+| Set up [budget alerts](/billing/manage/budget-alerts/) to catch unexpected spikes early | All products — prevents surprise invoices |
+
+For a detailed walkthrough of how a single request generates charges across multiple products, refer to [How charges accrue](/billing/understand/how-charges-accrue/).
+
 ## Monitor your usage
 
 The [billable usage dashboard](/billing/manage/billable-usage/) gives Pay-as-you-go customers daily visibility into usage-based costs. The dashboard shows a daily cost breakdown chart and a per-product usage table with free-tier allowances, so you can see exactly what you are being charged for.
@@ -48,3 +80,10 @@ For more information, refer to [Cloudflare notifications](/notifications/get-sta
 :::note
 Usage notifications monitor a single product metric (bytes, requests, minutes). To monitor your total dollar spend across all products, use [budget alerts](/billing/manage/budget-alerts/) instead.
 :::
+
+## Related resources
+
+- [How charges accrue](/billing/understand/how-charges-accrue/) — How a request generates charges across products
+- [Monitor billable usage](/billing/manage/billable-usage/) — Track daily usage-based costs
+- [Budget alerts](/billing/manage/budget-alerts/) — Get notified when spend crosses a threshold
+- [How Cloudflare billing works](/billing/understand/how-billing-works/) — Billing lifecycle and charge types


### PR DESCRIPTION
## Summary

Adds three improvements to the billing docs (plans, pricing, spend-management, limits, manage-and-optimize-usage, understanding-my-invoice, calculating-usage).

### 1. New page: How charges accrue (`/billing/understand/how-charges-accrue/`)

Walks through a real request hitting a Pro zone with Workers, R2, Argo, and Cache Reserve, showing which products generate charges at each stage:

DNS → edge request → cache lookup → Argo routing → Workers execution → R2 operations → cache write → Image Resizing → response

Each stage includes a table with the billable resource and its pricing. Ends with a cost optimization strategies table.

### 2. Enhanced: Usage-based billing page

Added two new sections:
- **Products table** — lists every usage-based product with its billable metric, free tier, and overage rate in one scannable table (previously this information was scattered across individual product pricing pages)
- **Optimization strategies** — per-product cost reduction guidance (increase cache hit ratio, use R2 lifecycle rules, use Workers Smart Placement, etc.)

### 3. Cross-linking: Related resources on all 17 pages

Added a `## Related resources` footer with 3-4 contextually relevant links to every billing page that was missing one (17 out of 19 pages).

## Validation

- `npm run check`: 0 errors (pre-existing unrelated errors only)
- All new/modified files follow style guide conventions