### PR TITLE
[Support] Update supported languages to reflect English-only support policy

### DIFF
--- a/src/content/docs/support/contacting-cloudflare-support.mdx
+++ b/src/content/docs/support/contacting-cloudflare-support.mdx
@@ -289,14 +289,9 @@ Below are definitions of the priority levels Cloudflare assigns to cases and the
 
 ## Supported languages
 
-For Enterprise support, Cloudflare provides support in English, but makes a best effort to offer help in the following languages:
+Cloudflare provides technical support in English to ensure accuracy during troubleshooting. All support cases, live chats, and phone interactions are conducted in English.
 
-- Chinese
-- French
-- German
-- Japanese
-- Portuguese
-- Spanish
+If you need help composing your request in English, browser-based translation tools such as Google Translate can assist with drafting your message.
 
 ## Supported regions
 


### PR DESCRIPTION
## Summary

- Updates the "Supported languages" section on the [Contacting Cloudflare Support](https://developers.cloudflare.com/support/contacting-cloudflare-support/#supported-languages) page to reflect that Cloudflare now provides technical support in English only.
- Removes the previous list of best-effort supported languages (Chinese, French, German, Japanese, Portuguese, Spanish) since the internal translation tool has been deprecated.
- Adds guidance for customers to use browser-based translation tools to compose requests in English.