### PR TITLE
Expand browser close reasons with descriptions and retry guidance

### DIFF
--- a/src/content/docs/browser-run/reference/browser-close-reasons.mdx
+++ b/src/content/docs/browser-run/reference/browser-close-reasons.mdx
@@ -10,7 +10,7 @@ products:
 
 import { DashButton } from "~/components";
 
-A browser session may close for a variety of reasons, occasionally due to connection errors or errors in the headless browser instance. As a best practice, wrap `puppeteer.connect` or `puppeteer.launch` in a [`try...catch`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) statement.
+A browser session may close for a variety of reasons, including normal completion, inactivity, connection errors, or errors in the headless browser instance. As a best practice, wrap `puppeteer.connect` or `puppeteer.launch` in a [`try...catch`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) statement to handle unexpected closures gracefully.
 
 To find the reason that a browser closed:
 
@@ -22,10 +22,54 @@ To find the reason that a browser closed:
 
 Browser Run sessions are billed based on [usage](/browser-run/pricing/). We do not charge for sessions that error due to underlying Browser Run infrastructure.
 
-| Reasons a session may end                            |
-| ---------------------------------------------------- |
-| User opens and closes browser normally.              |
-| Browser is idle for 60 seconds.                      |
-| Chromium instance crashes.                           |
-| Error connecting with the client, server, or Worker. |
-| Browser session is evicted.                          |
+## Close reasons
+
+| Reason | Description |
+| --- | --- |
+| **Normal closure** | Your code called `browser.close()` and the session ended normally. No action needed. |
+| **Browser idle** | The session received no commands for the configured inactivity timeout (60 seconds by default, up to 10 minutes with [`keep_alive`](/browser-run/puppeteer/#keep-alive)). To prevent idle closures, send commands within the inactivity window or increase the `keep_alive` value. |
+| **Chromium crashed** | The Chromium instance inside the session crashed, often because the page consumed too much memory (large DOMs, heavy JavaScript, or many concurrent pages). Try reducing page complexity, closing unused pages, or breaking work into smaller tasks. |
+| **Connection error** | The connection between the client and Browser Run was interrupted. This can be caused by network issues, your Worker reaching its CPU time limit, or a WebSocket disconnection. Retry the operation with a `try...catch` block. |
+| **Session evicted** | Browser Run recycled the session due to infrastructure maintenance or a new release deployment. This is normal behavior for a managed service and is not caused by your code. Retry the operation with a `try...catch` block and reconnection logic. |
+
+## Handling unexpected closures
+
+Sessions can close at any time due to infrastructure events, network issues, or browser crashes. Design your code to handle these cases by wrapping browser operations in a `try...catch` block and reconnecting when needed.
+
+```js
+async function runBrowser(env) {
+  let browser;
+  try {
+    browser = await puppeteer.launch(env.MYBROWSER);
+    const page = await browser.newPage();
+    await page.goto("https://example.com");
+    // Your browser automation logic
+  } catch (error) {
+    console.error("Browser session ended unexpectedly:", error.message);
+    // Retry or return an error response
+  } finally {
+    if (browser) {
+      try {
+        await browser.close();
+      } catch {
+        // Browser may already be closed
+      }
+    }
+  }
+}
+```
+
+For long-running or critical workflows, consider adding retry logic:
+
+```js
+async function runWithRetry(env, maxRetries = 3) {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await runBrowser(env);
+    } catch (error) {
+      if (attempt === maxRetries) throw error;
+      console.log(`Attempt ${attempt} failed, retrying...`);
+    }
+  }
+}
+```

--- a/src/content/docs/browser-run/reference/browser-close-reasons.mdx
+++ b/src/content/docs/browser-run/reference/browser-close-reasons.mdx
@@ -30,7 +30,7 @@ Browser Run sessions are billed based on [usage](/browser-run/pricing/). We do n
 | **Browser idle** | The session received no commands for the configured inactivity timeout (60 seconds by default, up to 10 minutes with [`keep_alive`](/browser-run/puppeteer/#keep-alive)). To prevent idle closures, send commands within the inactivity window or increase the `keep_alive` value. |
 | **Chromium crashed** | The Chromium instance inside the session crashed, often because the page consumed too much memory (large DOMs, heavy JavaScript, or many concurrent pages). Try reducing page complexity, closing unused pages, or breaking work into smaller tasks. |
 | **Connection error** | The connection between the client and Browser Run was interrupted. This can be caused by network issues, your Worker reaching its CPU time limit, or a WebSocket disconnection. Retry the operation with a `try...catch` block. |
-| **Session evicted** | Browser Run recycled the session due to infrastructure maintenance or a new release deployment. This is normal behavior for a managed service and is not caused by your code. Retry the operation with a `try...catch` block and reconnection logic. |
+| **Session evicted** | Browser Run recycled the session due to infrastructure maintenance or a new release deployment. This is not caused by your code. Retry the operation with a `try...catch` block and reconnection logic. |
 
 ## Handling unexpected closures
 
@@ -48,13 +48,7 @@ async function runBrowser(env) {
     console.error("Browser session ended unexpectedly:", error.message);
     // Retry or return an error response
   } finally {
-    if (browser) {
-      try {
-        await browser.close();
-      } catch {
-        // Browser may already be closed
-      }
-    }
+    await browser?.close();
   }
 }
 ```


### PR DESCRIPTION
## Summary

Expands the [Browser close reasons](https://developers.cloudflare.com/browser-run/reference/browser-close-reasons/) reference page from a bare list of reasons into a table with descriptions and actionable guidance for each close reason.

## Changes

- **Expanded close reasons table** — Each reason now includes a description explaining what happened and what the user can do about it
- **Added "Handling unexpected closures" section** — Code examples showing `try...catch` patterns and retry logic for resilient browser automation
- Reframed infrastructure-level events (session evicted) as normal managed-service behavior without exposing internal architecture details

## Why

A user asked why their session was being evicted mid-session and we had no explanation in the docs — just a row in a table that said "Browser session is evicted" with no context. This update helps users understand close reasons and write more resilient code.