### PR TITLE
[Workers AI] Add Kimi K2.6 model

### DIFF
--- a/src/content/changelog/workers-ai/2026-04-20-kimi-k2-6-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-04-20-kimi-k2-6-workers-ai.mdx
@@ -1,0 +1,34 @@
+---
+title: "Moonshot AI Kimi K2.6 now available on Workers AI"
+description: Kimi K2.6 is now available on Workers AI, bringing a 1T parameter MoE model with 32B active parameters, 262.1k context window, vision, and agentic capabilities to the Cloudflare Developer Platform.
+products:
+  - workers-ai
+date: 2026-04-20T18:00:00Z
+---
+
+[`@cf/moonshotai/kimi-k2.6`](/workers-ai/models/kimi-k2.6/) is now available on Workers AI, in partnership with Moonshot AI for Day 0 support. Kimi K2.6 is a native multimodal agentic model from Moonshot AI that advances practical capabilities in long-horizon coding, coding-driven design, proactive autonomous execution, and swarm-based task orchestration.
+
+Built on a Mixture-of-Experts architecture with 1T total parameters and 32B active per token, Kimi K2.6 delivers frontier-scale intelligence with efficient inference. It scores competitively against GPT-5.4 and Claude Opus 4.6 on agentic and coding benchmarks, including BrowseComp (83.2), SWE-Bench Verified (80.2), and Terminal-Bench 2.0 (66.7).
+
+## Key capabilities
+
+- **262.1k token context window** for retaining full conversation history, tool definitions, and codebases across long-running agent sessions
+- **Long-horizon coding** with significant improvements on complex, end-to-end coding tasks across languages including Rust, Go, and Python
+- **Coding-driven design** that transforms simple prompts and visual inputs into production-ready interfaces and full-stack workflows
+- **Agent swarm orchestration** scaling horizontally to 300 sub-agents executing 4,000 coordinated steps for complex autonomous tasks
+- **Vision inputs** for processing images alongside text
+- **Thinking mode** with configurable reasoning depth
+- **Multi-turn tool calling** for building agents that invoke tools across multiple conversation turns
+
+## Differences from Kimi K2.5
+
+If you are migrating from Kimi K2.5, note the following API changes:
+
+- K2.6 uses `chat_template_kwargs.thinking` to control reasoning, replacing `chat_template_kwargs.enable_thinking`
+- K2.6 returns reasoning content in the `reasoning` field, replacing `reasoning_content`
+
+## Get started
+
+Use Kimi K2.6 through the [Workers AI binding](/workers-ai/configuration/bindings/) (`env.AI.run()`), the REST API at `/ai/run`, or the OpenAI-compatible endpoint at `/v1/chat/completions`. You can also use [AI Gateway](/ai-gateway/) with any of these endpoints.
+
+For more information, refer to the [Kimi K2.6 model page](/workers-ai/models/kimi-k2.6/) and [pricing](/workers-ai/platform/pricing/).

--- a/src/content/changelog/workers-ai/2026-04-20-kimi-k2-6-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2026-04-20-kimi-k2-6-workers-ai.mdx
@@ -3,7 +3,7 @@ title: "Moonshot AI Kimi K2.6 now available on Workers AI"
 description: Kimi K2.6 is now available on Workers AI, bringing a 1T parameter MoE model with 32B active parameters, 262.1k context window, vision, and agentic capabilities to the Cloudflare Developer Platform.
 products:
   - workers-ai
-date: 2026-04-20T18:00:00Z
+date: 2026-04-20
 ---
 
 [`@cf/moonshotai/kimi-k2.6`](/workers-ai/models/kimi-k2.6/) is now available on Workers AI, in partnership with Moonshot AI for Day 0 support. Kimi K2.6 is a native multimodal agentic model from Moonshot AI that advances practical capabilities in long-horizon coding, coding-driven design, proactive autonomous execution, and swarm-based task orchestration.

