### PR TITLE
fix(artifacts): align binding docs with workerd types

### DIFF
--- a/src/content/docs/artifacts/api/git-protocol.mdx
+++ b/src/content/docs/artifacts/api/git-protocol.mdx
@@ -23,7 +23,7 @@ Git routes accept repo access tokens in two forms:
 
 ### Token format
 
-Repo tokens are issued in the control-plane response format `art_v1_<40 hex>?expires=<unix_seconds>`.
+Repo tokens are issued in the format `art_v1_<40 hex>?expires=<unix_seconds>`. The `?expires=` suffix is the token's expiry as a unix timestamp in seconds. To check when a token expires, parse the value after `?expires=`.
 
 ### Git `extraHeader` parameter
 

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -18,7 +18,7 @@ Use the Artifacts REST API to manage repos, remotes, forks, imports, and tokens 
 Artifacts REST routes use this base path:
 
 ```txt
-https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE
+https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE
 ```
 
 Requests to `/v1/api/...` use Bearer authentication:
@@ -27,17 +27,18 @@ Requests to `/v1/api/...` use Bearer authentication:
 Authorization: Bearer <CLOUDFLARE_API_TOKEN>
 ```
 
-All routes below are relative to the base URL your deployment exposes. The examples use `https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE`.
+All routes below are relative to this base URL.
 
 Cloudflare API tokens authenticate REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
 
 The following examples assume:
 
 ```sh
+export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 All responses use the standard Cloudflare v4 envelope.
@@ -149,7 +150,6 @@ export interface CreateRepoResult {
 	default_branch: string;
 	remote: string;
 	token: ArtifactToken;
-	expires_at: string;
 }
 
 export type CreateRepoResponse = ApiEnvelope<CreateRepoResult>;
@@ -175,8 +175,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos" \
 		"description": "Repository for automation experiments",
 		"default_branch": "main",
 		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
-		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
-		"expires_at": "<ISO_TIMESTAMP>"
+		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000"
 	},
 	"success": true,
 	"errors": [],
@@ -357,7 +356,6 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/fork" \
 		"default_branch": "main",
 		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo-copy.git",
 		"token": "art_v1_89abcdef0123456789abcdef0123456789abcdef?expires=1760003600",
-		"expires_at": "<ISO_TIMESTAMP>",
 		"objects": 128
 	},
 	"success": true,
@@ -411,8 +409,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos/react-mirror/import" \
 		"description": null,
 		"default_branch": "main",
 		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/react-mirror.git",
-		"token": "art_v1_fedcba9876543210fedcba9876543210fedcba98?expires=1760007200",
-		"expires_at": "<ISO_TIMESTAMP>"
+		"token": "art_v1_fedcba9876543210fedcba9876543210fedcba98?expires=1760007200"
 	},
 	"success": true,
 	"errors": [],

--- a/src/content/docs/artifacts/api/workers-binding.mdx
+++ b/src/content/docs/artifacts/api/workers-binding.mdx
@@ -17,9 +17,7 @@ import {
 	WranglerConfig,
 } from "~/components";
 
-Use the Artifacts Workers binding to create, inspect, fork, and delete repos directly from your Worker. The Artifacts binding returns repo handles that allow repo-scoped operations such as token management and forking.
-
-Use the [REST API](/artifacts/api/rest-api/) when you need to import a repo from another remote.
+Use the Artifacts Workers binding to create, import, inspect, fork, and delete repos directly from your Worker. The Artifacts binding returns repo handles that allow repo-scoped operations such as token management and forking.
 
 ## Configure the binding
 
@@ -30,7 +28,7 @@ Add the Artifacts binding to your Wrangler config file:
 ```toml title="wrangler.toml"
 [[artifacts]]
 binding = "ARTIFACTS"
-namespace = "default"
+namespace = "default" # any name works — use namespaces to organise repos
 ```
 
 </WranglerConfig>
@@ -49,7 +47,7 @@ If you authenticate with `wrangler login`, Wrangler requests `artifacts:write` b
 
 ## Namespace methods
 
-Use namespace methods on `env.ARTIFACTS` to create, list, inspect, or delete repos.
+Use namespace methods on `env.ARTIFACTS` to create, list, inspect, import, or delete repos.
 
 ### `create(name, opts?)`
 
@@ -57,7 +55,7 @@ Use namespace methods on `env.ARTIFACTS` to create, list, inspect, or delete rep
 - `opts.readOnly` <Type text="boolean" /> <MetaInfo text="optional" />
 - `opts.description` <Type text="string" /> <MetaInfo text="optional" />
 - `opts.setDefaultBranch` <Type text="string" /> <MetaInfo text="optional" />
