### PR TITLE
[Agents] Add authentication section to Agents docs

### DIFF
--- a/src/content/docs/agents/authentication/better-auth.mdx
+++ b/src/content/docs/agents/authentication/better-auth.mdx
@@ -274,7 +274,7 @@ export default {
 					const authHeader = req.headers.get("Authorization");
 					const token = authHeader?.startsWith("Bearer ")
 						? authHeader.slice(7)
-						: null;
+						: new URL(req.url).searchParams.get("token");
 					if (!token) {
 						return Response.json({ error: "Missing token" }, { status: 401 });
 					}

--- a/src/content/docs/agents/authentication/better-auth.mdx
+++ b/src/content/docs/agents/authentication/better-auth.mdx
@@ -1,0 +1,425 @@
+---
+pcx_content_type: tutorial
+title: Full-stack auth with Better Auth
+sidebar:
+  order: 3
+description: Add complete user management to your Agent with Better Auth — sign-up, sign-in, email/password, sessions, and JWT verification, all running on Cloudflare.
+head: []
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+[Better Auth](https://www.better-auth.com/) is a full-stack authentication library that provides sign-up, sign-in, email/password, session management, and JWT issuance. When combined with the Agents SDK, you get a complete user management system running entirely on Cloudflare, using [D1](/d1/) as the user database.
+
+This approach is ideal when:
+
+- You need user registration and sign-in (not just token validation).
+- You want to own the entire auth stack without a third-party auth service.
+- You need session management, password hashing, and JWT issuance in one package.
+- You are building a product where users create accounts and interact with personalized Agent instances.
+
+## How it works
+
+The architecture splits requests across three paths in your Worker's `fetch` handler:
+
+| Path          | Handler             | Purpose                                                  |
+| ------------- | ------------------- | -------------------------------------------------------- |
+| `/api/auth/*` | Better Auth         | Sign-up, sign-in, session management, JWT issuance, JWKS |
+| `/agents/*`   | `routeAgentRequest` | Agent routes, protected by JWT validation in auth hooks  |
+| `/*`          | Your frontend       | SPA or static assets                                     |
+
+```mermaid
+flowchart LR
+    A[Client] -->|POST /api/auth/sign-up| B[Better Auth]
+    A -->|POST /api/auth/sign-in| B
+    A -->|GET /api/auth/token| B
+    B -->|Session cookie → JWT| A
+    A -->|WebSocket /agents/* ?token=JWT| C[routeAgentRequest]
+    C -->|JWT valid| D[Agent DO]
+    C -->|JWT invalid| E[401 Unauthorized]
+```
+
+The authentication flow is:
+
+1. User signs up or signs in via Better Auth. A session cookie is set automatically.
+2. Client calls the Better Auth token endpoint to get a short-lived JWT (authenticated via the session cookie).
+3. The JWT is stored client-side and passed as `?token=` on WebSocket connections or as a `Bearer` token on HTTP requests.
+4. The `onBeforeConnect` / `onBeforeRequest` hooks on the server verify the JWT before the request reaches the Agent.
+
+## Set up the database
+
+Better Auth needs a D1 database to store users, sessions, accounts, and signing keys.
+
+Create the database:
+
+```sh
+npx wrangler d1 create auth-db
+```
+
+Add the binding to your Wrangler configuration:
+
+<WranglerConfig>
+
+```toml
+[[d1_databases]]
+binding = "AUTH_DB"
+database_name = "auth-db"
+database_id = "your-database-id"
+```
+
+</WranglerConfig>
+
+Create the required tables. Better Auth uses `user`, `session`, `account`, and `jwks` tables:
+
+```sql
+-- db/setup.sql
+CREATE TABLE IF NOT EXISTS "user" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "name" TEXT NOT NULL,
+  "email" TEXT NOT NULL UNIQUE,
+  "emailVerified" INTEGER NOT NULL DEFAULT 0,
+  "image" TEXT,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "session" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "expiresAt" TEXT NOT NULL,
+  "token" TEXT NOT NULL UNIQUE,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL,
+  "ipAddress" TEXT,
+  "userAgent" TEXT,
+  "userId" TEXT NOT NULL REFERENCES "user"("id")
+);
+
+CREATE TABLE IF NOT EXISTS "account" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "accountId" TEXT NOT NULL,
+  "providerId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL REFERENCES "user"("id"),
+  "accessToken" TEXT,
+  "refreshToken" TEXT,
+  "idToken" TEXT,
+  "accessTokenExpiresAt" TEXT,
+  "refreshTokenExpiresAt" TEXT,
+  "scope" TEXT,
+  "password" TEXT,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "jwks" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "publicKey" TEXT NOT NULL,
+  "privateKey" TEXT NOT NULL,
+  "createdAt" TEXT NOT NULL
+);
+```
+
+Apply the schema locally:
+
+```sh
+npx wrangler d1 execute auth-db --local --file=db/setup.sql
+```
+
+For production, omit the `--local` flag:
+
+```sh
+npx wrangler d1 execute auth-db --file=db/setup.sql
+```
+
+## Install dependencies
+
+```sh
+npm install better-auth jose kysely-d1
+```
+
+| Package       | Purpose                                                   |
+| ------------- | --------------------------------------------------------- |
+| `better-auth` | User management, session handling, JWT issuance           |
+| `jose`        | JWT verification using JWKS                               |
+| `kysely-d1`   | SQL query builder dialect that connects Better Auth to D1 |
+
+## Configure Better Auth
+
+Create the auth configuration module. This sets up Better Auth with D1 as the database and enables the JWT plugin for token issuance.
+
+<TypeScriptExample>
+
+```ts
+// src/auth.ts
+import { betterAuth } from "better-auth";
+import { bearer, jwt } from "better-auth/plugins";
+import { D1Dialect } from "kysely-d1";
+import { createLocalJWKSet, jwtVerify, type JWTPayload } from "jose";
+import { env } from "cloudflare:workers";
+
+// Lazy singleton — betterAuth()'s init() does async I/O (telemetry
+// filesystem detection) that only resolves inside a request context.
+// See the note below for details.
+let _auth: ReturnType<typeof betterAuth>;
+export function getAuth() {
+	return (_auth ??= betterAuth({
+		database: {
+			dialect: new D1Dialect({ database: env.AUTH_DB }),
+			type: "sqlite",
+		},
+		emailAndPassword: { enabled: true },
+		secret: env.BETTER_AUTH_SECRET,
+		baseURL: env.BETTER_AUTH_URL,
+		plugins: [bearer(), jwt()],
+	}));
+}
+```
+
+</TypeScriptExample>
+
+Key configuration points:
+
+- **`database`** — Uses `kysely-d1` to connect Better Auth to your D1 database. The `type: "sqlite"` tells Better Auth to use SQLite-compatible queries.
+- **`emailAndPassword`** — Enables the built-in email/password sign-up and sign-in flows. Better Auth handles password hashing automatically.
+- **`secret`** — A secret key used to sign session tokens. Must be set as a Workers secret.
+- **`baseURL`** — The public URL of your Worker (for example, `https://my-agent.example.com`). Used to construct callback URLs.
+- **`plugins`** — The `bearer()` plugin allows session lookup via `Authorization: Bearer <session-token>` headers. The `jwt()` plugin adds a `/api/auth/token` endpoint that issues short-lived JWTs.
+
+:::note[Why a lazy singleton?]
+
+Environment bindings are available at module scope via `import { env } from "cloudflare:workers"`, so that is not why `getAuth()` defers initialization. The reason is that `betterAuth()`'s internal `init()` triggers async I/O — telemetry filesystem detection via a dynamic `import("fs/promises")` — that cannot resolve outside a request context on Workers. Calling `betterAuth()` at module scope causes `auth.handler()` to hang indefinitely. Creating the instance lazily on first request avoids this.
+
+:::
+
+## Add JWT verification
+
+Add a function to verify JWTs by reading the signing keys directly from D1:
+
+<TypeScriptExample>
+
+```ts
+// src/auth.ts (continued)
+
+// Verify a JWT by reading JWKS directly from D1.
+export async function verifyToken(token: string): Promise<JWTPayload | null> {
+	try {
+		const result = await env.AUTH_DB.prepare(
+			"SELECT id, publicKey FROM jwks",
+		).all<{ id: string; publicKey: string }>();
+
+		if (!result.results?.length) return null;
+
+		const jwks = createLocalJWKSet({
+			keys: result.results.map((row) => ({
+				...JSON.parse(row.publicKey),
+				kid: row.id,
+			})),
+		});
+
+		const { payload } = await jwtVerify(token, jwks);
+		return payload;
+	} catch {
+		return null;
+	}
+}
+```
+
+</TypeScriptExample>
+
+:::note[Why `createLocalJWKSet` instead of `createRemoteJWKSet`?]
+
+When both Better Auth and your Agent run on the same Worker, using `createRemoteJWKSet` to fetch from your own Worker's `/api/auth/jwks` endpoint will fail. Same-zone subrequests bypass Workers on Cloudflare, meaning the request would hit the origin rather than your Worker. Reading the keys directly from D1 with `createLocalJWKSet` avoids this issue.
+
+:::
+
+## Wire up the Worker
+
+Connect Better Auth and the Agent routes in your Worker's `fetch` handler:
+
+<TypeScriptExample>
+
+```ts
+// src/server.ts
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { routeAgentRequest } from "agents";
+import { getAuth, verifyToken } from "./auth";
+
+export class SecuredChatAgent extends AIChatAgent<Env> {
+	// Your agent logic here — only reachable by authenticated users
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+
+		// 1. Auth routes — sign-up, sign-in, token issuance, JWKS
+		if (url.pathname.startsWith("/api/auth")) {
+			return getAuth().handler(request);
+		}
+
+		// 2. Agent routes — protected by JWT validation
+		if (url.pathname.startsWith("/agents")) {
+			const response = await routeAgentRequest(request, env, {
+				onBeforeConnect: async (req) => {
+					const token = new URL(req.url).searchParams.get("token");
+					if (!token) {
+						return Response.json({ error: "Missing token" }, { status: 401 });
+					}
+					const payload = await verifyToken(token);
+					if (!payload) {
+						return Response.json({ error: "Unauthorized" }, { status: 401 });
+					}
+					return req;
+				},
+				onBeforeRequest: async (req) => {
+					const authHeader = req.headers.get("Authorization");
+					const token = authHeader?.startsWith("Bearer ")
+						? authHeader.slice(7)
+						: null;
+					if (!token) {
+						return Response.json({ error: "Missing token" }, { status: 401 });
+					}
+					const payload = await verifyToken(token);
+					if (!payload) {
+						return Response.json({ error: "Unauthorized" }, { status: 401 });
+					}
+					return req;
+				},
+			});
+			if (response) return response;
+			return new Response("Agent not found", { status: 404 });
+		}
+
+		// 3. Everything else — serve your frontend
+		return new Response("Not found", { status: 404 });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+## Set up the client
+
+On the client side, use Better Auth's React client to manage sign-in state and pass JWTs to the Agent.
+
+### Create the auth client
+
+```tsx
+// src/auth-client.ts
+import { createAuthClient } from "better-auth/react";
+import { jwtClient } from "better-auth/client/plugins";
+
+export const authClient = createAuthClient({
+	plugins: [jwtClient()],
+});
+```
+
+The `jwtClient()` plugin adds a `authClient.token()` method that exchanges the current session cookie for a short-lived JWT.
+
+### Fetch and store JWTs
+
+```tsx
+// src/auth-client.ts (continued)
+
+// After sign-in, fetch a JWT and store it for WebSocket auth
+export async function fetchAndStoreJwt(): Promise<string | null> {
+	const result = await authClient.token();
+	if (result.data?.token) {
+		localStorage.setItem("jwt_token", result.data.token);
+		return result.data.token;
+	}
+	return null;
+}
+```
+
+### Connect to the Agent
+
+Use the `useAgent` React hook with the stored JWT:
+
+```tsx
+// src/client.tsx
+import { useAgent } from "agents/react";
+import { fetchAndStoreJwt } from "./auth-client";
+
+function ChatView() {
+	const agent = useAgent({
+		agent: "SecuredChatAgent",
+		name: "default",
+		// The query function provides params appended to the WebSocket URL
+		query: async () => ({
+			token: localStorage.getItem("jwt_token") || "",
+		}),
+	});
+
+	// Use agent for chat, state sync, etc.
+}
+```
+
+### Handle sign-in and token refresh
+
+A complete sign-in flow fetches the JWT immediately after authentication:
+
+```tsx
+import { authClient, fetchAndStoreJwt } from "./auth-client";
+
+async function handleSignIn(email: string, password: string) {
+	const result = await authClient.signIn.email({ email, password });
+	if (result.error) {
+		// Handle error
+		return;
+	}
+
+	// Fetch a JWT for Agent auth
+	await fetchAndStoreJwt();
+}
+
+async function handleSignUp(name: string, email: string, password: string) {
+	const result = await authClient.signUp.email({ name, email, password });
+	if (result.error) {
+		// Handle error
+		return;
+	}
+
+	// Fetch a JWT for Agent auth
+	await fetchAndStoreJwt();
+}
+```
+
+Since JWTs are short-lived, refresh them periodically or when a WebSocket disconnects:
+
+```tsx
+import { useAgent } from "agents/react";
+import { fetchAndStoreJwt } from "./auth-client";
+
+function ChatView() {
+	const agent = useAgent({
+		agent: "SecuredChatAgent",
+		name: "default",
+		query: async () => ({
+			// fetchAndStoreJwt fetches a fresh JWT each time the
+			// WebSocket connects or reconnects
+			token: (await fetchAndStoreJwt()) || "",
+		}),
+	});
+}
+```
+
+## Set secrets
+
+Set the Better Auth secret for local development:
+
+```sh
+echo 'BETTER_AUTH_SECRET="your-secret-key-here"' >> .dev.vars
+echo 'BETTER_AUTH_URL="http://localhost:8787"' >> .dev.vars
+```
+
+For production, set them as Workers secrets:
+
+```sh
+npx wrangler secret put BETTER_AUTH_SECRET
+npx wrangler secret put BETTER_AUTH_URL
+```
+
+## Next steps
+
+- For simpler token-based auth without user management, see [Token and middleware auth](/agents/authentication/token-and-middleware/).
+- For OAuth 2.1 flows with third-party identity providers, see [Workers OAuth Provider](/agents/authentication/oauth-provider/).

--- a/src/content/docs/agents/authentication/index.mdx
+++ b/src/content/docs/agents/authentication/index.mdx
@@ -1,0 +1,55 @@
+---
+title: Authentication
+pcx_content_type: navigation
+sidebar:
+  order: 5
+  group:
+    hideIndex: false
+description: Learn how to add authentication to your Agents, from simple token validation to full OAuth and user management.
+head: []
+---
+
+Adding authentication to your Agents ensures that only authorized users can connect to and interact with your Agent instances. There are several approaches depending on the complexity of your application.
+
+## Choose an approach
+
+| Approach                                                                  | Best for                                                              | Complexity  |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------- |
+| [Token and middleware auth](/agents/authentication/token-and-middleware/) | Token validation, API keys, JWT verification, or framework middleware | Low–Medium  |
+| [Workers OAuth Provider](/agents/authentication/oauth-provider/)          | OAuth 2.1 flows, third-party identity providers, MCP servers          | Medium–High |
+| [Full-stack auth (Better Auth)](/agents/authentication/better-auth/)      | Complete user management with sign-up, sign-in, sessions, and JWT     | High        |
+
+:::note
+
+This section covers authentication for Agents apps in general (HTTP and WebSocket). For MCP-specific OAuth authorization, refer to [MCP Authorization](/agents/model-context-protocol/authorization/).
+
+:::
+
+## Core principle
+
+All approaches follow the same principle: **authenticate the request in your Worker before it reaches the Agent**. The Agent itself should not need to handle authentication logic.
+
+```mermaid
+flowchart LR
+    A[Client] -->|Request with credentials| B[Worker fetch handler]
+    B -->|Valid| C[Agent Durable Object]
+    B -->|Invalid| D[401 Unauthorized]
+```
+
+Your Worker's `fetch` handler acts as a gatekeeper. Whether you validate a static token, verify a JWT, run framework middleware, or check an OAuth access token, the check always happens before the request is forwarded to the Agent's Durable Object.
+
+## Best practices
+
+- **Authenticate before the Agent.** Handle authentication in your Worker's `fetch` handler or middleware, not inside the Agent's `onConnect` or `onRequest` methods. This prevents unauthenticated requests from reaching the Durable Object.
+- **Use short-lived tokens for WebSockets.** WebSocket upgrade requests cannot include custom headers. Pass tokens as query parameters, and keep them short-lived (minutes, not hours) to limit exposure.
+- **Name Agents by user identity.** Use the authenticated user's ID as the Agent instance name. This ensures each user gets their own Agent and makes routing deterministic. See [Instance naming patterns](/agents/api-reference/routing/#instance-naming-patterns) for more.
+- **Handle token expiration on the client.** Check for expired tokens when a WebSocket disconnects. If the token is expired, redirect the user to sign in again rather than attempting to reconnect.
+- **Return consistent error responses.** Always return a `401 Unauthorized` with a JSON body for invalid credentials. This makes it easier for clients to detect and handle auth failures programmatically.
+
+## Related resources
+
+- [Routing](/agents/api-reference/routing/) — `routeAgentRequest` and `getAgentByName` API reference
+- [MCP Authorization](/agents/model-context-protocol/authorization/) — OAuth 2.1 authorization for MCP servers
+- [Workers OAuth Provider](https://github.com/cloudflare/workers-oauth-provider) — OAuth 2.1 provider library for Workers
+- [Better Auth](https://www.better-auth.com/) — Full-stack authentication library
+- [Auth Agent example](https://github.com/cloudflare/agents/tree/main/examples/auth-agent) — Working example demonstrating JWT authentication with `onBeforeConnect` and `onBeforeRequest`

--- a/src/content/docs/agents/authentication/oauth-provider.mdx
+++ b/src/content/docs/agents/authentication/oauth-provider.mdx
@@ -1,0 +1,294 @@
+---
+pcx_content_type: how-to
+title: Workers OAuth Provider
+sidebar:
+  order: 2
+description: Use the Workers OAuth Provider library to add OAuth 2.1 authorization to your Agent, with support for third-party identity providers.
+head: []
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+The [`@cloudflare/workers-oauth-provider`](https://github.com/cloudflare/workers-oauth-provider) library implements a full [OAuth 2.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12) authorization server as a Cloudflare Worker. It handles token issuance, refresh, revocation, dynamic client registration, and serves the standard OAuth metadata endpoints — all running at the edge.
+
+This approach is ideal when:
+
+- Your Agent is accessed by third-party clients (for example, MCP clients, API consumers).
+- You want to use a standard OAuth flow to authenticate users via GitHub, Google, or another identity provider.
+- You need fine-grained token scoping and revocation.
+- You need to comply with the OAuth 2.1 specification.
+
+## How it works
+
+The `OAuthProvider` wraps your Worker and intercepts OAuth-related requests. Non-OAuth requests (your API traffic) are forwarded to your handler with the authenticated user's identity available on `ctx.props`.
+
+```mermaid
+flowchart LR
+    A[Client] -->|1. GET /authorize| B[OAuthProvider]
+    B -->|2. Redirect to IdP| C[GitHub / Google / etc.]
+    C -->|3. Callback with code| B
+    B -->|4. Issue access token| A
+    A -->|5. Request with token| B
+    B -->|6. Validate token, forward| D[Agent API Handler]
+    D -->|7. ctx.props has user| E[Agent DO]
+```
+
+The library splits your Worker into two handlers:
+
+| Handler          | Purpose                                                                                                                                            |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiHandler`     | Receives authenticated API requests. The user's identity and scopes are available on `this.ctx.props`. Use this to forward requests to your Agent. |
+| `defaultHandler` | Receives all non-API requests — login pages, consent screens, OAuth callbacks from upstream identity providers.                                    |
+
+## Set up the KV namespace
+
+The library stores OAuth clients, authorization grants, and tokens in a Workers KV namespace.
+
+```sh
+npx wrangler kv namespace create OAUTH_KV
+```
+
+Add the binding to your Wrangler configuration:
+
+<WranglerConfig>
+
+```toml
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = "your-kv-namespace-id"
+```
+
+</WranglerConfig>
+
+## Install the library
+
+```sh
+npm install @cloudflare/workers-oauth-provider
+```
+
+## Implement the handlers
+
+The following example shows the core structure. The `AgentApiHandler` forwards authenticated requests to an Agent instance, and the `AuthHandler` handles the OAuth authorization flow.
+
+<TypeScriptExample>
+
+```ts
+import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { Agent, getAgentByName, type AgentNamespace } from "agents";
+
+interface Env {
+	MyAgent: AgentNamespace<MyAgent>;
+	OAUTH_PROVIDER: OAuthHelpers;
+	OAUTH_KV: KVNamespace;
+}
+
+// Handles authenticated API requests.
+// ctx.props is populated by OAuthProvider after token validation.
+class AgentApiHandler extends WorkerEntrypoint<Env> {
+	async fetch(request: Request): Promise<Response> {
+		const userId = this.ctx.props.userId as string;
+
+		// Route to the user's Agent instance
+		const agent = await getAgentByName(this.env.MyAgent, userId);
+		return agent.fetch(request);
+	}
+}
+
+// Handles login, consent, and OAuth callbacks.
+class AuthHandler extends WorkerEntrypoint<Env> {
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/authorize") {
+			// Parse the incoming OAuth authorization request
+			const oauthReq = await this.env.OAUTH_PROVIDER.parseAuthRequest(request);
+			const client = await this.env.OAUTH_PROVIDER.lookupClient(
+				oauthReq.clientId,
+			);
+
+			// Your login UI and consent logic here...
+			// After the user authenticates and consents:
+			const { redirectTo } =
+				await this.env.OAUTH_PROVIDER.completeAuthorization({
+					request: oauthReq,
+					userId: "authenticated-user-id",
+					metadata: { label: "User session" },
+					scope: oauthReq.scope,
+					props: { userId: "authenticated-user-id" },
+				});
+
+			return Response.redirect(redirectTo);
+		}
+
+		return new Response("Not found", { status: 404 });
+	}
+}
+
+// Wire everything together.
+// OAuthProvider handles /oauth/token, /oauth/register, and
+// /.well-known/oauth-authorization-server automatically.
+export default new OAuthProvider({
+	apiRoute: "/api/",
+	apiHandler: AgentApiHandler,
+	defaultHandler: AuthHandler,
+	authorizeEndpoint: "/authorize",
+	tokenEndpoint: "/oauth/token",
+	clientRegistrationEndpoint: "/oauth/register",
+});
+
+export class MyAgent extends Agent<Env> {
+	// Your Agent implementation — only reachable by authenticated users
+}
+```
+
+</TypeScriptExample>
+
+## OAuthProvider configuration
+
+The `OAuthProvider` constructor accepts the following options:
+
+| Option                       | Description                                                                                                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apiRoute`                   | URL prefix for authenticated API requests (for example, `"/api/"`). Requests matching this prefix are forwarded to `apiHandler` with `ctx.props` populated. |
+| `apiHandler`                 | `WorkerEntrypoint` class that handles authenticated API traffic.                                                                                            |
+| `defaultHandler`             | `WorkerEntrypoint` class that handles everything else (login UI, consent, callbacks).                                                                       |
+| `authorizeEndpoint`          | Path for the OAuth authorization endpoint (for example, `"/authorize"`).                                                                                    |
+| `tokenEndpoint`              | Path for the token exchange endpoint (for example, `"/oauth/token"`).                                                                                       |
+| `clientRegistrationEndpoint` | Path for [dynamic client registration](https://datatracker.ietf.org/doc/html/rfc7591) (for example, `"/oauth/register"`).                                   |
+
+The library also automatically serves the [OAuth Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414) endpoint at `/.well-known/oauth-authorization-server`.
+
+## Integrate with a third-party identity provider
+
+In most real applications, the `AuthHandler` does not authenticate users directly. Instead, it redirects to an upstream identity provider (GitHub, Google, Auth0, etc.) and processes the callback.
+
+The general flow is:
+
+1. Client starts the OAuth flow by requesting `/authorize`.
+2. `AuthHandler` redirects the user to the upstream IdP (for example, GitHub's `/login/oauth/authorize`).
+3. The user authenticates with the IdP and is redirected back to your callback URL.
+4. `AuthHandler` exchanges the IdP's authorization code for an access token, fetches the user's profile, and calls `completeAuthorization` with the user's identity.
+5. The client receives an access token scoped to your Agent.
+
+<TypeScriptExample>
+
+```ts
+class AuthHandler extends WorkerEntrypoint<Env> {
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname === "/authorize") {
+			const oauthReq = await this.env.OAUTH_PROVIDER.parseAuthRequest(request);
+
+			// Store the OAuth request state, then redirect to GitHub
+			const state = btoa(
+				JSON.stringify({
+					oauthReq,
+				}),
+			);
+
+			const githubAuthUrl = new URL("https://github.com/login/oauth/authorize");
+			githubAuthUrl.searchParams.set("client_id", this.env.GITHUB_CLIENT_ID);
+			githubAuthUrl.searchParams.set("redirect_uri", `${url.origin}/callback`);
+			githubAuthUrl.searchParams.set("state", state);
+			githubAuthUrl.searchParams.set("scope", "read:user user:email");
+
+			return Response.redirect(githubAuthUrl.toString());
+		}
+
+		if (url.pathname === "/callback") {
+			const code = url.searchParams.get("code");
+			const state = JSON.parse(atob(url.searchParams.get("state") || ""));
+
+			// Exchange the GitHub code for an access token
+			const tokenResponse = await fetch(
+				"https://github.com/login/oauth/access_token",
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Accept: "application/json",
+					},
+					body: JSON.stringify({
+						client_id: this.env.GITHUB_CLIENT_ID,
+						client_secret: this.env.GITHUB_CLIENT_SECRET,
+						code,
+					}),
+				},
+			);
+			const { access_token } = await tokenResponse.json<{
+				access_token: string;
+			}>();
+
+			// Fetch the user's GitHub profile
+			const userResponse = await fetch("https://api.github.com/user", {
+				headers: {
+					Authorization: `Bearer ${access_token}`,
+					"User-Agent": "cloudflare-agent",
+				},
+			});
+			const user = await userResponse.json<{ id: number; login: string }>();
+
+			// Complete the OAuth flow — issue a token to the client
+			const { redirectTo } =
+				await this.env.OAUTH_PROVIDER.completeAuthorization({
+					request: state.oauthReq,
+					userId: String(user.id),
+					metadata: { label: `GitHub: ${user.login}` },
+					scope: state.oauthReq.scope,
+					props: {
+						userId: String(user.id),
+						username: user.login,
+					},
+				});
+
+			return Response.redirect(redirectTo);
+		}
+
+		return new Response("Not found", { status: 404 });
+	}
+}
+```
+
+</TypeScriptExample>
+
+Store the GitHub OAuth credentials as [Workers secrets](/workers/configuration/secrets/):
+
+```sh
+npx wrangler secret put GITHUB_CLIENT_ID
+npx wrangler secret put GITHUB_CLIENT_SECRET
+```
+
+## Token scoping and revocation
+
+The `completeAuthorization` call accepts a `scope` parameter that controls what the issued token can access. You can check scopes in your `AgentApiHandler` via `this.ctx.props`:
+
+<TypeScriptExample>
+
+```ts
+class AgentApiHandler extends WorkerEntrypoint<Env> {
+	async fetch(request: Request): Promise<Response> {
+		const scopes = (this.ctx.props.scope as string[]) || [];
+
+		// Check for required scope before forwarding to the Agent
+		if (!scopes.includes("agent:write")) {
+			return Response.json({ error: "Insufficient scope" }, { status: 403 });
+		}
+
+		const userId = this.ctx.props.userId as string;
+		const agent = await getAgentByName(this.env.MyAgent, userId);
+		return agent.fetch(request);
+	}
+}
+```
+
+</TypeScriptExample>
+
+Token revocation is handled automatically by the library at the token endpoint. Clients can revoke tokens by sending a `POST` request to your token endpoint with `token_type_hint=access_token`.
+
+## Next steps
+
+- For a complete walkthrough of OAuth with MCP servers, see the [MCP Authorization guide](/agents/model-context-protocol/authorization/).
+- For integration with specific providers (Auth0, Stytch, WorkOS), see the [`workers-oauth-provider` examples](https://github.com/cloudflare/workers-oauth-provider).
+- For complete user management with sign-up/sign-in flows, see [Full-stack auth with Better Auth](/agents/authentication/better-auth/).

--- a/src/content/docs/agents/authentication/token-and-middleware.mdx
+++ b/src/content/docs/agents/authentication/token-and-middleware.mdx
@@ -1,0 +1,360 @@
+---
+pcx_content_type: how-to
+title: Token and middleware auth
+sidebar:
+  order: 1
+description: Validate tokens and API keys using built-in auth hooks or framework middleware before requests reach your Agent.
+head: []
+---
+
+import { TypeScriptExample } from "~/components";
+
+The Agents SDK provides two ways to validate credentials before a request reaches your Agent:
+
+- **Auth hooks** via [`routeAgentRequest`](/agents/api-reference/routing/) — built-in hooks that run before each request is forwarded. Best for straightforward token or JWT checks with no external framework.
+- **Custom routing** via [`getAgentByName`](/agents/api-reference/routing/) — look up Agent instances manually after running your own middleware. Best when you use a framework like [Hono](https://hono.dev) and want to use its middleware ecosystem.
+
+Both follow the same principle: authenticate in the Worker, then forward to the Agent only if the credentials are valid.
+
+The examples below assume you have already [configured your Agent's Durable Object binding](/agents/getting-started/testing-your-agent/#add-the-agent-configuration) in your Wrangler configuration.
+
+## Auth hooks with `routeAgentRequest`
+
+`routeAgentRequest` accepts two optional hooks:
+
+| Hook              | Runs before                                   | Typical credential source      |
+| ----------------- | --------------------------------------------- | ------------------------------ |
+| `onBeforeConnect` | A WebSocket upgrade request reaches the Agent | Query parameter (`?token=...`) |
+| `onBeforeRequest` | An HTTP request reaches the Agent             | `Authorization` header         |
+
+Both hooks follow the same contract:
+
+- Return a `Request` (or `void`) to allow the request through to the Agent.
+- Return a `Response` to short-circuit and reject the request (for example, a `401 Unauthorized`).
+
+Both hooks also receive a second argument `{ party, name }` containing the resolved Agent class name and instance name from the URL. You can use this to make per-instance authorization decisions — for example, restricting which Agents a user can access.
+
+### Validate a static token
+
+The simplest approach checks for a known token on both WebSocket and HTTP requests. In production, store tokens as [Workers secrets](/workers/configuration/secrets/) rather than hardcoding them.
+
+<TypeScriptExample>
+
+```ts
+import { Agent, routeAgentRequest } from "agents";
+
+function authenticate(request: Request, env: Env): Request | Response {
+	const url = new URL(request.url);
+	// Check query param (?token=...) or Authorization header
+	const token =
+		url.searchParams.get("token") ||
+		request.headers.get("Authorization")?.replace("Bearer ", "");
+
+	if (token === env.AUTH_TOKEN) {
+		return request; // Valid — continue to the Agent
+	}
+	return Response.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		return (
+			(await routeAgentRequest(request, env, {
+				onBeforeConnect: async (req) => authenticate(req, env),
+				onBeforeRequest: async (req) => authenticate(req, env),
+			})) || new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+
+export class MyAgent extends Agent<Env> {
+	// Agent code here -- only reached by authenticated requests
+}
+```
+
+</TypeScriptExample>
+
+The `AUTH_TOKEN` value should be set as a [Workers secret](/workers/configuration/secrets/):
+
+```sh
+npx wrangler secret put AUTH_TOKEN
+```
+
+### Validate a JWT
+
+For production applications, validate a JSON Web Token (JWT) instead of a static token. This lets you verify the caller's identity and any claims without maintaining a session store.
+
+This example uses the [`jose`](https://github.com/panva/jose) library:
+
+```sh
+npm install jose
+```
+
+<TypeScriptExample>
+
+```ts
+import { Agent, routeAgentRequest } from "agents";
+import { jwtVerify, createRemoteJWKSet } from "jose";
+
+// Fetch public keys from your identity provider's JWKS endpoint.
+// createRemoteJWKSet caches keys automatically.
+const jwks = createRemoteJWKSet(
+	new URL("https://your-idp.example.com/.well-known/jwks.json"),
+);
+
+async function verifyJwt(
+	token: string,
+): Promise<Record<string, unknown> | null> {
+	try {
+		const { payload } = await jwtVerify(token, jwks, {
+			issuer: "https://your-idp.example.com",
+			audience: "your-app-id",
+		});
+		return payload;
+	} catch {
+		return null;
+	}
+}
+
+function extractToken(request: Request): string | null {
+	// WebSocket clients pass tokens as query parameters because
+	// upgrade requests cannot set custom headers.
+	const queryToken = new URL(request.url).searchParams.get("token");
+	if (queryToken) return queryToken;
+
+	// HTTP clients pass tokens in the Authorization header.
+	const authHeader = request.headers.get("Authorization");
+	if (authHeader?.startsWith("Bearer ")) return authHeader.slice(7);
+
+	return null;
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		return (
+			(await routeAgentRequest(request, env, {
+				onBeforeConnect: async (req) => {
+					const token = extractToken(req);
+					if (!token) {
+						return Response.json({ error: "Missing token" }, { status: 401 });
+					}
+					const payload = await verifyJwt(token);
+					if (!payload) {
+						return Response.json({ error: "Invalid token" }, { status: 401 });
+					}
+					return req;
+				},
+				onBeforeRequest: async (req) => {
+					const token = extractToken(req);
+					if (!token) {
+						return Response.json({ error: "Missing token" }, { status: 401 });
+					}
+					const payload = await verifyJwt(token);
+					if (!payload) {
+						return Response.json({ error: "Invalid token" }, { status: 401 });
+					}
+					return req;
+				},
+			})) || new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+Key points for JWT validation:
+
+- **`issuer` and `audience`** — Always set both to prevent tokens issued for a different service from being accepted.
+- **JWKS caching** — `createRemoteJWKSet` fetches and caches the public keys from your identity provider. It automatically refreshes when keys rotate.
+- **Clock skew** — `jose` allows a small clock tolerance by default. For Workers environments, this is usually sufficient.
+
+### Pass tokens from the client
+
+When using the `useAgent` React hook, pass the token via the `query` parameter. The SDK appends these as query parameters to the WebSocket URL:
+
+```tsx
+import { useAgent } from "agents/react";
+
+function ChatApp() {
+	const agent = useAgent({
+		agent: "MyAgent",
+		name: "user-123",
+		// query can be a function (sync or async) that returns params
+		query: async () => ({
+			token: localStorage.getItem("auth_token") || "",
+		}),
+	});
+
+	// Use the agent connection...
+}
+```
+
+For HTTP requests using `agentFetch` or direct `fetch`, include the token in the `Authorization` header:
+
+```ts
+const response = await fetch("/agents/my-agent/user-123", {
+	headers: {
+		Authorization: `Bearer ${token}`,
+	},
+});
+```
+
+### Per-instance authorization
+
+The second argument to `onBeforeConnect` and `onBeforeRequest` contains the resolved Agent class name and instance name. Use this to restrict which Agents a user can access:
+
+<TypeScriptExample>
+
+```ts
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		return (
+			(await routeAgentRequest(request, env, {
+				onBeforeConnect: async (req, { name }) => {
+					const token = new URL(req.url).searchParams.get("token");
+					const payload = await verifyJwt(token);
+					if (!payload) {
+						return Response.json({ error: "Unauthorized" }, { status: 401 });
+					}
+
+					// Only allow users to connect to their own Agent instance
+					if (payload.sub !== name) {
+						return Response.json({ error: "Forbidden" }, { status: 403 });
+					}
+
+					return req;
+				},
+			})) || new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+## Custom routing with `getAgentByName`
+
+When you need more control over routing — for example, using a framework like [Hono](https://hono.dev) with its own middleware stack — use [`getAgentByName`](/agents/api-reference/routing/) to look up Agent instances after authenticating the request yourself.
+
+This approach is useful when:
+
+- You want to use your framework's middleware ecosystem for auth.
+- You need to derive the Agent instance name from the authenticated user (for example, one Agent per user).
+- You have non-Agent routes in the same Worker that also need auth.
+
+### Hono with bearer auth
+
+<TypeScriptExample>
+
+```ts
+import { Agent, getAgentByName, type AgentNamespace } from "agents";
+import { Hono } from "hono";
+import { bearerAuth } from "hono/bearer-auth";
+
+interface Env {
+	MyAgent: AgentNamespace<MyAgent>;
+	AUTH_TOKEN: string;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+// Apply auth middleware to all agent routes
+app.use("/agent/*", bearerAuth({ token: "my-secret-token" }));
+
+// Route authenticated requests to an Agent named by user ID
+app.all("/agent/:userId/*", async (c) => {
+	const userId = c.req.param("userId");
+	const agent = await getAgentByName<Env, MyAgent>(c.env.MyAgent, userId);
+	return agent.fetch(c.req.raw);
+});
+
+// You can also call Agent methods directly via RPC
+app.post("/agent/:userId/summarize", async (c) => {
+	const userId = c.req.param("userId");
+	const agent = await getAgentByName<Env, MyAgent>(c.env.MyAgent, userId);
+	const summary = await agent.summarize();
+	return c.json({ summary });
+});
+
+export default app;
+
+export class MyAgent extends Agent<Env> {
+	async summarize() {
+		return "Here is a summary of your data.";
+	}
+}
+```
+
+</TypeScriptExample>
+
+Since `getAgentByName` returns a Durable Object stub, you can also call [methods directly on the Agent via RPC](/agents/api-reference/routing/#server-side-agent-access), without going through HTTP.
+
+### Hono Agents middleware
+
+The [`hono-agents`](https://www.npmjs.com/package/hono-agents) package provides an `agentsMiddleware()` that wraps `routeAgentRequest` as Hono middleware. You can combine it with Hono's auth middleware to protect Agent routes:
+
+```ts
+import { Hono } from "hono";
+import { bearerAuth } from "hono/bearer-auth";
+import { agentsMiddleware } from "hono-agents";
+
+const app = new Hono();
+
+// Auth first, then route to agents
+app.use("/agents/*", bearerAuth({ token: "my-secret-token" }));
+app.use("/agents/*", agentsMiddleware());
+
+export default app;
+```
+
+### Hono with JWT middleware
+
+For JWT-based auth with Hono, use the built-in `jwt` middleware:
+
+```ts
+import { Hono } from "hono";
+import { jwt } from "hono/jwt";
+import { Agent, getAgentByName, type AgentNamespace } from "agents";
+
+interface Env {
+	MyAgent: AgentNamespace<MyAgent>;
+	JWT_SECRET: string;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+// Verify JWT on all agent routes
+app.use("/agent/*", (c, next) => {
+	const jwtMiddleware = jwt({ secret: c.env.JWT_SECRET });
+	return jwtMiddleware(c, next);
+});
+
+// The JWT payload is available on the context
+app.all("/agent/:userId/*", async (c) => {
+	const jwtPayload = c.get("jwtPayload");
+	const userId = c.req.param("userId");
+
+	// Ensure the JWT subject matches the requested Agent
+	if (jwtPayload.sub !== userId) {
+		return c.json({ error: "Forbidden" }, 403);
+	}
+
+	const agent = await getAgentByName<Env, MyAgent>(c.env.MyAgent, userId);
+	return agent.fetch(c.req.raw);
+});
+
+export default app;
+
+export class MyAgent extends Agent<Env> {}
+```
+
+## Complete example
+
+For a working end-to-end implementation of the JWT pattern shown above — including `onBeforeConnect`, `onBeforeRequest`, a token endpoint, and a React client — see the [`auth-agent` example](https://github.com/cloudflare/agents/tree/main/examples/auth-agent) in the Agents SDK repository.
+
+## Next steps
+
+- For OAuth 2.1 flows and third-party identity providers, see [Workers OAuth Provider](/agents/authentication/oauth-provider/).
+- For complete user management with sign-up, sign-in, and sessions, see [Full-stack auth with Better Auth](/agents/authentication/better-auth/).
+- For MCP-specific authorization, see [MCP Authorization](/agents/model-context-protocol/authorization/).

--- a/src/content/docs/agents/authentication/token-and-middleware.mdx
+++ b/src/content/docs/agents/authentication/token-and-middleware.mdx
@@ -82,98 +82,124 @@ npx wrangler secret put AUTH_TOKEN
 
 ### Validate a JWT
 
-For production applications, validate a JSON Web Token (JWT) instead of a static token. This lets you verify the caller's identity and any claims without maintaining a session store.
-
-This example uses the [`jose`](https://github.com/panva/jose) library:
+A JSON Web Token (JWT) lets you verify the caller's identity and any claims without maintaining a session store. This example uses the [`jose`](https://github.com/panva/jose) library and signs tokens with HMAC-SHA256, sharing a single secret between the signer and verifier.
 
 ```sh
 npm install jose
 ```
 
+Define JWT helpers that issue and verify tokens using a shared secret stored as a [Workers secret](/workers/configuration/secrets/):
+
 <TypeScriptExample>
 
 ```ts
-import { Agent, routeAgentRequest } from "agents";
-import { jwtVerify, createRemoteJWKSet } from "jose";
+import { SignJWT, jwtVerify } from "jose";
 
-// Fetch public keys from your identity provider's JWKS endpoint.
-// createRemoteJWKSet caches keys automatically.
-const jwks = createRemoteJWKSet(
-	new URL("https://your-idp.example.com/.well-known/jwks.json"),
-);
+function getSecret(env: Env) {
+	if (!env.AUTH_SECRET) {
+		throw new Error("AUTH_SECRET is not set");
+	}
+	return new TextEncoder().encode(env.AUTH_SECRET);
+}
 
-async function verifyJwt(
-	token: string,
-): Promise<Record<string, unknown> | null> {
+// Issue a short-lived JWT containing the user's name.
+async function issueToken(env: Env, name: string) {
+	return new SignJWT({ sub: name })
+		.setProtectedHeader({ alg: "HS256" })
+		.setIssuer("auth-agent")
+		.setAudience("auth-agent")
+		.setIssuedAt()
+		.setExpirationTime("1h")
+		.sign(getSecret(env));
+}
+
+// Verify a JWT and return its payload, or null if invalid or expired.
+async function verifyToken(env: Env, token: string) {
 	try {
-		const { payload } = await jwtVerify(token, jwks, {
-			issuer: "https://your-idp.example.com",
-			audience: "your-app-id",
+		const { payload } = await jwtVerify(token, getSecret(env), {
+			issuer: "auth-agent",
+			audience: "auth-agent",
 		});
 		return payload;
 	} catch {
 		return null;
 	}
 }
-
-function extractToken(request: Request): string | null {
-	// WebSocket clients pass tokens as query parameters because
-	// upgrade requests cannot set custom headers.
-	const queryToken = new URL(request.url).searchParams.get("token");
-	if (queryToken) return queryToken;
-
-	// HTTP clients typically use the Authorization header. However,
-	// the SDK also appends query parameters from the useAgent `query`
-	// option on its own HTTP requests, so check both sources.
-	const authHeader = request.headers.get("Authorization");
-	if (authHeader?.startsWith("Bearer ")) return authHeader.slice(7);
-
-	return null;
-}
-
-export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
-		return (
-			(await routeAgentRequest(request, env, {
-				onBeforeConnect: async (req) => {
-					const token = extractToken(req);
-					if (!token) {
-						return Response.json({ error: "Missing token" }, { status: 401 });
-					}
-					const payload = await verifyJwt(token);
-					if (!payload) {
-						return Response.json({ error: "Invalid token" }, { status: 401 });
-					}
-					return req;
-				},
-				onBeforeRequest: async (req) => {
-					const token = extractToken(req);
-					if (!token) {
-						return Response.json({ error: "Missing token" }, { status: 401 });
-					}
-					const payload = await verifyJwt(token);
-					if (!payload) {
-						return Response.json({ error: "Invalid token" }, { status: 401 });
-					}
-					return req;
-				},
-			})) || new Response("Not found", { status: 404 })
-		);
-	},
-} satisfies ExportedHandler<Env>;
 ```
 
 </TypeScriptExample>
 
+Wire the verifier into `routeAgentRequest`. `onBeforeConnect` reads the JWT from the `?token=` query parameter, and `onBeforeRequest` checks the `Authorization` header, falling back to the query parameter:
+
+<TypeScriptExample>
+
+```ts
+import { Agent, routeAgentRequest } from "agents";
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (url.pathname.startsWith("/agents")) {
+			const response = await routeAgentRequest(request, env, {
+				// WebSocket: JWT passed as ?token= query param
+				onBeforeConnect: async (req) => {
+					const token = new URL(req.url).searchParams.get("token");
+					if (!token) {
+						return Response.json({ error: "Missing token" }, { status: 401 });
+					}
+					const payload = await verifyToken(env, token);
+					if (!payload) {
+						return Response.json({ error: "Unauthorized" }, { status: 401 });
+					}
+					return req;
+				},
+				// HTTP: JWT from Authorization header or ?token= query param
+				onBeforeRequest: async (req) => {
+					const authHeader = req.headers.get("Authorization");
+					const token = authHeader?.startsWith("Bearer ")
+						? authHeader.slice(7)
+						: new URL(req.url).searchParams.get("token");
+					if (!token) {
+						return Response.json({ error: "Missing token" }, { status: 401 });
+					}
+					const payload = await verifyToken(env, token);
+					if (!payload) {
+						return Response.json({ error: "Unauthorized" }, { status: 401 });
+					}
+					return req;
+				},
+			});
+			if (response) return response;
+			return new Response("Agent not found", { status: 404 });
+		}
+
+		return new Response("Not found", { status: 404 });
+	},
+} satisfies ExportedHandler<Env>;
+
+export class MyAgent extends Agent<Env> {
+	// Agent code here — only reached by authenticated requests
+}
+```
+
+</TypeScriptExample>
+
+Set `AUTH_SECRET` as a Workers secret. A 32-byte random value is sufficient:
+
+```sh
+npx wrangler secret put AUTH_SECRET
+```
+
 Key points for JWT validation:
 
-- **`issuer` and `audience`** — Always set both to prevent tokens issued for a different service from being accepted.
-- **JWKS caching** — `createRemoteJWKSet` fetches and caches the public keys from your identity provider. It automatically refreshes when keys rotate.
-- **Clock skew** — `jose` allows a small clock tolerance by default. For Workers environments, this is usually sufficient.
+- **`issuer` and `audience`** — Always set both on both signing and verification to prevent tokens issued for a different service from being accepted.
+- **Shared-secret (HS256) vs. asymmetric signing** — The example above signs and verifies with the same secret, which is the simplest setup when one Worker both issues and verifies tokens. If your tokens come from an external identity provider, verify them against the provider's JWKS endpoint with `createRemoteJWKSet` instead.
+- **Short expiration** — Keep JWTs short-lived (for example, one hour). On the client, detect expired tokens and re-authenticate rather than reusing a stale token.
 
 :::note[Check both header and query parameter in `onBeforeRequest`]
 
-When using the `useAgent` React hook, the `query` option appends parameters to both WebSocket upgrade requests **and** the SDK's own HTTP requests (for example, fetching initial messages). This means `onBeforeRequest` should check the query parameter as a fallback, not only the `Authorization` header. The `extractToken` helper above handles both sources.
+When using the `useAgent` React hook, the `query` option appends parameters to both WebSocket upgrade requests **and** the SDK's own HTTP requests (for example, fetching initial messages). `onBeforeRequest` should check the query parameter as a fallback, not only the `Authorization` header.
 
 :::
 
@@ -224,7 +250,7 @@ export default {
 					if (!token) {
 						return Response.json({ error: "Missing token" }, { status: 401 });
 					}
-					const payload = await verifyJwt(token);
+					const payload = await verifyToken(env, token);
 					if (!payload) {
 						return Response.json({ error: "Unauthorized" }, { status: 401 });
 					}

--- a/src/content/docs/agents/authentication/token-and-middleware.mdx
+++ b/src/content/docs/agents/authentication/token-and-middleware.mdx
@@ -22,17 +22,17 @@ The examples below assume you have already [configured your Agent's Durable Obje
 
 `routeAgentRequest` accepts two optional hooks:
 
-| Hook              | Runs before                                   | Typical credential source      |
-| ----------------- | --------------------------------------------- | ------------------------------ |
-| `onBeforeConnect` | A WebSocket upgrade request reaches the Agent | Query parameter (`?token=...`) |
-| `onBeforeRequest` | An HTTP request reaches the Agent             | `Authorization` header         |
+| Hook              | Runs before                                   | Typical credential source                 |
+| ----------------- | --------------------------------------------- | ----------------------------------------- |
+| `onBeforeConnect` | A WebSocket upgrade request reaches the Agent | Query parameter (`?token=...`)            |
+| `onBeforeRequest` | An HTTP request reaches the Agent             | `Authorization` header or query parameter |
 
 Both hooks follow the same contract:
 
 - Return a `Request` (or `void`) to allow the request through to the Agent.
 - Return a `Response` to short-circuit and reject the request (for example, a `401 Unauthorized`).
 
-Both hooks also receive a second argument `{ party, name }` containing the resolved Agent class name and instance name from the URL. You can use this to make per-instance authorization decisions — for example, restricting which Agents a user can access.
+Both hooks also receive a second argument containing the resolved Agent `className` and instance `name` from the URL. You can use this to make per-instance authorization decisions — for example, restricting which Agents a user can access.
 
 ### Validate a static token
 
@@ -122,7 +122,9 @@ function extractToken(request: Request): string | null {
 	const queryToken = new URL(request.url).searchParams.get("token");
 	if (queryToken) return queryToken;
 
-	// HTTP clients pass tokens in the Authorization header.
+	// HTTP clients typically use the Authorization header. However,
+	// the SDK also appends query parameters from the useAgent `query`
+	// option on its own HTTP requests, so check both sources.
 	const authHeader = request.headers.get("Authorization");
 	if (authHeader?.startsWith("Bearer ")) return authHeader.slice(7);
 
@@ -169,6 +171,12 @@ Key points for JWT validation:
 - **JWKS caching** — `createRemoteJWKSet` fetches and caches the public keys from your identity provider. It automatically refreshes when keys rotate.
 - **Clock skew** — `jose` allows a small clock tolerance by default. For Workers environments, this is usually sufficient.
 
+:::note[Check both header and query parameter in `onBeforeRequest`]
+
+When using the `useAgent` React hook, the `query` option appends parameters to both WebSocket upgrade requests **and** the SDK's own HTTP requests (for example, fetching initial messages). This means `onBeforeRequest` should check the query parameter as a fallback, not only the `Authorization` header. The `extractToken` helper above handles both sources.
+
+:::
+
 ### Pass tokens from the client
 
 When using the `useAgent` React hook, pass the token via the `query` parameter. The SDK appends these as query parameters to the WebSocket URL:
@@ -213,6 +221,9 @@ export default {
 			(await routeAgentRequest(request, env, {
 				onBeforeConnect: async (req, { name }) => {
 					const token = new URL(req.url).searchParams.get("token");
+					if (!token) {
+						return Response.json({ error: "Missing token" }, { status: 401 });
+					}
 					const payload = await verifyJwt(token);
 					if (!payload) {
 						return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/content/docs/agents/guides/add-authentication.mdx
+++ b/src/content/docs/agents/guides/add-authentication.mdx
@@ -1,0 +1,670 @@
+---
+pcx_content_type: how-to
+title: Add Authentication to Agents
+sidebar:
+  order: 3
+description: Learn how to add authentication to your Agents, from simple token validation to full OAuth and user management.
+head: []
+---
+
+import { TypeScriptExample, WranglerConfig } from "~/components";
+
+Adding authentication to your Agents ensures that only authorized users can connect to and interact with your Agent instances. This guide covers multiple approaches, from simple token validation to full user management with OAuth.
+
+:::note
+
+This guide covers authentication for Agents apps in general (HTTP and WebSocket). For MCP-specific OAuth authorization, refer to [MCP Authorization](/agents/model-context-protocol/authorization/).
+
+:::
+
+## Overview
+
+There are several ways to add authentication to your Agents, depending on the complexity of your application:
+
+| Approach | Best for | Complexity |
+| --- | --- | --- |
+| [Auth hooks with `routeAgentRequest`](#auth-hooks-with-routeagentrequest) | Simple token or API key validation | Low |
+| [Custom routing with `getAgentByName`](#custom-routing-with-getagentbyname) | Full control over routing with framework middleware | Medium |
+| [Workers OAuth Provider](#workers-oauth-provider) | OAuth 2.1 flows, third-party identity providers, MCP servers | Medium-High |
+| [Full-stack auth (Better Auth)](#full-stack-auth-with-better-auth) | Complete user management with sign-up, sign-in, sessions, and JWT | High |
+
+All approaches follow the same principle: **authenticate the request in your Worker before it reaches the Agent**. The Agent itself should not need to handle authentication logic.
+
+The examples below assume you have already [configured your Agent's Durable Object binding](/agents/getting-started/testing-your-agent/#add-the-agent-configuration) in your Wrangler configuration.
+
+## Auth hooks with `routeAgentRequest`
+
+The simplest way to add authentication is through the `onBeforeConnect` and `onBeforeRequest` hooks provided by [`routeAgentRequest`](/agents/api-reference/calling-agents/). These hooks run before a request is forwarded to an Agent, letting you validate credentials and reject unauthorized requests.
+
+- `onBeforeConnect` runs before a WebSocket upgrade request reaches the Agent.
+- `onBeforeRequest` runs before an HTTP request reaches the Agent.
+
+Both hooks follow the same pattern:
+- Return a `Request` (or `void`) to continue to the Agent.
+- Return a `Response` to short-circuit and reject the request (for example, a `401 Unauthorized`).
+
+Both hooks also receive a second argument `{ party, name }` containing the resolved Agent class name and instance name from the URL. You can use this to make per-instance authorization decisions (for example, restricting which Agents a user can access).
+
+### Validate a static token
+
+The following example checks for a known token on both WebSocket and HTTP requests. In production, store tokens as [Workers secrets](/workers/configuration/secrets/) rather than hardcoding them.
+
+<TypeScriptExample>
+
+```ts
+import { Agent, routeAgentRequest } from "agents";
+
+function authenticate(request: Request): Request | Response {
+  const url = new URL(request.url);
+  // Check query param (?token=...) or Authorization header
+  const token =
+    url.searchParams.get("token") ||
+    request.headers.get("Authorization")?.replace("Bearer ", "");
+
+  if (token === "my-secret-token") {
+    return request; // Valid — continue to the Agent
+  }
+  return Response.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return (
+      (await routeAgentRequest(request, env, {
+        onBeforeConnect: async (req) => authenticate(req),
+        onBeforeRequest: async (req) => authenticate(req),
+      })) || new Response("Not found", { status: 404 })
+    );
+  },
+} satisfies ExportedHandler<Env>;
+
+export class MyAgent extends Agent<Env> {
+  // Agent code here -- only reached by authenticated requests
+}
+```
+
+</TypeScriptExample>
+
+### Validate a JWT
+
+For production applications, validate a JSON Web Token (JWT) instead of a static token. This example uses the [`jose`](https://github.com/panva/jose) library:
+
+<TypeScriptExample>
+
+```ts
+import { Agent, routeAgentRequest } from "agents";
+import { jwtVerify, createRemoteJWKSet } from "jose";
+
+// Fetch public keys from your identity provider's JWKS endpoint
+const jwks = createRemoteJWKSet(
+  new URL("https://your-idp.example.com/.well-known/jwks.json")
+);
+
+async function verifyJwt(token: string) {
+  try {
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: "https://your-idp.example.com",
+      audience: "your-app-id",
+    });
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return (
+      (await routeAgentRequest(request, env, {
+        onBeforeConnect: async (req) => {
+          // WebSocket clients pass the token as a query parameter,
+          // since WebSocket upgrade requests cannot set custom headers.
+          const token = new URL(req.url).searchParams.get("token");
+          if (!token) {
+            return Response.json(
+              { error: "Missing token" },
+              { status: 401 }
+            );
+          }
+          const payload = await verifyJwt(token);
+          if (!payload) {
+            return Response.json(
+              { error: "Invalid token" },
+              { status: 401 }
+            );
+          }
+          return req;
+        },
+        onBeforeRequest: async (req) => {
+          // HTTP clients pass the token as a Bearer token in the
+          // Authorization header.
+          const authHeader = req.headers.get("Authorization");
+          const token = authHeader?.startsWith("Bearer ")
+            ? authHeader.slice(7)
+            : null;
+          if (!token) {
+            return Response.json(
+              { error: "Missing token" },
+              { status: 401 }
+            );
+          }
+          const payload = await verifyJwt(token);
+          if (!payload) {
+            return Response.json(
+              { error: "Invalid token" },
+              { status: 401 }
+            );
+          }
+          return req;
+        },
+      })) || new Response("Not found", { status: 404 })
+    );
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+### Pass the token from the client
+
+When using the `useAgent` React hook, pass the token via the `query` parameter. The SDK appends these as query parameters to the WebSocket URL:
+
+```tsx
+import { useAgent } from "agents/react";
+
+function ChatApp() {
+  const agent = useAgent({
+    agent: "MyAgent",
+    name: "user-123",
+    query: async () => ({
+      token: localStorage.getItem("auth_token") || "",
+    }),
+  });
+
+  // Use the agent connection...
+}
+```
+
+For HTTP requests using `agentFetch` or direct `fetch`, include the token in the `Authorization` header:
+
+```ts
+const response = await fetch("/agents/my-agent/user-123", {
+  headers: {
+    Authorization: `Bearer ${token}`,
+  },
+});
+```
+
+## Custom routing with `getAgentByName`
+
+When you need more control over routing — for example, using a framework like [Hono](https://hono.dev) with its own middleware stack — use [`getAgentByName`](/agents/api-reference/calling-agents/) to look up Agent instances after authenticating the request yourself.
+
+This approach is useful when:
+- You want to use your framework's middleware ecosystem for auth.
+- You need to derive the Agent instance name from the authenticated user (for example, one Agent per user).
+- You have non-Agent routes in the same Worker that also need auth.
+
+<TypeScriptExample>
+
+```ts
+import { Agent, getAgentByName, type AgentNamespace } from "agents";
+import { Hono } from "hono";
+import { bearerAuth } from "hono/bearer-auth";
+
+interface Env {
+  MyAgent: AgentNamespace<MyAgent>;
+  AUTH_TOKEN: string;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+// Apply auth middleware to all agent routes
+app.use("/agent/*", bearerAuth({ token: "my-secret-token" }));
+
+// Route authenticated requests to an Agent named by user ID
+app.all("/agent/:userId/*", async (c) => {
+  const userId = c.req.param("userId");
+  const agent = await getAgentByName<Env, MyAgent>(
+    c.env.MyAgent,
+    userId
+  );
+  return agent.fetch(c.req.raw);
+});
+
+// You can also call Agent methods directly via RPC
+app.post("/agent/:userId/summarize", async (c) => {
+  const userId = c.req.param("userId");
+  const agent = await getAgentByName<Env, MyAgent>(
+    c.env.MyAgent,
+    userId
+  );
+  const summary = await agent.summarize();
+  return c.json({ summary });
+});
+
+export default app;
+
+export class MyAgent extends Agent<Env> {
+  async summarize() {
+    return "Here is a summary of your data.";
+  }
+}
+```
+
+</TypeScriptExample>
+
+Since `getAgentByName` returns a Durable Object stub, you can also call [methods directly on the Agent via RPC](/agents/api-reference/calling-agents/#calling-methods-on-agents), without going through HTTP.
+
+### Use with Hono Agents middleware
+
+The [`hono-agents`](https://www.npmjs.com/package/hono-agents) package provides an `agentsMiddleware()` that wraps `routeAgentRequest` as Hono middleware. You can combine it with Hono's auth middleware:
+
+```ts
+import { Hono } from "hono";
+import { bearerAuth } from "hono/bearer-auth";
+import { agentsMiddleware } from "hono-agents";
+
+const app = new Hono();
+
+// Auth first, then route to agents
+app.use("/agents/*", bearerAuth({ token: "my-secret-token" }));
+app.use("/agents/*", agentsMiddleware());
+
+export default app;
+```
+
+## Workers OAuth Provider
+
+The [`@cloudflare/workers-oauth-provider`](https://github.com/cloudflare/workers-oauth-provider) library implements a full OAuth 2.1 authorization server as a Cloudflare Worker. It handles token issuance, refresh, revocation, dynamic client registration, and serves the standard OAuth metadata endpoints.
+
+This approach is ideal when:
+- Your Agent is accessed by third-party clients (for example, MCP clients, API consumers).
+- You want to use a standard OAuth flow to authenticate users via GitHub, Google, or another identity provider.
+- You need fine-grained token scoping and revocation.
+
+The `OAuthProvider` acts as middleware wrapping your Worker. It intercepts OAuth-related requests (token exchange, metadata endpoints) and forwards authenticated API requests to your handler with the user's identity available on `ctx.props`.
+
+<TypeScriptExample>
+
+```ts
+import { OAuthProvider } from "@cloudflare/workers-oauth-provider";
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { Agent, getAgentByName, type AgentNamespace } from "agents";
+
+interface Env {
+  MyAgent: AgentNamespace<MyAgent>;
+  OAUTH_PROVIDER: OAuthHelpers;
+  OAUTH_KV: KVNamespace;
+}
+
+// Handles authenticated API requests — ctx.props contains the user identity
+class AgentApiHandler extends WorkerEntrypoint<Env> {
+  async fetch(request: Request): Promise<Response> {
+    // ctx.props is populated by OAuthProvider after token validation
+    const userId = this.ctx.props.userId as string;
+    const agent = await getAgentByName(this.env.MyAgent, userId);
+    return agent.fetch(request);
+  }
+}
+
+// Handles the login/authorization UI and any non-API routes
+class AuthHandler extends WorkerEntrypoint<Env> {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/authorize") {
+      // Parse the OAuth authorization request
+      const oauthReq = await this.env.OAUTH_PROVIDER.parseAuthRequest(request);
+      const client = await this.env.OAUTH_PROVIDER.lookupClient(
+        oauthReq.clientId
+      );
+
+      // Your login UI and consent logic here...
+      // After the user authenticates and consents:
+      const { redirectTo } = await this.env.OAUTH_PROVIDER.completeAuthorization({
+        request: oauthReq,
+        userId: "authenticated-user-id",
+        metadata: { label: "User session" },
+        scope: oauthReq.scope,
+        props: { userId: "authenticated-user-id" },
+      });
+
+      return Response.redirect(redirectTo);
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+}
+
+export default new OAuthProvider({
+  apiRoute: "/api/",
+  apiHandler: AgentApiHandler,
+  defaultHandler: AuthHandler,
+  authorizeEndpoint: "/authorize",
+  tokenEndpoint: "/oauth/token",
+  clientRegistrationEndpoint: "/oauth/register",
+});
+
+export class MyAgent extends Agent<Env> {
+  // Your Agent implementation
+}
+```
+
+</TypeScriptExample>
+
+The library requires a Workers KV namespace bound as `OAUTH_KV` for storing clients, grants, and tokens.
+
+<WranglerConfig>
+
+```toml
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = "your-kv-namespace-id"
+```
+
+</WranglerConfig>
+
+For more details on integrating OAuth with third-party providers (GitHub, Google, Auth0, Stytch, WorkOS), see the [MCP Authorization guide](/agents/model-context-protocol/authorization/) and the [`workers-oauth-provider` documentation](https://github.com/cloudflare/workers-oauth-provider).
+
+## Full-stack auth with Better Auth
+
+For applications that need complete user management — sign-up, sign-in, email/password, sessions, and JWTs — you can use a library like [Better Auth](https://www.better-auth.com/) alongside the Agents SDK. This approach gives you a full authentication system running entirely on Cloudflare, using D1 as the user database.
+
+You can view the full example code on [GitHub](https://github.com/cloudflare/agents/tree/main/examples/auth-agent).
+
+### How it works
+
+The architecture splits requests across three paths in your Worker's `fetch` handler:
+
+1. **`/api/auth/*`** — Handled by Better Auth (sign-up, sign-in, JWT issuance, JWKS).
+2. **`/agents/*`** — Handled by `routeAgentRequest` with JWT validation in the `onBeforeConnect` and `onBeforeRequest` hooks.
+3. **`/*`** — Your frontend (SPA or static assets).
+
+```mermaid
+flowchart LR
+    A[Client] -->|POST /api/auth/sign-in| B[Better Auth]
+    A -->|GET /api/auth/token| B
+    B -->|Session cookie → JWT| A
+    A -->|WebSocket /agents/* ?token=JWT| C[routeAgentRequest]
+    C -->|JWT valid| D[Agent DO]
+    C -->|JWT invalid| E[401 Unauthorized]
+```
+
+### Set up the server
+
+Install dependencies:
+
+```sh
+npm install better-auth jose kysely-d1
+```
+
+Configure Better Auth with D1 and the JWT plugin:
+
+<TypeScriptExample>
+
+```ts
+// src/auth.ts
+import { betterAuth } from "better-auth";
+import { bearer, jwt } from "better-auth/plugins";
+import { D1Dialect } from "kysely-d1";
+import { createLocalJWKSet, jwtVerify, type JWTPayload } from "jose";
+import { env } from "cloudflare:workers";
+
+// Lazy singleton — betterAuth() must be called inside a request context
+// on Workers, not at module scope.
+let _auth: ReturnType<typeof betterAuth>;
+export function getAuth() {
+  return (_auth ??= betterAuth({
+    database: {
+      dialect: new D1Dialect({ database: env.AUTH_DB }),
+      type: "sqlite",
+    },
+    emailAndPassword: { enabled: true },
+    secret: env.BETTER_AUTH_SECRET,
+    baseURL: env.BETTER_AUTH_URL,
+    plugins: [bearer(), jwt()],
+  }));
+}
+
+// Verify a JWT by reading JWKS directly from D1.
+// Uses createLocalJWKSet instead of createRemoteJWKSet because the
+// JWKS endpoint is on this same Worker — same-zone subrequests bypass
+// Workers and hit the origin, which does not serve JWKS.
+export async function verifyToken(
+  token: string
+): Promise<JWTPayload | null> {
+  try {
+    const result = await env.AUTH_DB.prepare(
+      "SELECT id, publicKey FROM jwks"
+    ).all<{ id: string; publicKey: string }>();
+
+    if (!result.results?.length) return null;
+
+    const jwks = createLocalJWKSet({
+      keys: result.results.map((row) => ({
+        ...JSON.parse(row.publicKey),
+        kid: row.id,
+      })),
+    });
+
+    const { payload } = await jwtVerify(token, jwks);
+    return payload;
+  } catch {
+    return null;
+  }
+}
+```
+
+</TypeScriptExample>
+
+Wire it into your Worker's `fetch` handler alongside `routeAgentRequest`:
+
+<TypeScriptExample>
+
+```ts
+// src/server.ts
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { routeAgentRequest } from "agents";
+import { getAuth, verifyToken } from "./auth";
+
+export class SecuredChatAgent extends AIChatAgent<Env> {
+  // Your agent logic here — only reachable by authenticated users
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // Auth routes — sign-up, sign-in, token issuance, JWKS
+    if (url.pathname.startsWith("/api/auth")) {
+      return getAuth().handler(request);
+    }
+
+    // Agent routes — protected by JWT validation
+    if (url.pathname.startsWith("/agents")) {
+      const response = await routeAgentRequest(request, env, {
+        onBeforeConnect: async (req) => {
+          const token = new URL(req.url).searchParams.get("token");
+          if (!token)
+            return Response.json({ error: "Missing token" }, { status: 401 });
+          const payload = await verifyToken(token);
+          if (!payload)
+            return Response.json({ error: "Unauthorized" }, { status: 401 });
+          return req;
+        },
+        onBeforeRequest: async (req) => {
+          const authHeader = req.headers.get("Authorization");
+          const token = authHeader?.startsWith("Bearer ")
+            ? authHeader.slice(7)
+            : null;
+          if (!token)
+            return Response.json({ error: "Missing token" }, { status: 401 });
+          const payload = await verifyToken(token);
+          if (!payload)
+            return Response.json({ error: "Unauthorized" }, { status: 401 });
+          return req;
+        },
+      });
+      if (response) return response;
+      return new Response("Agent not found", { status: 404 });
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+### Set up the database
+
+Better Auth needs a D1 database. Create it and run the schema setup:
+
+```sh
+npx wrangler d1 create auth-db
+```
+
+Add the binding to your Wrangler config:
+
+<WranglerConfig>
+
+```toml
+[[d1_databases]]
+binding = "AUTH_DB"
+database_name = "auth-db"
+database_id = "your-database-id"
+```
+
+</WranglerConfig>
+
+Create the required tables (Better Auth uses `user`, `session`, `account`, and `jwks` tables):
+
+```sql
+-- db/setup.sql
+CREATE TABLE IF NOT EXISTS "user" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "name" TEXT NOT NULL,
+  "email" TEXT NOT NULL UNIQUE,
+  "emailVerified" INTEGER NOT NULL DEFAULT 0,
+  "image" TEXT,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "session" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "expiresAt" TEXT NOT NULL,
+  "token" TEXT NOT NULL UNIQUE,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL,
+  "ipAddress" TEXT,
+  "userAgent" TEXT,
+  "userId" TEXT NOT NULL REFERENCES "user"("id")
+);
+
+CREATE TABLE IF NOT EXISTS "account" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "accountId" TEXT NOT NULL,
+  "providerId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL REFERENCES "user"("id"),
+  "accessToken" TEXT,
+  "refreshToken" TEXT,
+  "idToken" TEXT,
+  "accessTokenExpiresAt" TEXT,
+  "refreshTokenExpiresAt" TEXT,
+  "scope" TEXT,
+  "password" TEXT,
+  "createdAt" TEXT NOT NULL,
+  "updatedAt" TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS "jwks" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "publicKey" TEXT NOT NULL,
+  "privateKey" TEXT NOT NULL,
+  "createdAt" TEXT NOT NULL
+);
+```
+
+Apply the schema:
+
+```sh
+npx wrangler d1 execute auth-db --local --file=db/setup.sql
+```
+
+Set the secret for local development:
+
+```sh
+echo 'BETTER_AUTH_SECRET="your-secret-key-here"' >> .dev.vars
+```
+
+### Set up the client
+
+On the client, use Better Auth's React client to manage sign-in state, and pass JWTs to the Agent via the `useAgent` hook:
+
+```tsx
+// src/auth-client.ts
+import { createAuthClient } from "better-auth/react";
+import { jwtClient } from "better-auth/client/plugins";
+
+export const authClient = createAuthClient({
+  plugins: [jwtClient()],
+});
+
+// After sign-in, fetch a JWT and store it for WebSocket auth
+export async function fetchAndStoreJwt(): Promise<string | null> {
+  const result = await authClient.token();
+  if (result.data?.token) {
+    localStorage.setItem("jwt_token", result.data.token);
+    return result.data.token;
+  }
+  return null;
+}
+```
+
+```tsx
+// src/client.tsx
+import { useAgent } from "agents/react";
+import { fetchAndStoreJwt } from "./auth-client";
+
+function ChatView() {
+  const agent = useAgent({
+    agent: "SecuredChatAgent",
+    name: "default",
+    // The query function provides params appended to the WebSocket URL
+    query: async () => ({
+      token: localStorage.getItem("jwt_token") || "",
+    }),
+  });
+
+  // Use agent for chat, state sync, etc.
+}
+```
+
+The authentication flow is:
+
+1. User signs in via Better Auth (session cookie set automatically).
+2. Client calls `authClient.token()` to get a short-lived JWT (authenticated via the session cookie).
+3. JWT is stored in `localStorage` and passed as `?token=` on WebSocket connections.
+4. The `onBeforeConnect` hook on the server verifies the JWT before the connection reaches the Agent.
+
+:::note[JWKS verification on Workers]
+
+When both Better Auth and your Agent run on the same Worker, use `createLocalJWKSet` from `jose` to verify JWTs by reading keys directly from D1. Using `createRemoteJWKSet` to fetch from your own Worker's `/api/auth/jwks` endpoint will fail because same-zone subrequests bypass Workers on Cloudflare.
+
+:::
+
+## Best practices
+
+- **Authenticate before the Agent.** Handle authentication in your Worker's `fetch` handler or middleware, not inside the Agent's `onConnect` or `onRequest` methods. This prevents unauthenticated requests from reaching the Durable Object.
+- **Use short-lived tokens for WebSockets.** WebSocket upgrade requests cannot include custom headers. Pass tokens as query parameters, and keep them short-lived (minutes, not hours) to limit exposure.
+- **Name Agents by user identity.** Use the authenticated user's ID as the Agent instance name. This ensures each user gets their own Agent and makes routing deterministic. See [Naming your Agents](/agents/api-reference/calling-agents/#naming-your-agents) for more.
+- **Handle token expiration on the client.** Check for expired tokens when a WebSocket disconnects. If the token is expired, redirect the user to sign in again rather than attempting to reconnect.
+
+## Related resources
+
+- [Calling Agents](/agents/api-reference/calling-agents/) — `routeAgentRequest` and `getAgentByName` API reference
+- [MCP Authorization](/agents/model-context-protocol/authorization/) — OAuth 2.1 authorization for MCP servers
+- [Workers OAuth Provider](https://github.com/cloudflare/workers-oauth-provider) — OAuth 2.1 provider library for Workers
+- [Better Auth](https://www.better-auth.com/) — Full-stack authentication library
+- [Auth Agent example](https://github.com/cloudflare/agents/tree/main/examples/auth-agent) — Complete working example with Better Auth

--- a/src/content/docs/agents/guides/add-authentication.mdx
+++ b/src/content/docs/agents/guides/add-authentication.mdx
@@ -253,7 +253,7 @@ export class MyAgent extends Agent<Env> {
 
 </TypeScriptExample>
 
-Since `getAgentByName` returns a Durable Object stub, you can also call [methods directly on the Agent via RPC](/agents/api-reference/calling-agents/#calling-methods-on-agents), without going through HTTP.
+Since `getAgentByName` returns a Durable Object stub, you can also call [methods directly on the Agent via RPC](/agents/api-reference/routing/#server-side-agent-access), without going through HTTP.
 
 ### Use with Hono Agents middleware
 

--- a/src/content/docs/agents/guides/add-authentication.mdx
+++ b/src/content/docs/agents/guides/add-authentication.mdx
@@ -658,7 +658,7 @@ When both Better Auth and your Agent run on the same Worker, use `createLocalJWK
 
 - **Authenticate before the Agent.** Handle authentication in your Worker's `fetch` handler or middleware, not inside the Agent's `onConnect` or `onRequest` methods. This prevents unauthenticated requests from reaching the Durable Object.
 - **Use short-lived tokens for WebSockets.** WebSocket upgrade requests cannot include custom headers. Pass tokens as query parameters, and keep them short-lived (minutes, not hours) to limit exposure.
-- **Name Agents by user identity.** Use the authenticated user's ID as the Agent instance name. This ensures each user gets their own Agent and makes routing deterministic. See [Naming your Agents](/agents/api-reference/calling-agents/#naming-your-agents) for more.
+- **Name Agents by user identity.** Use the authenticated user's ID as the Agent instance name. This ensures each user gets their own Agent and makes routing deterministic. See [Naming your Agents](/agents/api-reference/routing/#instance-naming-patterns) for more.
 - **Handle token expiration on the client.** Check for expired tokens when a WebSocket disconnects. If the token is expired, redirect the user to sign in again rather than attempting to reconnect.
 
 ## Related resources

--- a/src/content/docs/agents/guides/add-authentication.mdx
+++ b/src/content/docs/agents/guides/add-authentication.mdx
@@ -496,7 +496,7 @@ export default {
           const authHeader = req.headers.get("Authorization");
           const token = authHeader?.startsWith("Bearer ")
             ? authHeader.slice(7)
-            : null;
+            : new URL(req.url).searchParams.get("token");
           if (!token)
             return Response.json({ error: "Missing token" }, { status: 401 });
           const payload = await verifyToken(token);


### PR DESCRIPTION
### Summary

Adds a new **Authentication** section to the Agents documentation, replacing the single-page auth guide with four focused pages:

| Page                                                                      | Content                                                                                                              |
| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| [Overview](/agents/authentication/)                                       | Decision table for choosing an auth approach, core principle (authenticate before the Agent), best practices.        |
| [Token and middleware auth](/agents/authentication/token-and-middleware/) | Static token validation, JWT verification, passing tokens from clients, per-instance authorization, Hono middleware. |
| [Workers OAuth Provider](/agents/authentication/oauth-provider/)          | OAuth 2.1 authorization server setup, third-party IdP integration (GitHub example), token scoping and revocation.    |
| [Full-stack auth with Better Auth](/agents/authentication/better-auth/)   | Tutorial for user management with sign-up/sign-in, D1 database setup, JWT issuance, and client integration.          |

Replaces the stale #28654 and addresses the two review comments left there:

- **`better-auth.mdx`** — removed links to the `cloudflare/agents` [`auth-agent` example](https://github.com/cloudflare/agents/tree/main/examples/auth-agent). That example was rewritten in [cloudflare/agents#948](https://github.com/cloudflare/agents/pull/948) as a lightweight JWT demo and no longer uses Better Auth.
- **`better-auth.mdx`** — corrected the "Lazy initialization" note. Environment bindings _are_ available at module scope via `import { env } from "cloudflare:workers"`, so the original explanation was inaccurate. The real reason, per [this commit](https://github.com/cloudflare/agents/pull/948/commits/17639a7f157d2060ed1b62d394e6aeffc084c4e1), is that `betterAuth()`'s internal `init()` does async I/O (telemetry filesystem detection via dynamic `import("fs/promises")`) that only resolves inside a request context — calling `betterAuth()` at module scope causes `auth.handler()` to hang indefinitely.
- **`token-and-middleware.mdx`** — added a "Complete example" link to the `auth-agent` example, since the rewritten example now demonstrates exactly the JWT + `onBeforeConnect` / `onBeforeRequest` pattern this page describes.
- **`index.mdx`** — updated the `auth-agent` description in Related resources to reflect that it demonstrates JWT auth (not Better Auth).

### Documentation checklist

~- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).~
~- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.~