--- a/src/content/docs/workers-ai/platform/pricing.mdx
+++ b/src/content/docs/workers-ai/platform/pricing.mdx
@@ -62,6 +62,7 @@ The Price in Tokens column is equivalent to the Price in Neurons column - the di
 | @cf/zai-org/glm-4.7-flash                    | $0.060 per M input tokens <br/> $0.400 per M output tokens                                        | 5500 neurons per M input tokens <br/> 36400 neurons per M output tokens                                                |
 | @cf/nvidia/nemotron-3-120b-a12b              | $0.500 per M input tokens <br/> $1.500 per M output tokens                                        | 45455 neurons per M input tokens <br/> 136364 neurons per M output tokens                                              |
 | @cf/moonshotai/kimi-k2.5                     | $0.600 per M input tokens <br/> $0.100 per M cached input tokens <br/> $3.000 per M output tokens | 54545 neurons per M input tokens <br/> 9091 neurons per M cached input tokens <br/> 272727 neurons per M output tokens |
+| @cf/moonshotai/kimi-k2.6                     | $0.950 per M input tokens <br/> $0.160 per M cached input tokens <br/> $4.000 per M output tokens | 86364 neurons per M input tokens <br/> 14545 neurons per M cached input tokens <br/> 363636 neurons per M output tokens |
 | @cf/google/gemma-4-26b-a4b-it                | $0.100 per M input tokens <br/> $0.300 per M output tokens                                        | 9091 neurons per M input tokens <br/> 27273 neurons per M output tokens                                                |
 
 ## Embeddings model pricing

--- a/src/content/release-notes/workers-ai.yaml
+++ b/src/content/release-notes/workers-ai.yaml
@@ -3,6 +3,11 @@ link: "/workers-ai/changelog/"
 productName: Workers AI
 productLink: "/workers-ai/"
 entries:
+  - publish_date: "2026-04-20"
+    title: Moonshot AI Kimi K2.6 now available on Workers AI
+    description: |-
+      - [`@cf/moonshotai/kimi-k2.6`](/workers-ai/models/kimi-k2.6/) now available on Workers AI. The latest frontier-scale model from Moonshot AI with improved reasoning, coding, and agentic capabilities. Read [changelog](/changelog/post/2026-04-20-kimi-k2-6-workers-ai/) to get started.
+      - K2.6 uses the `chat_template_kwargs.thinking` parameter to control reasoning (instead of `chat_template_kwargs.enable_thinking`) and returns reasoning content in the `reasoning` field (instead of `reasoning_content`).
   - publish_date: "2026-04-04"
     title: Google Gemma 4 26B A4B now available on Workers AI
     description: |-

