### PR TITLE
[Agents] Drop "experimental" compat flag requirement for sub-agents and Think

### DIFF
--- a/src/content/docs/agents/api-reference/sub-agents.mdx
+++ b/src/content/docs/agents/api-reference/sub-agents.mdx
@@ -50,7 +50,7 @@ Both classes must be exported from the worker entry point. No separate Durable O
 
 ```toml
 compatibility_date = "$today"
-compatibility_flags = ["nodejs_compat", "experimental"]
+compatibility_flags = ["nodejs_compat"]
 
 [[durable_objects.bindings]]
 class_name = "Orchestrator"
@@ -320,14 +320,16 @@ export class Streamer extends Agent {
 
 Sub-agents run as facets of the parent Durable Object. Some `Agent` methods are not available in sub-agents:
 
-| Method             | Behavior in sub-agent                              |
-| ------------------ | -------------------------------------------------- |
-| `schedule()`       | Throws `"not supported in sub-agents"`             |
-| `cancelSchedule()` | Throws `"not supported in sub-agents"`             |
-| `keepAlive()`      | Throws `"not supported in sub-agents"`             |
-| `setState()`       | Works normally (writes to the child's own storage) |
-| `this.sql`         | Works normally (child's own SQLite)                |
-| `subAgent()`       | Works — sub-agents can spawn their own children    |
+| Method              | Behavior in sub-agent                                        |
+| ------------------- | ------------------------------------------------------------ |
+| `schedule()`        | Throws `"not supported in sub-agents"`                       |
+| `cancelSchedule()`  | Throws `"not supported in sub-agents"`                       |
+| `keepAlive()`       | Throws `"not supported in sub-agents"`                       |
+| `broadcast()`       | No-op — sub-agents do not accept WebSocket clients           |
+| `getConnections()`  | Returns empty — sub-agents do not accept WebSocket clients   |
+| `setState()`        | Writes to the child's own storage; broadcast step is skipped |
+| `this.sql`          | Works normally (child's own SQLite)                          |
+| `subAgent()`        | Works — sub-agents can spawn their own children              |
 
 For scheduled work, have the parent schedule the task and delegate to the sub-agent when the schedule fires.
 

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -109,7 +109,7 @@ function Chat() {
 
 ```toml
 compatibility_date = "$today"
-compatibility_flags = ["nodejs_compat", "experimental"]
+compatibility_flags = ["nodejs_compat"]
 
 [ai]
 binding = "AI"


### PR DESCRIPTION
`ctx.facets`, `ctx.exports`, and `env.LOADER` have graduated out of the `"experimental"` compatibility flag in workerd. Remove it from the wrangler snippets on the sub-agents and Think pages.

Also tighten the sub-agent limitations table:

- Add `broadcast()` and `getConnections()` rows (no-op / empty because sub-agents do not accept WebSocket clients of their own).
- Clarify `setState()` — it still persists state, but the broadcast step is skipped on facets.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
