### PR TITLE
fix: flagship permissions typo

### DIFF
--- a/src/content/docs/flagship/get-started.mdx
+++ b/src/content/docs/flagship/get-started.mdx
@@ -143,7 +143,7 @@ export default {
 
 </TabItem> <TabItem label="With app ID">
 
-Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). The provider makes HTTP requests to the Flagship evaluation endpoint. Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship Evaluate permissions.
+Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). The provider makes HTTP requests to the Flagship evaluation endpoint. Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship Evaluate permission.
 
 <TypeScriptExample>
 

--- a/src/content/docs/flagship/get-started.mdx
+++ b/src/content/docs/flagship/get-started.mdx
@@ -143,7 +143,7 @@ export default {
 
 </TabItem> <TabItem label="With app ID">
 
-Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). The provider makes HTTP requests to the Flagship evaluation endpoint. Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship evaluate permissions.
+Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). The provider makes HTTP requests to the Flagship evaluation endpoint. Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship Evaluate permissions.
 
 <TypeScriptExample>
 

--- a/src/content/docs/flagship/get-started.mdx
+++ b/src/content/docs/flagship/get-started.mdx
@@ -143,7 +143,7 @@ export default {
 
 </TabItem> <TabItem label="With app ID">
 
-Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). The provider makes HTTP requests to the Flagship evaluation endpoint. Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship read permissions.
+Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). The provider makes HTTP requests to the Flagship evaluation endpoint. Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship evaluate permissions.
 
 <TypeScriptExample>
 


### PR DESCRIPTION
### Summary

Flagship evaluation required `flagship:evaluate` permission, not `flagship:read`.

### Screenshots (optional)

### Documentation checklist