### PR TITLE
Clarify Spectrum plan requirements for custom TCP/UDP applications

### DIFF
--- a/src/content/docs/spectrum/index.mdx
+++ b/src/content/docs/spectrum/index.mdx
@@ -28,6 +28,7 @@ Spectrum provides security and acceleration for any [TCP](https://www.cloudflare
 
 Spectrum allows you to route MQTT, email, file transfer, version control, games, and more over TCP or UDP through Cloudflare to mask the origin and protect it from [DDoS attacks](https://www.cloudflare.com/learning/ddos/what-is-a-ddos-attack/).
 
+**Note:** Custom TCP/UDP applications require an Enterprise plan with Spectrum as a paid add-on. See [Protocols per plan](/spectrum/protocols-per-plan/) for details, or contact your account team to enable.
 ---
 
 ## Features


### PR DESCRIPTION
## Summary
Clarifies Spectrum plan requirements for custom TCP/UDP applications. Adds note about Enterprise + paid add-on requirement to the main Spectrum overview page.
## Changes
Page:https://developers.cloudflare.com/spectrum/
**Current text:**
:::Spectrum allows you to route MQTT, email, file transfer, version control, games, and more over TCP or UDP through Cloudflare to mask the origin and protect it from [DDoS attacks ↗](https://www.cloudflare.com/learning/ddos/what-is-a-ddos-attack/).:::
**Proposed text:**
 :::Spectrum allows you to route MQTT, email, file transfer, version control, games, and more over TCP or UDP through Cloudflare to mask the origin and protect it from [[DDoS attacks](https://www.cloudflare.com/learning/ddos/what-is-a-ddos-attack/)](https://www.cloudflare.com/learning/ddos/what-is-a-ddos-attack/).

Note:Custom TCP/UDP applications require an Enterprise account with Spectrum as a paid add-on. Refer to [[Protocols per plan](https://github.com/spectrum/protocols-per-plan/)](/spectrum/protocols-per-plan/) for a full breakdown, or contact your account team to get started.
 :::
## Related Issue
https://jira.cfdata.org/browse/SPM-3317
