### PR TITLE
CF1: Update Gateway dashboard link and add Zero Trust nav

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/application-app-types.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/application-app-types.mdx
@@ -126,7 +126,7 @@ To optimize performance for Microsoft 365 applications and services, you can byp
 
 To turn on the Microsoft 365 integration:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings** > **Policy settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings** > **Policy settings**.
 2. In **Bypass decryption of Microsoft 365 traffic**, select **Create policy**.
 3. To verify the policy was created, select **View policy**. Alternatively, go to **Traffic policies** > **HTTP policies**. A policy named Microsoft 365 Auto Generated will be enabled in your list.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/dns-policies/test-dns-filtering.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/dns-policies/test-dns-filtering.mdx
@@ -125,7 +125,7 @@ Once you have configured your Gateway policy to block the category, the test dom
 EDNS client subnet (ECS) is a DNS extension that sends a portion of the user's IP address to authoritative DNS nameservers, allowing them to return geographically optimal answers. Cloudflare sends the first `/24` of the user's IP address to preserve privacy while still providing location information. If you [enabled EDNS client subnet](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/) for your DNS location, you can validate it as follows:
 
 1. Obtain your DNS location's DoH (DNS over HTTPS) subdomain:
-   1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Networks** > **Resolvers & Proxies** > **DNS locations**.
+   1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Networks** > **Resolvers & Proxies** > **DNS locations**.
    2. Select the DNS location you are testing.
    3. Note the value of **DNS over HTTPS**.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/dns-policies/timed-policies.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/dns-policies/timed-policies.mdx
@@ -26,7 +26,7 @@ You can use a time-based policy duration to set a specific time frame for the po
 
 To set a duration for a DNS policy:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Firewall policies** > **DNS**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies** > **DNS**.
 2. Create a new DNS policy or choose an existing policy and select **Edit**.
 3. In **Apply durations and schedules**, turn on **Policy duration**.
 4. In **Input method**, choose the type of duration:
@@ -61,7 +61,7 @@ You can use Gateway to create a new DNS policy with a schedule or add a schedule
 <Tabs syncKey="dashPlusAPI">
 <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Firewall policies** > **DNS**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies** > **DNS**.
 2. Create a new DNS policy or choose an existing policy and select **Edit**.
 3. In **Apply durations and schedules**, turn on **Policy schedule**.
 4. (Optional) In **Time Zone**, choose a time zone to apply the policy based on the time zone you select, regardless of the user's location. By default, Gateway will use the end user's time zone to apply the policy based on the local time of the user making the DNS query.