--- a/src/content/workers-ai-models/kimi-k2.6.json
+++ b/src/content/workers-ai-models/kimi-k2.6.json
@@ -1,0 +1,4755 @@
+{
+    "id": "8a5d00bd-de28-4a28-b37a-ce46d01ebaeb",
+    "source": 1,
+    "name": "@cf/moonshotai/kimi-k2.6",
+    "description": "Kimi K2.6 is a frontier-scale open-source 1T parameter model with a 262.1k context window, multi-turn tool calling, vision inputs, and structured outputs for agentic workloads.",
+    "task": {
+        "id": "c329a1f9-323d-4e91-b2aa-582dd4188d34",
+        "name": "Text Generation",
+        "description": "Family of generative text models, such as large language models (LLM), that can be adapted for a variety of natural language tasks."
+    },
+    "created_at": "2026-04-20 01:40:35.001",
+    "tags": [],
+    "properties": [
+        {
+            "property_id": "context_window",
+            "value": "262144"
+        },
+        {
+            "property_id": "price",
+            "value": [
+                {
+                    "unit": "per M input tokens",
+                    "price": 0.95,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M cached input tokens",
+                    "price": 0.16,
+                    "currency": "USD"
+                },
+                {
+                    "unit": "per M output tokens",
+                    "price": 4,
+                    "currency": "USD"
+                }
+            ]
+        },
+        {
+            "property_id": "function_calling",
+            "value": "true"
+        },
+        {
+            "property_id": "reasoning",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://huggingface.co/moonshotai/Kimi-K2.6/blob/main/LICENSE"
+        },
+        {
+            "property_id": "vision",
+            "value": "true"
+        }
+    ],
+    "schema": {
+        "input": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "title": "Prompt",
+                            "properties": {
+                                "prompt": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "description": "The input text prompt for the model to generate a response."
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "prompt"
+                            ]
+                        },
+                        {
+                            "title": "Messages",
+                            "properties": {
+                                "messages": {
+                                    "type": "array",
+                                    "description": "A list of messages comprising the conversation so far.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "developer"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "system"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "user"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "image_url",
+                                                                                "input_audio",
+                                                                                "file"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "image_url": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "detail": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "auto",
+                                                                                        "low",
+                                                                                        "high"
+                                                                                    ],
+                                                                                    "default": "auto"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "input_audio": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "format": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "wav",
+                                                                                        "mp3"
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "file": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "file_data": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "file_id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "filename": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                },
+                                                                "minItems": 1
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "assistant"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text",
+                                                                                "refusal"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "refusal": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "refusal": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "null"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "audio": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "id"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_calls": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "oneOf": [
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        "function": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string",
+                                                                                    "description": "JSON-encoded arguments string."
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "custom"
+                                                                            ]
+                                                                        },
+                                                                        "custom": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "input": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "input"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "id",
+                                                                        "type",
+                                                                        "custom"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "function_call": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "arguments": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "name",
+                                                                    "arguments"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "tool"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string"
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "text"
+                                                                            ]
+                                                                        },
+                                                                        "text": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "text"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "tool_call_id": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "tool_call_id"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "role": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "content": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "role",
+                                                    "content",
+                                                    "name"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "minItems": 1
+                                },
+                                "model": {
+                                    "type": "string",
+                                    "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                },
+                                "audio": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                            "properties": {
+                                                "voice": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "id"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "format": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "wav",
+                                                        "aac",
+                                                        "mp3",
+                                                        "flac",
+                                                        "opus",
+                                                        "pcm16"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "voice",
+                                                "format"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "frequency_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                },
+                                "logit_bias": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                },
+                                "logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to return log probabilities of the output tokens."
+                                },
+                                "top_logprobs": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 20
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                },
+                                "max_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                },
+                                "max_completion_tokens": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                },
+                                "metadata": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Set of 16 key-value pairs that can be attached to the object."
+                                },
+                                "modalities": {
+                                    "anyOf": [
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "text",
+                                                    "audio"
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                },
+                                "n": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "maximum": 128
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "How many chat completion choices to generate for each input message."
+                                },
+                                "parallel_tool_calls": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Whether to enable parallel function calling during tool use."
+                                },
+                                "prediction": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "content"
+                                                    ]
+                                                },
+                                                "content": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    },
+                                                                    "text": {
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "text"
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "type",
+                                                "content"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "presence_penalty": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": -2,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 0,
+                                    "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                },
+                                "reasoning_effort": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "low",
+                                                "medium",
+                                                "high"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                },
+                                "chat_template_kwargs": {
+                                    "type": "object",
+                                    "properties": {
+                                        "thinking": {
+                                            "type": "boolean",
+                                            "default": true,
+                                            "description": "Whether to enable reasoning, enabled by default."
+                                        },
+                                        "clear_thinking": {
+                                            "type": "boolean",
+                                            "default": false,
+                                            "description": "If false, preserves reasoning context between turns."
+                                        }
+                                    }
+                                },
+                                "response_format": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Specifies the format the model must output.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_object"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "json_schema"
+                                                            ]
+                                                        },
+                                                        "json_schema": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": {
+                                                                    "type": "string"
+                                                                },
+                                                                "schema": {
+                                                                    "type": "object"
+                                                                },
+                                                                "strict": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "boolean"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "json_schema"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "seed": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If specified, the system will make a best effort to sample deterministically."
+                                },
+                                "service_tier": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "auto",
+                                                "default",
+                                                "flex",
+                                                "scale",
+                                                "priority"
+                                            ]
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": "auto",
+                                    "description": "Specifies the processing type used for serving the request."
+                                },
+                                "stop": {
+                                    "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        },
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "minItems": 1,
+                                            "maxItems": 4
+                                        }
+                                    ]
+                                },
+                                "store": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "Whether to store the output for model distillation / evals."
+                                },
+                                "stream": {
+                                    "anyOf": [
+                                        {
+                                            "type": "boolean"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": false,
+                                    "description": "If true, partial message deltas will be sent as server-sent events."
+                                },
+                                "stream_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "include_usage": {
+                                                    "type": "boolean"
+                                                },
+                                                "include_obfuscation": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "temperature": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 2
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Sampling temperature between 0 and 2."
+                                },
+                                "tool_choice": {
+                                    "anyOf": [
+                                        {
+                                            "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                            "oneOf": [
+                                                {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "auto",
+                                                        "required"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific function tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        "function": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "function"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Force a specific custom tool.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "custom"
+                                                            ]
+                                                        },
+                                                        "custom": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "custom"
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "description": "Constrain to an allowed subset of tools.",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "allowed_tools"
+                                                            ]
+                                                        },
+                                                        "allowed_tools": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "mode": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "auto",
+                                                                        "required"
+                                                                    ]
+                                                                },
+                                                                "tools": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "object"
+                                                                    }
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "mode",
+                                                                "tools"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "allowed_tools"
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "tools": {
+                                    "type": "array",
+                                    "description": "A list of tools the model may call.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "function"
+                                                        ]
+                                                    },
+                                                    "function": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string",
+                                                                "description": "The name of the function to be called."
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "description": "A description of what the function does."
+                                                            },
+                                                            "parameters": {
+                                                                "type": "object",
+                                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                            },
+                                                            "strict": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ],
+                                                                "default": false,
+                                                                "description": "Whether to enable strict schema adherence."
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "function"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "type": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "custom"
+                                                        ]
+                                                    },
+                                                    "custom": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": {
+                                                                "type": "string"
+                                                            },
+                                                            "format": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "grammar"
+                                                                                ]
+                                                                            },
+                                                                            "grammar": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "definition": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "syntax": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "lark",
+                                                                                            "regex"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "definition",
+                                                                                    "syntax"
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "grammar"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type",
+                                                    "custom"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "top_p": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 1
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "default": 1,
+                                    "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                },
+                                "user": {
+                                    "type": "string",
+                                    "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                },
+                                "web_search_options": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "description": "Options for the web search tool (when using built-in web search).",
+                                            "properties": {
+                                                "search_context_size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "low",
+                                                        "medium",
+                                                        "high"
+                                                    ],
+                                                    "default": "medium"
+                                                },
+                                                "user_location": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "approximate"
+                                                            ]
+                                                        },
+                                                        "approximate": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "city": {
+                                                                    "type": "string"
+                                                                },
+                                                                "country": {
+                                                                    "type": "string"
+                                                                },
+                                                                "region": {
+                                                                    "type": "string"
+                                                                },
+                                                                "timezone": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "type",
+                                                        "approximate"
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "function_call": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "enum": [
+                                                "none",
+                                                "auto"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "functions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the function to be called."
+                                            },
+                                            "description": {
+                                                "type": "string",
+                                                "description": "A description of what the function does."
+                                            },
+                                            "parameters": {
+                                                "type": "object",
+                                                "description": "The parameters the function accepts, described as a JSON Schema object."
+                                            },
+                                            "strict": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to enable strict schema adherence."
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    "minItems": 1,
+                                    "maxItems": 128
+                                }
+                            },
+                            "required": [
+                                "messages"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "oneOf": [
+                                    {
+                                        "title": "Prompt",
+                                        "properties": {
+                                            "prompt": {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "description": "The input text prompt for the model to generate a response."
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "prompt"
+                                        ]
+                                    },
+                                    {
+                                        "title": "Messages",
+                                        "properties": {
+                                            "messages": {
+                                                "type": "array",
+                                                "description": "A list of messages comprising the conversation so far.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "developer"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "system"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "user"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "image_url",
+                                                                                            "input_audio",
+                                                                                            "file"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "image_url": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "url": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "detail": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "auto",
+                                                                                                    "low",
+                                                                                                    "high"
+                                                                                                ],
+                                                                                                "default": "auto"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "input_audio": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "format": {
+                                                                                                "type": "string",
+                                                                                                "enum": [
+                                                                                                    "wav",
+                                                                                                    "mp3"
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "file": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "file_data": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "file_id": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "filename": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            },
+                                                                            "minItems": 1
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "assistant"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text",
+                                                                                            "refusal"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "refusal": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "refusal": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "null"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                },
+                                                                "audio": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_calls": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "oneOf": [
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "function"
+                                                                                        ]
+                                                                                    },
+                                                                                    "function": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "arguments": {
+                                                                                                "type": "string",
+                                                                                                "description": "JSON-encoded arguments string."
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "arguments"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "function"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "id": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "custom"
+                                                                                        ]
+                                                                                    },
+                                                                                    "custom": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "name": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "input": {
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "name",
+                                                                                            "input"
+                                                                                        ]
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "id",
+                                                                                    "type",
+                                                                                    "custom"
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "function_call": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "arguments": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "arguments"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "tool"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "string"
+                                                                        },
+                                                                        {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "type": {
+                                                                                        "type": "string",
+                                                                                        "enum": [
+                                                                                            "text"
+                                                                                        ]
+                                                                                    },
+                                                                                    "text": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "type",
+                                                                                    "text"
+                                                                                ]
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "tool_call_id": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "tool_call_id"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "role": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "content": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "role",
+                                                                "content",
+                                                                "name"
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "minItems": 1
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "description": "ID of the model to use (e.g. '@cf/zai-org/glm-4.7-flash, etc')."
+                                            },
+                                            "audio": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Parameters for audio output. Required when modalities includes 'audio'.",
+                                                        "properties": {
+                                                            "voice": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "format": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "wav",
+                                                                    "aac",
+                                                                    "mp3",
+                                                                    "flac",
+                                                                    "opus",
+                                                                    "pcm16"
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "voice",
+                                                            "format"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "frequency_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on their existing frequency in the text so far."
+                                            },
+                                            "logit_bias": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Modify the likelihood of specified tokens appearing in the completion. Maps token IDs to bias values from -100 to 100."
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to return log probabilities of the output tokens."
+                                            },
+                                            "top_logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 0,
+                                                        "maximum": 20
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "How many top log probabilities to return at each token position (0-20). Requires logprobs=true."
+                                            },
+                                            "max_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Deprecated in favor of max_completion_tokens. The maximum number of tokens to generate."
+                                            },
+                                            "max_completion_tokens": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "An upper bound for the number of tokens that can be generated for a completion."
+                                            },
+                                            "metadata": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Set of 16 key-value pairs that can be attached to the object."
+                                            },
+                                            "modalities": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "text",
+                                                                "audio"
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Output types requested from the model (e.g. ['text'] or ['text', 'audio'])."
+                                            },
+                                            "n": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "maximum": 128
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "How many chat completion choices to generate for each input message."
+                                            },
+                                            "parallel_tool_calls": {
+                                                "type": "boolean",
+                                                "default": true,
+                                                "description": "Whether to enable parallel function calling during tool use."
+                                            },
+                                            "prediction": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "type": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "content"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "text"
+                                                                                    ]
+                                                                                },
+                                                                                "text": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "type",
+                                                                                "text"
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type",
+                                                            "content"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "presence_penalty": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": -2,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 0,
+                                                "description": "Penalizes new tokens based on whether they appear in the text so far."
+                                            },
+                                            "reasoning_effort": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "low",
+                                                            "medium",
+                                                            "high"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Constrains effort on reasoning for reasoning models (o1, o3-mini, etc.)."
+                                            },
+                                            "chat_template_kwargs": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "thinking": {
+                                                        "type": "boolean",
+                                                        "default": true,
+                                                        "description": "Whether to enable reasoning, enabled by default."
+                                                    },
+                                                    "clear_thinking": {
+                                                        "type": "boolean",
+                                                        "default": false,
+                                                        "description": "If false, preserves reasoning context between turns."
+                                                    }
+                                                }
+                                            },
+                                            "response_format": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Specifies the format the model must output.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "text"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_object"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "json_schema"
+                                                                        ]
+                                                                    },
+                                                                    "json_schema": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "description": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "schema": {
+                                                                                "type": "object"
+                                                                            },
+                                                                            "strict": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "null"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "json_schema"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "seed": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "If specified, the system will make a best effort to sample deterministically."
+                                            },
+                                            "service_tier": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "auto",
+                                                            "default",
+                                                            "flex",
+                                                            "scale",
+                                                            "priority"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": "auto",
+                                                "description": "Specifies the processing type used for serving the request."
+                                            },
+                                            "stop": {
+                                                "description": "Up to 4 sequences where the API will stop generating further tokens.",
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "minItems": 1,
+                                                        "maxItems": 4
+                                                    }
+                                                ]
+                                            },
+                                            "store": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "Whether to store the output for model distillation / evals."
+                                            },
+                                            "stream": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "boolean"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": false,
+                                                "description": "If true, partial message deltas will be sent as server-sent events."
+                                            },
+                                            "stream_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "include_usage": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "include_obfuscation": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "temperature": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 2
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Sampling temperature between 0 and 2."
+                                            },
+                                            "tool_choice": {
+                                                "anyOf": [
+                                                    {
+                                                        "description": "Controls which (if any) tool is called by the model. 'none' = no tools, 'auto' = model decides, 'required' = must call a tool.",
+                                                        "oneOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "none",
+                                                                    "auto",
+                                                                    "required"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific function tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "function"
+                                                                        ]
+                                                                    },
+                                                                    "function": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "function"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Force a specific custom tool.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "custom"
+                                                                        ]
+                                                                    },
+                                                                    "custom": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "custom"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "description": "Constrain to an allowed subset of tools.",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "allowed_tools"
+                                                                        ]
+                                                                    },
+                                                                    "allowed_tools": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "mode": {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "auto",
+                                                                                    "required"
+                                                                                ]
+                                                                            },
+                                                                            "tools": {
+                                                                                "type": "array",
+                                                                                "items": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "mode",
+                                                                            "tools"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "allowed_tools"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "tools": {
+                                                "type": "array",
+                                                "description": "A list of tools the model may call.",
+                                                "items": {
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "function"
+                                                                    ]
+                                                                },
+                                                                "function": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string",
+                                                                            "description": "The name of the function to be called."
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
+                                                                            "description": "A description of what the function does."
+                                                                        },
+                                                                        "parameters": {
+                                                                            "type": "object",
+                                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                                        },
+                                                                        "strict": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                {
+                                                                                    "type": "null"
+                                                                                }
+                                                                            ],
+                                                                            "default": false,
+                                                                            "description": "Whether to enable strict schema adherence."
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "function"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "custom"
+                                                                    ]
+                                                                },
+                                                                "custom": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "format": {
+                                                                            "oneOf": [
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "text"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type"
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "type": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "grammar"
+                                                                                            ]
+                                                                                        },
+                                                                                        "grammar": {
+                                                                                            "type": "object",
+                                                                                            "properties": {
+                                                                                                "definition": {
+                                                                                                    "type": "string"
+                                                                                                },
+                                                                                                "syntax": {
+                                                                                                    "type": "string",
+                                                                                                    "enum": [
+                                                                                                        "lark",
+                                                                                                        "regex"
+                                                                                                    ]
+                                                                                                }
+                                                                                            },
+                                                                                            "required": [
+                                                                                                "definition",
+                                                                                                "syntax"
+                                                                                            ]
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "type",
+                                                                                        "grammar"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "type",
+                                                                "custom"
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "top_p": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "number",
+                                                        "minimum": 0,
+                                                        "maximum": 1
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "default": 1,
+                                                "description": "Nucleus sampling: considers the results of the tokens with top_p probability mass."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "A unique identifier representing your end-user, for abuse monitoring."
+                                            },
+                                            "web_search_options": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "description": "Options for the web search tool (when using built-in web search).",
+                                                        "properties": {
+                                                            "search_context_size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "low",
+                                                                    "medium",
+                                                                    "high"
+                                                                ],
+                                                                "default": "medium"
+                                                            },
+                                                            "user_location": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "type": {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "approximate"
+                                                                        ]
+                                                                    },
+                                                                    "approximate": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "city": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "country": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "region": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "timezone": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "type",
+                                                                    "approximate"
+                                                                ]
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "function_call": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "none",
+                                                            "auto"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "name": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "functions": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string",
+                                                            "description": "The name of the function to be called."
+                                                        },
+                                                        "description": {
+                                                            "type": "string",
+                                                            "description": "A description of what the function does."
+                                                        },
+                                                        "parameters": {
+                                                            "type": "object",
+                                                            "description": "The parameters the function accepts, described as a JSON Schema object."
+                                                        },
+                                                        "strict": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "boolean"
+                                                                },
+                                                                {
+                                                                    "type": "null"
+                                                                }
+                                                            ],
+                                                            "default": false,
+                                                            "description": "Whether to enable strict schema adherence."
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ]
+                                                },
+                                                "minItems": 1,
+                                                "maxItems": 128
+                                            }
+                                        },
+                                        "required": [
+                                            "messages"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "output": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "contentType": "application/json",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "A unique identifier for the chat completion."
+                        },
+                        "object": {
+                            "type": "string"
+                        },
+                        "created": {
+                            "type": "integer",
+                            "description": "Unix timestamp (seconds) of when the completion was created."
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "The model used for the chat completion."
+                        },
+                        "choices": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "index": {
+                                                "type": "integer"
+                                            },
+                                            "message": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "role": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                    "assistant"
+                                                                ]
+                                                            },
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string"
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "annotations": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "url_citation"
+                                                                            ]
+                                                                        },
+                                                                        "url_citation": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "url": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "title": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "start_index": {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                "end_index": {
+                                                                                    "type": "integer"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "url",
+                                                                                "title",
+                                                                                "start_index",
+                                                                                "end_index"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "type",
+                                                                        "url_citation"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "audio": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "id": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "data": {
+                                                                                "type": "string",
+                                                                                "description": "Base64 encoded audio bytes."
+                                                                            },
+                                                                            "expires_at": {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            "transcript": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "id",
+                                                                            "data",
+                                                                            "expires_at",
+                                                                            "transcript"
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "tool_calls": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "oneOf": [
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "function"
+                                                                                    ]
+                                                                                },
+                                                                                "function": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "arguments": {
+                                                                                            "type": "string",
+                                                                                            "description": "JSON-encoded arguments string."
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "arguments"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "function"
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "id": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "custom"
+                                                                                    ]
+                                                                                },
+                                                                                "custom": {
+                                                                                    "type": "object",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "input": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name",
+                                                                                        "input"
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "id",
+                                                                                "type",
+                                                                                "custom"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "function_call": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "arguments": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "name",
+                                                                            "arguments"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "role",
+                                                            "content",
+                                                            "refusal"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "finish_reason": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "stop",
+                                                    "length",
+                                                    "tool_calls",
+                                                    "content_filter",
+                                                    "function_call"
+                                                ]
+                                            },
+                                            "logprobs": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "content": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "refusal": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "token": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "logprob": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "bytes": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "array",
+                                                                                            "items": {
+                                                                                                "type": "integer"
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "null"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "top_logprobs": {
+                                                                                    "type": "array",
+                                                                                    "items": {
+                                                                                        "type": "object",
+                                                                                        "properties": {
+                                                                                            "token": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "logprob": {
+                                                                                                "type": "number"
+                                                                                            },
+                                                                                            "bytes": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "array",
+                                                                                                        "items": {
+                                                                                                            "type": "integer"
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "null"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "token",
+                                                                                            "logprob",
+                                                                                            "bytes"
+                                                                                        ]
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "token",
+                                                                                "logprob",
+                                                                                "bytes",
+                                                                                "top_logprobs"
+                                                                            ]
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "null"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "index",
+                                            "message",
+                                            "finish_reason",
+                                            "logprobs"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "minItems": 1
+                        },
+                        "usage": {
+                            "anyOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "prompt_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "completion_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "total_tokens": {
+                                            "type": "integer"
+                                        },
+                                        "prompt_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "cached_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "completion_tokens_details": {
+                                            "type": "object",
+                                            "properties": {
+                                                "reasoning_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "audio_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "accepted_prediction_tokens": {
+                                                    "type": "integer"
+                                                },
+                                                "rejected_prediction_tokens": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "prompt_tokens",
+                                        "completion_tokens",
+                                        "total_tokens"
+                                    ]
+                                }
+                            ]
+                        },
+                        "system_fingerprint": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "service_tier": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "enum": [
+                                        "auto",
+                                        "default",
+                                        "flex",
+                                        "scale",
+                                        "priority"
+                                    ]
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "id",
+                        "object",
+                        "created",
+                        "model",
+                        "choices"
+                    ]
+                },
+                {
+                    "type": "string",
+                    "contentType": "text/event-stream",
+                    "format": "binary"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Adds documentation for the new Moonshot AI Kimi K2.6 model on Workers AI, launched in partnership with Moonshot AI.

Key changes:

- New model JSON (`kimi-k2.6.json`) with schema based on K2.5, updated for K2.6 API differences: `chat_template_kwargs.thinking` replaces `enable_thinking`, and `reasoning` replaces `reasoning_content` in responses
- Changelog entry for the launch
- Release notes entry including the API migration notes
- Pricing row (input $0.95/M, cached $0.16/M, output $4.00/M)

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
