### PR TITLE
Add note on HTTP public key pinning support

### DIFF
--- a/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
@@ -55,6 +55,12 @@ Advanced certificates are [Domain Validated (DV)](/ssl/concepts/#validation-leve
 
 Advanced certificates do not cover multiple different domains. For multi-domain certificate (MDC), consider the [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) product. You can also find further guidance in [Leveraging Cloudflare for your SaaS applications](/reference-architecture/design-guides/leveraging-cloudflare-for-your-saas-applications/).
 
+:::note
+
+Cloudflare does not support HTTP public key pinning (HPKP)[^1] for Universal, Advanced, or Custom Hostname certificates. Read more [here](/ssl/reference/certificate-pinning/).
+
+:::
+
 ## Related resources
 
 <DirectoryListing />

--- a/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
@@ -57,7 +57,7 @@ Advanced certificates do not cover multiple different domains. For multi-domain 
 
 :::note
 
-Cloudflare does not support HTTP public key pinning (HPKP)[^1] for Universal, Advanced, or Custom Hostname certificates. Read more [here](/ssl/reference/certificate-pinning/).
+<Render file="hpkp-not-supported" product="ssl" />
 
 :::
 

--- a/src/content/docs/ssl/edge-certificates/custom-certificates/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/custom-certificates/index.mdx
@@ -56,3 +56,7 @@ By default, Cloudflare encrypts and securely distributes private keys to all Clo
 ### Keyless SSL
 
 If you want to upload a custom certificate but retain your private key on your own infrastructure, consider using [Keyless SSL](/ssl/keyless-ssl/).
+
+### Certificate pinning
+
+Custom certificates are the only certificate type where certificate pinning can work on Cloudflare. For guidance on pinning and its risks, refer to [Certificate pinning](/ssl/reference/certificate-pinning/).

--- a/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
+++ b/src/content/docs/ssl/edge-certificates/universal-ssl/limitations.mdx
@@ -9,10 +9,9 @@ description: Review the limitations of Universal certificates, such as hostname 
 head:
   - tag: title
     content: Limitations for Universal SSL
-
 ---
 
-import { GlossaryTooltip } from "~/components"
+import { GlossaryTooltip, Render } from "~/components";
 
 Universal SSL certificates present some limitations.
 
@@ -28,8 +27,8 @@ When you rely only on Universal SSL in a full setup zone, coverage is limited to
 
 To enable SSL for deeper subdomains, you can:
 
-* Purchase [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) — then turn on [Total TLS](/ssl/edge-certificates/additional-options/total-tls/) for automatic certificate coverage of all proxied subdomains, or manually create advanced certificates for specific hostnames.
-* Upload a [custom SSL certificate](/ssl/edge-certificates/custom-certificates/) that includes the required subdomains as Subject Alternative Names (SANs).
+- Purchase [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) — then turn on [Total TLS](/ssl/edge-certificates/additional-options/total-tls/) for automatic certificate coverage of all proxied subdomains, or manually create advanced certificates for specific hostnames.
+- Upload a [custom SSL certificate](/ssl/edge-certificates/custom-certificates/) that includes the required subdomains as Subject Alternative Names (SANs).
 
 ### CNAME setup
 
@@ -42,7 +41,6 @@ For Universal SSL certificates, Cloudflare chooses the <GlossaryTooltip term="Ce
 Cloudflare can change the [certificate authority](/ssl/reference/certificate-authorities/) without prior notification, and will not send any notification as the change happens.
 
 If you want to choose the issuing certificate authority, [order an advanced certificate](/ssl/edge-certificates/advanced-certificate-manager/).
-
 
 ## Validity period
 
@@ -76,5 +74,9 @@ Some domains are not eligible for Universal SSL if they contain words that confl
 
 To resolve this issue, you can:
 
-* Purchase an [advanced certificate](/ssl/edge-certificates/advanced-certificate-manager/).
-* Upload your own [custom certificate](/ssl/edge-certificates/custom-certificates/uploading/).
+- Purchase an [advanced certificate](/ssl/edge-certificates/advanced-certificate-manager/).
+- Upload your own [custom certificate](/ssl/edge-certificates/custom-certificates/uploading/).
+
+## Certificate pinning
+
+<Render file="hpkp-not-supported" product="ssl" />

--- a/src/content/docs/ssl/reference/certificate-pinning.mdx
+++ b/src/content/docs/ssl/reference/certificate-pinning.mdx
@@ -6,15 +6,15 @@ products:
 sidebar:
   order: 8
 head: []
-description: Learn why Cloudflare does not support HTTP public key pinning
-  (HPKP) and consider an alternative solution to prevent certificate
-  misissuance.
+description: Learn why Cloudflare does not support HTTP public key pinning (HPKP) and consider an alternative solution to prevent certificate misissuance.
 
 ---
 
-Cloudflare does not support HTTP public key pinning (HPKP)[^1] for Universal, Advanced, or Custom Hostname certificates.
+import { GlossaryTooltip } from "~/components";
 
-Cloudflare regularly rotates the edge certificates provisioned for your domain. If HPKP were enabled, your domain would go offline each time a certificate rotates because the new certificate would not match the pinned key. Additionally, [industry experts](https://scotthelme.co.uk/im-giving-up-on-hpkp/) discourage using HPKP. For a detailed overview, refer to the Cloudflare blog post on [why certificate pinning is outdated](https://blog.cloudflare.com/why-certificate-pinning-is-outdated/).
+Cloudflare does not support <GlossaryTooltip term="certificate pinning" link="/ssl/reference/certificate-pinning/">HTTP public key pinning (HPKP)</GlossaryTooltip> for universal, advanced, or custom hostname certificates.
+
+Cloudflare regularly rotates the edge certificates provisioned for your domain. If HPKP was enabled, your domain would go offline each time a certificate rotates because the new certificate would not match the pinned key. Additionally, [industry experts](https://scotthelme.co.uk/im-giving-up-on-hpkp/) discourage using HPKP. For a detailed overview, refer to the Cloudflare blog post on [why certificate pinning is outdated](https://blog.cloudflare.com/why-certificate-pinning-is-outdated/).
 
 ## Recommended alternative
 

--- a/src/content/partials/ssl/hpkp-not-supported.mdx
+++ b/src/content/partials/ssl/hpkp-not-supported.mdx
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+Cloudflare does not support HTTP public key pinning (HPKP) for universal, advanced, or custom hostname certificates. For details and recommended alternatives, refer to [Certificate pinning](/ssl/reference/certificate-pinning/).


### PR DESCRIPTION
### Summary

Added note about lack of support for HTTP public key pinning in certain certificate types. I had to open a support case to figure this out. It would be really helpful to have a link to this limitation under the limitations.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
