### PR TITLE
docs: adding compat_flag doc for nonretryable errors in workflows

### DIFF
--- a/src/content/compatibility-flags/workflows-preserve-non-retryable-error-message.md
+++ b/src/content/compatibility-flags/workflows-preserve-non-retryable-error-message.md
@@ -1,0 +1,33 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Workflows preserve `NonRetryableError` message"
+sort_date: "2026-05-14"
+enable_date: "2026-05-14"
+experimental: true
+enable_flag: "workflows_preserve_non_retryable_error_message"
+disable_flag: "workflows_replace_non_retryable_error_message"
+---
+
+When enabled, if a [Workflow](/workflows/) step throws a [`NonRetryableError`](/workflows/build/rules-of-workflows/#nonretryableerror), the error `message` and `name` properties are preserved on the thrown exception instead of being replaced with a generic termination string.
+
+Previously, throwing a `NonRetryableError` with a custom message would result in the original error message being lost and replaced with `"The execution of the Workflow instance was terminated, as a step threw an NonRetryableError and it was not handled"`:
+
+```js
+import { WorkflowEntrypoint, NonRetryableError } from "cloudflare:workers";
+
+export class MyWorkflow extends WorkflowEntrypoint {
+  async run(event, step) {
+    await step.do("my-step", async () => {
+      throw new NonRetryableError("custom error message");
+      // Without this flag: error.message === "The execution of the Workflow instance was terminated, as a step threw an NonRetryableError and it was not handled"
+      // With this flag: error.message === "custom error message"
+    });
+  }
+}
+```
+
+With the `workflows_preserve_non_retryable_error_message` flag enabled, the original error message and name are preserved, making it easier to debug and handle specific error cases in your Workflow code.

--- a/src/content/compatibility-flags/workflows-preserve-non-retryable-error-message.md
+++ b/src/content/compatibility-flags/workflows-preserve-non-retryable-error-message.md
@@ -7,7 +7,6 @@ _build:
 name: "Workflows preserve `NonRetryableError` message"
 sort_date: "2026-05-14"
 enable_date: "2026-05-14"
-experimental: true
 enable_flag: "workflows_preserve_non_retryable_error_message"
 disable_flag: "workflows_replace_non_retryable_error_message"
 ---

--- a/src/content/compatibility-flags/workflows-preserve-non-retryable-error-message.md
+++ b/src/content/compatibility-flags/workflows-preserve-non-retryable-error-message.md
@@ -11,7 +11,7 @@ enable_flag: "workflows_preserve_non_retryable_error_message"
 disable_flag: "workflows_replace_non_retryable_error_message"
 ---
 
-When enabled, if a [Workflow](/workflows/) step throws a [`NonRetryableError`](/workflows/build/rules-of-workflows/#nonretryableerror), the error `message` and `name` properties are preserved on the thrown exception instead of being replaced with a generic termination string.
+When enabled, if a [Workflow](/workflows/) step throws a [`NonRetryableError`](/workflows/build/workers-api/#nonretryableerror), the error `message` and `name` properties are preserved on the thrown exception instead of being replaced with a generic termination string.
 
 Previously, throwing a `NonRetryableError` with a custom message would result in the original error message being lost and replaced with `"The execution of the Workflow instance was terminated, as a step threw an NonRetryableError and it was not handled"`:
 


### PR DESCRIPTION
### Summary

Adds a new compatibility flag documentation entry for workflows_preserve_non_retryable_error_message.
When enabled, Workflow steps that throw a NonRetryableError will preserve the original error message and name on the thrown exception. 

### Screenshots (optional)
N/A

### Documentation checklist
- [ ] Is there a changelog (https://developers.cloudflare.com/changelog/) entry (guidelines (https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to RSS feeds (https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the Discord (https://discord.com/channels/595317990191398933/1040420029080018945), and X (https://x.com/CFchangelog).
- [x] The change adheres to the documentation style guide (https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated redirects (https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
