### PR TITLE
[Cache] Fix formatting in tiered-cache.mdx note section

### DIFF
--- a/src/content/docs/cache/how-to/tiered-cache.mdx
+++ b/src/content/docs/cache/how-to/tiered-cache.mdx
@@ -118,7 +118,7 @@ For more API examples and configuration options for Tiered Cache, refer to the [
 :::note
 
 
-To confirm that Tiered Cache is working, make sure you have the value of `[CacheTieredFill](/logs/logpush/logpush-job/datasets/zone/http_requests/#cachetieredfill)` in your http\_requests logs, this will indicate if Tiered Cache was used to serve the request.
+To confirm that Tiered Cache is working, make sure you have the value of [CacheTieredFill](/logs/logpush/logpush-job/datasets/zone/http_requests/#cachetieredfill) in your http\_requests logs, this will indicate if Tiered Cache was used to serve the request.
 
 
 :::


### PR DESCRIPTION
The link was not rendering because of the backticks
