### PR TITLE
Add cross-product discovery tags to 51 pages across 12 sections

### DIFF
--- a/src/content/docs/cache/concepts/cache-behavior.mdx
+++ b/src/content/docs/cache/concepts/cache-behavior.mdx
@@ -6,6 +6,7 @@ products:
   - cache
 tags:
   - Headers
+  - Cookies
 ---
 
 In this page, we document how Cloudflare's cache system behaves in interaction with:

--- a/src/content/docs/cache/how-to/cache-keys.mdx
+++ b/src/content/docs/cache/how-to/cache-keys.mdx
@@ -7,6 +7,8 @@ products:
 tags:
   - CORS
   - Geolocation
+  - Headers
+  - Cookies
 head:
   - tag: title
     content: Cache Keys

--- a/src/content/docs/cache/troubleshooting/dynamic-content-and-login-issues.mdx
+++ b/src/content/docs/cache/troubleshooting/dynamic-content-and-login-issues.mdx
@@ -6,6 +6,7 @@ products:
 description: Troubleshoot login failures, missing session cookies, and challenge loops caused by caching dynamic content.
 tags:
   - Cookies
+  - Debugging
 sidebar:
   order: 2
 ---

--- a/src/content/docs/china-network/get-started.mdx
+++ b/src/content/docs/china-network/get-started.mdx
@@ -6,6 +6,8 @@ products:
   - china-network
 sidebar:
   order: 2
+tags:
+  - Compliance
 ---
 
 import { Steps } from "~/components";

--- a/src/content/docs/dns/internal-dns/connectivity.mdx
+++ b/src/content/docs/dns/internal-dns/connectivity.mdx
@@ -7,6 +7,8 @@ products:
 sidebar:
   order: 8
   label: Connectivity
