### PR TITLE
docs: add compatibility flag documentation for diagnostics_channel_has_subscribers_getter

### DIFF
--- a/src/content/compatibility-flags/diagnostics-channel-has-subscribers-getter.md
+++ b/src/content/compatibility-flags/diagnostics-channel-has-subscribers-getter.md
@@ -1,0 +1,18 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Node.js diagnostics_channel hasSubscribers getter"
+sort_date: "2026-05-19"
+enable_date: "2026-05-19"
+enable_flag: "diagnostics_channel_has_subscribers_getter"
+disable_flag: "no_diagnostics_channel_has_subscribers_getter"
+---
+
+When `diagnostics_channel_has_subscribers_getter` is enabled, `Channel.hasSubscribers` and `TracingChannel.hasSubscribers` from `node:diagnostics_channel` become read-only getter properties that evaluate directly to a boolean, matching Node.js behavior.
+
+Previously, `hasSubscribers` was registered as a method, requiring users to call `ch.hasSubscribers()` with parentheses. With this flag enabled, `ch.hasSubscribers` returns a boolean without a function call, consistent with the [Node.js documentation](https://nodejs.org/docs/latest/api/diagnostics_channel.html#channelhassubscribers).
+
+This flag requires [`nodejs_compat`](/workers/runtime-apis/nodejs/) to be enabled.


### PR DESCRIPTION
## Summary

Adds compatibility flag documentation for the `diagnostics_channel_has_subscribers_getter` flag (enable date: 2026-05-19).

This flag changes `Channel.hasSubscribers` and `TracingChannel.hasSubscribers` from `node:diagnostics_channel` from methods to read-only getter properties, matching Node.js behavior.

**workerd PR:** https://github.com/cloudflare/workerd/pull/6601

## Files added

- `src/content/compatibility-flags/diagnostics-channel-has-subscribers-getter.md`