### PR TITLE
[DLP] Streaming ZIP file scanning removes per-file size limits

### DIFF
--- a/src/content/changelog/dlp/2026-03-26-streaming-zip-handler.mdx
+++ b/src/content/changelog/dlp/2026-03-26-streaming-zip-handler.mdx
@@ -1,0 +1,12 @@
+---
+title: "Streaming ZIP file scanning removes per-file size limits"
+description: "DLP now uses a streaming ZIP handler that processes archive contents as data arrives, removing previous file size limitations for content within ZIP files."
+date: "2026-03-26"
+products: [dlp]
+---
+
+DLP now processes ZIP files using a streaming handler that scans archive contents element-by-element as data arrives. This removes previous file size limitations and improves memory efficiency when scanning large archives.
+
+Microsoft Office documents (DOCX, XLSX, PPTX) also benefit from this improvement, as they use ZIP as a container format.
+
+This improvement is automatic — no configuration changes are required.

--- a/src/content/docs/cloudflare-one/data-loss-prevention/index.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/index.mdx
@@ -61,6 +61,6 @@ DLP supports reporting and scanning the following file types:
 
 DLP will scan the text contained in text, Microsoft Office, and PDF files.
 
-### Size
-
-DLP can scan files less than or equal to 100 MB in size. ZIP files can be recursively compressed a maximum of 10 times, and each content file within the ZIP file must be less than or equal to 200 MB in uncompressed size.
+:::note
+ZIP files can be recursively compressed a maximum of 10 times.
+:::


### PR DESCRIPTION
## Summary

- Adds changelog entry for the streaming ZIP handler feature (RM-20605), GA'd March 26, 2026
- Removes the outdated 100 MB file size limit and 200 MB per-file-within-ZIP limit from the DLP overview docs
- Moves the ZIP recursion limit (10x) into a note callout under the Supported file types section

## Changes

- **New:** `src/content/changelog/dlp/2026-03-26-streaming-zip-handler.mdx`
- **Updated:** `src/content/docs/cloudflare-one/policies/data-loss-prevention/index.mdx`

## Context

DLP now processes ZIP files using a streaming handler that scans archive contents element-by-element as data arrives, removing previous per-file size limitations. Microsoft Office documents (DOCX, XLSX, PPTX) also benefit since they use ZIP as a container format. The improvement is automatic — no user configuration required.

Jira: RM-20605