### PR TITLE
[Workers AI] Add Claude Opus 4.7 and clean up cover images

### DIFF
--- a/src/content/catalog-models/alibaba-wan-2.6-image.json
+++ b/src/content/catalog-models/alibaba-wan-2.6-image.json
@@ -91,7 +91,7 @@
 	"supports_async": false,
 	"external_info": "https://wan.video/",
 	"terms": "https://www.alibabacloud.com/help/en/legal",
-	"cover_image_url": "https://replicate.delivery/xezq/fG590HpoJ3xvPyBfT7VJrwvgaeINUIKiijWbnhrmAatPbZ1sA/tmp962by18n.jpeg",
+	"cover_image_url": null,
 	"metadata": {
 		"Size Format": "WxH (e.g. 1024x1024)",
 		"Negative Prompt": "Yes"

--- a/src/content/catalog-models/anthropic-claude-opus-4.7.json
+++ b/src/content/catalog-models/anthropic-claude-opus-4.7.json
@@ -1,16 +1,19 @@
 {
-	"model_id": "anthropic/claude-sonnet-4.6",
+	"model_id": "anthropic/claude-opus-4.7",
 	"provider_id": "anthropic",
-	"name": "Claude Sonnet 4.6",
-	"description": "Claude Sonnet 4.6 is Anthropic's latest balanced model offering strong coding, reasoning, and agentic capabilities with improved instruction following.",
+	"name": "Claude Opus 4.7",
+	"description": "Claude Opus 4.7 is Anthropic's most capable generally available model to date. It is highly autonomous and performs exceptionally well on long-horizon agentic work, knowledge work, vision tasks, and memory tasks.",
 	"task": "Text Generation",
 	"tags": [
 		"LLM",
 		"Coding",
 		"Reasoning",
-		"Agentic"
+		"Enterprise",
+		"Agentic",
+		"Financial Analysis",
+		"Legal"
 	],
-	"context_length": 200000,
+	"context_length": 1000000,
 	"max_output_tokens": 128000,
 	"schema_version": "1.0.0",
 	"pricing": {},
@@ -31,7 +34,7 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const response = await env.AI.run(\n  'anthropic/claude-sonnet-4.6',\n  {\n    messages: [\n      {\n        role: 'user',\n        content: 'What are the three laws of thermodynamics?',\n      },\n    ],\n    max_tokens: 1024,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'anthropic/claude-opus-4.7',\n  {\n    messages: [\n      {\n        role: 'user',\n        content: 'What are the three laws of thermodynamics?',\n      },\n    ],\n    max_tokens: 1024,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		},
@@ -53,7 +56,7 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const response = await env.AI.run(\n  'anthropic/claude-sonnet-4.6',\n  {\n    system: 'You are a helpful coding assistant specializing in Python.',\n    messages: [\n      {\n        role: 'user',\n        content: 'How do I read a JSON file in Python?',\n      },\n    ],\n    max_tokens: 1024,\n    temperature: 0.3,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'anthropic/claude-opus-4.7',\n  {\n    system: 'You are a helpful coding assistant specializing in Python.',\n    messages: [\n      {\n        role: 'user',\n        content: 'How do I read a JSON file in Python?',\n      },\n    ],\n    max_tokens: 1024,\n    temperature: 0.3,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		},
@@ -81,7 +84,7 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const response = await env.AI.run(\n  'anthropic/claude-sonnet-4.6',\n  {\n    messages: [\n      {\n        role: 'user',\n        content:\n          'I need help planning a road trip from San Francisco to Los Angeles.',\n      },\n      {\n        role: 'assistant',\n        content:\n          \"I'd be happy to help! The drive is about 380 miles and takes roughly 5-6 hours. Would you like suggestions for scenic routes or interesting stops along the way?\",\n      },\n      {\n        role: 'user',\n        content: 'Yes, what are some good places to stop?',\n      },\n    ],\n    max_tokens: 1024,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'anthropic/claude-opus-4.7',\n  {\n    messages: [\n      {\n        role: 'user',\n        content:\n          'I need help planning a road trip from San Francisco to Los Angeles.',\n      },\n      {\n        role: 'assistant',\n        content:\n          \"I'd be happy to help! The drive is about 380 miles and takes roughly 5-6 hours. Would you like suggestions for scenic routes or interesting stops along the way?\",\n      },\n      {\n        role: 'user',\n        content: 'Yes, what are some good places to stop?',\n      },\n    ],\n    max_tokens: 1024,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		},
@@ -102,7 +105,7 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const response = await env.AI.run(\n  'anthropic/claude-sonnet-4.6',\n  {\n    messages: [\n      {\n        role: 'user',\n        content:\n          'Write a short story opening about a detective finding an unusual clue.',\n      },\n    ],\n    max_tokens: 512,\n    temperature: 0.8,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'anthropic/claude-opus-4.7',\n  {\n    messages: [\n      {\n        role: 'user',\n        content:\n          'Write a short story opening about a detective finding an unusual clue.',\n      },\n    ],\n    max_tokens: 512,\n    temperature: 0.8,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		},
@@ -123,23 +126,24 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const response = await env.AI.run(\n  'anthropic/claude-sonnet-4.6',\n  {\n    messages: [\n      {\n        role: 'user',\n        content: 'Explain the concept of recursion with a simple example.',\n      },\n    ],\n    max_tokens: 1024,\n    stream: true,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'anthropic/claude-opus-4.7',\n  {\n    messages: [\n      {\n        role: 'user',\n        content: 'Explain the concept of recursion with a simple example.',\n      },\n    ],\n    max_tokens: 1024,\n    stream: true,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		}
 	],
 	"supports_async": false,
-	"external_info": "https://www.anthropic.com/claude/sonnet",
+	"external_info": "https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7",
 	"terms": "https://www.anthropic.com/legal/commercial-terms",
-	"cover_image_url": null,
+	"cover_image_url": "https://replicateassets.com/cdn-cgi/image/width=640,quality=85,fit=scale-down,format=auto/https://tjzk.replicate.delivery/models_models_cover_image/b200dc70-63c7-491d-a71f-e2b0b616ee18/replicate-prediction-amzhv0d91srm.jpg",
 	"metadata": {
-		"Architecture": "Transformer"
+		"Architecture": "Transformer",
+		"Extended Thinking": "Yes"
 	},
-	"created_at": "2026-04-13 16:44:14",
+	"created_at": "2026-04-16 19:12:00",
 	"default_example": null,
 	"code_snippets": [],
 	"schema": {
-		"model_id": "anthropic/claude-sonnet-4.6",
+		"model_id": "anthropic/claude-opus-4.7",
 		"version": "1.0.0",
 		"input": {
 			"$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/content/catalog-models/assemblyai-universal-3-pro.json
+++ b/src/content/catalog-models/assemblyai-universal-3-pro.json
@@ -94,7 +94,7 @@
 	"supports_async": false,
 	"external_info": "https://www.assemblyai.com/",
 	"terms": "https://www.assemblyai.com/legal/terms-of-service",
-	"cover_image_url": "https://replicate.delivery/xezq/PfO5HW1Y1ESxfkAeLEdMmbCU2eeaAcMBXetLOXv54c74kMrmF/tmpw_lr805x.jpeg",
+	"cover_image_url": null,
 	"metadata": {
 		"Multilingual": "Yes"
 	},

--- a/src/content/catalog-models/bytedance-seedream-4.0.json
+++ b/src/content/catalog-models/bytedance-seedream-4.0.json
@@ -112,7 +112,7 @@
 	"supports_async": false,
 	"external_info": "https://seed.bytedance.com/en/seedream4_0",
 	"terms": null,
-	"cover_image_url": "https://tjzk.replicate.delivery/models_models_featured_image/53dda182-2998-4fde-b235-e1b2a09b0484/seedream4-sm.jpg",
+	"cover_image_url": null,
 	"metadata": {
 		"Max Resolution": "4K",
 		"Editing": "Yes (single-sentence)"

--- a/src/content/catalog-models/google-gemini-3.1-flash-lite.json
+++ b/src/content/catalog-models/google-gemini-3.1-flash-lite.json
@@ -141,7 +141,7 @@
 	"supports_async": false,
 	"external_info": "https://deepmind.google/technologies/gemini/",
 	"terms": "https://ai.google.dev/gemini-api/terms",
-	"cover_image_url": "https://replicate.delivery/xezq/0eTvjvx0PhVoIaslnszKL5MPNGfu27HuPlsWHk8aWloTvsaWA/tmp7qu1pn34.jpeg",
+	"cover_image_url": null,
 	"metadata": {
 		"Architecture": "Transformer (multimodal)"
 	},

--- a/src/content/catalog-models/google-veo-3.1-fast.json
+++ b/src/content/catalog-models/google-veo-3.1-fast.json
@@ -102,7 +102,7 @@
 	"supports_async": false,
 	"external_info": "https://deepmind.google/technologies/veo/",
 	"terms": "https://ai.google.dev/gemini-api/terms",
-	"cover_image_url": "https://tjzk.replicate.delivery/models_models_featured_image/8a4d195c-cdd7-4544-9ee4-d9f67bb9017d/replicate-prediction-9y7jqn5by.mp4",
+	"cover_image_url": null,
 	"metadata": {
 		"Max Duration": "8 seconds",
 		"Audio Generation": "Yes",

--- a/src/content/catalog-models/google-veo-3.1.json
+++ b/src/content/catalog-models/google-veo-3.1.json
@@ -102,7 +102,7 @@
 	"supports_async": false,
 	"external_info": "https://deepmind.google/technologies/veo/",
 	"terms": "https://ai.google.dev/gemini-api/terms",
-	"cover_image_url": "https://tjzk.replicate.delivery/models_models_featured_image/7600d853-2847-4c46-afc9-faef04fea2c5/veo3.1-sm.mp4",
+	"cover_image_url": null,
 	"metadata": {
 		"Max Duration": "8 seconds",
 		"Audio Generation": "Yes",

--- a/src/content/catalog-models/minimax-hailuo-2.3-fast.json
+++ b/src/content/catalog-models/minimax-hailuo-2.3-fast.json
@@ -79,7 +79,7 @@
 	"supports_async": false,
 	"external_info": "https://hailuoai.com/",
 	"terms": "https://hailuoai.com/terms",
-	"cover_image_url": "https://tjzk.replicate.delivery/models_models_featured_image/9f1d0e6a-6b73-4b0f-97e2-c4ceeae8c585/hailuio-2.3-sm.mp4",
+	"cover_image_url": null,
 	"metadata": {
 		"Resolutions": "540p, 720p, 1080p"
 	},

--- a/src/content/catalog-models/minimax-hailuo-2.3.json
+++ b/src/content/catalog-models/minimax-hailuo-2.3.json
@@ -97,7 +97,7 @@
 	"supports_async": false,
 	"external_info": "https://hailuoai.com/",
 	"terms": "https://hailuoai.com/terms",
-	"cover_image_url": "https://tjzk.replicate.delivery/models_models_featured_image/1c5d6ebb-8251-4f70-b3bb-dd64729d0858/hailuo-23-sm.mp4",
+	"cover_image_url": null,
 	"metadata": {
 		"Resolutions": "540p, 720p, 1080p"
 	},

--- a/src/content/catalog-models/minimax-music-2.6.json
+++ b/src/content/catalog-models/minimax-music-2.6.json
@@ -111,7 +111,7 @@
 	"supports_async": false,
 	"external_info": "https://www.minimaxi.com/",
 	"terms": "https://www.minimaxi.com/terms",
-	"cover_image_url": "https://replicate.delivery/xezq/neH2tENTnnWzFqnRuusIeBR6GaPQYL20xLkJ2XoScJrsTCbWA/tmpkkqbd2it.mp3",
+	"cover_image_url": null,
 	"metadata": {
 		"Max Duration": "~6 minutes",
 		"Modes": "Vocals, Instrumental, Auto-Lyrics",

--- a/src/content/catalog-models/openai-gpt-4o-transcribe.json
+++ b/src/content/catalog-models/openai-gpt-4o-transcribe.json
@@ -27,7 +27,7 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const resp = await fetch('https://cdn.openai.com/API/docs/audio/alloy.wav')\nconst buffer = await resp.arrayBuffer();\nconst bytes = new Uint8Array(buffer);\nlet binary = '';\nfor (let i = 0; i < bytes.length; i++) {\n  binary += String.fromCharCode(bytes[i]);\n}\nconst encoded = btoa(binary);\nconst response = await env.AI.run(\n  'openai/gpt-4o-transcribe',\n  {\n    file: `data:audio/wav;base64,${encoded}`,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'openai/gpt-4o-transcribe',\n  {\n    file: 'https://cdn.openai.com/API/docs/audio/alloy.wav',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		},
@@ -45,7 +45,7 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const resp = await fetch('https://cdn.openai.com/API/docs/audio/shimmer.wav')\nconst buffer = await resp.arrayBuffer();\nconst bytes = new Uint8Array(buffer);\nlet binary = '';\nfor (let i = 0; i < bytes.length; i++) {\n  binary += String.fromCharCode(bytes[i]);\n}\nconst encoded = btoa(binary);\nconst response = await env.AI.run(\n  'openai/gpt-4o-transcribe',\n  {\n    file: `data:audio/wav;base64,${encoded}`,\n    language: 'en',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'openai/gpt-4o-transcribe',\n  {\n    file: 'https://cdn.openai.com/API/docs/audio/shimmer.wav',\n    language: 'en',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		},
@@ -64,7 +64,7 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const resp = await fetch('https://cdn.openai.com/API/docs/audio/fable.wav')\nconst buffer = await resp.arrayBuffer();\nconst bytes = new Uint8Array(buffer);\nlet binary = '';\nfor (let i = 0; i < bytes.length; i++) {\n  binary += String.fromCharCode(bytes[i]);\n}\nconst encoded = btoa(binary);\nconst response = await env.AI.run(\n  'openai/gpt-4o-transcribe',\n  {\n    file: `data:audio/wav;base64,${encoded}`,\n    language: 'en',\n    prompt:\n      'This is a technical discussion about Kubernetes and cloud-native architecture.',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'openai/gpt-4o-transcribe',\n  {\n    file: 'https://cdn.openai.com/API/docs/audio/fable.wav',\n    language: 'en',\n    prompt:\n      'This is a technical discussion about Kubernetes and cloud-native architecture.',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		},
@@ -82,7 +82,7 @@
 				{
 					"label": "typescript",
 					"language": "typescript",
-					"code": "const resp = await fetch('https://cdn.openai.com/API/docs/audio/echo.wav')\nconst buffer = await resp.arrayBuffer();\nconst bytes = new Uint8Array(buffer);\nlet binary = '';\nfor (let i = 0; i < bytes.length; i++) {\n  binary += String.fromCharCode(bytes[i]);\n}\nconst encoded = btoa(binary);\nconst response = await env.AI.run(\n  'openai/gpt-4o-transcribe',\n  {\n    file: `data:audio/wav;base64,${encoded}`,\n    temperature: 0.5,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+					"code": "const response = await env.AI.run(\n  'openai/gpt-4o-transcribe',\n  {\n    file: 'https://cdn.openai.com/API/docs/audio/echo.wav',\n    temperature: 0.5,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
 				}
 			]
 		}

--- a/src/content/catalog-models/openai-gpt-4o-transcribe.json
+++ b/src/content/catalog-models/openai-gpt-4o-transcribe.json
@@ -4,11 +4,7 @@
 	"name": "GPT-4o Transcribe",
 	"description": "A speech-to-text model that uses GPT-4o to transcribe audio with improved word error rate and better language recognition compared to original Whisper models.",
 	"task": "Automatic Speech Recognition",
-	"tags": [
-		"Speech-to-Text",
-		"Transcription",
-		"Multilingual"
-	],
+	"tags": ["Speech-to-Text", "Transcription", "Multilingual"],
 	"context_length": null,
 	"max_output_tokens": null,
 	"schema_version": "1.0.0",
@@ -107,7 +103,7 @@
 			"type": "object",
 			"properties": {
 				"file": {
-					"description": "The audio file as a data URI (data:audio/...;base64,...). Supported formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm.",
+					"description": "The audio file as a URL or data URI (data:audio/...;base64,...). Supported formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm.",
 					"type": "string"
 				},
 				"language": {
@@ -126,10 +122,7 @@
 					"maximum": 1
 				}
 			},
-			"required": [
-				"file",
-				"temperature"
-			],
+			"required": ["file", "temperature"],
 			"additionalProperties": false
 		},
 		"output": {
@@ -141,9 +134,7 @@
 					"type": "string"
 				}
 			},
-			"required": [
-				"text"
-			],
+			"required": ["text"],
 			"additionalProperties": false
 		}
 	}

--- a/src/content/catalog-models/openai-gpt-5.4-mini.json
+++ b/src/content/catalog-models/openai-gpt-5.4-mini.json
@@ -133,7 +133,7 @@
 	"supports_async": false,
 	"external_info": "https://openai.com/",
 	"terms": "https://openai.com/policies/",
-	"cover_image_url": "https://replicate.delivery/xezq/Oktjm48c1doBBNO22jKdfeyAnaQe7KfF00AtLMKpHej2tlVzC/tmpi91v9z4c.jpeg",
+	"cover_image_url": null,
 	"metadata": {
 		"Architecture": "Transformer"
 	},

--- a/src/content/catalog-models/openai-gpt-5.4-nano.json
+++ b/src/content/catalog-models/openai-gpt-5.4-nano.json
@@ -134,7 +134,7 @@
 	"supports_async": false,
 	"external_info": "https://openai.com/",
 	"terms": "https://openai.com/policies/",
-	"cover_image_url": "https://replicate.delivery/xezq/DRjKvIeQasTlTiry1hyRVDdCQSu05KT2oton8ybTIUzetsaWA/tmpecgggl6o.jpeg",
+	"cover_image_url": null,
 	"metadata": {
 		"Architecture": "Transformer"
 	},

--- a/src/content/catalog-models/openai-tts-1-hd.json
+++ b/src/content/catalog-models/openai-tts-1-hd.json
@@ -90,7 +90,7 @@
 	"supports_async": false,
 	"external_info": "https://platform.openai.com/docs/guides/text-to-speech",
 	"terms": "https://openai.com/policies/",
-	"cover_image_url": "https://replicate.delivery/xezq/1DGqzN0pZE7fKKrcUrcfXXdhUvwHLadYEm1seL3BxcANeyqZB/tmp57lzzngv.jpeg",
+	"cover_image_url": null,
 	"metadata": {
 		"Voices": "alloy, echo, fable, onyx, nova, shimmer"
 	},

--- a/src/content/catalog-models/openai-tts-1.json
+++ b/src/content/catalog-models/openai-tts-1.json
@@ -108,7 +108,7 @@
 	"supports_async": false,
 	"external_info": "https://platform.openai.com/docs/guides/text-to-speech",
 	"terms": "https://openai.com/policies/",
-	"cover_image_url": "https://replicate.delivery/xezq/K99qxjVN2GJ2FZNZJzeKM8t4GxgGRRzY2HzIUpzoqjIGXWNLA/tmp34i73hyw.jpeg",
+	"cover_image_url": null,
 	"metadata": {
 		"Voices": "alloy, echo, fable, onyx, nova, shimmer"
 	},

--- a/src/content/catalog-models/runwayml-gen-4.5.json
+++ b/src/content/catalog-models/runwayml-gen-4.5.json
@@ -156,7 +156,7 @@
 	"supports_async": false,
 	"external_info": "https://runwayml.com/",
 	"terms": "https://runwayml.com/terms-of-use",
-	"cover_image_url": "https://replicate.delivery/xezq/C7zMCnrf7dxMUqAonkhC523DgcOZWcsEc0dWvZz0C7ffsD2sA/tmpow5qjpky.mp4",
+	"cover_image_url": null,
 	"metadata": {
 		"Max Duration": "10 seconds",
 		"Resolutions": "1280:720, 720:1280, 1104:832, 832:1104, 960:960, 1584:672",


### PR DESCRIPTION
### Summary

Adds the Claude Opus 4.7 catalog model entry and clears stale `cover_image_url` values (pointing at `replicate.delivery` URLs) across a handful of existing catalog models. Also simplifies the `openai/gpt-4o-transcribe` code snippets to pass a URL directly instead of fetching and base64-encoding the audio.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).