### PR TITLE
Fix broken link to DigiCert AWS SSL installation guide

### DIFF
--- a/src/content/docs/ssl/origin-configuration/origin-ca/index.mdx
+++ b/src/content/docs/ssl/origin-configuration/origin-ca/index.mdx
@@ -83,7 +83,7 @@ To add an Origin CA certificate to your origin web server
 - [Microsoft IIS 10](https://www.digicert.com/kb/csr-creation-ssl-installation-iis-10.htm)
 - [NGINX](https://www.digicert.com/kb/csr-ssl-installation/nginx-openssl.htm)
 - [Apache Tomcat](https://www.digicert.com/csr-ssl-installation/tomcat-keytool.htm#ssl_certificate_install)
-- [Amazon Web Services](https://www.digicert.com/ssl-certficate-installation-amazon-web-services.htm)
+- [Amazon Web Services](https://www.digicert.com/ssl-certificate-installation-amazon-web-services.htm)
 - [Apache cPanel](https://www.digicert.com/kb/ssl-certificate-installation-apache-cpanel.htm)
 - [Ubuntu Server with Apache2](https://www.digicert.com/kb/csr-ssl-installation/ubuntu-server-with-apache2-openssl.htm#ssl_certificate_install)
 


### PR DESCRIPTION
The link to DigiCert's AWS SSL installation guide had a typo ('certficate' instead of 'certificate'), causing a 404. This fixes the URL to the correct one.