### PR TITLE
[Audit Logs] Document Audit Logs v2 organization-level support

### DIFF
--- a/src/content/changelog/audit-logs/2026-04-23-audit-logs-v2-organization-level.mdx
+++ b/src/content/changelog/audit-logs/2026-04-23-audit-logs-v2-organization-level.mdx
@@ -1,0 +1,23 @@
+---
+title: Audit Logs v2 — Organization-level support
+description: Audit Logs v2 now supports organization-level audit logs.
+products:
+  - audit-logs
+date: 2026-04-23
+---
+
+Audit Logs v2 now supports organization-level audit logs. Org Admins can retrieve audit events for actions performed at the organization level via the Audit Logs v2 API.
+
+To retrieve organization-level audit logs, use the following endpoint:
+
+```bash
+GET https://api.cloudflare.com/client/v4/organizations/{organization_id}/logs/audit
+```
+
+This release covers user-initiated actions performed through organization-level APIs. Audit logs for system-initiated actions, a dashboard UI, and Logpush support for organizations will be added in future releases.
+
+:::note
+Organization-level audit logs are separate from account-level audit logs. Actions performed within a specific account continue to be available via the account-level Audit Logs UI, Audit Logs v2 API, and Logpush.
+:::
+
+For more information, refer to the [Audit Logs documentation](/fundamentals/account/account-security/audit-logs/).

--- a/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
+++ b/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
@@ -159,6 +159,20 @@ Reflect actions associated with a user's login (email) across multiple accounts.
 
 The `GET /memberships` endpoint supports cross-account access. To query memberships, use the parameter `resource_scope=memberships`.
 
+#### Organization Activity Logs
+
+Contain events scoped to specific Cloudflare organizations. These logs capture user-initiated actions performed by Org Admins through organization-level APIs and are retrievable via the Audit Logs v2 API.
+
+```bash
+GET https://api.cloudflare.com/client/v4/organizations/{organization_id}/logs/audit
+```
+
+:::note
+Organization-level audit logs are separate from account-level audit logs. Actions performed within a specific account continue to be available via the account-level Audit Logs UI, Audit Logs v2 API, and Logpush.
+
+This initial release covers user-initiated actions only. Support for system-initiated actions, a dashboard UI, and Logpush for organizations will be added in future releases.
+:::
+
 ## Example how to query Audit Logs
 
 Use the following example to get a list of audit logs for a user account.


### PR DESCRIPTION
### Summary

Documents Audit Logs v2 support for organization-level audit logs. Adds a changelog entry announcing the release and a new "Organization Activity Logs" subsection under Activity Scope on the Audit Logs reference page, covering the new `/organizations/{organization_id}/logs/audit` endpoint and the current scope of coverage (user-initiated actions only).

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
