### PR TITLE
[Workers] Add diagnostics_channel_has_subscribers_getter compat flag

### DIFF
--- a/src/content/compatibility-flags/diagnostics-channel-has-subscribers-getter.md
+++ b/src/content/compatibility-flags/diagnostics-channel-has-subscribers-getter.md
@@ -1,0 +1,38 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "`hasSubscribers` is a getter on `diagnostics_channel.Channel`"
+sort_date: "2026-05-01"
+enable_date: "2026-05-01"
+enable_flag: "diagnostics_channel_has_subscribers_getter"
+disable_flag: "no_diagnostics_channel_has_subscribers_getter"
+---
+
+Aligns the [`node:diagnostics_channel`](https://nodejs.org/docs/latest/api/diagnostics_channel.html) module with Node.js by making `hasSubscribers` a boolean getter property on `Channel` and `TracingChannel` instances, instead of a method.
+
+Originally, `Channel.prototype.hasSubscribers` and `TracingChannel.prototype.hasSubscribers` were registered as methods, so the value had to be read by invoking the method:
+
+```js
+import { channel } from "node:diagnostics_channel";
+const ch = channel("my-channel");
+if (ch.hasSubscribers()) {
+	ch.publish({ hello: "world" });
+}
+```
+
+In Node.js, `hasSubscribers` is a read-only getter that evaluates directly to a boolean. When the `diagnostics_channel_has_subscribers_getter` flag is enabled, workerd matches that behavior:
+
+```js
+import { channel } from "node:diagnostics_channel";
+const ch = channel("my-channel");
+if (ch.hasSubscribers) {
+	ch.publish({ hello: "world" });
+}
+```
+
+Workers that have this flag enabled must access `hasSubscribers` without parentheses. Workers that rely on the legacy method form can continue using it by setting the `no_diagnostics_channel_has_subscribers_getter` flag.
+
+The top-level `diagnostics_channel.hasSubscribers(name)` function is unaffected — it remains a function in both Node.js and workerd.

--- a/src/content/compatibility-flags/diagnostics-channel-has-subscribers-getter.md
+++ b/src/content/compatibility-flags/diagnostics-channel-has-subscribers-getter.md
@@ -5,8 +5,8 @@ _build:
   list: never
 
 name: "`hasSubscribers` is a getter on `diagnostics_channel.Channel`"
-sort_date: "2026-05-01"
-enable_date: "2026-05-01"
+sort_date: "2026-05-19"
+enable_date: "2026-05-19"
 enable_flag: "diagnostics_channel_has_subscribers_getter"
 disable_flag: "no_diagnostics_channel_has_subscribers_getter"
 ---


### PR DESCRIPTION
Documents the new compat flag that makes Channel.hasSubscribers and TracingChannel.hasSubscribers boolean getter properties on the node:diagnostics_channel module, matching Node.js.

### Summary

Documentation for compat flag for https://github.com/cloudflare/workerd/pull/6601 

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
