### PR TITLE
Update sandbox backup/restore flow for local dev

### DIFF
--- a/src/content/docs/sandbox/api/backups.mdx
+++ b/src/content/docs/sandbox/api/backups.mdx
@@ -261,7 +261,6 @@ interface BackupOptions {
 interface DirectoryBackup {
 	readonly id: string;
 	readonly dir: string;
-	readonly localBucket?: boolean;
 }
 ```
 
@@ -269,7 +268,6 @@ interface DirectoryBackup {
 
 - `id` - Unique backup identifier (UUID)
 - `dir` - Directory that was backed up
-- `localBucket` - Whether the backup was created using the local R2 binding path
 
 ### `RestoreBackupResult`
 

--- a/src/content/docs/sandbox/api/backups.mdx
+++ b/src/content/docs/sandbox/api/backups.mdx
@@ -29,6 +29,7 @@ await sandbox.createBackup(options: BackupOptions): Promise<DirectoryBackup>
   - `name` (optional) - Human-readable name for the backup. Maximum 256 characters, no control characters.
   - `ttl` (optional) - Time-to-live in seconds until the backup expires. Default: `259200` (3 days). Must be a positive number.
   - `useGitignore` (optional) - When `true`, excludes files matching `.gitignore` rules from the backup. Default: `false`. If the directory is not inside a git repository, no exclusions are applied. Requires `git` to be available in the container.
+  - `localBucket` (optional) - When `true`, uses the `BACKUP_BUCKET` R2 binding directly instead of presigned URLs. Intended for use with `wrangler dev`. Default: `false`.
 
 **Returns**: `Promise<DirectoryBackup>` containing:
 
@@ -53,18 +54,27 @@ await sandbox.restoreBackup(backup);
 
 **How it works**:
 
+In production:
+
 1. The container creates a compressed squashfs archive from the directory.
 2. The container uploads the archive directly to R2 using a presigned URL.
 3. Metadata is stored alongside the archive in R2.
 4. The local archive is cleaned up.
 
+With `localBucket: true` (local development):
+
+1. The container creates a compressed squashfs archive from the directory.
+2. The archive is uploaded directly to the `BACKUP_BUCKET` R2 binding.
+3. Metadata is stored alongside the archive in R2.
+4. The local archive is cleaned up.
+
 **Throws**:
 
-- `InvalidBackupConfigError` - If `dir` is not absolute, contains `..`, the `BACKUP_BUCKET` binding is missing, or the R2 presigned URL credentials are not configured
+- `InvalidBackupConfigError` - If `dir` is not absolute, contains `..`, the `BACKUP_BUCKET` binding is missing, or (in production) the R2 presigned URL credentials are not configured
 - `BackupCreateError` - If the container fails to create the archive, the upload to R2 fails, or `useGitignore` is `true` but `git` is not available in the container
 
-:::note[R2 binding and credentials required]
-You must configure a `BACKUP_BUCKET` R2 binding and R2 presigned URL credentials (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `CLOUDFLARE_ACCOUNT_ID`, `BACKUP_BUCKET_NAME`) in your `wrangler.jsonc` before using backup methods. Refer to the [Wrangler configuration](/sandbox/configuration/wrangler/) for binding setup.
+:::note[R2 binding required]
+You must configure a `BACKUP_BUCKET` R2 binding in your `wrangler.jsonc` before using backup methods. For production, you must also configure R2 presigned URL credentials (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `CLOUDFLARE_ACCOUNT_ID`, `BACKUP_BUCKET_NAME`). Refer to the [backup and restore guide](/sandbox/guides/backup-restore/#prerequisites) for setup details.
 :::
 
 :::caution[Path permissions]
@@ -79,7 +89,7 @@ Partially-written files may not be captured consistently. Only completed writes 
 
 ### `restoreBackup()`
 
-Restore a previously created backup into a directory using FUSE overlayfs (copy-on-write).
+Restore a previously created backup into a directory.
 
 ```ts
 await sandbox.restoreBackup(backup: DirectoryBackup): Promise<RestoreBackupResult>
@@ -113,9 +123,17 @@ await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
 
 **How it works**:
 
+In production:
+
 1. Metadata is downloaded from R2 and the TTL is checked. If expired, an error is thrown (with a 60-second buffer).
 2. The container downloads the archive directly from R2 using a presigned URL.
 3. The container mounts the squashfs archive with FUSE overlayfs.
+
+With `localBucket: true` (local development):
+
+1. Metadata is downloaded from the `BACKUP_BUCKET` R2 binding and the TTL is checked.
+2. The archive is downloaded from the R2 binding.
+3. The archive is extracted into the target directory using `unsquashfs`.
 
 **Throws**:
 
@@ -125,11 +143,11 @@ await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
 - `BackupRestoreError` - If the container fails to restore
 
 :::note[Copy-on-write]
-Restore uses copy-on-write semantics. The backup is mounted as a read-only lower layer, and new writes go to a writable upper layer. The backup can be restored into a different directory than the original.
+In production, restore uses copy-on-write semantics. The backup is mounted as a read-only lower layer, and new writes go to a writable upper layer. The backup can be restored into a different directory than the original. In local development, the directory is replaced on restore.
 :::
 
 :::caution[Ephemeral mount]
-The FUSE mount is lost when the sandbox sleeps or restarts. Re-restore from the backup handle to recover. Stop processes writing to the target directory before restoring.
+In production, the FUSE mount is lost when the sandbox sleeps or restarts. Re-restore from the backup handle to recover. Stop processes writing to the target directory before restoring.
 :::
 
 ## Usage patterns
@@ -225,6 +243,7 @@ interface BackupOptions {
 	name?: string;
 	ttl?: number;
 	useGitignore?: boolean;
+	localBucket?: boolean;
 }
 ```
 
@@ -234,6 +253,7 @@ interface BackupOptions {
 - `name` (optional) - Human-readable backup name. Maximum 256 characters, no control characters.
 - `ttl` (optional) - Time-to-live in seconds. Default: `259200` (3 days). Must be a positive number.
 - `useGitignore` (optional) - When `true`, excludes files matching `.gitignore` rules if the directory is inside a git repository. Default: `false`. If the directory is not inside a git repository, no git-based exclusions are applied.
+- `localBucket` (optional) - When `true`, uses the `BACKUP_BUCKET` R2 binding directly instead of presigned URLs. Intended for use with `wrangler dev`. Default: `false`.
 
 ### `DirectoryBackup`
 
@@ -241,6 +261,7 @@ interface BackupOptions {
 interface DirectoryBackup {
 	readonly id: string;
 	readonly dir: string;
+	readonly localBucket?: boolean;
 }
 ```
 
@@ -248,6 +269,7 @@ interface DirectoryBackup {
 
 - `id` - Unique backup identifier (UUID)
 - `dir` - Directory that was backed up
+- `localBucket` - Whether the backup was created using the local R2 binding path
 
 ### `RestoreBackupResult`
 

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -12,10 +12,6 @@ import { TypeScriptExample, WranglerConfig } from "~/components";
 
 Create point-in-time snapshots of sandbox directories and restore them using copy-on-write overlays. Backups are stored in an R2 bucket and use squashfs compression.
 
-:::caution[Production only]
-Backup and restore does not work with `wrangler dev` because it requires FUSE support that wrangler does not currently provide. Deploy your Worker with `wrangler deploy` to use this feature. All other Sandbox SDK features work in local development.
-:::
-
 ## Prerequisites
 
 1. Create an R2 bucket for storing backups:
@@ -78,6 +74,10 @@ Backup and restore does not work with `wrangler dev` because it requires FUSE su
 
    You can create R2 API tokens in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **R2** > **Overview** > **Manage R2 API Tokens**. The token needs **Object Read & Write** permissions for your backup bucket.
 
+:::note
+The `vars` and API secrets in steps 2 and 3 are only required for production. For local development with `wrangler dev`, only the `BACKUP_BUCKET` R2 binding is required. Refer to [Local development](#local-development) for details.
+:::
+
 ## Create a backup
 
 Use `createBackup()` to snapshot a directory and upload it to R2:
@@ -120,7 +120,7 @@ console.log(`Restored: ${result.success}`);
 </TypeScriptExample>
 
 :::caution[Ephemeral mount]
-The FUSE mount is lost when the sandbox sleeps or the container restarts. Re-restore from the backup handle to recover.
+In production, the FUSE mount is lost when the sandbox sleeps or the container restarts. Re-restore from the backup handle to recover. This does not apply to local development.
 :::
 
 ## Exclude gitignored files
@@ -259,6 +259,74 @@ To automatically remove expired backup objects from R2, set up an [R2 object lif
 
 For example, if your longest TTL is 7 days, configure a lifecycle rule to delete objects older than 7 days from the `backups/` prefix. This ensures R2 storage does not grow unbounded while giving you a buffer to restore any non-expired backup.
 
+## Local development
+
+You can use backup and restore during local development with `wrangler dev` by passing the `localBucket: true` option to `createBackup()`. This uses the `BACKUP_BUCKET` R2 binding from your Worker environment directly, so no presigned URL credentials are required.
+
+### Configure R2 binding
+
+Add a `BACKUP_BUCKET` R2 binding to your Wrangler configuration:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"r2_buckets": [
+		{
+			"binding": "BACKUP_BUCKET",
+			"bucket_name": "my-backup-bucket"
+		}
+	]
+}
+```
+
+</WranglerConfig>
+
+### Back up and restore with `localBucket`
+
+Pass `localBucket: true` to `createBackup()` to back up and restore using the R2 binding directly:
+
+<TypeScriptExample>
+
+```ts
+const sandbox = getSandbox(env.Sandbox, "my-sandbox");
+
+// Create a local backup
+const backup = await sandbox.createBackup({
+	dir: "/workspace",
+	localBucket: true,
+});
+
+// Restore the backup
+const result = await sandbox.restoreBackup(backup);
+console.log(`Restored: ${result.success}`);
+```
+
+</TypeScriptExample>
+
+:::note
+You can use an environment variable to toggle `localBucket` between local development and production. Set an environment variable such as `LOCAL_DEV` in your Wrangler configuration using `vars` for local development, then reference it in your code:
+
+```typescript
+const backup = await sandbox.createBackup({
+	dir: "/workspace",
+	localBucket: Boolean(env.LOCAL_DEV),
+});
+```
+
+When `localBucket` is `true`, presigned URL credentials are not required and the SDK uses the R2 binding directly. For more information on setting environment variables, refer to [Environment variables in Wrangler configuration](/workers/configuration/environment-variables/).
+:::
+
+### Local development considerations
+
+- **No presigned URLs** - The SDK reads and writes backup archives directly through the R2 binding, so no S3-compatible credentials are needed.
+- **No FUSE required** - Local restore extracts the archive using `unsquashfs` instead of mounting with FUSE overlayfs. The backup is not applied as a copy-on-write overlay; the directory is replaced on restore.
+- **Same archive format** - Local backups use the same squashfs archive format as production backups.
+
+:::note
+These considerations apply to local development with `wrangler dev` only. In production, backup and restore use presigned URLs and FUSE overlayfs.
+:::
+
 ## Clean up backup objects in R2
 
 Backup archives are stored in your R2 bucket under the `backups/` prefix with the structure `backups/{backupId}/data.sqsh` and `backups/{backupId}/meta.json`. You can use the `BACKUP_BUCKET` R2 binding to manage these objects directly.
@@ -336,7 +404,7 @@ await env.BACKUP_BUCKET.delete(`backups/${backupId}/meta.json`);
 
 ## Copy-on-write behavior
 
-Restore uses FUSE overlayfs to mount the backup as a read-only lower layer. New writes go to a writable upper layer and do not affect the original backup:
+In production, restore uses FUSE overlayfs to mount the backup as a read-only lower layer. New writes go to a writable upper layer and do not affect the original backup:
 
 <TypeScriptExample>
 
@@ -451,7 +519,7 @@ This means `mksquashfs` could not read one or more files inside the directory yo
 - **Configure R2 lifecycle rules** - Set up [object lifecycle rules](/r2/buckets/object-lifecycles/) to automatically delete expired backups from R2, since TTL is only enforced at restore time
 - **Clean up old backups** - Delete previous backup objects from R2 when you no longer need them, or use the delete-then-write pattern for rolling backups
 - **Handle errors** - Wrap backup and restore calls in `try...catch` blocks
-- **Re-restore after restart** - The FUSE mount is ephemeral, so re-restore from the backup handle after container restarts
+- **Re-restore after restart** - In production, the FUSE mount is ephemeral, so re-restore from the backup handle after container restarts
 
 ## Related resources
 

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -307,7 +307,7 @@ console.log(`Restored: ${result.success}`);
 :::note
 You can use an environment variable to toggle `localBucket` between local development and production. Set an environment variable such as `LOCAL_DEV` in your Wrangler configuration using `vars` for local development, then reference it in your code:
 
-```typescript
+```ts
 const backup = await sandbox.createBackup({
 	dir: "/workspace",
 	localBucket: Boolean(env.LOCAL_DEV),


### PR DESCRIPTION
### Summary

Updates the backup and restore docs to reflect local development support added in [cloudflare/sandbox-sdk#567](https://github.com/cloudflare/sandbox-sdk/pull/567). The SDK now supports `createBackup({ localBucket: true })` and `restoreBackup()` locally via the `BACKUP_BUCKET` R2 binding, using `unsquashfs` extraction instead of presigned URLs and FUSE. Removes the production-only caution and adds a Local development section mirroring the mount buckets guide.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
