### PR TITLE
Vite wrangler config path environment variable

### DIFF
--- a/src/content/docs/workers/vite-plugin/reference/api.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/api.mdx
@@ -27,8 +27,15 @@ It accepts an optional `PluginConfig` parameter.
 
 - `configPath` <Type text='string' /> <MetaInfo text='optional' />
 
-  An optional path to your Worker config file.
-  By default, a `wrangler.jsonc`, `wrangler.json`, or `wrangler.toml` file in the root of your application will be used as the Worker config.
+  An optional path to your entry Worker config file.
+
+  For the entry Worker, the plugin resolves the config path in this order:
+
+  1. `configPath`
+  2. `CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH` (typically set by a framework or other external tool)
+  3. `wrangler.jsonc`, `wrangler.json`, or `wrangler.toml` in the root of your application
+
+  This applies in `vite dev` and `vite build`.
 
   For more information about the Worker configuration, see [Configuration](/workers/wrangler/configuration/).
 
@@ -89,6 +96,7 @@ It accepts an optional `PluginConfig` parameter.
 ## `interface AuxiliaryWorkerConfig`
 
 Auxiliary Workers require a `configPath`, a `config` option, or both.
+`CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH` only applies to the entry Worker. Auxiliary Workers do not use this environment variable. If an auxiliary Worker uses a config file, set `configPath` explicitly.
 
 - `configPath` <Type text='string' /> <MetaInfo text='optional' />
 

--- a/src/content/docs/workers/vite-plugin/reference/api.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/api.mdx
@@ -96,7 +96,7 @@ It accepts an optional `PluginConfig` parameter.
 ## `interface AuxiliaryWorkerConfig`
 
 Auxiliary Workers require a `configPath`, a `config` option, or both.
-`CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH` only applies to the entry Worker. Auxiliary Workers do not use this environment variable. If an auxiliary Worker uses a config file, set `configPath` explicitly.
+`CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH` only applies to the entry Worker. Auxiliary Workers do not use this environment variable. If you use a config file for an auxiliary Worker, set `configPath` explicitly.
 
 - `configPath` <Type text='string' /> <MetaInfo text='optional' />
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Vite plugin docs for https://github.com/cloudflare/workers-sdk/pull/13587

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
