### PR TITLE
[Email Sending] Document 5 MiB total message size limit

### DIFF
--- a/src/content/docs/email-service/api/send-emails/rest-api.mdx
+++ b/src/content/docs/email-service/api/send-emails/rest-api.mdx
@@ -86,7 +86,7 @@ curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/email/sending/s
 
 ## Attachments
 
-Send files by including base64-encoded content in the `attachments` array:
+Send files by including base64-encoded content in the `attachments` array. The total message size must not exceed **5 MiB** (including attachments).
 
 ```bash
 curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/email/sending/send" \

--- a/src/content/docs/email-service/platform/limits.mdx
+++ b/src/content/docs/email-service/platform/limits.mdx
@@ -25,12 +25,13 @@ Accounts on a paid plan can send emails to any recipient, subject to daily sendi
 
 ## Email content limits
 
-| Component                    | Limit          | Notes                                |
-| ---------------------------- | -------------- | ------------------------------------ |
-| **Recipients (to, cc, bcc)** | 50 per email   | Combined across all recipient fields |
-| **Subject line**             | 998 characters | RFC 5322 compliant                   |
-| **Total message size**       | 25 MiB         | Including attachments                |
-| **Header size**              | 16 KB          | All custom headers combined          |
+| Component                    | Limit          | Notes                                                                                |
+| ---------------------------- | -------------- | ------------------------------------------------------------------------------------ |
+| **Recipients (to, cc, bcc)** | 50 per email   | Combined across all recipient fields                                                 |
+| **Subject line**             | 998 characters | RFC 5322 compliant                                                                   |
+| **Total message size**       | 5 MiB          | Including attachments                                                                |
+| **Total message size**       | 25 MiB         | For [verified addresses](/email-service/configuration/email-routing-addresses/) only |
+| **Header size**              | 16 KB          | All custom headers combined                                                          |
 
 ## Workers binding limits
 


### PR DESCRIPTION


### Summary

Updates the Email Service limits documentation to specify that the total message size limit (including attachments) is 5 MiB, not 25 MiB. This aligns with Email Routing's documented limit pattern.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
