### PR TITLE
[Workers AI] Fix model detail page dark mode, output badges, and playground visibility

### DIFF
--- a/src/components/models/ModelDetailPage.astro
+++ b/src/components/models/ModelDetailPage.astro
@@ -144,7 +144,8 @@ const hasRemainingExamples = remainingExamples.length > 0;
 const description = model.description;
 const isBeta = hasProperty(model.properties, "beta");
 
-let hasPlayground = model.task.name === "Text Generation";
+let hasPlayground =
+	model.task.name === "Text Generation" && model.hosting === "hosted";
 if (model.name.includes("@cf/openai/gpt-oss")) {
 	hasPlayground = false;
 }

--- a/src/components/models/SchemaDisplay.astro
+++ b/src/components/models/SchemaDisplay.astro
@@ -29,6 +29,7 @@ interface Props {
 }
 
 const { schema, title } = Astro.props;
+const hideRequired = title === "Output";
 
 // Check if schema is a flat/simple schema (no properties, no oneOf/anyOf with properties)
 // These are things like streaming output: { type: "string", contentType: "...", format: "binary" }
@@ -420,6 +421,7 @@ const variantRows =
 			<SchemaVariantSelector
 				variants={variantRows}
 				schemaId={schemaId}
+				hideRequired={hideRequired}
 				client:load
 			/>
 		) : rows.length === 0 ? (
@@ -427,7 +429,7 @@ const variantRows =
 				No parameters defined.
 			</p>
 		) : (
-			<SchemaTreeView rows={rows} schemaId={schemaId} client:load />
+			<SchemaTreeView rows={rows} schemaId={schemaId} hideRequired={hideRequired} client:load />
 		)
 	}
 </div>

