### PR TITLE
[WAF] Document Partitioned (CHIPS) attribute on cf_clearance

### DIFF
--- a/src/content/docs/fundamentals/reference/policies-compliances/cloudflare-cookies.mdx
+++ b/src/content/docs/fundamentals/reference/policies-compliances/cloudflare-cookies.mdx
@@ -54,6 +54,8 @@ Bot Management is available to Enterprise customers as an add-on service. Contac
 
 The `cf_clearance` cookie is required for [JavaScript detections](/bots/additional-configurations/javascript-detections/). JavaScript detections are stored in the `cf_clearance` cookie.
 
+The `cf_clearance` cookie is set with `SameSite=None; Secure; Partitioned` so that challenge state is preserved across cross-site requests while complying with [CHIPS ↗](https://developers.google.com/privacy-sandbox/cookies/chips). When the cookie is issued inside a third-party context, it is stored in a partition keyed to the top-level site and is not shared across embedding sites. For details, refer to [Partitioned cookies (CHIPS) and `cf_clearance`](/waf/troubleshooting/samesite-cookie-interaction/#partitioned-cookies-chips-and-cf_clearance).
+
 ### cf_ob_info and cf_use_ob cookie for Cloudflare Always Online
 
 The `cf_ob_info` cookie provides information on:

--- a/src/content/docs/waf/troubleshooting/samesite-cookie-interaction.mdx
+++ b/src/content/docs/waf/troubleshooting/samesite-cookie-interaction.mdx
@@ -18,11 +18,11 @@ The `SameSite` cookie attribute has three different modes:
 
 `SameSite` settings for [Cloudflare cookies](/fundamentals/reference/policies-compliances/cloudflare-cookies/) include:
 
-| Cloudflare cookie | SameSite setting        | HTTPS Only |
-| ----------------- | ----------------------- | ---------- |
-| `__cf_bm`         | `SameSite=None; Secure` | Yes        |
-| `cf_clearance`    | `SameSite=None; Secure` | Yes        |
-| `__cflb`          | `SameSite=Lax`          | No         |
+| Cloudflare cookie | SameSite setting        | HTTPS Only | Partitioned (CHIPS) |
+| ----------------- | ----------------------- | ---------- | ------------------- |
+| `__cf_bm`         | `SameSite=None; Secure` | Yes        | No                  |
+| `cf_clearance`    | `SameSite=None; Secure` | Yes        | Yes                 |
+| `__cflb`          | `SameSite=Lax`          | No         | No                  |
 
 ## SameSite attribute in session affinity cookies
 
@@ -64,10 +64,28 @@ Cloudflare uses `SameSite=None` in the `cf_clearance` cookie so that visitor req
 
 Using the `Secure` flag requires sending the cookie via an HTTPS connection. If you use HTTP on any part of your website, the `cf_clearance` cookie defaults to `SameSite=Lax`, which may cause your website not to function properly.
 
-To resolve the issue, move your website traffic to HTTPS. Cloudflare offers two features for this purpose:
+To resolve the issue, move your website traffic to HTTPS. Cloudflare offers two features for this purpose:
 
 - [Automatic HTTPS Rewrites](/ssl/edge-certificates/additional-options/automatic-https-rewrites/)
 - [Always Use HTTPS](/ssl/edge-certificates/additional-options/always-use-https/)
+
+---
+
+## Partitioned cookies (CHIPS) and `cf_clearance`
+
+Cloudflare sets the `Partitioned` attribute on the `cf_clearance` cookie (and on the internal `cf_chl_*` cookies used by the Challenge Platform) to comply with [Cookies Having Independent Partitioned State (CHIPS) ↗](https://developers.google.com/privacy-sandbox/cookies/chips).
+
+With CHIPS, a cookie set in a third-party context (for example, inside an iframe or from a cross-site subresource) is stored in a partition keyed to the top-level site, rather than being shared across all sites that embed the third party. On Chromium-based browsers that block third-party cookies, this preserves challenge state for cross-site embeds that would otherwise be broken. On browsers that do not implement CHIPS, the `Partitioned` attribute is ignored and behavior is unchanged.
+
+The `Partitioned` attribute is not applied to `__cf_bm`.
+
+### Impact on embedded challenges
+
+Because `cf_clearance` is partitioned, a clearance obtained in one top-level context is not reused in a different top-level context. A visitor who passes a challenge while browsing a site directly will not automatically carry that clearance into another site that embeds it, and vice versa. This is the intended behavior under CHIPS.
+
+### `Partitioned` requires `SameSite=None; Secure`
+
+The `Partitioned` attribute only takes effect on cookies that are also set with `SameSite=None; Secure`. If your site does not serve all traffic over HTTPS, the `cf_clearance` cookie falls back to `SameSite=Lax` (refer to [Known issues with SameSite and `cf_clearance` cookies](#known-issues-with-samesite-and-cf_clearance-cookies)), and the `Partitioned` attribute has no effect.
 
 ---
 


### PR DESCRIPTION
### Summary

Tracked by SPM-2253.

### Documentation checklist

- [x] The change adheres to the documentation style guide.
- [x] Internal links validated.
- [x] MDX parses (no unescaped `{`, `}`, `<`, `>` in prose).
