### PR TITLE
docs: add build/deploy separation guidance, troubleshooting, and SBOM generation

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/advanced-setups.mdx
+++ b/src/content/docs/workers/ci-cd/builds/advanced-setups.mdx
@@ -80,3 +80,38 @@ When a new commit is detected in the repository, a new build/deploy will trigger
 Imagine you have a Worker named `my-worker`, and you want to set up two environments `staging` and `production` set in the `wrangler.jsonc`. If you have not already, you can deploy `my-worker` for each environment using the commands `wrangler deploy --env staging` and `wrangler deploy --env production`.
 
 In your Cloudflare Dashboard, you should find the two Workers `my-worker-staging` and `my-worker-production`. Then, connect the Git repository for the Worker, `my-worker`, to both of the environment Workers. In the build configurations of each environment Worker, edit the deploy commands to be `npx wrangler deploy --env staging` and `npx wrangler deploy --env production` and the non-production branch deploy commands to be `npx wrangler versions upload --env staging` and `npx wrangler versions upload --env production` respectively.
+
+## SBOM generation
+
+You can generate a Software Bill of Materials (SBOM) during your Workers Build to produce an inventory of every dependency included in your deployed application. This is useful for:
+
+- **Vulnerability scanning**: Run the SBOM through tools like [Snyk](https://snyk.io/), [Grype](https://github.com/anchore/grype), or [Trivy](https://trivy.dev/) to check dependencies against known CVE databases.
+- **Compliance**: Meet regulatory requirements that mandate visibility into deployed software components.
+- **Incident response**: When a new vulnerability is disclosed, quickly determine if your production deployments are affected.
+
+Generating the SBOM during the build (rather than locally) ensures it reflects the exact dependency tree that was installed and shipped to production.
+
+### Setup
+
+1. Add a dependency on an SBOM generator such as [`@cyclonedx/cyclonedx-npm`](https://www.npmjs.com/package/@cyclonedx/cyclonedx-npm):
+
+    ```json title="package.json"
+    {
+    	"devDependencies": {
+    		"@cyclonedx/cyclonedx-npm": "^1.19.0"
+    	},
+    	"scripts": {
+    		"generate-sbom": "npx @cyclonedx/cyclonedx-npm --output-file sbom.json --output-format JSON"
+    	}
+    }
+    ```
+
+2. Chain the SBOM generation into your dashboard build command, after the main build step:
+
+    ```
+    npm run build && npm run generate-sbom
+    ```
+
+3. To push the SBOM back to your repository for security tooling to scan, create a script that commits and pushes the generated file using the GitHub or GitLab API with an access token stored as a [build secret](/workers/ci-cd/builds/configuration/#environment-variables). Add `[skip ci]` to the commit message to prevent the push from triggering another build.
+
+4. Add the SBOM output file (for example, `sbom.json`) to your [build watch paths](/workers/ci-cd/builds/build-watch-paths/) exclude list so that pushing it back to the repository does not trigger a new build.

--- a/src/content/docs/workers/ci-cd/builds/configuration.mdx
+++ b/src/content/docs/workers/ci-cd/builds/configuration.mdx
@@ -69,6 +69,47 @@ Examples of other non-production branch deploy commands you can set include:
 | `yarn exec wrangler versions upload`         | You can customize the package manager used to run Wrangler.                                                                                                                                                                                                                                           |
 | `npx wrangler versions upload --env staging` | If you have a [Wrangler environment](/workers/ci-cd/builds/advanced-setups/#wrangler-environments) Worker, you should set your non-production branch deploy command with the environment flag. For more details, see [Advanced Setups](/workers/ci-cd/builds/advanced-setups/#wrangler-environments). |
 
+### Separating build and deploy commands
+
+Workers Builds runs your build command and deploy command as **separate steps**. Your `package.json` scripts should reflect this separation — the `build` script should only compile your project, and the `deploy` script should only deploy. Do not bundle build and deploy into a single script (for example, `"deploy": "astro build && wrangler deploy"`), as this causes your project to be built twice.
+
+This is especially important when using a framework adapter like `@opennextjs/cloudflare` that internally calls `npm run build`. If your `package.json` has `"build": "opennextjs-cloudflare build"`, this creates an infinite loop because `opennextjs-cloudflare build` calls `npm run build`, which calls `opennextjs-cloudflare build` again.
+
+**Recommended pattern:** Use framework adapter commands directly in the dashboard settings, and keep `package.json` scripts simple:
+
+```json title="package.json"
+{
+	"scripts": {
+		"build": "next build",
+		"deploy": "wrangler deploy"
+	}
+}
+```
+
+| Setting | Example (OpenNext) | Example (Astro) |
+| --- | --- | --- |
+| **Build command** | `npx opennextjs-cloudflare build` | `npm run build` |
+| **Deploy command** | `npx opennextjs-cloudflare deploy` | `npx wrangler deploy` |
+| **Non-production deploy command** | `npx opennextjs-cloudflare upload` | `npx wrangler versions upload` |
+
+:::caution
+Do not use npm lifecycle hooks (`prebuild`, `postbuild`) when your framework adapter internally calls `npm run build`. Lifecycle hooks fire on every `npm run build` invocation — including internal ones from framework adapters — causing duplicate or recursive execution. Chain pre-build steps in the dashboard build command instead.
+:::
+
+For example, if you need to generate static tokens, download a manifest, and lint before building:
+
+```
+node ./bin/generate-tokens.js && npm run download:manifest && npm run lint && npx opennextjs-cloudflare build
+```
+
+Or for a simpler project that just needs to lint before an Astro build:
+
+```
+npm run lint && npm run build
+```
+
+For troubleshooting, see [Double builds or infinite loops](/workers/ci-cd/builds/troubleshoot/#double-builds-or-infinite-loops).
+
 ### Automatic configuration for new projects
 
 If your repository does not have a Wrangler configuration file, the deploy command (`wrangler deploy`) will trigger [automatic project configuration](/workers/framework-guides/automatic-configuration/). This detects your framework, creates the necessary configuration, and opens a [pull request](/workers/ci-cd/builds/automatic-prs/) for you to review. Once you merge the PR, your project is configured and future builds will deploy normally.

--- a/src/content/docs/workers/ci-cd/builds/troubleshoot.mdx
+++ b/src/content/docs/workers/ci-cd/builds/troubleshoot.mdx
@@ -51,6 +51,46 @@ The API Token dropdown in Build Configuration settings may show stale tokens tha
 
 There is a maximum build duration of 20 minutes. If a build exceeds this time, then the build will be terminated and the above error log is shown. For more details, see [Workers Builds limits](/workers/ci-cd/builds/limits-and-pricing/).
 
+### Double builds or infinite loops
+
+If your build runs the same steps twice, or loops indefinitely until it times out, the cause is usually that your `package.json` scripts bundle build and deploy together, or that a framework adapter internally calls `npm run build`.
+
+**Why this happens:** Workers Builds runs your build command and deploy command as separate steps. If your `package.json` `deploy` script includes a build step (for example, `"deploy": "astro build && wrangler deploy"` or `"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy"`), and you set your dashboard deploy command to `npm run deploy`, your project gets built twice — once by the dashboard build command and once inside the deploy script.
+
+This becomes an **infinite loop** when a framework adapter internally calls `npm run build`. For example, `opennextjs-cloudflare build` runs `npm run build` internally. If your `package.json` has `"build": "opennextjs-cloudflare build"`, this creates recursion: `opennextjs-cloudflare build` → `npm run build` → `opennextjs-cloudflare build` → forever. npm lifecycle hooks (`prebuild`, `postbuild`) make this worse, since they fire on every `npm run build` invocation.
+
+**How to fix it:**
+
+1. **Keep build and deploy as separate, single-purpose commands** in your `package.json`. The `build` script should only compile your project (for example, `next build` or `astro build`), and the `deploy` script should only deploy (for example, `wrangler deploy`). Do not chain build+deploy together.
+
+2. **Use framework adapter commands directly in the dashboard**, not via `npm run`. For example, with OpenNext:
+
+| Setting | Value |
+| --- | --- |
+| **Build command** | `npx opennextjs-cloudflare build` |
+| **Deploy command** | `npx opennextjs-cloudflare deploy` |
+| **Non-production deploy command** | `npx opennextjs-cloudflare upload` |
+
+3. **Do not use npm lifecycle hooks** (`prebuild`, `postbuild`) when your framework adapter internally calls `npm run build`. If you need pre-build steps, chain them in the dashboard build command instead. For example:
+
+```
+node ./bin/generate-tokens.js && npm run download:manifest && npm run lint && npx opennextjs-cloudflare build
+```
+
+For more details, see [Separating build and deploy commands](/workers/ci-cd/builds/configuration/#separating-build-and-deploy-commands).
+
+### Private registry lockfile errors
+
+`npm error network request to https://internal-registry.example.com/... failed, reason: getaddrinfo ENOTFOUND internal-registry.example.com`
+
+If your build fails trying to reach an internal or private npm registry, the cause is likely hardcoded `resolved` URLs in your `package-lock.json`. When developers install dependencies locally against a private registry (such as Nexus, Artifactory, or GitHub Packages), the lockfile records the resolved tarball URLs pointing to that registry. When Workers Builds runs `npm install`, it follows those URLs — even if your `.npmrc` points to a different (public) registry.
+
+**How to fix it:**
+
+- **Option 1: Remove the lockfile.** Without a `package-lock.json`, `npm install` resolves packages fresh using the registry configured in `.npmrc`. This works if your private packages are also available on the public registry.
+- **Option 2: Use a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/).** Set up a tunnel to expose your private registry to Workers Builds, so the lockfile URLs are reachable.
+- **Option 3: Regenerate the lockfile.** Run `npm install` in an environment that resolves against a publicly reachable registry, then commit the updated lockfile.
+
 ### Git integration issues
 
 If you are running into errors associated with your Git integration, you can try removing access to your [GitHub](/workers/ci-cd/builds/git-integration/github-integration/#removing-access) or [GitLab](/workers/ci-cd/builds/git-integration/gitlab-integration/#removing-access) integration from Cloudflare, then reinstalling the [GitHub](/workers/ci-cd/builds/git-integration/github-integration/#reinstall-a-git-integration) or [GitLab](/workers/ci-cd/builds/git-integration/gitlab-integration/#reinstall-a-git-integration) integration.


### PR DESCRIPTION
## Summary
- Add "Separating build and deploy commands" section to the builds configuration page with general guidance and OpenNext/Astro examples
- Add "Double builds or infinite loops" and "Private registry lockfile errors" troubleshooting entries
- Add SBOM generation guide to advanced setups

These changes address recurring issues seen with enterprise customers deploying Next.js apps via OpenNext on Workers Builds, where bundling build+deploy in `package.json` scripts or using npm lifecycle hooks (`prebuild`) causes double builds or infinite recursion. The guidance is framed as a general principle (separate build and deploy commands) with OpenNext as a specific example.

The private registry lockfile section documents the behavior where `npm install` follows hardcoded `resolved` URLs in `package-lock.json` even when `.npmrc` points to a different registry, and provides three fix options.

The SBOM section covers generating a Software Bill of Materials during builds for compliance and vulnerability scanning use cases.