### PR TITLE
Remove unmaintained software from Wrangler's recommended installation

### DIFF
--- a/src/content/docs/workers/wrangler/install-and-update.mdx
+++ b/src/content/docs/workers/wrangler/install-and-update.mdx
@@ -16,7 +16,7 @@ Wrangler is a command-line tool for building with Cloudflare developer products.
 
 ## Install Wrangler
 
-To install [Wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler), ensure you have [Node.js](https://nodejs.org/en/) and [npm](https://docs.npmjs.com/getting-started) installed, preferably using a Node version manager like [Volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to change Node.js versions.
+To install [Wrangler](https://github.com/cloudflare/workers-sdk/tree/main/packages/wrangler), ensure you have [Node.js](https://nodejs.org/en/) and [npm](https://docs.npmjs.com/getting-started) installed, preferably using a Node version manager like [mise](https://github.com/jdx/mise) or [nvm](https://github.com/nvm-sh/nvm). Using a version manager helps avoid permission issues and allows you to change Node.js versions.
 
 <details>
 <summary>Wrangler System Requirements</summary>


### PR DESCRIPTION
### Summary

Volta is unmaintained, see https://github.com/volta-cli/volta/commit/49d2a346c26c3069a76fefd9b82e1292d12a32fe.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

### Notes

I chose to replace the first recommended version manager with [mise-en-place](https://mise.jdx.dev) not just because it's what Volta recommends but rather because it is popular across industry and it works well in my experience.