### PR TITLE
[Artifacts] Sync docs with API schema

### DIFF
--- a/src/content/docs/artifacts/api/git-protocol.mdx
+++ b/src/content/docs/artifacts/api/git-protocol.mdx
@@ -16,10 +16,10 @@ Use the returned repo `remote` with a regular Git client for `clone`, `fetch`, `
 
 Git routes accept repo access tokens in two forms:
 
-| Format                             | Details                                                                                                                               | Example                                                                                                      |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Format                             | Details                                                                                                                              | Example                                                                                                      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | Bearer token in `http.extraHeader` | Recommended for local workflows. Use the full token string returned by the control plane and keep credentials out of the remote URL. | `git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" clone "$ARTIFACTS_REMOTE" artifacts-clone` |
-| HTTP Basic auth in the remote URL  | Use for short-lived, one-off commands when you need a self-contained remote. Put the token secret in the password slot.              | `https://x:<token-secret>@<accountId>.artifacts.cloudflare.net/git/<namespace>/<repo>.git`                 |
+| HTTP Basic auth in the remote URL  | Use for short-lived, one-off commands when you need a self-contained remote. Put the full token in the password slot.                | `https://x:<token>@<accountId>.artifacts.cloudflare.net/git/<namespace>/<repo>.git`                          |
 
 ### Token format
 
@@ -37,13 +37,12 @@ git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" clone "$ARTIFAC
 
 ### HTTPS remote with Basic auth
 
-For the URL form, use the token secret in the password slot. Artifacts ignores the Basic auth username.
+For the URL form, use the full token string in the password slot. Artifacts ignores the Basic auth username.
 
 Use this form only when you need a self-contained remote URL for a short-lived command.
 
 ```sh
-export ARTIFACTS_TOKEN_SECRET="${ARTIFACTS_TOKEN%%\?expires=*}"
-export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN_SECRET}@${ARTIFACTS_REMOTE#https://}"
+export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN}@${ARTIFACTS_REMOTE#https://}"
 ```
 
 ```sh

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -15,30 +15,32 @@ Use the Artifacts REST API to manage repos, remotes, forks, imports, and tokens 
 
 ## Base URL and authentication
 
-Artifacts REST routes use this base path:
+Artifacts REST routes use one of these base paths:
 
 ```txt
-https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE
+https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE
+https://artifacts.cloudflare.dev/edge/v1/api/namespaces/$ARTIFACTS_NAMESPACE
 ```
 
-Requests to `/v1/api/...` use Bearer authentication:
+Requests to `/v1/api/...` use a gateway JWT:
 
 ```txt
-Authorization: Bearer <CLOUDFLARE_API_TOKEN>
+Authorization: Bearer <ARTIFACTS_GATEWAY_JWT>
 ```
 
-All routes below are relative to this base URL.
+Requests to `/edge/v1/api/...` use edge gateway auth from Cloudflare Access and `cf-apigateway-metadata`.
 
-Cloudflare API tokens authenticate REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
+All routes below are relative to either base path.
+
+Gateway auth authenticates REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
 
 The following examples assume:
 
 ```sh
-export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
-export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 All responses use the standard Cloudflare v4 envelope.
@@ -48,12 +50,12 @@ Returned repo tokens are secrets. Do not log them or store them in long-lived re
 ## Shared types
 
 ```ts
-export type NamespaceName = string;
-export type RepoName = string;
-export type BranchName = string;
+export type NamespaceName = string; // /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
+export type RepoName = string; // same regex
+export type BranchName = string; // allows slashes, disallows ..
 export type Scope = "read" | "write";
 export type TokenState = "active" | "expired" | "revoked";
-export type ArtifactToken = string;
+export type ArtifactToken = string; // art_v1_<40hex>?expires=<unix_seconds>
 export type Cursor = string;
 export type RepoSortField =
 	| "created_at"
@@ -150,6 +152,7 @@ export interface CreateRepoResult {
 	default_branch: string;
 	remote: string;
 	token: ArtifactToken;
+	token_expires_at: string;
 }
 
 export type CreateRepoResponse = ApiEnvelope<CreateRepoResult>;
@@ -157,7 +160,7 @@ export type CreateRepoResponse = ApiEnvelope<CreateRepoResult>;
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
   --header "Content-Type: application/json" \
   --data '{
     "name": "starter-repo",
@@ -175,7 +178,8 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos" \
 		"description": "Repository for automation experiments",
 		"default_branch": "main",
 		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
-		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000"
+		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
+		"token_expires_at": "<ISO_TIMESTAMP>"
 	},
 	"success": true,
 	"errors": [],
@@ -211,7 +215,7 @@ export type ListReposResponse = ApiEnvelope<RepoInfo[]>;
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos?limit=20&sort=updated_at&direction=desc" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
 ```
 
 ```json
@@ -252,7 +256,7 @@ export type GetRepoResponse = ApiEnvelope<RemoteRepoInfo>;
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
 ```
 
 ```json
@@ -293,7 +297,7 @@ export type DeleteRepoResponse = ApiEnvelope<DeleteRepoResult>;
 
 ```bash
 curl --request DELETE "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
 ```
 
 ```json
