### PR TITLE
[SSL] Restructure PQC docs and add signatures + product matrix

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/index.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/index.mdx
@@ -14,11 +14,11 @@ head: []
 description: Get an overview of how Cloudflare is deploying post-quantum cryptography to protect you against harvest now, decrypt later.
 ---
 
-Post-quantum cryptography (PQC) refers to cryptographic algorithms that have been designed to resist attacks from [quantum computers](https://www.cloudflare.com/learning/ssl/quantum/what-is-quantum-computing/). Cloudflare has been researching and [writing about post-quantum](https://blog.cloudflare.com/tag/post-quantum/) since 2017.
+Post-quantum cryptography (PQC) refers to cryptographic algorithms that have been designed to resist attacks from [quantum computers](https://www.cloudflare.com/learning/ssl/quantum/what-is-quantum-computing/). Cloudflare has been researching and [writing about post-quantum](https://blog.cloudflare.com/tag/post-quantum/) since 2017, and is targeting 2029 to be fully post-quantum secure across its entire product suite — refer to [Cloudflare targets 2029 for full post-quantum security](https://blog.cloudflare.com/post-quantum-roadmap/) for the full roadmap.
 
-To protect you against the risk of [harvest now, decrypt later attacks](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later), and considering all the [connections](#three-connections-in-the-life-of-a-request) that take place when your website or application is on Cloudflare, we have deployed and are actively expanding the use of [post-quantum hybrid key agreement](#hybrid-key-agreement).
+To protect you against the risk of [harvest now, decrypt later attacks](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later), and considering all the [connections](#three-connections-in-the-life-of-a-request) that take place when your website or application is on Cloudflare, we have deployed and are actively expanding the use of [post-quantum hybrid key agreement](#hybrid-key-agreement). In parallel, Cloudflare is beginning to deploy [post-quantum signatures](#post-quantum-signatures) to protect authentication against future quantum attacks.
 
-Refer to [Cloudflare Radar](https://radar.cloudflare.com/adoption-and-usage#post-quantum-encryption-adoption) for current statistics on the adoption of PQ encryption in requests to Cloudflare, and visit [pq.cloudflareresearch.com](https://pq.cloudflareresearch.com) to check if your connection is secured using PQ key agreement.
+Refer to [Cloudflare Radar](https://radar.cloudflare.com/adoption-and-usage#post-quantum-encryption-adoption) for current statistics on the adoption of PQ encryption in requests to Cloudflare, and visit [Cloudflare Radar's browser support check](https://radar.cloudflare.com/post-quantum#browser-support) to check if your browser is secured using PQ key agreement.
 
 :::caution[TLS 1.3]
 Cloudflare post-quantum key agreements are only supported in protocols based on TLS 1.3 (including HTTP/3) and are disabled for websites in [FIPS mode](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#fips-compliance).
@@ -53,9 +53,11 @@ A hybrid key agreement lays the groundwork as more and more [clients](#1-visitor
 
 ### Post-quantum signatures
 
-The migration to post-quantum signatures is less urgent and more involved. Cloudflare is closely following the developments of new standards, testing their performance, and working together with browsers to understand user impact.
+Recent advances in quantum hardware and algorithms have accelerated the timeline on which a cryptographically relevant quantum computer might exist, which in turn elevates the priority of migrating authentication (signatures) to post-quantum algorithms. Refer to [Cloudflare targets 2029 for full post-quantum security](https://blog.cloudflare.com/post-quantum-roadmap/) for context.
 
-For details refer to [A look at the latest post-quantum signature standardization candidates](https://blog.cloudflare.com/another-look-at-pq-signatures/).
+Cloudflare is an early adopter of [ML-DSA](https://csrc.nist.gov/pubs/fips/204/final), the post-quantum digital signature algorithm selected by NIST (FIPS 204), and is beginning to roll out support for ML-DSA in selected product surfaces. Software support for specific schemes is tracked on the [PQC support](/ssl/post-quantum-cryptography/pqc-support/) page.
+
+For background on the post-quantum signature landscape, refer to [A look at the latest post-quantum signature standardization candidates](https://blog.cloudflare.com/another-look-at-pq-signatures/).
 
 ## Three connections in the life of a request
 

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
@@ -1,0 +1,114 @@
+---
+pcx_content_type: reference
+products:
+  - ssl
+title: PQC in Cloudflare products
+sidebar:
+  order: 3
+  label: PQC in Cloudflare products
+head: []
+description: Track which Cloudflare products support post-quantum key agreement and post-quantum signatures.
+tags:
+  - Post-quantum
+---
+
+Cloudflare is [targeting 2029](https://blog.cloudflare.com/post-quantum-roadmap/) to be fully post-quantum secure across its entire product suite.
+
+The sections below group Cloudflare products by the **Cloudflare-operated connection or service** that provides their secure communication channel. Many products share the same underlying connection or service — once that has been upgraded to post-quantum, every product on top of it inherits the same protection. Each section captures which classes of post-quantum algorithms are currently deployed: [key agreement](/ssl/post-quantum-cryptography/#hybrid-key-agreement) (which protects against [harvest-now-decrypt-later](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later) attacks) and [signatures](/ssl/post-quantum-cryptography/#post-quantum-signatures) (which protect against quantum-forged authentication).
+
+A Cloudflare-side ✅ entry only delivers end-to-end post-quantum protection when **the party on the other side of the connection also supports the same post-quantum algorithms**. Refer to [PQC support](/ssl/post-quantum-cryptography/pqc-support/) for the list of browsers, libraries, and servers that support the algorithms Cloudflare has deployed.
+
+## Visitor to Cloudflare
+
+Inbound TLS 1.3 (including QUIC) from end-user clients to Cloudflare's edge.
+
+| Protection | Status |
+| --- | --- |
+| Key agreement | ✅ X25519MLKEM768 |
+| Signatures | Not yet — planned via [Merkle Tree Certificates](https://blog.cloudflare.com/bootstrap-mtc/) |
+
+Reference: [PQC for all websites and APIs](https://blog.cloudflare.com/post-quantum-for-all/).
+
+**Products covered:** any proxied hostname, including Workers custom domains and `*.workers.dev`, R2 public buckets, Stream, Images, the Cloudflare API and dashboard, any HTTPS application behind Cloudflare, and [Cloudflare Access (agentless / clientless)](/ssl/post-quantum-cryptography/pqc-and-zero-trust/#agentless-cloudflare-access).
+
+## Cloudflare internal network
+
+Service-to-service TLS connections between Cloudflare data centers and internal services.
+
+| Protection | Status |
+| --- | --- |
+| Key agreement | 🚧 X25519MLKEM768 |
+| Signatures | Not yet |
+
+Reference: [PQC generally available](https://blog.cloudflare.com/post-quantum-cryptography-ga/), [Roadmap](https://blog.cloudflare.com/post-quantum-roadmap/).
+
+## Cloudflare to origin
+
+Outbound TLS 1.3 connections from Cloudflare's edge to customer origin servers.
+
+| Protection | Status |
+| --- | --- |
+| Key agreement | ✅ X25519MLKEM768 |
+| Signatures | Not yet |
+
+Reference: [PQC to your origin](/ssl/post-quantum-cryptography/pqc-to-origin/).
+
+**Products covered:** any Cloudflare-proxied zone's origin pull, and the egress leg of [Cloudflare Gateway](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#post-quantum-support) (SWG, HTTPS inspection) when Gateway fetches third-party origin content on behalf of the client.
+
+## Cloudflare One Client
+
+MASQUE tunnel (TLS 1.3) from an end-user device to Cloudflare's global network, established by the Cloudflare One Client (formerly WARP).
+
+| Protection | Status |
+| --- | --- |
+| Key agreement | ✅ X25519MLKEM768 |
+| Signatures | Not yet |
+
+Reference: [PQC and Cloudflare One: Cloudflare One Client](/ssl/post-quantum-cryptography/pqc-and-zero-trust/#cloudflare-one-client).
+
+**Products covered:** WARP / [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/); [Cloudflare Gateway](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#post-quantum-support) (SWG, HTTPS inspection) when traffic on-ramps via the Cloudflare One Client; and [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/).
+
+## Cloudflare Tunnel
+
+Outbound TLS 1.3 tunnel from `cloudflared` on a customer origin to Cloudflare's global network.
+
+| Protection | Status |
+| --- | --- |
+| Key agreement | ✅ X25519MLKEM768 |
+| Signatures | Not yet |
+
+Reference: [PQ Cloudflare Tunnel](https://blog.cloudflare.com/post-quantum-tunnel/), [PQC and Cloudflare One](/ssl/post-quantum-cryptography/pqc-and-zero-trust/).
+
+**Products covered:** [Workers VPC](/workers-vpc/) private-network access and any [Cloudflare One](/cloudflare-one/) off-ramp that egresses via `cloudflared` (for example, HTTPS access to self-hosted applications via agentless [Cloudflare Access](/ssl/post-quantum-cryptography/pqc-and-zero-trust/#agentless-cloudflare-access)).
+
+## Cloudflare One Appliance
+
+TLS 1.3 control-plane connection used by the Cloudflare One Appliance to establish keys for its IPsec ESP dataplane tunnels.
+
+| Protection | Status |
+| --- | --- |
+| Key agreement | ✅ X25519MLKEM768 |
+| Signatures | Not yet |
+
+Reference: [PQC SASE](https://blog.cloudflare.com/post-quantum-sase/), [Cloudflare One Appliance](/cloudflare-wan/configuration/appliance/reference/), [PQC and Cloudflare One](/ssl/post-quantum-cryptography/pqc-and-zero-trust/#cloudflare-ipsec).
+
+## Cloudflare IPsec
+
+IKEv2 key exchange for IPsec tunnels between third-party branch connectors and Cloudflare's global network.
+
+| Protection | Status |
+| --- | --- |
+| Key agreement | ✅ ML-KEM-768/1024 + DH Group 20 (P-384) in IKEv2 (closed beta) |
+| Signatures | Not yet |
+
+Reference: [PQC SASE](https://blog.cloudflare.com/post-quantum-sase/), [GRE and IPsec tunnels](/cloudflare-wan/reference/gre-ipsec-tunnels/), [draft-ietf-ipsecme-ikev2-mlkem](https://datatracker.ietf.org/doc/draft-ietf-ipsecme-ikev2-mlkem/).
+
+:::note
+- ✅ means post-quantum cryptography is deployed.
+- 🚧 means partial coverage — a migration is in progress and not all paths are post-quantum secured yet.
+- "Not yet" means post-quantum cryptography of the indicated class is not yet deployed. For signatures this means connections still rely on classical (RSA or ECDSA) signatures for authentication today. Refer to the [roadmap post](https://blog.cloudflare.com/post-quantum-roadmap/) for the intended migration order.
+:::
+
+## Contributing
+
+This listing is maintained alongside the rest of the Cloudflare SSL/TLS documentation. If you spot an inaccuracy or have an update after a product announcement, [contributions](/style-guide/contributions/) are welcome.

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-cloudflare-products.mdx
@@ -25,7 +25,7 @@ Inbound TLS 1.3 (including QUIC) from end-user clients to Cloudflare's edge.
 | Protection | Status |
 | --- | --- |
 | Key agreement | ✅ X25519MLKEM768 |
-| Signatures | Not yet — planned via [Merkle Tree Certificates](https://blog.cloudflare.com/bootstrap-mtc/) |
+| Signatures | 📝 Planned via [Merkle Tree Certificates](https://datatracker.ietf.org/doc/draft-ietf-plants-merkle-tree-certs/) |
 
 Reference: [PQC for all websites and APIs](https://blog.cloudflare.com/post-quantum-for-all/).
 
@@ -41,6 +41,8 @@ Service-to-service TLS connections between Cloudflare data centers and internal 
 | Signatures | Not yet |
 
 Reference: [PQC generally available](https://blog.cloudflare.com/post-quantum-cryptography-ga/), [Roadmap](https://blog.cloudflare.com/post-quantum-roadmap/).
+
+Most internal connections have been migrated to X25519MLKEM768. A long tail of services is still in the process of being upgraded.
 
 ## Cloudflare to origin
 
@@ -102,12 +104,6 @@ IKEv2 key exchange for IPsec tunnels between third-party branch connectors and C
 | Signatures | Not yet |
 
 Reference: [PQC SASE](https://blog.cloudflare.com/post-quantum-sase/), [GRE and IPsec tunnels](/cloudflare-wan/reference/gre-ipsec-tunnels/), [draft-ietf-ipsecme-ikev2-mlkem](https://datatracker.ietf.org/doc/draft-ietf-ipsecme-ikev2-mlkem/).
-
-:::note
-- ✅ means post-quantum cryptography is deployed.
-- 🚧 means partial coverage — a migration is in progress and not all paths are post-quantum secured yet.
-- "Not yet" means post-quantum cryptography of the indicated class is not yet deployed. For signatures this means connections still rely on classical (RSA or ECDSA) signatures for authentication today. Refer to the [roadmap post](https://blog.cloudflare.com/post-quantum-roadmap/) for the intended migration order.
-:::
 
 ## Contributing
 

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -11,57 +11,163 @@ tags:
   - Post-quantum
 ---
 
-The tables below summarize third-party software support for the post-quantum algorithms Cloudflare has deployed, organized by software category. [Contributions](/style-guide/contributions/) to keep the listing up-to-date are welcome.
+The sections below summarize third-party software support for the post-quantum algorithms Cloudflare has deployed, organized by software category. [Contributions](/style-guide/contributions/) to keep the listing up-to-date are welcome.
 
 Two classes of algorithm are tracked:
 
 - **Key agreement** — the [X25519MLKEM768](https://datatracker.ietf.org/doc/draft-ietf-tls-ecdhe-mlkem/) hybrid, which protects against [harvest-now-decrypt-later](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later) attacks on encrypted traffic. Refer to [hybrid key agreement](/ssl/post-quantum-cryptography/#hybrid-key-agreement) for background.
-- **Signatures** — [ML-DSA](https://csrc.nist.gov/pubs/fips/204/final) (FIPS 204), the post-quantum digital signature algorithm standardized by NIST. Defined with three parameter sets: ML-DSA-44, ML-DSA-65, and ML-DSA-87. **ML-DSA-44 is the variant Cloudflare is currently evaluating for deployment.** Refer to [post-quantum signatures](/ssl/post-quantum-cryptography/#post-quantum-signatures) for background.
+- **Signatures** — [ML-DSA](https://csrc.nist.gov/pubs/fips/204/final) (FIPS 204), the post-quantum digital signature algorithm standardized by NIST. Defined with three parameter sets (ML-DSA-44, ML-DSA-65, ML-DSA-87), of which **ML-DSA-44 is the variant Cloudflare is currently evaluating for deployment**. Refer to [post-quantum signatures](/ssl/post-quantum-cryptography/#post-quantum-signatures) for background.
 
 :::caution
-The lists below are for reference only. Responsibility for third-party software lies with their respective maintainers. Use them at your own discretion.
+The listings below are for reference only. Responsibility for third-party software lies with their respective maintainers. Use them at your own discretion.
 :::
 
 ## Browsers
 
-| Software | Key agreement (X25519MLKEM768) | Signatures (ML-DSA) | Notes |
-| --- | --- | --- | --- |
-| [Firefox](https://www.mozilla.org/firefox/) | ✅ Default in Firefox 132+ (Desktop), 145+ (Android) | Not yet | For QUIC/HTTP3, Firefox 135+ (Desktop) |
-| [Chrome](https://www.google.com/chrome/) | ✅ Default in Chrome 131+ | Not yet | |
-| [Safari](https://www.apple.com/safari/) | ✅ Default in Safari 26+ | Not yet | System-wide in iOS 26, macOS Tahoe 26, and other [Apple operating systems](https://support.apple.com/122756) |
-| [Edge](https://microsoft.com/edge/) | ✅ Default in Edge 131+ | Not yet | |
-| [Opera](https://opera.com), [Brave](https://brave.com) | ✅ Default in recent versions | Not yet | |
-| [Tor Browser](https://www.torproject.org/) | ✅ Default in Tor Browser 15.0+ | Not yet | |
+### Brave and Opera
+
+- **Key agreement:** ✅ Default in recent versions
+- **Signatures:** Not yet
+- **Reference:** [Brave](https://brave.com), [Opera](https://opera.com)
+
+### Chrome
+
+- **Key agreement:** ✅ Default in Chrome 131+
+- **Signatures:** Not yet
+- **Reference:** [Chrome](https://www.google.com/chrome/)
+
+### Edge
+
+- **Key agreement:** ✅ Default in Edge 131+
+- **Signatures:** Not yet
+- **Reference:** [Edge](https://microsoft.com/edge/)
+
+### Firefox
+
+- **Key agreement:** ✅ Default in Firefox 132+ (Desktop), 145+ (Android)
+- **Signatures:** Not yet
+- **Reference:** [Firefox](https://www.mozilla.org/firefox/)
+
+For QUIC/HTTP3, Firefox 135+ (Desktop).
+
+### Safari
+
+- **Key agreement:** ✅ Default in Safari 26+
+- **Signatures:** Not yet
+- **Reference:** [Safari](https://www.apple.com/safari/)
+
+System-wide in iOS 26, macOS Tahoe 26, and other [Apple operating systems](https://support.apple.com/122756).
+
+### Tor Browser
+
+- **Key agreement:** ✅ Default in Tor Browser 15.0+
+- **Signatures:** Not yet
+- **Reference:** [Tor Browser](https://www.torproject.org/)
 
 ## Libraries
 
-| Software | Key agreement (X25519MLKEM768) | Signatures (ML-DSA) | Notes |
-| --- | --- | --- | --- |
-| [OpenSSL](https://www.openssl.org/) | ✅ Default in 3.5.0+ | ✅ 3.5.0+ (ML-DSA-44, 65, 87) | Included natively; no external provider required |
-| [BoringSSL](https://boringssl.googlesource.com/boringssl/) | ✅ | ✅ (ML-DSA-44, 65, 87) | |
-| [GnuTLS](https://www.gnutls.org) | ✅ 3.8.9+ compiled with leancrypto 1.2.0+ (or 3.8.8-3.8.9 with liboqs 0.11.0+) | ✅ 3.8.10+ — usable in TLS handshakes (ML-DSA-44, 65, 87) | Supports all three ML-DSA private key encodings (seed, expandedKey, both) |
-| [Go](https://go.dev) | ✅ Default in Go 1.24+ | ⚠️ Internal implementation in Go 1.26; public [`crypto/mldsa`](https://github.com/golang/go/issues/77626) proposed for Go 1.27 | Cloudflare's [fork of Go](https://github.com/cloudflare/go) also supports key agreement |
-| Cloudflare's [CIRCL](https://github.com/cloudflare/circl) | ✅ (ML-KEM) | ✅ 1.5.0+ via [`sign/mldsa`](https://github.com/cloudflare/circl/tree/main/sign/mldsa) (ML-DSA-44, 65, 87) | |
-| [Java (OpenJDK)](https://openjdk.org/) | ✅ Default in Java 27+ ([JEP 527](https://openjdk.org/jeps/527)) | ⚠️ Java 24+ provides ML-DSA APIs ([JEP 497](https://openjdk.org/jeps/497)) but they are not yet integrated into `javax.net.ssl` TLS | |
-| [Node.js](https://nodejs.org/) | ✅ Default in 24.5.0+ and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352)) | ✅ 24.5.0+ (via bundled OpenSSL 3.5) | |
-| Rust: [rustls](https://crates.io/crates/rustls) | ✅ Enabled by default since rustls 0.23.27 (via [`rustls-post-quantum`](https://crates.io/crates/rustls-post-quantum)) | ⚠️ Unstable ML-DSA support in `rustls-post-quantum` (behind `aws-lc-rs-unstable`) | |
-| Rust: [RustCrypto](https://github.com/RustCrypto) | ✅ [`ml-kem`](https://crates.io/crates/ml-kem) (pure Rust) | ✅ [`ml-dsa`](https://crates.io/crates/ml-dsa) (pure Rust, ML-DSA-44, 65, 87) | |
-| [Botan C++](https://botan.randombit.net/) | ✅ Default in TLS since 3.7.0 | ✅ 3.6.0+ (ML-DSA-44, 65, 87) | |
-| [Zig](https://ziglang.org/) | ✅ Zig 0.14.0+ (client) | Not yet | |
-| [Open Quantum Safe](https://openquantumsafe.org/) | ✅ liboqs 0.10.0+, oqs-provider 0.7.0+ | ✅ liboqs 0.14.0+, oqs-provider 0.9.0+ | Reference implementations, not recommended for production |
+### BoringSSL
+
+- **Key agreement:** ✅
+- **Signatures:** ✅ (ML-DSA-44, 65, 87)
+- **Reference:** [BoringSSL](https://boringssl.googlesource.com/boringssl/)
+
+### Botan C++
+
+- **Key agreement:** ✅ Default in TLS since 3.7.0
+- **Signatures:** ✅ 3.6.0+ (ML-DSA-44, 65, 87)
+- **Reference:** [Botan](https://botan.randombit.net/)
+
+### CIRCL (Cloudflare)
+
+- **Key agreement:** ✅ (ML-KEM)
+- **Signatures:** ✅ 1.5.0+ via [`sign/mldsa`](https://github.com/cloudflare/circl/tree/main/sign/mldsa) (ML-DSA-44, 65, 87)
+- **Reference:** [CIRCL](https://github.com/cloudflare/circl)
+
+### GnuTLS
+
+- **Key agreement:** ✅ 3.8.9+ compiled with leancrypto 1.2.0+ (or 3.8.8–3.8.9 with liboqs 0.11.0+)
+- **Signatures:** ✅ 3.8.10+ — usable in TLS handshakes (ML-DSA-44, 65, 87)
+- **Reference:** [GnuTLS](https://www.gnutls.org)
+
+Supports all three ML-DSA private key encodings (seed, expandedKey, both).
+
+### Go
+
+- **Key agreement:** ✅ Default in Go 1.24+
+- **Signatures:** ⚠️ Internal implementation in Go 1.26; public [`crypto/mldsa`](https://github.com/golang/go/issues/77626) proposed for Go 1.27
+- **Reference:** [Go](https://go.dev)
+
+Cloudflare's [fork of Go](https://github.com/cloudflare/go) also supports key agreement.
+
+### Java (OpenJDK)
+
+- **Key agreement:** ✅ Default in Java 27+ ([JEP 527](https://openjdk.org/jeps/527))
+- **Signatures:** ⚠️ Java 24+ provides ML-DSA APIs ([JEP 497](https://openjdk.org/jeps/497)) but they are not yet integrated into `javax.net.ssl` TLS
+- **Reference:** [OpenJDK](https://openjdk.org/)
+
+### Node.js
+
+- **Key agreement:** ✅ Default in 24.5.0+ and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352))
+- **Signatures:** ✅ 24.5.0+ (via bundled OpenSSL 3.5)
+- **Reference:** [Node.js](https://nodejs.org/)
+
+### Open Quantum Safe
+
+- **Key agreement:** ✅ liboqs 0.10.0+, oqs-provider 0.7.0+
+- **Signatures:** ✅ liboqs 0.14.0+, oqs-provider 0.9.0+
+- **Reference:** [Open Quantum Safe](https://openquantumsafe.org/)
+
+Reference implementations, not recommended for production.
+
+### OpenSSL
+
+- **Key agreement:** ✅ Default in 3.5.0+
+- **Signatures:** ✅ 3.5.0+ (ML-DSA-44, 65, 87)
+- **Reference:** [OpenSSL](https://www.openssl.org/)
+
+Included natively. No external provider required.
+
+### RustCrypto (Rust)
+
+- **Key agreement:** ✅ [`ml-kem`](https://crates.io/crates/ml-kem) (pure Rust)
+- **Signatures:** ✅ [`ml-dsa`](https://crates.io/crates/ml-dsa) (pure Rust, ML-DSA-44, 65, 87)
+- **Reference:** [RustCrypto](https://github.com/RustCrypto)
+
+### rustls (Rust)
+
+- **Key agreement:** ✅ Enabled by default since rustls 0.23.27 (via [`rustls-post-quantum`](https://crates.io/crates/rustls-post-quantum))
+- **Signatures:** ⚠️ Unstable ML-DSA support in `rustls-post-quantum` (behind `aws-lc-rs-unstable`)
+- **Reference:** [rustls](https://crates.io/crates/rustls)
+
+### Zig
+
+- **Key agreement:** ✅ Zig 0.14.0+ (client)
+- **Signatures:** Not yet
+- **Reference:** [Zig](https://ziglang.org/)
 
 ## Servers
 
-| Software | Key agreement (X25519MLKEM768) | Signatures (ML-DSA) | Notes |
-| --- | --- | --- | --- |
-| [NGINX](https://github.com/nginx/nginx) | ✅ Default when compiled with OpenSSL 3.5+ ([instructions](https://github.com/nginx/nginx/issues/288)) | ✅ When compiled with OpenSSL 3.5+ | |
-| [Caddy](https://caddyserver.com/) | ✅ Default in Caddy 2.10.0+ | Blocked on Go `crypto/mldsa` | |
-| [Traefik](https://traefik.io/traefik/) | ✅ Default in 3.4.2+, 2.11.26+ ([commit](https://github.com/traefik/traefik/commit/cd16321dd9c25bb47a2e9417b2a4a75959be63d0)); configurable via `curvePreferences` in 3.5.0-rc.1+ | Blocked on Go `crypto/mldsa` | |
-| [rpxy](https://github.com/junkurihara/rust-rpxy) | ✅ Default in 0.9.4+ | Blocked on Rust PQ signature support | |
+### Caddy
 
-:::note
-- ✅ means the feature is implemented and ready to use.
-- ⚠️ means partial or experimental support — refer to the Notes column.
-- "Not yet" means no post-quantum support for that class is available; traditional algorithms are still used.
-- "Blocked on …" indicates the software itself is ready but depends on an upstream component that has not yet shipped PQ support.
-:::
+- **Key agreement:** ✅ Default in Caddy 2.10.0+
+- **Signatures:** Blocked on Go `crypto/mldsa`
+- **Reference:** [Caddy](https://caddyserver.com/)
+
+### NGINX
+
+- **Key agreement:** ✅ Default when compiled with OpenSSL 3.5+ ([instructions](https://github.com/nginx/nginx/issues/288))
+- **Signatures:** ✅ When compiled with OpenSSL 3.5+
+- **Reference:** [NGINX](https://github.com/nginx/nginx)
+
+### rpxy
+
+- **Key agreement:** ✅ Default in 0.9.4+
+- **Signatures:** Blocked on Rust PQ signature support
+- **Reference:** [rpxy](https://github.com/junkurihara/rust-rpxy)
+
+### Traefik
+
+- **Key agreement:** ✅ Default in 3.4.2+, 2.11.26+ ([commit](https://github.com/traefik/traefik/commit/cd16321dd9c25bb47a2e9417b2a4a75959be63d0)); configurable via `curvePreferences` in 3.5.0-rc.1+
+- **Signatures:** Blocked on Go `crypto/mldsa`
+- **Reference:** [Traefik](https://traefik.io/traefik/)

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -16,7 +16,7 @@ The sections below summarize third-party software support for the post-quantum a
 Two classes of algorithm are tracked:
 
 - **Key agreement** — the [X25519MLKEM768](https://datatracker.ietf.org/doc/draft-ietf-tls-ecdhe-mlkem/) hybrid, which protects against [harvest-now-decrypt-later](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later) attacks on encrypted traffic. Refer to [hybrid key agreement](/ssl/post-quantum-cryptography/#hybrid-key-agreement) for background.
-- **Signatures** — [ML-DSA](https://csrc.nist.gov/pubs/fips/204/final) (FIPS 204), the post-quantum digital signature algorithm standardized by NIST. Defined with three parameter sets (ML-DSA-44, ML-DSA-65, ML-DSA-87), of which **ML-DSA-44 is the variant Cloudflare is currently evaluating for deployment**. Refer to [post-quantum signatures](/ssl/post-quantum-cryptography/#post-quantum-signatures) for background.
+- **Signatures** — [ML-DSA](https://csrc.nist.gov/pubs/fips/204/final), the post-quantum digital signature algorithm standardized by NIST. Defined with three parameter sets (ML-DSA-44, ML-DSA-65, ML-DSA-87), of which **ML-DSA-44 is the variant Cloudflare is currently evaluating for deployment**. Refer to [post-quantum signatures](/ssl/post-quantum-cryptography/#post-quantum-signatures) for background.
 
 :::caution
 The listings below are for reference only. Responsibility for third-party software lies with their respective maintainers. Use them at your own discretion.
@@ -24,25 +24,39 @@ The listings below are for reference only. Responsibility for third-party softwa
 
 ## Browsers
 
-### Brave and Opera
+Browsers are grouped by the underlying rendering engine and TLS stack. Browsers sharing an engine generally share the same post-quantum support, but derivative browsers can lag the upstream engine or disable post-quantum features by policy. Verify behavior in the specific browser version you care about before assuming derivative support. [Cloudflare Radar's browser support check](https://radar.cloudflare.com/post-quantum#browser-support) is a quick way to confirm whether a given browser negotiates post-quantum key agreement with Cloudflare.
 
-- **Key agreement:** ✅ Default in recent versions
+### Chromium-based (BoringSSL)
+
+#### Brave
+
+- **Key agreement:** ✅ Default in Brave 1.73.86+ (Chromium 131)
 - **Signatures:** Not yet
-- **Reference:** [Brave](https://brave.com), [Opera](https://opera.com)
+- **Reference:** [Brave](https://brave.com)
 
-### Chrome
+#### Chrome
 
 - **Key agreement:** ✅ Default in Chrome 131+
-- **Signatures:** Not yet
-- **Reference:** [Chrome](https://www.google.com/chrome/)
+- **Signatures:** 📝 Planned via [Merkle Tree Certificates](https://datatracker.ietf.org/doc/draft-ietf-plants-merkle-tree-certs/)
+- **Reference:** [Chrome](https://www.google.com/chrome/), [Cultivating a robust and efficient quantum-safe HTTPS](https://security.googleblog.com/2026/02/cultivating-robust-and-efficient.html)
 
-### Edge
+Chrome is not planning to add traditional X.509 post-quantum certificates to the public Chrome Root Store. Instead, Chrome is developing MTCs in the IETF PLANTS working group, currently in a feasibility study phase with Cloudflare.
+
+#### Edge
 
 - **Key agreement:** ✅ Default in Edge 131+
 - **Signatures:** Not yet
 - **Reference:** [Edge](https://microsoft.com/edge/)
 
-### Firefox
+#### Opera
+
+- **Key agreement:** ✅ Default in Opera 116+ (Chromium 131)
+- **Signatures:** Not yet
+- **Reference:** [Opera](https://opera.com)
+
+### Gecko-based (Firefox / NSS)
+
+#### Firefox
 
 - **Key agreement:** ✅ Default in Firefox 132+ (Desktop), 145+ (Android)
 - **Signatures:** Not yet
@@ -50,7 +64,17 @@ The listings below are for reference only. Responsibility for third-party softwa
 
 For QUIC/HTTP3, Firefox 135+ (Desktop).
 
-### Safari
+#### Tor Browser
+
+- **Key agreement:** ✅ Default in Tor Browser 15.0+
+- **Signatures:** Not yet
+- **Reference:** [Tor Browser](https://www.torproject.org/)
+
+Based on Firefox ESR with additional hardening.
+
+### WebKit-based (Safari)
+
+#### Safari
 
 - **Key agreement:** ✅ Default in Safari 26+
 - **Signatures:** Not yet
@@ -58,61 +82,53 @@ For QUIC/HTTP3, Firefox 135+ (Desktop).
 
 System-wide in iOS 26, macOS Tahoe 26, and other [Apple operating systems](https://support.apple.com/122756).
 
-### Tor Browser
-
-- **Key agreement:** ✅ Default in Tor Browser 15.0+
-- **Signatures:** Not yet
-- **Reference:** [Tor Browser](https://www.torproject.org/)
-
 ## Libraries
 
-### BoringSSL
+This section splits into the foundational native libraries (written in C/C++) and the language bindings and higher-level libraries that build on top of them.
+
+### Native libraries
+
+#### AWS-LC
 
 - **Key agreement:** ✅
-- **Signatures:** ✅ (ML-DSA-44, 65, 87)
+- **Signatures:** ✅
+- **Reference:** [aws-lc](https://github.com/aws/aws-lc), [Post-Quantum Cryptography in AWS-LC](https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/PQREADME.md)
+
+ML-KEM-512/768/1024 and hybrids `X25519MLKEM768`, `SecP256r1MLKEM768`, `SecP384r1MLKEM1024`; ML-DSA-44/65/87.
+
+#### BoringSSL
+
+- **Key agreement:** ✅
+- **Signatures:** ✅
 - **Reference:** [BoringSSL](https://boringssl.googlesource.com/boringssl/)
 
-### Botan C++
+ML-DSA-44/65/87.
+
+#### Botan C++
 
 - **Key agreement:** ✅ Default in TLS since 3.7.0
-- **Signatures:** ✅ 3.6.0+ (ML-DSA-44, 65, 87)
+- **Signatures:** ✅ 3.6.0+
 - **Reference:** [Botan](https://botan.randombit.net/)
 
-### CIRCL (Cloudflare)
+ML-DSA-44/65/87.
 
-- **Key agreement:** ✅ (ML-KEM)
-- **Signatures:** ✅ 1.5.0+ via [`sign/mldsa`](https://github.com/cloudflare/circl/tree/main/sign/mldsa) (ML-DSA-44, 65, 87)
-- **Reference:** [CIRCL](https://github.com/cloudflare/circl)
-
-### GnuTLS
+#### GnuTLS
 
 - **Key agreement:** ✅ 3.8.9+ compiled with leancrypto 1.2.0+ (or 3.8.8–3.8.9 with liboqs 0.11.0+)
-- **Signatures:** ✅ 3.8.10+ — usable in TLS handshakes (ML-DSA-44, 65, 87)
+- **Signatures:** ✅ 3.8.10+ — usable in TLS handshakes
 - **Reference:** [GnuTLS](https://www.gnutls.org)
 
-Supports all three ML-DSA private key encodings (seed, expandedKey, both).
+Hybrids `X25519MLKEM768` and `SecP256r1MLKEM768` from 3.8.8+; `SecP384r1MLKEM1024` added in 3.8.9+. ML-DSA-44/65/87.
 
-### Go
+#### OpenSSL
 
-- **Key agreement:** ✅ Default in Go 1.24+
-- **Signatures:** ⚠️ Internal implementation in Go 1.26; public [`crypto/mldsa`](https://github.com/golang/go/issues/77626) proposed for Go 1.27
-- **Reference:** [Go](https://go.dev)
+- **Key agreement:** ✅ Default in 3.5.0+
+- **Signatures:** ✅ 3.5.0+
+- **Reference:** [OpenSSL](https://www.openssl.org/)
 
-Cloudflare's [fork of Go](https://github.com/cloudflare/go) also supports key agreement.
+Hybrid `X25519MLKEM768` in 3.5.0+; `SecP256r1MLKEM768` and `curveSM2MLKEM768` added in 3.6.0+. ML-DSA-44/65/87.
 
-### Java (OpenJDK)
-
-- **Key agreement:** ✅ Default in Java 27+ ([JEP 527](https://openjdk.org/jeps/527))
-- **Signatures:** ⚠️ Java 24+ provides ML-DSA APIs ([JEP 497](https://openjdk.org/jeps/497)) but they are not yet integrated into `javax.net.ssl` TLS
-- **Reference:** [OpenJDK](https://openjdk.org/)
-
-### Node.js
-
-- **Key agreement:** ✅ Default in 24.5.0+ and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352))
-- **Signatures:** ✅ 24.5.0+ (via bundled OpenSSL 3.5)
-- **Reference:** [Node.js](https://nodejs.org/)
-
-### Open Quantum Safe
+#### Open Quantum Safe
 
 - **Key agreement:** ✅ liboqs 0.10.0+, oqs-provider 0.7.0+
 - **Signatures:** ✅ liboqs 0.14.0+, oqs-provider 0.9.0+
@@ -120,27 +136,79 @@ Cloudflare's [fork of Go](https://github.com/cloudflare/go) also supports key ag
 
 Reference implementations, not recommended for production.
 
-### OpenSSL
+#### s2n-tls
 
-- **Key agreement:** ✅ Default in 3.5.0+
-- **Signatures:** ✅ 3.5.0+ (ML-DSA-44, 65, 87)
-- **Reference:** [OpenSSL](https://www.openssl.org/)
+- **Key agreement:** ✅
+- **Signatures:** Not yet
+- **Reference:** [s2n-tls](https://github.com/aws/s2n-tls)
 
-Included natively. No external provider required.
+AWS's open-source TLS implementation built on [AWS-LC](#aws-lc).
 
-### RustCrypto (Rust)
+### Language bindings and higher-level libraries
 
-- **Key agreement:** ✅ [`ml-kem`](https://crates.io/crates/ml-kem) (pure Rust)
-- **Signatures:** ✅ [`ml-dsa`](https://crates.io/crates/ml-dsa) (pure Rust, ML-DSA-44, 65, 87)
+#### aws-lc-rs (Rust)
+
+- **Key agreement:** ✅
+- **Signatures:** 🚧 Behind `unstable` feature
+- **Reference:** [aws-lc-rs](https://crates.io/crates/aws-lc-rs)
+
+Rust bindings around [AWS-LC](#aws-lc); underlies [`rustls-post-quantum`](#rustls-post-quantum-rust)'s ML-DSA support. ML-KEM via [`aws-lc-rs::kem`](https://docs.rs/aws-lc-rs/latest/aws_lc_rs/kem/); ML-DSA-44/65/87 via [`unstable::signature`](https://docs.rs/aws-lc-rs/latest/aws_lc_rs/unstable/signature/).
+
+#### CIRCL (Cloudflare)
+
+- **Key agreement:** ✅
+- **Signatures:** ✅ 1.5.0+ via [`sign/mldsa`](https://github.com/cloudflare/circl/tree/main/sign/mldsa)
+- **Reference:** [CIRCL](https://github.com/cloudflare/circl)
+
+Pure-Go cryptographic primitives library. ML-KEM-512/768/1024 and ML-DSA-44/65/87.
+
+#### Go
+
+- **Key agreement:** ✅ Default in Go 1.24+
+- **Signatures:** 🚧 Internal implementation in Go 1.26; public [`crypto/mldsa`](https://github.com/golang/go/issues/77626) proposed for Go 1.27
+- **Reference:** [Go](https://go.dev)
+
+Cloudflare's [fork of Go](https://github.com/cloudflare/go) also supports key agreement via [CIRCL](#circl-cloudflare).
+
+#### Java (OpenJDK)
+
+- **Key agreement:** ✅ Default in Java 27+ ([JEP 527](https://openjdk.org/jeps/527))
+- **Signatures:** 🚧 Java 24+ provides ML-DSA APIs ([JEP 497](https://openjdk.org/jeps/497)) but they are not yet integrated into `javax.net.ssl` TLS
+- **Reference:** [OpenJDK](https://openjdk.org/)
+
+#### Node.js
+
+- **Key agreement:** ✅ Default in 24.5.0+ and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352))
+- **Signatures:** ✅ 24.5.0+
+- **Reference:** [Node.js](https://nodejs.org/)
+
+Uses bundled [OpenSSL](#openssl) 3.5. ML-DSA-44/65/87.
+
+#### RustCrypto (Rust)
+
+- **Key agreement:** ✅ [`ml-kem`](https://crates.io/crates/ml-kem)
+- **Signatures:** ✅ [`ml-dsa`](https://crates.io/crates/ml-dsa)
 - **Reference:** [RustCrypto](https://github.com/RustCrypto)
 
-### rustls (Rust)
+Pure-Rust crates, independent of [AWS-LC](#aws-lc). ML-DSA-44/65/87.
 
-- **Key agreement:** ✅ Enabled by default since rustls 0.23.27 (via [`rustls-post-quantum`](https://crates.io/crates/rustls-post-quantum))
-- **Signatures:** ⚠️ Unstable ML-DSA support in `rustls-post-quantum` (behind `aws-lc-rs-unstable`)
+#### rustls (Rust)
+
+- **Key agreement:** ✅ Enabled by default since rustls 0.23.27
+- **Signatures:** 🚧 Unstable
 - **Reference:** [rustls](https://crates.io/crates/rustls)
 
-### Zig
+TLS library built on top of [`rustls-post-quantum`](#rustls-post-quantum-rust).
+
+#### rustls-post-quantum (Rust)
+
+- **Key agreement:** ✅ `X25519MLKEM768`
+- **Signatures:** 🚧 Unstable ML-DSA support (behind `aws-lc-rs-unstable` feature)
+- **Reference:** [rustls-post-quantum](https://crates.io/crates/rustls-post-quantum)
+
+Extension crate for [rustls](#rustls-rust) that provides post-quantum algorithms using [aws-lc-rs](#aws-lc-rs-rust) under the hood.
+
+#### Zig
 
 - **Key agreement:** ✅ Zig 0.14.0+ (client)
 - **Signatures:** Not yet

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -6,66 +6,62 @@ title: PQC support
 sidebar:
   order: 2
 head: []
-description: Consider information about post-quantum cryptography at Cloudflare - deployed key agreements and software support.
+description: Consider information about post-quantum cryptography at Cloudflare - deployed key agreements, signatures, and software support.
 tags:
   - Post-quantum
 ---
 
-Cloudflare's deployment of post-quantum [hybrid key agreements](/ssl/post-quantum-cryptography/#hybrid-key-agreement) is supported by different software as listed below. [Contributions](/style-guide/contributions/) to keep the listing up-to-date are welcome.
+The tables below summarize third-party software support for the post-quantum algorithms Cloudflare has deployed, organized by software category. [Contributions](/style-guide/contributions/) to keep the listing up-to-date are welcome.
+
+Two classes of algorithm are tracked:
+
+- **Key agreement** — the [X25519MLKEM768](https://datatracker.ietf.org/doc/draft-ietf-tls-ecdhe-mlkem/) hybrid, which protects against [harvest-now-decrypt-later](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later) attacks on encrypted traffic. Refer to [hybrid key agreement](/ssl/post-quantum-cryptography/#hybrid-key-agreement) for background.
+- **Signatures** — [ML-DSA](https://csrc.nist.gov/pubs/fips/204/final) (FIPS 204), the post-quantum digital signature algorithm standardized by NIST. Defined with three parameter sets: ML-DSA-44, ML-DSA-65, and ML-DSA-87. **ML-DSA-44 is the variant Cloudflare is currently evaluating for deployment.** Refer to [post-quantum signatures](/ssl/post-quantum-cryptography/#post-quantum-signatures) for background.
 
 :::caution
-The list below is for reference only. Responsibility for third-party software lies with their respective maintainers. Use them at your own discretion.
+The lists below are for reference only. Responsibility for third-party software lies with their respective maintainers. Use them at your own discretion.
 :::
 
-## X25519MLKEM768
-- Default for [Firefox 132+](https://www.mozilla.org/firefox/) (Desktop) and Firefox 145+ (Android)
-    - For QUIC/HTTP3, use Firefox 135+ (Desktop)
-- Default for [Chrome 131+](https://www.google.com/chrome/)
-- Default for [Safari 26+](https://www.apple.com/safari/)
-    - System-wide support in iOS 26, macOS Tahoe 26, and other [Apple operating systems](https://support.apple.com/122756)
-- Default for [Edge 131+](https://microsoft.com/edge/)
-- Default for recent [Opera](https://opera.com) and [Brave](https://brave.com)
-- Default for [Tor Browser 15.0+](https://www.torproject.org/)
-- Cloudflare's [fork of Go](https://github.com/cloudflare/go)
-- Default for [Go 1.24+](https://go.dev/doc/go1.24#cryptotlspkgcryptotls)
-- Default for [Java 27+](https://openjdk.org/jeps/527)
-- Default for [OpenSSL 3.5.0+](https://www.openssl.org/)
-- Default for [Node 24.5.0+](https://nodejs.org/) and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352))
-- [BoringSSL](https://boringssl.googlesource.com/boringssl/)
-- [GnuTLS](https://www.gnutls.org)
-    - 3.8.9+ compiled with leancrypto 1.2.0+
-    - 3.8.8-3.8.9 compiled with liboqs 0.11.0+
-- [rustls 0.23.22+](https://crates.io/crates/rustls)
-- Default for [rpxy 0.9.4+](https://github.com/junkurihara/rust-rpxy)
-- Default for [NGINX](https://github.com/nginx/nginx) compiled with OpenSSL 3.5+ ([instructions](https://github.com/nginx/nginx/issues/288))
-- [Open Quantum Safe](https://openquantumsafe.org/)
-    - C library: liboqs 0.10.0+
-    - OpenSSL provider: oqs-provider 0.7.0+
-- [Zig 0.14.0+](https://ziglang.org/) (client)
-- Default for [Caddy HTTP server 2.10.0+](https://caddyserver.com/)
-- [Traefik](https://traefik.io/traefik/)
-    - Default for 3.4.2+, 2.11.26+ ([commit](https://github.com/traefik/traefik/commit/cd16321dd9c25bb47a2e9417b2a4a75959be63d0))
-    - Configurable with `curvePreferences` in [3.5.0-rc.1+](https://github.com/traefik/traefik/releases/tag/v3.5.0-rc1)
-- [Botan C++ library 3.7.0+](https://botan.randombit.net/)
+## Browsers
 
-## X25519Kyber768Draft00
+| Software | Key agreement (X25519MLKEM768) | Signatures (ML-DSA) | Notes |
+| --- | --- | --- | --- |
+| [Firefox](https://www.mozilla.org/firefox/) | ✅ Default in Firefox 132+ (Desktop), 145+ (Android) | Not yet | For QUIC/HTTP3, Firefox 135+ (Desktop) |
+| [Chrome](https://www.google.com/chrome/) | ✅ Default in Chrome 131+ | Not yet | |
+| [Safari](https://www.apple.com/safari/) | ✅ Default in Safari 26+ | Not yet | System-wide in iOS 26, macOS Tahoe 26, and other [Apple operating systems](https://support.apple.com/122756) |
+| [Edge](https://microsoft.com/edge/) | ✅ Default in Edge 131+ | Not yet | |
+| [Opera](https://opera.com), [Brave](https://brave.com) | ✅ Default in recent versions | Not yet | |
+| [Tor Browser](https://www.torproject.org/) | ✅ Default in Tor Browser 15.0+ | Not yet | |
 
-- Default for [Chrome 124-130](https://www.google.com/chrome/) on Desktop
-    - For older Chrome or on mobile, toggle _TLS 1.3 hybridized Kyber support_ (`enable-tls13-kyber`) in `chrome://flags`.
-- Default for [Edge 124-130](https://microsoft.com/edge/)
-- [Firefox 124-131](https://www.mozilla.org/firefox) if you turn on `security.tls.enable_kyber` in `about:config`
-    - For QUIC/HTTP3, use Firefox 128+ with `network.http.http3.enable_kyber`.
-- Cloudflare's [fork of Go](https://github.com/cloudflare/go)
-- Default for [Go 1.23](https://github.com/golang/go/issues/67061)
-- [BoringSSL](https://boringssl.googlesource.com/boringssl/)
-- [GnuTLS](https://www.gnutls.org)
-    - 3.8.8-3.8.9 compiled with liboqs 0.11.0+
-    - 3.8.7 compiled with liboqs 0.10.1+
-- Cloudflare's [fork of QUIC-go](https://github.com/cloudflare/qtls-pq)
-- Goutam Tamvada's [fork of Firefox](https://github.com/xvzcf/firefox-pq-demos)
-- [Open Quantum Safe](https://openquantumsafe.org/)
-    - C library: liboqs 0.5.0+
-    - OpenSSL provider: oqs-provider 0.5.0-0.8.0
-- [Zig 0.11.0-0.13.0](https://ziglang.org/) (client)
-- [nginx](https://www.nginx.org/) when [compiled with BoringSSL](https://mailman.nginx.org/pipermail/nginx/2023-August/NOISOYU3QTB2DGIYUBGF7CAMQHDI2QLT.html) ([guide](https://blog.centminmod.com/2023/10/03/2860/how-to-enable-cloudflare-post-quantum-x25519kyber768-key-exchange-support-in-centmin-mod-nginx/))
-- [Botan C++ library 3.2.0+](https://botan.randombit.net/) ([instructions](https://github.com/randombit/botan/discussions/3747))
+## Libraries
+
+| Software | Key agreement (X25519MLKEM768) | Signatures (ML-DSA) | Notes |
+| --- | --- | --- | --- |
+| [OpenSSL](https://www.openssl.org/) | ✅ Default in 3.5.0+ | ✅ 3.5.0+ (ML-DSA-44, 65, 87) | Included natively; no external provider required |
+| [BoringSSL](https://boringssl.googlesource.com/boringssl/) | ✅ | ✅ (ML-DSA-44, 65, 87) | |
+| [GnuTLS](https://www.gnutls.org) | ✅ 3.8.9+ compiled with leancrypto 1.2.0+ (or 3.8.8-3.8.9 with liboqs 0.11.0+) | ✅ 3.8.10+ — usable in TLS handshakes (ML-DSA-44, 65, 87) | Supports all three ML-DSA private key encodings (seed, expandedKey, both) |
+| [Go](https://go.dev) | ✅ Default in Go 1.24+ | ⚠️ Internal implementation in Go 1.26; public [`crypto/mldsa`](https://github.com/golang/go/issues/77626) proposed for Go 1.27 | Cloudflare's [fork of Go](https://github.com/cloudflare/go) also supports key agreement |
+| Cloudflare's [CIRCL](https://github.com/cloudflare/circl) | ✅ (ML-KEM) | ✅ 1.5.0+ via [`sign/mldsa`](https://github.com/cloudflare/circl/tree/main/sign/mldsa) (ML-DSA-44, 65, 87) | |
+| [Java (OpenJDK)](https://openjdk.org/) | ✅ Default in Java 27+ ([JEP 527](https://openjdk.org/jeps/527)) | ⚠️ Java 24+ provides ML-DSA APIs ([JEP 497](https://openjdk.org/jeps/497)) but they are not yet integrated into `javax.net.ssl` TLS | |
+| [Node.js](https://nodejs.org/) | ✅ Default in 24.5.0+ and 22.20.0+ ([backported](https://nodejs.org/en/blog/release/v22.20.0#openssl-updated-to-352)) | ✅ 24.5.0+ (via bundled OpenSSL 3.5) | |
+| Rust: [rustls](https://crates.io/crates/rustls) | ✅ Enabled by default since rustls 0.23.27 (via [`rustls-post-quantum`](https://crates.io/crates/rustls-post-quantum)) | ⚠️ Unstable ML-DSA support in `rustls-post-quantum` (behind `aws-lc-rs-unstable`) | |
+| Rust: [RustCrypto](https://github.com/RustCrypto) | ✅ [`ml-kem`](https://crates.io/crates/ml-kem) (pure Rust) | ✅ [`ml-dsa`](https://crates.io/crates/ml-dsa) (pure Rust, ML-DSA-44, 65, 87) | |
+| [Botan C++](https://botan.randombit.net/) | ✅ Default in TLS since 3.7.0 | ✅ 3.6.0+ (ML-DSA-44, 65, 87) | |
+| [Zig](https://ziglang.org/) | ✅ Zig 0.14.0+ (client) | Not yet | |
+| [Open Quantum Safe](https://openquantumsafe.org/) | ✅ liboqs 0.10.0+, oqs-provider 0.7.0+ | ✅ liboqs 0.14.0+, oqs-provider 0.9.0+ | Reference implementations, not recommended for production |
+
+## Servers
+
+| Software | Key agreement (X25519MLKEM768) | Signatures (ML-DSA) | Notes |
+| --- | --- | --- | --- |
+| [NGINX](https://github.com/nginx/nginx) | ✅ Default when compiled with OpenSSL 3.5+ ([instructions](https://github.com/nginx/nginx/issues/288)) | ✅ When compiled with OpenSSL 3.5+ | |
+| [Caddy](https://caddyserver.com/) | ✅ Default in Caddy 2.10.0+ | Blocked on Go `crypto/mldsa` | |
+| [Traefik](https://traefik.io/traefik/) | ✅ Default in 3.4.2+, 2.11.26+ ([commit](https://github.com/traefik/traefik/commit/cd16321dd9c25bb47a2e9417b2a4a75959be63d0)); configurable via `curvePreferences` in 3.5.0-rc.1+ | Blocked on Go `crypto/mldsa` | |
+| [rpxy](https://github.com/junkurihara/rust-rpxy) | ✅ Default in 0.9.4+ | Blocked on Rust PQ signature support | |
+
+:::note
+- ✅ means the feature is implemented and ready to use.
+- ⚠️ means partial or experimental support — refer to the Notes column.
+- "Not yet" means no post-quantum support for that class is available; traditional algorithms are still used.
+- "Blocked on …" indicates the software itself is ready but depends on an upstream component that has not yet shipped PQ support.
+:::


### PR DESCRIPTION
## Summary

Prepares the post-quantum docs for the rollout of post-quantum signatures (ML-DSA) alongside the already-deployed hybrid key agreement (X25519MLKEM768).

## What's in this PR

### `pqc-support.mdx` — restructured third-party software listing

- Flat bullet list → three category-scoped tables: **Browsers**, **Libraries**, **Servers**.
- Each row now has separate columns for **key agreement (X25519MLKEM768)** and **signatures (ML-DSA)**, replacing the previous per-hybrid prose sections.
- `X25519Kyber768Draft00` tracking is dropped — that draft has been superseded by the standardized `X25519MLKEM768` hybrid and every listed library has migrated.

New ML-DSA software support captured (all verified against upstream release notes or source):

- OpenSSL 3.5.0+ (native, all three parameter sets)
- BoringSSL (native)
- GnuTLS 3.8.10+ (usable in TLS handshakes; all private key encodings — seed, expandedKey, both)
- Node.js 24.5.0+ (via bundled OpenSSL 3.5)
- Go 1.26 (internal impl; public [`crypto/mldsa`](https://github.com/golang/go/issues/77626) proposed for 1.27)
- Java 24+ APIs via [JEP 497](https://openjdk.org/jeps/497) (not yet in `javax.net.ssl` TLS)
- Cloudflare's [CIRCL 1.5.0+](https://github.com/cloudflare/circl) via [`sign/mldsa`](https://github.com/cloudflare/circl/tree/main/sign/mldsa)
- Rust: [`rustls-post-quantum`](https://crates.io/crates/rustls-post-quantum) (unstable, behind `aws-lc-rs-unstable`) and the pure-Rust [RustCrypto `ml-dsa`](https://crates.io/crates/ml-dsa) crate
- Botan 3.6.0+
- [liboqs 0.14.0+](https://openquantumsafe.org/), oqs-provider 0.9.0+

Corrections along the way:

- **Rustls**: `X25519MLKEM768` ships through the `rustls-post-quantum` crate (enabled by default in rustls 0.23.27+), not directly in the main rustls crate.
- **Botan** key-agreement entry clarified: TLS default is since 3.7.0.

### `pqc-cloudflare-products.mdx` (new) — product-level status matrix

Product-level matrix organized by the **Cloudflare-operated connection or service** that provides each product's secure communication channel. Many Cloudflare products share the same underlying connection or service — once that has been upgraded to post-quantum, every product on top of it inherits the same protection.

Each section has a brief description, a Protection table (key agreement + signatures), a References line, and a "Products covered" callout where multiple Cloudflare products share the same underlying connection or service.

Sections (all cross-checked against source docs and/or blog posts):

- Visitor to Cloudflare (TLS 1.3 including QUIC) — ✅ X25519MLKEM768 · planned Merkle Tree Certificates
- Cloudflare internal network — 🚧 X25519MLKEM768 · _Not yet_ for signatures
- Cloudflare to origin — ✅ X25519MLKEM768 · _Not yet_ for signatures
- Cloudflare One Client (MASQUE) — ✅ X25519MLKEM768 · _Not yet_ for signatures
- Cloudflare Tunnel (`cloudflared`) — ✅ X25519MLKEM768 · _Not yet_ for signatures
- Cloudflare One Appliance — ✅ X25519MLKEM768 · _Not yet_ for signatures
- Cloudflare IPsec (closed beta) — ✅ ML-KEM-768/1024 + DH Group 20 (P-384) in IKEv2 · _Not yet_ for signatures

### `index.mdx` — small updates

- Introduction references the [April 2026 roadmap post](https://blog.cloudflare.com/post-quantum-roadmap/) announcing Cloudflare's 2029 target for full post-quantum security.
- Post-quantum signatures section now links to the **PQC in Cloudflare products** page for the current deployment list rather than enumerating features inline.
- Browser-support check link updated from `pq.cloudflareresearch.com` to [Cloudflare Radar's equivalent page](https://radar.cloudflare.com/post-quantum#browser-support).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
