### PR TITLE
Fix incorrect links in agentic Internet changelog post

### DIFF
--- a/src/content/changelog/ai-crawl-control/2026-04-17-tools-for-agentic-internet.mdx
+++ b/src/content/changelog/ai-crawl-control/2026-04-17-tools-for-agentic-internet.mdx
@@ -12,6 +12,6 @@ The **Metrics** tab now includes a **Content Format** chart showing what content
 
 ## Directives tab (formerly Robots.txt)
 
-The **Robots.txt** tab has been renamed to **Directives** and now includes a link to check your site's [Agent Readiness](https://isitagentready.org) score.
+The **Robots.txt** tab has been renamed to **Directives** and now includes a link to check your site's [Agent Readiness](https://isitagentready.com) score.
 
-Refer to our [blog post on preparing for the agentic Internet](https://blog.cloudflare.com/welcome-to-agents-week/) for more on why these capabilities matter.
+Refer to our [blog post on preparing for the agentic Internet](https://blog.cloudflare.com/agent-readiness/) for more on why these capabilities matter.


### PR DESCRIPTION
## Summary
- Fix Agent Readiness link: `isitagentready.org` → `isitagentready.com` (`.org` is not the correct domain)
- Fix blog post link: `/welcome-to-agents-week/` → `/agent-readiness/`

Affects: https://developers.cloudflare.com/changelog/post/2026-04-17-tools-for-agentic-internet/