### PR TITLE
[DO NOT MERGE] CACHE-13511: add workers cache response rules docs

### DIFF
--- a/src/content/changelog/cache/2026-04-21-workers-override-cache-response-rules.mdx
+++ b/src/content/changelog/cache/2026-04-21-workers-override-cache-response-rules.mdx
@@ -1,0 +1,36 @@
+---
+title: Workers override Cache Response Rules
+description: Workers `cf` object properties now take precedence over Cache Response Rules, giving you per-request control over response-phase cache settings.
+products:
+  - cache
+date: YYYY-MM-DD
+---
+
+Workers `fetch()` requests now take precedence over matching [Cache Response Rules](/cache/how-to/cache-response-rules/). Combined with the existing ability to override [Cache Rules](/cache/how-to/cache-rules/), `cf` object properties are now the highest-precedence cache configuration in Cloudflare's cache pipeline on a per-request basis.
+
+## What changed
+
+New `cf` object properties are available on `fetch()` subrequests for fine-grained cache control:
+
+- **`cacheControl`**: Sets an explicit `Cache-Control` value on the cached response, overriding any `set_cache_control` [Cache Response Rule](/cache/how-to/cache-response-rules/settings/).
+- **`cacheTtlByStatus`**: Now also overrides `set_cache_control` Cache Response Rules for matching status codes.
+- **`cacheTags`**: Now replaces response cache tags, overriding any `set_cache_tags` Cache Response Rule.
+- **`stripEtags`**: Strips `ETag` headers from the origin response, overriding the `strip_etags` parameter of `set_cache_settings`.
+- **`stripLastModified`**: Strips `Last-Modified` headers from the origin response, overriding the `strip_last_modified` parameter of `set_cache_settings`.
+- **`respectStrongEtag`**: Preserves strong `ETag` headers from the origin, overriding the [Respect Strong ETags](/cache/how-to/cache-rules/settings/#respect-strong-etags) setting.
+- **`cacheDeceptionArmor`**: Enables [Cache Deception Armor](/cache/cache-security/cache-deception-armor/) for the request, overriding the Cache Rules setting.
+- **`cacheReserveEligible`**: Controls [Cache Reserve](/cache/advanced-configuration/cache-reserve/) eligibility, overriding the Cache Rules setting.
+- **`cacheReserveMinimumFileSize`**: Sets the minimum response size for [Cache Reserve](/cache/advanced-configuration/cache-reserve/) eligibility, overriding the Cache Rules setting.
+
+## Precedence order
+
+Cache behavior now follows this order of precedence, highest to lowest:
+
+1. Workers script settings (`cf` object on `fetch()`)
+2. [Cache Response Rules](/cache/how-to/cache-response-rules/)
+3. [Cache Rules](/cache/how-to/cache-rules/)
+4. [Page Rules](/rules/page-rules/)
+
+## Get started
+
+For the full list of `cf` object properties, refer to the [`cf` property documentation](/workers/runtime-apis/request/#the-cf-property-requestinitcfproperties) and [How Workers interact with Cache Rules and Cache Response Rules](/cache/interaction-cloudflare-products/workers-cache-rules/).

--- a/src/content/docs/cache/interaction-cloudflare-products/workers-cache-rules.mdx
+++ b/src/content/docs/cache/interaction-cloudflare-products/workers-cache-rules.mdx
@@ -1,30 +1,60 @@
 ---
 pcx_content_type: how-to
-description: How Workers interact with Cache Rules execution.
+description: How Workers interact with Cache Rules and Cache Response Rules execution.
 products:
   - cache
-title: How Workers interact with Cache Rules
+title: How Workers interact with Cache Rules and Cache Response Rules
 sidebar:
   order: 2
 head:
   - tag: title
-    content: How Workers interact with Cache Rules
+    content: How Workers interact with Cache Rules and Cache Response Rules
 
 ---
 
-Your Workers script can override [Cache Rules](/cache/how-to/cache-rules/) behavior, whether it is applied to a zone using Cloudflare or a zone that is not proxied through Cloudflare.
+Your Workers script can override [Cache Rules](/cache/how-to/cache-rules/) and [Cache Response Rules](/cache/how-to/cache-response-rules/) behavior, whether it is applied to a zone using Cloudflare or a zone that is not proxied through Cloudflare.
 
 For example, if there is a cache rule configured to bypass cache for `example.com/foo`, but your Workers script sets `cacheEverything: true`, the script's setting will take precedence, and the request will be cached. The same applies if the request is made to a non-Cloudflare zone — the Worker's `cacheEverything` setting will still override.
 
 ## Precedence order
 
-Cache behavior is determined by the following order of precedence:
+Cache behavior is determined by the following order of precedence, highest to lowest:
 
-1. [Workers](/workers/) script settings
-2. [Cache rules](/cache/how-to/cache-rules/)
-3. [Page rules](/rules/page-rules/)
+1. [Workers](/workers/) script settings (`cf` properties on `fetch()` subrequests)
+2. [Cache Response Rules](/cache/how-to/cache-response-rules/) (response-phase actions such as `set_cache_control`, `set_cache_tags`, and `set_cache_settings`)
+3. [Cache Rules](/cache/how-to/cache-rules/) (request-phase settings such as cache eligibility, edge TTL, and cache key)
+4. [Page Rules](/rules/page-rules/)
 
-Cache rules override page rule settings, and Workers scripts override cache rules. Among rules at the same level, the one with the highest specificity takes priority.
+Workers script settings take precedence over all rules-based configurations. Cache Response Rules override Cache Rules, and Cache Rules override Page Rules. Among rules at the same level, the one with the highest specificity takes priority.
+
+### Workers override Cache Rules
+
+The following `cf` object properties on a `fetch()` subrequest override matching [Cache Rules](/cache/how-to/cache-rules/settings/) settings:
+
+| `cf` property | Cache Rules setting |
+| --- | --- |
+| `cacheEverything` | Cache eligibility |
+| `cacheTtl` | Edge TTL |
+| `cacheTtlByStatus` | Edge TTL by status code |
+| `cacheKey` | Custom cache key |
+| `cacheDeceptionArmor` | [Cache Deception Armor](/cache/cache-security/cache-deception-armor/) |
+| `cacheReserveEligible` | [Cache Reserve](/cache/advanced-configuration/cache-reserve/) eligibility |
+| `cacheReserveMinimumFileSize` | [Cache Reserve](/cache/advanced-configuration/cache-reserve/) minimum file size |
+| `respectStrongEtag` | [Respect Strong ETags](/cache/how-to/cache-rules/settings/#respect-strong-etags) |
+
+### Workers override Cache Response Rules
+
+The following `cf` object properties also override matching [Cache Response Rules](/cache/how-to/cache-response-rules/settings/) actions:
+
+| `cf` property | Cache Response Rules action |
+| --- | --- |
+| `cacheControl` | `set_cache_control` |
+| `cacheTags` | `set_cache_tags` (replaces the tag list) |
+| `cacheTtlByStatus` | `set_cache_control` for matching status codes |
+| `stripEtags` | `set_cache_settings` (`strip_etags`) |
+| `stripLastModified` | `set_cache_settings` (`strip_last_modified`) |
+
+When a Worker sets one of these properties, the value takes effect even when a Cache Response Rule configures a different value for the same request.
 
 ## Compatibility flags
 

--- a/src/content/docs/workers/runtime-apis/request.mdx
+++ b/src/content/docs/workers/runtime-apis/request.mdx
@@ -109,6 +109,14 @@ Invalid or incorrectly-named keys in the `cf` object will be silently ignored. C
 
   * Whether [Cloudflare Apps](https://www.cloudflare.com/apps/) should be enabled for this request. Defaults to `true`.
 
+* `cacheControl` <Type text="string" /> <MetaInfo text="optional" />
+
+  * Sets an explicit `Cache-Control` directive value on the response stored in cache (for example, `"public, max-age=3600, s-maxage=86400"`). Cannot be used together with `cacheTtl` or the `cache` request option (`"no-store"` or `"no-cache"`) — these are mutually exclusive cache control mechanisms and setting them together throws a `TypeError`. Can be combined with `cacheTtlByStatus`, where `cacheTtlByStatus` overrides `cacheControl` for matching status codes. This option applies to `GET` and `HEAD` request methods only.
+
+* `cacheDeceptionArmor` <Type text="boolean" /> <MetaInfo text="optional" />
+
+  * Enables [Cache Deception Armor](/cache/cache-security/cache-deception-armor/), which protects against web cache deception attacks by verifying that the response `Content-Type` matches the file extension of the URL path.
+
 * `cacheEverything` <Type text="boolean" /> <MetaInfo text="optional" />
 
   * Treats all content as static and caches all [file types](/cache/concepts/default-cache-behavior#default-cached-file-extensions) beyond the Cloudflare default cached content. Respects cache headers from the origin web server. This is equivalent to setting the Page Rule [**Cache Level** (to **Cache Everything**)](/rules/page-rules/reference/settings/). Defaults to `false`.
@@ -116,7 +124,15 @@ Invalid or incorrectly-named keys in the `cf` object will be silently ignored. C
 
 * `cacheKey` <Type text="string" /> <MetaInfo text="optional" />
 
-  * A request’s cache key is what determines if two requests are the same for caching purposes. If a request has the same cache key as some previous request, then Cloudflare can serve the same cached response for both.
+  * A request's cache key is what determines if two requests are the same for caching purposes. If a request has the same cache key as some previous request, then Cloudflare can serve the same cached response for both.
+
+* `cacheReserveEligible` <Type text="boolean" /> <MetaInfo text="optional" />
+
+  * Controls whether the response is eligible to be stored in [Cache Reserve](/cache/advanced-configuration/cache-reserve/). Set to `false` to prevent the response from being written to Cache Reserve.
+
+* `cacheReserveMinimumFileSize` <Type text="number" /> <MetaInfo text="optional" />
+
+  * Minimum response size in bytes for eligibility to be stored in [Cache Reserve](/cache/advanced-configuration/cache-reserve/). Responses smaller than this value are not written to Cache Reserve.
 
 * `cacheTags` Array\<string> optional
 
@@ -124,7 +140,7 @@ Invalid or incorrectly-named keys in the `cf` object will be silently ignored. C
 
 * `cacheTtl` <Type text="number" /> <MetaInfo text="optional" />
 
-  * This option forces Cloudflare to cache the response for this request, regardless of what headers are seen on the response. This is equivalent to setting two Page Rules: [**Edge Cache TTL**](/cache/how-to/edge-browser-cache-ttl/) and [**Cache Level** (to **Cache Everything**)](/rules/page-rules/reference/settings/). The value must be zero or a positive number. A value of `0` indicates that the cache asset expires immediately. This option applies to `GET` and `HEAD` request methods only.
+  * This option forces Cloudflare to cache the response for this request, regardless of what headers are seen on the response. This is equivalent to setting two Page Rules: [**Edge Cache TTL**](/cache/how-to/edge-browser-cache-ttl/) and [**Cache Level** (to **Cache Everything**)](/rules/page-rules/reference/settings/). The value must be zero or a positive number. A value of `0` indicates that the cache asset expires immediately. Cannot be used together with `cacheControl`. This option applies to `GET` and `HEAD` request methods only.
 
 * `cacheTtlByStatus` `{ [key: string]: number }` optional
 
@@ -142,9 +158,21 @@ Invalid or incorrectly-named keys in the `cf` object will be silently ignored. C
 
   * Directs the request to an alternate origin server by overriding the DNS lookup. The value of `resolveOverride` specifies an alternate hostname which will be used when determining the origin IP address, instead of using the hostname specified in the URL. The `Host` header of the request will still match what is in the URL. Thus, `resolveOverride` allows a request to be sent to a different server than the URL / `Host` header specifies. However, `resolveOverride` will only take effect if both the URL host and the host specified by `resolveOverride` are within your zone. If either specifies a host from a different zone / domain, then the option will be ignored for security reasons. If you need to direct a request to a host outside your zone (while keeping the `Host` header pointing within your zone), first create a CNAME record within your zone pointing to the outside host, and then set `resolveOverride` to point at the CNAME record. Note that, for security reasons, it is not possible to set the `Host` header to specify a host outside of your zone unless the request is actually being sent to that host.
 
+* `respectStrongEtag` <Type text="boolean" /> <MetaInfo text="optional" />
+
+  * When set to `true`, preserves strong `ETag` headers from the origin response rather than converting them to weak ETags (`W/"..."`). Refer to [Respect Strong ETags](/cache/how-to/cache-rules/settings/#respect-strong-etags) for more information.
+
 * `scrapeShield` <Type text="boolean" /> <MetaInfo text="optional" />
 
   * Whether [ScrapeShield](https://blog.cloudflare.com/introducing-scrapeshield-discover-defend-dete/) should be enabled for this request, if otherwise configured for this zone. Defaults to `true`.
+
+* `stripEtags` <Type text="boolean" /> <MetaInfo text="optional" />
+
+  * When set to `true`, removes the `ETag` header from the origin response before caching and serving.
+
+* `stripLastModified` <Type text="boolean" /> <MetaInfo text="optional" />
+
+  * When set to `true`, removes the `Last-Modified` header from the origin response before caching and serving.
 
 * `webp` <Type text="boolean" /> <MetaInfo text="optional" />
 


### PR DESCRIPTION
### Summary

Add docs for more fine-grained control over cache via the workers fetch APIs `request.cf` object.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
