### PR TITLE
[Cloudflare One] ELI5 clarity improvements for Insights analytics dashboards

### DIFF
--- a/src/content/docs/cloudflare-one/insights/analytics/access.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/access.mdx
@@ -16,7 +16,7 @@ Access event analytics allows you to review login attempts to the applications y
 
 To view Access event analytics:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Go to **Dashboards**.
 3. Select **Access event analytics**.
 

--- a/src/content/docs/cloudflare-one/insights/analytics/access.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/access.mdx
@@ -28,7 +28,7 @@ Access Event Analytics aggregates authentication activity based on your [Access 
 
 ## Available insights
 
-The Access event analytics dashboard includes a chart of Access activity over time. You can view a chronological chart of access events. The Access event analytics dashboard shows when access requests occurred, helping you spot spikes in login attempts.
+The Access event analytics dashboard includes a time-series chart of authentication events, allowing you to identify spikes in login activity over a selected period.
 
 - Events are displayed on the vertical axis.
 - Time (in your local timezone) is shown along the horizontal axis.

--- a/src/content/docs/cloudflare-one/insights/analytics/ai-security.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/ai-security.mdx
@@ -26,7 +26,7 @@ To populate the AI security report dashboard, you must have:
 
 * [Cloudflare Gateway](/cloudflare-one/traffic-policies/) enabled to inspect outbound HTTP and DNS traffic.
 * User traffic to SaaS AI applications (for example, ChatGPT or Gemini) sent through Cloudflare Gateway.
-* MCP servers behind Cloudflare Access policies.
+* [Model Context Protocol (MCP) servers](/cloudflare-one/access-controls/ai-controls/) behind [Cloudflare Access](/cloudflare-one/access-controls/) policies.
 
 ## Available insights
 
@@ -62,10 +62,8 @@ Use this report to understand whether sensitive data is being sent to unapproved
 
 ### MCP servers behind Access over time
 
-Displays the number of Managed Control Plane (MCP) servers that are protected behind Access policies over time.  
-Use this panel to monitor the number of MCP servers protected behind Access policies.
+Displays the number of Model Context Protocol (MCP) servers protected by [Cloudflare Access](/cloudflare-one/access-controls/) policies over time. Use this panel to verify that newly deployed MCP servers are protected.
 
 ### Access login events to MCP servers
 
-Reports the number of login events to MCP servers protected behind Access policies.  
-Use this panel to monitor the number of login events to MCP servers protected behind Access policies.
+Reports the number of login events to MCP servers protected by Access policies. Use this panel to identify unusual login patterns, such as spikes in access from unexpected users.

--- a/src/content/docs/cloudflare-one/insights/analytics/ai-security.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/ai-security.mdx
@@ -14,7 +14,7 @@ The AI security report dashboard summarizes your organization's AI usage and pot
 
 To view the AI security report dashboard:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Go to **Dashboards**.
 3. Select **AI security report**.
 

--- a/src/content/docs/cloudflare-one/insights/analytics/application-access.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/application-access.mdx
@@ -17,7 +17,7 @@ The Application Access Report is powered by [Access authentication logs](/cloudf
 
 To view the Application Access Report dashboard:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Go to **Dashboards**.
 3. Select **Application Access Report**.
 

--- a/src/content/docs/cloudflare-one/insights/analytics/application-access.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/application-access.mdx
@@ -83,7 +83,7 @@ These insights help administrators identify usage patterns and trends.
 
 Provides a summary of Access configurations made by admin in your organization, including:
 
-* Applications configured — Total number of Access-protected applications, broken down by type (for example, Self-hosted, SaaS, RDP, SSH, Private network, and [Cloudflare Dashboard SSO](/fundamentals/manage-members/dashboard-sso/).)
-* Policies configured — Total number of Access policies, grouped by [policy action](/cloudflare-one/access-controls/policies/#actions) (for example, Allow, Block, Bypass, or Service Auth.)
+* Applications configured — Total number of Access-protected applications, broken down by type (for example, Self-hosted, SaaS, RDP, SSH, Private network, and [Cloudflare Dashboard SSO](/fundamentals/manage-members/dashboard-sso/)).
+* Policies configured — Total number of Access policies, grouped by [policy action](/cloudflare-one/access-controls/policies/#actions) (for example, Allow, Block, Bypass, or Service Auth).
 
 This section helps administrators audit their Access setup and verify that expected resources and policies are in place.

--- a/src/content/docs/cloudflare-one/insights/analytics/application-access.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/application-access.mdx
@@ -83,7 +83,7 @@ These insights help administrators identify usage patterns and trends.
 
 Provides a summary of Access configurations made by admin in your organization, including:
 
-* Applications configured — Total number of Access-protected applications, broken down by type (for example, Self-hosted, SaaS, RDP, SSH, Private network, and Dash SSO.)
-* Policies configured — Total number of Access policies, grouped by policy type (for example, Allow, Block, Bypass, or Service Auth.)
+* Applications configured — Total number of Access-protected applications, broken down by type (for example, Self-hosted, SaaS, RDP, SSH, Private network, and [Cloudflare Dashboard SSO](/fundamentals/manage-members/dashboard-sso/).)
+* Policies configured — Total number of Access policies, grouped by [policy action](/cloudflare-one/access-controls/policies/#actions) (for example, Allow, Block, Bypass, or Service Auth.)
 
 This section helps administrators audit their Access setup and verify that expected resources and policies are in place.

--- a/src/content/docs/cloudflare-one/insights/analytics/data-analytics.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/data-analytics.mdx
@@ -22,10 +22,12 @@ To view the Data security analytics dashboard:
 
 ## Prerequisites
 
-To populate this dashboard, you need at least one of the following:
+To populate this dashboard with partial data, you need at least one of the following:
 
-- [Data Loss Prevention (DLP)](/cloudflare-one/data-loss-prevention/) configured to generate detections from scanned web traffic or SaaS applications. DLP populates the **DLP matches in HTTP requests over time** panel.
-- At least one [Cloud Access Security Broker (CASB)](/cloudflare-one/integrations/cloud-and-saas/) integration connected to capture findings from your SaaS applications or cloud environments. CASB populates the **SaaS and Cloud findings** and **Posture findings** panels.
+- At least one HTTP policy that references a [DLP profile](/cloudflare-one/data-loss-prevention/dlp-policies/).
+- At least one SaaS integration enrolled in [CASB](/cloudflare-one/integrations/cloud-and-saas/).
+- At least one Cloud integration enrolled in [CASB](/cloudflare-one/integrations/cloud-and-saas/).
+- At least one SaaS or Cloud integration enrolled in [CASB](/cloudflare-one/integrations/cloud-and-saas/) and a DLP profile applied to it.
 
 ## Available insights
 

--- a/src/content/docs/cloudflare-one/insights/analytics/data-analytics.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/data-analytics.mdx
@@ -14,7 +14,7 @@ The Data security analytics dashboard reports security issues and sensitive data
 
 To view the Data security analytics dashboard:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Go to **Dashboards**.
 3. Select **Data security analytics**.
 
@@ -45,13 +45,13 @@ The SaaS and Cloud findings by count chart shows a time series view of Posture a
 
 Each bar represents the total number of findings detected within a given time interval. You can use this view to observe patterns or spikes in findings over time. Hover over any bar to view the exact count of Posture and Content findings for that period.
 
-To review findings in detail, log into [Cloudflare One](https://one.dash.cloudflare.com) and go to **Cloud & SaaS findings** > **Posture Findings** or **Content Findings**.
+To review findings in detail, log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and go to **Zero Trust** > **Cloud & SaaS findings** > **Posture Findings** or **Content Findings**.
 
 ### Posture findings by Severity
 
 The Posture findings by severity chart displays the distribution of CASB findings based on their [severity levels](/cloudflare-one/cloud-and-saas-findings/manage-findings/#severity-levels). Each segment of the circle represents the number of posture issues classified as `Critical`, `High`, `Medium`, or `Low`.
 
-To review findings in detail, log into [Cloudflare One](https://one.dash.cloudflare.com) and go to **Cloud & SaaS findings** > **Posture Findings**.
+To review findings in detail, log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and go to **Zero Trust** > **Cloud & SaaS findings** > **Posture Findings**.
 
 ### DLP matches in HTTP requests over time
 
@@ -59,4 +59,4 @@ The DLP matches in HTTP requests over time chart displays when [DLP policies](/c
 
 Unlike the SaaS and Cloud findings by count chart, which shows CASB findings from data at rest (files already stored in your connected SaaS applications), the DLP matches in HTTP requests over time chart shows DLP detections in HTTP traffic — data actively moving through your network.
 
-To review DLP detections in detail, log into [Cloudflare One](https://one.dash.cloudflare.com) and go to **Insights** > **Logs** > **HTTP request logs**. Use the **DLP profiles** or **DLP match data** filters to view HTTP requests that triggered a DLP policy.
+To review DLP detections in detail, log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and go to **Zero Trust** > **Insights** > **Logs** > **HTTP request logs**. Use the **DLP profiles** or **DLP match data** filters to view HTTP requests that triggered a DLP policy.

--- a/src/content/docs/cloudflare-one/insights/analytics/data-analytics.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/data-analytics.mdx
@@ -10,7 +10,7 @@ tags:
 
 import { Render } from "~/components";
 
-The Data security analytics dashboard reports security issues and sensitive data found within your SaaS applications, cloud environments, and HTTP traffic. It visualizes event data collected from your DLP and CASB policies. If neither DLP nor CASB is enabled in your account, the dashboard appears empty.
+The Data security analytics dashboard reports security issues and sensitive data found within your SaaS applications, cloud environments, and HTTP traffic. It visualizes security findings and sensitive data detections collected from your Data Loss Prevention (DLP) and Cloud Access Security Broker (CASB) policies. If neither DLP nor CASB is configured in your account, the dashboard appears empty.
 
 To view the Data security analytics dashboard:
 
@@ -22,10 +22,10 @@ To view the Data security analytics dashboard:
 
 ## Prerequisites
 
-To populate this dashboard, you must have:
+To populate this dashboard, you need at least one of the following:
 
-- [Data Loss Prevention (DLP)](/cloudflare-one/data-loss-prevention/) configured to generate event data from scanned web traffic or SaaS applications.
-- At least one [Cloud Access Security Broker (CASB)](/cloudflare-one/integrations/cloud-and-saas/) integration connected to capture findings from your SaaS applications or cloud environments.
+- [Data Loss Prevention (DLP)](/cloudflare-one/data-loss-prevention/) configured to generate detections from scanned web traffic or SaaS applications. DLP populates the **DLP matches in HTTP requests over time** panel.
+- At least one [Cloud Access Security Broker (CASB)](/cloudflare-one/integrations/cloud-and-saas/) integration connected to capture findings from your SaaS applications or cloud environments. CASB populates the **SaaS and Cloud findings** and **Posture findings** panels.
 
 ## Available insights
 
@@ -41,7 +41,7 @@ The dashboard includes the following panels and metrics:
 
 ### SaaS and Cloud findings by count
 
-The SaaS and Cloud findings by count chart shows a time series view of Posture and Content findings. [Posture](/cloudflare-one/cloud-and-saas-findings/manage-findings/#posture-findings) denotes posture findings which include misconfigurations, unauthorized user activity, and other data security issues. [Content](/cloudflare-one/cloud-and-saas-findings/manage-findings/#content-findings) denotes content findings which include instances of potential data exposure as identified by [DLP](/cloudflare-one/data-loss-prevention/).
+The SaaS and Cloud findings by count chart shows a time series view of Posture and Content findings. [Posture findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/#posture-findings) are configuration and access issues detected by CASB, such as misconfigurations, unauthorized user activity, and other data security issues. [Content findings](/cloudflare-one/cloud-and-saas-findings/manage-findings/#content-findings) are instances of potential data exposure as identified by [DLP](/cloudflare-one/data-loss-prevention/).
 
 Each bar represents the total number of findings detected within a given time interval. You can use this view to observe patterns or spikes in findings over time. Hover over any bar to view the exact count of Posture and Content findings for that period.
 
@@ -57,6 +57,6 @@ To review findings in detail, log into [Cloudflare One](https://one.dash.cloudfl
 
 The DLP matches in HTTP requests over time chart displays when [DLP policies](/cloudflare-one/data-loss-prevention/dlp-policies/) were triggered by users over a specified period of time.
 
-Unlike the SaaS and Cloud findings by count chart above, which relies on CASB findings from data at rest, the DLP matches in HTTP requests over time chart reflects DLP detections in HTTP traffic — helping you monitor sensitive data movement in real time.
+Unlike the SaaS and Cloud findings by count chart, which shows CASB findings from data at rest (files already stored in your connected SaaS applications), the DLP matches in HTTP requests over time chart shows DLP detections in HTTP traffic — data actively moving through your network.
 
 To review DLP detections in detail, log into [Cloudflare One](https://one.dash.cloudflare.com) and go to **Insights** > **Logs** > **HTTP request logs**. Use the **DLP profiles** or **DLP match data** filters to view HTTP requests that triggered a DLP policy.

--- a/src/content/docs/cloudflare-one/insights/analytics/gateway.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/gateway.mdx
@@ -21,7 +21,7 @@ Gateway analytics include three separate dashboards:
 
 To review Gateway analytics:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Go to **Dashboards**.
 3. Select your desired dashboard.
 
@@ -35,7 +35,7 @@ The HTTP request analytics dashboard helps you identify trends in how your HTTP 
 
 To review a detailed description of an HTTP request and its associated policy:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Select **Logs**.
 3. Select **HTTP request logs**.
 4. Use the **Policy** filter to view HTTP requests that triggered a policy or other filters to narrow down your results.
@@ -59,7 +59,7 @@ The DNS query analytics dashboard helps you identify trends in how your DNS poli
 
 To review a detailed description of a DNS query and its associated policy:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Select **Logs**.
 3. Select **DNS query logs**.
 4. Use the **Policy** filter to view DNS queries that triggered a policy or other filters to narrow down your results.
@@ -82,7 +82,7 @@ The Network policy analytics dashboard helps you identify trends in how your Gat
 
 To review a detailed description of a network session and its associated policy:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Select **Logs**.
 3. Select **Network logs**.
 4. Use the **Policy** filter to view network sessions that triggered a policy or other filters to narrow down your results.

--- a/src/content/docs/cloudflare-one/insights/analytics/gateway.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/gateway.mdx
@@ -31,7 +31,7 @@ To review Gateway analytics:
 
 Your [Gateway HTTP policies](/cloudflare-one/traffic-policies/http-policies/) power the HTTP request analytics dashboard. If you are not using Gateway HTTP policies, the dashboard will appear empty.
 
-The HTTP request analytics dashboard helps you identify trends in how your HTTP policies apply over time. By visualizing allowed, isolated, and do not inspect requests, the dashboard provides insights into traffic behavior and policy trends, making it easier to spot anomalies or shifts in usage patterns.
+The HTTP request analytics dashboard helps you identify trends in how your HTTP policies apply over time. By visualizing allowed, [isolated](/cloudflare-one/remote-browser-isolation/) (rendered in a remote browser), and [Do Not Inspect](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) (bypassing TLS decryption) requests, the dashboard provides insights into traffic behavior and policy trends, making it easier to spot anomalies or shifts in usage patterns.
 
 To review a detailed description of an HTTP request and its associated policy:
 
@@ -55,7 +55,7 @@ To review a detailed description of an HTTP request and its associated policy:
 
 Your [Gateway DNS policies](/cloudflare-one/traffic-policies/dns-policies/) power the DNS query analytics dashboard. If you are not using Gateway DNS policies, the dashboard will appear empty.
 
-The DNS query analytics dashboard helps you identify trends in how your DNS policies apply over time. By visualizing allowed, blocked, and overridden queries, the dashboard provides insights into traffic behavior and policy trends, making it easier to spot anomalies or shifts in usage patterns.
+The DNS query analytics dashboard helps you identify trends in how your DNS policies apply over time. By visualizing allowed, blocked, and overridden (DNS response replaced by a policy-defined address) queries, the dashboard provides insights into traffic behavior and policy trends, making it easier to spot anomalies or shifts in usage patterns.
 
 To review a detailed description of a DNS query and its associated policy:
 
@@ -78,7 +78,7 @@ To review a detailed description of a DNS query and its associated policy:
 
 Your [Gateway network policies](/cloudflare-one/traffic-policies/network-policies/) power the Network policy analytics dashboard. If you are not using Gateway network policies, the dashboard will appear empty.
 
-The Network policy analytics dashboard helps you identify trends in how your Gateway network policies apply over time. By visualizing allowed, blocked, and overridden sessions, the dashboard provides insights into traffic behavior and policy trends, making it easier to spot anomalies or shifts in usage patterns.
+The Network policy analytics dashboard helps you identify trends in how your Gateway network policies apply over time. By visualizing allowed, blocked, and overridden (traffic rerouted by a policy-defined rule) sessions, the dashboard provides insights into traffic behavior and policy trends, making it easier to spot anomalies or shifts in usage patterns.
 
 To review a detailed description of a network session and its associated policy:
 

--- a/src/content/docs/cloudflare-one/insights/analytics/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/index.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { DirectoryListing, Render } from "~/components";
 
-[Cloudflare One](https://one.dash.cloudflare.com/) provides a catalog of saved analytics views for reporting and investigation. Analytics Dashboards provide visualizations of your log data.
+The [Cloudflare dashboard](https://dash.cloudflare.com/) provides a catalog of saved analytics views under **Zero Trust** > **Insights** for reporting and investigation. Analytics Dashboards provide visualizations of your log data.
 
 <Render file="analytics/observability-tools-note" product="cloudflare-one" />
 

--- a/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { Render } from "~/components";
 
-The Network session analytics dashboard provides visibility into your Cloudflare One traffic patterns. This dashboard helps you understand how traffic flows through your network, including on-ramps (entry points like WARP or Magic Tunnel) and off-ramps (destinations like Internet or Cloudflare Tunnel).
+The Network session analytics dashboard provides visibility into your Cloudflare One traffic patterns. This dashboard helps you understand how traffic flows through your network, including on-ramps (how traffic enters Cloudflare, such as the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) or Magic Tunnel) and off-ramps (how traffic exits Cloudflare, such as the public Internet or a [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/)).
 
 The dashboard is based on the [Zero Trust network sessions Logpush dataset](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/). For definitions on any field, refer to the dataset schema documentation.
 
@@ -34,14 +34,14 @@ The Network session analytics dashboard helps you:
 
 ### Summary metrics
 
-- **Session count**: Total number of network sessions
+- **Session count**: Total number of network sessions. Each session represents an individual TCP, UDP, ICMP, or ICMPv6 flow that passes through Gateway.
 - **Bytes total**: Total bytes transferred (upload + download)
 - **Unique users**: Number of distinct users
 
 ### Traffic by location
 
-- **World map**: Geographic visualization of network traffic by the Cloudflare data center (or colocation) of the ingress and egress
-- **Location list**: Top Cloudflare data center (or colocation) locations of the ingress and egress by session count with accompanying graph
+- **World map**: Geographic visualization of network traffic by the Cloudflare data center where traffic entered the network (ingress) and where it exited (egress)
+- **Location list**: Top Cloudflare data center locations by ingress and egress session count with accompanying graph
 - **Change**: Shows the total change across ingress and egress for each location
 
 ### Top analytics

--- a/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
@@ -16,7 +16,7 @@ The dashboard is based on the [Zero Trust network sessions Logpush dataset](/log
 
 To review Network session analytics:
 
-1. In [Cloudflare One](https://dash.cloudflare.com), go to **Insights** > **Dashboards**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights** > **Dashboards**.
 2. Select **Network session analytics**.
 
 <Render file="analytics/observability-tools-note" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { Render } from "~/components";
 
-The Network session analytics dashboard provides visibility into your Cloudflare One traffic patterns. This dashboard helps you understand how traffic flows through your network, including on-ramps (how traffic enters Cloudflare, such as the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) or Cloudflare Tunnel) and off-ramps (how traffic exits Cloudflare, such as the public Internet or a [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/)).
+The Network session analytics dashboard provides visibility into your Cloudflare One traffic patterns. This dashboard helps you understand how traffic flows through your network, including on-ramps (how traffic enters Cloudflare, such as the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) or Cloudflare Tunnel) and off-ramps (how traffic exits Cloudflare, such as the public Internet or a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/)).
 
 The dashboard is based on the [Zero Trust network sessions Logpush dataset](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/). For definitions on any field, refer to the dataset schema documentation.
 
@@ -47,7 +47,7 @@ The Network session analytics dashboard helps you:
 ### Top analytics
 
 - **Top protocols**: Most used network protocols (TCP, UDP, ICMP, ICMPv6)
-- **Top connection close reasons**: Common reasons for session termination
+- **Top connection close reasons**: Common reasons for session termination:
   - Client closed
   - Origin closed
   - Client idle timeout
@@ -59,6 +59,7 @@ The Network session analytics dashboard helps you:
   - Origin TLS error
   - Origin unroutable
 
+For the full list of reasons for session termination, refer to [ConnectionCloseReason](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/#connectionclosereason).
 
 ## Related resources
 

--- a/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/network-sessions.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { Render } from "~/components";
 
-The Network session analytics dashboard provides visibility into your Cloudflare One traffic patterns. This dashboard helps you understand how traffic flows through your network, including on-ramps (how traffic enters Cloudflare, such as the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) or Magic Tunnel) and off-ramps (how traffic exits Cloudflare, such as the public Internet or a [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/)).
+The Network session analytics dashboard provides visibility into your Cloudflare One traffic patterns. This dashboard helps you understand how traffic flows through your network, including on-ramps (how traffic enters Cloudflare, such as the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) or Cloudflare Tunnel) and off-ramps (how traffic exits Cloudflare, such as the public Internet or a [Cloudflare Tunnel](/cloudflare-one/connections/connect-networks/)).
 
 The dashboard is based on the [Zero Trust network sessions Logpush dataset](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/). For definitions on any field, refer to the dataset schema documentation.
 

--- a/src/content/docs/cloudflare-one/insights/analytics/shadow-it-discovery.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/shadow-it-discovery.mdx
@@ -41,7 +41,7 @@ Review the Shadow IT SaaS analytics dashboard for application usage. Filter the 
     | Field            | Description                                                                                                                  |
     | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
     | Application      | SaaS application's name and logo.                                                                                            |
-    | Application type | [Application type](/cloudflare-one/traffic-policies/application-app-types/#app-types) assigned by Cloudflare Cloudflare One.     |
+    | Application type | [Application type](/cloudflare-one/traffic-policies/application-app-types/#app-types) assigned by Cloudflare One.     |
     | Status           | Application's approval status.                                                                           |
     | Secured          | Whether the application is currently secured behind Cloudflare Access.                                                       |
     | Users            | Number of users who connected to the application over the period of time specified on the Shadow IT Discovery overview page. |

--- a/src/content/docs/cloudflare-one/insights/analytics/shadow-it-discovery.mdx
+++ b/src/content/docs/cloudflare-one/insights/analytics/shadow-it-discovery.mdx
@@ -16,7 +16,7 @@ Shadow IT SaaS analytics provides visibility into the SaaS applications your use
 
 To access Shadow IT SaaS analytics:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Go to **Dashboards**.
 3. Select **Shadow IT: SaaS analytics**.
 
@@ -58,7 +58,7 @@ After marking applications, you can create [HTTP policies](/cloudflare-one/traff
 
 To create an HTTP status policy directly from Shadow IT Discovery:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Insights**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights**.
 2. Select **Dashboards** > **Shadow IT: SaaS analytics**.
 3. Select **Set application statuses**.
 4. Select **Manage HTTP status policies**, then choose an application status and select **Create policy**.


### PR DESCRIPTION
### Summary

Fixes factual errors and improves clarity across 7 analytics dashboard pages in Cloudflare One Insights, based on an ELI5 review.

**Factual fixes:**
- `ai-security.mdx`: Corrected "Managed Control Plane (MCP)" → "Model Context Protocol (MCP)" — this was the only incorrect expansion in the entire repo.
- `shadow-it-discovery.mdx`: Fixed "Cloudflare Cloudflare One" duplicate-word typo.
- `application-access.mdx`: Changed "policy type" → "policy action" to match the [Access policies docs](/cloudflare-one/access-controls/policies/#actions).
- `data-analytics.mdx`: Fixed prerequisites section — changed "you must have" (implying both required) to "you need at least one of the following" to match the intro's "If neither DLP nor CASB is configured" logic.

**Clarity improvements:**
- `ai-security.mdx`: Expanded MCP acronym on first use with link to `/cloudflare-one/access-controls/ai-controls/`. Collapsed redundant "Use this panel" sentences that repeated the descriptions verbatim.
- `access.mdx`: Collapsed three near-identical sentences describing the same chart into one clear sentence.
- `gateway.mdx`: Added inline definitions and cross-links for "Isolated" (Browser Isolation), "Do Not Inspect" (bypass TLS decryption), and "Overridden" (policy-defined address replacement) actions.
- `data-analytics.mdx`: Expanded DLP/CASB acronyms on first use. Fixed circular "Posture denotes posture findings" definition. Added inline definition of "data at rest."
- `application-access.mdx`: Expanded "Dash SSO" to "Cloudflare Dashboard SSO" with link.
- `network-sessions.mdx`: Replaced "WARP" with "Cloudflare One Client" with link. Defined "network session" on first use (TCP/UDP/ICMP/ICMPv6 flow). Clarified "ingress" and "egress" inline, removed confusing "(or colocation)" parenthetical.

**Remaining items left as PR comments (require team verification):**
- `network-sessions.mdx`: "Magic Tunnel" is not a canonical product name — needs team input on correct replacement.
- `network-sessions.mdx`: Connection close reasons list shows 10 of 16 values from the Logpush schema.
- `gateway.mdx`: Upstream/Downstream dataset descriptions may be inverted relative to standard networking convention.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
