### PR TITLE
Add support for Connector on RHEL 9

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
@@ -116,7 +116,7 @@ As of December 2025, the following versions of Ubuntu are supported:
 
 Cloudflare One Client support for RHEL is pending. Once testing is complete, our policy will be to support all major versions of RHEL within their [Full Support window](https://access.redhat.com/product-life-cycles). Devices must be updated to the latest minor release (for example, `9.4`) to receive support.
 
-As of April 2026, only RHEL 8 has completed full compatibility testing, which is now out of the Red Hat Full Support window. Starting with Cloudflare One Client v2026.3.846.0, RHEL 9 is supported for Connector functionality only.
+As of April 2026, only RHEL 8 has completed full compatibility testing, which is now out of the Red Hat Full Support window. Starting with Cloudflare One Client version 2026.3.846.0, RHEL 9 is supported for [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) functionality only.
 
 This section will be updated as we add RHEL support to match Red Hat's support lifecycle.
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
@@ -116,7 +116,9 @@ As of December 2025, the following versions of Ubuntu are supported:
 
 Cloudflare One Client support for RHEL is pending. Once testing is complete, our policy will be to support all major versions of RHEL within their [Full Support window](https://access.redhat.com/product-life-cycles). Devices must be updated to the latest minor release (for example, `9.4`) to receive support.
 
-As of December 2025, only RHEL 8 has completed full compatibility testing, which is now out of the Red Hat Full Support window. This section will be updated as we add RHEL support to match Red Hat's support lifecycle.
+As of April 2026, only RHEL 8 has completed full compatibility testing, which is now out of the Red Hat Full Support window. Starting with Cloudflare One Client v2026.3.846.0, RHEL 9 is supported for Connector functionality only.
+
+This section will be updated as we add RHEL support to match Red Hat's support lifecycle.
 
 | RHEL version | Supported until                                                        |
 | ------------ | ---------------------------------------------------------------------- |


### PR DESCRIPTION
### Summary

Companion edit to the client release notes for v2026.3.846.0 to disclose RHEL 9 support for Connector role.

### Screenshots (optional)

N/A

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).

^ Waiting for full change to supported platforms to avoid any changelog title doing a bait and switch (since RHEL 9 is *not* fully supported for all Cloudflare One Client functionality)

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
