### PR TITLE
[Fundamentals] Clarify Okta IdP-initiated SSO is a separate integration

### DIFF
--- a/src/content/docs/fundamentals/manage-members/dashboard-sso.mdx
+++ b/src/content/docs/fundamentals/manage-members/dashboard-sso.mdx
@@ -217,7 +217,7 @@ Configure an identity provider (IdP)-initiated single sign-on (SSO) session usin
 #### Configure Okta as the IdP
 
 1. Log in to your [Okta Admin Dashboard](https://login.okta.com/) and go to **Applications** > **Applications**.
-2. Select **Create App Integration** to start a new SAML integration to handle the IdP-initiated SSO flow.
+2. Select **Create App Integration** to start a new SAML integration to handle the IdP-initiated SSO flow. Note that this is a second, distinct Cloudflare-Okta integration, created separately from the [IdP integration with Zero Trust](/cloudflare-one/integrations/identity-providers/).
 3. In the pop-up, select **SAML 2.0** and select **Next**.
 4. Enter a name for the app and select **Next**.
 5. In the **Single Sign-On URL** field, paste the **SSO Endpoint URL** [you copied earlier](/fundamentals/manage-members/dashboard-sso/#prerequisites-1).


### PR DESCRIPTION
### Summary

Clarifies in the [dashboard SSO docs](/fundamentals/manage-members/dashboard-sso/#configure-okta-as-the-idp) that the Okta SAML app created for IdP-initiated SSO is a second, separate integration from the existing Okta IdP integration used with Cloudflare Zero Trust. This avoids confusion for users who already have an Okta IdP configured and might otherwise assume the existing integration should be reused.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
