### PR TITLE
[SSL] Fix outdated DigiCert links on origin CA page

### DIFF
--- a/src/content/docs/ssl/origin-configuration/origin-ca/index.mdx
+++ b/src/content/docs/ssl/origin-configuration/origin-ca/index.mdx
@@ -78,12 +78,12 @@ To add an Origin CA certificate to your origin web server
 
 - [Apache httpd](https://www.digicert.com/kb/csr-ssl-installation/apache-openssl.htm)
 - [GoDaddy Hosting](https://www.digitalcandy.agency/website-tips/cloudflare-origin-ca-free-ssl-installation-on-godaddy/)
-- [Microsoft IIS 7](https://www.digicert.com/csr-ssl-installation/iis-7.htm#ssl_certificate_install)
-- [Microsoft IIS 8 and 8.5](https://www.digicert.com/csr-ssl-installation/iis-8-and-8.5.htm#ssl_certificate_install)
+- [Microsoft IIS 7](https://knowledge.digicert.com/tutorials/iis7-create-csr-install-ssl-certificate)
+- [Microsoft IIS 8 and 8.5](https://knowledge.digicert.com/tutorials/iis-8-create-csr-install-ssl-certificate)
 - [Microsoft IIS 10](https://www.digicert.com/kb/csr-creation-ssl-installation-iis-10.htm)
 - [NGINX](https://www.digicert.com/kb/csr-ssl-installation/nginx-openssl.htm)
-- [Apache Tomcat](https://www.digicert.com/csr-ssl-installation/tomcat-keytool.htm#ssl_certificate_install)
-- [Amazon Web Services](https://www.digicert.com/ssl-certficate-installation-amazon-web-services.htm)
+- [Apache Tomcat](https://knowledge.digicert.com/tutorials/tomcat-install-your-ssl-certificate-on-a-tomcat-server)
+- [Amazon Web Services](https://knowledge.digicert.com/tutorials/amazon-aws-create-csr-install-ssl-certificate)
 - [Apache cPanel](https://www.digicert.com/kb/ssl-certificate-installation-apache-cpanel.htm)
 - [Ubuntu Server with Apache2](https://www.digicert.com/kb/csr-ssl-installation/ubuntu-server-with-apache2-openssl.htm#ssl_certificate_install)
 


### PR DESCRIPTION
Update four broken DigiCert external links to their new knowledge.digicert.com/tutorials URLs:
- Microsoft IIS 7
- Microsoft IIS 8 and 8.5
- Apache Tomcat
- Amazon Web Services

Closes #29769 