### PR TITLE
docs(cloudflare-one): note Google tag gateway incompatibility with Ac…

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/index.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/index.mdx
@@ -138,7 +138,7 @@ The `CF_Authorization` cookie cannot be used without the associated binding cook
 Do not enable Binding Cookie if:
 
 - You are using the Access application for non-browser based tools (such as SSH or RDP).
-- You have enabled [incompatible Cloudflare products](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/#product-compatibility) on the application domain.
+- You have enabled [incompatible Cloudflare products](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/#product-compatibility) on the application domain, such as [Zaraz](/zaraz) or [Google tag gateway](/google-tag-gateway/). Enabling Binding Cookie alongside these products can cause an authentication redirect loop (`ERR_TOO_MANY_REDIRECTS`).
 - You have turned on [Device authentication identity](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/client-sessions/) for the application.
 
 ### Cookie Path Attribute


### PR DESCRIPTION
docs(cloudflare-one): note Google tag gateway incompatibility with Access Binding Cookie
### Summary

Updates the "When not to use Binding Cookie" section on the Access authorization cookie page to explicitly list [Google tag gateway](https://developers.cloudflare.com/google-tag-gateway/) alongside [Zaraz](https://developers.cloudflare.com/zaraz/) as incompatible with the Binding Cookie setting on self-hosted Access applications.
Enabling Binding Cookie on an Access application whose domain also has Google tag gateway (or Zaraz) enabled can cause an `ERR_TOO_MANY_REDIRECTS` authentication loop. Disabling the Binding Cookie on the Access application resolves the loop while keeping Google tag gateway functional.
### Screenshots (optional)


### Documentation checklist


- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