--- a/src/components/models/SchemaTree.tsx
+++ b/src/components/models/SchemaTree.tsx
@@ -15,6 +15,7 @@ import type { SchemaRowData } from "./types";
 interface SchemaTreeProps {
 	rows: SchemaRowData[];
 	schemaId: string;
+	hideRequired?: boolean;
 }
 
 interface SchemaNodeProps {
@@ -24,6 +25,7 @@ interface SchemaNodeProps {
 	forceExpand: boolean;
 	expandedNodes: Set<string>;
 	onToggle: (id: string) => void;
+	hideRequired?: boolean;
 }
 
 // Highlight matching text in search
@@ -115,6 +117,7 @@ function SchemaNode({
 	forceExpand,
 	expandedNodes,
 	onToggle,
+	hideRequired,
 }: SchemaNodeProps) {
 	const hasChildren = row.children && row.children.length > 0;
 	const isExpanded = forceExpand || expandedNodes.has(row.id);
@@ -225,6 +228,7 @@ function SchemaNode({
 									forceExpand={forceExpand}
 									expandedNodes={expandedNodes}
 									onToggle={onToggle}
+									hideRequired={hideRequired}
 								/>
 							))}
 						</div>
@@ -282,7 +286,7 @@ function SchemaNode({
 						<code className="text-xs text-gray-500 dark:text-gray-400">
 							{row.type}
 						</code>
-						{row.required && (
+						{row.required && !hideRequired && (
 							<span className="rounded border border-amber-200 bg-amber-100 px-1 py-0.5 text-xs leading-none text-amber-800 dark:border-amber-700 dark:bg-amber-900 dark:text-amber-200">
 								required
 							</span>
@@ -329,6 +333,7 @@ function SchemaNode({
 							forceExpand={forceExpand}
 							expandedNodes={expandedNodes}
 							onToggle={onToggle}
+							hideRequired={hideRequired}
 						/>
 					))}
 				</div>
@@ -337,7 +342,11 @@ function SchemaNode({
 	);
 }
 
-export default function SchemaTree({ rows, schemaId }: SchemaTreeProps) {
+export default function SchemaTree({
+	rows,
+	schemaId,
+	hideRequired,
+}: SchemaTreeProps) {
 	const [searchTerm, setSearchTerm] = useState("");
 	const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
 
@@ -425,6 +434,7 @@ export default function SchemaTree({ rows, schemaId }: SchemaTreeProps) {
 								forceExpand={searchTerm.length > 0}
 								expandedNodes={mergedExpandedNodes}
 								onToggle={handleToggle}
+								hideRequired={hideRequired}
 							/>
 						))}
 					</div>

--- a/src/components/models/SchemaTree.tsx
+++ b/src/components/models/SchemaTree.tsx
@@ -157,7 +157,16 @@ function SchemaNode({
 					}
 				>
 					<div
-						className={`py-3 ${hasChildren ? "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50" : ""} ${hasChildren && isExpanded ? "border-b border-gray-100 dark:border-gray-800" : ""}`}
+						className={[
+							"py-3",
+							hasChildren &&
+								"cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50",
+							hasChildren &&
+								isExpanded &&
+								"border-b border-gray-100 dark:border-gray-800",
+						]
+							.filter(Boolean)
+							.join(" ")}
 						style={{ paddingLeft: indentPx }}
 						onClick={hasChildren ? handleToggle : undefined}
 						role={hasChildren ? "button" : undefined}
@@ -168,9 +177,12 @@ function SchemaNode({
 							<span className="w-4 flex-shrink-0 text-center">
 								{hasChildren && (
 									<span
-										className={`inline-block text-xs text-gray-400 transition-transform ${
-											isExpanded ? "rotate-90" : ""
-										}`}
+										className={[
+											"inline-block text-xs text-gray-400 transition-transform",
+											isExpanded && "rotate-90",
+										]
+											.filter(Boolean)
+											.join(" ")}
 									>
 										▶
 									</span>
@@ -249,7 +261,16 @@ function SchemaNode({
 		>
 			{/* Clickable row */}
 			<div
-				className={`py-3 ${hasChildren ? "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50" : ""} ${hasChildren && isExpanded ? "border-b border-gray-100 dark:border-gray-800" : ""}`}
+				className={[
+					"py-3",
+					hasChildren &&
+						"cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50",
+					hasChildren &&
+						isExpanded &&
+						"border-b border-gray-100 dark:border-gray-800",
+				]
+					.filter(Boolean)
+					.join(" ")}
 				style={{ paddingLeft: indentPx }}
 				onClick={hasChildren ? handleToggle : undefined}
 				role={hasChildren ? "button" : undefined}
@@ -260,9 +281,12 @@ function SchemaNode({
 					<span className="w-4 flex-shrink-0 text-center">
 						{hasChildren && (
 							<span
-								className={`inline-block text-xs text-gray-400 transition-transform ${
-									isExpanded ? "rotate-90" : ""
-								}`}
+								className={[
+									"inline-block text-xs text-gray-400 transition-transform",
+									isExpanded && "rotate-90",
+								]
+									.filter(Boolean)
+									.join(" ")}
 							>
 								▶
 							</span>

--- a/src/components/models/SchemaVariantSelector.tsx
+++ b/src/components/models/SchemaVariantSelector.tsx
@@ -11,6 +11,7 @@ interface SchemaVariant {
 interface SchemaVariantSelectorProps {
 	variants: SchemaVariant[];
 	schemaId: string;
+	hideRequired?: boolean;
 }
 
 // Map variant titles to descriptions
@@ -23,6 +24,7 @@ const variantDescriptions: Record<string, string> = {
 export default function SchemaVariantSelector({
 	variants,
 	schemaId,
+	hideRequired,
 }: SchemaVariantSelectorProps) {
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const selectedVariant = variants[selectedIndex];
@@ -44,7 +46,7 @@ export default function SchemaVariantSelector({
 								className={`mt-0 flex flex-1 cursor-pointer flex-col justify-start rounded-lg border p-3 text-left transition-colors ${
 									isSelected
 										? "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950"
-										: "border-gray-200 hover:border-gray-300 dark:border-gray-700 dark:hover:border-gray-600"
+										: "border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600"
 								}`}
 							>
 								<span
@@ -74,6 +76,7 @@ export default function SchemaVariantSelector({
 				<SchemaTree
 					rows={selectedVariant.rows}
 					schemaId={`${schemaId}-${selectedVariant.title.toLowerCase().replace(/\s+/g, "-")}`}
+					hideRequired={hideRequired}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
### Summary

Three fixes for the AI model detail pages:

- **Dark mode variant selector**: the Prompt/Messages toggle cards in `SchemaVariantSelector` had no explicit background, making them look washed out in dark mode. Added `bg-white dark:bg-gray-800` to match the pattern used by other card-like components in the codebase.
- **"Required" badges on output schemas**: output parameters displayed "required" badges, which is meaningless — users don't construct the response. Added a `hideRequired` prop threaded from `SchemaDisplay` through `SchemaVariantSelector` and `SchemaTree` that suppresses the badge when `title === "Output"`.
- **Playground section on proxied models**: catalog models (like `openai/gpt-5.4`) showed the LLM Playground section with copy claiming "no setup or authentication" needed, but these third-party models aren't available in the playground. Gated `hasPlayground` on `model.hosting === "hosted"` so proxied models never show the section.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).