-- Returns <Type text="Promise<ArtifactsCreateRepoResult & { repo: ArtifactsRepo } >" />
+- Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
 
 <TypeScriptExample>
 
@@ -83,18 +81,14 @@ async function createRepo(artifacts: Artifacts) {
 ### `get(name)`
 
 - `name` <Type text="RepoName" /> <MetaInfo text="required" />
-- Returns <Type text="Promise<ArtifactsRepo | null>" />
+- Returns <Type text="Promise<ArtifactsRepo>" />
+- Throws if the repo does not exist.
 
 <TypeScriptExample>
 
 ```ts
 async function getRepoHandle(artifacts: Artifacts) {
 	const repo = await artifacts.get("starter-repo");
-
-	if (!repo) {
-		return null;
-	}
-
 	return repo;
 }
 ```
@@ -122,6 +116,42 @@ async function listRepos(artifacts: Artifacts) {
 
 </TypeScriptExample>
 
+### `import(params)`
+
+Import a repository from an external git remote.
+
+- `params.source.url` <Type text="string" /> <MetaInfo text="required" /> — HTTPS URL of the source repository.
+- `params.source.branch` <Type text="string" /> <MetaInfo text="optional" /> — Branch to import (defaults to the remote's default branch).
+- `params.source.depth` <Type text="number" /> <MetaInfo text="optional" /> — Shallow clone depth.
+- `params.target.name` <Type text="RepoName" /> <MetaInfo text="required" /> — Name for the imported repo.
+- `params.target.opts.description` <Type text="string" /> <MetaInfo text="optional" />
+- `params.target.opts.readOnly` <Type text="boolean" /> <MetaInfo text="optional" />
+- Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
+
+<TypeScriptExample>
+
+```ts
+async function importFromGitHub(artifacts: Artifacts) {
+	const imported = await artifacts.import({
+		source: {
+			url: "https://github.com/cloudflare/workers-sdk",
+			branch: "main",
+		},
+		target: {
+			name: "workers-sdk",
+		},
+	});
+
+	return {
+		name: imported.name,
+		remote: imported.remote,
+		token: imported.token,
+	};
+}
+```
+
+</TypeScriptExample>
+
 ### `delete(name)`
 
 - `name` <Type text="RepoName" /> <MetaInfo text="required" />
@@ -139,27 +169,14 @@ async function deleteRepo(artifacts: Artifacts) {
 
 ## Repo handle methods
 
-Use the `repo` returned by `create()`, or first check that `await artifacts.get(name)` returned a repo handle.
-
-These examples match the current runtime binding surface. If your generated types show `import()` or a discriminated union for `get()`, those types are ahead of the current runtime.
-
-### `info()`
-
-- Returns <Type text="Promise<ArtifactsRepoInfo | null>" />
-
-Use `info()` when you need repo metadata, including the remote URL.
+Call `await artifacts.get(name)` to get a repo handle. The handle extends `ArtifactsRepoInfo`, so repo metadata (`id`, `name`, `remote`, `defaultBranch`, etc.) is available directly as properties.
 
 <TypeScriptExample>
 
 ```ts
 async function getRemoteUrl(artifacts: Artifacts) {
 	const repo = await artifacts.get("starter-repo");
-	if (!repo) {
-		return null;
-	}
-
-	const info = await repo.info();
-	return info?.remote ?? null;
+	return repo.remote;
 }
 ```
 
@@ -176,31 +193,7 @@ async function getRemoteUrl(artifacts: Artifacts) {
 ```ts
 async function mintReadToken(artifacts: Artifacts) {
 	const repo = await artifacts.get("starter-repo");
-	if (!repo) {
-		throw new Error("Repo not found");
-	}
-
 	return repo.createToken("read", 3600);
-}
-```
-
-</TypeScriptExample>
-
-### `validateToken(token)`
-
-- `token` <Type text="ArtifactToken" /> <MetaInfo text="required" />
-- Returns <Type text="Promise<ArtifactsTokenValidation>" />
-
-<TypeScriptExample>
-
-```ts
-async function validateToken(artifacts: Artifacts, token: string) {
-	const repo = await artifacts.get("starter-repo");
-	if (!repo) {
-		throw new Error("Repo not found");
-	}
-
-	return repo.validateToken(token);
 }
 ```
 
@@ -215,10 +208,6 @@ async function validateToken(artifacts: Artifacts, token: string) {
 ```ts
 async function listRepoTokens(artifacts: Artifacts) {
 	const repo = await artifacts.get("starter-repo");
-	if (!repo) {
-		throw new Error("Repo not found");
-	}
-
 	const result = await repo.listTokens();
 	return {
 		total: result.total,
@@ -239,10 +228,6 @@ async function listRepoTokens(artifacts: Artifacts) {
 ```ts
 async function revokeToken(artifacts: Artifacts, tokenOrId: string) {
 	const repo = await artifacts.get("starter-repo");
-	if (!repo) {
-		throw new Error("Repo not found");
-	}
-
 	return repo.revokeToken(tokenOrId);
 }
 ```
@@ -262,10 +247,6 @@ async function revokeToken(artifacts: Artifacts, tokenOrId: string) {
 ```ts
 async function forkRepo(artifacts: Artifacts) {
 	const repo = await artifacts.get("starter-repo");
-	if (!repo) {
-		throw new Error("Repo not found");
-	}
-
 	const forked = await repo.fork("starter-repo-copy", {
 		description: "Fork for testing",
 		defaultBranchOnly: true,
@@ -303,19 +284,16 @@ export default {
 
 		if (request.method === "GET" && url.pathname === "/repos/starter-repo") {
 			const repo = await env.ARTIFACTS.get("starter-repo");
-			if (!repo) {
-				return Response.json({ error: "Repo not found" }, { status: 404 });
-			}
-			const info = await repo.info();
-			return Response.json(info);
+			return Response.json({
+				id: repo.id,
+				name: repo.name,
+				remote: repo.remote,
+				defaultBranch: repo.defaultBranch,
+			});
 		}
 
 		if (request.method === "POST" && url.pathname === "/tokens") {
 			const repo = await env.ARTIFACTS.get("starter-repo");
-			if (!repo) {
-				return Response.json({ error: "Repo not found" }, { status: 404 });
-			}
-
 			const token = await repo.createToken("read", 3600);
 			return Response.json(token);
 		}

--- a/src/content/docs/artifacts/concepts/best-practices.mdx
+++ b/src/content/docs/artifacts/concepts/best-practices.mdx
@@ -74,10 +74,6 @@ interface Env {
 
 async function forkFromBaseline(env: Env, sessionId: string) {
 	const baseline = await env.ARTIFACTS.get("starter-repo");
-	if (!baseline) {
-		throw new Error("Baseline repo not found");
-	}
-
 	const forked = await baseline.fork(`starter-repo-${sessionId}`, {
 		description: `Fork for session ${sessionId}`,
 		defaultBranchOnly: true,
@@ -118,10 +114,6 @@ export default {
 		const repoName = url.searchParams.get("repo") ?? "starter-repo";
 
 		const repo = await env.ARTIFACTS.get(repoName);
-		if (!repo) {
-			return Response.json({ error: "Repo not found" }, { status: 404 });
-		}
-
 		const token = await repo.createToken("read", 900);
 
 		return Response.json({

--- a/src/content/docs/artifacts/examples/git-client.mdx
+++ b/src/content/docs/artifacts/examples/git-client.mdx
@@ -17,10 +17,11 @@ First, fetch the repo metadata from the REST API. Then mint a read token for tha
 The example below uses `jq` to extract fields from the JSON responses.
 
 ```bash
+export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
 
 REPO_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")

--- a/src/content/docs/artifacts/examples/sandbox-sdk-artifacts.mdx
+++ b/src/content/docs/artifacts/examples/sandbox-sdk-artifacts.mdx
@@ -37,22 +37,18 @@ The template keeps one Artifacts repo per sandbox ID:
 <TypeScriptExample filename="src/index.ts">
 
 ```ts
-const repo = await env.ARTIFACTS.get(sandboxId);
-
 let defaultBranch: string;
 let remote: string;
 let token: string;
 
-if (repo) {
-	const info = await repo.info();
-	if (!info) {
-		throw new Error("Repo metadata not found");
-	}
+try {
+	const repo = await env.ARTIFACTS.get(sandboxId);
 
-	defaultBranch = info.defaultBranch;
-	remote = info.remote;
+	defaultBranch = repo.defaultBranch;
+	remote = repo.remote;
 	token = (await repo.createToken("write", 3600)).plaintext;
-} else {
+} catch {
+	// Repo doesn't exist yet — create it.
 	const created = await env.ARTIFACTS.create(sandboxId);
 
 	defaultBranch = created.defaultBranch;

--- a/src/content/docs/artifacts/get-started/rest-api.mdx
+++ b/src/content/docs/artifacts/get-started/rest-api.mdx
@@ -35,7 +35,8 @@ Set the variables used in the examples:
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
+export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 Use a unique repo name each time you run this guide.
@@ -70,8 +71,7 @@ The response resembles the following:
 		"description": null,
 		"default_branch": "main",
 		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
-		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
-		"expires_at": "<ISO_TIMESTAMP>"
+		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000"
 	},
 	"success": true,
 	"errors": [],

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -123,7 +123,6 @@ export default {
 				name: created.name,
 				remote: created.remote,
 				token: created.token,
-				expiresAt: created.expiresAt,
 			});
 		}
 
@@ -172,8 +171,7 @@ The response resembles the following:
 {
 	"name": "starter-repo",
 	"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
-	"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
-	"expiresAt": "<ISO_TIMESTAMP>"
+	"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000"
 }
 ```
 

--- a/src/content/docs/artifacts/guides/authentication.mdx
+++ b/src/content/docs/artifacts/guides/authentication.mdx
@@ -55,9 +55,10 @@ export CLOUDFLARE_ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 The REST API uses a Cloudflare API token in the `Authorization` header. Use **Artifacts** > **Read** for read routes, and **Artifacts** > **Edit** for routes that change repo state.
 
 ```sh
+export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 Read repo metadata with a read-capable token:

--- a/src/content/docs/artifacts/guides/import-repositories.mdx
+++ b/src/content/docs/artifacts/guides/import-repositories.mdx
@@ -14,7 +14,7 @@ This works well for:
 - a template repo for new sessions or users
 - a shared prompts or configuration repo used across workflows
 
-Artifacts imports public HTTPS remotes through the REST API. After import, the repo has a normal Artifacts remote URL and can be cloned, forked, or issued repo-scoped tokens like any other repo.
+Artifacts imports public HTTPS remotes through the [REST API](/artifacts/api/rest-api/#import-a-public-https-remote) or the [Workers binding](/artifacts/api/workers-binding/#importparams). After import, the repo has a normal Artifacts remote URL and can be cloned, forked, or issued repo-scoped tokens like any other repo.
 
 ## Import a repo from GitHub
 
@@ -23,10 +23,11 @@ This example imports a public GitHub repo into the `default` namespace.
 Use a [Cloudflare API token](/fundamentals/api/get-started/create-token/) with **Artifacts** > **Edit**.
 
 ```sh
+export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="workers-sdk-baseline"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 ```bash


### PR DESCRIPTION
Aligns Artifacts docs with the canonical types from [cloudflare/workerd#6508](https://github.com/cloudflare/workerd/pull/6508/files) and the actual API surface.

## Binding docs (`workers-binding.mdx`)

| Issue | Before | After |
|-------|--------|-------|
| `create()` return type | `ArtifactsCreateRepoResult & { repo: ArtifactsRepo }` | `ArtifactsCreateRepoResult` |
| `get()` return type | `ArtifactsRepo \| null` (null checks everywhere) | `ArtifactsRepo` (throws on not found) |
| `info()` method | Documented as `repo.info()` | Removed — `ArtifactsRepo` extends `ArtifactsRepoInfo`, metadata is directly on the handle |
| `validateToken()` | Documented | Removed — not in workerd types or binding |
| `import()` | Missing (docs said 'use REST API') | Added with full signature and example |
| Namespace config | No explanation | Added comment that any name works |
| Null checks on `get()` | All examples checked `if (!repo)` | Removed — `get()` throws |
| Intro text | 'create, list, inspect, or delete' | Added 'import' |

## REST API base URL (all docs)

The REST API examples used `artifacts.cloudflare.net/v1/api/...` which is not the public API endpoint. Fixed to `api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/...`.

Git remote URLs (`<account_id>.artifacts.cloudflare.net/git/...`) are unchanged — those are correct.

**Files fixed:** `rest-api.mdx`, `get-started/rest-api.mdx`, `guides/authentication.mdx`, `guides/import-repositories.mdx`, `examples/git-client.mdx`

## Response field names

Create repo / fork / import responses used `expires_at` but the actual API returns `token_expires_at` (verified in `response-schemas.ts`). Token endpoints correctly use `expires_at`.

**Files fixed:** `rest-api.mdx` (3 responses), `get-started/rest-api.mdx`, `get-started/workers.mdx`