@@ -91,7 +91,7 @@ To schedule a policy with the API, use the [Create a Zero Trust Gateway rule end
 </TabItem>
 </Tabs>
 
-The policy's schedule will appear in Cloudflare One under **Traffic policies** > **Firewall policies** > **DNS** when you select the policy.
+The policy's schedule will appear in the Cloudflare dashboard under **Zero Trust** > **Traffic policies** > **Firewall policies** > **DNS** when you select the policy.
 
 ### How Gateway determines time zone
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -28,7 +28,7 @@ You can request additional dedicated egress IPs at any time. Contact your accoun
 To start routing traffic through dedicated egress IPs:
 
 1. Contact your account team to obtain a dedicated egress IP.
-2. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Traffic settings**.
+2. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 3. Turn on **Allow Secure Web Gateway to proxy traffic**.
 4. Select **TCP**.
 5. (Optional) Select **UDP**. This will allow HTTP/3 traffic to egress with your dedicated IPs.

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/egress-cloudflared.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/egress-cloudflared.mdx
@@ -59,7 +59,7 @@ Requires `cloudflared` version 2025.7.0 or later.
 
 To route a public hostname through Cloudflare Tunnel:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Networks** > **Routes** > **Hostname routes**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Networks** > **Routes** > **Hostname routes**.
 
 2. Select **Create hostname route**.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/host-selectors.mdx
@@ -44,7 +44,7 @@ To turn on the selectors for your account:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. In **Policy settings**, turn on **Allow egress policy host selectors**.
 
 </TabItem> <TabItem label="API">

--- a/src/content/docs/cloudflare-one/traffic-policies/enable-ids.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/enable-ids.mdx
@@ -38,7 +38,7 @@ This feature is available for Cloudflare Advanced Network Firewall users. For ac
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In the [Cloudflare One](https://one.dash.cloudflare.com) dashboard, go to **Traffic policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies**.
 2. Select **Policy settings** and turn on **IDS**.
 
 </TabItem> <TabItem label="API">

--- a/src/content/docs/cloudflare-one/traffic-policies/get-started/dns.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/get-started/dns.mdx
@@ -73,7 +73,7 @@ A DNS policy has two parts: a **traffic condition** that defines which queries t
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 2. In the **DNS** tab, select **Add a policy**.
 3. Name the policy.
 4. Under **Traffic**, use the condition builder to define which DNS queries this policy applies to. Select a selector (such as **Security Categories**), an operator (such as **in**), and one or more values.

--- a/src/content/docs/cloudflare-one/traffic-policies/get-started/network.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/get-started/network.mdx
@@ -45,7 +45,7 @@ Verifying connectivity ensures that traffic from your device is actually flowing
 
 To verify your device is connected to Cloudflare One:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. Under **Log traffic activity**, enable activity logging for all Network logs. This tells Cloudflare to record network-level traffic so you can confirm your device appears in the logs.
 3. On your Cloudflare One Client device, open a browser and visit any website. This generates traffic that should appear in the logs.
 4. Determine the **Source IP** for your device (the public-facing address Cloudflare sees for your connection):
@@ -65,7 +65,7 @@ To verify your device is connected to Cloudflare One:
   </TabItem>
   </Tabs>
 
-5. In Cloudflare One, go to **Insights** > **Logs** > **Network logs**. Before building network policies, make sure you see network logs from the Source IP assigned to your device.
+5. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights** > **Logs** > **Network logs**. Before building network policies, make sure you see network logs from the Source IP assigned to your device.
 
 If no logs appear after a few minutes, check two things: first, verify that the [Gateway proxy is turned on](/cloudflare-one/traffic-policies/proxy/#turn-on-the-gateway-proxy). Second, confirm that the device is enrolled in your Zero Trust organization by checking the Cloudflare One Client connection status.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/antivirus-scanning.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/antivirus-scanning.mdx
@@ -18,7 +18,7 @@ In addition to AV scanning, Gateway can quarantine previously unseen files into 
 
 To turn on AV scanning:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. In **Policy settings**, turn on **Scan files for malware**.
 3. Choose whether to scan files for malicious payloads during uploads, downloads, or both. You can also block requests containing [non-scannable files](#non-scannable-files).
 4. (Optional) Turn on **Display AV block notification for Cloudflare One Client** to send [block notifications](#cloudflare-one-client-block-notifications) to users connected to Gateway with the Cloudflare One Client when AV inspection blocks a file.

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/file-sandboxing.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/file-sandboxing.mdx
@@ -52,7 +52,7 @@ flowchart TD
 
 To begin quarantining downloaded files, turn on file sandboxing:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. In **Policy settings**, turn on **Open previously unseen files in a sandbox environment**.
 3. (Optional) To block requests containing [non-scannable files](#non-scannable-files), select **Block requests for files that cannot be scanned**.
 
@@ -62,7 +62,7 @@ You can now create [Quarantine HTTP policies](/cloudflare-one/traffic-policies/h
 
 To test if file sandboxing is working, you can create a Quarantine policy that matches the [Cloudflare Sandbox Test](https://sandbox.cloudflaredemos.com/):
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies** > **HTTP**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Add the following expression:
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/granular-controls.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/granular-controls.mdx
@@ -37,7 +37,7 @@ To create a Gateway HTTP policy with Application Granular Controls:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies** > **HTTP**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Name the policy.
 4. Under **Traffic**, build a logical expression that defines the traffic you want to allow or block. Because granular controls are specific to each application, you must use the _Application_ selector with the _is_ operator.

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/http3.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/http3.mdx
@@ -23,7 +23,7 @@ Before you can inspect any HTTPS traffic, you must deploy a [user-side certifica
 
 To turn on the Gateway proxy for UDP and TLS decryption:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. In **Proxy and inspection**, turn on **Allow Secure Web Gateway to proxy traffic**.
 3. Select **TCP** and **UDP**.
 4. Turn on **TLS decryption**.

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/index.mdx
@@ -64,7 +64,7 @@ The **Untrusted certificate action** determines how to handle insecure requests.
 | Option       | Action                                                                                                                                                                                                                                               |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Error        | Display Gateway error page. Matches the default behavior when no action is configured.                                                                                                                                                               |
-| Block        | Display [block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) as set in Cloudflare One.                                                                                                                                 |
+| Block        | Display [block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) as set in the Cloudflare dashboard.                                                                                                                                 |
 | Pass through | Bypass insecure connection warnings and seamlessly connect to the upstream. For more information on what statuses are bypassed, refer to [Troubleshooting Gateway](/cloudflare-one/traffic-policies/troubleshooting/#error-526-invalid-ssl-certificate). |
 
 ### Block

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/tenant-control.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/tenant-control.mdx
@@ -18,7 +18,7 @@ Gateway implements tenant control by injecting custom HTTP headers into matching
 
 To create an HTTP policy with custom headers:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Firewall policies** > **HTTP**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies** > **HTTP**.
 2. Select **Add a policy**.
 3. Build an expression to match the SaaS traffic you want to control.
 4. In **Action**, select _Allow_. In **Untrusted certificate action**, select _Block_.

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/protocol-detection.mdx
@@ -20,7 +20,7 @@ Protocol detection only applies to devices connected to Cloudflare One via the C
 
 To turn on protocol detection:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings** > **Proxy and inspection settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings** > **Proxy and inspection settings**.
 2. Turn on **Allow protocol detection**.
 
 You can now use _Detected Protocol_ as a selector in a [Network policy](/cloudflare-one/traffic-policies/network-policies/#detected-protocol).

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/ssh-logging.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/ssh-logging.mdx
@@ -64,7 +64,7 @@ cat /etc/ssh/sshd_config
 
 ## 7. Create an Audit SSH policy
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 
 2. In the **Network** tab, select **Add a network policy**.
 
@@ -112,7 +112,7 @@ ssh-keygen -R <targetIP or hostname>
 
 ## View SSH Logs
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights** >**Logs** > **SSH command logs**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights** >**Logs** > **SSH command logs**.
 
 2. If you enabled the **SSH Command Logging** feature, you can **Download** a session's command log.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/packet-filtering/enable-managed-rulesets.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/packet-filtering/enable-managed-rulesets.mdx
@@ -140,7 +140,7 @@ https://api.cloudflare.com/client/v4/accounts/{account_id}/rulesets/{root_kind_r
 
 To delete a ruleset, refer to [Delete a rule in a ruleset](/ruleset-engine/rulesets-api/delete-rule/).
 
-## Cloudflare One dashboard
+## Cloudflare dashboard
 
 ### Enable rules
 

--- a/src/content/docs/cloudflare-one/traffic-policies/proxy.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/proxy.mdx
@@ -122,7 +122,7 @@ By default the [`cloudflared` Docker container](https://github.com/cloudflare/cl
 
 The Gateway proxy toggle only applies to traffic from Cloudflare One Client devices. Gateway will always proxy traffic sent with [PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/) or [Browser Isolation](/cloudflare-one/remote-browser-isolation/) regardless of this setting.
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. In **Proxy and inspection settings**, turn on **Allow Secure Web Gateway to proxy traffic**.
 3. Select **TCP**.
 4. (Optional) Depending on your use case, you can select **UDP** and/or **ICMP**.

--- a/src/content/docs/cloudflare-one/traffic-policies/tiered-policies/organizations.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/tiered-policies/organizations.mdx
@@ -112,7 +112,7 @@ You can create, configure, and share your tiered policies in the source account 
 
 To share a Gateway policy from a source account to a recipient account:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 2. Choose the policy type you want to share. If you want to share a resolver policy, go to **Traffic policies** > **Resolver policies**.
 3. Find the policy you want to share from the list. In the three-dot menu, select **Share**. Alternatively, to bulk share multiple policies, you can select each policy you want to share, then select **Actions** > **Share**.
 4. In **Select account**, choose the accounts you want to share the policy with. To share the policy with all existing and future recipient accounts in your Organization, choose _Select all accounts in org_.
@@ -130,7 +130,7 @@ If a policy fails to share to recipient accounts, Gateway will retry deploying t
 
 To change or remove recipients for a Gateway policy:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 2. Choose the policy type you want to edit. If you want to edit a resolver policy, go to **Traffic policies** > **Resolver policies**.
 3. Find the policy you want to edit from the list.
 4. In the three-dot menu, select **Edit shared configuration recipients**.
@@ -147,7 +147,7 @@ If you selected _Select all accounts in org_ when sharing the policy, you will n
 
 To stop sharing a policy with all recipient accounts:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 2. Choose the policy type you want to remove. If you want to remove a resolver policy, go to **Traffic policies** > **Resolver policies**.
 3. Find the policy you want to remove from the list. In the three-dot menu, select **Unshare**. Alternatively, to bulk remove multiple policies, you can select each policy you want to remove, then select **Actions** > **Unshare**.
 4. Select **Unshare**.
@@ -166,7 +166,7 @@ You can share certain Gateway settings - the Gateway block page and extended ema
 
 To share your [Gateway block page](/cloudflare-one/reusable-components/custom-pages/gateway-block-page/) settings from a source account to a recipient account:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Reusable components** > **Custom pages**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Reusable components** > **Custom pages**.
 2. In **Account Gateway block page**, select the three-dot menu and choose **Share**.
 3. In **Select account**, choose the accounts you want to share the settings with. To share the settings with all existing and future recipient accounts in your Organization, choose _Select all accounts in org_.
 4. Select **Continue**, then select **Share**.
@@ -179,7 +179,7 @@ To modify share recipients or unshare the setting, select the three-dot menu and
 
 To share your [extended email address matching](/cloudflare-one/traffic-policies/identity-selectors/#extended-email-addresses) settings from a source account to a recipient account:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. In **Firewall** > **Matched extended email address**, select the three-dot menu and choose **Share**.
 3. In **Select account**, choose the accounts you want to share the settings with. To share the settings with all existing and future recipient accounts in your Organization, choose _Select all accounts in org_.
 4. Select **Continue**, then select **Share**.

--- a/src/content/docs/cloudflare-one/traffic-policies/troubleshoot-gateway.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/troubleshoot-gateway.mdx
@@ -62,7 +62,7 @@ The most important concept is [Gateway policy precedence](/cloudflare-one/traffi
 
 To resolve Gateway policy precedence issues:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 2. Review the order of your DNS, Network, and HTTP policies.
 3. Ensure that your most specific Allow, Do Not Scan, or Do Not Inspect policies have a lower order number than your general Block policies.
 4. Drag and drop policies to reorder them as needed. An Allow policy for `teams.microsoft.com` should be placed before a general Block policy for all file sharing applications.

--- a/src/content/partials/cloudflare-one/gateway/add-block-page.mdx
+++ b/src/content/partials/cloudflare-one/gateway/add-block-page.mdx
@@ -6,7 +6,7 @@ params:
 
 import { Markdown } from "~/components";
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to <Markdown text={props.firewallPolicyPath} />.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > <Markdown text={props.firewallPolicyPath} />.
 2. Select **Add a policy** to create a new policy, or choose the policy you want to customize and select **Edit**. You can only edit the block page for policies with a Block action.
 3. Under **Configure policy settings**, {props.blockBehaviorAction} **Modify Gateway block behavior**.
 4. Choose your block behavior:

--- a/src/content/partials/cloudflare-one/gateway/add-locations.mdx
+++ b/src/content/partials/cloudflare-one/gateway/add-locations.mdx
@@ -12,7 +12,7 @@ The fastest way to start filtering DNS queries from a location is by changing th
 
 To add a DNS location to Gateway:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Networks** > **Resolvers & Proxies** > **DNS locations**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Networks** > **Resolvers & Proxies** > **DNS locations**.
 2. Select **Add a location**.
 3. Choose a name for your DNS location.
 4. Choose at least one [DNS endpoint](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/#dns-endpoints) to resolve your organization's DNS queries.

--- a/src/content/partials/cloudflare-one/gateway/create-resolver-policy.mdx
+++ b/src/content/partials/cloudflare-one/gateway/create-resolver-policy.mdx
@@ -12,7 +12,7 @@ To create a resolver policy:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Resolver policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Resolver policies**.
 2. Select **Add a policy**.
 3. Create an expression for your desired traffic. For example, you can resolve a hostname for an internal service:
 

--- a/src/content/partials/cloudflare-one/gateway/customize-block-page.mdx
+++ b/src/content/partials/cloudflare-one/gateway/customize-block-page.mdx
@@ -10,7 +10,7 @@ To customize your block page:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Reusable components** > **Custom pages**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Reusable components** > **Custom pages**.
 2. Under **Account Gateway block page**, select **Customize**.
 3. Choose **Custom Gateway block page**. Gateway will display a preview of your custom block page. Available customizations include:
    - Your organization's name

--- a/src/content/partials/cloudflare-one/gateway/debugging-policies.mdx
+++ b/src/content/partials/cloudflare-one/gateway/debugging-policies.mdx
@@ -3,6 +3,6 @@
 
 ---
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 2. Disable all DNS, Network, and HTTP policies and see if the issue persists. It may take up to two minutes for the change to take effect. Note that all policy enforcement happens on the Cloudflare global network, not on your local device.
 3. Slowly re-enable your policies. Once you have narrowed down the issue, modify the policies or their [order of enforcement](/cloudflare-one/traffic-policies/order-of-enforcement/).

--- a/src/content/partials/cloudflare-one/gateway/enable-tls-decryption.mdx
+++ b/src/content/partials/cloudflare-one/gateway/enable-tls-decryption.mdx
@@ -6,7 +6,7 @@ import { TabItem, Tabs } from "~/components";
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. In **Proxy and inspection**, turn on **Inspect HTTPS requests with TLS decryption**.
 
 </TabItem>

--- a/src/content/partials/cloudflare-one/gateway/get-started/create-http-policy.mdx
+++ b/src/content/partials/cloudflare-one/gateway/get-started/create-http-policy.mdx
@@ -8,7 +8,7 @@ To create a new HTTP policy:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 2. In the **HTTP** tab, select **Add a policy**.
 3. Name the policy.
 4. Under **Traffic**, build a logical expression that defines the traffic you want to allow or block.

--- a/src/content/partials/cloudflare-one/gateway/get-started/create-network-policy.mdx
+++ b/src/content/partials/cloudflare-one/gateway/get-started/create-network-policy.mdx
@@ -8,7 +8,7 @@ To create a new network policy:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Firewall policies**.
 2. In the **Network** tab, select **Add a network policy**.
 3. Name the policy.
 4. Under **Traffic**, build a logical expression that defines the traffic you want to allow or block.

--- a/src/content/partials/cloudflare-one/gateway/lists.mdx
+++ b/src/content/partials/cloudflare-one/gateway/lists.mdx
@@ -23,11 +23,11 @@ When you format a CSV file for upload:
 - Trailing whitespace characters are not allowed.
 - CRLF (Windows) and LF (Unix) line endings are valid.
 
-To upload the list to Cloudflare One:
+To upload the list to the Cloudflare dashboard:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Reusable components** > **Lists**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Reusable components** > **Lists**.
 2. Select **Upload CSV**.
 3. Next, specify a **List name**, enter an optional description, and choose a **List type**.
 4. Drag and drop a file into the **CSV file** window, or select a file.
@@ -68,7 +68,7 @@ You can now use this list in the policy builder by choosing the _in list_ operat
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Reusable components** > **Lists**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Reusable components** > **Lists**.
 2. Select **Create manual list**.
 3. Next, specify a **List name**, enter an optional description, and choose a **List type**.
 4. Enter your list element manually into the **Add entry** field and select **Add**.

--- a/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
+++ b/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
@@ -94,7 +94,7 @@ Cloudflare Network Firewall is available to Enterprise users only.
 
 To block TCP SYN packets to a specific destination:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Firewall policies** > **Custom policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Firewall policies** > **Custom policies**.
 2. Select **Add a policy**.
 3. Create a rule with the destination IP address or CIDR range you want to block. For example, to block all traffic to `10.0.0.0/8`, use the expression `ip.dst in {10.0.0.0/8}` with a **Block** action.
 4. Select **Add new policy**.
@@ -174,9 +174,9 @@ Order of precedence refers to the priority of individual policies within the DNS
 
 The order of precedence follows the first match principle. Once traffic matches an Allow or Block policy, evaluation stops and no subsequent policies can override the decision. Therefore, Cloudflare recommends assigning the most specific policies and exceptions with the highest precedence and the most general policies with the lowest precedence.
 
-#### Cloudflare One
+#### Cloudflare dashboard
 
-In Cloudflare One, policies are in order of precedence from top to bottom of the list. Policies begin with precedence `1` and count upward. You can modify the order of precedence by dragging and dropping individual policies in the dashboard.
+In the Cloudflare dashboard, policies are in order of precedence from top to bottom of the list. Policies begin with precedence `1` and count upward. You can modify the order of precedence by dragging and dropping individual policies in the dashboard.
 
 #### Cloudflare API
 
@@ -239,11 +239,11 @@ Therefore, the user is able to connect to `https://test.example.com`.
 
 ## Precedence calculations
 
-When arranging policies in [Cloudflare One](https://one.dash.cloudflare.com/), Gateway automatically calculates the precedence for rearranged policies.
+When arranging policies in the [Cloudflare dashboard](https://dash.cloudflare.com/), Gateway automatically calculates the precedence for rearranged policies.
 
 When using the API to create a policy, unless the precedence is explicitly defined in the policy, Gateway will assign precedence to policies starting at `1000`. Every time a new policy is added to the bottom of the order, Gateway will calculate the current highest precedence in the account and add a random integer between 1 and 100 to `1000` so that it now claims the maximum precedence in the account. To manually update a policy's precedence, use the [Update a Zero Trust Gateway rule](/api/resources/zero_trust/subresources/gateway/subresources/rules/methods/update/) endpoint. You can set a policy's precedence to any value that is not already in use.
 
-Changing the order within Cloudflare One or API may result in configuration issues when using [Terraform](#manage-precedence-with-terraform).
+Changing the order within the Cloudflare dashboard or API may result in configuration issues when using [Terraform](#manage-precedence-with-terraform).
 
 ## Manage precedence with Terraform
 
@@ -269,4 +269,4 @@ resource "cloudflare_zero_trust_gateway_policy" "policy_3" {
 }
 ```
 
-To avoid precedence calculation errors when reordering policies with Terraform, you should move one policy at a time before running `terraform plan` and `terraform apply`. If you use both Terraform and Cloudflare One or API, sync your polices with `terraform refresh` before reordering policies in Terraform. Alternatively, you can set your account to [read-only in Cloudflare One](/cloudflare-one/api-terraform/#set-dashboard-to-read-only), only allowing changes using the API or Terraform.
+To avoid precedence calculation errors when reordering policies with Terraform, you should move one policy at a time before running `terraform plan` and `terraform apply`. If you use both Terraform and the Cloudflare dashboard or API, sync your polices with `terraform refresh` before reordering policies in Terraform. Alternatively, you can set your account to [read-only in the Cloudflare dashboard](/cloudflare-one/api-terraform/#set-dashboard-to-read-only), only allowing changes using the API or Terraform.

--- a/src/content/partials/cloudflare-one/gateway/verify-connectivity.mdx
+++ b/src/content/partials/cloudflare-one/gateway/verify-connectivity.mdx
@@ -4,8 +4,8 @@ inputParameters: GatewayLogType;;trafficTypePlural
 
 import { Markdown } from "~/components";
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. Under **Log traffic activity**, enable activity logging for all {props.one} logs.
 3. On your device, open a browser and go to any website.
-4. In Cloudflare One, go to **Insights** > **Logs** > **{props.one}**.
+4. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights** > **Logs** > **{props.one}**.
 5. Make sure {props.one} {props.two} from your device appear.

--- a/src/content/partials/cloudflare-one/ssh/ssh-proxy-ca.mdx
+++ b/src/content/partials/cloudflare-one/ssh/ssh-proxy-ca.mdx
@@ -7,7 +7,7 @@ import { Render, Details, APIRequest, Tabs, TabItem } from "~/components";
 <Tabs>
 <TabItem label="Dashboard">
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Access controls** > **Service credentials** > **SSH**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **Service credentials** > **SSH**.
 
 2. Select **Add a certificate**.
 

--- a/src/content/partials/cloudflare-one/ssh/upload-ssh-key.mdx
+++ b/src/content/partials/cloudflare-one/ssh/upload-ssh-key.mdx
@@ -22,7 +22,7 @@ To log SSH commands, you will need to generate an HPKE key pair and upload the p
 
    This command outputs two files, an `sshkey.pub` public key and a matching `sshkey` private key.
 
-3. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** > **Traffic settings**.
+3. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 
 4. In **SSH log encryption public key**, paste the contents of `sshkey.pub` and select **Save**. <Markdown text={props.note} />
 

--- a/src/content/partials/cloudflare-one/troubleshooting/gateway.mdx
+++ b/src/content/partials/cloudflare-one/troubleshooting/gateway.mdx
@@ -72,7 +72,7 @@ The most important concept is [Gateway policy precedence](/cloudflare-one/traffi
 
 To resolve Gateway policy precedence issues:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Traffic policies** &gt; **Firewall policies**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** &gt; **Firewall policies**.
 2. Review the order of your DNS, Network, and HTTP policies.
 3. Ensure that your most specific Allow, Do Not Scan, or Do Not Inspect policies have a lower order number than your general Block policies.
 4. Drag and drop policies to reorder them as needed. An Allow policy for `teams.microsoft.com` should be placed before a general Block policy for all file sharing applications.

--- a/src/content/partials/cloudflare-one/troubleshooting/warp-client.mdx
+++ b/src/content/partials/cloudflare-one/troubleshooting/warp-client.mdx
@@ -11,7 +11,7 @@ import {
 This guide helps you diagnose and resolve common issues with the Cloudflare One Client (formerly WARP). It covers how to troubleshoot the Cloudflare One Client on desktop operating systems, including Windows, macOS, and Linux.
 
 1. **Before you start**: [Prerequisites](#prerequisites), permissions, [version control](#check-your-client-version), and client basics.
-2. **Collect logs**: Through [Cloudflare One](#option-a-collect-logs-via-the-cloudflare-dashboard) (with DEX remote capture) or the [command-line interface](#option-b-collect-logs-via-the-cli) (CLI) (`warp-diag`).
+2. **Collect logs**: Through the [Cloudflare dashboard](#option-a-collect-logs-via-the-cloudflare-dashboard) (with DEX remote capture) or the [command-line interface](#option-b-collect-logs-via-the-cli) (CLI) (`warp-diag`).
 3. **Review logs**: [Status](#check-client-status), [settings](#check-client-settings), [profile ID](#profile-id), [split tunnel](#exclude-mode-with-hostsips) configuration, and other settings.
 4. **Fix common misconfigurations**: [Profile mismatch](#wrong-profile-id), [split tunnel issues](#wrong-split-tunnel-configuration), [managed network issues](#review-your-managed-network-settings), [user group mismatch](#check-a-users-group-membership).
 5. **File a support ticket**: [How to file a ticket](#5-file-a-support-ticket) after you have exhausted your troubleshooting options.
@@ -61,9 +61,9 @@ After updating the Cloudflare One Client, monitor the issue to see if it recurs.
 </TabItem>
 </Tabs>
 
-#### Via the Cloudflare One dashboard
+#### Via the Cloudflare dashboard
 
-1. Log into [Cloudflare One](https://one.dash.cloudflare.com/) &gt; go to **Team & Resources** &gt; **Devices** &gt; **Your devices**.
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and go to **Zero Trust** &gt; **Team & Resources** &gt; **Devices** &gt; **Your devices**.
 2. Select the device you want to investigate.
 3. Find the device's client version under **Client version** in the side menu.
 4. Compare your device's version with the [latest version of the Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/).
@@ -107,7 +107,7 @@ You can collect diagnostic logs in two ways: the [Cloudflare dashboard](#option-
 
 ### Option A: Collect logs via the Cloudflare dashboard
 
-Collect client diagnostic logs remotely from the Cloudflare One dashboard by using Digital Experience Monitoring's (DEX) remote captures.
+Collect client diagnostic logs remotely from the Cloudflare dashboard by using Digital Experience Monitoring's (DEX) remote captures.
 
 :::tip[Best practice]
 
@@ -350,17 +350,17 @@ To verify that the Cloudflare One Client is configured and working properly, rev
 
 ### Wrong profile ID
 
-A profile ID is a unique identifier assigned to each [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) in the Cloudflare One dashboard, used to determine which configuration settings apply to a device.
+A profile ID is a unique identifier assigned to each [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) in the Cloudflare dashboard, used to determine which configuration settings apply to a device.
 
 #### Check the applied device profile
 
 To check that the applied device profile is the intended device profile:
 
-1. Go to [Cloudflare One](https://one.dash.cloudflare.com/) &gt; **Team & Resources** &gt; **Devices** &gt; **Device profiles** &gt; **General profiles**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** &gt; **Team & Resources** &gt; **Devices** &gt; **Device profiles** &gt; **General profiles**.
 2. Find and select the device profile intended for the device.
 3. Under **Profile details**, compare the displayed **Profile ID** with the `Profile ID` in the `warp-settings.txt` file.
 
-If your organization has multiple device profiles defined in the Cloudflare One dashboard, a device may be matched to an unexpected profile because:
+If your organization has multiple device profiles defined in the Cloudflare dashboard, a device may be matched to an unexpected profile because:
 
 - How [profile precedence](#review-profile-precedence) is configured.
 - [Managed network](#review-your-managed-network-settings) issues (if you are using a managed network.)
@@ -395,7 +395,7 @@ When troubleshooting the Cloudflare One Client for managed network issues:
    If the endpoint is down, you will receive a `Could not find certificate from <stdin>` response.
 
    If you received a returned SHA-256 fingerprint:
-   1. Log into [Cloudflare One](https://one.dash.cloudflare.com/), and go to **Team & Resources** &gt; **Devices** &gt; **Device profiles**.
+   1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and go to **Zero Trust** &gt; **Team & Resources** &gt; **Devices** &gt; **Device profiles**.
    2. Go to **Managed networks** &gt; **Edit**.
    3. Compare the TLS Cert SHA-256 in the dashboard with the returned fingerprint in your terminal to ensure they match.
 
@@ -409,7 +409,7 @@ If a user is having issues with a device profile, it may be because they are not
 
 To check that the user belongs to the intended group:
 
-1. Log into [Cloudflare One](https://one.dash.cloudflare.com/) &gt; go to **Team & Resources** &gt; **Devices** &gt; **Your devices**.
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and go to **Zero Trust** &gt; **Team & Resources** &gt; **Devices** &gt; **Your devices**.
 2. Select the user.
 3. Under **User Registry Identity**, select the user's name.
 4. The **Get-identity endpoint** lists all the groups the user belongs to.
@@ -450,11 +450,11 @@ After downloading the client diagnostic logs, review that your configuration is 
    `Include mode` means only traffic destined to the IPs or domains you specify will be sent through the WARP tunnel.
    :::
 
-2. Log into [Cloudflare One](https://one.dash.cloudflare.com/), go to **Team & Resources** &gt; **Devices** &gt; **Device profiles** &gt; **General profiles**.
+2. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and go to **Zero Trust** &gt; **Team & Resources** &gt; **Devices** &gt; **Device profiles** &gt; **General profiles**.
 3. Find and select the device profile intended for the device.
 4. Select **Edit**.
 5. Find **Split Tunnels** and note the mode you have selected &gt; select **Manage**.
-6. Cross-reference the IPs/hosts you have configured in the Cloudflare One dashboard with the IPs/hosts listed in `warp-settings.txt`.
+6. Cross-reference the IPs/hosts you have configured in the Cloudflare dashboard with the IPs/hosts listed in `warp-settings.txt`.
 
 If your dashboard split tunnel configuration does not match your `warp-settings.txt` file configuration, you may need to force the Cloudflare One Client to [update its settings](#update-the-cloudflare-one-clients-settings).
 


### PR DESCRIPTION
## Summary

Updates Cloudflare One Gateway/traffic-policies docs to use the new dashboard URL (`dash.cloudflare.com`) and adds **Zero Trust** to navigation instructions so users can reach the CF1 dashboard from the unified Cloudflare dashboard.

Ref: [PCX-21544](https://jira.cfdata.org/browse/PCX-21544)

### What changed

- **Dashboard link**: Replaced `one.dash.cloudflare.com` with `dash.cloudflare.com` across 21 doc pages and 15 partials (36 files total)
- **Navigation instructions**: Added **Zero Trust** > to nav paths (e.g., "go to **Zero Trust** > **Traffic policies** > **Firewall policies**")
- **Dashboard name**: Changed "Cloudflare One" dashboard references to "Cloudflare dashboard" where referring to the UI
- **Style fix**: Corrected "Log into" to "Log in to" per style guide

### What was NOT changed

- `global-policies.mdx` — references to `one.dash.cloudflare.com` in that file are domain names used in policy rule examples, not dashboard links
- "Cloudflare One Client" references — these refer to the client app, not the dashboard
- Product-name references to "Cloudflare One" (the service/product) — only dashboard UI references were updated