### PR TITLE
Add DLP settings page for account-level DLP configuration

### DIFF
--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/logging-options.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-policies/logging-options.mdx
@@ -24,43 +24,9 @@ The data that triggers a DLP policy is stored in the body of the HTTP request �
 
 ## Set a DLP payload encryption public key
 
-Before you begin logging DLP payloads, you will need to set a DLP payload encryption public key. DLP uses public-key encryption so that matched sensitive data is readable only by you — Cloudflare does not have access to your private key and cannot decrypt your logs.
+Before you begin logging DLP payloads, you will need to [set a DLP payload encryption public key](/cloudflare-one/data-loss-prevention/dlp-settings/#payload-encryption-key). DLP uses public-key encryption so that matched sensitive data is readable only by you — Cloudflare does not have access to your private key and cannot decrypt your logs.
 
-### Generate a key pair
-
-You will generate two keys: a public key (uploaded to Cloudflare to encrypt log data) and a private key (kept by you to decrypt log data later).
-
-To generate a public/private key pair in the command line, refer to [Generate a key pair](/waf/managed-rules/payload-logging/command-line/generate-key-pair/).
-
-### Upload the public key to Cloudflare
-
-1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to  **Zero Trust** > **Data loss prevention** > **DLP settings**.
-2. In the **Set a DLP payload and prompt encryption public key** field, select **Edit**.
-3. Paste your public key.
-4. Select **Save**.
-
-:::note
-The matching private key is required to view logs. If you lose your private key, you will need to [generate](#generate-a-key-pair) and [upload](#upload-the-public-key-to-cloudflare) a new public key. The payload of new requests will be encrypted with the new public key. Previously logged data encrypted with the old key will be permanently unreadable.
-:::
-
-## Configure payload log masking
-
-You can control how sensitive data appears in your DLP payload logs by selecting a masking level. This determines how much of the matched content is visible after decryption.
-
-1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to  **Zero Trust** >  **Data loss prevention** > **DLP settings**.
-2. Go to the **Payload log masking** card.
-3. Choose one of the following masking levels:
-   - **Full Mask (default):** Masks the match while preserving character count and visual formatting. For example, a Social Security Number appears as `***-**-****`.
-   - **Partial Mask:** Reveals 25% of the matched content while masking the remainder. For example, `***-**-6789`.
-   - **Clear Text:** Stores the full, unmasked match for detailed investigation. For example, `123-45-6789`.
-
-:::note
-The masking level is applied at detection time, before the payload is encrypted. Your team will see the selected format when they decrypt the log with your private key.
-:::
-
-:::caution
-The selected masking level applies to all sensitive data matches found within a payload window — not just the match that triggered the policy.
-:::
+You can also [configure payload log masking](/cloudflare-one/data-loss-prevention/dlp-settings/#payload-log-masking) to control how DLP redacts sensitive data in logs.
 
 ## Log the payload of matched rules
 

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
@@ -31,11 +31,21 @@ Match count sets a minimum threshold for detections. DLP does not trigger an act
 
 ### Optical Character Recognition (OCR)
 
+:::note[Deprecation notice]
+Profile-level OCR settings will be deprecated in a future release. We recommend configuring OCR in [DLP settings](/cloudflare-one/data-loss-prevention/dlp-settings/#optical-character-recognition-ocr) instead.
+:::
+
 Optical Character Recognition (OCR) analyzes and interprets text within image files. When used with DLP profiles, OCR can detect sensitive data within images your users upload.
 
 OCR supports scanning `.jpg`/`.jpeg` and `.png` files between 4 KB and 1 MB in size. Text is encoded in UTF-8 format, including support for non-Latin characters.
 
+For more information, refer to [DLP settings](/cloudflare-one/data-loss-prevention/dlp-settings/#optical-character-recognition-ocr).
+
 ### AI context analysis {/* ai-context-analysis */}
+
+:::note[Deprecation notice]
+Profile-level AI context analysis settings will be deprecated in a future release. We recommend configuring AI context analysis in [DLP settings](/cloudflare-one/data-loss-prevention/dlp-settings/#ai-context-analysis) instead.
+:::
 
 :::note
 AI context analysis only supports Gateway HTTP and HTTPS traffic.
@@ -43,15 +53,7 @@ AI context analysis only supports Gateway HTTP and HTTPS traffic.
 
 AI context analysis uses a pretrained model to analyze surrounding context and adjust the confidence level of a detection. For example, a number that matches a credit card pattern may receive a lower confidence score if it appears in a context where credit card numbers are unlikely. DLP will log any matches that are above your confidence threshold.
 
-DLP redacts any matched text, then converts the surrounding context into a vector embedding and submits it to [Cloudflare Workers AI](/workers-ai/). Vector embeddings (not raw text) are stored in user-specific private namespaces for up to six months, along with hit count and the [false positive/negative report](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#report-false-and-true-positives-to-ai-context-analysis).
-
-To use AI context analysis:
-
-1. Choose the **Confidence threshold** in a DLP profile.
-2. [Add the profile](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy) to a DLP policy.
-3. When configuring the DLP policy, turn on [payload logging](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#log-the-payload-of-matched-rules).
-
-AI context analysis results will appear in the payload section of your [DLP logs](/cloudflare-one/data-loss-prevention/dlp-policies/#4-view-dlp-logs). To improve future detections of sensitive data, you need to [report false and true positives](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#report-false-and-true-positives-to-ai-context-analysis).
+For full documentation on AI context analysis, refer to [DLP settings](/cloudflare-one/data-loss-prevention/dlp-settings/#ai-context-analysis).
 
 ### Confidence thresholds
 

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-settings.mdx
@@ -3,8 +3,6 @@ pcx_content_type: how-to
 title: DLP settings
 sidebar:
   order: 5
-tags:
-  - Configuration
 ---
 
 DLP settings allow you to configure account-level settings that apply across all DLP profiles and policies. These settings are located in **Zero Trust** > **Data loss prevention** > **DLP settings** in the [Cloudflare dashboard](https://dash.cloudflare.com/).

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-settings.mdx
@@ -1,0 +1,97 @@
+---
+pcx_content_type: how-to
+title: DLP settings
+sidebar:
+  order: 5
+tags:
+  - Configuration
+---
+
+import { Badge } from "~/components";
+
+DLP settings allow you to configure account-level settings that apply across all DLP profiles and policies. These settings are located in **Data loss prevention** > **DLP settings** in [Cloudflare One](https://one.dash.cloudflare.com/).
+
+## Optical Character Recognition (OCR)
+
+Optical Character Recognition (OCR) analyzes and interprets text within image files. When turned on, OCR can detect sensitive data within images your users upload.
+
+OCR supports scanning `.jpg`/`.jpeg` and `.png` files between 4 KB and 1 MB in size. Text is encoded in UTF-8 format, including support for non-Latin characters.
+
+To turn on OCR:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Data loss prevention** > **DLP settings**.
+2. Turn on **Optical Character Recognition (OCR)**.
+
+## AI context analysis <Badge text="Beta" variant="caution" size="small" />
+
+:::note
+AI context analysis only supports Gateway HTTP and HTTPS traffic.
+:::
+
+AI context analysis uses a pretrained model to analyze surrounding context and adjust the confidence level of a detection. For example, a number that matches a credit card pattern may receive a lower confidence score if it appears in a context where credit card numbers are unlikely. DLP will log any matches that are above your confidence threshold.
+
+DLP redacts any matched text, then converts the surrounding context into a vector embedding and submits it to [Cloudflare Workers AI](/workers-ai/). Vector embeddings (not raw text) are stored in user-specific private namespaces for up to six months, along with hit count and the [false positive/negative report](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#report-false-and-true-positives-to-ai-context-analysis).
+
+To turn on AI context analysis:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Data loss prevention** > **DLP settings**.
+2. Turn on **AI context analysis**.
+3. [Add the profile](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy) to a DLP policy.
+4. When configuring the DLP policy, turn on [payload logging](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#log-the-payload-of-matched-rules).
+
+AI context analysis results will appear in the payload section of your [DLP logs](/cloudflare-one/data-loss-prevention/dlp-policies/#4-view-dlp-logs). To improve future detections of sensitive data, you need to [report false and true positives](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#report-false-and-true-positives-to-ai-context-analysis).
+
+## Payload encryption key
+
+Before you begin logging DLP payloads, you will need to set a DLP payload encryption public key. DLP uses public-key encryption so that matched sensitive data is readable only by you — Cloudflare does not have access to your private key and cannot decrypt your logs.
+
+### Generate a key pair
+
+You will generate two keys: a public key (uploaded to Cloudflare to encrypt log data) and a private key (kept by you to decrypt log data later).
+
+To generate a public/private key pair in the command line, refer to [Generate a key pair](/waf/managed-rules/payload-logging/command-line/generate-key-pair/).
+
+### Upload the public key to Cloudflare
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Data loss prevention** > **DLP settings**.
+2. In the **DLP Payload Encryption public key** field, paste your public key.
+3. Select **Save**.
+
+:::note
+The matching private key is required to view logs. If you lose your private key, you will need to [generate](#generate-a-key-pair) and [upload](#upload-the-public-key-to-cloudflare) a new public key. The payload of new requests will be encrypted with the new public key. Previously logged data encrypted with the old key will be permanently unreadable.
+:::
+
+## Payload log masking
+
+You can control how sensitive data appears in your DLP payload logs by selecting a masking level. This determines how much of the matched content is visible after decryption.
+
+To configure payload log masking:
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Data loss prevention** > **DLP settings**.
+2. Go to the **Payload log masking** card.
+3. Choose one of the following masking levels:
+   - **Full Mask (default):** Masks the match while preserving character count and visual formatting. For example, a Social Security Number appears as `***-**-****`.
+   - **Partial Mask:** Reveals 25% of the matched content while masking the remainder. For example, `***-**-6789`.
+   - **Clear Text:** Stores the full, unmasked match for detailed investigation. For example, `123-45-6789`.
+
+:::note
+The masking level is applied at detection time, before the payload is encrypted. Your team will see the selected format when they decrypt the log with your private key.
+:::
+
+:::caution
+The selected masking level applies to all sensitive data matches found within a payload window — not just the match that triggered the policy.
+:::
+
+## Migrate from profile-level settings
+
+OCR and AI context analysis are available at both the profile level (**Data loss prevention** > **Profiles**) and the account level (**Data loss prevention** > **DLP settings**) during the migration period. When both are configured, DLP uses OR logic for evaluation. A match occurs if either the profile-level or account-level setting would trigger a detection.
+
+Profile-level OCR and AI context analysis settings will be deprecated in a future release. We recommend migrating to account-level settings in **DLP settings** to ensure consistent behavior across all profiles.
+
+To migrate:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Data loss prevention** > **DLP settings**.
+2. Turn on **Optical Character Recognition (OCR)** and/or **AI context analysis** as needed.
+3. Go to **Data loss prevention** > **Profiles**.
+4. For each profile with OCR or AI context analysis enabled, edit the profile and turn off the profile-level settings.
+5. Select **Save profile**.

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-settings.mdx
@@ -9,7 +9,7 @@ tags:
 
 import { Badge } from "~/components";
 
-DLP settings allow you to configure account-level settings that apply across all DLP profiles and policies. These settings are located in **Data loss prevention** > **DLP settings** in [Cloudflare One](https://one.dash.cloudflare.com/).
+DLP settings allow you to configure account-level settings that apply across all DLP profiles and policies. These settings are located in **Zero Trust** > **Data loss prevention** > **DLP settings** in the [Cloudflare dashboard](https://dash.cloudflare.com/).
 
 ## Optical Character Recognition (OCR)
 
@@ -19,7 +19,7 @@ OCR supports scanning `.jpg`/`.jpeg` and `.png` files between 4 KB and 1 MB in s
 
 To turn on OCR:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Data loss prevention** > **DLP settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Data loss prevention** > **DLP settings**.
 2. Turn on **Optical Character Recognition (OCR)**.
 
 ## AI context analysis <Badge text="Beta" variant="caution" size="small" />
@@ -34,7 +34,7 @@ DLP redacts any matched text, then converts the surrounding context into a vecto
 
 To turn on AI context analysis:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Data loss prevention** > **DLP settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Data loss prevention** > **DLP settings**.
 2. Turn on **AI context analysis**.
 3. [Add the profile](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy) to a DLP policy.
 4. When configuring the DLP policy, turn on [payload logging](/cloudflare-one/data-loss-prevention/dlp-policies/logging-options/#log-the-payload-of-matched-rules).
@@ -53,7 +53,7 @@ To generate a public/private key pair in the command line, refer to [Generate a 
 
 ### Upload the public key to Cloudflare
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Data loss prevention** > **DLP settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Data loss prevention** > **DLP settings**.
 2. In the **DLP Payload Encryption public key** field, paste your public key.
 3. Select **Save**.
 
@@ -90,8 +90,8 @@ Profile-level OCR and AI context analysis settings will be deprecated in a futur
 
 To migrate:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Data loss prevention** > **DLP settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Data loss prevention** > **DLP settings**.
 2. Turn on **Optical Character Recognition (OCR)** and/or **AI context analysis** as needed.
-3. Go to **Data loss prevention** > **Profiles**.
+3. Go to **Zero Trust** > **Data loss prevention** > **Profiles**.
 4. For each profile with OCR or AI context analysis enabled, edit the profile and turn off the profile-level settings.
 5. Select **Save profile**.

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-settings.mdx
@@ -7,8 +7,6 @@ tags:
   - Configuration
 ---
 
-import { Badge } from "~/components";
-
 DLP settings allow you to configure account-level settings that apply across all DLP profiles and policies. These settings are located in **Zero Trust** > **Data loss prevention** > **DLP settings** in the [Cloudflare dashboard](https://dash.cloudflare.com/).
 
 ## Optical Character Recognition (OCR)
@@ -22,7 +20,7 @@ To turn on OCR:
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Data loss prevention** > **DLP settings**.
 2. Turn on **Optical Character Recognition (OCR)**.
 
-## AI context analysis <Badge text="Beta" variant="caution" size="small" />
+## AI context analysis
 
 :::note
 AI context analysis only supports Gateway HTTP and HTTPS traffic.

--- a/src/content/docs/cloudflare-one/data-loss-prevention/troubleshoot-dlp.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/troubleshoot-dlp.mdx
@@ -5,7 +5,7 @@ description: Troubleshoot Troubleshoot DLP issues in Cloudflare One.
 products:
   - cloudflare-one
 sidebar:
-  order: 5
+  order: 6
 tags:
   - Debugging
 ---
@@ -59,7 +59,7 @@ You can also create policies that match trusted applications using the [**Do Not
 
 If DLP detects sensitive data in plain text but not within images or certain applications, check for the following issues:
 
-- **OCR is turned on**: For DLP to scan text within images (such as a picture of a credit card), you must turn on [Optical Character Recognition (OCR)](/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings/#optical-character-recognition-ocr) in the corresponding DLP profile.
+- **OCR is turned on**: For DLP to scan text within images (such as a picture of a credit card), you must turn on [Optical Character Recognition (OCR)](/cloudflare-one/data-loss-prevention/dlp-settings/#optical-character-recognition-ocr) in DLP settings.
 - **Application-specific behavior**: Some applications, such as WhatsApp Web, use protocols or encryption methods (such as WebSocket connections) that Gateway may not be able to fully inspect with HTTP policies.
 - **Supported file types**: Content must be in a [supported file type](/cloudflare-one/data-loss-prevention/#supported-file-types) for DLP inspection.
 


### PR DESCRIPTION
## Summary
- Create new `dlp-settings.mdx` page documenting account-level DLP settings: OCR, AI context analysis, payload encryption key, and payload log masking
- Update `logging-options.mdx` to link to new DLP settings page for encryption key and masking configuration  
- Update `advanced-settings.mdx` with deprecation notices for profile-level OCR and AI context analysis settings, linking to new DLP settings page
- Update `troubleshoot-dlp.mdx` sidebar order from 5 to 6 and update OCR link to point to new DLP settings page
- Add migration guidance for moving from profile-level to account-level settings

## Related
- Follows changelog PR #29922 (account-level DLP settings)
- Follows changelog PR #29932 (configurable payload log masking)