### PR TITLE
CF1: ELI5 on Insights root pages (analytics-overview, index)

### DIFF
--- a/src/content/docs/cloudflare-one/insights/analytics-overview.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics-overview.mdx
@@ -14,7 +14,7 @@ import { Render } from "~/components";
 
 The Cloudflare One Analytics overview provides a dashboard that reports on how Cloudflare One is protecting your organization and networks. Use this page to monitor usage and potential security concerns within your organization.
 
-To view the Analytics overview, log into [Cloudflare One](https://one.dash.cloudflare.com) and go to **Overview**.
+To view the Analytics overview, log in to [Cloudflare One](https://one.dash.cloudflare.com) and go to **Overview**.
 
 The Analytics overview includes reports and insights across the following products and categories:
 
@@ -37,9 +37,9 @@ In **Global status**, you can view a report on your organization's Cloudflare On
 - Gateway network policies
 - Gateway DNS policies
 - SaaS integrations
-- DLP profiles
+- Data Loss Prevention (DLP) profiles
 
-You can also view a report on your [seat usage](/cloudflare-one/team-and-resources/users/seat-management/) across your Zero Trust Organization that contains the following metrics:
+You can also view a report on your [seat usage](/cloudflare-one/team-and-resources/users/seat-management/) across your Zero Trust Organization that contains the following metrics. A seat is a billable unit consumed when a user authenticates to your Zero Trust organization.
 
 - Total seats
 - Used seats
@@ -47,14 +47,14 @@ You can also view a report on your [seat usage](/cloudflare-one/team-and-resourc
 
 ## Access
 
-In **Access**, you can view a report on your Access configuration that contains:
+In **Access**, you can view a report on your [Cloudflare Access](/cloudflare-one/access-controls/) configuration that contains:
 
 **Metrics:**
 
 - Total access attempts
 - Granted access
 - Denied (policy violation)
-- Active logins overtime
+- Active logins over time
 - Top applications with most logins
 
 **Filters:**
@@ -65,14 +65,14 @@ In **Access**, you can view a report on your Access configuration that contains:
 
 ### Proxy traffic
 
-In **Proxy traffic**, you can view a report on your Gateway HTTP traffic that contains:
+In **Proxy traffic**, you can view a report on your [Cloudflare Gateway](/cloudflare-one/traffic-policies/) HTTP traffic that contains:
 
 **Metrics:**
 
-- Total requests overtime
+- Total requests over time
 - Allowed requests
 - Blocked requests
-- Isolated requests
+- Isolated requests (served through [Browser Isolation](/cloudflare-one/remote-browser-isolation/))
 - Do not inspect requests
 - Top bandwidth consumers (GB)
 - Top denied users
@@ -130,7 +130,7 @@ In **Gateway insights**, you can view a report on your Gateway firewall policies
 
 ### CASB metrics
 
-In **CASB**, you can review instances of security issues found in your SaaS integrations.
+In **CASB**, you can review instances of security issues — such as misconfigurations, unauthorized user activity, and shadow IT — found in your SaaS integrations by [Cloudflare CASB](/cloudflare-one/cloud-and-saas-findings/).
 
 - Integrations by number of findings
-- DLP findings by profile name
+- [DLP](/cloudflare-one/data-loss-prevention/) findings by profile name

--- a/src/content/docs/cloudflare-one/insights/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/index.mdx
@@ -14,16 +14,16 @@ Cloudflare One offers observability tools to monitor and troubleshoot your envir
 
 - [Analytics Overview](/cloudflare-one/insights/analytics-overview/) to monitor overall Cloudflare One usage.
 - [Analytics Dashboards](/cloudflare-one/insights/analytics/) to review organizational traffic trends and policy insights.
-- [Logs](/cloudflare-one/insights/logs/) for event-level investigation.  
+- [Logs](/cloudflare-one/insights/logs/) for event-level investigation.
 - [Digital Experience Monitoring (DEX)](/cloudflare-one/insights/dex/) for device, network, and application performance.
 
 ## Troubleshooting workflow example
 
 A user reports they cannot reach an internal application behind [Cloudflare Access](/cloudflare-one/). To address the issue:
 
-1. The admin checks the [Access Event Analytics dashboard](/cloudflare-one/insights/analytics-overview/) to review if other users are experiencing similar issues.
-2. The admin then reviews [Logs](/cloudflare-one/insights/logs/) to examine the user's authentication attempts and blocked requests.
-3. Finally, the admin uses [DEX](/cloudflare-one/insights/dex/) to evaluate the user's device health and network performance.
+1. Check the [Analytics overview dashboard](/cloudflare-one/insights/analytics-overview/) to review if other users are experiencing similar issues.
+2. Review [Logs](/cloudflare-one/insights/logs/) to examine the user's authentication attempts and blocked requests.
+3. Use [DEX](/cloudflare-one/insights/dex/) to evaluate the user's device health and network performance.
 
 ## How to use these tools together
 
@@ -31,32 +31,32 @@ A user reports they cannot reach an internal application behind [Cloudflare Acce
 
 After onboarding your devices and users, use these tools to confirm everything is set up correctly and to monitor your organization's activity.
 
-  1. Start with [Logs](/cloudflare-one/insights/logs/) to validate initial configuration and confirm that authentication is successful.
-  2. Use [Analytics Overview](/cloudflare-one/insights/analytics-overview/) to confirm expected patterns and policy activity.
+1. Start with [Logs](/cloudflare-one/insights/logs/) to validate initial configuration and confirm that authentication is successful.
+2. Use [Analytics Overview](/cloudflare-one/insights/analytics-overview/) to confirm expected patterns and policy activity.
 
 If your device is experiencing connectivity issues, Cloudflare recommends starting with [troubleshooting WARP](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/troubleshooting-guide/) as WARP misconfiguration is the most common cause of connectivity issues.
 
 ### Daily monitoring
 
-  1. Use [Analytics Dashboards](/cloudflare-one/insights/analytics/) to understand trends and for visualizations of your log data.
+1. Use [Analytics Dashboards](/cloudflare-one/insights/analytics/) to understand trends and for visualizations of your log data.
 
-      Administrators typically start with Analytics Dashboards because they offer:
+    Administrators typically start with Analytics Dashboards because they offer:
 
-      - A high-level view of activity across your products, like Access, or security use cases, such as AI and shadow IT.  
-      - Visibility into trends, provided through time-series graphs, to track the evolution of key metrics (such as [DNS queries](/cloudflare-one/insights/analytics/gateway/#dns-query-analytics), [network sessions](/cloudflare-one/insights/analytics/gateway/#network-session-analytics), [HTTP requests](/cloudflare-one/insights/analytics/gateway/#http-request-analytics), and [CASB posture/content findings](/cloudflare-one/insights/analytics/data-analytics/)) over time.
+    - A high-level view of activity across your products, like Access, or security use cases, such as AI and shadow IT.
+    - Visibility into trends, provided through time-series graphs, to track the evolution of key metrics (such as [DNS queries](/cloudflare-one/insights/analytics/gateway/#dns-query-analytics), [network sessions](/cloudflare-one/insights/analytics/gateway/#network-session-analytics), [HTTP requests](/cloudflare-one/insights/analytics/gateway/#http-request-analytics), and [CASB posture/content findings](/cloudflare-one/insights/analytics/data-analytics/)) over time.
 
-  2. Use [Logs](/cloudflare-one/insights/logs/) as needed for event-level verification.
+2. Use [Logs](/cloudflare-one/insights/logs/) as needed for event-level verification.
 
-      Use Logs when you need to:
+    Use Logs when you need to:
 
-      - Investigate a specific event; for example, a user's [failed authentication attempt](/cloudflare-one/insights/logs/dashboard-logs/access-authentication-logs/) when trying to log into an application.
-      - Validate identity or device details; for example, confirming which user made the request, how they authenticated, and whether their device met required [posture conditions](/cloudflare-one/insights/logs/dashboard-logs/posture-logs/).
-      - Confirm policy matches; for example, verifying which [specific rule](/cloudflare-one/access-controls/policies/#rule-types) allowed, blocked, or challenged a user's request and why it was applied.
+    - Investigate a specific event; for example, a user's [failed authentication attempt](/cloudflare-one/insights/logs/dashboard-logs/access-authentication-logs/) when trying to log in to an application.
+    - Validate identity or device details; for example, confirming which user made the request, how they authenticated, and whether their device met required [posture conditions](/cloudflare-one/insights/logs/dashboard-logs/posture-logs/).
+    - Confirm policy matches; for example, verifying which [specific rule](/cloudflare-one/access-controls/policies/#rule-types) allowed, blocked, or challenged a user's request and why it was applied.
 
 ### User-reported issues
 
 Users may report problems like slow or failing connections to internal apps.
 
-  1. Start with [Analytics Dashboards](/cloudflare-one/insights/analytics/) to review whether the issue impacts others.  
-  2. Check [Logs](/cloudflare-one/insights/logs/) for failed authentication attempts, blocked requests, or unexpected policy matches.
-  3. Use [DEX](/cloudflare-one/insights/dex/) to diagnose device- or network-level causes with [synthetic tests](/cloudflare-one/insights/dex/tests/) and [device monitoring](/cloudflare-one/insights/dex/monitoring/).
+1. Start with [Analytics Dashboards](/cloudflare-one/insights/analytics/) to review whether the issue impacts others.
+2. Check [Logs](/cloudflare-one/insights/logs/) for failed authentication attempts, blocked requests, or unexpected policy matches.
+3. Use [DEX](/cloudflare-one/insights/dex/) to diagnose device- or network-level causes with [synthetic tests](/cloudflare-one/insights/dex/tests/) and [device monitoring](/cloudflare-one/insights/dex/monitoring/).


### PR DESCRIPTION
## Summary

ELI5 pass on two Cloudflare One Insights root pages following the repo-scoped ELI5 skill workflow (9-step process including adversarial review).

### `analytics-overview.mdx`
- Expanded DLP acronym on first use
- Added inline seat definition sourced from `device-registration.mdx`
- Added cross-links to Cloudflare Access (`/cloudflare-one/access-controls/`), Gateway (`/cloudflare-one/traffic-policies/`), Browser Isolation (`/cloudflare-one/remote-browser-isolation/`), CASB (`/cloudflare-one/cloud-and-saas-findings/`), and DLP (`/cloudflare-one/data-loss-prevention/`)
- Expanded CASB "security issues" with specific examples from CASB docs (misconfigurations, unauthorized user activity, shadow IT)
- Fixed "log into" → "log in to" and "overtime" → "over time" typos

### `index.mdx`
- Converted third-person "The admin checks..." to second-person imperative per style guide
- Fixed link text "Access Event Analytics dashboard" → "Analytics overview dashboard" to match the linked page title
- Normalized inconsistent numbered list indentation
- Fixed "log into" → "log in to"
- Removed trailing whitespace

### Adversarial review corrections
Three issues caught and fixed before applying changes:
1. Seat definition reworded from "represents a user" to "billable unit consumed by a user" (sourced)
2. CASB examples replaced with terms from actual CASB docs instead of glossary-level descriptions
3. Access link target changed from `/cloudflare-one/` to `/cloudflare-one/access-controls/` (matches 13/14 repo usages)