### PR TITLE
Add missing build_token_uuid to Builds API trigger docs

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/api-reference.mdx
+++ b/src/content/docs/workers/ci-cd/builds/api-reference.mdx
@@ -25,9 +25,8 @@ Create your token at [dash.cloudflare.com/profile/api-tokens](https://dash.cloud
 
 <Aside type="note">
 	This API token is different from a **build token**. Build tokens are used by
-	the build system to deploy your Worker. By default, Cloudflare automatically
-	generates a build token for your account, but you can also [create your
-	own](/workers/ci-cd/builds/configuration/#api-token-optional). The API token
+	the build system to deploy your Worker — you will need a build token UUID
+	when [creating triggers](#step-4-get-your-build-token-uuid). The API token
 	described above is what you use to call the Builds API itself.
 </Aside>
 
@@ -51,6 +50,7 @@ A **trigger** is a configuration that defines how your Worker gets built and dep
 | Field                   | Type    | Description                                                              |
 | ----------------------- | ------- | ------------------------------------------------------------------------ |
 | `trigger_name`          | string  | Display name for the trigger                                             |
+| `build_token_uuid`      | string  | UUID of the build token used to deploy your Worker. Find this in your Worker's **Settings** > **Builds** > **API token** section, or via the [`GET /builds/tokens`](/api/resources/workers_builds/subresources/build_tokens/methods/list/) endpoint. |
 | `build_command`         | string  | Command to build your project (for example, `npm run build`)             |
 | `deploy_command`        | string  | Command to deploy your Worker (for example, `npx wrangler deploy`)       |
 | `root_directory`        | string  | Path to your project root                                                |
@@ -299,10 +299,11 @@ This example walks through the complete process of connecting a GitHub repositor
 | 1    | Get GitHub account/repo IDs | `GET api.github.com/users/...` and `GET api.github.com/repos/...` |
 | 2    | Create repo connection      | `PUT /builds/repos/connections`                                   |
 | 3    | Get Worker tag              | `GET /workers/scripts`                                            |
-| 4a   | Create production trigger   | `POST /builds/triggers`                                           |
-| 4b   | Create preview trigger      | `POST /builds/triggers`                                           |
-| 5    | Set environment variables   | `PATCH /builds/triggers/:trigger_uuid/environment_variables`       |
-| 6    | Trigger first build         | `POST /builds/triggers/:trigger_uuid/builds`                      |
+| 4    | Get build token UUID        | `GET /builds/tokens`                                              |
+| 5a   | Create production trigger   | `POST /builds/triggers`                                           |
+| 5b   | Create preview trigger      | `POST /builds/triggers`                                           |
+| 6    | Set environment variables   | `PATCH /builds/triggers/:trigger_uuid/environment_variables`       |
+| 7    | Trigger first build         | `POST /builds/triggers/:trigger_uuid/builds`                      |
 
 #### Prerequisites
 
@@ -356,7 +357,25 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/workers/scri
   | jq '.result[] | {name: .id, tag: .tag}'
 ```
 
-#### Step 4: Create a production trigger
+#### Step 4: Get your build token UUID
+
+A build token authorizes the build system to deploy your Worker. To get your build token UUID:
+
+1. Go to your Worker in the [Cloudflare dashboard](https://dash.cloudflare.com).
+2. Navigate to **Settings** > **Builds** > **API token**.
+3. Select an existing build token or create a new one.
+
+You can also list your build tokens via the API:
+
+```bash
+curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/tokens" \
+  --header "Authorization: Bearer <API_TOKEN>" \
+  | jq '.result[] | {build_token_uuid, build_token_name}'
+```
+
+Save the `build_token_uuid` for the next step.
+
+#### Step 5: Create a production trigger
 
 Create a trigger that deploys when you push to `main`:
 
@@ -368,6 +387,7 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/trigg
   --data '{
     "external_script_id": "<WORKER_TAG>",
     "repo_connection_uuid": "<REPO_CONNECTION_UUID>",
+    "build_token_uuid": "<BUILD_TOKEN_UUID>",
     "trigger_name": "Deploy production",
     "build_command": "npm run build",
     "deploy_command": "npx wrangler deploy",
@@ -379,7 +399,7 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/trigg
   }'
 ```
 
-#### Step 5: Create a preview trigger (optional)
+#### Step 6: Create a preview trigger (optional)
 
 Create a second trigger for preview deployments on all other branches:
 
@@ -391,6 +411,7 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/trigg
   --data '{
     "external_script_id": "<WORKER_TAG>",
     "repo_connection_uuid": "<REPO_CONNECTION_UUID>",
+    "build_token_uuid": "<BUILD_TOKEN_UUID>",
     "trigger_name": "Deploy preview branches",
     "build_command": "npm run build",
     "deploy_command": "npx wrangler versions upload",
@@ -404,7 +425,7 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/trigg
 
 Note the different `deploy_command`: production uses `wrangler deploy` while preview uses `wrangler versions upload` to create preview URLs without affecting the live deployment.
 
-#### Step 6: Set environment variables for each trigger
+#### Step 7: Set environment variables for each trigger
 
 Set production environment variables:
 
@@ -434,7 +455,7 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/trigg
   }'
 ```
 
-#### Step 7: Trigger your first build
+#### Step 8: Trigger your first build
 
 ```bash
 curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/triggers/{production_trigger_uuid}/builds" \


### PR DESCRIPTION
## Summary

Fixes #30064 — the `POST /builds/triggers` examples were missing the required `build_token_uuid` field, causing `[12002] Invalid request body` errors for anyone following the docs.

### Changes
- Added `build_token_uuid` to the trigger fields table
- Added new Step 4 explaining how to get your build token UUID (dashboard: Worker > Settings > Builds > API token, or via `GET /builds/tokens`)
- Added `build_token_uuid` to both the production and preview trigger creation curl examples
- Updated the build token note to link to the new step instead of an unrelated config page
- Renumbered steps accordingly