### PR TITLE
[Rules] Remove FL2/latest CDN proxy notes from body buffering docs

### DIFF
--- a/src/content/changelog/rules/2026-01-27-body-buffering-settings.mdx
+++ b/src/content/changelog/rules/2026-01-27-body-buffering-settings.mdx
@@ -29,10 +29,6 @@ Controls how Cloudflare buffers HTTP response bodies before forwarding them to t
 Setting body buffering to **None** may break security functionality that requires body inspection, including the Web Application Firewall (WAF) and Bot Management. Ensure that any paths where you disable buffering do not require security inspection.
 :::
 
-:::note[Availability]
-These settings only take effect on zones running Cloudflare's [latest CDN proxy](https://blog.cloudflare.com/20-percent-internet-upgrade/). Enterprise customers can contact their account team to enable the latest proxy on their zones.
-:::
-
 ### API example
 
 ```json

--- a/src/content/docs/rules/configuration-rules/settings.mdx
+++ b/src/content/docs/rules/configuration-rules/settings.mdx
@@ -254,8 +254,6 @@ Use the Request Body Buffering setting to configure the request body buffering m
 - **Full**: Buffers the entire request body before sending the request to your origin server.
 - **None**: Strictly no buffering. The request body is streamed directly to the origin server without inspection.
 
-This setting only takes effect on zones running Cloudflare's [latest CDN proxy](https://blog.cloudflare.com/20-percent-internet-upgrade/). Enterprise customers can contact their account team to enable the latest proxy on their zones.
-
 :::caution
 Setting request body buffering to **None** may break functionality that requires body inspection. In particular, this can impact the effectiveness of the Web Application Firewall (WAF) and other security features that rely on analyzing request bodies to detect and block threats.
 :::
@@ -282,8 +280,6 @@ Use the Response Body Buffering setting to configure the response body buffering
 
 - **Standard** (default): Allows Cloudflare products to inspect a prefix of the response body when necessary for enabled functionality on your zone.
 - **None**: Strictly no buffering. The response body is streamed directly to the client without inspection.
-
-This setting only takes effect on zones running Cloudflare's [latest CDN proxy](https://blog.cloudflare.com/20-percent-internet-upgrade/). Enterprise customers can contact their account team to enable the latest proxy on their zones.
 
 :::caution
 Setting response body buffering to **None** may break functionality that requires body inspection. In particular, this can impact the effectiveness of the Web Application Firewall (WAF) and other security features that rely on analyzing response bodies to detect and block threats.


### PR DESCRIPTION
## Summary

Removes outdated notes about the "latest CDN proxy" (FL2) from the request and response body buffering documentation. The FL2 proxy is now broadly available, making these notes no longer relevant.

## Changes

- **`src/content/docs/rules/configuration-rules/settings.mdx`**: Removed the FL2 note from both the Request Body Buffering and Response Body Buffering sections.
- **`src/content/changelog/rules/2026-01-27-body-buffering-settings.mdx`**: Removed the `:::note[Availability]` block referencing the latest CDN proxy.

## Related

- Jira: [PCX-21712](https://jira.cfdata.org/browse/PCX-21712)