@@ -337,7 +341,7 @@ export type ForkRepoResponse = ApiEnvelope<ForkRepoResult>;
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/fork" \
-	--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+	--header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
 	--header "Content-Type: application/json" \
 	--data '{
 	  "name": "starter-repo-copy",
@@ -356,6 +360,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/fork" \
 		"default_branch": "main",
 		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo-copy.git",
 		"token": "art_v1_89abcdef0123456789abcdef0123456789abcdef?expires=1760003600",
+		"token_expires_at": "<ISO_TIMESTAMP>",
 		"objects": 128
 	},
 	"success": true,
@@ -390,9 +395,11 @@ export type ImportRepoResponse = ApiEnvelope<CreateRepoResult>;
 
 Pass a full HTTPS Git remote URL, for example `https://github.com/facebook/react` or `https://gitlab.com/group/project.git`.
 
+If the repo already exists but is still importing or forking, some routes return `409 Conflict` with a retriable error. Retry after a short delay.
+
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos/react-mirror/import" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+	--header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
 	--header "Content-Type: application/json" \
 	--data '{
 	  "url": "https://github.com/facebook/react",
@@ -409,7 +416,8 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos/react-mirror/import" \
 		"description": null,
 		"default_branch": "main",
 		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/react-mirror.git",
-		"token": "art_v1_fedcba9876543210fedcba9876543210fedcba98?expires=1760007200"
+		"token": "art_v1_fedcba9876543210fedcba9876543210fedcba98?expires=1760007200",
+		"token_expires_at": "<ISO_TIMESTAMP>"
 	},
 	"success": true,
 	"errors": [],
@@ -445,7 +453,7 @@ export type ListTokensResponse = ApiEnvelope<TokenInfo[]>;
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/tokens?state=all&per_page=30&page=1" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
 ```
 
 ```json
@@ -503,7 +511,7 @@ export type CreateTokenResponse = ApiEnvelope<CreateTokenResult>;
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/tokens" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
   --header "Content-Type: application/json" \
   --data '{
     "repo": "starter-repo",
@@ -542,7 +550,7 @@ export type RevokeTokenResponse = ApiEnvelope<RevokeTokenResult>;
 
 ```bash
 curl --request DELETE "$ARTIFACTS_BASE_URL/tokens/tok_123" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
 ```
 
 ```json

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -15,22 +15,19 @@ Use the Artifacts REST API to manage repos, remotes, forks, imports, and tokens 
 
 ## Base URL and authentication
 
-Artifacts REST routes use one of these base paths:
+All REST routes use the following base path:
 
 ```txt
 https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE
-https://artifacts.cloudflare.dev/edge/v1/api/namespaces/$ARTIFACTS_NAMESPACE
 ```
 
-Requests to `/v1/api/...` use a gateway JWT:
+Authenticate with a gateway JWT:
 
 ```txt
 Authorization: Bearer <ARTIFACTS_GATEWAY_JWT>
 ```
 
-Requests to `/edge/v1/api/...` use edge gateway auth from Cloudflare Access and `cf-apigateway-metadata`.
-
-All routes below are relative to either base path.
+All routes below are relative to this base path.
 
 Gateway auth authenticates REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
 

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -15,28 +15,30 @@ Use the Artifacts REST API to manage repos, remotes, forks, imports, and tokens 
 
 ## Base URL and authentication
 
-All REST routes use the following base path:
+Artifacts REST routes use this base path:
 
 ```txt
 https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE
 ```
 
-Authenticate with a gateway JWT:
+Requests use Bearer authentication:
 
 ```txt
-Authorization: Bearer <ARTIFACTS_GATEWAY_JWT>
+Authorization: Bearer $CLOUDFLARE_API_TOKEN
 ```
 
 All routes below are relative to this base path.
 
-Gateway auth authenticates REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
+Cloudflare API tokens authenticate REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
+
+Use **Artifacts** > **Read** for read routes. Use **Artifacts** > **Edit** for create, import, delete, and token routes.
 
 The following examples assume:
 
 ```sh
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
-export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
 export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
@@ -157,7 +159,7 @@ export type CreateRepoResponse = ApiEnvelope<CreateRepoResult>;
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
     "name": "starter-repo",
@@ -212,7 +214,7 @@ export type ListReposResponse = ApiEnvelope<RepoInfo[]>;
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos?limit=20&sort=updated_at&direction=desc" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 ```json
@@ -253,7 +255,7 @@ export type GetRepoResponse = ApiEnvelope<RemoteRepoInfo>;
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 ```json
@@ -294,7 +296,7 @@ export type DeleteRepoResponse = ApiEnvelope<DeleteRepoResult>;
 
 ```bash
 curl --request DELETE "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 ```json
@@ -338,7 +340,7 @@ export type ForkRepoResponse = ApiEnvelope<ForkRepoResult>;
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/fork" \
-	--header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+	--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
 	--header "Content-Type: application/json" \
 	--data '{
 	  "name": "starter-repo-copy",
@@ -396,7 +398,7 @@ If the repo already exists but is still importing or forking, some routes return
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos/react-mirror/import" \
-	--header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+	--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
 	--header "Content-Type: application/json" \
 	--data '{
 	  "url": "https://github.com/facebook/react",
