### PR TITLE
Document the partial support for RHEL 9

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/index.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/index.mdx
@@ -41,9 +41,10 @@ Cloudflare also offers an unstable [beta release track](/cloudflare-one/team-and
 
 ## Linux
 
-:::note[Support for Connector on RHEL 9]
+:::note[Support for Cloudflare Mesh on RHEL 9]
 
-Starting with Cloudflare One Client v2026.3.846.0, the Connector functionality is supported for RHEL 9 in addition to RHEL 8, whereas full Cloudflare One Client functionality is currently only supported on RHEL 8. This note will be removed once RHEL 9 support is complete.
+Starting with Cloudflare One Client version 2026.3.846.0, [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) functionality is supported for both RHEL 9 and RHEL 8, whereas full Cloudflare One Client functionality is currently only supported on RHEL 8. This note will be removed once RHEL 9 support is complete.
+:::
 
 <LinkButton href="https://pkg.cloudflareclient.com/">
 	Package repository

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/index.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/index.mdx
@@ -41,6 +41,10 @@ Cloudflare also offers an unstable [beta release track](/cloudflare-one/team-and
 
 ## Linux
 
+:::note[Support for Connector on RHEL 9]
+
+Starting with Cloudflare One Client v2026.3.846.0, the Connector functionality is supported for RHEL 9 in addition to RHEL 8, whereas full Cloudflare One Client functionality is currently only supported on RHEL 8. This note will be removed once RHEL 9 support is complete.
+
 <LinkButton href="https://pkg.cloudflareclient.com/">
 	Package repository
 </LinkButton>


### PR DESCRIPTION
### Summary

Cloudflare One Client has been certified on RHEL 9 for Connector functionality. This changes notes that in a way that makes it clear that it is **not** the same as fully supporting RHEL 9 (which would be implied by simply changing the version number in the download dropdown).

### Screenshots (optional)

N/A

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).

^ Purposefully waiting for full platform support for this to avoid any bait-and-switch expectations from exciting announcements versus explicitly disclosing what will be supported when issues are reported.

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
