### PR TITLE
docs(billing): add backup payment method auto-retry documentation

### DIFF
--- a/src/content/docs/billing/backup-payment-method-auto-retry.mdx
+++ b/src/content/docs/billing/backup-payment-method-auto-retry.mdx
@@ -21,11 +21,12 @@ If your subscription renewal payment fails on your primary payment method, Cloud
 
 ## Eligibility
 
-To use backup payment method auto-retry, you need:
+Backup auto-retry is enabled automatically for eligible accounts. You need:
 
 - A **Pay-as-you-go (PayGo)** account
 - Exactly **2 payment methods** on file (one primary, one backup)
-- The **auto-retry setting enabled** in your billing page
+
+No action is needed to turn it on.
 
 Auto-retry works with any combination of credit/debit cards and PayPal:
 
@@ -36,11 +37,15 @@ Auto-retry works with any combination of credit/debit cards and PayPal:
 | PayPal  | Card   | Yes       |
 | PayPal  | PayPal | Yes       |
 
-## Enable or disable auto-retry
+## Disable auto-retry
+
+Backup auto-retry is enabled by default for eligible accounts. If you prefer not to use it:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com).
 2. Go to **Manage Account** > **Billing**.
-3. In the **Payment Methods** section, toggle **Auto-retry with backup payment method** on or off.
+3. In the **Payment Methods** section, toggle off **Auto-retry with backup payment method**.
+
+To re-enable, toggle the setting back on from the same location.
 
 :::note
 The toggle is only visible if you have at least 2 payment methods on file. If you remove a payment method and only have 1 remaining, auto-retry is automatically disabled.
@@ -70,7 +75,7 @@ Auto-retry applies to subscription renewal payments only. One-time purchases and
 </Details>
 
 <Details header="Can I turn this off?">
-Yes. You can disable auto-retry at any time from the **Billing** page in the Cloudflare dashboard.
+Yes. Auto-retry is on by default, but you can disable it at any time from the **Billing** page in the Cloudflare dashboard by toggling off the setting in the Payment Methods section.
 </Details>
 
 <Details header="What if I have more than 2 payment methods?">

--- a/src/content/docs/billing/backup-payment-method-auto-retry.mdx
+++ b/src/content/docs/billing/backup-payment-method-auto-retry.mdx
@@ -1,0 +1,82 @@
+---
+title: Backup payment method auto-retry
+pcx_content_type: concept
+sidebar:
+  order: 8
+head:
+  - tag: title
+    content: Backup payment method auto-retry | Cloudflare Docs
+---
+
+import { Details } from "~/components";
+
+If your subscription renewal payment fails on your primary payment method, Cloudflare can automatically retry the payment using your backup payment method. This keeps your services active without requiring you to take action.
+
+## How it works
+
+1. Your subscription renewal payment is attempted using your primary (default) payment method.
+2. If the payment fails, Cloudflare automatically attempts to charge your backup payment method.
+3. If the backup payment succeeds, your services remain active and you receive an email notification confirming which payment method was charged.
+4. If the backup payment also fails, standard payment retry processes continue on your primary payment method.
+
+## Eligibility
+
+To use backup payment method auto-retry, you need:
+
+- A **Pay-as-you-go (PayGo)** account
+- Exactly **2 payment methods** on file (one primary, one backup)
+- The **auto-retry setting enabled** in your billing page
+
+Auto-retry works with any combination of credit/debit cards and PayPal:
+
+| Primary | Backup | Supported |
+|---------|--------|-----------|
+| Card    | Card   | Yes       |
+| Card    | PayPal | Yes       |
+| PayPal  | Card   | Yes       |
+| PayPal  | PayPal | Yes       |
+
+## Enable or disable auto-retry
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com).
+2. Go to **Manage Account** > **Billing**.
+3. In the **Payment Methods** section, toggle **Auto-retry with backup payment method** on or off.
+
+:::note
+The toggle is only visible if you have at least 2 payment methods on file. If you remove a payment method and only have 1 remaining, auto-retry is automatically disabled.
+:::
+
+## Email notification
+
+When your backup payment method is charged, you receive an email with:
+
+- The invoice amount and number
+- Which primary payment method failed
+- Which backup payment method was charged
+- A link to manage your payment methods
+
+## FAQ
+
+<Details header="Will I be charged twice?">
+No. The backup payment method is only charged if your primary payment method fails. You will never be charged on both payment methods for the same invoice.
+</Details>
+
+<Details header="What happens if both payment methods fail?">
+If your backup payment method also fails, the standard payment retry process continues using your primary payment method. You may receive a separate email asking you to update your payment information.
+</Details>
+
+<Details header="Does this apply to all payments?">
+Auto-retry applies to subscription renewal payments only. One-time purchases and initial subscription setup payments are not affected.
+</Details>
+
+<Details header="Can I turn this off?">
+Yes. You can disable auto-retry at any time from the **Billing** page in the Cloudflare dashboard.
+</Details>
+
+<Details header="What if I have more than 2 payment methods?">
+Auto-retry is currently available for accounts with exactly 2 payment methods. If you have 3 or more, auto-retry will not activate.
+</Details>
+
+<Details header="Will my next renewal use my primary payment method again?">
+Yes. Each renewal always attempts your primary (default) payment method first. The backup is only used if the primary fails for that specific renewal.
+</Details>


### PR DESCRIPTION
## Summary
- Adds documentation for the Backup Payment Method Auto-Retry feature
- New page at `src/content/docs/billing/backup-payment-method-auto-retry.mdx`
- Covers: how it works, eligibility, enable/disable instructions, email notification, FAQ

## What is this feature?
When a PayGo customer's subscription renewal fails on their primary payment method, Cloudflare automatically retries using their backup payment method. Supports all combinations of cards and PayPal. The feature requires exactly 2 PMs on file and an explicit opt-in.

## Related
- SHIP-14763
- Internal wiki: [Backup PM Auto-Retry - Rollout](https://wiki.cfdata.org/pages/viewpage.action?pageId=1387682146)
- PRD: [Backup Payment Method Auto-Retry](https://wiki.cfdata.org/pages/viewpage.action?pageId=1374959721)


## Implementation MRs
- cfps !2251 — Email template
- subscriptions-api !9745 — Core retry logic
- subscriptions-api !9724 — PayPal + 3DS safety
- stratus !35745 — Frontend toggle