+tags:
+  - Private networks
 ---
 
 To connect to Cloudflare Gateway resolver - which is [required to reach private resources in Internal DNS](/dns/internal-dns/#architecture-overview) - you can use the following options:

--- a/src/content/docs/dns/internal-dns/internal-zones/index.mdx
+++ b/src/content/docs/dns/internal-dns/internal-zones/index.mdx
@@ -8,6 +8,8 @@ sidebar:
   order: 2
   group:
     label: Internal zones
+tags:
+  - Private networks
 ---
 
 import { Example, Render, DirectoryListing } from "~/components";

--- a/src/content/docs/dns/internal-dns/internal-zones/internal-dns-records.mdx
+++ b/src/content/docs/dns/internal-dns/internal-zones/internal-dns-records.mdx
@@ -7,6 +7,8 @@ description: Manage internal DNS records in Cloudflare. Learn about supported DN
 sidebar:
   order: 4
   label: Internal DNS records
+tags:
+  - Private networks
 ---
 
 import { Details, Example } from "~/components";

--- a/src/content/docs/dns/internal-dns/internal-zones/reference-zones.mdx
+++ b/src/content/docs/dns/internal-dns/internal-zones/reference-zones.mdx
@@ -6,6 +6,8 @@ title: Reference zones
 description: Learn about reference zones. Cloudflare Internal DNS allows zones to reference others for query resolution when no direct record is found.
 sidebar:
   order: 4
+tags:
+  - Private networks
 ---
 
 import { Example, Render, Tabs, TabItem, DashButton } from "~/components";

--- a/src/content/docs/dns/internal-dns/internal-zones/setup.mdx
+++ b/src/content/docs/dns/internal-dns/internal-zones/setup.mdx
@@ -6,6 +6,8 @@ title: Manage internal zones
 description: Understand how to set up and manage internal DNS zones with Cloudflare. Explore configuration conditions, zone creation, and available API endpoints.
 sidebar:
   order: 2
+tags:
+  - Private networks
 ---
 
 import { Example, Render, Tabs, TabItem } from "~/components";

--- a/src/content/docs/dns/manage-dns-records/troubleshooting/exposed-ip-address.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/exposed-ip-address.mdx
@@ -7,6 +7,8 @@ title: Exposed IP addresses
 description: Understand and resolve warnings about DNS records that expose your origin server IP address.
 sidebar:
   order: 12
+tags:
+  - Proxying
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/dns/proxy-status/index.mdx
+++ b/src/content/docs/dns/proxy-status/index.mdx
@@ -7,6 +7,8 @@ title: Proxy status
 sidebar:
   order: 7
   label: Overview
+tags:
+  - Proxying
 ---
 
 import { Render, Example, Details, GlossaryTooltip } from "~/components";

--- a/src/content/docs/dns/proxy-status/limitations.mdx
+++ b/src/content/docs/dns/proxy-status/limitations.mdx
@@ -7,6 +7,8 @@ title: Proxying limitations
 sidebar:
   order: 2
   label: Limitations
+tags:
+  - Proxying
 ---
 
 import { Render, GlossaryTooltip, Details } from "~/components";

--- a/src/content/docs/smart-shield/configuration/cache-reserve/index.mdx
+++ b/src/content/docs/smart-shield/configuration/cache-reserve/index.mdx
@@ -6,6 +6,8 @@ products:
   - smart-shield
 sidebar:
   order: 5
+tags:
+  - Caching
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/smart-shield/configuration/cache-reserve/operations.mdx
+++ b/src/content/docs/smart-shield/configuration/cache-reserve/operations.mdx
@@ -7,6 +7,8 @@ products:
 sidebar:
   order: 2
   label: Operations
+tags:
+  - Caching
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
+++ b/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
@@ -6,6 +6,8 @@ products:
   - smart-shield
 sidebar:
   order: 4
+tags:
+  - Caching
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/smart-shield/configuration/smart-tiered-cache.mdx
+++ b/src/content/docs/smart-shield/configuration/smart-tiered-cache.mdx
@@ -6,6 +6,8 @@ products:
   - smart-shield
 sidebar:
   order: 3
+tags:
+  - Caching
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/spectrum/reference/simple-proxy-protocol-header.mdx
+++ b/src/content/docs/spectrum/reference/simple-proxy-protocol-header.mdx
@@ -6,6 +6,8 @@ products:
   - spectrum
 weight: 0
 
+tags:
+  - UDP
 ---
 
 The client source IP and port is encoded in a fixed-length, 38-octet long header and prepended to the payload of each proxied UDP datagram in the format described below.

--- a/src/content/docs/speed/optimization/content/compression.mdx
+++ b/src/content/docs/speed/optimization/content/compression.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Content compression | Brotli
+tags:
+  - Headers
 ---
 
 import { Stream, Render } from "~/components";

--- a/src/content/docs/speed/optimization/content/fonts/troubleshooting.mdx
+++ b/src/content/docs/speed/optimization/content/fonts/troubleshooting.mdx
@@ -8,6 +8,8 @@ head:
   - tag: title
     content: Cloudflare Fonts troubleshooting
 
+tags:
+  - Debugging
 ---
 
 ## Validate the Fonts feature is working

--- a/src/content/docs/speed/optimization/content/troubleshooting/content-encoding-issues.mdx
+++ b/src/content/docs/speed/optimization/content/troubleshooting/content-encoding-issues.mdx
@@ -4,6 +4,8 @@ description: Fix content encoding mismatches with compression settings.
 products:
   - speed
 title: Content encoding issues
+tags:
+  - Debugging
 ---
 
 If you are noticing any encoding errors with your HTML pages, we recommend verifying that the impacted pages are explicitly setting the correct charset in the `Content-Type` header from your origin for all text/html pages, for example `Content-Type: text/html; charset=utf-8`. This is particularly important if you are not using [UTF-8 encoding standard](https://en.wikipedia.org/wiki/UTF-8) for characters. Alternatively you can set the correct charset within the HTML.

--- a/src/content/docs/speed/optimization/images/troubleshooting/troubleshooting-missing-images.mdx
+++ b/src/content/docs/speed/optimization/images/troubleshooting/troubleshooting-missing-images.mdx
@@ -6,6 +6,8 @@ products:
 source: https://support.cloudflare.com/hc/en-us/articles/200169906-Troubleshooting-missing-images
 title: Troubleshoot missing images
 
+tags:
+  - Debugging
 ---
 
 If images are missing from your website, other Cloudflare features may be interfering with those images.

--- a/src/content/docs/speed/optimization/protocol/troubleshooting/protocol-troubleshooting.mdx
+++ b/src/content/docs/speed/optimization/protocol/troubleshooting/protocol-troubleshooting.mdx
@@ -5,6 +5,8 @@ products:
   - speed
 title: Troubleshoot protocol issues
 
+tags:
+  - Debugging
 ---
 
 This guide covers common HTTP/2 and HTTP/3 issues, including origin incompatibility, multiplexing errors, and browser errors, with steps to diagnose and resolve them.

--- a/src/content/docs/ssl/client-certificates/byo-ca.mdx
+++ b/src/content/docs/ssl/client-certificates/byo-ca.mdx
@@ -10,6 +10,8 @@ head: []
 description: Cloudflare mTLS now supports client certificates that have not been
   issued by Cloudflare CA. Learn how you can bring your own CA and use it with
   Cloudflare mTLS.
+tags:
+  - mTLS
 ---
 
 import { APIRequest, Render, TabItem, Tabs, DashButton } from "~/components";

--- a/src/content/docs/ssl/client-certificates/client-certificate-variables.mdx
+++ b/src/content/docs/ssl/client-certificates/client-certificate-variables.mdx
@@ -6,6 +6,8 @@ products:
 title: Client certificate variables
 sidebar:
   order: 10
+tags:
+  - mTLS
 ---
 
 When a request includes a client certificate for [mTLS authentication](/ssl/client-certificates/enable-mtls/), Cloudflare exposes certificate details as variables in the Ruleset Engine and as properties on the Workers `request.cf` object.

--- a/src/content/docs/ssl/client-certificates/configure-your-mobile-app-or-iot-device.mdx
+++ b/src/content/docs/ssl/client-certificates/configure-your-mobile-app-or-iot-device.mdx
@@ -7,6 +7,10 @@ sidebar:
   order: 9
 description: >-
   This tutorial demonstrates how to configure your Internet-of-things (IoT) device and mobile application to use client certificates with API Shield.
+tags:
+  - mTLS
+  - iOS
+  - Android
 ---
 
 This tutorial demonstrates how to configure your Internet-of-things (IoT) device and mobile application to use client certificates with [API Shield](/api-shield/).

--- a/src/content/docs/ssl/client-certificates/create-a-client-certificate.mdx
+++ b/src/content/docs/ssl/client-certificates/create-a-client-certificate.mdx
@@ -6,6 +6,8 @@ products:
 title: Create a client certificate
 sidebar:
   order: 3
+tags:
+  - mTLS
 ---
 
 import { Details, DashButton, GlossaryTooltip } from "~/components";

--- a/src/content/docs/ssl/client-certificates/forward-a-client-certificate.mdx
+++ b/src/content/docs/ssl/client-certificates/forward-a-client-certificate.mdx
@@ -6,6 +6,9 @@ products:
 title: Forward certificate to server
 sidebar:
   order: 6
+tags:
+  - mTLS
+  - Headers
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/ssl/client-certificates/troubleshooting.mdx
+++ b/src/content/docs/ssl/client-certificates/troubleshooting.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Troubleshooting client certificates
+tags:
+  - mTLS
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/always-use-https.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/always-use-https.mdx
@@ -9,6 +9,8 @@ learning_center:
   link: https://www.cloudflare.com/learning/ssl/what-is-https/
 sidebar:
   order: 15
+tags:
+  - Redirects
 ---
 
 import { FeatureTable, TabItem, Tabs, DashButton } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/compliance-status.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/compliance-status.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Cipher suites compliance standards
+tags:
+  - TLS
 ---
 
 import { Render, Details } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api.mdx
@@ -7,6 +7,8 @@ products:
 sidebar:
   order: 2
   label: Use the API
+tags:
+  - TLS
 ---
 
 import { Render, TabItem, Tabs, APIRequest } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard.mdx
@@ -7,6 +7,8 @@ products:
 sidebar:
   order: 1
   label: Use the dashboard
+tags:
+  - TLS
 ---
 
 import { Render, Details, DashButton } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/index.mdx
@@ -10,6 +10,8 @@ head:
   - tag: title
     content: Customize cipher suites
 
+tags:
+  - TLS
 ---
 
 import { Render, TabItem, Tabs, DirectoryListing } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/index.mdx
@@ -10,6 +10,8 @@ head: []
 description: Consider information about supported cipher suites, how to meet
   your security requirements, and how to troubleshoot compatibility and other
   issues.
+tags:
+  - TLS
 ---
 
 import { DirectoryListing, Render } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/recommendations.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/recommendations.mdx
@@ -10,6 +10,8 @@ head:
   - tag: title
     content: Cipher suite recommendations
 
+tags:
+  - TLS
 ---
 
 import { Render, Details } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/supported-cipher-suites.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/supported-cipher-suites.mdx
@@ -10,6 +10,8 @@ head:
   - tag: title
     content: Supported cipher suites
 
+tags:
+  - TLS
 ---
 
 Cloudflare supports the following cipher suites by default. If needed, you can [restrict your website or application](/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/) to only use specific cipher suites.

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/troubleshooting.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/troubleshooting.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Troubleshooting - Cipher suites — Edge certificates
+tags:
+  - TLS
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/additional-options/http-strict-transport-security.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/http-strict-transport-security.mdx
@@ -6,6 +6,8 @@ products:
 title: HTTP Strict Transport Security (HSTS)
 sidebar:
   order: 4
+tags:
+  - Headers
 ---
 
 import { FeatureTable, TabItem, Tabs, DashButton } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/caa-records.mdx
+++ b/src/content/docs/ssl/edge-certificates/caa-records.mdx
@@ -6,6 +6,8 @@ products:
 title: Add CAA records
 sidebar:
   order: 6
+tags:
+  - DNS
 ---
 
 import { Render, TabItem, Tabs, DashButton } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/ech.mdx
+++ b/src/content/docs/ssl/edge-certificates/ech.mdx
@@ -9,6 +9,8 @@ sidebar:
   badge:
     text: Beta
 
+tags:
+  - Privacy
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/ssl/edge-certificates/encrypt-visitor-traffic.mdx
+++ b/src/content/docs/ssl/edge-certificates/encrypt-visitor-traffic.mdx
@@ -7,6 +7,8 @@ title: Enforce HTTPS connections
 sidebar:
   order: 4
 
+tags:
+  - Redirects
 ---
 
 Even with an active SSL/TLS certificate, visitors can still access resources over unsecured HTTP connections.

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/explanation.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/explanation.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: How Authenticated Origin Pulls works
+tags:
+  - mTLS
 ---
 
 ## Simple explanation

--- a/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/global.mdx
+++ b/src/content/docs/ssl/origin-configuration/authenticated-origin-pull/set-up/global.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Global authenticated origin pulls
+tags:
+  - mTLS
 ---
 
 import { Render, Tabs, TabItem, DashButton } from "~/components";

--- a/src/content/docs/ssl/origin-configuration/cipher-suites.mdx
+++ b/src/content/docs/ssl/origin-configuration/cipher-suites.mdx
@@ -11,6 +11,8 @@ head:
 description: Review a list of cipher suites that Cloudflare presents to origins
   during an SSL/TLS handshake.
 
+tags:
+  - TLS
 ---
 
 Refer to the following list to know what cipher suites Cloudflare presents to origin servers during an SSL/TLS handshake.

--- a/src/content/docs/ssl/reference/compliance-and-vulnerabilities.mdx
+++ b/src/content/docs/ssl/reference/compliance-and-vulnerabilities.mdx
@@ -6,6 +6,8 @@ products:
 source: https://support.cloudflare.com/hc/en-us/articles/205043158-PCI-compliance-and-Cloudflare-SSL-TLS
 title: PCI compliance and vulnerabilities mitigation
 
+tags:
+  - TLS
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/waiting-room/additional-options/embed-waiting-room-in-iframe.mdx
+++ b/src/content/docs/waiting-room/additional-options/embed-waiting-room-in-iframe.mdx
@@ -7,6 +7,8 @@ title: Embed in an iFrame
 sidebar:
   order: 5
 
+tags:
+  - Cookies
 ---
 
 import { Details, APIRequest } from "~/components"

--- a/src/content/docs/web-analytics/data-metrics/data-origin-and-collection.mdx
+++ b/src/content/docs/web-analytics/data-metrics/data-origin-and-collection.mdx
@@ -7,6 +7,8 @@ title: Data origin and collection
 sidebar:
   order: 5
 
+tags:
+  - Privacy
 ---
 
 import { GlossaryTooltip } from "~/components"


### PR DESCRIPTION
Adding another batch of tags to Docs. 

Sections: cache, china-network, dns, web-analytics, speed, waiting-room, spectrum, smart-shield, ssl, load-balancing, health-checks, google-tag-gateway

Tags applied: A/B testing, Android, Caching, Compliance, Cookies, Debugging, DNS, Headers, iOS, mTLS, Privacy, Private networks, Proxying, Redirects, TLS, UDP