### PR TITLE
CF1: ELI5 on DEX/Synthetic

### DIFF
--- a/src/content/docs/cloudflare-one/insights/dex/tests/http.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/http.mdx
@@ -33,6 +33,8 @@ import { Details, Render } from "~/components";
 
 <Render file="dex/http-test-intro" product="cloudflare-one" />
 
+HTTP tests run periodically from devices that have the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) installed and turned on. You can use them to verify that an internal application is reachable after a configuration change or to monitor a SaaS application for outages that affect your organization.
+
 ## Create a test
 
 <Render file="dex/http-test-create-steps" product="cloudflare-one" />
@@ -40,6 +42,8 @@ import { Details, Render } from "~/components";
 ## Test results
 
 <Render file="dex/http-test-results-metrics" product="cloudflare-one" />
+
+Use these metrics together to identify where in the connection a problem occurs. For example, a high DNS response time with a normal server response time points to a DNS resolution issue rather than a problem with the target server.
 
 ## Export DEX application test logs
 
@@ -49,6 +53,8 @@ import { Details, Render } from "~/components";
 	params={{ applicationTests: true }}
 />
 
+You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export test data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the [7-day log retention period](/cloudflare-one/insights/logs/#log-retention) or correlate DEX data with other log sources.
+
 ## Related resources
 
-- [DEX rules](/cloudflare-one/insights/dex/rules/) - Specify the target group of a test.
+- [DEX rules](/cloudflare-one/insights/dex/rules/) - Define which users or groups a test applies to, using selectors such as user email, user group, operating system, or managed network.

--- a/src/content/docs/cloudflare-one/insights/dex/tests/http.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/http.mdx
@@ -53,8 +53,6 @@ Use these metrics together to identify where in the connection a problem occurs.
 	params={{ applicationTests: true }}
 />
 
-You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export test data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the [7-day log retention period](/cloudflare-one/insights/logs/#log-retention) or correlate DEX data with other log sources.
-
 ## Related resources
 
 - [DEX rules](/cloudflare-one/insights/dex/rules/) - Define which users or groups a test applies to, using selectors such as user email, user group, operating system, or managed network.

--- a/src/content/docs/cloudflare-one/insights/dex/tests/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/index.mdx
@@ -21,5 +21,3 @@ To control which users or groups run a test, use [DEX rules](/cloudflare-one/ins
 ## Export DEX application test logs
 
 <Render file="dex/logpush-export" product="cloudflare-one" params={{ applicationTests: true }} />
-
-You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export test data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. For the full list of available data fields, refer to [DEX application tests](/logs/logpush/logpush-job/datasets/account/dex_application_tests/).

--- a/src/content/docs/cloudflare-one/insights/dex/tests/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/index.mdx
@@ -14,12 +14,12 @@ import { DirectoryListing, Render } from "~/components";
 
 DEX tests will only run when the Cloudflare One Client is turned on, whereas [fleet status](/cloudflare-one/insights/dex/monitoring/#fleet-status) metrics are always available.
 
-To specify the target group of a test, use [DEX rules](/cloudflare-one/insights/dex/rules/).
+To control which users or groups run a test, use [DEX rules](/cloudflare-one/insights/dex/rules/).
 
 <DirectoryListing />
 
 ## Export DEX application test logs
 
-The Cloudflare Logs documentation lists the full set of data fields available in [DEX application tests](/logs/logpush/logpush-job/datasets/account/dex_application_tests/).
-
 <Render file="dex/logpush-export" product="cloudflare-one" params={{ applicationTests: true }} />
+
+You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export test data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. For the full list of available data fields, refer to [DEX application tests](/logs/logpush/logpush-job/datasets/account/dex_application_tests/).

--- a/src/content/docs/cloudflare-one/insights/dex/tests/traceroute.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/traceroute.mdx
@@ -31,7 +31,7 @@ import { Details, Render } from "~/components";
 
 </Details>
 
-A traceroute test measures the network path of an IP packet from an end-user device to a server. You can use the test results to troubleshoot network issues. For example, increased latency may indicate a problem with connectivity along the network path.
+A traceroute test measures the network path of an IP packet from an end-user device to a server. The packet passes through a series of intermediate routers — each called a "hop" — and the test records the response time and packet loss at each one. You can use the results to troubleshoot network issues by identifying which hop along the path is causing increased latency or dropped packets.
 
 ## Create a test
 
@@ -43,7 +43,7 @@ To set up a traceroute test for an application:
 4. Fill in the following fields:
    - **Name**: Enter any name for the test.
    - **Target**: Enter the IP address of the server you want to test (for example, `192.0.2.0`). You can test either a public-facing endpoint or a private endpoint you have connected to Cloudflare.
-   - **Source device profiles**: (Optional) Select the [device profiles](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) that you want to run the test on. If no profiles are selected, the test will run on all supported devices connected to your Zero Trust organization.
+   - **Source device profiles**: (Optional) Select the [device profiles](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) that you want to run the test on. A device profile defines Cloudflare One Client settings for a specific set of devices in your organization. If no profiles are selected, the test will run on all supported devices connected to your Zero Trust organization.
    - **Test type**: Select _Traceroute_.
    - **Test frequency**: Specify how often the test will run. Input a minute value between 5 and 60.
 5. Select **Add test**.
@@ -56,12 +56,12 @@ A traceroute test measures the following data:
 
 | Data            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Network path    | IP address, average response time, and packet loss for each hop between the device and the target.                                                                                                                                                                                                                                                                                                                                                          |
-| Round trip time | Time between sending out a packet and receiving a response from the target.                                                                                                                                                                                                                                                                                                                                                                                 |
+| Network path    | IP address, average response time, and packet loss for each hop (router) between the device and the target. This is the core traceroute data — it maps the route your traffic takes.                                                                                                                                                                                                                                                                       |
+| Round trip time | Time, in milliseconds, between sending out a packet and receiving a response from the target. This is the end-to-end latency measurement.                                                                                                                                                                                                                                                                                                                  |
 | Number of hops  | Number of routers encountered between the device and the target.                                                                                                                                                                                                                                                                                                                                                                                            |
 | Packet loss     | Percentage of IP packets that failed to receive a response.                                                                                                                                                                                                                                                                                                                                                                                                 |
-| Availability    | Percentage of tests where at least one packet reached the destination.                                                                                                                                                                                                                                                                                                                                                                                      |
-| Last seen ISP   | The Internet Service Provider that is managing the connection from the device to Cloudflare. (Only available on macOS and Windows.) <br/> <br/> DEX looks up the IP address of the ISP in a geolocation database and returns the corresponding [ASO and ASN](https://www.cloudflare.com/learning/network-layer/what-is-an-autonomous-system/). If the ASO and ASN are `Unknown`, it means this information is unavailable in the geolocation data provider. |
+| Availability    | Percentage of tests where at least one packet reached the destination. A value below 100% means the destination was completely unreachable during some test runs.                                                                                                                                                                                                                                                                                           |
+| Last seen ISP   | The Internet Service Provider that is managing the connection from the device to Cloudflare. (Only available on macOS and Windows.) <br/> <br/> DEX looks up the IP address of the ISP in a geolocation database and returns the corresponding [ASO (Autonomous System Organization) and ASN (Autonomous System Number)](https://www.cloudflare.com/learning/network-layer/what-is-an-autonomous-system/). If the ASO and ASN are `Unknown`, it means this information is unavailable in the geolocation data provider. |
 
 ## Export DEX application test logs
 
@@ -71,6 +71,8 @@ A traceroute test measures the following data:
 	params={{ applicationTests: true }}
 />
 
+You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export test data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the [7-day log retention period](/cloudflare-one/insights/logs/#log-retention) or correlate DEX data with other log sources.
+
 ## Related resources
 
-- [DEX rules](/cloudflare-one/insights/dex/rules/) - Specify the target group of a test.
+- [DEX rules](/cloudflare-one/insights/dex/rules/) - Define which users or groups a test applies to, using selectors such as user email, user group, operating system, or managed network.

--- a/src/content/docs/cloudflare-one/insights/dex/tests/traceroute.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/traceroute.mdx
@@ -71,8 +71,6 @@ A traceroute test measures the following data:
 	params={{ applicationTests: true }}
 />
 
-You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export test data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the [7-day log retention period](/cloudflare-one/insights/logs/#log-retention) or correlate DEX data with other log sources.
-
 ## Related resources
 
 - [DEX rules](/cloudflare-one/insights/dex/rules/) - Define which users or groups a test applies to, using selectors such as user email, user group, operating system, or managed network.

--- a/src/content/docs/cloudflare-one/insights/dex/tests/view-results.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/view-results.mdx
@@ -42,8 +42,6 @@ To view analytics on a per-device level:
 	params={{ applicationTests: true }}
 />
 
-You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export test data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the 7-day retention period or correlate DEX data with other log sources.
-
 ## Related resources
 
 - [DEX HTTP test](/cloudflare-one/insights/dex/tests/http/) - Send a `GET` request from enrolled devices to a web application and measure response times.

--- a/src/content/docs/cloudflare-one/insights/dex/tests/view-results.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/view-results.mdx
@@ -15,7 +15,7 @@ Use the results of a Digital Experience Monitoring (DEX) test to monitor availab
 ## Prerequisites
 
 - At least one [test](/cloudflare-one/insights/dex/tests/) has been created under **DEX** > **Tests**.
-- Admins must have at least the [Cloudflare Zero Trust Reporting role](/cloudflare-one/roles-permissions/#zero-trust-roles), which grants DEX Read and Gateway Report access.
+- Admins must have at least the [Cloudflare Zero Trust Reporting role](/cloudflare-one/roles-permissions/#zero-trust-roles).
 
 ## View results for all devices
 

--- a/src/content/docs/cloudflare-one/insights/dex/tests/view-results.mdx
+++ b/src/content/docs/cloudflare-one/insights/dex/tests/view-results.mdx
@@ -10,12 +10,12 @@ sidebar:
 
 import { Render } from "~/components";
 
-Use the results of a DEX test to monitor availability and performance for a specific application. DEX will store test results according to our [log retention policy](/cloudflare-one/insights/logs/#log-retention).
+Use the results of a Digital Experience Monitoring (DEX) test to monitor availability and performance for a specific application. DEX stores test results for 7 days on all plans, according to the [log retention policy](/cloudflare-one/insights/logs/#log-retention).
 
 ## Prerequisites
 
 - At least one [test](/cloudflare-one/insights/dex/tests/) has been created under **DEX** > **Tests**.
-- Admins must have at least the [Cloudflare Zero Trust Reporting role](/cloudflare-one/roles-permissions/#zero-trust-roles).
+- Admins must have at least the [Cloudflare Zero Trust Reporting role](/cloudflare-one/roles-permissions/#zero-trust-roles), which grants DEX Read and Gateway Report access.
 
 ## View results for all devices
 
@@ -42,8 +42,10 @@ To view analytics on a per-device level:
 	params={{ applicationTests: true }}
 />
 
+You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export test data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the 7-day retention period or correlate DEX data with other log sources.
+
 ## Related resources
 
-- [DEX HTTP test](/cloudflare-one/insights/dex/tests/http/) - Assess the accessibility of a web application.
-- [DEX Traceroute test](/cloudflare-one/insights/dex/tests/traceroute/) - Measure the network path of an IP packet from an end-user device to a server.
-- [DEX rules](/cloudflare-one/insights/dex/rules/) - Specify the target group of a test.
+- [DEX HTTP test](/cloudflare-one/insights/dex/tests/http/) - Send a `GET` request from enrolled devices to a web application and measure response times.
+- [DEX Traceroute test](/cloudflare-one/insights/dex/tests/traceroute/) - Map the network route between a device and a server, showing each hop along the path.
+- [DEX rules](/cloudflare-one/insights/dex/rules/) - Define which users or groups a test applies to, using selectors such as user email, user group, operating system, or managed network.

--- a/src/content/partials/cloudflare-one/dex/logpush-export.mdx
+++ b/src/content/partials/cloudflare-one/dex/logpush-export.mdx
@@ -2,12 +2,14 @@
 {}
 ---
 
+import { Markdown } from "~/components";
+
 {props.applicationTests ? (
   <>
-    <p>You can use <a href="/cloudflare-one/insights/logs/logpush/">Logpush</a> to export <a href="/logs/logpush/logpush-job/datasets/account/dex_application_tests/">DEX application test</a> data to <a href="/r2/">R2</a> (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the <a href="/cloudflare-one/insights/logs/#log-retention">7-day log retention period</a> or correlate DEX data with other log sources.</p>
+    <Markdown text={`You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export [DEX application test](/logs/logpush/logpush-job/datasets/account/dex_application_tests/) data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the [7-day log retention period](/cloudflare-one/insights/logs/#log-retention) or correlate DEX data with other log sources.`} inline={false} />
   </>
 ) : (
   <>
-    <p>The log data for all <a href="/logs/logpush/logpush-job/datasets/account/dex_device_state_events/">DEX device state events</a> can be exported to <a href="/r2/">R2</a>, a cloud bucket, or a SIEM via <a href="/cloudflare-one/insights/logs/logpush/">Logpush</a>.</p>
+    <Markdown text={`The log data for all [DEX device state events](/logs/logpush/logpush-job/datasets/account/dex_device_state_events/) can be exported to [R2](/r2/), a cloud bucket, or a SIEM via [Logpush](/cloudflare-one/insights/logs/logpush/).`} inline={false} />
   </>
 )}

--- a/src/content/partials/cloudflare-one/dex/logpush-export.mdx
+++ b/src/content/partials/cloudflare-one/dex/logpush-export.mdx
@@ -2,14 +2,12 @@
 {}
 ---
 
-import { Markdown } from "~/components";
-
 {props.applicationTests ? (
   <>
-    <Markdown text={`You can use [Logpush](/cloudflare-one/insights/logs/logpush/) to export [DEX application test](/logs/logpush/logpush-job/datasets/account/dex_application_tests/) data to [R2](/r2/) (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the [7-day log retention period](/cloudflare-one/insights/logs/#log-retention) or correlate DEX data with other log sources.`} inline={false} />
+    <p>You can use <a href="/cloudflare-one/insights/logs/logpush/">Logpush</a> to export <a href="/logs/logpush/logpush-job/datasets/account/dex_application_tests/">DEX application test</a> data to <a href="/r2/">R2</a> (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the <a href="/cloudflare-one/insights/logs/#log-retention">7-day log retention period</a> or correlate DEX data with other log sources.</p>
   </>
 ) : (
   <>
-    <Markdown text={`The log data for all [DEX device state events](/logs/logpush/logpush-job/datasets/account/dex_device_state_events/) can be exported to [R2](/r2/), a cloud bucket, or a SIEM via [Logpush](/cloudflare-one/insights/logs/logpush/).`} inline={false} />
+    <p>The log data for all <a href="/logs/logpush/logpush-job/datasets/account/dex_device_state_events/">DEX device state events</a> can be exported to <a href="/r2/">R2</a>, a cloud bucket, or a SIEM via <a href="/cloudflare-one/insights/logs/logpush/">Logpush</a>.</p>
   </>
 )}

--- a/src/content/partials/cloudflare-one/dex/logpush-export.mdx
+++ b/src/content/partials/cloudflare-one/dex/logpush-export.mdx
@@ -1,13 +1,6 @@
 ---
 {}
 ---
-{/* Consumed by:
-  - /cloudflare-one/insights/dex/monitoring/
-  - /cloudflare-one/insights/dex/tests/
-  - /cloudflare-one/insights/dex/tests/http/
-  - /cloudflare-one/insights/dex/tests/traceroute/
-  - /cloudflare-one/insights/dex/tests/view-results/
-*/}
 
 {props.applicationTests ? (
   <>

--- a/src/content/partials/cloudflare-one/dex/logpush-export.mdx
+++ b/src/content/partials/cloudflare-one/dex/logpush-export.mdx
@@ -1,11 +1,17 @@
 ---
 {}
 ---
-
+{/* Consumed by:
+  - /cloudflare-one/insights/dex/monitoring/
+  - /cloudflare-one/insights/dex/tests/
+  - /cloudflare-one/insights/dex/tests/http/
+  - /cloudflare-one/insights/dex/tests/traceroute/
+  - /cloudflare-one/insights/dex/tests/view-results/
+*/}
 
 {props.applicationTests ? (
   <>
-    <p>The log data for all <a href="/logs/logpush/logpush-job/datasets/account/dex_application_tests/">DEX application tests</a> (including HTTP tests) can be exported to <a href="/r2/">R2</a>, a cloud bucket, or a SIEM via <a href="/cloudflare-one/insights/logs/logpush/">Logpush</a>.</p>
+    <p>You can use <a href="/cloudflare-one/insights/logs/logpush/">Logpush</a> to export <a href="/logs/logpush/logpush-job/datasets/account/dex_application_tests/">DEX application test</a> data to <a href="/r2/">R2</a> (Cloudflare's object storage), a third-party cloud storage bucket, or a Security Information and Event Management (SIEM) tool. This is useful if you need to retain test data beyond the <a href="/cloudflare-one/insights/logs/#log-retention">7-day log retention period</a> or correlate DEX data with other log sources.</p>
   </>
 ) : (
   <>


### PR DESCRIPTION
## Summary

Applies ELI5 (Explain Like I'm 5) skill enhancements to three DEX synthetic test pages to improve accessibility for readers who are not network specialists. All additions were verified by an adversarial fact-check review against the source documentation — no unsourced claims, fabricated selectors, or misleading simplifications were included.

### Pages changed

- `src/content/docs/cloudflare-one/insights/dex/tests/http.mdx`
- `src/content/docs/cloudflare-one/insights/dex/tests/traceroute.mdx`
- `src/content/docs/cloudflare-one/insights/dex/tests/view-results.mdx`

### What changed

**Across all three pages:**
- Define R2, SIEM, and Logpush inline in the export section (previously undefined jargon)
- Link to 7-day log retention policy with the actual retention period stated
- Expand DEX rules description with documented selectors (user email, user group, OS, managed network)

**http.mdx:**
- Add context paragraph noting tests run periodically via the Cloudflare One Client
- Add interpretive guidance after test results table connecting metrics to troubleshooting

**traceroute.mdx:**
- Define "hop" inline in the opening paragraph
- Expand ASO/ASN acronyms inline in the test results table
- Add clarifying context to Network path, Round trip time, and Availability descriptions
- Define "device profile" inline in the create-a-test steps

**view-results.mdx:**
- Expand "DEX" on first use (Digital Experience Monitoring)
- State 7-day retention period directly instead of only linking
- Narrow Reporting role description to actual granted permissions (DEX Read, Gateway Report)
- Improve related resources descriptions with actionable detail

### Adversarial review findings addressed

The following issues from the adversarial review were excluded from the final content:
- ❌ "device serial number" as a DEX rule selector (fabricated — not a real selector)
- ❌ "Non-200 codes indicate the server received the request but returned an error" (wrong — includes redirects)
- ❌ "A 0 or missing status code typically means the request never reached the server" (unsourced)
- ❌ "1-2% packet loss can be normal" (unsourced threshold)
- ❌ "consume more device resources" (unsourced claim about test frequency)
- ❌ "15-30 minutes provides sufficient visibility" (unsourced editorial guidance)
- ⚠️ "continuous monitoring" changed to "periodic" (tests run at intervals, not continuously)
- ⚠️ Reporting role description narrowed to actual permissions (not broad "Zero Trust analytics")
- ⚠️ "which devices" changed to "which users or groups" (DEX rules target by user groups, not individual devices)