### PR TITLE
[Artifacts] Fix hostname for artifacts.cloudflare.dev

### DIFF
--- a/src/content/changelog/artifacts/2026-04-16-artifacts-now-in-beta.mdx
+++ b/src/content/changelog/artifacts/2026-04-16-artifacts-now-in-beta.mdx
@@ -27,7 +27,7 @@ const remote = (await created.repo.info())?.remote;
 Or, use the REST API to create a repo inside a namespace from your agent(s) running on any platform:
 
 ```bash
-curl --request POST "https://artifacts.cloudflare.net/v1/api/namespaces/some-namespace/repos" --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" --header "Content-Type: application/json" --data '{"name":"agent-007"}'
+curl --request POST "https://artifacts.cloudflare.dev/v1/api/namespaces/some-namespace/repos" --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" --header "Content-Type: application/json" --data '{"name":"agent-007"}'
 ```
 
 Any Git client that speaks smart HTTP can use the returned remote URL:
@@ -35,7 +35,7 @@ Any Git client that speaks smart HTTP can use the returned remote URL:
 ```bash
 # Agents know git.
 # Every repository can act as a git repo, allowing agents to interact with Artifacts the way they know best: using the git CLI.
-git clone https://x:${REPO_TOKEN}@artifacts.cloudflare.net/some-namespace/agent-007.git
+git clone https://x:${REPO_TOKEN}@artifacts.cloudflare.dev/some-namespace/agent-007.git
 ```
 
 To learn more, refer to [Get started](/artifacts/get-started/), [Workers binding](/artifacts/api/workers-binding/), and [Git protocol](/artifacts/api/git-protocol/).

--- a/src/content/docs/artifacts/api/git-protocol.mdx
+++ b/src/content/docs/artifacts/api/git-protocol.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 Artifacts exposes Git access for every Artifacts repository.
 
-Each repo has a standard Git smart HTTP remote at `https://{accountId}.artifacts.cloudflare.net/git/{namespace}/{repo}.git`.
+Each repo has a standard Git smart HTTP remote at `https://{accountId}.artifacts.cloudflare.dev/git/{namespace}/{repo}.git`.
 
 Use the returned repo `remote` with a regular Git client for `clone`, `fetch`, `pull`, and `push`.
 
@@ -19,7 +19,7 @@ Git routes accept repo access tokens in two forms:
 | Format                             | Details                                                                                                                               | Example                                                                                                      |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Bearer token in `http.extraHeader` | Recommended for local workflows. Use the full token string returned by the control plane and keep credentials out of the remote URL. | `git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" clone "$ARTIFACTS_REMOTE" artifacts-clone` |
-| HTTP Basic auth in the remote URL  | Use for short-lived, one-off commands when you need a self-contained remote. Put the token secret in the password slot.              | `https://x:<token-secret>@<accountId>.artifacts.cloudflare.net/git/<namespace>/<repo>.git`                 |
+| HTTP Basic auth in the remote URL  | Use for short-lived, one-off commands when you need a self-contained remote. Put the token secret in the password slot.              | `https://x:<token-secret>@<accountId>.artifacts.cloudflare.dev/git/<namespace>/<repo>.git`                 |
 
 ### Token format
 

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -18,7 +18,7 @@ Use the Artifacts REST API to manage repos, remotes, forks, imports, and tokens 
 Artifacts REST routes use this base path:
 
 ```txt
-https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE
+https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE
 ```
 
 Requests to `/v1/api/...` use Bearer authentication:
