### PR TITLE
Update note about Audit Logs version 2 availability

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/review-audit-logs.mdx
+++ b/src/content/docs/fundamentals/account/account-security/review-audit-logs.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { Render } from "~/components";
 
 :::note
-Audit Logs version 2 is available in beta. Refer to the [Audit Logs v2 documentation](/fundamentals/account/account-security/audit-logs/) for more details.
+Audit Logs version 2 is available. Refer to the [Audit Logs v2 documentation](/fundamentals/account/account-security/audit-logs/) for more details.
 :::
 
 <Render file="account-audit-logs-definition" product="fundamentals" />


### PR DESCRIPTION
Outdated info.
Audit Logs v2 is not in Beta anymore.
https://developers.cloudflare.com/logs/changelog/audit-logs/
