### PR TITLE
chore: exclude external_link pages from sitemap

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,7 +9,8 @@ import icon from "astro-icon";
 import sitemap from "@astrojs/sitemap";
 import react from "@astrojs/react";
 
-import { readdir } from "fs/promises";
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
 import { fileURLToPath } from "url";
 
 import remarkValidateImages from "./src/plugins/remark/validate-images";
@@ -57,8 +58,33 @@ async function autogenStyles() {
 	return styles;
 }
 
+async function getExternalLinkPaths(dir: string): Promise<Set<string>> {
+	const paths = new Set<string>();
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			for (const p of await getExternalLinkPaths(full)) {
+				paths.add(p);
+			}
+		} else if (entry.name.endsWith(".mdx") || entry.name.endsWith(".md")) {
+			const content = await readFile(full, "utf-8");
+			const match = content.match(/^---\n([\s\S]*?)\n---/);
+			if (match?.[1].includes("external_link:")) {
+				let rel = full.slice("src/content/docs".length);
+				rel = rel.replace(/\.(mdx|md)$/, "");
+				rel = rel.replace(/\/index$/, "/");
+				if (!rel.endsWith("/")) rel += "/";
+				paths.add(rel);
+			}
+		}
+	}
+	return paths;
+}
+
 const sidebar = await autogenSections();
 const customCss = await autogenStyles();
+const externalLinkPaths = await getExternalLinkPaths("src/content/docs");
 
 const RUN_LINK_CHECK =
 	process.env.RUN_LINK_CHECK?.toLowerCase() === "true" || false;
@@ -199,6 +225,11 @@ export default defineConfig({
 				}
 
 				if (page.endsWith("/404/")) {
+					return false;
+				}
+
+				const pathname = new URL(page).pathname;
+				if (externalLinkPaths.has(pathname)) {
 					return false;
 				}
 


### PR DESCRIPTION
### Summary

Pages with `external_link` frontmatter are stub MDX files that exist only to create sidebar entries pointing to other docs pages or external URLs. They have no real content — the sidebar already links directly to the target URL, not to the stub page.

Previously, these ~233 pages were included in the sitemap despite being empty shells with a meta-refresh redirect and a `noindex` robot tag. This PR excludes them from the sitemap by scanning for `external_link` frontmatter at config time and filtering matching URLs in the sitemap integration's `filter()` callback.
