### PR TITLE
chore: remove devEngines.packageManager from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,11 +148,6 @@
 			"name": "node",
 			"version": ">=24.0.0",
 			"onFail": "error"
-		},
-		"packageManager": {
-			"name": "npm",
-			"version": ">=11.0.0",
-			"onFail": "error"
 		}
 	}
 }


### PR DESCRIPTION
### Summary

Removes the `devEngines.packageManager` entry from `package.json`. As we transition to pnpm, this will only be a headache