### PR TITLE
Add Google tag gateway to Access binding cookie incompatible products

### DIFF
--- a/src/content/partials/cloudflare-one/access/self-hosted-app/product-compatibility.mdx
+++ b/src/content/partials/cloudflare-one/access/self-hosted-app/product-compatibility.mdx
@@ -8,5 +8,8 @@ However, the following products are not supported:
 
 * [Automatic Platform Optimization](/automatic-platform-optimization)
 * [Zaraz](/zaraz)
+* [Google tag gateway for advertisers](/google-tag-gateway)
 
 You can disable Zaraz for a specific application - instead of across your entire zone - using a [Configuration Rule](/rules/configuration-rules/) scoped to the application domain.
+
+Google tag gateway is configured at the zone level and cannot be scoped to specific hostnames. To use Access binding cookie on a hostname, disable Google tag gateway for the entire zone.


### PR DESCRIPTION
## Summary

Add Google tag gateway for advertisers to the list of Cloudflare products that are incompatible with Access self-hosted applications — and, by extension, the Access binding cookie.

## Why

Google tag gateway is architecturally similar to Zaraz: both inject a zone-level worker in front of origin traffic to rewrite third-party script URLs. That worker sits in the request/response path and interferes with how Access sets and reads the `CF_Binding` cookie, producing infinite 302 redirect loops on hostnames protected by Access self-hosted applications with binding cookie enabled.

Disabling either Google tag gateway or binding cookie resolves the loop. Google tag gateway is zone-scoped, so it cannot be disabled per hostname via Configuration Rules the way Zaraz can — hence the need to flag it as incompatible alongside Zaraz.

## Change

`src/content/partials/cloudflare-one/access/self-hosted-app/product-compatibility.mdx` — added Google tag gateway to the unsupported list and noted that it is zone-scoped (unlike Zaraz, it cannot be disabled per hostname via Configuration Rules).

This partial is already transcluded into the Access binding cookie docs via the [product-compatibility link](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/#when-not-to-use-binding-cookie), so no other pages need to change.