@@ -450,7 +452,7 @@ export type ListTokensResponse = ApiEnvelope<TokenInfo[]>;
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/tokens?state=all&per_page=30&page=1" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 ```json
@@ -508,7 +510,7 @@ export type CreateTokenResponse = ApiEnvelope<CreateTokenResult>;
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/tokens" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
     "repo": "starter-repo",
@@ -547,7 +549,7 @@ export type RevokeTokenResponse = ApiEnvelope<RevokeTokenResult>;
 
 ```bash
 curl --request DELETE "$ARTIFACTS_BASE_URL/tokens/tok_123" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 ```json

--- a/src/content/docs/artifacts/api/workers-binding.mdx
+++ b/src/content/docs/artifacts/api/workers-binding.mdx
@@ -34,6 +34,10 @@ namespace = "default" # any name works — use namespaces to organise repos
 
 </WranglerConfig>
 
+:::note
+You must be on `wrangler` `4.84.0` or later. Use `npx wrangler@latest` to always use the latest available `wrangler` version.
+:::
+
 After you run `npx wrangler types`, your Worker environment looks like this:
 
 ```ts

--- a/src/content/docs/artifacts/api/workers-binding.mdx
+++ b/src/content/docs/artifacts/api/workers-binding.mdx
@@ -29,6 +29,7 @@ Add the Artifacts binding to your Wrangler config file:
 [[artifacts]]
 binding = "ARTIFACTS"
 namespace = "default" # any name works — use namespaces to organise repos
+# remote = true # optional in local development
 ```
 
 </WranglerConfig>
