### PR TITLE
feat: implement WebMCP API to expose site tools to AI agents

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -270,4 +270,5 @@ metaTags.map((attrs) => {
 <script src="src/scripts/mermaid.ts"></script>
 <script src="src/scripts/analytics.ts"></script>
 <script src="src/scripts/explain-code.ts"></script>
+<script src="src/scripts/webmcp.ts"></script>
 <Default><slot /></Default>

--- a/src/components/search/InstantSearch.tsx
+++ b/src/components/search/InstantSearch.tsx
@@ -1,4 +1,5 @@
 import { liteClient as algoliasearch } from "algoliasearch/lite";
+import { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX } from "~/util/algolia";
 import { useEffect, useState } from "react";
 import {
 	InstantSearch,
@@ -229,11 +230,8 @@ function FilterDropdown({
 export default function InstantSearchComponent() {
 	return (
 		<InstantSearch
-			searchClient={algoliasearch(
-				"D32WIYFTUF",
-				"5cec275adc19dd3bc17617f7d9cf312a",
-			)}
-			indexName="prod_devdocs"
+			searchClient={algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY)}
+			indexName={ALGOLIA_INDEX}
 			future={{
 				preserveSharedStateOnUnmount: true,
 			}}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -8,9 +8,7 @@ interface ToolAnnotations {
 }
 
 interface ModelContextClient {
-	requestUserInteraction(
-		callback: () => Promise<unknown>,
-	): Promise<unknown>;
+	requestUserInteraction(callback: () => Promise<unknown>): Promise<unknown>;
 }
 
 type ToolExecuteCallback = (

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,43 @@
+/// <reference types="astro/client" />
+
+// WebMCP API — https://webmachinelearning.github.io/webmcp/
+// Chrome Early Preview Program implementation
+
+interface ToolAnnotations {
+	readOnlyHint?: boolean;
+}
+
+interface ModelContextClient {
+	requestUserInteraction(
+		callback: () => Promise<unknown>,
+	): Promise<unknown>;
+}
+
+type ToolExecuteCallback = (
+	input: object,
+	client: ModelContextClient,
+) => Promise<unknown>;
+
+interface ModelContextTool {
+	name: string;
+	title?: string;
+	description: string;
+	inputSchema?: object;
+	execute: ToolExecuteCallback;
+	annotations?: ToolAnnotations;
+}
+
+interface ModelContextRegisterToolOptions {
+	signal?: AbortSignal;
+}
+
+interface ModelContext {
+	registerTool(
+		tool: ModelContextTool,
+		options?: ModelContextRegisterToolOptions,
+	): void;
+}
+
+interface Navigator {
+	readonly modelContext?: ModelContext;
+}

--- a/src/plugins/docsearch/index.ts
+++ b/src/plugins/docsearch/index.ts
@@ -1,12 +1,18 @@
 import { track } from "~/util/zaraz";
 import type { DocSearchClientOptions } from "@astrojs/starlight-docsearch";
+import {
+	ALGOLIA_APP_ID,
+	ALGOLIA_API_KEY,
+	ALGOLIA_INDEX,
+	ALGOLIA_INDEX_STYLE_GUIDE,
+} from "~/util/algolia";
 
 const isStyleGuide = window.location.pathname.startsWith("/style-guide/");
 
 export default {
-	appId: "D32WIYFTUF",
-	apiKey: "5cec275adc19dd3bc17617f7d9cf312a",
-	indexName: isStyleGuide ? "prod_devdocs_styleguide" : "prod_devdocs",
+	appId: ALGOLIA_APP_ID,
+	apiKey: ALGOLIA_API_KEY,
+	indexName: isStyleGuide ? ALGOLIA_INDEX_STYLE_GUIDE : ALGOLIA_INDEX,
 	insights: true,
 	// Replace URL with the current origin so search
 	// can be used in local development and previews.

--- a/src/scripts/webmcp.ts
+++ b/src/scripts/webmcp.ts
@@ -1,0 +1,213 @@
+/**
+ * WebMCP — exposes Cloudflare Docs site tools to AI agents via the browser.
+ * Spec: https://webmachinelearning.github.io/webmcp/
+ */
+
+const ALGOLIA_APP_ID = "D32WIYFTUF";
+const ALGOLIA_API_KEY = "5cec275adc19dd3bc17617f7d9cf312a";
+const ALGOLIA_INDEX = "prod_devdocs";
+const LLMS_TXT_URL = "https://developers.cloudflare.com/llms.txt";
+
+// Cache for list-directories results — fetched once per session.
+let directoriesCache: DirectoryEntry[] | null = null;
+
+interface DirectoryEntry {
+	name: string;
+	url: string;
+	description: string;
+	group: string;
+}
+
+interface AlgoliaHit {
+	objectID: string;
+	url?: string;
+	hierarchy?: {
+		lvl0?: string;
+		lvl1?: string;
+		lvl2?: string;
+	};
+	content?: string;
+	_snippetResult?: {
+		content?: { value?: string };
+		hierarchy?: {
+			lvl1?: { value?: string };
+			lvl2?: { value?: string };
+		};
+	};
+}
+
+interface AlgoliaResponse {
+	hits: AlgoliaHit[];
+}
+
+// ---------------------------------------------------------------------------
+// Tool: search
+// ---------------------------------------------------------------------------
+async function executeSearch(input: object): Promise<unknown> {
+	const { query, limit = 5 } = input as { query: string; limit?: number };
+
+	const clampedLimit = Math.min(Math.max(1, limit), 20);
+
+	const response = await fetch(
+		`https://${ALGOLIA_APP_ID}-dsn.algolia.net/1/indexes/${ALGOLIA_INDEX}/query`,
+		{
+			method: "POST",
+			headers: {
+				"X-Algolia-Application-Id": ALGOLIA_APP_ID,
+				"X-Algolia-API-Key": ALGOLIA_API_KEY,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				query,
+				filters: "type:content",
+				hitsPerPage: clampedLimit,
+				attributesToRetrieve: ["url", "hierarchy", "content"],
+				attributesToSnippet: ["content:20", "hierarchy.lvl1:10"],
+			}),
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(`Search failed: ${response.status} ${response.statusText}`);
+	}
+
+	const data = (await response.json()) as AlgoliaResponse;
+
+	return data.hits.map((hit) => ({
+		title:
+			hit.hierarchy?.lvl2 ??
+			hit.hierarchy?.lvl1 ??
+			hit.hierarchy?.lvl0 ??
+			"Untitled",
+		url: hit.url ?? "",
+		snippet:
+			hit._snippetResult?.content?.value ??
+			hit._snippetResult?.hierarchy?.lvl1?.value ??
+			hit._snippetResult?.hierarchy?.lvl2?.value ??
+			hit.content?.slice(0, 200) ??
+			"",
+	}));
+}
+
+// ---------------------------------------------------------------------------
+// Tool: list-directories
+// ---------------------------------------------------------------------------
+async function executeListDirectories(
+	_input: object,
+): Promise<DirectoryEntry[]> {
+	if (directoriesCache) {
+		return directoriesCache;
+	}
+
+	const response = await fetch(LLMS_TXT_URL);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch directory: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	const text = await response.text();
+	const results: DirectoryEntry[] = [];
+	let currentGroup = "";
+
+	for (const line of text.split("\n")) {
+		// Group headings: "## Application performance"
+		const headingMatch = /^##\s+(.+)$/.exec(line);
+		if (headingMatch) {
+			currentGroup = headingMatch[1].trim();
+			continue;
+		}
+
+		// Product entries: "- [Name](url): description"
+		const entryMatch = /^-\s+\[([^\]]+)\]\(([^)]+)\)(?::\s+(.*))?$/.exec(
+			line,
+		);
+		if (entryMatch) {
+			const name = entryMatch[1].trim();
+			// Convert per-product llms.txt URL to the docs root URL
+			const llmsUrl = entryMatch[2].trim();
+			const url = llmsUrl.replace(/\/llms\.txt$/, "/");
+			const description = (entryMatch[3] ?? "").trim();
+
+			results.push({ name, url, description, group: currentGroup });
+		}
+	}
+
+	directoriesCache = results;
+	return results;
+}
+
+// ---------------------------------------------------------------------------
+// Registration / lifecycle
+// ---------------------------------------------------------------------------
+function registerTools(): void {
+	if (!("modelContext" in navigator) || !navigator.modelContext) {
+		return;
+	}
+
+	const controller = new AbortController();
+	const { signal } = controller;
+
+	navigator.modelContext.registerTool(
+		{
+			name: "search",
+			title: "Search Cloudflare Docs",
+			description:
+				"Full-text search across Cloudflare developer documentation. Returns matching pages with titles, URLs, and content snippets. Use this to find documentation on any Cloudflare product or feature.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					query: {
+						type: "string",
+						description: "The search query",
+					},
+					limit: {
+						type: "integer",
+						description: "Maximum number of results to return (1–20, default 5)",
+						default: 5,
+						minimum: 1,
+						maximum: 20,
+					},
+				},
+				required: ["query"],
+			},
+			execute: executeSearch,
+			annotations: { readOnlyHint: true },
+		},
+		{ signal },
+	);
+
+	navigator.modelContext.registerTool(
+		{
+			name: "list-directories",
+			title: "List Cloudflare Docs Products",
+			description:
+				"Returns a list of all Cloudflare products available in the developer documentation, including each product's name, docs URL, short description, and category group. Use this to discover what products exist before searching or navigating.",
+			inputSchema: {
+				type: "object",
+				properties: {},
+			},
+			execute: executeListDirectories,
+			annotations: { readOnlyHint: true },
+		},
+		{ signal },
+	);
+
+	// Unregister all tools on Astro page transitions.
+	document.addEventListener(
+		"astro:before-swap",
+		() => {
+			controller.abort();
+		},
+		{ once: true },
+	);
+}
+
+// Register on initial load and after each Astro page navigation.
+document.addEventListener("astro:page-load", registerTools);
+
+if (document.readyState === "loading") {
+	document.addEventListener("DOMContentLoaded", registerTools);
+} else {
+	registerTools();
+}

--- a/src/scripts/webmcp.ts
+++ b/src/scripts/webmcp.ts
@@ -3,9 +3,11 @@
  * Spec: https://webmachinelearning.github.io/webmcp/
  */
 
-const ALGOLIA_APP_ID = "D32WIYFTUF";
-const ALGOLIA_API_KEY = "5cec275adc19dd3bc17617f7d9cf312a";
-const ALGOLIA_INDEX = "prod_devdocs";
+import {
+	ALGOLIA_APP_ID,
+	ALGOLIA_API_KEY,
+	ALGOLIA_INDEX,
+} from "~/util/algolia";
 const LLMS_TXT_URL = "https://developers.cloudflare.com/llms.txt";
 
 // Cache for list-directories results — fetched once per session.

--- a/src/scripts/webmcp.ts
+++ b/src/scripts/webmcp.ts
@@ -3,11 +3,7 @@
  * Spec: https://webmachinelearning.github.io/webmcp/
  */
 
-import {
-	ALGOLIA_APP_ID,
-	ALGOLIA_API_KEY,
-	ALGOLIA_INDEX,
-} from "~/util/algolia";
+import { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX } from "~/util/algolia";
 const LLMS_TXT_URL = "https://developers.cloudflare.com/llms.txt";
 
 // Cache for list-directories results — fetched once per session.

--- a/src/scripts/webmcp.ts
+++ b/src/scripts/webmcp.ts
@@ -119,9 +119,7 @@ async function executeListDirectories(
 		}
 
 		// Product entries: "- [Name](url): description"
-		const entryMatch = /^-\s+\[([^\]]+)\]\(([^)]+)\)(?::\s+(.*))?$/.exec(
-			line,
-		);
+		const entryMatch = /^-\s+\[([^\]]+)\]\(([^)]+)\)(?::\s+(.*))?$/.exec(line);
 		if (entryMatch) {
 			const name = entryMatch[1].trim();
 			// Convert per-product llms.txt URL to the docs root URL
@@ -163,7 +161,8 @@ function registerTools(): void {
 					},
 					limit: {
 						type: "integer",
-						description: "Maximum number of results to return (1–20, default 5)",
+						description:
+							"Maximum number of results to return (1–20, default 5)",
 						default: 5,
 						minimum: 1,
 						maximum: 20,

--- a/src/util/algolia.ts
+++ b/src/util/algolia.ts
@@ -1,0 +1,4 @@
+export const ALGOLIA_APP_ID = "D32WIYFTUF";
+export const ALGOLIA_API_KEY = "5cec275adc19dd3bc17617f7d9cf312a";
+export const ALGOLIA_INDEX = "prod_devdocs";
+export const ALGOLIA_INDEX_STYLE_GUIDE = "prod_devdocs_styleguide";


### PR DESCRIPTION
### Summary

Implements the [WebMCP API](https://webmachinelearning.github.io/webmcp/) to expose two structured tools to AI agents browsing the docs site via a supporting browser (Chrome Early Preview Program).

WebMCP lets web pages register JavaScript tools that agents can call directly — structured data in, structured data out — instead of scraping HTML. Two tools are registered on every page:

| Tool | What it does |
| --- | --- |
| `search` | Full-text search via Algolia (existing public API key). Returns `{ title, url, snippet }[]`. |
| `list-directories` | Fetches and parses `/llms.txt`, returns `{ name, url, description, group }[]` for all ~100 products. Cached in memory. |

**Files changed:**

- `src/env.d.ts` — new ambient TypeScript declarations for the W3C WebMCP API surface (`Navigator.modelContext`, `ModelContext`, etc.)
- `src/scripts/webmcp.ts` — new script implementing the two tools with feature detection guard and Astro page transition lifecycle
- `src/components/overrides/Head.astro` — adds `<script src="src/scripts/webmcp.ts"></script>` alongside the existing four global scripts

Tools are guarded with `'modelContext' in navigator` so they no-op silently on unsupported browsers. After deploy, validate with:

```
POST https://isitagentready.com/api/scan
{"url": "https://developers.cloudflare.com"}
```
