### PR TITLE
[R2 Data Catalog] Update snapshot expiration docs to reflect data file cleanup

### DIFF
--- a/src/content/changelog/r2/2026-04-22-snapshot-expiration-cleans-data-files.mdx
+++ b/src/content/changelog/r2/2026-04-22-snapshot-expiration-cleans-data-files.mdx
@@ -1,0 +1,24 @@
+---
+title: R2 Data Catalog snapshot expiration now removes unreferenced data files
+description: Automatic snapshot expiration now cleans up unreferenced data files in addition to Iceberg metadata
+products:
+  - r2
+date: 2026-04-22
+---
+
+[R2 Data Catalog](/r2/data-catalog/), a managed [Apache Iceberg](https://iceberg.apache.org/) catalog built into R2, now removes unreferenced data files during automatic snapshot expiration.
+
+Previously, snapshot expiration only cleaned up Iceberg metadata files such as manifests and manifest lists. Data files that were no longer referenced by active snapshots remained in R2 storage until you manually ran `remove_orphan_files` or `expire_snapshots` through an engine like Spark. This required extra operational overhead and left stale data files consuming storage.
+
+Snapshot expiration now handles both metadata and data file cleanup automatically. When a snapshot is expired, any data files that are no longer referenced by retained snapshots are removed from R2 storage.
+
+```bash
+# Enable catalog-level snapshot expiration
+npx wrangler r2 bucket catalog snapshot-expiration enable my-bucket \
+  --older-than-days 7 \
+  --retain-last 10
+```
+
+This improvement reduces storage costs and eliminates the need to run manual maintenance jobs to reclaim space from deleted data.
+
+To learn more about snapshot expiration and other automatic maintenance operations, refer to the [table maintenance documentation](/r2/data-catalog/table-maintenance/).

--- a/src/content/changelog/r2/2026-04-22-snapshot-expiration-cleans-data-files.mdx
+++ b/src/content/changelog/r2/2026-04-22-snapshot-expiration-cleans-data-files.mdx
@@ -6,7 +6,7 @@ products:
 date: 2026-04-22
 ---
 
-[R2 Data Catalog](/r2/data-catalog/), a managed [Apache Iceberg](https://iceberg.apache.org/) catalog built into R2, now removes unreferenced data files during automatic snapshot expiration.
+[R2 Data Catalog](/r2/data-catalog/), a managed [Apache Iceberg](https://iceberg.apache.org/) catalog built into R2, now removes unreferenced data files during automatic snapshot expiration. This improvement reduces storage costs and eliminates the need to run manual maintenance jobs to reclaim space from deleted data.
 
 Previously, snapshot expiration only cleaned up Iceberg metadata files such as manifests and manifest lists. Data files that were no longer referenced by active snapshots remained in R2 storage until you manually ran `remove_orphan_files` or `expire_snapshots` through an engine like Spark. This required extra operational overhead and left stale data files consuming storage.
 
@@ -18,7 +18,5 @@ npx wrangler r2 bucket catalog snapshot-expiration enable my-bucket \
   --older-than-days 7 \
   --retain-last 10
 ```
-
-This improvement reduces storage costs and eliminates the need to run manual maintenance jobs to reclaim space from deleted data.
 
 To learn more about snapshot expiration and other automatic maintenance operations, refer to the [table maintenance documentation](/r2/data-catalog/table-maintenance/).

--- a/src/content/docs/r2/data-catalog/deleting-data.mdx
+++ b/src/content/docs/r2/data-catalog/deleting-data.mdx
@@ -14,7 +14,7 @@ Deleting data from R2 Data Catalog or any Apache Iceberg catalog requires that o
 
 ## Automatic table maintenance
 R2 Data Catalog can automatically manage table maintenance operations such as snapshot expiration and compaction. These continuous operations help keep latency and storage costs down.
- - **Snapshot expiration**: Automatically removes old snapshots. This reduces metadata overhead. Data files are not removed until orphan file removal is run.
+ - **Snapshot expiration**: Automatically removes old snapshots and the respective unreferenced data files. This reduces both metadata overhead and storage costs.
  - **Compaction**: Merges small data files into larger ones. This optimizes read performance and reduces the number of files read during queries.
 
  Without enabling automatic maintenance, you need to manually handle these operations.

--- a/src/content/docs/r2/data-catalog/manage-catalogs.mdx
+++ b/src/content/docs/r2/data-catalog/manage-catalogs.mdx
@@ -161,7 +161,7 @@ npx wrangler r2 bucket catalog compaction disable <BUCKET_NAME> <NAMESPACE> <TAB
 
 ## Enable snapshot expiration
 
-Snapshot expiration automatically removes old table snapshots to reduce metadata bloat and storage costs. For more information about snapshot expiration and why it is valuable, refer to [Table maintenance](/r2/data-catalog/table-maintenance/).
+Snapshot expiration automatically removes old table snapshots and any unreferenced data files to reduce metadata overhead and storage costs. For more information about snapshot expiration and why it is important, refer to [Table maintenance](/r2/data-catalog/table-maintenance/).
 
 :::note
 Snapshot expiration commands are available as of Wrangler version 4.56.0.

--- a/src/content/docs/r2/data-catalog/manage-catalogs.mdx
+++ b/src/content/docs/r2/data-catalog/manage-catalogs.mdx
@@ -161,7 +161,7 @@ npx wrangler r2 bucket catalog compaction disable <BUCKET_NAME> <NAMESPACE> <TAB
 
 ## Enable snapshot expiration
 
-Snapshot expiration automatically removes old table snapshots and any unreferenced data files to reduce metadata overhead and storage costs. For more information about snapshot expiration and why it is important, refer to [Table maintenance](/r2/data-catalog/table-maintenance/).
+Snapshot expiration automatically removes old table snapshots and any unreferenced data files to reduce metadata overhead and storage costs.
 
 :::note
 Snapshot expiration commands are available as of Wrangler version 4.56.0.

--- a/src/content/docs/r2/data-catalog/table-maintenance.mdx
+++ b/src/content/docs/r2/data-catalog/table-maintenance.mdx
@@ -11,7 +11,7 @@ Table maintenance encompasses a set of operations that keep your Apache Iceberg 
 R2 Data Catalog automates two critical maintenance operations:
 
 - **Compaction**: Combines small data files into larger, more efficient files to improve query performance
-- **Snapshot expiration**: Removes old table snapshots to reduce metadata overhead and storage costs
+- **Snapshot expiration**: Removes old table snapshots and any unreferenced data files to reduce metadata overhead and storage costs
 
 Without regular maintenance, tables can suffer from:
 
@@ -73,7 +73,7 @@ Performance tradeoffs depend on your use case. For example, queries that return 
 Every write to an Iceberg table—whether an insert, update, or delete—creates a new snapshot. Over time, these snapshots can accumulate and cause performance issues:
 
 - **Metadata overhead**: Each snapshot adds entries to the table's metadata files. As the number of snapshots grows, metadata files become larger, slowing down query planning and table operations
-- **Increased storage costs**: Old snapshots reference data files that may no longer be needed, preventing them from being cleaned up and consuming unnecessary storage
+- **Increased storage costs**: Old snapshots reference data files that may no longer be needed. Without snapshot expiration, these files continue consuming unnecessary storage
 - **Slower table operations**: Operations like listing snapshots or accessing table history become slower over time
 
 ## R2 Data Catalog automatic snapshot expiration
@@ -127,5 +127,5 @@ These are generic recommendations, make sure to consider:
 
 - During open beta, compaction will compact up to 2 GB worth of files once per hour for each table.
 - Only data files stored in parquet format are currently supported with compaction.
-- Orphan file cleanup is not supported yet.
+- Files that were not previously referenced by a snapshot will not be cleaned up (orphaned files).
 - Minimum target file size for compaction is 64 MB and maximum is 512 MB.


### PR DESCRIPTION
### Summary

Updates R2 Data Catalog docs to reflect that automatic snapshot expiration now removes unreferenced data files in addition to Iceberg metadata. Previously, data file cleanup required manual `remove_orphan_files` or `expire_snapshots` operations via Spark.

- Add changelog entry for the behavior change
- Update snapshot expiration descriptions across docs
- Clarify orphan file cleanup limitations

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
