### PR TITLE
Update deprecations.mdx to fix typo error

### DIFF
--- a/src/content/docs/workers/wrangler/deprecations.mdx
+++ b/src/content/docs/workers/wrangler/deprecations.mdx
@@ -33,7 +33,7 @@ Use `npm create cloudflare@latest` for new Workers and Pages projects.
 
 #### `publish`
 
-The `wrangler deploy` command is deprecated, but still active in v3. `wrangler deploy` will be fully removed in v4.
+The `wrangler publish` command is deprecated, but still active in v3. `wrangler publish` will be fully removed in v4.
 
 Use [`npx wrangler deploy`](/workers/wrangler/commands/general/#deploy) to deploy Workers.
 


### PR DESCRIPTION


### Summary
I think there’s a typo in the current version.
publish
The wrangler deploy command is deprecated, but still active in v3. wrangler deploy will be fully removed in v4.

Use npx wrangler deploy to deploy Workers.

This should be:
publish
The wrangler publish command is deprecated, but still active in v3. wrangler publish will be fully removed in v4.

Use npx wrangler deploy to deploy Workers.

### Screenshots (optional)


### Documentation checklist


- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
