### PR TITLE
Add Workers plans link to Browser Run pricing page

### DIFF
--- a/src/content/docs/browser-run/pricing.mdx
+++ b/src/content/docs/browser-run/pricing.mdx
@@ -21,6 +21,10 @@ Browser hours are shared across all methods.
 | Browser hours                               | 10 minutes per day | 10 hours per month, then $0.09 per additional hour                                                                        |
 | Concurrent browsers (Browser Sessions only) | 3 browsers         | 10 browsers ([averaged monthly](#how-is-the-number-of-concurrent-browsers-calculated)), then $2.00 per additional browser |
 
+To view or change your plan, go to the **Workers plans** page in the Cloudflare dashboard:
+
+<DashButton url="/?to=/:account/workers/plans" />
+
 ## Examples of Workers Paid pricing
 
 #### Example: Quick Actions pricing


### PR DESCRIPTION
User feedback that the how to upgrade to Workers paid was not clearly surfaced
--> Add Workers plans link to Browser Run pricing page

- Add DashButton linking to Workers plans dashboard after the pricing table

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
