### PR TITLE
[AI Crawl Control] Add Redirects for AI Training docs and dashboard updates

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -744,6 +744,7 @@
 /fundamentals/setup/allow-cloudflare-ip-addresses/ /fundamentals/concepts/cloudflare-ip-addresses/ 301
 /fundamentals/basic-tasks/login/ /fundamentals/user-profiles/login/ 301
 /fundamentals/concepts/redirects/ /fundamentals/reference/redirects/ 301
+/fundamentals/reference/redirects-for-ai-training/ /ai-crawl-control/reference/redirects-for-ai-training/ 301
 /fundamentals/reference/changelog/ /fundamentals/reference/ 302
 /fundamentals/basic-tasks/optimize-speed-external-link/ /fundamentals/performance/optimize-speed-external-link/ 301
 /fundamentals/basic-tasks/prevent-ddos-attacks-external/ /fundamentals/security/prevent-ddos-attacks-external/ 301

--- a/src/content/changelog/ai-crawl-control/2026-03-24-waf-rule-preservation.mdx
+++ b/src/content/changelog/ai-crawl-control/2026-03-24-waf-rule-preservation.mdx
@@ -1,0 +1,11 @@
+---
+title: Advanced WAF customization for AI Crawl Control blocks
+description: You can now extend the AI Crawl Control WAF rule with custom user agents, path-based exceptions, and additional expression clauses without affecting your AI Crawl Control settings.
+date: 2026-03-24
+---
+
+AI Crawl Control now supports extending the underlying WAF rule with custom modifications. Any changes you make directly in the WAF custom rules editor — such as adding path-based exceptions, extra user agents, or additional expression clauses — are preserved when you update crawler actions in AI Crawl Control.
+
+If the WAF rule expression has been modified in a way AI Crawl Control cannot parse, a warning banner appears on the **Crawlers** page with a link to view the rule directly in WAF.
+
+For more information, refer to [WAF rule management](/ai-crawl-control/features/manage-ai-crawlers/#waf-rule-management).

--- a/src/content/changelog/ai-crawl-control/2026-04-17-redirects-for-ai-training.mdx
+++ b/src/content/changelog/ai-crawl-control/2026-04-17-redirects-for-ai-training.mdx
@@ -1,0 +1,11 @@
+---
+title: Introducing Redirects for AI Training
+description: Direct AI training crawlers to canonical URLs to ensure models train on authoritative content.
+date: 2026-04-17
+---
+
+Cloudflare's network now supports redirecting verified AI training crawlers to canonical URLs when they request deprecated or duplicate pages. When enabled via **AI Crawl Control** > **Quick Actions**, AI training crawlers that request a page with a canonical tag pointing elsewhere receive a 301 redirect to the canonical version. Humans, search engine crawlers, and AI Search agents continue to see the original page normally.
+
+This feature leverages your existing `<link rel="canonical">` tags—no additional configuration required beyond enabling the toggle. Available on Pro, Business, and Enterprise plans at no additional cost.
+
+Refer to the [Redirects for AI Training documentation](/ai-crawl-control/reference/redirects-for-ai-training/) for details.

--- a/src/content/changelog/ai-crawl-control/2026-04-17-tools-for-agentic-internet.mdx
+++ b/src/content/changelog/ai-crawl-control/2026-04-17-tools-for-agentic-internet.mdx
@@ -1,0 +1,17 @@
+---
+title: Tools to prepare your site for the agentic Internet
+description: New dashboard features to help you understand and optimize how AI agents interact with your content.
+date: 2026-04-17
+---
+
+AI Crawl Control now includes new tools to help you prepare your site for the agentic Internet—a web where AI agents are first-class citizens that discover and interact with content differently than human visitors.
+
+## Content Format insights
+
+The **Metrics** tab now includes a **Content Format** chart showing what content types AI systems request versus what your origin serves. Understanding these patterns helps you optimize content delivery for both human and agent consumption.
+
+## Directives tab (formerly Robots.txt)
+
+The **Robots.txt** tab has been renamed to **Directives** and now includes a link to check your site's [Agent Readiness](https://isitagentready.org) score.
+
+Refer to our [blog post on preparing for the agentic Internet](https://blog.cloudflare.com/welcome-to-agents-week/) for more on why these capabilities matter.

--- a/src/content/docs/ai-crawl-control/configuration/ai-crawl-control-with-waf.mdx
+++ b/src/content/docs/ai-crawl-control/configuration/ai-crawl-control-with-waf.mdx
@@ -120,9 +120,9 @@ The AI Crawl Control rule is named **AI Crawl Control** and can be found under *
 
 Common additions include:
 
-- **Path-based exceptions** — allow a blocked crawler to access specific sections of your site by adding an `AND` clause that excludes certain paths
-- **Extra user agents or detection IDs** — match crawlers that are not listed in AI Crawl Control
-- **Additional expression clauses** — restrict blocking to specific hostnames or other request properties
+- Path-based exceptions, such as allowing a blocked crawler to access specific sections of your site by adding an `AND` clause that excludes certain paths
+- Extra user agents or detection IDs for crawlers not listed in AI Crawl Control
+- Additional expression clauses to restrict blocking to specific hostnames or other request properties
 
 Any additions you make are preserved when you subsequently update crawler actions in AI Crawl Control. If the expression has been modified in a way AI Crawl Control cannot parse, a warning banner will appear on the **Crawlers** page. Select **View rule in WAF** in the banner to inspect or correct the rule.
 

--- a/src/content/docs/ai-crawl-control/configuration/ai-crawl-control-with-waf.mdx
+++ b/src/content/docs/ai-crawl-control/configuration/ai-crawl-control-with-waf.mdx
@@ -112,3 +112,21 @@ In this scenario, you have two custom rules, each directing a different logic fo
 
 </TabItem> </Tabs>
 
+## Extending the AI Crawl Control WAF rule
+
+For most use cases, managing crawlers directly in AI Crawl Control is recommended. However, the underlying WAF rule supports additional customization for scenarios the dashboard does not cover.
+
+The AI Crawl Control rule is named **AI Crawl Control** and can be found under **Security** > **WAF** > **Custom rules**.
+
+Common additions include:
+
+- **Path-based exceptions** — allow a blocked crawler to access specific sections of your site by adding an `AND` clause that excludes certain paths
+- **Extra user agents or detection IDs** — match crawlers that are not listed in AI Crawl Control
+- **Additional expression clauses** — restrict blocking to specific hostnames or other request properties
+
+Any additions you make are preserved when you subsequently update crawler actions in AI Crawl Control. If the expression has been modified in a way AI Crawl Control cannot parse, a warning banner will appear on the **Crawlers** page. Select **View rule in WAF** in the banner to inspect or correct the rule.
+
+:::caution
+Changes made directly to the WAF rule are not reflected back in the AI Crawl Control dashboard. Use the **Crawlers** tab as your primary interface, and reserve direct WAF edits for cases where the dashboard does not cover your requirements.
+:::
+

--- a/src/content/docs/ai-crawl-control/features/analyze-ai-traffic.mdx
+++ b/src/content/docs/ai-crawl-control/features/analyze-ai-traffic.mdx
@@ -84,6 +84,18 @@ The **Status code distribution** chart shows HTTP response codes for AI crawler 
 
 Use this chart to identify patterns in how your site responds to AI crawlers, including the distribution of error codes and the volume of redirects.
 
+### Content Format
+
+The **Content Format** chart shows what content types AI systems request versus what your origin serves. This visibility helps you understand content negotiation patterns and optimize how your content is delivered to AI systems.
+
+The chart includes three views:
+
+| View          | Description                                                                 |
+| ------------- | --------------------------------------------------------------------------- |
+| **Comparison** | A grouped bar chart comparing requested content types versus served content types |
+| **Request Type** | Breakdown of requests by Accept header                                      |
+| **Response Type** | Breakdown of responses by Content-Type header                              |
+
 ### Top referrers
 
 :::note

--- a/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
+++ b/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
@@ -126,33 +126,9 @@ You can also create more complex rules when taking action on AI crawlers, using 
 
 ## WAF rule management
 
-When you block a crawler in AI Crawl Control, the system creates or updates a [WAF custom rule](/waf/custom-rules/) on your zone to enforce that block. For most use cases, managing crawlers directly in AI Crawl Control is recommended. However, the underlying WAF rule supports additional customization for more advanced scenarios.
+When you block a crawler in AI Crawl Control, the system creates or updates a WAF custom rule on your zone to enforce that block. For advanced scenarios — such as adding path-based exceptions or extra user agents — you can extend this rule directly in WAF.
 
-### How AI Crawl Control uses WAF
-
-AI Crawl Control maintains a single WAF custom rule per zone that covers all blocked crawlers. The rule expression matches requests based on bot detection IDs (for Bot Management customers) and user agent strings (for all plans), combined with any path exclusions you have configured on the **Settings** tab.
-
-### Extending the WAF rule
-
-For scenarios not covered by AI Crawl Control's settings, you can add your own expression clauses directly to the WAF rule. The AI Crawl Control rule is named **AI Crawl Control** and can be found under **Security** > **WAF** > **Custom rules**.
-
-Common additions include:
-
-- Path-based exceptions — for example, allowing a blocked crawler to access specific sections of your site
-- Extra user agents or detection IDs beyond those listed in AI Crawl Control
-- Additional `AND` clauses to restrict blocking to specific hostnames or request properties
-
-Any additions you make are preserved when you subsequently update crawler actions in AI Crawl Control. If the expression has been modified in a way AI Crawl Control cannot parse, a warning banner will appear on the **Crawlers** page. Select **View rule in WAF** in the banner to inspect or correct the rule.
-
-:::caution
-Editing the WAF rule directly gives you flexibility, but changes are not reflected back in the AI Crawl Control dashboard. Use the **Crawlers** tab as your primary interface, and reserve direct WAF edits for cases where the dashboard does not cover your requirements.
-:::
-
-### Precedence and rule order
-
-The AI Crawl Control WAF rule evaluates alongside all other WAF custom rules on your zone. WAF rules are evaluated in order, and the first matching rule's action applies. If you have other WAF rules that match the same crawler traffic, verify that their order and actions do not conflict with your AI Crawl Control settings.
-
-For more information on WAF rule order, refer to [Custom rules](/waf/custom-rules/).
+For more information, refer to [AI Crawl Control with Cloudflare WAF](/ai-crawl-control/configuration/ai-crawl-control-with-waf/).
 
 ## Configure block response
 
@@ -194,7 +170,7 @@ Use the dropdown menu to select the desired response code. You can choose from:
 :::note
 AI Crawl Control uses [Cloudflare WAF](/waf/) to return custom block responses. If you have manually configured the AI Crawl Control WAF rule to return a response code other than `403` or `402`, AI Crawl Control will not be able to enforce the response code you have selected, and the dropdown will appear blank. Ensure you have selected either `403` or `402`.
 
-Refer to [Configure a custom response for blocked requests](/waf/custom-rules/create-dashboard/#configure-a-custom-response-for-blocked-requests) and [WAF rule management](/ai-crawl-control/features/manage-ai-crawlers/#waf-rule-management) for more information.
+Refer to [Configure a custom response for blocked requests](/waf/custom-rules/create-dashboard/#configure-a-custom-response-for-blocked-requests) and [AI Crawl Control with Cloudflare WAF](/ai-crawl-control/configuration/ai-crawl-control-with-waf/) for more information.
 :::
 
 ### Edit the response body
@@ -206,5 +182,4 @@ In the **Response body** text field, enter the response you wish to display for 
 ## Related resources
 
 - Use [pay per crawl](/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl/) to charge AI crawlers every time they access your content.
-- Create more complex crawler rules using [WAF custom rules](/waf/custom-rules/).
-- Copy detection IDs and user agents for use in custom WAF rules from the [Crawlers tab actions menu](/ai-crawl-control/features/manage-ai-crawlers/#review-ai-crawler-activity).
+- Learn how AI Crawl Control interacts with WAF, including advanced rule customization, in [AI Crawl Control with Cloudflare WAF](/ai-crawl-control/configuration/ai-crawl-control-with-waf/).

--- a/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
+++ b/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
@@ -126,7 +126,7 @@ You can also create more complex rules when taking action on AI crawlers, using 
 
 ## WAF rule management
 
-When you block a crawler in AI Crawl Control, the system creates or updates a WAF custom rule on your zone to enforce that block. For advanced scenarios — such as adding path-based exceptions or extra user agents — you can extend this rule directly in WAF.
+When you block a crawler in AI Crawl Control, the system creates or updates a WAF custom rule on your zone to enforce that block. For advanced scenarios such as adding path-based exceptions or extra user agents, you can extend this rule directly in WAF.
 
 For more information, refer to [AI Crawl Control with Cloudflare WAF](/ai-crawl-control/configuration/ai-crawl-control-with-waf/).
 

--- a/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
+++ b/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
@@ -124,6 +124,36 @@ For more information, refer to [What is Pay Per Crawl?](/ai-crawl-control/featur
 You can also create more complex rules when taking action on AI crawlers, using [Cloudflare WAF](/waf/). For more information on creating more specific rules, refer to [Create a custom rule in the dashboard](/waf/custom-rules/create-dashboard/).
 :::
 
+## WAF rule management
+
+When you block a crawler in AI Crawl Control, the system creates or updates a [WAF custom rule](/waf/custom-rules/) on your zone to enforce that block. For most use cases, managing crawlers directly in AI Crawl Control is recommended. However, the underlying WAF rule supports additional customization for more advanced scenarios.
+
+### How AI Crawl Control uses WAF
+
+AI Crawl Control maintains a single WAF custom rule per zone that covers all blocked crawlers. The rule expression matches requests based on bot detection IDs (for Bot Management customers) and user agent strings (for all plans), combined with any path exclusions you have configured on the **Settings** tab.
+
+### Extending the WAF rule
+
+For scenarios not covered by AI Crawl Control's settings, you can add your own expression clauses directly to the WAF rule. The AI Crawl Control rule is named **AI Crawl Control** and can be found under **Security** > **WAF** > **Custom rules**.
+
+Common additions include:
+
+- Path-based exceptions — for example, allowing a blocked crawler to access specific sections of your site
+- Extra user agents or detection IDs beyond those listed in AI Crawl Control
+- Additional `AND` clauses to restrict blocking to specific hostnames or request properties
+
+Any additions you make are preserved when you subsequently update crawler actions in AI Crawl Control. If the expression has been modified in a way AI Crawl Control cannot parse, a warning banner will appear on the **Crawlers** page. Select **View rule in WAF** in the banner to inspect or correct the rule.
+
+:::caution
+Editing the WAF rule directly gives you flexibility, but changes are not reflected back in the AI Crawl Control dashboard. Use the **Crawlers** tab as your primary interface, and reserve direct WAF edits for cases where the dashboard does not cover your requirements.
+:::
+
+### Precedence and rule order
+
+The AI Crawl Control WAF rule evaluates alongside all other WAF custom rules on your zone. WAF rules are evaluated in order, and the first matching rule's action applies. If you have other WAF rules that match the same crawler traffic, verify that their order and actions do not conflict with your AI Crawl Control settings.
+
+For more information on WAF rule order, refer to [Custom rules](/waf/custom-rules/).
+
 ## Configure block response
 
 <Plan type="paid" />
@@ -162,11 +192,9 @@ Use the dropdown menu to select the desired response code. You can choose from:
 - `402 Payment Required`: Use this option if you wish to indicate that the AI crawler must pay to access your content.
 
 :::note
-Behind the scenes, AI Crawl Control uses [Cloudflare WAF](/waf/) to return custom block responses.
+AI Crawl Control uses [Cloudflare WAF](/waf/) to return custom block responses. If you have manually configured the AI Crawl Control WAF rule to return a response code other than `403` or `402`, AI Crawl Control will not be able to enforce the response code you have selected, and the dropdown will appear blank. Ensure you have selected either `403` or `402`.
 
-If you have manually configured a WAF rule to return a response code other than `403` or `402`, AI Crawl Control will not be able to enforce the response code you have selected, and the dropdown will appear blank. Ensure you have selected either `403` or `402`.
-
-Refer to [Configure a custom response for blocked requests](/waf/custom-rules/create-dashboard/#configure-a-custom-response-for-blocked-requests) for more information.
+Refer to [Configure a custom response for blocked requests](/waf/custom-rules/create-dashboard/#configure-a-custom-response-for-blocked-requests) and [WAF rule management](/ai-crawl-control/features/manage-ai-crawlers/#waf-rule-management) for more information.
 :::
 
 ### Edit the response body
@@ -178,3 +206,5 @@ In the **Response body** text field, enter the response you wish to display for 
 ## Related resources
 
 - Use [pay per crawl](/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl/) to charge AI crawlers every time they access your content.
+- Create more complex crawler rules using [WAF custom rules](/waf/custom-rules/).
+- Copy detection IDs and user agents for use in custom WAF rules from the [Crawlers tab actions menu](/ai-crawl-control/features/manage-ai-crawlers/#review-ai-crawler-activity).

--- a/src/content/docs/ai-crawl-control/features/track-robots-txt.mdx
+++ b/src/content/docs/ai-crawl-control/features/track-robots-txt.mdx
@@ -1,5 +1,5 @@
 ---
-title: Track robots.txt
+title: Directives
 pcx_content_type: concept
 sidebar:
   order: 6
@@ -7,16 +7,16 @@ sidebar:
 
 import { Steps, GlossaryTooltip, DashButton } from "~/components";
 
-The **Robots.txt** tab in AI Crawl Control provide insights into how AI crawlers interact with your <GlossaryTooltip term="robots.txt">`robots.txt`</GlossaryTooltip> files across your hostnames. You can monitor request patterns, verify file availability, and identify crawlers that violate your directives.
+The **Directives** tab in AI Crawl Control provides insights into how AI crawlers interact with your <GlossaryTooltip term="robots.txt">`robots.txt`</GlossaryTooltip> files across your hostnames. You can monitor request patterns, verify file availability, identify crawlers that violate your directives, and assess your site's readiness for AI agents.
 
-To access robots.txt insights:
+To access directives insights:
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/), and select your account and domain.
 2. Go to **AI Crawl Control**.
 
    <DashButton url="/?to=/:account/:zone/ai" />
 
-3. Go to the **Robots.txt** tab.
+3. Go to the **Directives** tab.
 
 ## Check managed robots.txt status
 
@@ -37,7 +37,7 @@ The values in all tables and metrics will update according to your filters.
 
 ## Monitor robots.txt availability
 
-The **Availability** table shows the historical request frequency and health status of `robots.txt` files across your hostnames over the selected time frame.
+The **Robots.txt availability** table shows the historical request frequency and health status of `robots.txt` files across your hostnames over the selected time frame.
 
 | Column          | Description                                                                                                                                                                                                                    |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -55,7 +55,7 @@ From this table, you can take the following actions:
 
 ## Track robots.txt violations
 
-The **Violations** table identifies AI crawlers that have requested paths explicitly disallowed by your `robots.txt` file. This helps you identify non-compliant crawlers and take appropriate action.
+The **Robots.txt violations** table identifies AI crawlers that have requested paths explicitly disallowed by your `robots.txt` file. This helps you identify non-compliant crawlers and take appropriate action.
 
 :::note[How violations are calculated]
 
@@ -76,6 +76,16 @@ When you identify crawlers violating your `robots.txt` directives, you have seve
 - Navigate to the [**Crawlers** tab](/ai-crawl-control/features/manage-ai-crawlers/) to permanently block the non-compliant crawler.
 - Use [Cloudflare WAF](/waf/) to create a path-specific security rules for the violating crawler.
 - Use [Redirect Rules](/rules/url-forwarding/) to guide violating crawlers to an appropriate area of your site.
+
+## Check Agent Readiness
+
+The **Agent Readiness** card helps you assess how well your site is configured for AI agents. Select **Check readiness score** to scan your site against emerging standards for AI agent interaction, including:
+
+- **Robots.txt configuration**: Whether your site has a valid `robots.txt` file with appropriate directives
+- **Markdown for Agents**: Whether your site supports content negotiation for AI-optimized content delivery
+- **Content Signals Policy**: Whether your site signals content usage preferences to AI crawlers
+
+The scan is powered by [isitagentready.org](https://isitagentready.org). Results include recommendations for improving your site's compatibility with AI agents and crawlers.
 
 ## Related resources
 

--- a/src/content/docs/ai-crawl-control/reference/redirects-for-ai-training.mdx
+++ b/src/content/docs/ai-crawl-control/reference/redirects-for-ai-training.mdx
@@ -1,0 +1,95 @@
+---
+title: Redirects for AI Training
+pcx_content_type: reference
+sidebar:
+  group:
+    hideIndex: false
+---
+
+import {
+	Render,
+} from "~/components";
+
+Redirects for AI Training enforces your existing `<link rel="canonical">` tags as 301 redirects for [verified AI training crawlers](/bots/concepts/bot/#verified-bots). When a verified bot with the [AI Crawler category](/bots/concepts/bot/verified-bots/#categories) requests a page whose canonical tag points to a different same-origin URL, Cloudflare returns a `301 Moved Permanently` to the canonical. All other visitors—browsers, search engines, [AI Assistants](/bots/concepts/bot/verified-bots/#categories)—receive the original page unchanged.
+
+Read the [announcement blog post](https://blog.cloudflare.com/ai-redirects/) for background on why this feature exists.
+
+## How to enable
+
+Redirects for AI Training is available as a toggle in **AI Crawl Control** > **Quick Actions**, alongside [Markdown for Agents](/fundamentals/reference/markdown-for-agents/) and [Managed robots.txt](/bots/additional-configurations/managed-robots-txt/).
+
+<Render file="redirects-for-ai-training" product="fundamentals" />
+
+## How it works
+
+Cloudflare inspects the origin HTML response to verified AI training crawlers and:
+
+1. Stream-parses the `<head>` of the origin response to extract `<link rel="canonical" href="...">`
+2. Resolves relative canonical URLs against the request URL
+3. Validates that the canonical URL is same-origin and differs from the current URL
+4. Returns a `301` redirect to the canonical URL
+
+If no canonical tag is found, the canonical is cross-origin, or the page is self-canonical, the origin response passes through unchanged.
+
+:::note[Interaction with Markdown for Agents]
+Redirects for AI Training operates on the origin HTML response before [Markdown for Agents](/fundamentals/reference/markdown-for-agents/) content conversion runs. If a crawler requests `text/markdown` and the origin returns HTML with a non-self canonical tag, the 301 redirect is issued based on the original HTML. Markdown conversion only applies to responses that are not redirected.
+:::
+
+### Canonical tag parsing
+
+The feature parses the `<link rel="canonical">` tag from the `<head>` section of the origin response:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="canonical" href="https://example.com/current-version">
+</head>
+<body>
+  <!-- Page content -->
+</body>
+</html>
+```
+
+Both absolute and relative URLs are supported:
+
+```html
+<!-- Absolute URL -->
+<link rel="canonical" href="https://example.com/page">
+
+<!-- Relative URL (resolved against request URL) -->
+<link rel="canonical" href="/current-page">
+```
+
+### Interaction with other redirect features
+
+Redirects for AI Training operates at a different layer than [Single Redirects](/rules/url-forwarding/single-redirects/) and [Bulk Redirects](/rules/url-forwarding/bulk-redirects/). Those redirect rules execute before the origin is contacted. Redirects for AI Training executes after the origin responds, because it needs to read the canonical tag from the origin HTML.
+
+If a Single Redirect or Bulk Redirect matches first, the request is redirected before Redirects for AI Training has a chance to evaluate it.
+
+## Availability
+
+Available on Pro, Business, and Enterprise plans at no additional cost.
+
+## Limitations
+
+- Only HTML responses (`content-type: text/html`) from the origin are evaluated. Other content types pass through unchanged.
+- The canonical tag must appear within the first 256 KB of the uncompressed HTML response body.
+- Only same-origin canonical URLs trigger a redirect. Cross-origin canonicals are ignored.
+- Only [verified bots](/bots/concepts/bot/#verified-bots) with the [AI Crawler category](/bots/concepts/bot/verified-bots/#categories) are redirected. [AI Assistants and AI Search bots](/bots/concepts/bot/verified-bots/#categories) are not affected.
+- Self-canonical pages (where the canonical URL matches the request URL) are not redirected.
+- Best-effort loop detection uses the `Referer` header. If a crawler was just redirected from the canonical URL back to the current page, the origin HTML is served instead of redirecting. This handles common two-page canonical misconfigurations (Page A canonical points to Page B, Page B canonical points to Page A).
+
+## Logging
+
+When a redirect is issued, Cloudflare logs the canonical target URL in your HTTP request logs via the `redirects_for_ai_training_target` field. You can use the [GraphQL Analytics API](/ai-crawl-control/reference/graphql-api/) or [Logpush](/logs/about/) to query this data.
+
+## Related
+
+- [Manage AI crawlers](/ai-crawl-control/features/manage-ai-crawlers/) - Set allow or block rules per crawler
+- [Analyze AI traffic](/ai-crawl-control/features/analyze-ai-traffic/) - View request metrics by crawler, operator, and content type
+- [Markdown for Agents](/fundamentals/reference/markdown-for-agents/) - Serve HTML as markdown via content negotiation
+- [Content Signals Policy](https://contentsignals.org/) - Signal post-access content usage preferences in `robots.txt`
+- [Directives](/ai-crawl-control/features/track-robots-txt/) - Monitor `robots.txt` compliance and check Agent Readiness
+- [Single Redirects](/rules/url-forwarding/single-redirects/) - Rule-based URL redirects that execute before origin
+- [Verified bots](/bots/concepts/bot/verified-bots/#categories) - Bot categories including AI Crawler, AI Assistant, and AI Search

--- a/src/content/partials/fundamentals/redirects-for-ai-training.mdx
+++ b/src/content/partials/fundamentals/redirects-for-ai-training.mdx
@@ -1,0 +1,120 @@
+---
+{}
+---
+
+import { TabItem, Tabs } from "~/components";
+
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+To enable Redirects for AI Training for your zone in the dashboard:
+
+1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account (you need a Pro or Business plan).
+2. Select the zone you want to configure.
+3. Visit the [AI Crawl Control](https://dash.cloudflare.com/?to=/:account/:zone/ai) section.
+4. Enable **Redirects for AI Training**.
+
+### Enable for specific subdomains or paths
+
+To enable Redirects for AI Training for specific subdomains or paths instead of your entire zone, create a [configuration rule](/rules/configuration-rules/):
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account.
+2. Select the zone you want to configure.
+3. Go to **Rules** > **Overview** and select **Create rule** > **Configuration Rules**.
+4. Under **When incoming requests match**, build an expression to match your subdomain (for example, `http.host eq "docs.example.com"`) or path.
+5. Under **Then the settings are**, select **Add setting** > **Redirects for AI Training** and set it to **On**.
+6. Select **Deploy**.
+
+</TabItem> <TabItem label="API">
+
+To enable Redirects for AI Training for your zone using APIs, send a `PATCH` to `/client/v4/zones/{zone_tag}/settings/redirects_for_ai_training` with the payload `{"value": "on"}` to the Cloudflare API.
+
+You will need to create an API token with the Zone Settings edit permissions enabled.
+
+Example:
+
+```bash title="Enable Redirects for AI Training"
+curl -X PATCH 'https://api.cloudflare.com/client/v4/zones/{zone_tag}/settings/redirects_for_ai_training' \
+  --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer {api_token}" --data-raw '{"value": "on"}'
+```
+
+### Enable for specific subdomains or paths
+
+To enable Redirects for AI Training for specific subdomains or paths instead of your entire zone, create a [configuration rule](/rules/configuration-rules/create-api/):
+
+```bash title="Enable Redirects for AI Training for a subdomain"
+curl --request PUT \
+  --url "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_config_settings/entrypoint" \
+  --header "Authorization: Bearer {api_token}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "rules": [{
+      "expression": "http.host eq \"docs.example.com\"",
+      "action": "set_config",
+      "action_parameters": {
+        "redirects_for_ai_training": true
+      },
+      "description": "Enable Redirects for AI Training for docs subdomain"
+    }]
+  }'
+```
+
+You can also use path-based expressions like `starts_with(http.request.uri.path, "/docs/")`. For more information on building expressions, refer to [Rules language](/ruleset-engine/rules-language/).
+
+</TabItem> <TabItem label="Custom Hostnames">
+
+If you are using [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) and want to enable Redirects for AI Training for your [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/), you have two options:
+
+### Enable for all custom hostnames
+
+To enable Redirects for AI Training for all custom hostnames on your SaaS zone:
+
+1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account.
+2. Select your SaaS zone.
+3. Look for **Quick Actions**.
+4. Toggle the **Redirects for AI Training** button to enable.
+
+### Enable for specific custom hostnames
+
+Enabling Redirects for AI Training for specific custom hostnames requires an [advanced subscription](/cloudflare-for-platforms/cloudflare-for-saas/plans/) with access to [custom metadata](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/custom-metadata/).
+
+#### Step 1: Set custom metadata on the custom hostname
+
+When creating or updating a custom hostname via API, add `redirects_for_ai_training` to the `custom_metadata` object:
+
+```bash
+curl --request PATCH \
+  --url "https://api.cloudflare.com/client/v4/zones/{zone_id}/custom_hostnames/{custom_hostname_id}" \
+  --header "Authorization: Bearer {api_token}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "custom_metadata": {
+      "redirects_for_ai_training": "enabled"
+    }
+  }'
+```
+
+#### Step 2: Create a Configuration Rule
+
+Create a Configuration Rule on your SaaS zone that matches custom hostnames with the metadata and enables the feature:
+
+```bash
+curl --request PUT \
+  --url "https://api.cloudflare.com/client/v4/zones/{zone_id}/rulesets/phases/http_config_settings/entrypoint" \
+  --header "Authorization: Bearer {api_token}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "rules": [{
+      "expression": "lookup_json_string(cf.hostname.metadata, \"redirects_for_ai_training\") eq \"enabled\"",
+      "action": "set_config",
+      "action_parameters": {
+        "redirects_for_ai_training": true
+      },
+      "description": "Enable Redirects for AI Training for opted-in custom hostnames"
+    }]
+  }'
+```
+
+This will enable the feature on custom hostnames that have the `redirects_for_ai_training` custom metadata tag set.
+
+</TabItem> </Tabs>


### PR DESCRIPTION
### Summary

Adding documentation for new AI Crawl Control features launching April 17, 2026:

- **Redirects for AI Training**: New reference doc covering how the feature enforces `<link rel="canonical">` tags as 301 redirects for verified AI training crawlers. Includes enablement instructions for Dashboard, API, and Custom Hostnames.
- **Content Format chart**: New section in Analyze AI traffic docs for the Content Format metrics view.
- **Directives tab**: Renamed from Robots.txt tab, added Agent Readiness section linking to isitagentready.org.
- **Changelog entries**: Two new entries under `ai-crawl-control/` for the feature launch and dashboard updates.

### Screenshots (optional)

N/A — content-only changes, no component or layout modifications.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).