### PR TITLE
[SSL] Review Tunnel references in Keyless SSL

### DIFF
--- a/src/content/docs/ssl/keyless-ssl/configuration/cloudflare-tunnel.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/cloudflare-tunnel.mdx
@@ -24,15 +24,15 @@ First, install `cloudflared` on your key server.
 
 <Render file="keyless-tunnel-setup" product="ssl" /> <br />
 
-## 2. Create a Tunnel
+## 2. Create a tunnel and add a route
 
 Then, create a Cloudflare Tunnel.
 
 <Render file="keyless-tunnel-setup" product="ssl" /> <br />
 
-In these steps, you should choose the option to **Connect a network** and use the private IP address of your key server.
+During tunnel creation, go to the **CIDR** tab and enter the private IP address of your key server. You can also [add a CIDR route](/cloudflare-one/networks/routes/add-routes/#add-a-cidr-route) after creating the tunnel.
 
-After you create the Tunnel, use the Cloudflare API to [List tunnel routes](/api/resources/zero_trust/subresources/networks/subresources/routes/methods/list/), saving the following values for a future step:
+After you create the tunnel, use the Cloudflare API to [List tunnel routes](/api/resources/zero_trust/subresources/networks/subresources/routes/methods/list/), saving the following values for a future step:
 
 - `"virtual_network_id"`
 - `"network"`

--- a/src/content/docs/ssl/keyless-ssl/configuration/cloudflare-tunnel.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/cloudflare-tunnel.mdx
@@ -22,13 +22,13 @@ Through an integration with [Cloudflare Tunnel](/cloudflare-one/networks/connect
 
 First, install `cloudflared` on your key server.
 
-<Render file="keyless-tunnel-setup" product="ssl" /> <br />
+<Render file="keyless-tunnel-setup" product="ssl" />
 
 ## 2. Create a tunnel and add a route
 
 Then, create a Cloudflare Tunnel.
 
-<Render file="keyless-tunnel-setup" product="ssl" /> <br />
+<Render file="keyless-tunnel-setup" product="ssl" />
 
 During tunnel creation, go to the **CIDR** tab and enter the private IP address of your key server. You can also [add a CIDR route](/cloudflare-one/networks/routes/add-routes/#add-a-cidr-route) after creating the tunnel.
 


### PR DESCRIPTION
### Summary

Replaces the outdated "Connect a network" UI reference in the Keyless SSL Cloudflare Tunnel setup page with instructions that match the current dashboard flow.

The tunnel creation wizard no longer presents a "Connect a network" button. Instead, users add a CIDR route via the **CIDR** tab during tunnel creation, or separately through **Networks** > **Routes**. This update aligns the Keyless SSL instructions with the current [Create a tunnel (dashboard)](/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/create-remote-tunnel/) and [Add routes](/cloudflare-one/networks/routes/add-routes/) documentation.

Fixes https://github.com/cloudflare/cloudflare-docs/issues/29637

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.