### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-04-16)

### DIFF
--- a/src/content/changelog/logs/2026-04-16-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-04-16-log-fields-updated.mdx
@@ -1,0 +1,18 @@
+---
+title: New Email Security Post-Delivery Events Logpush dataset and updated fields across multiple Logpush datasets in Cloudflare Logs
+description: The Email Security Post-Delivery Events Logpush dataset is now available, and fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-04-16
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### New datasets
+
+- **Email Security Post-Delivery Events**: A new dataset with fields including `AlertID`, `CompletedAt`, `Destination`, `FinalDisposition`, `Folder`, `From`, `FromName`, `MessageID`, `MessageTimestamp`, `MicrosoftTenantID`, `Operation`, `PostfixID`, `Reasons`, `Recipient`, `RequestedAt`, `RequestedBy`, `RequestedDisposition`, `Status`, `Subject`, `Success`, and `To`.
+
+### Updated fields in existing datasets
+
+- **Firewall events** (added): `AISecurityInjectionScore`, `AISecurityPIICategories`, `AISecurityTokenCount`, and `AISecurityUnsafeTopicCategories`.
+- **HTTP requests** (added): `AISecurityInjectionScore`, `AISecurityPIICategories`, `AISecurityTokenCount`, and `AISecurityUnsafeTopicCategories`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/email_security_post_delivery_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/email_security_post_delivery_events.md
@@ -1,0 +1,136 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: Email Security Post-Delivery Events
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `email_security_post_delivery_events`.
+
+## AlertID
+
+Type: `string`
+
+Email Security alert ID for the original message.
+
+## CompletedAt
+
+Type: `int or string`
+
+The timestamp when the post-delivery action completed. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+
+## Destination
+
+Type: `string`
+
+Target folder for MOVE operations (for example, 'RecoverableItemsPurges').
+
+## FinalDisposition
+
+Type: `string`
+
+Threat disposition of the original message. <br />Possible values are <em>unset</em> \| <em>none</em> \| <em>malicious</em> \| <em>suspicious</em> \| <em>spam</em> \| <em>spoof</em> \| <em>bulk</em>.
+
+## Folder
+
+Type: `string`
+
+Resolved folder name after a successful MOVE.
+
+## From
+
+Type: `string`
+
+From header address of the original message (for example, 'firstlast@cloudflare.com').
+
+## FromName
+
+Type: `string`
+
+From header display name of the original message (for example, 'First Last').
+
+## MessageID
+
+Type: `string`
+
+RFC Message-ID header of the original message.
+
+## MessageTimestamp
+
+Type: `int or string`
+
+The timestamp of the original message. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+
+## MicrosoftTenantID
+
+Type: `string`
+
+Microsoft 365 tenant identifier.
+
+## Operation
+
+Type: `string`
+
+Post-delivery action type. <br />Possible values are <em>move</em> \| <em>submission</em> \| <em>quarantineRelease</em>.
+
+## PostfixID
+
+Type: `string`
+
+Email Security postfix queue identifier for the original message.
+
+## Reasons
+
+Type: `array[string]`
+
+Detection findings that prompted the post-delivery action (for example, 'Malicious URL').
+
+## Recipient
+
+Type: `string`
+
+Email address of the targeted mailbox (for example, 'firstlast@cloudflare.com').
+
+## RequestedAt
+
+Type: `int or string`
+
+The timestamp when the post-delivery action was requested. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+
+## RequestedBy
+
+Type: `string`
+
+Identity that requested the post-delivery action; expected format is an email address.
+
+## RequestedDisposition
+
+Type: `string`
+
+Requested disposition for SUBMISSION operations.
+
+## Status
+
+Type: `string`
+
+Status message returned by the post-delivery provider (for example, 'OK').
+
+## Subject
+
+Type: `string`
+
+Subject header of the original message.
+
+## Success
+
+Type: `bool`
+
+Whether the post-delivery action succeeded.
+
+## To
+
+Type: `array[string]`
+
+Recipient addresses of the original message (for example, 'firstlast@cloudflare.com').

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
@@ -9,6 +9,30 @@ sidebar:
 
 The descriptions below detail the fields available for `firewall_events`.
 
