### PR TITLE
docs(containers): update vite dev to support Cloudflare Registry images

### DIFF
--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -19,13 +19,11 @@ the `image` attribute to a local path, the image will be built using the local D
 If the `image` attribute is set to an image reference, the image will be pulled from the referenced registry, such as the Cloudflare Registry, Docker Hub, or Amazon ECR.
 
 :::note
-With `wrangler dev`, image references from the Cloudflare Registry, Docker Hub, and Amazon ECR are supported in local development.
+With both `wrangler dev` and `vite dev`, image references from the Cloudflare Registry, Docker Hub, and Amazon ECR are supported in local development.
 
-With `vite dev`, image references from external registries such as Docker Hub and Amazon ECR are supported, but `vite dev` cannot pull directly from the Cloudflare Registry.
+If you use a Cloudflare Registry image with `vite dev`, set the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` environment variables. The API token requires **Containers:Edit** and **Workers Scripts:Edit** permissions.
 
 If you use a private Docker Hub or ECR image with `vite dev`, authenticate to that registry locally, for example with `docker login`.
-
-As a workaround for Cloudflare Registry images, point `vite dev` at a local Dockerfile that uses `FROM <IMAGE_REFERENCE>`. Docker then pulls the base image during the local build. Make sure to `EXPOSE` a port for local dev as well.
 :::
 
 Container instances will be launched locally when your Worker code calls to create

--- a/src/content/docs/containers/platform-details/image-management.mdx
+++ b/src/content/docs/containers/platform-details/image-management.mdx
@@ -233,9 +233,9 @@ This will output an image registry URI that you can then use in your Wrangler co
 </WranglerConfig>
 
 :::note
-With `wrangler dev`, image references from the Cloudflare Registry, Docker Hub, and Amazon ECR are supported in local development.
+With both `wrangler dev` and `vite dev`, image references from the Cloudflare Registry, Docker Hub, and Amazon ECR are supported in local development.
 
-With `vite dev`, image references from external registries such as Docker Hub and Amazon ECR are supported, but `vite dev` cannot pull directly from the Cloudflare Registry.
+If you use a Cloudflare Registry image with `vite dev`, set the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` environment variables. The API token requires **Containers:Edit** and **Workers Scripts:Edit** permissions.
 
 If you use a private Docker Hub or ECR image with `vite dev`, authenticate to that registry locally, for example with `docker login`.
 :::


### PR DESCRIPTION
## Summary

- Remove the `vite dev` limitation note stating it cannot pull from the Cloudflare Registry
- Remove the associated workaround (using a local Dockerfile with `FROM <IMAGE_REFERENCE>`)
- Add a note that `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are required when using Cloudflare Registry images with `vite dev`, with **Containers:Edit** and **Workers Scripts:Edit** permissions

Relates to cloudflare/workers-sdk#13611, which adds Cloudflare Registry support to `vite dev`.

## Pages updated

- `containers/local-dev`
- `containers/platform-details/image-management`