### PR TITLE
[AI Search] Fix broken Items API reference URLs

### DIFF
--- a/src/content/docs/ai-search/api/items/rest-api.mdx
+++ b/src/content/docs/ai-search/api/items/rest-api.mdx
@@ -33,15 +33,15 @@ The available operations are the same for both paths. For the namespace-scoped A
 
 ## Items
 
-Upload, list, get, delete, and download items within an instance. For the full specification, refer to the [Items API reference](/api/resources/ai_search/subresources/instances/subresources/items/).
+Upload, list, get, delete, and download items within an instance. For the full specification, refer to the [Items API reference](/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/).
 
-| Operation                                                                                        | Method   | Description                    |
-| ------------------------------------------------------------------------------------------------ | -------- | ------------------------------ |
-| [Upload](/api/resources/ai_search/subresources/instances/subresources/items/methods/upload/)     | `POST`   | Upload a document for indexing |
-| [List](/api/resources/ai_search/subresources/instances/subresources/items/methods/list/)         | `GET`    | List all items in an instance  |
-| [Get](/api/resources/ai_search/subresources/instances/subresources/items/methods/get/)           | `GET`    | Get item info by ID            |
-| [Delete](/api/resources/ai_search/subresources/instances/subresources/items/methods/delete/)     | `DELETE` | Delete an item                 |
-| [Download](/api/resources/ai_search/subresources/instances/subresources/items/methods/download/) | `GET`    | Download the original file     |
+| Operation                                                                                                            | Method   | Description                    |
+| -------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------ |
+| [Upload](/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/methods/upload/)     | `POST`   | Upload a document for indexing |
+| [List](/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/methods/list/)         | `GET`    | List all items in an instance  |
+| [Get](/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/methods/get/)           | `GET`    | Get item info by ID            |
+| [Delete](/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/methods/delete/)     | `DELETE` | Delete an item                 |
+| [Download](/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/methods/download/) | `GET`    | Download the original file     |
 
 ### Example: Upload a document
 

--- a/src/content/docs/ai-search/get-started/api.mdx
+++ b/src/content/docs/ai-search/get-started/api.mdx
@@ -79,7 +79,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai-sear
 
 ## 3. Add content
 
-If you did not create an instance that is connected to a data source, upload files using the [Items API](/api/resources/ai_search/subresources/items/methods/upload/). You can skip this step if you connected a website or R2 bucket.
+If you did not create an instance that is connected to a data source, upload files using the [Items API](/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/methods/upload/). You can skip this step if you connected a website or R2 bucket.
 
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai-search/instances/my-instance/items" \

--- a/src/content/docs/ai-search/get-started/wrangler.mdx
+++ b/src/content/docs/ai-search/get-started/wrangler.mdx
@@ -26,7 +26,7 @@ Create a new instance.
 wrangler ai-search create my-instance
 ```
 
-You can upload files to the instance using the [dashboard](/ai-search/get-started/dashboard/#upload-content) or the [REST API](/api/resources/ai_search/subresources/items/methods/upload/).
+You can upload files to the instance using the [dashboard](/ai-search/get-started/dashboard/#upload-content) or the [REST API](/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/methods/upload/).
 
 ### Connect a data source (optional)
 


### PR DESCRIPTION
### Summary

Fixes 8 broken API reference links for the Items API (upload, list, get, delete, download) across 3 AI Search doc pages.

The Items API reference pages only exist under the namespace-scoped path (`/api/resources/ai_search/subresources/namespaces/subresources/instances/subresources/items/...`). The docs were using shorter paths that all return 404:

- `/api/resources/ai_search/subresources/items/methods/upload/` → 404
- `/api/resources/ai_search/subresources/instances/subresources/items/methods/upload/` → 404

All other AI Search API reference URLs (Instances, Jobs, Search, Chat Completions, Namespaces, Tokens) were verified as working correctly.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
