### PR TITLE
[Workers] Add a guide for sharing local dev server

### DIFF
--- a/src/content/docs/workers/development-testing/local-dev-tunnels.mdx
+++ b/src/content/docs/workers/development-testing/local-dev-tunnels.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: navigation
 title: Share a local dev server
 sidebar:
-  order: 2
+  order: 6
 head: []
 description: Expose a local Wrangler or Vite dev server over a public tunnel URL.
 ---
@@ -70,4 +70,3 @@ Anyone with the tunnel URL can reach your dev server, so review what your app ex
 ## Related docs
 
 - [Cloudflare Tunnel](/tunnel/)
-- [Quick Tunnels](/tunnel/setup/#quick-tunnels-development)

--- a/src/content/docs/workers/development-testing/local-dev-tunnels.mdx
+++ b/src/content/docs/workers/development-testing/local-dev-tunnels.mdx
@@ -1,0 +1,73 @@
+---
+pcx_content_type: navigation
+title: Share a local dev server
+sidebar:
+  order: 2
+head: []
+description: Expose a local Wrangler or Vite dev server over a public tunnel URL.
+---
+
+import { PackageManagers, TypeScriptExample } from "~/components";
+
+You can expose your local dev server over a [Cloudflare Quick Tunnel](/tunnel/setup/#quick-tunnels-development) when you need to share a preview, test a webhook, or access your app from another device. This provides a random `*.trycloudflare.com` hostname for the current dev session.
+
+This page covers tunnel support in [Wrangler](/workers/wrangler/commands/general/#dev) and the [Cloudflare Vite plugin](/workers/vite-plugin/).
+
+## Start a tunnel
+
+**Wrangler**
+
+Run `wrangler dev --tunnel`:
+
+<PackageManagers type="exec" pkg="wrangler" args="dev --tunnel" />
+
+Wrangler will print the public tunnel URL for the current dev session.
+
+**Cloudflare Vite plugin**
+
+Enable `tunnel` conditionally in the plugin config:
+
+<TypeScriptExample filename="vite.config.ts">
+```ts
+import { defineConfig } from "vite";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+	plugins: [
+		cloudflare({
+			tunnel: process.env.ENABLE_DEV_TUNNEL === "true",
+		}),
+	],
+});
+```
+</TypeScriptExample>
+
+Then enable the tunnel only for the sessions where you want a public URL:
+
+```sh
+ENABLE_DEV_TUNNEL=true vite dev # or "vite preview"
+```
+
+Once the tunnel opens:
+
+- The public tunnel URL is printed in the terminal for the current dev session.
+- The session expires after 1 hour by default.
+- A reminder is logged every 10 minutes while the tunnel is open.
+- You can extend the tunnel by 1 hour at a time, either by pressing `t` for Wrangler or `t + Enter` for Vite.
+- The tunnel can be extended up to 3 hours of remaining time.
+
+## Security considerations
+
+Anyone with the tunnel URL can reach your dev server, so review what your app exposes before enabling a tunnel.
+
+- Pay special attention to ungated preview or admin endpoints.
+- Review any [remote bindings](/workers/development-testing/#remote-bindings) connected to real resources.
+- Review any code that proxies requests to private or internal services.
+- If you are using the Cloudflare Vite plugin with `vite dev`, HMR and module serving may expose source files, file paths, or project structure over the tunnel. If you only need to share a built preview, prefer `vite preview` for public sharing.
+- Local dev-related routes, such as `/cdn-cgi/*`, remain restricted and are not exposed over the tunnel.
+- If you need a stable hostname or stricter access control, use a named tunnel protected by Cloudflare Access.
+
+## Related docs
+
+- [Cloudflare Tunnel](/tunnel/)
+- [Quick Tunnels](/tunnel/setup/#quick-tunnels-development)

--- a/src/content/docs/workers/vite-plugin/reference/api.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/api.mdx
@@ -67,6 +67,12 @@ It accepts an optional `PluginConfig` parameter.
 
   See [Debugging](/workers/vite-plugin/reference/debugging/) for more information.
 
+- `tunnel` <Type text='boolean' /> <MetaInfo text='optional' />
+
+  Open a publicly reachable Cloudflare Quick Tunnel for sharing a preview, testing webhooks, or accessing the app from another device.
+
+  See [Share a local dev server](/workers/development-testing/local-dev-tunnels/) for more information.
+
 - `auxiliaryWorkers` <Type text='Array<AuxiliaryWorkerConfig>' /> <MetaInfo text='optional' />
 
   An optional array of auxiliary Workers.

--- a/src/content/docs/workers/wrangler/commands/workers.mdx
+++ b/src/content/docs/workers/wrangler/commands/workers.mdx
@@ -119,6 +119,9 @@ None of the options for this command are required. Many of these options can be 
   - Specify directory to use for local persistence.
 - `--remote` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
   - Develop against remote resources and data stored on Cloudflare's network.
+- `--tunnel` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
+  - Open a publicly reachable Cloudflare Quick Tunnel for sharing a preview, testing webhooks, or accessing the app from another device.
+  - For more information, refer to [Share a local dev server](/workers/development-testing/local-dev-tunnels/).
 - `--test-scheduled` <Type text="boolean" /> <MetaInfo text="(default: false) optional" />
   - Exposes a `/__scheduled` fetch route which will trigger a scheduled event (Cron Trigger) for testing during development. To simulate different cron patterns, a `cron` query parameter can be passed in: `/__scheduled?cron=*+*+*+*+*` or `/cdn-cgi/handler/scheduled?cron=*+*+*+*+*`.
 - `--log-level` <Type text="'debug'|'info'|'log'|'warn'|'error|'none'" /> <MetaInfo text="(default: log) optional" />


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
