### PR TITLE
[Workers AI] Redesign model catalog with horizontal toolbar and searchable filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"@astrojs/starlight": "0.38.4",
 		"@astrojs/starlight-docsearch": "0.7.0",
 		"@astrojs/starlight-tailwind": "5.0.0",
+		"@base-ui/react": "1.4.0",
 		"@cloudflare/vitest-pool-workers": "0.14.9",
 		"@cloudflare/workers-types": "4.20260413.1",
 		"@eslint/js": "9.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@astrojs/starlight-tailwind':
         specifier: 5.0.0
         version: 5.0.0(@astrojs/starlight@0.38.4(astro@6.1.9(@types/node@24.6.0)(jiti@2.6.1)(lightningcss@1.29.2)(rollup@4.60.1)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)))(tailwindcss@4.1.4)
+      '@base-ui/react':
+        specifier: 1.4.0
+        version: 1.4.0(@date-fns/tz@1.4.1)(@types/react@19.0.7)(date-fns@4.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@cloudflare/vitest-pool-workers':
         specifier: 0.14.9
         version: 0.14.9(@cloudflare/workers-types@4.20260413.1)(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5(@types/node@24.6.0)(happy-dom@20.8.9)(vite@7.3.2(@types/node@24.6.0)(jiti@2.6.1)(lightningcss@1.29.2)(tsx@4.20.5)(yaml@2.8.3)))
@@ -689,6 +692,29 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@base-ui/react@1.4.0':
+    resolution: {integrity: sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/utils@0.2.7':
+    resolution: {integrity: sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
@@ -721,11 +747,11 @@ packages:
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@cloudflare/kv-asset-handler@0.4.2':
-    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==, tarball: https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz}
     engines: {node: '>=18.0.0'}
 
   '@cloudflare/unenv-preset@2.16.0':
-    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
+    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==, tarball: https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz}
     peerDependencies:
       unenv: 2.0.0-rc.24
       workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
@@ -801,7 +827,7 @@ packages:
     os: [win32]
 
   '@cloudflare/workers-types@4.20260413.1':
-    resolution: {integrity: sha512-4FFHIVIk645Wf20eCVfe0eM3ERsEw98DFng76QZf1C1JMgIVlfSV2gZF1EyXxNVwOG0RM/CBlu07+u/Z/0Oq9Q==}
+    resolution: {integrity: sha512-4FFHIVIk645Wf20eCVfe0eM3ERsEw98DFng76QZf1C1JMgIVlfSV2gZF1EyXxNVwOG0RM/CBlu07+u/Z/0Oq9Q==, tarball: https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260413.1.tgz}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -810,6 +836,9 @@ packages:
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@docsearch/css@3.9.0':
     resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
@@ -5751,6 +5780,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -7498,6 +7530,31 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@base-ui/react@1.4.0(@date-fns/tz@1.4.1)(@types/react@19.0.7)(date-fns@4.1.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.7(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@date-fns/tz': 1.4.1
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@floating-ui/utils': 0.2.11
+      date-fns: 4.1.0
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      use-sync-external-store: 1.6.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.7
+
+  '@base-ui/utils@0.2.7(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.7
+
   '@borewit/text-codec@0.2.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
@@ -7601,6 +7658,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.9
 
   '@ctrl/tinycolor@4.2.0': {}
+
+  '@date-fns/tz@1.4.1': {}
 
   '@docsearch/css@3.9.0': {}
 
@@ -13257,6 +13316,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
+import { Combobox } from "@base-ui/react/combobox";
+import { Select } from "@base-ui/react/select";
 import ModelInfo from "./models/ModelInfo";
 import ModelBadges from "./models/ModelBadges";
 import { authorData } from "./models/data";
@@ -18,6 +20,189 @@ type Filters = {
 	capabilities: string[];
 };
 
+type SortOrder = "newest" | "oldest";
+
+interface FilterItem {
+	value: string;
+	label: string;
+}
+
+function FilterDropdown({
+	label,
+	items,
+	selected,
+	onChange,
+}: {
+	label: string;
+	items: FilterItem[];
+	selected: string[];
+	onChange: (selected: string[]) => void;
+}) {
+	const hasSelection = selected.length > 0;
+	const triggerLabel = hasSelection ? `${label} (+${selected.length})` : label;
+
+	const selectedItems = items.filter((item) => selected.includes(item.value));
+
+	return (
+		<Combobox.Root
+			multiple
+			value={selectedItems}
+			onValueChange={(value) =>
+				onChange((value as FilterItem[]).map((item) => item.value))
+			}
+			items={items}
+			isItemEqualToValue={(a, b) => a.value === b.value}
+		>
+			<Combobox.Trigger
+				className={`flex cursor-pointer items-center gap-1.5 rounded-lg border bg-white px-3 py-2 text-sm whitespace-nowrap transition-colors select-none dark:bg-gray-800 ${
+					hasSelection
+						? "border-blue-300 text-blue-700 dark:border-blue-600 dark:text-blue-300"
+						: "border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+				}`}
+			>
+				<Combobox.Value placeholder={<span>{label}</span>}>
+					{() => triggerLabel}
+				</Combobox.Value>
+				<Combobox.Icon className="flex">
+					<ChevronUpDownIcon />
+				</Combobox.Icon>
+			</Combobox.Trigger>
+			<Combobox.Portal>
+				<Combobox.Positioner
+					className="z-50 outline-hidden"
+					align="start"
+					sideOffset={8}
+				>
+					<Combobox.Popup
+						className="max-h-[24rem] max-w-[var(--available-width)] origin-[var(--transform-origin)] rounded-lg border border-gray-200 bg-white shadow-lg transition-[transform,scale,opacity] [--input-height:2.75rem] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 dark:border-gray-600 dark:bg-gray-800"
+						aria-label={label}
+					>
+						<div className="w-64 p-2">
+							<Combobox.Input
+								placeholder={`Search ${label.toLowerCase()}...`}
+								className="h-9 w-full rounded-md border border-gray-200 bg-white px-3 text-sm font-normal text-gray-900 outline-none focus:border-blue-300 focus:ring-1 focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+							/>
+						</div>
+						<Combobox.Empty>
+							<div className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+								No results found.
+							</div>
+						</Combobox.Empty>
+						<Combobox.List className="max-h-[min(calc(24rem-var(--input-height)),calc(var(--available-height)-var(--input-height)))] scroll-py-1 overflow-y-auto overscroll-contain py-1">
+							{(item: FilterItem) => (
+								<Combobox.Item
+									key={item.value}
+									value={item}
+									className="group grid cursor-default grid-cols-[1rem_1fr] items-center gap-2 px-3 py-2 text-sm leading-4 outline-hidden select-none data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-700"
+								>
+									<span className="col-start-1 flex h-4 w-4 items-center justify-center rounded border border-gray-300 group-data-[selected]:border-blue-600 group-data-[selected]:bg-blue-600 group-data-[selected]:text-white dark:border-gray-500 dark:group-data-[selected]:border-blue-500 dark:group-data-[selected]:bg-blue-500">
+										<Combobox.ItemIndicator>
+											<CheckIcon />
+										</Combobox.ItemIndicator>
+									</span>
+									<span className="col-start-2 text-gray-700 dark:text-gray-200">
+										{item.label}
+									</span>
+								</Combobox.Item>
+							)}
+						</Combobox.List>
+					</Combobox.Popup>
+				</Combobox.Positioner>
+			</Combobox.Portal>
+		</Combobox.Root>
+	);
+}
+
+const sortOptions = [
+	{ value: "newest", label: "Newest first" },
+	{ value: "oldest", label: "Oldest first" },
+];
+
+function SortSelect({
+	sortOrder,
+	onChange,
+}: {
+	sortOrder: SortOrder;
+	onChange: (value: SortOrder) => void;
+}) {
+	return (
+		<Select.Root
+			value={sortOrder}
+			onValueChange={(value) => onChange(value as SortOrder)}
+			items={sortOptions}
+		>
+			<Select.Trigger className="flex cursor-pointer items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm whitespace-nowrap text-gray-700 transition-colors select-none hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700">
+				<Select.Value>
+					{() =>
+						sortOptions.find((o) => o.value === sortOrder)?.label ??
+						"Newest first"
+					}
+				</Select.Value>
+				<Select.Icon className="flex">
+					<ChevronUpDownIcon />
+				</Select.Icon>
+			</Select.Trigger>
+			<Select.Portal>
+				<Select.Positioner
+					className="z-50 outline-hidden"
+					sideOffset={8}
+					align="start"
+					alignItemWithTrigger={false}
+				>
+					<Select.Popup className="min-w-[var(--anchor-width)] origin-[var(--transform-origin)] rounded-lg border border-gray-200 bg-white py-1 shadow-lg transition-[transform,scale,opacity] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 dark:border-gray-600 dark:bg-gray-800">
+						{sortOptions.map((option) => (
+							<Select.Item
+								key={option.value}
+								value={option.value}
+								className="grid cursor-default grid-cols-[1rem_1fr] items-center gap-2 px-3 py-2 text-sm leading-4 outline-hidden select-none data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-700"
+							>
+								<Select.ItemIndicator className="col-start-1">
+									<CheckIcon />
+								</Select.ItemIndicator>
+								<Select.ItemText className="col-start-2 text-gray-700 dark:text-gray-200">
+									{option.label}
+								</Select.ItemText>
+							</Select.Item>
+						))}
+					</Select.Popup>
+				</Select.Positioner>
+			</Select.Portal>
+		</Select.Root>
+	);
+}
+
+function ChevronUpDownIcon() {
+	return (
+		<svg
+			width="8"
+			height="12"
+			viewBox="0 0 8 12"
+			fill="none"
+			stroke="currentcolor"
+			strokeWidth="1.5"
+		>
+			<path d="M0.5 4.5L4 1.5L7.5 4.5" />
+			<path d="M0.5 7.5L4 10.5L7.5 7.5" />
+		</svg>
+	);
+}
+
+function CheckIcon() {
+	return (
+		<svg fill="currentcolor" width="10" height="10" viewBox="0 0 10 10">
+			<path d="M9.1603 1.12218C9.50684 1.34873 9.60427 1.81354 9.37792 2.16038L5.13603 8.66012C5.01614 8.8438 4.82192 8.96576 4.60451 8.99384C4.3871 9.02194 4.1683 8.95335 4.00574 8.80615L1.24664 6.30769C0.939709 6.02975 0.916013 5.55541 1.19372 5.24822C1.47142 4.94102 1.94536 4.91731 2.2523 5.19524L4.36085 7.10461L8.12299 1.33999C8.34934 0.993152 8.81376 0.895638 9.1603 1.12218Z" />
+		</svg>
+	);
+}
+
+// List of model names to pin at the top
+const pinnedModelNames = [
+	"@cf/moonshotai/kimi-k2.6",
+	"@cf/zai-org/glm-4.7-flash",
+	"@cf/openai/gpt-oss-120b",
+	"@cf/meta/llama-4-scout-17b-16e-instruct",
+];
+
 const ModelCatalog = ({
 	models,
 	basePath = "/ai/models",
@@ -31,14 +216,8 @@ const ModelCatalog = ({
 		tasks: [],
 		capabilities: [],
 	});
-
-	// List of model names to pin at the top
-	const pinnedModelNames = [
-		"@cf/moonshotai/kimi-k2.6",
-		"@cf/zai-org/glm-4.7-flash",
-		"@cf/openai/gpt-oss-120b",
-		"@cf/meta/llama-4-scout-17b-16e-instruct",
-	];
+	const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
+	const initializedRef = useRef(false);
 
 	// Sort models by pinned status first, then by created_at date
 	const sortedModels = useMemo(() => {
@@ -58,12 +237,14 @@ const ModelCatalog = ({
 				);
 			}
 
-			// If neither is pinned, sort by created_at date (newest first)
+			// If neither is pinned, sort by created_at date
 			const dateA = a.created_at ? new Date(a.created_at) : new Date(0);
 			const dateB = b.created_at ? new Date(b.created_at) : new Date(0);
-			return dateB.getTime() - dateA.getTime();
+			return sortOrder === "newest"
+				? dateB.getTime() - dateA.getTime()
+				: dateA.getTime() - dateB.getTime();
 		});
-	}, [models]);
+	}, [models, sortOrder]);
 
 	useEffect(() => {
 		const params = new URLSearchParams(window.location.search);
@@ -79,9 +260,12 @@ const ModelCatalog = ({
 			tasks,
 			capabilities,
 		});
+		initializedRef.current = true;
 	}, []);
 
 	useEffect(() => {
+		if (!initializedRef.current) return;
+
 		const params = new URLSearchParams();
 
 		if (filters.search) {
@@ -113,19 +297,40 @@ const ModelCatalog = ({
 		model_display_name: model.name.split("/").at(-1),
 	}));
 
-	const tasks = [...new Set(models.map((model) => model.task.name))];
 	const getAuthorDisplayName = (id: string) => authorData[id]?.name ?? id;
-	const authors = [
-		...new Map(
-			models
-				.map((model) => getModelAuthor(model.name))
-				.map((id) => [getAuthorDisplayName(id), id] as const),
-		).values(),
-	].sort((a, b) =>
-		getAuthorDisplayName(a).localeCompare(getAuthorDisplayName(b)),
+
+	const taskItems: FilterItem[] = useMemo(
+		() =>
+			[...new Set(models.map((model) => model.task.name))]
+				.sort()
+				.map((t) => ({ value: t, label: t })),
+		[models],
 	);
-	const modelProperties = getLabelsByCategory(models, "model");
-	const platformProperties = getLabelsByCategory(models, "platform");
+
+	const authorItems: FilterItem[] = useMemo(
+		() =>
+			[
+				...new Map(
+					models
+						.map((model) => getModelAuthor(model.name))
+						.map((id) => [getAuthorDisplayName(id), id] as const),
+				).values(),
+			]
+				.sort((a, b) =>
+					getAuthorDisplayName(a).localeCompare(getAuthorDisplayName(b)),
+				)
+				.map((a) => ({ value: a, label: getAuthorDisplayName(a) })),
+		[models],
+	);
+
+	const capabilityItems: FilterItem[] = useMemo(
+		() =>
+			[
+				...getLabelsByCategory(models, "model"),
+				...getLabelsByCategory(models, "platform"),
+			].map((c) => ({ value: c, label: c })),
+		[models],
+	);
 
 	const modelList = mapped.filter(({ model }) => {
 		if (filters.authors.length > 0) {
@@ -159,165 +364,97 @@ const ModelCatalog = ({
 		return true;
 	});
 
+	const hasActiveFilters =
+		filters.authors.length > 0 ||
+		filters.tasks.length > 0 ||
+		filters.capabilities.length > 0;
+
 	return (
-		<div className="md:flex">
-			<div className="mr-8 w-full md:w-1/4">
-				<input
-					type="text"
-					className="mb-8 w-full rounded-md border-2 border-gray-200 bg-white px-2 py-2 dark:border-gray-700 dark:bg-gray-800"
-					placeholder="Search models"
-					value={filters.search}
-					onChange={(e) => setFilters({ ...filters, search: e.target.value })}
-				/>
+		<div className="not-content">
+			{/* Toolbar */}
+			<div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center">
+				{/* Search input */}
+				<div className="relative flex-1">
+					<svg
+						className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+						strokeWidth={2}
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+						/>
+					</svg>
+					<input
+						type="text"
+						className="w-full rounded-lg border border-gray-200 bg-white py-2 pr-3 pl-9 text-sm outline-none focus:border-blue-300 focus:ring-1 focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-blue-500 dark:focus:ring-blue-500"
+						placeholder="Search models"
+						value={filters.search}
+						onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+					/>
+				</div>
 
-				<details className="mb-6! hidden md:block" open>
-					<summary className="cursor-pointer text-sm font-bold text-gray-600 uppercase select-none dark:text-gray-200">
-						Task Type
-					</summary>
-
-					{tasks.map((task) => (
-						<label key={task} className="my-2! block">
-							<input
-								type="checkbox"
-								className="mr-2"
-								value={task}
-								checked={filters.tasks.includes(task)}
-								onChange={(e) => {
-									const target = e.target as HTMLInputElement;
-
-									if (target.checked) {
-										setFilters({
-											...filters,
-											tasks: [...filters.tasks, target.value],
-										});
-									} else {
-										setFilters({
-											...filters,
-											tasks: filters.tasks.filter((f) => f !== target.value),
-										});
-									}
-								}}
-							/>{" "}
-							{task}
-						</label>
-					))}
-				</details>
-
-				<details className="mb-6! hidden md:block" open>
-					<summary className="cursor-pointer text-sm font-bold text-gray-600 uppercase select-none dark:text-gray-200">
-						Capabilities
-					</summary>
-
-					{modelProperties.length > 0 && (
-						<>
-							<span className="mt-3! mb-1! block text-xs font-semibold text-gray-500 dark:text-gray-400">
-								Model
-							</span>
-							{modelProperties.map((prop) => (
-								<label key={prop} className="my-2! block">
-									<input
-										type="checkbox"
-										value={prop}
-										checked={filters.capabilities.includes(prop)}
-										className="mr-2"
-										onChange={(e) => {
-											const target = e.target as HTMLInputElement;
-											if (target.checked) {
-												setFilters({
-													...filters,
-													capabilities: [...filters.capabilities, target.value],
-												});
-											} else {
-												setFilters({
-													...filters,
-													capabilities: filters.capabilities.filter(
-														(f) => f !== target.value,
-													),
-												});
-											}
-										}}
-									/>{" "}
-									{prop}
-								</label>
-							))}
-						</>
-					)}
-
-					{platformProperties.length > 0 && (
-						<>
-							<span className="mt-3! mb-1! block text-xs font-semibold text-gray-500 dark:text-gray-400">
-								Platform
-							</span>
-							{platformProperties.map((prop) => (
-								<label key={prop} className="my-2! block">
-									<input
-										type="checkbox"
-										value={prop}
-										checked={filters.capabilities.includes(prop)}
-										className="mr-2"
-										onChange={(e) => {
-											const target = e.target as HTMLInputElement;
-											if (target.checked) {
-												setFilters({
-													...filters,
-													capabilities: [...filters.capabilities, target.value],
-												});
-											} else {
-												setFilters({
-													...filters,
-													capabilities: filters.capabilities.filter(
-														(f) => f !== target.value,
-													),
-												});
-											}
-										}}
-									/>{" "}
-									{prop}
-								</label>
-							))}
-						</>
-					)}
-				</details>
-
-				<details className="mb-6! hidden md:block" open>
-					<summary className="cursor-pointer text-sm font-bold text-gray-600 uppercase select-none dark:text-gray-200">
-						Authors
-					</summary>
-
-					{authors.map((author) => (
-						<label key={author} className="my-2! block">
-							<input
-								type="checkbox"
-								className="mr-2"
-								value={author}
-								checked={filters.authors.includes(author)}
-								onChange={(e) => {
-									const target = e.target as HTMLInputElement;
-
-									if (target.checked) {
-										setFilters({
-											...filters,
-											authors: [...filters.authors, target.value],
-										});
-									} else {
-										setFilters({
-											...filters,
-											authors: filters.authors.filter(
-												(f) => f !== target.value,
-											),
-										});
-									}
-								}}
-							/>{" "}
-							{authorData[author] ? authorData[author].name : author}
-						</label>
-					))}
-				</details>
+				{/* Filter dropdowns */}
+				<div className="flex flex-wrap items-center gap-2">
+					<FilterDropdown
+						label="Task Types"
+						items={taskItems}
+						selected={filters.tasks}
+						onChange={(tasks) => setFilters({ ...filters, tasks })}
+					/>
+					<FilterDropdown
+						label="Capabilities"
+						items={capabilityItems}
+						selected={filters.capabilities}
+						onChange={(capabilities) =>
+							setFilters({ ...filters, capabilities })
+						}
+					/>
+					<FilterDropdown
+						label="Authors"
+						items={authorItems}
+						selected={filters.authors}
+						onChange={(authors) => setFilters({ ...filters, authors })}
+					/>
+					<SortSelect sortOrder={sortOrder} onChange={setSortOrder} />
+				</div>
 			</div>
-			<div className="mt-0! grid w-full grid-cols-1 gap-3 self-start md:w-3/4 lg:grid-cols-2">
+
+			{/* Active filters + count */}
+			<div className="mb-4 flex items-center gap-3">
+				<span className="text-sm text-gray-600 dark:text-gray-400">
+					We found{" "}
+					<span className="font-semibold text-gray-900 dark:text-gray-100">
+						{modelList.length}
+					</span>{" "}
+					{modelList.length === 1 ? "model" : "models"}
+				</span>
+				{hasActiveFilters && (
+					<button
+						type="button"
+						onClick={() =>
+							setFilters({
+								...filters,
+								authors: [],
+								tasks: [],
+								capabilities: [],
+							})
+						}
+						className="cursor-pointer text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+					>
+						Clear filters
+					</button>
+				)}
+			</div>
+
+			{/* Model cards grid */}
+			<div className="grid w-full grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
 				{modelList.length === 0 && (
-					<div className="flex w-full flex-col justify-center rounded-md border bg-gray-50 py-6 text-center align-middle dark:border-gray-500 dark:bg-gray-800">
-						<span className="text-lg font-bold!">No models found</span>
+					<div className="col-span-full flex w-full flex-col justify-center rounded-md border bg-gray-50 py-6 text-center align-middle dark:border-gray-500 dark:bg-gray-800">
+						<span className="text-lg font-bold">No models found</span>
 						<p>
 							Try a different search term, or broaden your search by removing
 							filters.
@@ -334,7 +471,7 @@ const ModelCatalog = ({
 					return (
 						<a
 							key={model.model.id}
-							className="relative flex flex-col rounded-md border border-solid border-gray-200 p-3 text-inherit! no-underline hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
+							className="relative flex flex-col rounded-md border border-solid border-gray-200 p-3 text-inherit no-underline hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800"
 							href={`${basePath}/${basePath === "/workers-ai/models" ? model.model.name.split("/").at(-1) : model.model.name}/`}
 						>
 							{isPinned && (
@@ -359,13 +496,13 @@ const ModelCatalog = ({
 								</span>
 								{isBeta && <span className="sl-badge caution ml-1">Beta</span>}
 							</div>
-							<div className="m-0! text-xs">
+							<div className="text-xs">
 								<ModelInfo model={model.model} />
 							</div>
-							<p className="mt-2! line-clamp-2 flex-1 text-sm leading-6">
+							<p className="mt-2 line-clamp-2 flex-1 text-sm leading-6">
 								{model.model.description}
 							</p>
-							<div className="mt-2! min-h-6 text-xs">
+							<div className="mt-2 min-h-6 text-xs">
 								<ModelBadges model={model.model} />
 							</div>
 						</a>


### PR DESCRIPTION
### Summary

Redesigns the Workers AI model catalog page (`/workers-ai/models/`) to replace the sidebar filter layout with a horizontal toolbar that mirrors the Cloudflare dashboard design.

<img width="1213" height="800" alt="Screenshot 2026-04-16 at 2 12 00 PM" src="https://github.com/user-attachments/assets/a8d7cc5c-15a8-4f81-825b-c5d782c23779" />


**Changes:**
- Replaced sidebar layout (search + checkbox lists) with a horizontal toolbar: search input + three searchable multi-select dropdown filters (Task Types, Capabilities, Authors) + sort toggle
- Filter dropdowns use Base UI `Combobox` with `multiple` for proper accessibility (ARIA, keyboard navigation, focus management) and built-in search filtering within each dropdown
- Added `@base-ui/react` as a dependency
- Added a "We found N models" count with a "Clear filters" button
- Grid now uses full width (3 columns on `lg` instead of 2 in the old 3/4-width area)
- Added sort direction toggle (newest/oldest by date added)
- Fixed query parameter auto-population race condition: URL params (`?search=...&tasks=...`) now correctly populate filters on page load (previously a race between the read and write `useEffect` hooks cleared them)
- Wrapped component output in Starlight's `not-content` class to opt out of prose spacing rules
- Memoized derived filter item lists and moved `pinnedModelNames` to module scope

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).