### PR TITLE
docs: Network Session Logs now available for all on-ramps (RM-27324)

### DIFF
--- a/src/content/changelog/gateway/2026-04-24-nsl-all-onramps.mdx
+++ b/src/content/changelog/gateway/2026-04-24-nsl-all-onramps.mdx
@@ -1,0 +1,14 @@
+---
+title: Network Session Logs now available for all on-ramps
+description: Zero Trust Network Session Logs are now generated for all traffic proxied through Cloudflare Gateway, regardless of on-ramp type.
+products:
+  - gateway
+  - cloudflare-one
+date: 2026-04-24
+---
+
+[Zero Trust Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/) are now generated for all traffic proxied through Cloudflare Gateway, regardless of on-ramp type. This includes traffic from [proxy endpoints (PAC files)](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/) and [Browser Isolation](/cloudflare-one/remote-browser-isolation/) egress — on-ramps that previously did not generate session logs.
+
+Customers who already consume the `zero_trust_network_sessions` dataset via [Logpush](/cloudflare-one/insights/logs/logpush/) or [Log Explorer](/log-explorer/) may see increased log volume if they use these on-ramps.
+
+For field definitions, refer to [Zero Trust Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/). For traffic analysis, refer to [Network session analytics](/cloudflare-one/insights/analytics/network-sessions/).

--- a/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { Render } from "~/components";
 
-The Network session analytics dashboard provides visibility into your Cloudflare One traffic patterns. This dashboard helps you understand how traffic flows through your network, including on-ramps (how traffic enters Cloudflare, such as the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) or Cloudflare Tunnel) and off-ramps (how traffic exits Cloudflare, such as the public Internet or a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/)).
+The Network session analytics dashboard provides visibility into your Cloudflare One traffic patterns. This dashboard helps you understand how traffic flows through your network, including on-ramps (how traffic enters Cloudflare, such as the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/), [proxy endpoints (PAC files)](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/), [Browser Isolation](/cloudflare-one/remote-browser-isolation/), or Cloudflare Tunnel) and off-ramps (how traffic exits Cloudflare, such as the public Internet or a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/)).
 
 The dashboard is based on the [Zero Trust network sessions Logpush dataset](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/). For definitions on any field, refer to the dataset schema documentation.
 

--- a/src/content/docs/cloudflare-one/insights/logs/logpush/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/logs/logpush/index.mdx
@@ -54,7 +54,7 @@ Logpush supports all [dashboard logs](/cloudflare-one/insights/logs/dashboard-lo
 | [SSH Logs](/logs/logpush/logpush-job/datasets/account/ssh_logs/)                                           | SSH command logs for [Access for Infrastructure targets](/cloudflare-one/networks/connectors/cloudflare-tunnel/use-cases/ssh/ssh-infrastructure-access/) |
 | [WARP Config Changes](/logs/logpush/logpush-job/datasets/account/warp_config_changes/)                     | Event logs that Cloudflare generates whenever a device changes [profiles](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) |
 | [WARP Toggle Events](/logs/logpush/logpush-job/datasets/account/warp_toggle_changes/)                      | Event logs that Cloudflare generates whenever a device toggles the Cloudflare One Client on or off                                                       |
-| [Zero Trust Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/) | Network session logs for traffic proxied by Cloudflare Gateway                                                                                           |
+| [Zero Trust Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/) | Network session logs for all traffic proxied through Cloudflare Gateway across all supported on-ramps                                                    |
 
 ## Verify regional map application
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -39,6 +39,10 @@ Proxy endpoints are designed for environments where deploying the Cloudflare One
 - **Compliance-restricted endpoints**: Environments where you are legally or technically prohibited from installing software on the endpoint.
 - **Legacy SWG migration**: Organizations transitioning from legacy Secure Web Gateways that use PAC files.
 
+### Logging
+
+Traffic sent through proxy endpoints generates [Zero Trust Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/), which are available via [Logpush](/cloudflare-one/insights/logs/logpush/) and [Log Explorer](/log-explorer/).
+
 ### What is a PAC file
 
 <GlossaryDefinition term="PAC file" prepend="A PAC file is " />

--- a/src/content/docs/cloudflare-one/remote-browser-isolation/setup/clientless-browser-isolation.mdx
+++ b/src/content/docs/cloudflare-one/remote-browser-isolation/setup/clientless-browser-isolation.mdx
@@ -140,6 +140,7 @@ To turn on or off the address bar, users can right-click on any isolated page an
 - **Authentication events**: User login events are available in [Access authentication logs](/cloudflare-one/insights/logs/dashboard-logs/access-authentication-logs/).
 - **HTTP requests**: Traffic from the remote browser to the Internet is logged in [Gateway activity logs](/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/).
 - **DNS queries**: DNS queries from the remote browser are shown in [Gateway activity logs](/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/).
+- **Network sessions**: Egress traffic from the remote browser generates [Zero Trust Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/), available via [Logpush](/cloudflare-one/insights/logs/logpush/) and [Log Explorer](/log-explorer/).
 - **User actions**: Track copy/paste, download/upload, and print actions initiated by users in the remote browser (only available in [Logpush](/cloudflare-one/insights/logs/logpush/)).
 
 ## Redirect traffic to the remote browser

--- a/src/content/docs/learning-paths/secure-internet-traffic/connect-devices-networks/choose-on-ramp.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/connect-devices-networks/choose-on-ramp.mdx
@@ -42,6 +42,7 @@ Cloudflare Browser Isolation runs a headless, Chromium-based browser for your us
 | Configurable via MDM              | Yes                                  | Yes            | N/A                                   |
 | Gateway policy types supported    | DNS, Network, HTTP, Resolver, Egress | HTTP           | DNS, Network, HTTP, Resolver, Egress  |
 | Identity-based policies supported | Yes                                  | No             | Yes                                   |
+| [Network Session Logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/) | Yes                                  | Yes            | Yes                                   |
 
 ## Network on-ramps
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
@@ -7,6 +7,8 @@ sidebar:
   order: 21
 ---
 
+Network session logs are generated for all traffic proxied through Cloudflare Gateway across all supported [on-ramps](/cloudflare-one/networks/connectivity-options/), such as the Cloudflare One Client (WARP), proxy endpoints (PAC files), Browser Isolation, and Cloudflare Tunnel.
+
 The descriptions below detail the fields available for `zero_trust_network_sessions`.
 
 ## AccountID


### PR DESCRIPTION
## Summary

- Updates documentation to reflect that Zero Trust Network Session Logs are now generated for **all on-ramp types** proxied through Cloudflare Gateway, including proxy endpoints (PAC files) and Browser Isolation egress — not just WARP and network tunnels.
- Adds a changelog entry under **Gateway** and **Cloudflare One** products.

## Changes

| File | Change |
|------|--------|
| `zero_trust_network_sessions.md` | Added on-ramp coverage description to NSL dataset page |
| `network-sessions.mdx` | Added PAC files and Browser Isolation to on-ramp examples |
| `logpush/index.mdx` | Updated NSL row description to "all supported on-ramps" |
| `proxy-endpoints/index.mdx` | Added **Logging** section noting NSL generation |
| `choose-on-ramp.mdx` | Added linked "Network Session Logs" row to device on-ramp comparison table |
| `clientless-browser-isolation.mdx` | Added "Network sessions" bullet to the Logs section |
| `2026-04-21-nsl-all-onramps.mdx` | New changelog entry (Gateway + Cloudflare One) |

## Note

This PR should be published **after** the feature rollout is complete.