### PR TITLE
Dedupe author filter by display name on Workers AI models catalog

### DIFF
--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -114,15 +114,26 @@ const ModelCatalog = ({
 	}));
 
 	const tasks = [...new Set(models.map((model) => model.task.name))];
+	const getAuthorDisplayName = (id: string) => authorData[id]?.name ?? id;
 	const authors = [
-		...new Set(models.map((model) => getModelAuthor(model.name))),
-	];
+		...new Map(
+			models
+				.map((model) => getModelAuthor(model.name))
+				.map((id) => [getAuthorDisplayName(id), id] as const),
+		).values(),
+	].sort((a, b) =>
+		getAuthorDisplayName(a).localeCompare(getAuthorDisplayName(b)),
+	);
 	const modelProperties = getLabelsByCategory(models, "model");
 	const platformProperties = getLabelsByCategory(models, "platform");
 
 	const modelList = mapped.filter(({ model }) => {
 		if (filters.authors.length > 0) {
-			if (!filters.authors.includes(getModelAuthor(model.name))) {
+			const selectedAuthorNames = new Set(
+				filters.authors.map(getAuthorDisplayName),
+			);
+			const modelAuthorName = getAuthorDisplayName(getModelAuthor(model.name));
+			if (!selectedAuthorNames.has(modelAuthorName)) {
 				return false;
 			}
 		}


### PR DESCRIPTION
### Summary

Current models catalog for Workers AI has duplicate author listings 

### Screenshots (optional)

Current: 
<img width="266" height="374" alt="image" src="https://github.com/user-attachments/assets/b70345f6-a011-4f8c-b72c-9049645947da" />

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).