### PR TITLE
feat: handle external_link frontmatter correctly llms.txt

### DIFF
--- a/src/pages/[...product]/llms.txt.ts
+++ b/src/pages/[...product]/llms.txt.ts
@@ -58,7 +58,8 @@ export const getStaticPaths = (async () => {
 					(e.id.startsWith(prefix + "/") || e.id === prefix) &&
 					!isDirectoryOnlyPage(e.body ?? "") &&
 					!isDisallowedByRobots(`/${e.id}/`) &&
-					!isExternalRedirect(`/${e.id}/`),
+					!isExternalRedirect(`/${e.id}/`) &&
+					(!e.data.external_link || e.data.external_link.startsWith("/")),
 			);
 
 			if (pages.length === 0) return null;
@@ -76,8 +77,10 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 type Page = InferGetStaticPropsType<typeof getStaticPaths>["pages"][number];
 
 function formatPage(base: string, e: Page) {
-	const resolved = resolveRedirect(`/${e.id}/`);
-	const line = `- [${e.data.title}](${base}${resolved}index.md)`;
+	const path = e.data.external_link?.startsWith("/")
+		? resolveRedirect(e.data.external_link)
+		: resolveRedirect(`/${e.id}/`);
+	const line = `- [${e.data.title}](${base}${path}index.md)`;
 	return e.data.description ? line.concat(`: ${e.data.description}`) : line;
 }
 


### PR DESCRIPTION
### Summary

Updates the per-product llms.txt generator to handle pages with `external_link` frontmatter more accurately:

- Pages where `external_link` is an **external URL** (e.g. `https://github.com/...`) are excluded. 
- Pages where `external_link` is an **internal path** (e.g. `/workers/wrangler/api/`) are kept and their llms.txt entry links directly to the target page rather than the stub. The stub's title and description are preserved.

Previously, the `isExternalRedirect` check only caught pages redirected via `public/__redirects` — pages that redirect via the `external_link` frontmatter field (which injects a `<meta http-equiv="refresh">` tag) were not filtered at all.

#### For example...

[https://developers.cloudflare.com/agents/llms.txt](https://developers.cloudflare.com/agents/llms.txt) currently includes

```
[Prompt an AI model](https://developers.cloudflare.com/agents/getting-started/prompting/index.md): Use the Workers "mega prompt" to build a Agents using your preferred AI tools and/or IDEs. The prompt understands the Agents SDK APIs, best practices and guidelines, and makes it easier to build valid Agents and Workers.
```

[https://developers.cloudflare.com/agents/getting-started/prompting/index.md](https://developers.cloudflare.com/agents/getting-started/prompting) actually just redirects to [https://developers.cloudflare.com/workers/get-started/prompting/](https://developers.cloudflare.com/workers/get-started/prompting/) if you're a human in a browser via ` <meta http-equiv="refresh">`, but markdown for agents happens before that redirect and just picks up an empty page:

```md
---
title: Prompt an AI model
description: Use the Workers &#34;mega prompt&#34; to build a Agents using your preferred AI tools and/or IDEs. The prompt understands the Agents SDK APIs, best practices and guidelines, and makes it easier to build valid Agents and Workers.
image: https://developers.cloudflare.com/dev-products-preview.png
---

[Skip to content](#%5Ftop)

Was this helpful?

YesNo

[ Edit page ](https://github.com/cloudflare/cloudflare-docs/edit/production/src/content/docs/agents/getting-started/prompting.mdx) [ Report issue ](https://github.com/cloudflare/cloudflare-docs/issues/new/choose)

Copy page

# Prompt an AI model
```