### PR TITLE
[Workers] Document websocket_standard_binary_type compat flag

### DIFF
--- a/src/content/changelog/workers/2026-04-21-websocket-standard-binary-type.mdx
+++ b/src/content/changelog/workers/2026-04-21-websocket-standard-binary-type.mdx
@@ -1,0 +1,38 @@
+---
+title: WebSocket binary messages now delivered as Blob by default
+description: The Workers runtime now exposes the WebSocket binaryType property and delivers binary frames as Blob by default, matching the WebSocket specification.
+products:
+  - workers
+date: 2026-04-21
+---
+
+Binary frames received on a `WebSocket` are now delivered to the `message` event as [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) objects by default. This matches the [WebSocket specification](https://websockets.spec.whatwg.org/) and standard browser behavior. Previously, binary frames were always delivered as [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). The [`binaryType`](/workers/runtime-apis/websockets/#binarytype) property on `WebSocket` controls the delivery type on a per-WebSocket basis.
+
+This change has been active for Workers with compatibility dates on or after `2026-03-17`, via the [`websocket_standard_binary_type`](/workers/configuration/compatibility-flags/#websocket-standard-binary-type) compatibility flag. We should have documented this change when it shipped but didn't. We're sorry for the trouble that caused. If your Worker handles binary WebSocket messages and assumes `event.data` is an `ArrayBuffer`, the frames will arrive as `Blob` instead, and a naive `instanceof ArrayBuffer` check will silently drop every frame.
+
+To opt back into `ArrayBuffer` delivery, assign `binaryType` before calling `accept()`. This works regardless of the compatibility flag:
+
+```js
+const resp = await fetch("https://example.com", {
+	headers: { Upgrade: "websocket" },
+});
+const ws = resp.webSocket;
+
+// Opt back into ArrayBuffer delivery for this WebSocket.
+ws.binaryType = "arraybuffer";
+ws.accept();
+
+ws.addEventListener("message", (event) => {
+	if (typeof event.data === "string") {
+		// Text frame.
+	} else {
+		// event.data is an ArrayBuffer because we set binaryType above.
+	}
+});
+```
+
+If you are not ready to migrate and want to keep `ArrayBuffer` as the default for all WebSockets in your Worker, add the `no_websocket_standard_binary_type` flag to your [Wrangler configuration file](/workers/wrangler/configuration/).
+
+This change has no effect on the Durable Object hibernatable WebSocket [`webSocketMessage`](/durable-objects/best-practices/websockets/) handler, which continues to receive binary data as `ArrayBuffer`.
+
+For more information, refer to [WebSockets binary messages](/workers/runtime-apis/websockets/#binary-messages).

--- a/src/content/compatibility-flags/websocket-standard-binary-type.md
+++ b/src/content/compatibility-flags/websocket-standard-binary-type.md
@@ -1,0 +1,35 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "WebSocket standard binary type"
+sort_date: "2026-03-17"
+enable_date: "2026-03-17"
+enable_flag: "websocket_standard_binary_type"
+disable_flag: "no_websocket_standard_binary_type"
+---
+
+This flag controls the default value of the [`binaryType`](/workers/runtime-apis/websockets/#binarytype) property on `WebSocket`, which in turn controls how binary frames are delivered to the `message` event. With the flag active, `binaryType` defaults to `"blob"` and binary frames arrive as [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) objects, matching the [WebSocket specification](https://websockets.spec.whatwg.org/) and standard browser behavior. Without the flag, `binaryType` defaults to `"arraybuffer"` and binary frames arrive as [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), matching the runtime's historical behavior.
+
+The `binaryType` property itself is available on every `WebSocket` regardless of the flag. Assigning a value overrides the default for that specific WebSocket:
+
+```js
+const resp = await fetch("https://example.com", {
+  headers: { Upgrade: "websocket" },
+});
+const ws = resp.webSocket;
+
+// Opt back into ArrayBuffer delivery before calling accept().
+ws.binaryType = "arraybuffer";
+ws.accept();
+
+ws.addEventListener("message", (event) => {
+  // event.data is an ArrayBuffer for binary frames.
+});
+```
+
+If you are not ready to migrate and want to keep `ArrayBuffer` as the default for every WebSocket in your Worker, add the `no_websocket_standard_binary_type` flag to your [Wrangler configuration file](/workers/wrangler/configuration/).
+
+This flag has no effect on the Durable Object hibernatable WebSocket [`webSocketMessage`](/durable-objects/best-practices/websockets/) handler, which always receives binary data as `ArrayBuffer`.

--- a/src/content/docs/workers/runtime-apis/websockets.mdx
+++ b/src/content/docs/workers/runtime-apis/websockets.mdx
@@ -140,6 +140,12 @@ let [client, server] = Object.values(new WebSocketPair());
     | `WebSocket.CLOSING` | `2` | The connection is in the process of closing. |
     | `WebSocket.CLOSED` | `3` | The connection is closed. |
 
+### binaryType
+
+* `binaryType` string
+
+  * Controls how binary frames received on this WebSocket are surfaced to the `message` event. Valid values are `"blob"` and `"arraybuffer"`. The value is consulted when each incoming binary frame is dispatched, so assigning a new value affects subsequent messages only. The default is controlled by the [`websocket_standard_binary_type`](/workers/configuration/compatibility-flags/#websocket-standard-binary-type) compatibility flag. Refer to [Binary messages](#binary-messages) for details.
+
 ***
 
 ## Events
@@ -215,6 +221,58 @@ WebSockets created with `new WebSocket(url)` always auto-reply to Close frames a
 ### Prior behavior
 
 On compatibility dates before `2026-04-07` (or with the `web_socket_manual_reply_to_close` flag), receiving a Close frame leaves the WebSocket in `CLOSING` state, and your code must call `close()` to complete the handshake. Failing to do so can result in `1006` abnormal closure errors on the client.
+
+***
+
+## Binary messages
+
+WebSocket frames carry either text or binary payloads, and the choice between the two is made by the sender at the time the frame is sent. Text frames are always delivered to the `message` event as JavaScript strings. Binary frames are delivered either as [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) or as [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), depending on the WebSocket's `binaryType`.
+
+With the [`websocket_standard_binary_type`](/workers/configuration/compatibility-flags/#websocket-standard-binary-type) compatibility flag (enabled by default on compatibility dates on or after `2026-03-17`), `binaryType` defaults to `"blob"` and binary frames are delivered as `Blob` objects. This matches the [WebSocket specification](https://websockets.spec.whatwg.org/) and standard browser behavior. Without the flag, `binaryType` defaults to `"arraybuffer"` and binary frames are delivered as `ArrayBuffer`, matching the runtime's historical behavior.
+
+The `binaryType` property itself is always available. To opt back into `ArrayBuffer` delivery for a single WebSocket, assign `binaryType` before calling `accept()`:
+
+```js
+const resp = await fetch("https://example.com", {
+  headers: { Upgrade: "websocket" },
+});
+const ws = resp.webSocket;
+
+// Opt back into ArrayBuffer delivery for this WebSocket.
+ws.binaryType = "arraybuffer";
+ws.accept();
+
+ws.addEventListener("message", (event) => {
+  if (typeof event.data === "string") {
+    // Text frame.
+  } else {
+    // event.data is an ArrayBuffer because we set binaryType above.
+  }
+});
+```
+
+### Reading binary payloads
+
+An incoming binary frame is fully buffered before the `message` event fires, regardless of `binaryType`. The choice between `Blob` and `ArrayBuffer` does not change when or whether the frame is received — only how you access its bytes:
+
+- With `"arraybuffer"`, `event.data` is an [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). You can inspect its size and read bytes synchronously (for example, `new Uint8Array(event.data)`).
+- With `"blob"`, `event.data` is a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob). Reading the bytes is asynchronous — for example, `await event.data.arrayBuffer()` or `await event.data.bytes()`.
+
+Under the new default, a binary message handler must be `async` in order to read the payload. If you want to keep an existing synchronous handler, set `binaryType` to `"arraybuffer"` on the WebSocket.
+
+### When the value takes effect
+
+Per the [WebSocket specification](https://websockets.spec.whatwg.org/#feedback-from-the-protocol), `binaryType` is mutable: the value is consulted at the moment each binary frame is dispatched to the `message` event, so assigning a new value affects only subsequent messages. If you want every binary message on a WebSocket to be delivered as the same type, assign `binaryType` before calling `accept()`. That guarantees the setting is in place before the runtime starts dispatching any incoming frames.
+
+### Worker-wide opt-out
+
+If you are not ready to migrate and want to keep `ArrayBuffer` as the default for every WebSocket in your Worker, add the `no_websocket_standard_binary_type` flag to your [Wrangler configuration file](/workers/wrangler/configuration/). Individual WebSockets can still override the default by assigning `binaryType`.
+
+:::note
+
+This flag has no effect on the Durable Object hibernatable WebSocket [`webSocketMessage`](/durable-objects/best-practices/websockets/) handler. That handler always receives binary data as `ArrayBuffer`, since it operates outside the normal WebSocket read loop.
+
+:::
 
 ***
 


### PR DESCRIPTION
Adds documentation for the websocket_standard_binary_type compatibility flag (default on 2026-03-17), which changes the WebSocket binaryType default from "arraybuffer" to "blob" and causes binary messages to be delivered as Blob objects.

- Add a compat flag entry in src/content/compatibility-flags/.
- Document the binaryType property and a "Binary messages" reference section in runtime-apis/websockets.mdx.
- Add a changelog entry dated today acknowledging that we shipped this change without documentation.

The compat flag only controls the initial default value of binaryType; the property is always available, so assigning ws.binaryType = "arraybuffer" works regardless of the flag.

Closes cloudflare/workerd#6615.

Assisted-by: OpenCode:claude-opus-4.7

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).