### PR TITLE
Mesh: Make IPv4/IPv6 forwarding persistent and document service mode requirement

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
@@ -103,6 +103,7 @@ If your account already has a Cloudflare One deployment, the setup wizard will n
 - [ ] **Device profile for Mesh nodes** — Your Mesh nodes need a [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/) that uses **Include mode** with the Mesh IP range (`100.96.0.0/12`) included. If your nodes use Exclude mode instead, remove `100.64.0.0/10` (the default CGNAT exclusion) from the exclude list.
 - [ ] **Mesh connectivity** — In your device profile settings, enable [Allow all Cloudflare One traffic to reach enrolled devices](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#allow-all-cloudflare-one-traffic-to-reach-enrolled-devices).
 - [ ] **Unique device IPs** — Enable [Assign a unique IP address to each device](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#assign-a-unique-ip-address-to-each-device) so that each participant gets a routable Mesh IP.
+- [ ] **Service mode** — Mesh nodes must run in [Gateway with WARP](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/warp-modes/) mode (also called "Traffic and DNS" mode). DNS-only or proxy-only modes are not supported.
 - [ ] **Traffic proxying** — Enable the [Gateway proxy](/cloudflare-one/traffic-policies/proxy/) for TCP, UDP, and ICMP so that Mesh traffic can flow between devices.
 
 ## Troubleshooting

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/get-started.mdx
@@ -103,7 +103,7 @@ If your account already has a Cloudflare One deployment, the setup wizard will n
 - [ ] **Device profile for Mesh nodes** — Your Mesh nodes need a [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/split-tunnels/) that uses **Include mode** with the Mesh IP range (`100.96.0.0/12`) included. If your nodes use Exclude mode instead, remove `100.64.0.0/10` (the default CGNAT exclusion) from the exclude list.
 - [ ] **Mesh connectivity** — In your device profile settings, enable [Allow all Cloudflare One traffic to reach enrolled devices](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#allow-all-cloudflare-one-traffic-to-reach-enrolled-devices).
 - [ ] **Unique device IPs** — Enable [Assign a unique IP address to each device](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#assign-a-unique-ip-address-to-each-device) so that each participant gets a routable Mesh IP.
-- [ ] **Service mode** — Mesh nodes must run in [Gateway with WARP](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/warp-modes/) mode (also called "Traffic and DNS" mode). DNS-only or proxy-only modes are not supported.
+- [ ] **Client mode** — Mesh nodes must run in [Traffic and DNS mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/). DNS-only or proxy-only modes are not supported.
 - [ ] **Traffic proxying** — Enable the [Gateway proxy](/cloudflare-one/traffic-policies/proxy/) for TCP, UDP, and ICMP so that Mesh traffic can flow between devices.
 
 ## Troubleshooting

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/tips.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/tips.mdx
@@ -59,6 +59,24 @@ Updating a Mesh node means updating the `cloudflare-warp` package on the Linux h
 
    You should see `Status update: Connected` in the output.
 
+## Make IP forwarding persistent
+
+IP forwarding allows a Mesh node to act as a gateway, forwarding packets between its network interface and the Cloudflare network. This is only required if the node advertises [CIDR routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) — if you are only reaching the node by its Mesh IP, forwarding is not needed.
+
+Older installations may have used `sysctl -w` for IP forwarding, which does not persist across reboots. If your node loses route connectivity after a server restart, run the following to make forwarding permanent:
+
+```sh
+printf 'net.ipv4.ip_forward = 1\nnet.ipv6.conf.all.forwarding = 1\nnet.ipv6.conf.all.accept_ra = 2\n' | sudo tee /etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf && sudo sysctl --system
+```
+
+You can verify the settings are active with:
+
+```sh
+sysctl net.ipv4.ip_forward net.ipv6.conf.all.forwarding net.ipv6.conf.all.accept_ra
+```
+
+New installations include this step automatically.
+
 ## Cloud VPC deployments
 
 When deploying Mesh nodes in a cloud VPC, you may need to configure additional provider settings so the node can forward traffic for other devices on the subnet.
@@ -76,6 +94,12 @@ When deploying Mesh nodes in a cloud VPC, you may need to configure additional p
 
 - [Enable IP forwarding](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-network-interface?tabs=azure-portal#enable-or-disable-ip-forwarding) on the network interface of the VM.
 - Add a [user-defined route](https://learn.microsoft.com/en-us/azure/virtual-network/manage-route-table) for Mesh traffic pointing to the VM's private IP.
+
+## Running Mesh on a DNS server
+
+Mesh nodes run in [Gateway with WARP](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/warp-modes/) mode, which redirects DNS queries on the host to Cloudflare Gateway. This will conflict with DNS services running on the same machine (for example, Active Directory DNS, Pi-hole, Unbound, BIND, or dnsmasq).
+
+If your server runs a DNS service, do not install the Mesh node on that host. Instead, install the node on a separate machine on the same subnet and use [CIDR routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) to make the DNS server reachable.
 
 ## Running Mesh with Cloudflare Tunnel
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/tips.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/tips.mdx
@@ -97,7 +97,7 @@ When deploying Mesh nodes in a cloud VPC, you may need to configure additional p
 
 ## Running Mesh on a DNS server
 
-Mesh nodes run in [Gateway with WARP](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/warp-modes/) mode, which redirects DNS queries on the host to Cloudflare Gateway. This will conflict with DNS services running on the same machine (for example, Active Directory DNS, Pi-hole, Unbound, BIND, or dnsmasq).
+Mesh nodes run in [Traffic and DNS mode](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/), which redirects DNS queries on the host to Cloudflare Gateway. This will conflict with DNS services running on the same machine (for example, Active Directory DNS, Pi-hole, Unbound, BIND, or dnsmasq).
 
 If your server runs a DNS service, do not install the Mesh node on that host. Instead, install the node on a separate machine on the same subnet and use [CIDR routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) to make the DNS server reachable.
 

--- a/src/content/partials/cloudflare-one/mesh/install-node.mdx
+++ b/src/content/partials/cloudflare-one/mesh/install-node.mdx
@@ -9,9 +9,10 @@ import { Tabs, TabItem } from "~/components";
 
 ```sh
 curl -fsSL https://pkg.cloudflareclient.com/pubkey.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg &&
-echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list &&
-sudo apt-get update && sudo apt-get install -y cloudflare-warp &&
-sudo sysctl -w net.ipv4.ip_forward=1
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(. /etc/os-release && echo $VERSION_CODENAME) main" | sudo tee /etc/apt/sources.list.d/cloudflare-client.list &&
+sudo apt-get update -qq && sudo apt-get install -y -qq cloudflare-warp &&
+printf 'net.ipv4.ip_forward = 1\nnet.ipv6.conf.all.forwarding = 1\nnet.ipv6.conf.all.accept_ra = 2\n' | sudo tee /etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf &&
+sudo sysctl --system
 ```
 
 ```sh
@@ -24,7 +25,8 @@ sudo warp-cli connector new <TOKEN> && sudo warp-cli connect
 ```sh
 sudo rpm -ivh https://pkg.cloudflareclient.com/cloudflare-release-el8.rpm &&
 sudo yum install -y cloudflare-warp &&
-sudo sysctl -w net.ipv4.ip_forward=1
+printf 'net.ipv4.ip_forward = 1\nnet.ipv6.conf.all.forwarding = 1\nnet.ipv6.conf.all.accept_ra = 2\n' | sudo tee /etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf &&
+sudo sysctl --system
 ```
 
 ```sh


### PR DESCRIPTION
## Summary

Updates Mesh node install commands, adds service mode documentation, and documents DNS server conflicts.

## Changes

### Install command updates (`src/content/partials/cloudflare-one/mesh/install-node.mdx`)
- Replace `$(lsb_release -cs)` with `$(. /etc/os-release && echo "$VERSION_CODENAME")` — works on minimal installs without lsb-release
- Add `-qq` flags to `apt-get` for cleaner output
- Replace `sysctl -w net.ipv4.ip_forward=1` (lost on reboot) with persistent `/etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf` that enables:
  - `net.ipv4.ip_forward = 1`
  - `net.ipv6.conf.all.forwarding = 1`
  - `net.ipv6.conf.all.accept_ra = 2`
- Applied to both Debian/Ubuntu and RedHat/CentOS install blocks

### Service mode requirement (`get-started.mdx`)
- Added "Service mode" to the existing Cloudflare One accounts checklist — Mesh nodes must run in Gateway with WARP (Traffic and DNS) mode

### DNS server conflict (`tips.mdx`)
- New "Running Mesh on a DNS server" section documenting that Gateway with WARP redirects DNS on the host, conflicting with AD DNS, Pi-hole, Unbound, BIND, dnsmasq
- Recommends installing on a separate machine and using CIDR routes instead

### Other fixes (`tips.mdx`)
- "Make IP forwarding persistent" section for users who set up nodes before this change
- Fixed "Mesh tunnel" → "Cloudflare network" to avoid conflating with Cloudflare Tunnel product