@@ -42,6 +43,8 @@ export interface Env {
 ```
 
 Wrangler generates the `Artifacts` type for consumers and binds it directly in your environment.
+
+Use `remote = true` in local development when you want Miniflare to call the remote Artifacts service. In named Wrangler environments, repeat the `artifacts` block because it is non-inheritable.
 
 If you authenticate with `wrangler login`, Wrangler requests `artifacts:write` by default.
 
@@ -72,6 +75,7 @@ async function createRepo(artifacts: Artifacts) {
 		name: created.name,
 		remote: created.remote,
 		initialToken: created.token,
+		initialTokenExpiresAt: created.tokenExpiresAt,
 	};
 }
 ```
@@ -82,7 +86,7 @@ async function createRepo(artifacts: Artifacts) {
 
 - `name` <Type text="RepoName" /> <MetaInfo text="required" />
 - Returns <Type text="Promise<ArtifactsRepo>" />
-- Throws if the repo does not exist.
+- Throws if the repo does not exist or is not ready yet.
 
 <TypeScriptExample>
 
@@ -101,6 +105,8 @@ async function getRepoHandle(artifacts: Artifacts) {
 - `opts.cursor` <Type text="Cursor" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsRepoListResult>" />
 
+Each returned repo includes `status`, which is one of `"ready"`, `"importing"`, or `"forking"`.
+
 <TypeScriptExample>
 
 ```ts
@@ -108,7 +114,11 @@ async function listRepos(artifacts: Artifacts) {
 	const page = await artifacts.list({ limit: 10 });
 
 	return {
-		names: page.repos.map((repo) => repo.name),
+		total: page.total,
+		repos: page.repos.map((repo) => ({
+			name: repo.name,
+			status: repo.status,
+		})),
 		nextCursor: page.cursor ?? null,
 	};
 }
@@ -131,7 +141,7 @@ Import a repository from an external git remote.
 <TypeScriptExample>
 
 ```ts
-async function importFromGitHub(artifacts: Artifacts) {
+async function importFromRemote(artifacts: Artifacts) {
 	const imported = await artifacts.import({
 		source: {
 			url: "https://github.com/cloudflare/workers-sdk",
@@ -146,6 +156,7 @@ async function importFromGitHub(artifacts: Artifacts) {
 		name: imported.name,
 		remote: imported.remote,
 		token: imported.token,
+		tokenExpiresAt: imported.tokenExpiresAt,
 	};
 }
 ```
@@ -253,7 +264,10 @@ async function forkRepo(artifacts: Artifacts) {
 		readOnly: false,
 	});
 
-	return forked.remote;
+	return {
+		remote: forked.remote,
+		tokenExpiresAt: forked.tokenExpiresAt,
+	};
 }
 ```
 

--- a/src/content/docs/artifacts/examples/git-client.mdx
+++ b/src/content/docs/artifacts/examples/git-client.mdx
@@ -8,7 +8,9 @@ sidebar:
 
 Use this pattern when you want to discover a repo over the REST API and then hand the returned HTTPS remote to a standard Git client.
 
-This example assumes the repo already exists and that you have a [Cloudflare API token](/fundamentals/api/get-started/create-token/) with **Artifacts** > **Edit**.
+This example assumes the repo already exists and that you have a gateway JWT that can call the Artifacts REST control plane.
+
+For REST auth details, refer to [Authentication](/artifacts/guides/authentication/#authenticate-the-rest-api).
 
 ## Fetch the remote and clone the repo
 
@@ -17,19 +19,18 @@ First, fetch the repo metadata from the REST API. Then mint a read token for tha
 The example below uses `jq` to extract fields from the JSON responses.
 
 ```bash
-export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
-export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 
 REPO_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT")
 
 ARTIFACTS_REMOTE=$(printf '%s' "$REPO_JSON" | jq -r '.result.remote')
 
 TOKEN_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/tokens" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
   --header "Content-Type: application/json" \
   --data "{\"repo\":\"$ARTIFACTS_REPO\",\"scope\":\"read\",\"ttl\":3600}")
 
@@ -42,11 +43,10 @@ This flow is useful when another system owns repo discovery or access control, b
 
 Treat `ARTIFACTS_TOKEN` as a secret. Keep it out of logs, and prefer `http.extraHeader` over saving credentials in a remote URL.
 
-If you need a self-contained remote URL for a short-lived workflow, extract the token secret and build the authenticated remote only for that command:
+If you need a self-contained remote URL for a short-lived workflow, put the full token in the password slot and build the authenticated remote only for that command:
 
 ```sh
-ARTIFACTS_TOKEN_SECRET="${ARTIFACTS_TOKEN%%\?expires=*}"
-ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN_SECRET}@${ARTIFACTS_REMOTE#https://}"
+ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN}@${ARTIFACTS_REMOTE#https://}"
 
 git clone "$ARTIFACTS_AUTH_REMOTE" artifacts-clone
 ```

--- a/src/content/docs/artifacts/examples/git-client.mdx
+++ b/src/content/docs/artifacts/examples/git-client.mdx
@@ -8,7 +8,9 @@ sidebar:
 
 Use this pattern when you want to discover a repo over the REST API and then hand the returned HTTPS remote to a standard Git client.
 
-This example assumes the repo already exists and that you have a gateway JWT that can call the Artifacts REST control plane.
+This example assumes the repo already exists and that you have a Cloudflare API token with **Artifacts** > **Edit**.
+
+This flow needs edit access because it mints a repo-scoped read token before it runs `git clone`.
 
 For REST auth details, refer to [Authentication](/artifacts/guides/authentication/#authenticate-the-rest-api).
 
@@ -21,16 +23,16 @@ The example below uses `jq` to extract fields from the JSON responses.
 ```bash
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
-export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
 export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 
 REPO_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT")
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
 
 ARTIFACTS_REMOTE=$(printf '%s' "$REPO_JSON" | jq -r '.result.remote')
 
 TOKEN_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/tokens" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
   --data "{\"repo\":\"$ARTIFACTS_REPO\",\"scope\":\"read\",\"ttl\":3600}")
 

--- a/src/content/docs/artifacts/examples/isomorphic-git.mdx
+++ b/src/content/docs/artifacts/examples/isomorphic-git.mdx
@@ -45,8 +45,7 @@ export default {
 		const created = await env.ARTIFACTS.create(repoName);
 
 		// Artifacts returns art_v1_<secret>?expires=<unix_seconds>.
-		// For Git Basic auth, pass only the secret as the password.
-		const tokenSecret = created.token.split("?expires=")[0];
+		// For Git Basic auth, pass the full token as the password.
 		const dir = "/workspace";
 		const fs = new MemoryFS();
 
@@ -82,7 +81,7 @@ export default {
 			ref: "main",
 			onAuth: () => ({
 				username: "x",
-				password: tokenSecret,
+				password: created.token,
 			}),
 		});
 

--- a/src/content/docs/artifacts/examples/sandbox-sdk-artifacts.mdx
+++ b/src/content/docs/artifacts/examples/sandbox-sdk-artifacts.mdx
@@ -83,8 +83,7 @@ Use a short-lived token and pass it into the sandbox only after the sandbox sess
 
 ```ts
 function toAuthenticatedRemote(remote: string, token: string) {
-	const tokenSecret = token.split("?expires=")[0];
-	return `https://x:${tokenSecret}@${remote.slice("https://".length)}`;
+	return `https://x:${token}@${remote.slice("https://".length)}`;
 }
 
 await sandbox.setEnvVars({

--- a/src/content/docs/artifacts/get-started/index.mdx
+++ b/src/content/docs/artifacts/get-started/index.mdx
@@ -13,6 +13,6 @@ import { DirectoryListing } from "~/components";
 Start here to create, inspect, and version Artifacts from Cloudflare developer workflows.
 
 - Use **Workers** when you want the simplest path and already use Wrangler.
-- Use **REST API** when you want control-plane HTTP access with a Cloudflare API token.
+- Use **REST API** when you want control-plane HTTP access with [REST API gateway auth](/artifacts/guides/authentication/#authenticate-the-rest-api).
 
 <DirectoryListing />

--- a/src/content/docs/artifacts/get-started/index.mdx
+++ b/src/content/docs/artifacts/get-started/index.mdx
@@ -13,6 +13,6 @@ import { DirectoryListing } from "~/components";
 Start here to create, inspect, and version Artifacts from Cloudflare developer workflows.
 
 - Use **Workers** when you want the simplest path and already use Wrangler.
-- Use **REST API** when you want control-plane HTTP access with [REST API gateway auth](/artifacts/guides/authentication/#authenticate-the-rest-api).
+- Use **REST API** when you want control-plane HTTP access with a [Cloudflare API token](/artifacts/guides/authentication/#authenticate-the-rest-api).
 
 <DirectoryListing />

--- a/src/content/docs/artifacts/get-started/rest-api.mdx
+++ b/src/content/docs/artifacts/get-started/rest-api.mdx
@@ -20,12 +20,14 @@ By the end of this guide, you will create a repo inside an existing namespace, r
 You need:
 
 - A Cloudflare account with access to Artifacts.
-- A [Cloudflare API token](/fundamentals/api/get-started/create-token/) with **Artifacts** > **Edit**.
+- A gateway JWT that can call the Artifacts REST control plane.
 - An existing Artifacts namespace, for example `default`.
 - A local `git` client.
 - `jq`, if you want to extract response fields automatically.
 
 For Workers-based access instead of direct HTTP calls, use the [Workers get started guide](/artifacts/get-started/workers/).
+
+For REST auth details, refer to [Authentication](/artifacts/guides/authentication/#authenticate-the-rest-api).
 
 ## 1. Export your environment variables
 
@@ -34,17 +36,16 @@ Set the variables used in the examples:
 ```sh
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
-export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
-export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 Use a unique repo name each time you run this guide.
 
-Artifacts uses Bearer authentication for control-plane requests:
+Artifacts uses Bearer authentication for `/v1/api/...` control-plane requests:
 
 ```txt
-Authorization: Bearer $CLOUDFLARE_API_TOKEN
+Authorization: Bearer $ARTIFACTS_GATEWAY_JWT
 ```
 
 ## 2. Create a repo
@@ -56,7 +57,7 @@ Choose one of the following ways to create a repo inside that namespace:
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
   --header "Content-Type: application/json" \
   --data "{\"name\":\"$ARTIFACTS_REPO\"}"
 ```
@@ -71,7 +72,8 @@ The response resembles the following:
 		"description": null,
 		"default_branch": "main",
 		"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
-		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000"
+		"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
+		"token_expires_at": "<ISO_TIMESTAMP>"
 	},
 	"success": true,
 	"errors": [],
@@ -95,7 +97,7 @@ Capture the create response once and extract the fields with `jq`:
 
 ```bash
 CREATE_RESPONSE=$(curl --silent --request POST "$ARTIFACTS_BASE_URL/repos" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
   --header "Content-Type: application/json" \
   --data "{\"name\":\"$ARTIFACTS_REPO\"}")
 
@@ -113,7 +115,7 @@ Fetch the repo metadata when you need to recover the remote URL later:
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
 ```
 
 ```json
@@ -155,11 +157,10 @@ git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" push -u origin 
 
 This uses the recommended header-based form and keeps the token out of the remote URL.
 
-If you need a self-contained remote URL for a short-lived command, build one from the token secret instead:
+If you need a self-contained remote URL for a short-lived command, use the full token string in the password slot:
 
 ```sh
-export ARTIFACTS_TOKEN_SECRET="${ARTIFACTS_TOKEN%%\?expires=*}"
-export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN_SECRET}@${ARTIFACTS_REMOTE#https://}"
+export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN}@${ARTIFACTS_REMOTE#https://}"
 git push "$ARTIFACTS_AUTH_REMOTE" HEAD:main
 ```
 

--- a/src/content/docs/artifacts/get-started/rest-api.mdx
+++ b/src/content/docs/artifacts/get-started/rest-api.mdx
@@ -20,7 +20,7 @@ By the end of this guide, you will create a repo inside an existing namespace, r
 You need:
 
 - A Cloudflare account with access to Artifacts.
-- A gateway JWT that can call the Artifacts REST control plane.
+- A Cloudflare API token with **Artifacts** > **Edit**.
 - An existing Artifacts namespace, for example `default`.
 - A local `git` client.
 - `jq`, if you want to extract response fields automatically.
@@ -36,16 +36,16 @@ Set the variables used in the examples:
 ```sh
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
-export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
 export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 Use a unique repo name each time you run this guide.
 
-Artifacts uses Bearer authentication for `/v1/api/...` control-plane requests:
+Artifacts uses Bearer authentication for control-plane requests:
 
 ```txt
-Authorization: Bearer $ARTIFACTS_GATEWAY_JWT
+Authorization: Bearer $CLOUDFLARE_API_TOKEN
 ```
 
 ## 2. Create a repo
@@ -57,7 +57,7 @@ Choose one of the following ways to create a repo inside that namespace:
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
   --data "{\"name\":\"$ARTIFACTS_REPO\"}"
 ```
@@ -97,7 +97,7 @@ Capture the create response once and extract the fields with `jq`:
 
 ```bash
 CREATE_RESPONSE=$(curl --silent --request POST "$ARTIFACTS_BASE_URL/repos" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
   --data "{\"name\":\"$ARTIFACTS_REPO\"}")
 
@@ -115,7 +115,7 @@ Fetch the repo metadata when you need to recover the remote URL later:
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 ```json

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -123,6 +123,7 @@ export default {
 				name: created.name,
 				remote: created.remote,
 				token: created.token,
+				tokenExpiresAt: created.tokenExpiresAt,
 			});
 		}
 
@@ -171,7 +172,8 @@ The response resembles the following:
 {
 	"name": "starter-repo",
 	"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
-	"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000"
+	"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
+	"tokenExpiresAt": "<ISO_TIMESTAMP>"
 }
 ```
 
@@ -217,11 +219,10 @@ git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" push -u origin 
 
 This uses the recommended header-based form and keeps the token out of the remote URL.
 
-If you need a self-contained remote URL for a short-lived command, build one from the token secret instead:
+If you need a self-contained remote URL for a short-lived command, use the full token string in the password slot:
 
 ```sh
-export ARTIFACTS_TOKEN_SECRET="${ARTIFACTS_TOKEN%%\?expires=*}"
-export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN_SECRET}@${ARTIFACTS_REMOTE#https://}"
+export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN}@${ARTIFACTS_REMOTE#https://}"
 git push "$ARTIFACTS_AUTH_REMOTE" HEAD:main
 ```
 

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -88,6 +88,10 @@ This exposes Artifacts as `env.ARTIFACTS` inside your Worker.
 
 If you authenticate with `wrangler login`, Wrangler requests `artifacts:write` by default.
 
+:::note
+You must be on `wrangler` `4.84.0` or later. Use `npx wrangler@latest` to always use the latest available `wrangler` version.
+:::
+
 If you are using TypeScript, regenerate your local binding types:
 
 <PackageManagers type="exec" pkg="wrangler" args="types" />

--- a/src/content/docs/artifacts/guides/artifact-fs.mdx
+++ b/src/content/docs/artifacts/guides/artifact-fs.mdx
@@ -39,8 +39,7 @@ go install github.com/cloudflare/artifact-fs/cmd/artifact-fs@latest
 
 export ARTIFACTS_REMOTE="https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git"
 export ARTIFACTS_TOKEN="<YOUR_READ_TOKEN>"
-export ARTIFACTS_TOKEN_SECRET="${ARTIFACTS_TOKEN%%\?expires=*}"
-export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN_SECRET}@${ARTIFACTS_REMOTE#https://}"
+export ARTIFACTS_AUTH_REMOTE="https://x:${ARTIFACTS_TOKEN}@${ARTIFACTS_REMOTE#https://}"
 
 artifact-fs add-repo \
   --name starter-repo \

--- a/src/content/docs/artifacts/guides/authentication.mdx
+++ b/src/content/docs/artifacts/guides/authentication.mdx
@@ -12,13 +12,13 @@ Artifacts uses a different authentication path for each interface. Choose auth b
 
 ## Compare auth methods
 
-| Interface | Authenticate with | Permissions or scopes | Use for |
-| --- | --- | --- | --- |
-| Workers binding | Wrangler OAuth or a Cloudflare API token | `wrangler login` requests `artifacts:write` by default. API tokens need **Artifacts** > **Read** or **Artifacts** > **Edit**. | Worker code that calls `env.ARTIFACTS` |
-| REST API | Cloudflare API token in `Authorization: Bearer ...` | **Artifacts** > **Read** for read routes, **Artifacts** > **Edit** for create, import, delete, and token routes | Control-plane HTTP requests |
-| Git protocol | Repo-scoped Artifacts token | `read` for clone, fetch, and pull. `write` for push. | Standard Git over HTTPS |
+| Interface       | Authenticate with                                                                       | Permissions or scopes                                                                                                         | Use for                                |
+| --------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Workers binding | Wrangler OAuth or a Cloudflare API token                                                | `wrangler login` requests `artifacts:write` by default. API tokens need **Artifacts** > **Read** or **Artifacts** > **Edit**. | Worker code that calls `env.ARTIFACTS` |
+| REST API        | Gateway JWT in `Authorization: Bearer ...`, or edge gateway auth for `/edge/v1/api/...` | Use gateway credentials that allow the target namespace and route                                                             | Control-plane HTTP requests            |
+| Git protocol    | Repo-scoped Artifacts token                                                             | `read` for clone, fetch, and pull. `write` for push.                                                                          | Standard Git over HTTPS                |
 
-Cloudflare API tokens authenticate control-plane access. Repo-scoped Artifacts tokens authenticate Git access.
+Gateway credentials authenticate control-plane access. Repo-scoped Artifacts tokens authenticate Git access.
 
 ## Authenticate the Workers binding
 
@@ -52,27 +52,26 @@ export CLOUDFLARE_ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 
 ## Authenticate the REST API
 
-The REST API uses a Cloudflare API token in the `Authorization` header. Use **Artifacts** > **Read** for read routes, and **Artifacts** > **Edit** for routes that change repo state.
+The REST API uses a gateway JWT in the `Authorization` header for `/v1/api/...` routes. For `/edge/v1/api/...` routes, use edge gateway auth from Cloudflare Access and `cf-apigateway-metadata`.
 
 ```sh
-export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
-export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
-Read repo metadata with a read-capable token:
+Read repo metadata with a gateway JWT:
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos/starter-repo" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
 ```
 
-Create a repo with an edit-capable token:
+Create a repo with the same auth flow:
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
   --header "Content-Type: application/json" \
   --data '{
     "name": "starter-repo"
@@ -83,10 +82,10 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos" \
 
 Git uses repo-scoped Artifacts tokens, not Cloudflare API tokens. Mint these tokens from the Workers binding or the REST API, then use them with the repo `remote` URL.
 
-| Token scope | Allowed commands |
-| --- | --- |
-| `read` | `git clone`, `git fetch`, `git pull` |
-| `write` | `git clone`, `git fetch`, `git pull`, `git push` |
+| Token scope | Allowed commands                                 |
+| ----------- | ------------------------------------------------ |
+| `read`      | `git clone`, `git fetch`, `git pull`             |
+| `write`     | `git clone`, `git fetch`, `git pull`, `git push` |
 
 Use a read token to clone:
 

--- a/src/content/docs/artifacts/guides/authentication.mdx
+++ b/src/content/docs/artifacts/guides/authentication.mdx
@@ -12,13 +12,13 @@ Artifacts uses a different authentication path for each interface. Choose auth b
 
 ## Compare auth methods
 
-| Interface       | Authenticate with                          | Permissions or scopes                                                                                                         | Use for                                |
-| --------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| Workers binding | Wrangler OAuth or a Cloudflare API token   | `wrangler login` requests `artifacts:write` by default. API tokens need **Artifacts** > **Read** or **Artifacts** > **Edit**. | Worker code that calls `env.ARTIFACTS` |
-| REST API        | Gateway JWT in `Authorization: Bearer ...` | Use gateway credentials that allow the target namespace and route                                                             | Control-plane HTTP requests            |
-| Git protocol    | Repo-scoped Artifacts token                | `read` for clone, fetch, and pull. `write` for push.                                                                          | Standard Git over HTTPS                |
+| Interface       | Authenticate with                                   | Permissions or scopes                                                                                                         | Use for                                |
+| --------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Workers binding | Wrangler OAuth or a Cloudflare API token            | `wrangler login` requests `artifacts:write` by default. API tokens need **Artifacts** > **Read** or **Artifacts** > **Edit**. | Worker code that calls `env.ARTIFACTS` |
+| REST API        | Cloudflare API token in `Authorization: Bearer ...` | **Artifacts** > **Read** for read routes. **Artifacts** > **Edit** for create, import, delete, and token routes.              | Control-plane HTTP requests            |
+| Git protocol    | Repo-scoped Artifacts token                         | `read` for clone, fetch, and pull. `write` for push.                                                                          | Standard Git over HTTPS                |
 
-Gateway credentials authenticate control-plane access. Repo-scoped Artifacts tokens authenticate Git access.
+Cloudflare API tokens authenticate control-plane access. Repo-scoped Artifacts tokens authenticate Git access.
 
 ## Authenticate the Workers binding
 
@@ -52,26 +52,26 @@ export CLOUDFLARE_ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 
 ## Authenticate the REST API
 
-The REST API uses a gateway JWT in the `Authorization` header.
+The REST API uses a [Cloudflare API token](/fundamentals/api/get-started/create-token/) in the `Authorization` header.
 
 ```sh
 export ARTIFACTS_NAMESPACE="default"
-export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
 export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
-Read repo metadata with a gateway JWT:
+Read repo metadata with a read-capable token:
 
 ```bash
 curl "$ARTIFACTS_BASE_URL/repos/starter-repo" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT"
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
-Create a repo with the same auth flow:
+Create a repo with an edit-capable token:
 
 ```bash
 curl --request POST "$ARTIFACTS_BASE_URL/repos" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
     "name": "starter-repo"

--- a/src/content/docs/artifacts/guides/authentication.mdx
+++ b/src/content/docs/artifacts/guides/authentication.mdx
@@ -12,11 +12,11 @@ Artifacts uses a different authentication path for each interface. Choose auth b
 
 ## Compare auth methods
 
-| Interface       | Authenticate with                                                                       | Permissions or scopes                                                                                                         | Use for                                |
-| --------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| Workers binding | Wrangler OAuth or a Cloudflare API token                                                | `wrangler login` requests `artifacts:write` by default. API tokens need **Artifacts** > **Read** or **Artifacts** > **Edit**. | Worker code that calls `env.ARTIFACTS` |
-| REST API        | Gateway JWT in `Authorization: Bearer ...`, or edge gateway auth for `/edge/v1/api/...` | Use gateway credentials that allow the target namespace and route                                                             | Control-plane HTTP requests            |
-| Git protocol    | Repo-scoped Artifacts token                                                             | `read` for clone, fetch, and pull. `write` for push.                                                                          | Standard Git over HTTPS                |
+| Interface       | Authenticate with                          | Permissions or scopes                                                                                                         | Use for                                |
+| --------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Workers binding | Wrangler OAuth or a Cloudflare API token   | `wrangler login` requests `artifacts:write` by default. API tokens need **Artifacts** > **Read** or **Artifacts** > **Edit**. | Worker code that calls `env.ARTIFACTS` |
+| REST API        | Gateway JWT in `Authorization: Bearer ...` | Use gateway credentials that allow the target namespace and route                                                             | Control-plane HTTP requests            |
+| Git protocol    | Repo-scoped Artifacts token                | `read` for clone, fetch, and pull. `write` for push.                                                                          | Standard Git over HTTPS                |
 
 Gateway credentials authenticate control-plane access. Repo-scoped Artifacts tokens authenticate Git access.
 
@@ -52,7 +52,7 @@ export CLOUDFLARE_ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 
 ## Authenticate the REST API
 
-The REST API uses a gateway JWT in the `Authorization` header for `/v1/api/...` routes. For `/edge/v1/api/...` routes, use edge gateway auth from Cloudflare Access and `cf-apigateway-metadata`.
+The REST API uses a gateway JWT in the `Authorization` header.
 
 ```sh
 export ARTIFACTS_NAMESPACE="default"

--- a/src/content/docs/artifacts/guides/import-repositories.mdx
+++ b/src/content/docs/artifacts/guides/import-repositories.mdx
@@ -16,23 +16,22 @@ This works well for:
 
 Artifacts imports public HTTPS remotes through the [REST API](/artifacts/api/rest-api/#import-a-public-https-remote) or the [Workers binding](/artifacts/api/workers-binding/#importparams). After import, the repo has a normal Artifacts remote URL and can be cloned, forked, or issued repo-scoped tokens like any other repo.
 
-## Import a repo from GitHub
+## Import a repo from a public HTTPS remote
 
-This example imports a public GitHub repo into the `default` namespace.
+This example imports a public GitHub repo into the `default` namespace. The same route also accepts other public HTTPS Git remotes.
 
-Use a [Cloudflare API token](/fundamentals/api/get-started/create-token/) with **Artifacts** > **Edit**.
+Use a gateway JWT that can call the Artifacts REST control plane.
 
 ```sh
-export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="workers-sdk-baseline"
-export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
-export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 ```bash
 IMPORT_RESPONSE=$(curl --silent --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/import" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
   --header "Content-Type: application/json" \
   --data '{
     "url": "https://github.com/cloudflare/workers-sdk",
@@ -43,7 +42,11 @@ IMPORT_RESPONSE=$(curl --silent --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIF
 printf '%s\n' "$IMPORT_RESPONSE"
 ```
 
-The response includes the new Artifacts repo metadata, including `result.remote` and an initial repo token.
+The response includes the new Artifacts repo metadata, including `result.remote`, an initial repo token, and `result.token_expires_at`.
+
+:::note[Retry during import]
+While the repo is still importing, some routes can return `409 Conflict`. Retry after a short delay.
+:::
 
 ## Use the imported repo
 

--- a/src/content/docs/artifacts/guides/import-repositories.mdx
+++ b/src/content/docs/artifacts/guides/import-repositories.mdx
@@ -20,18 +20,18 @@ Artifacts imports public HTTPS remotes through the [REST API](/artifacts/api/res
 
 This example imports a public GitHub repo into the `default` namespace. The same route also accepts other public HTTPS Git remotes.
 
-Use a gateway JWT that can call the Artifacts REST control plane.
+Use a Cloudflare API token with **Artifacts** > **Edit**.
 
 ```sh
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="workers-sdk-baseline"
-export ARTIFACTS_GATEWAY_JWT="<YOUR_GATEWAY_JWT>"
+export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
 export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.dev/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
 ```
 
 ```bash
 IMPORT_RESPONSE=$(curl --silent --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/import" \
-  --header "Authorization: Bearer $ARTIFACTS_GATEWAY_JWT" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
     "url": "https://github.com/cloudflare/workers-sdk",

--- a/src/content/docs/artifacts/platform/limits.mdx
+++ b/src/content/docs/artifacts/platform/limits.mdx
@@ -10,13 +10,13 @@ Limits that apply to creating, importing, cloning, and pushing Artifacts are det
 
 These limits cover naming rules and request rates for control-plane and git operations.
 
-| Feature                           | Limit                                                      |
-| --------------------------------- | ---------------------------------------------------------- |
-| Control-plane request rate        | 2,000 requests per 10 seconds                              |
-| Git request rate (per namespace)  | 2,000 requests per 10 seconds                              |
-| Maximum storage per repository    | 10 GB                                                      |
-| Maximum storage per account       | 1 TB (can be raised on request)                            |
-| Maximum number of repositories    | Unlimited                                                  |
-| Maximum number of namespaces      | Unlimited                                                  |
-| Namespace and repo names          | 3-63 characters, lowercase only, `a-z` and hyphens allowed |
-| Maximum name length               | 63 characters                                              |
+| Feature                          | Limit                                                                                                 |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Control-plane request rate       | 2,000 requests per 10 seconds                                                                         |
+| Git request rate (per namespace) | 2,000 requests per 10 seconds                                                                         |
+| Maximum storage per repository   | 10 GB                                                                                                 |
+| Maximum storage per account      | 1 TB (can be raised on request)                                                                       |
+| Maximum number of repositories   | Unlimited                                                                                             |
+| Maximum number of namespaces     | Unlimited                                                                                             |
+| Namespace and repo names         | Must start with an alphanumeric. Remaining characters may include letters, numbers, `.`, `_`, and `-` |
+| Maximum name length              | 63 characters                                                                                         |


### PR DESCRIPTION
Updates the Artifacts docs to match the current public REST and Workers interfaces.

- Remove internal `/edge/*` route references and switch REST examples back to Cloudflare API token auth.
- Document current response fields, repo status values, and retry guidance for import and fork flows.
- Prefer `x:$TOKEN@...` in short-lived Git URL examples and fix the namespace and repo naming rules.
- Add a Wrangler version note to the Workers guide and Workers binding reference.

Validation: `npx prettier --check` passed for the changed files. `npm run check` still fails on unrelated repo issues in `astro.config.ts` and missing `@testing-library/dom`.