@@ -27,7 +27,7 @@ Requests to `/v1/api/...` use Bearer authentication:
 Authorization: Bearer <CLOUDFLARE_API_TOKEN>
 ```
 
-All routes below are relative to the base URL your deployment exposes. The examples use `https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE`.
+All routes below are relative to the base URL your deployment exposes. The examples use `https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE`.
 
 Cloudflare API tokens authenticate REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
 
@@ -37,7 +37,7 @@ The following examples assume:
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 All responses use the standard Cloudflare v4 envelope.
@@ -174,7 +174,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos" \
 		"name": "starter-repo",
 		"description": "Repository for automation experiments",
 		"default_branch": "main",
-		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
+		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo.git",
 		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
 		"expires_at": "<ISO_TIMESTAMP>"
 	},
@@ -268,7 +268,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
 		"last_push_at": "<ISO_TIMESTAMP>",
 		"source": null,
 		"read_only": false,
-		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git"
+		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo.git"
 	},
 	"success": true,
 	"errors": [],
@@ -355,7 +355,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/fork" \
 		"name": "starter-repo-copy",
 		"description": "Repository for automation experiments",
 		"default_branch": "main",
-		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo-copy.git",
+		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo-copy.git",
 		"token": "art_v1_89abcdef0123456789abcdef0123456789abcdef?expires=1760003600",
 		"expires_at": "<ISO_TIMESTAMP>",
 		"objects": 128
@@ -410,7 +410,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos/react-mirror/import" \
 		"name": "react-mirror",
 		"description": null,
 		"default_branch": "main",
-		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/react-mirror.git",
+		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/react-mirror.git",
 		"token": "art_v1_fedcba9876543210fedcba9876543210fedcba98?expires=1760007200",
 		"expires_at": "<ISO_TIMESTAMP>"
 	},

--- a/src/content/docs/artifacts/examples/git-client.mdx
+++ b/src/content/docs/artifacts/examples/git-client.mdx
@@ -20,7 +20,7 @@ The example below uses `jq` to extract fields from the JSON responses.
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 
 REPO_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")

--- a/src/content/docs/artifacts/get-started/rest-api.mdx
+++ b/src/content/docs/artifacts/get-started/rest-api.mdx
@@ -35,7 +35,7 @@ Set the variables used in the examples:
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 Use a unique repo name each time you run this guide.
@@ -69,7 +69,7 @@ The response resembles the following:
 		"name": "starter-repo",
 		"description": null,
 		"default_branch": "main",
-		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
+		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo.git",
 		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
 		"expires_at": "<ISO_TIMESTAMP>"
 	},
@@ -128,7 +128,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
 		"last_push_at": null,
 		"source": null,
 		"read_only": false,
-		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git"
+		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo.git"
 	},
 	"success": true,
 	"errors": [],

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -171,7 +171,7 @@ The response resembles the following:
 ```json
 {
 	"name": "starter-repo",
-	"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
+	"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo.git",
 	"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
 	"expiresAt": "<ISO_TIMESTAMP>"
 }

--- a/src/content/docs/artifacts/guides/artifact-fs.mdx
+++ b/src/content/docs/artifacts/guides/artifact-fs.mdx
@@ -37,7 +37,7 @@ This example assumes you already have a working FUSE implementation on the host 
 ```bash
 go install github.com/cloudflare/artifact-fs/cmd/artifact-fs@latest
 
-export ARTIFACTS_REMOTE="https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git"
+export ARTIFACTS_REMOTE="https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo.git"
 export ARTIFACTS_TOKEN="<YOUR_READ_TOKEN>"
 export ARTIFACTS_TOKEN_SECRET="${ARTIFACTS_TOKEN%%\?expires=*}"
 export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN_SECRET}@${ARTIFACTS_REMOTE#https://}"

--- a/src/content/docs/artifacts/guides/authentication.mdx
+++ b/src/content/docs/artifacts/guides/authentication.mdx
@@ -57,7 +57,7 @@ The REST API uses a Cloudflare API token in the `Authorization` header. Use **Ar
 ```sh
 export ARTIFACTS_NAMESPACE="default"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 Read repo metadata with a read-capable token:
@@ -90,13 +90,13 @@ Git uses repo-scoped Artifacts tokens, not Cloudflare API tokens. Mint these tok
 Use a read token to clone:
 
 ```sh
-git -c http.extraHeader="Authorization: Bearer <YOUR_READ_TOKEN>" clone "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git" artifacts-clone
+git -c http.extraHeader="Authorization: Bearer <YOUR_READ_TOKEN>" clone "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo.git" artifacts-clone
 ```
 
 Use a write token to push:
 
 ```sh
-git -c http.extraHeader="Authorization: Bearer <YOUR_WRITE_TOKEN>" push "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git" HEAD:main
+git -c http.extraHeader="Authorization: Bearer <YOUR_WRITE_TOKEN>" push "https://<ACCOUNT_ID>.artifacts.cloudflare.dev/git/default/starter-repo.git" HEAD:main
 ```
 
 For more information on token handling and authenticated remotes, refer to [Git protocol](/artifacts/api/git-protocol/).

--- a/src/content/docs/artifacts/guides/import-repositories.mdx
+++ b/src/content/docs/artifacts/guides/import-repositories.mdx
@@ -26,7 +26,7 @@ Use a [Cloudflare API token](/fundamentals/api/get-started/create-token/) with *
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="workers-sdk-baseline"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 ```bash


### PR DESCRIPTION
### Summary

`artifacts.cloudflare.net` does not resolve, the correct hostname appears to be `artifacts.cloudflare.dev`.

### Screenshots (optional)

N/A

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/29973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
