### PR TITLE
docs(wrangler/deprecations): 'wrangler deploy' -> 'wrangler publish' in publish deprecation section

### DIFF
--- a/src/content/docs/workers/wrangler/deprecations.mdx
+++ b/src/content/docs/workers/wrangler/deprecations.mdx
@@ -33,7 +33,7 @@ Use `npm create cloudflare@latest` for new Workers and Pages projects.
 
 #### `publish`
 
-The `wrangler deploy` command is deprecated, but still active in v3. `wrangler deploy` will be fully removed in v4.
+The `wrangler publish` command is deprecated, but still active in v3. `wrangler publish` will be fully removed in v4.
 
 Use [`npx wrangler deploy`](/workers/wrangler/commands/general/#deploy) to deploy Workers.
 


### PR DESCRIPTION
Fixes #30079.

The `#### \`publish\`` subsection under Wrangler v4 deprecations describes the **deprecated** command but says `wrangler deploy` — which is the new command users should migrate to, not the deprecated one. Under a heading titled `publish` the body should reference `wrangler publish`.

The last line (`Use [\`npx wrangler deploy\`]...`) correctly stays — that's the replacement command.

```diff
  #### \`publish\`

- The \`wrangler deploy\` command is deprecated, but still active in v3. \`wrangler deploy\` will be fully removed in v4.
+ The \`wrangler publish\` command is deprecated, but still active in v3. \`wrangler publish\` will be fully removed in v4.

  Use [\`npx wrangler deploy\`](...) to deploy Workers.
```