### PR TITLE
[AI Gateway] Fix full URLs, add TypeScriptExample components, and cor…

### DIFF
--- a/src/content/docs/ai-gateway/features/unified-billing.mdx
+++ b/src/content/docs/ai-gateway/features/unified-billing.mdx
@@ -57,7 +57,7 @@ Workers AI models (models prefixed with `@cf/`) routed through AI Gateway are no
 
 ### AI binding
 
-Call any model listed in the [model catalog](https://developers.cloudflare.com/ai/models/) using `env.AI.run()`. This includes both Workers AI models and third-party models from providers like OpenAI, Anthropic, and Google.
+Call any model listed in the [model catalog](/ai/models/) using `env.AI.run()`. This includes both Workers AI models and third-party models from providers like OpenAI, Anthropic, and Google.
 
 ```typescript
 const resp = await env.AI.run(

--- a/src/content/docs/ai-gateway/integrations/vercel-ai-sdk.mdx
+++ b/src/content/docs/ai-gateway/integrations/vercel-ai-sdk.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-import { Details, Tabs, TabItem } from "~/components";
+import { Details, Tabs, TabItem, TypeScriptExample } from "~/components";
 import CodeSnippets from "~/components/ai-gateway/code-examples.astro";
 
 The [Vercel AI SDK](https://sdk.vercel.ai/) is a TypeScript library for building AI applications. The SDK supports many different AI providers, tools for streaming completions, and more.
@@ -24,6 +24,8 @@ npm install ai-gateway-provider
 ### AI binding with third-party models
 
 If you are already using the [`workers-ai-provider`](https://www.npmjs.com/package/workers-ai-provider) package, you can route requests through AI Gateway to call third-party models without needing separate provider SDKs. Pass a `gateway` option with your gateway ID to `createWorkersAI`:
+
+<TypeScriptExample>
 
 ```ts
 import { createWorkersAI } from "workers-ai-provider";
@@ -46,7 +48,9 @@ export default {
 } satisfies ExportedHandler<Env>;
 ```
 
-This works with any [supported provider and model](/ai-gateway/usage/providers/) available through AI Gateway.
+</TypeScriptExample>
+
+This works with any [supported provider and model](/ai/models/) available through AI Gateway.
 
 ### Fallback Providers
 

--- a/src/content/docs/ai-gateway/integrations/worker-binding-methods.mdx
+++ b/src/content/docs/ai-gateway/integrations/worker-binding-methods.mdx
@@ -12,7 +12,7 @@ description: >-
   for feedback, logging, URLs, and universal requests.
 ---
 
-import { Render, WranglerConfig } from "~/components";
+import { Render, TypeScriptExample, WranglerConfig } from "~/components";
 
 The AI binding (`env.AI`) lets you call AI models and access AI Gateway features directly from your Worker.
 
@@ -44,7 +44,9 @@ Runs an inference request through AI Gateway. Accepts Workers AI models (`@cf/` 
 
 **Workers AI model:**
 
-```typescript
+<TypeScriptExample>
+
+```ts
 const resp = await env.AI.run(
 	"@cf/moonshotai/kimi-k2.5",
 	{
@@ -58,9 +60,13 @@ const resp = await env.AI.run(
 );
 ```
 
+</TypeScriptExample>
+
 **Third-party model:**
 
-```typescript
+<TypeScriptExample>
+
+```ts
 const resp = await env.AI.run(
 	"openai/gpt-4.1-mini",
 	{
@@ -74,13 +80,15 @@ const resp = await env.AI.run(
 );
 ```
 
+</TypeScriptExample>
+
 Third-party models require an AI Gateway and use [Unified Billing](/ai-gateway/features/unified-billing/). Cloudflare manages the provider credentials and deducts credits from your account. You do not need to supply your own API keys.
 
 :::note
 [BYOK (Bring Your Own Keys)](/ai-gateway/configuration/bring-your-own-keys/) is not supported for third-party models called through the AI binding. To use your own provider keys, use the [AI Gateway REST API](/ai-gateway/usage/providers/) or the [chat completions endpoint](/ai-gateway/usage/chat-completion/) instead.
 :::
 
-Browse available models in the [model catalog](https://developers.cloudflare.com/ai/models/).
+Browse available models in the [model catalog](/ai/models/).
 
 ### Gateway options
 


### PR DESCRIPTION
…rect model catalog link

Address PR #29864 feedback: convert full URLs to root-relative paths, wrap Workers code examples with TypeScriptExample for TS/JS tabs, and point the Vercel AI SDK model link to /ai/models/ instead of /ai-gateway/usage/providers/.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
