### PR TITLE
[Cloudflare One] ELI5 clarity pass on DEX root pages

### DIFF
--- a/src/content/docs/cloudflare-one/insights/dex/dex-mcp-server.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/dex-mcp-server.mdx
@@ -9,7 +9,7 @@ sidebar:
 
 The MCP server [(Model Context Protocol)](https://cloudflare.com/learning/ai/what-is-model-context-protocol-mcp/) for Digital Experience Monitoring (DEX) is an AI tool that allows customers to ask a question like, "Show me the connectivity and performance metrics for the device used by carly&#8204;@acme.com", and receive an answer that contains data from the DEX API.
 
-Any Cloudflare One customer using a Free, Pay-as-you-go, or Enterprise account can access the DEX MCP Server. This feature is available to everyone.
+Any Cloudflare One customer using a Free, Pay-as-you-go, or Enterprise account can access the DEX MCP server.
 
 There are two primary options for connecting to the DEX MCP server:
 
@@ -18,7 +18,7 @@ There are two primary options for connecting to the DEX MCP server:
 
 ## Cloudflare AI Playground
 
-Cloudflare's AI Playground is a great way to quickly try out a new MCP Server.
+Cloudflare's AI Playground allows you to quickly try out the DEX MCP server.
 
 You can test the DEX MCP server in less than one minute by visiting the AI Playground's website.
 
@@ -34,7 +34,7 @@ You need to ask specific and explicit questions to get a response. For example, 
 
 ## AI Assistant
 
-Customers will get a more flexible and robust prompt experience by configuring the DEX MCP server with their preferred AI assistant (for example, Claude, Gemini, or ChatGPT).
+You can get a more flexible and robust experience by configuring the DEX MCP server with your preferred AI assistant (for example, Claude, Gemini, or ChatGPT).
 
 If you have any issues during the configuration process, you can ask your AI assistant for help with configuring an MCP server via URL.
 

--- a/src/content/docs/cloudflare-one/insights/dex/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/index.mdx
@@ -9,7 +9,7 @@ import { DirectoryListing, Render } from "~/components";
 
 <Render file="dex/intro" product="cloudflare-one" />
 
-DEX is compatible with Cloudflare's [Customer Metadata Boundary](/data-localization/metadata-boundary/) for the 'EU' (European Union) which ensures that customer log will not leave the 'EU' region.
+DEX is compatible with Cloudflare's [Customer Metadata Boundary](/data-localization/metadata-boundary/) (CMB) for the EU (European Union). When CMB is configured for the EU, customer logs are stored exclusively in the EU region.
 
 <Render file="analytics/observability-tools-note" product="cloudflare-one" />
 
@@ -18,7 +18,7 @@ DEX is compatible with Cloudflare's [Customer Metadata Boundary](/data-localizat
 If a user notifies that “the connection is not working” or “performance is slow,” DEX allows you to:
 
 - Use [device monitoring](/cloudflare-one/insights/dex/monitoring/) to check device health and endpoint connectivity.
-- Test network health and application responsiveness with [synthetic tests](/cloudflare-one/insights/dex/tests/).
+- Test network health and application responsiveness with [synthetic tests](/cloudflare-one/insights/dex/tests/) — automated connectivity checks that run periodically from user devices.
 - Identify whether problems originate from the device (such as [issues with the Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/troubleshooting-guide/)), the network, or Cloudflare.
 
 ## Troubleshooting other Cloudflare One features

--- a/src/content/docs/cloudflare-one/insights/dex/ip-visibility.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/ip-visibility.mdx
@@ -40,13 +40,13 @@ The ISP IP is only visible to users with the [Zero Trust PII role](/cloudflare-o
 
 DEX's IP visibility supports both IPv6 and IPv4 addresses.
 
-IP information is crucial for IT administrators to accurately troubleshoot network issues and identify user locations. IT administrators face challenges like:
+IP information helps IT administrators troubleshoot network issues and identify device locations. Common uses include:
 
-- Pinpointing the exact location of a user experiencing issues ("AP 87 is bad.")
-- Identifying network access control policy violations ("NAC Policies is not applied properly.")
-- Troubleshooting firewall restrictions ("Firewall on VLAN 93 is blocking.")
-- Resolving Layer 2 and DHCP related problems.
-- Indirectly determining user identity and device location.
+- Identifying which access point or network segment a user is connected to
+- Verifying that network access control (NAC) policies are applied correctly
+- Diagnosing firewall restrictions on specific VLANs (virtual local area networks)
+- Troubleshooting Layer 2 (data link layer) and DHCP (Dynamic Host Configuration Protocol) issues
+- Indirectly determining user identity and device location
 
 ## View a device's IP information
 
@@ -73,4 +73,4 @@ To find which Cloudflare data center a device is connected to:
 
 1. Follow the steps listed in [View IP information](#view-a-devices-ip-history) to find a device's IP information.
 2. On the device page, select **Colocation & client** or find the **Client** table at the top of the page.
-3. In the **Client** table, find **Colocation** to review which Cloudflare data center your selected device's egress traffic is connected to.
+3. In the **Client** table, find **Colocation** to review which Cloudflare data center your selected device's outbound (egress) traffic is routed through.

--- a/src/content/docs/cloudflare-one/insights/dex/monitoring.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/monitoring.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Render } from "~/components";
 
-Monitor performance and network status for your organization's [fleet](/cloudflare-one/insights/dex/monitoring/#fleet-status) or individual [user devices](/cloudflare-one/insights/dex/monitoring/#device-monitoring).
+Monitor performance and network status for your organization's [fleet](/cloudflare-one/insights/dex/monitoring/#fleet-status) (all devices with the Cloudflare One Client installed and connected to your Zero Trust organization) or individual [user devices](/cloudflare-one/insights/dex/monitoring/#device-monitoring).
 
 Network and device performance data helps IT administrators troubleshoot performance issues, investigate network connectivity problems, and monitor device health.
 
@@ -34,10 +34,10 @@ To view analytics on a per-device level, go to [Device monitoring](/cloudflare-o
 
   | Status       | Description                                                                                                                                                                                                                                                                                                                                                                               |
   | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | Connected    | the Cloudflare One Client has successfully established a connection to the Cloudflare global network.                                                                                                                                                                                                                                                                                                          |
-  | Disconnected | the Cloudflare One Client has been intentionally or unintentionally disconnected from the Cloudflare global network.                                                                                                                                                                                                                                                                                           |
+  | Connected    | The Cloudflare One Client has successfully established a connection to the Cloudflare global network.                                                                                                                                                                                                                                                                                                          |
+  | Disconnected | The Cloudflare One Client has been intentionally or unintentionally disconnected from the Cloudflare global network.                                                                                                                                                                                                                                                                                           |
   | Paused       | A user or administrator has taken an explicit action to temporarily turn off WARP, for example by entering an [admin override code](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#allow-admin-override-codes). Paused clients will [auto-connect](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#auto-connect) after a timeout period. |
-  | Connecting   | the Cloudflare One Client is pending connection, but is actively trying to establish a connection to the Cloudflare global network.                                                                                                                                                                                                                                                                            |
+  | Connecting   | The Cloudflare One Client is pending connection, but is actively trying to establish a connection to the Cloudflare global network.                                                                                                                                                                                                                                                                            |
 
 - **Mode**: [Client mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/) deployed on the device.
 
@@ -68,7 +68,7 @@ To view a device's network and device performance metrics:
 
 #### Network performance metrics
 
-- **Unique networks over time**: How many unique SSIDs the device was connected to.
+- **Unique networks over time**: How many unique SSIDs (Wi-Fi network names) the device was connected to.
 
 - **Network I/O**: How much data the device transferred (uploads and downloads) over the primary network interface.
 

--- a/src/content/docs/cloudflare-one/insights/dex/notifications.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/notifications.mdx
@@ -24,10 +24,10 @@ DEX notifications are configured on the [Cloudflare dashboard](https://dash.clou
 
 ### Z-score
 
-Cloudflare uses a z-score to detect traffic spikes or drops. A [z-score](https://en.wikipedia.org/wiki/Standard_score) is the number of standard deviations the current value is to the mean. We calculate the mean and standard deviation by comparing the current five minutes to the past four hours. This is measured every five minutes.
+Cloudflare uses a z-score to detect unusual traffic spikes or drops. A [z-score](https://en.wikipedia.org/wiki/Standard_score) is the number of standard deviations the current value is from the mean. Cloudflare calculates the mean and standard deviation by comparing the current five minutes to the past four hours. This is measured every five minutes.
 
-To trigger an alert, the z-score value must be above 3.5 or less than -3.5.
+To trigger an alert, the z-score value must be above 3.5 or below -3.5, which indicates the current value is significantly different from the recent baseline.
 
 ### SLO
 
-A service-level objective (SLO) is defined as (x / y) \* 100 where x = the number of good events and y = the number of valid events for a given time period. DEX notifications look at both a short window (five minutes) and a long time window (one hour) and triggers an alert if the availability falls below the SLO threshold in either window.
+A service-level objective (SLO) measures the percentage of valid events that succeeded. It is defined as (good events / valid events) \* 100, where valid events are those that could be measured in a given time period. DEX notifications evaluate both a short window (five minutes) and a long window (one hour) and trigger an alert if availability falls below the SLO threshold in either window.

--- a/src/content/docs/cloudflare-one/insights/dex/remote-captures.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/remote-captures.mdx
@@ -11,7 +11,7 @@ import { Details, Render } from "~/components";
 
 <Render file="dex/pcaps-run-availability" product="cloudflare-one" />
 
-Remote captures allow administrators to collect packet captures (PCAPs) and Cloudflare One Client diagnostic logs directly from end user devices. This data can be used to troubleshoot network problems, investigate security incidents, and identify performance bottlenecks.
+Remote captures allow administrators to collect packet captures (PCAPs) and Cloudflare One Client diagnostic logs directly from end user devices. A packet capture is a recording of network traffic at the packet level. This data can be used to troubleshoot network problems, investigate security incidents, and identify performance bottlenecks.
 
 ## Start a remote capture
 

--- a/src/content/docs/cloudflare-one/insights/dex/rules.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/rules.mdx
@@ -9,9 +9,9 @@ tags:
 
 import { Render } from "~/components";
 
-DEX rules allow you to create and manage testing policies for targeted user groups within your [fleet](/cloudflare-one/insights/dex/tests/). After creating a rule, you can use it to define the scope of a [test](/cloudflare-one/insights/dex/tests/) to specific groups such as departments (like finance or sales), devices, and/or users. You can apply and reuse rules on your desired tests.
+DEX rules allow you to create and manage testing policies for targeted user groups within your [fleet](/cloudflare-one/insights/dex/tests/) (all devices with the Cloudflare One Client installed and connected to your Zero Trust organization). After creating a rule, you can use it to define the scope of a [test](/cloudflare-one/insights/dex/tests/) to specific groups such as departments (like finance or sales), devices, and/or users. You can apply and reuse rules on your desired tests.
 
-DEX rules are ideal for admins who want to define the scope of a test to a specific group within their fleet to allow for more precise problem detection and resolution.
+Use DEX rules to scope a test to a specific group within your fleet for more precise problem detection and resolution.
 
 ## Create a rule
 
@@ -39,7 +39,7 @@ Review the available selectors and their scope in the following list.
 | **Operating system version** | For specifying an operating system version (use Operator `in`) or versions (use Operator `is`).                                   |
 | **Managed network**          | For specifying users accessing the network from the office (managed network) compared to those accessing remotely.                |
 | **SAML attributes**          | For specifying a value from the [SAML Attribute Assertion](/cloudflare-one/traffic-policies/identity-selectors/#saml-attributes). |
-| **Colos**                    | For specifying a Cloudflare data center location users are connected to.                                                          |
+| **Colos**                    | For specifying a Cloudflare data center (colocation) that users are connected to.                                                          |
 
 ## Add a rule to a test
 


### PR DESCRIPTION
### Summary

ELI5 clarity pass across 7 root-level pages in `/cloudflare-one/insights/dex/`. These edits expand undefined jargon, fix grammar, remove marketing language, and add plain-language framing for technical concepts — all verified through an adversarial fact-check review.

**Pages edited:** `index.mdx`, `monitoring.mdx`, `rules.mdx`, `remote-captures.mdx`, `notifications.mdx`, `ip-visibility.mdx`, `dex-mcp-server.mdx`

Changes by category:

- **Jargon definitions added inline:** fleet (2 pages), SSID, colocation/colo, packet capture, NAC, VLAN, DHCP, Layer 2, egress traffic, synthetic tests
- **Grammar/accuracy fixes:** CMB sentence corrected from "customer log will not leave" to "customer logs are stored exclusively in" (aligns with CMB docs on storage vs. access); fixed SLO subject-verb agreement; fixed z-score preposition ("is to the mean" → "is from the mean")
- **Marketing language removed:** "ideal for admins" → "Use DEX rules to"; "a great way to" → "allows you to"; "Customers will get" → "You can get"; removed redundant availability sentence
- **Plain-language framing added:** z-score threshold explained in non-statistical terms; SLO formula given a one-sentence lead-in defining what it measures; "valid events" distinguished from "total events"
- **Docs voice cleanup:** ip-visibility.mdx IT challenges list rewritten from pitch-style parentheticals to standard documentation bullet points; table descriptions capitalized consistently in monitoring.mdx

**Not changed (flagged for writer verification):** `rules.mdx` line 39 — the operator guidance for Operating system version (`in` for single value, `is` for multiple) appears inverted from convention. Needs dashboard testing to confirm.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).