### PR TITLE
Fix isitagentready.org → isitagentready.com in AI Crawl Control docs

### DIFF
--- a/src/content/docs/ai-crawl-control/features/track-robots-txt.mdx
+++ b/src/content/docs/ai-crawl-control/features/track-robots-txt.mdx
@@ -85,7 +85,7 @@ The **Agent Readiness** card helps you assess how well your site is configured f
 - **Markdown for Agents**: Whether your site supports content negotiation for AI-optimized content delivery
 - **Content Signals Policy**: Whether your site signals content usage preferences to AI crawlers
 
-The scan is powered by [isitagentready.org](https://isitagentready.org). Results include recommendations for improving your site's compatibility with AI agents and crawlers.
+The scan is powered by [isitagentready.com](https://isitagentready.com). Results include recommendations for improving your site's compatibility with AI agents and crawlers.
 
 ## Related resources
 


### PR DESCRIPTION
## Summary
- Fix `isitagentready.org` → `isitagentready.com` in `track-robots-txt.mdx` (both link text and URL)

The `.org` domain is incorrect — the correct domain is `.com`. This is a separate instance from the one fixed in #30038 (changelog post).