### PR TITLE
[WAF] AI Security: Add 'bias' example custom topic

### DIFF
--- a/src/content/docs/waf/detections/ai-security-for-apps/unsafe-topics.mdx
+++ b/src/content/docs/waf/detections/ai-security-for-apps/unsafe-topics.mdx
@@ -195,10 +195,11 @@ Compare how the same two topic descriptions perform against two prompts that bot
 
 ### Example custom topics
 
-| Label              | Topic description                       |
-| ------------------ | --------------------------------------- |
-| `competitors`      | `seeking info on competitors`           |
-| `financial-advice` | `seeking financial advice`              |
-| `legal-advice`     | `asking for legal or regulatory advice` |
-| `sensitive-data`   | `requesting passwords or API keys`      |
-| `job-seeking`      | `asking about job openings or careers`  |
+| Label              | Topic description                                 |
+| ------------------ | ------------------------------------------------- |
+| `competitors`      | `seeking info on competitors`                     |
+| `financial-advice` | `seeking financial advice`                        |
+| `legal-advice`     | `asking for legal or regulatory advice`           |
+| `sensitive-data`   | `requesting passwords or API keys`                |
+| `job-seeking`      | `asking about job openings or careers`            |
+| `bias`             | `comparing demographic groups as better or worse` |


### PR DESCRIPTION
### Summary

Adds a new topic for `bias` to highlight comparisons of demographic groups.
Requested via internal chat.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
