### PR TITLE
fix: document Mesh as recommended on-ramp for L4/connection-sensitive workloads

### DIFF
--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
@@ -84,7 +84,7 @@ Both Cloudflare Mesh and [Cloudflare Tunnel](/cloudflare-one/networks/connectors
 | **Connector**         | `warp-cli`                                          | `cloudflared`                                             |
 | **Protocols**         | TCP, UDP, ICMP                                      | HTTP/S, TCP, SSH, RDP, SMB (proxied over WebSocket)       |
 
-Use Mesh when devices need to reach each other by private IP. Use Tunnel when you want to publish services by hostname or proxy traffic to specific IP ranges through `cloudflared`.
+Use Mesh when devices need to reach each other by private IP, or when your workload requires stable, long-lived TCP connections (SAP, database replication, ERP systems, RDP sessions). Mesh operates at L3/L4 and preserves connections end-to-end, making it the recommended software on-ramp for any traffic sensitive to connection interruptions. Use Tunnel when you want to publish services by hostname or proxy traffic to specific IP ranges through `cloudflared`.
 
 <Details header="Coming from another mesh networking product?">
 

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/tips.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/tips.mdx
@@ -101,6 +101,18 @@ Mesh nodes run in [Traffic and DNS mode](/cloudflare-one/team-and-resources/devi
 
 If your server runs a DNS service, do not install the Mesh node on that host. Instead, install the node on a separate machine on the same subnet and use [CIDR routes](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) to make the DNS server reachable.
 
+## Running Mesh alongside other VPN or mesh software
+
+The Cloudflare One Client creates a virtual network interface and manages the system routing table. Other software that does the same — Tailscale, WireGuard, OpenVPN, Cisco AnyConnect, GlobalProtect, ZScaler, Netskope, or any traditional VPN client — will compete for control of routing. Running them simultaneously causes unpredictable behavior: traffic may flow through the wrong tunnel or fail entirely.
+
+If you are migrating to Cloudflare Mesh from another solution:
+
+1. Uninstall or disable the other client (for example, `sudo systemctl stop tailscaled && sudo systemctl disable tailscaled` on Linux, or quit the application from the system tray on macOS/Windows).
+2. Restart the machine so the Cloudflare One Client's virtual network interface takes priority in the routing table.
+3. Verify connectivity by running `warp-cli status` and pinging a Mesh IP.
+
+This applies to both Mesh nodes and client devices.
+
 ## Running Mesh with Cloudflare Tunnel
 
 A Mesh node (`warp-cli`) and [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) (`cloudflared`) can run on the same Linux host. This is useful when you want to use the Mesh node as a gateway for your private network while also using Cloudflare Tunnel to publish specific applications.

--- a/src/content/docs/learning-paths/replace-vpn/connect-private-network/cloudflare-mesh.mdx
+++ b/src/content/docs/learning-paths/replace-vpn/connect-private-network/cloudflare-mesh.mdx
@@ -19,8 +19,10 @@ The setup wizard in the dashboard configures enrollment, device profiles, and co
 
 - Replacing a VPN for remote access to private networks
 - Bidirectional connectivity (VoIP, SIP, Active Directory, SCCM, DevOps pipelines)
+- Long-lived TCP connections sensitive to interruptions (SAP, database replication, ERP systems, RDP sessions)
 - Site-to-site networking between offices, data centers, or cloud VPCs
 - Client-to-client connectivity (two laptops reaching each other by private IP)
+- Any L3/L4 workload where source IP preservation matters
 
 ## Best practices
 

--- a/src/content/docs/learning-paths/replace-vpn/connect-private-network/connection-methods.mdx
+++ b/src/content/docs/learning-paths/replace-vpn/connect-private-network/connection-methods.mdx
@@ -38,7 +38,7 @@ There are [multiple ways](/reference-architecture/architectures/sase/#connecting
 | OSI layer             | L3                              | L7                          |
 | Protocol              | MASQUE                          | QUIC or HTTP/2              |
 | Protocols proxied     | TCP, UDP, ICMP                  | HTTP/S, TCP, SSH, RDP, SMB  |
-| Connection handling   | End-to-end — preserves long-lived TCP connections across the full path | Proxied — TCP connections are terminated and re-established at Cloudflare's edge, which can interrupt long-lived sessions (for example, SAP transactions, database replication streams, or persistent RDP sessions may drop when `cloudflared` reconnects to the edge) |
+| Connection handling   | End-to-end — preserves long-lived TCP connections across the full path | Proxied — TCP connections are terminated and re-established at Cloudflare, which can interrupt long-lived sessions (for example, SAP transactions, database replication streams, or persistent RDP sessions may drop when `cloudflared` reconnects) |
 
 ## Recommendation
 

--- a/src/content/docs/learning-paths/replace-vpn/connect-private-network/connection-methods.mdx
+++ b/src/content/docs/learning-paths/replace-vpn/connect-private-network/connection-methods.mdx
@@ -35,14 +35,15 @@ There are [multiple ways](/reference-architecture/architectures/sase/#connecting
 | Host machine          | Linux (amd64, arm64)            | Linux, macOS, Windows       |
 | IPv4                  | ✅                              | ✅                          |
 | IPv6                  | ❌                              | ✅                          |
-| OSI layer             | L3                              | L4                          |
+| OSI layer             | L3                              | L7                          |
 | Protocol              | MASQUE                          | QUIC or HTTP/2              |
 | Protocols proxied     | TCP, UDP, ICMP                  | HTTP/S, TCP, SSH, RDP, SMB  |
+| Connection handling   | End-to-end — preserves long-lived TCP connections across the full path | Proxied — TCP connections are terminated and re-established at Cloudflare's edge, which can interrupt long-lived sessions (for example, SAP transactions, database replication streams, or persistent RDP sessions may drop when `cloudflared` reconnects to the edge) |
 
 ## Recommendation
 
 For most VPN replacement scenarios, [Cloudflare Tunnel](/learning-paths/replace-vpn/connect-private-network/cloudflared/) is the easiest way to get started. It runs on all platforms (Linux, macOS, Windows, containers, Raspberry Pi), does not require return route configuration (traffic is source-NATed to the `cloudflared` host), and does not interfere with existing VPN software on the same machine.
 
-Use [Cloudflare Mesh](/learning-paths/replace-vpn/connect-private-network/cloudflare-mesh/) when you need bidirectional connectivity with server-initiated traffic (VoIP, SIP, AD updates, SCCM), site-to-site networking between multiple locations, or deployments where preserving the original source IP is important.
+Use [Cloudflare Mesh](/learning-paths/replace-vpn/connect-private-network/cloudflare-mesh/) when you need bidirectional connectivity with server-initiated traffic (VoIP, SIP, AD updates, SCCM), site-to-site networking between multiple locations, deployments where preserving the original source IP is important, or workloads with long-lived TCP connections sensitive to interruptions (SAP, database replication, ERP systems).
 
 Both methods can be used together. For example, use Tunnel for straightforward user-to-application access and add Mesh nodes where you need bidirectional or site-to-site connectivity.


### PR DESCRIPTION
## Summary

Documents Cloudflare Mesh as the recommended software on-ramp for workloads sensitive to connection interruptions (SAP, database replication, ERP systems, long-lived RDP sessions).

## Changes

### `cloudflare-mesh/index.mdx`
- Expanded the Mesh vs Tunnel guidance to call out long-lived TCP connections and L3/L4 connection preservation

### `learning-paths/.../connection-methods.mdx`
- Added SAP, database replication, ERP to the Mesh recommendation
- Added "Connection handling" row to comparison table: Mesh preserves connections end-to-end vs Tunnel re-establishes at the edge

### `learning-paths/.../cloudflare-mesh.mdx`
- Added "Long-lived TCP connections" and "L3/L4 source IP preservation" to the "When to use Mesh" list