### PR TITLE
chore: suppress install step in npm-to-pnpm skill

### DIFF
--- a/.agents/skills/npm-to-pnpm/SKILL.md
+++ b/.agents/skills/npm-to-pnpm/SKILL.md
@@ -84,24 +84,6 @@ Run:
 corepack enable pnpm
 ```
 
-## Step 3: Install dependencies
+## Step 3: Inform the user
 
-Run:
-
-```bash
-pnpm install --frozen-lockfile
-```
-
-If this succeeds, the migration is complete.
-
-## Step 4: Inform the user
-
-Let the user know that npm commands no longer apply in this repo. The equivalents are:
-
-| Before            | After            |
-| ----------------- | ---------------- |
-| `npm run dev`     | `pnpm run dev`   |
-| `npm run build`   | `pnpm run build` |
-| `npm run check`   | `pnpm run check` |
-| `npm install`     | `pnpm install`   |
-| `npm install pkg` | `pnpm add pkg`   |
+Let the user know that pnpm is now installed and ready. This repo currently uses npm, so they should continue using `npm` commands for this project — pnpm is installed for future use when the repo migrates.


### PR DESCRIPTION
### Summary

Removes the `pnpm install --frozen-lockfile` step from the npm-to-pnpm agent skill for now. Will add back in #29624. For now we just want to install pnpm, but remain using npm