### PR TITLE
docs: link to Cloudflare MCP server repo in Registrar API changelog

### DIFF
--- a/src/content/changelog/registrar/2026-04-15-registrar-api-beta.mdx
+++ b/src/content/changelog/registrar/2026-04-15-registrar-api-beta.mdx
@@ -16,7 +16,7 @@ You can now use the Cloudflare API to:
 
 This beta supports a subset of popular extensions available through Cloudflare Registrar. Search returns suggestions across API-supported extensions, check confirms current availability and pricing, and registration starts a workflow that can complete immediately or be polled if it takes longer.
 
-Because the Registrar API is part of the Cloudflare API, it can also be used in Cloudflare MCP and other agent-driven workflows.
+Because the Registrar API is part of the Cloudflare API, it can also be used in [Cloudflare MCP](https://github.com/cloudflare/mcp) and other agent-driven workflows.
 
 If you are using Cloudflare MCP or other agent-driven workflows, prompts can be as simple as:
 


### PR DESCRIPTION
This PR adds a link to https://github.com/cloudflare/mcp in the Registrar API beta changelog entry.

The changelog mentions "Cloudflare MCP" but doesn't link to the repo. This is a newer MCP server that's different from the older https://github.com/cloudflare/mcp-server-cloudflare, so having a direct link helps readers find it.

cc @carmada-cf @aninibread @DavidJKTofan @irvinebroque (authors/reviewers of #29837)