+## AISecurityInjectionScore
+
+Type: `int`
+
+The score indicating the likelihood of a prompt injection attack in the request, as determined by AI Security.
+
+## AISecurityPIICategories
+
+Type: `array[string]`
+
+List of PII categories detected in the request by AI Security.
+
+## AISecurityTokenCount
+
+Type: `int`
+
+The number of tokens in the request, as counted by AI Security.
+
+## AISecurityUnsafeTopicCategories
+
+Type: `array[string]`
+
+List of unsafe topic categories detected in the request by AI Security.
+
 ## Action
 
 Type: `string`
@@ -157,25 +181,25 @@ HTTP response status code returned to browser.
 
 Type: `int`
 
-The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI.
+The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI. Deprecated: Use AISecurityInjectionScore instead.
 
 ## FirewallForAIPIICategories
 
 Type: `array[string]`
 
-List of PII categories detected in the request by Firewall for AI.
+List of PII categories detected in the request by Firewall for AI. Deprecated: Use AISecurityPIICategories instead.
 
 ## FirewallForAITokenCount
 
 Type: `int`
 
-The number of tokens in the request, as counted by Firewall for AI.
+The number of tokens in the request, as counted by Firewall for AI. Deprecated: Use AISecurityTokenCount instead.
 
 ## FirewallForAIUnsafeTopicCategories
 
 Type: `array[string]`
 
-List of unsafe topic categories detected in the request by Firewall for AI.
+List of unsafe topic categories detected in the request by Firewall for AI. Deprecated: Use AISecurityUnsafeTopicCategories instead.
 
 ## FraudUserID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -9,6 +9,30 @@ sidebar:
 
 The descriptions below detail the fields available for `http_requests`.
 
+## AISecurityInjectionScore
+
+Type: `int`
+
+The score indicating the likelihood of a prompt injection attack in the request, as determined by AI Security.
+
+## AISecurityPIICategories
+
+Type: `array[string]`
+
+List of PII categories detected in the request by AI Security.
+
+## AISecurityTokenCount
+
+Type: `int`
+
+The number of tokens in the request, as counted by AI Security.
+
+## AISecurityUnsafeTopicCategories
+
+Type: `array[string]`
+
+List of unsafe topic categories detected in the request by AI Security.
+
 ## BotDetectionIDs
 
 Type: `array[int]`
@@ -349,25 +373,25 @@ Total view of Time To First Byte as measured at Cloudflare's edge. Starts after 
 
 Type: `int`
 
-The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI.
+The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI. Deprecated: Use AISecurityInjectionScore instead.
 
 ## FirewallForAIPIICategories
 
 Type: `array[string]`
 
-List of PII categories detected in the request by Firewall for AI.
+List of PII categories detected in the request by Firewall for AI. Deprecated: Use AISecurityPIICategories instead.
 
 ## FirewallForAITokenCount
 
 Type: `int`
 
-The number of tokens in the request, as counted by Firewall for AI.
+The number of tokens in the request, as counted by Firewall for AI. Deprecated: Use AISecurityTokenCount instead.
 
 ## FirewallForAIUnsafeTopicCategories
 
 Type: `array[string]`
 
-List of unsafe topic categories detected in the request by Firewall for AI.
+List of unsafe topic categories detected in the request by Firewall for AI. Deprecated: Use AISecurityUnsafeTopicCategories instead.
 
 ## FraudAttack
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### New datasets

- **Email Security Post-Delivery Events**: A new dataset with fields including `AlertID`, `CompletedAt`, `Destination`, `FinalDisposition`, `Folder`, `From`, `FromName`, `MessageID`, `MessageTimestamp`, `MicrosoftTenantID`, `Operation`, `PostfixID`, `Reasons`, `Recipient`, `RequestedAt`, `RequestedBy`, `RequestedDisposition`, `Status`, `Subject`, `Success`, and `To`.

### Updated fields in existing datasets

- **Firewall events** (added): `AISecurityInjectionScore`, `AISecurityPIICategories`, `AISecurityTokenCount`, and `AISecurityUnsafeTopicCategories`.
- **HTTP requests** (added): `AISecurityInjectionScore`, `AISecurityPIICategories`, `AISecurityTokenCount`, and `AISecurityUnsafeTopicCategories`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/{account,zone}/` — dataset pages
- `src/content/changelog/logs/2026-04-16-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
