### PR TITLE
[D1] Update docs to reflect current limitations (SPM-3384)

### DIFF
--- a/src/content/docs/d1/index.mdx
+++ b/src/content/docs/d1/index.mdx
@@ -24,7 +24,15 @@ Create new serverless SQL databases to query from your Workers and Pages project
 
 D1 is Cloudflare's managed, serverless database with SQLite's SQL semantics, built-in disaster recovery, and Worker and HTTP API access.
 
-D1 is designed for horizontal scale out across multiple, smaller (10 GB) databases, such as per-user, per-tenant or per-entity databases. D1 allows you to build applications with thousands of databases at no extra cost for isolating with multiple databases. D1 pricing is based only on query and storage costs.
+Each D1 database supports up to 10 GB of storage. D1 pricing is based on query and storage costs.
+
+:::note[Choosing the right database product]
+Cloudflare offers several database products for different use cases:
+
+- **D1** is a managed, serverless SQL database ideal for straightforward database needs without infrastructure management.
+- **[Durable Objects with SQLite storage](/durable-objects/best-practices/access-durable-objects-storage/)** is a better fit for per-user, per-tenant, or per-entity workloads that require dynamic database creation and lifecycle management at scale.
+- **[Hyperdrive](/hyperdrive/)** connects your Workers to existing PostgreSQL or MySQL databases with connection pooling and reduced latency.
+:::
 
 Create your first D1 database by [following the Get started guide](/d1/get-started/), learn how to [import data into a database](/d1/best-practices/import-export-data/), and how to [interact with your database](/d1/worker-api/) directly from [Workers](/workers/) or [Pages](/pages/functions/bindings/#d1-databases).
 

--- a/src/content/partials/d1/faq-limits.mdx
+++ b/src/content/partials/d1/faq-limits.mdx
@@ -4,8 +4,7 @@
 
 ### How much work can a D1 database do?
 
-D1 is designed for horizontal scale out across multiple, smaller (10 GB) databases, such as per-user, per-tenant or per-entity databases.
-D1 allows you to build applications with thousands of databases at no extra cost, as the pricing is based only on query and storage costs.
+You can create multiple D1 databases per account. Each database supports up to 10 GB of storage. D1 pricing is based on query and storage costs, with no per-database fee. For per-account database limits and per-Worker binding limits, refer to the limits table above.
 
 #### Storage
 


### PR DESCRIPTION
## Summary

- Removes misleading claims that D1 is "designed for horizontal scale out across multiple databases" and that users can "build applications with thousands of databases at no extra cost"
- Replaces with accurate language about D1 capabilities and pricing
- Adds an admonition on the D1 landing page guiding users to the right database product for their use case (D1, Durable Objects with SQLite, or Hyperdrive)

## Changes

### `src/content/docs/d1/index.mdx` (D1 landing page)
- Replaced the scale-out paragraph with a factual description of D1's storage and pricing
- Added a `:::note[Choosing the right database product]` admonition with guidance on D1 vs Durable Objects with SQLite vs Hyperdrive

### `src/content/partials/d1/faq-limits.mdx` (Limits FAQ)
- Replaced "horizontal scale out" and "thousands of databases at no extra cost" language with factual description of multi-database support and pricing

## Context

- Originated from community feedback on Discord regarding inaccurate D1 positioning