### PR TITLE
[agent-setup] Follow-ups: Manifest-driven Skills/MCP lists, static PlatformAccessSection

### DIFF
--- a/src/components/agent-setup/CloudflareToolsBanner.astro
+++ b/src/components/agent-setup/CloudflareToolsBanner.astro
@@ -16,7 +16,7 @@
 
 		<div class="cf-banner-item">
 			<p class="cf-banner-item-title">MCP</p>
-			<p class="cf-banner-item-desc">Connect agents to your Cloudflare account. Two flavors: <a href="/agents/api-reference/codemode/">Code Mode</a> for broad API coverage across all products, or <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">domain-specific servers &nearr;</a> for purpose-built tools within one product area.</p>
+			<p class="cf-banner-item-desc">Connect agents to your Cloudflare account. Two flavors: <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">Code Mode &nearr;</a> for broad API coverage across all products, or <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">domain-specific servers &nearr;</a> for purpose-built tools within one product area.</p>
 		</div>
 
 		<div class="cf-banner-item">

--- a/src/components/agent-setup/CloudflareToolsBanner.astro
+++ b/src/components/agent-setup/CloudflareToolsBanner.astro
@@ -1,0 +1,31 @@
+---
+// Shown between the page title and the agent catalog.
+// Communicates what Cloudflare provides before the user picks an agent.
+---
+
+<div class="cf-banner not-content">
+	<div class="cf-banner-items">
+
+		<div class="cf-banner-item">
+			<p class="cf-banner-item-title">Skills</p>
+			<p class="cf-banner-item-desc">Reusable prompt packages that teach agents about Cloudflare products and APIs.</p>
+			<div class="cf-banner-item-links">
+				<a href="https://github.com/cloudflare/skills" target="_blank" rel="noopener noreferrer">cloudflare/skills &nearr;</a>
+			</div>
+		</div>
+
+		<div class="cf-banner-item">
+			<p class="cf-banner-item-title">MCP</p>
+			<p class="cf-banner-item-desc">Connect agents to your Cloudflare account. Two flavors: <a href="/agents/api-reference/codemode/">Code Mode</a> for broad API coverage across all products, or <a href="https://github.com/cloudflare/mcp-server-cloudflare" target="_blank" rel="noopener noreferrer">domain-specific servers &nearr;</a> for purpose-built tools within one product area.</p>
+		</div>
+
+		<div class="cf-banner-item">
+			<p class="cf-banner-item-title">CLI</p>
+			<p class="cf-banner-item-desc">
+				<a href="/workers/wrangler/">Wrangler</a> for deploying and managing Workers, KV, D1, R2, and more.
+				<a href="https://blog.cloudflare.com/cf-cli-local-explorer/" target="_blank" rel="noopener noreferrer">cf CLI &nearr;</a> is a next-generation CLI covering every Cloudflare product — in technical preview.
+			</p>
+		</div>
+
+	</div>
+</div>

--- a/src/components/agent-setup/McpServerList.astro
+++ b/src/components/agent-setup/McpServerList.astro
@@ -1,5 +1,5 @@
 ---
-import { getEntry } from "astro:content";
+import { getCollection } from "astro:content";
 
 interface Props {
 	/** Whether to show the "bundled" chip. Only relevant for plugin-based agents (Claude Code, Cursor). */
@@ -8,83 +8,41 @@ interface Props {
 
 const { showBundled = false } = Astro.props;
 
-const card = await getEntry("cloudflare-mcp-server-card", "cloudflare-mcp");
+const CODE_MODE_URL = "https://mcp.cloudflare.com/mcp";
+
+const allServers = await getCollection("cloudflare-mcps-manifest");
+
+// Code Mode first, then the rest in manifest order
+const servers = [
+	...allServers.filter((s) => s.data.url === CODE_MODE_URL),
+	...allServers.filter((s) => s.data.url !== CODE_MODE_URL),
+];
 
 /**
- * Descriptions are not available in the server-card spec, so they are
- * maintained here and keyed by the server name derived from the remote URL.
- *
- * Name derivation: the subdomain of *.mcp.cloudflare.com becomes the suffix
- * after "cloudflare-", except for the root mcp.cloudflare.com which maps to
- * "cloudflare-api" (the Code Mode server).
- */
-const DESCRIPTIONS: Record<string, string> = {
-	"cloudflare-api":
-		"Entire Cloudflare API (2,500+ endpoints) in ~1,000 tokens via Code Mode.",
-	"cloudflare-docs": "Up-to-date Cloudflare documentation and reference.",
-	"cloudflare-bindings":
-		"Build Workers applications with storage, AI, and compute primitives.",
-	"cloudflare-builds": "Manage and get insights into Workers builds.",
-	"cloudflare-observability":
-		"Debug and analyze application logs and analytics.",
-	"cloudflare-radar":
-		"Global Internet traffic insights, trends, URL scans, and utilities.",
-	"cloudflare-containers": "Spin up a sandbox development environment.",
-	"cloudflare-browser":
-		"Fetch web pages, convert them to markdown, and take screenshots.",
-	"cloudflare-logs": "Quick summaries for Logpush job health.",
-	"cloudflare-ai-gateway":
-		"Search AI Gateway logs and inspect prompts, responses, and token usage.",
-	"cloudflare-auditlogs":
-		"Query audit logs and generate reports for review.",
-	"cloudflare-dns-analytics":
-		"Optimize DNS performance and debug issues based on current setup.",
-	"cloudflare-dex":
-		"Digital Experience Monitoring — insights on critical applications.",
-	"cloudflare-casb":
-		"Cloudflare One CASB — identify SaaS security misconfigurations.",
-	"cloudflare-graphql":
-		"Query analytics data through Cloudflare's GraphQL API.",
-};
-
-/**
- * Servers included in the cloudflare/skills plugin bundle (Claude Code, Cursor).
+ * URLs of servers included in the cloudflare/skills plugin bundle
+ * (Claude Code, Cursor).
  */
 const BUNDLED = new Set([
-	"cloudflare-api",
-	"cloudflare-docs",
-	"cloudflare-bindings",
-	"cloudflare-builds",
-	"cloudflare-observability",
+	"https://mcp.cloudflare.com/mcp",
+	"https://docs.mcp.cloudflare.com/mcp",
+	"https://bindings.mcp.cloudflare.com/mcp",
+	"https://builds.mcp.cloudflare.com/mcp",
+	"https://observability.mcp.cloudflare.com/mcp",
 ]);
-
-/**
- * Derive a stable server name from a remote URL.
- *
- * https://mcp.cloudflare.com/mcp          → cloudflare-api
- * https://docs.mcp.cloudflare.com/mcp     → cloudflare-docs
- * https://ai-gateway.mcp.cloudflare.com   → cloudflare-ai-gateway
- */
-function nameFromUrl(url: string): string {
-	const { hostname } = new URL(url);
-	// hostname: "mcp.cloudflare.com" or "{sub}.mcp.cloudflare.com"
-	const sub = hostname.replace(/\.mcp\.cloudflare\.com$/, "");
-	return sub === "mcp" ? "cloudflare-api" : `cloudflare-${sub}`;
-}
-
-// Use only the streamable-http remotes to get one entry per logical server.
-const servers = (card?.data.remotes ?? [])
-	.filter((r) => r.type === "streamable-http")
-	.map((r) => nameFromUrl(r.url));
 ---
 
 <ul class="agent-simple-list">
 	{
-		servers.map((name) => (
+		servers.map((s) => (
 			<li class="agent-simple-item">
 				<span class="agent-simple-name">
-					{name}
-					{showBundled && BUNDLED.has(name) && (
+					{s.data.name}
+					{s.data.url === CODE_MODE_URL && (
+						<span class="agent-simple-tag agent-simple-tag--codemode">
+							code mode
+						</span>
+					)}
+					{showBundled && BUNDLED.has(s.data.url) && (
 						<span
 							class="agent-simple-tag"
 							title="Included in the cloudflare/skills plugin"
@@ -93,9 +51,8 @@ const servers = (card?.data.remotes ?? [])
 						</span>
 					)}
 				</span>
-				<span class="agent-simple-desc">
-					{DESCRIPTIONS[name] ?? ""}
-				</span>
+				<span class="agent-simple-desc">{s.data.description}</span>
+				<span class="agent-simple-url">{s.data.url}</span>
 			</li>
 		))
 	}

--- a/src/components/agent-setup/McpServerList.astro
+++ b/src/components/agent-setup/McpServerList.astro
@@ -1,23 +1,5 @@
 ---
-// Simple list of Cloudflare MCP servers.
-// Renders each server as an orange name (+ optional "bundled" tag) followed
-// by a short description.
-//
-// Sources:
-//   • Code Mode API server — https://github.com/cloudflare/mcp (README + /.mcp.json)
-//   • Domain-specific servers — https://github.com/cloudflare/mcp-server-cloudflare
-//   • Plugin bundle — https://github.com/cloudflare/skills (/.mcp.json)
-//
-// When new servers are added upstream, add them here.
-
-interface McpServer {
-	/** Server name as it appears in JSON config (e.g. `"cloudflare-api"`). */
-	name: string;
-	/** One-line purpose, sourced from the upstream README. */
-	description: string;
-	/** True if this server is pre-registered by the cloudflare/skills plugin. */
-	bundled?: boolean;
-}
+import { getEntry } from "astro:content";
 
 interface Props {
 	/** Whether to show the "bundled" chip. Only relevant for plugin-based agents (Claude Code, Cursor). */
@@ -26,94 +8,83 @@ interface Props {
 
 const { showBundled = false } = Astro.props;
 
-const SERVERS: McpServer[] = [
-	{
-		name: "cloudflare-api",
-		description:
-			"Entire Cloudflare API (2,500+ endpoints) in ~1,000 tokens via Code Mode.",
-		bundled: true,
-	},
-	{
-		name: "cloudflare-docs",
-		description: "Up-to-date Cloudflare documentation and reference.",
-		bundled: true,
-	},
-	{
-		name: "cloudflare-bindings",
-		description:
-			"Build Workers applications with storage, AI, and compute primitives.",
-		bundled: true,
-	},
-	{
-		name: "cloudflare-builds",
-		description: "Manage and get insights into Workers builds.",
-		bundled: true,
-	},
-	{
-		name: "cloudflare-observability",
-		description: "Debug and analyze application logs and analytics.",
-		bundled: true,
-	},
-	{
-		name: "cloudflare-radar",
-		description:
-			"Global Internet traffic insights, trends, URL scans, and utilities.",
-	},
-	{
-		name: "cloudflare-containers",
-		description: "Spin up a sandbox development environment.",
-	},
-	{
-		name: "cloudflare-browser",
-		description:
-			"Fetch web pages, convert them to markdown, and take screenshots.",
-	},
-	{
-		name: "cloudflare-logpush",
-		description: "Quick summaries for Logpush job health.",
-	},
-	{
-		name: "cloudflare-ai-gateway",
-		description:
-			"Search AI Gateway logs and inspect prompts, responses, and token usage.",
-	},
-	{
-		name: "cloudflare-autorag",
-		description: "List and search documents on your AutoRAGs.",
-	},
-	{
-		name: "cloudflare-auditlogs",
-		description: "Query audit logs and generate reports for review.",
-	},
-	{
-		name: "cloudflare-dns-analytics",
-		description:
-			"Optimize DNS performance and debug issues based on current setup.",
-	},
-	{
-		name: "cloudflare-dex",
-		description:
-			"Digital Experience Monitoring — insights on critical applications.",
-	},
-	{
-		name: "cloudflare-casb",
-		description:
-			"Cloudflare One CASB — identify SaaS security misconfigurations.",
-	},
-	{
-		name: "cloudflare-graphql",
-		description: "Query analytics data through Cloudflare's GraphQL API.",
-	},
-];
+const card = await getEntry("cloudflare-mcp-server-card", "cloudflare-mcp");
+
+/**
+ * Descriptions are not available in the server-card spec, so they are
+ * maintained here and keyed by the server name derived from the remote URL.
+ *
+ * Name derivation: the subdomain of *.mcp.cloudflare.com becomes the suffix
+ * after "cloudflare-", except for the root mcp.cloudflare.com which maps to
+ * "cloudflare-api" (the Code Mode server).
+ */
+const DESCRIPTIONS: Record<string, string> = {
+	"cloudflare-api":
+		"Entire Cloudflare API (2,500+ endpoints) in ~1,000 tokens via Code Mode.",
+	"cloudflare-docs": "Up-to-date Cloudflare documentation and reference.",
+	"cloudflare-bindings":
+		"Build Workers applications with storage, AI, and compute primitives.",
+	"cloudflare-builds": "Manage and get insights into Workers builds.",
+	"cloudflare-observability":
+		"Debug and analyze application logs and analytics.",
+	"cloudflare-radar":
+		"Global Internet traffic insights, trends, URL scans, and utilities.",
+	"cloudflare-containers": "Spin up a sandbox development environment.",
+	"cloudflare-browser":
+		"Fetch web pages, convert them to markdown, and take screenshots.",
+	"cloudflare-logs": "Quick summaries for Logpush job health.",
+	"cloudflare-ai-gateway":
+		"Search AI Gateway logs and inspect prompts, responses, and token usage.",
+	"cloudflare-auditlogs":
+		"Query audit logs and generate reports for review.",
+	"cloudflare-dns-analytics":
+		"Optimize DNS performance and debug issues based on current setup.",
+	"cloudflare-dex":
+		"Digital Experience Monitoring — insights on critical applications.",
+	"cloudflare-casb":
+		"Cloudflare One CASB — identify SaaS security misconfigurations.",
+	"cloudflare-graphql":
+		"Query analytics data through Cloudflare's GraphQL API.",
+};
+
+/**
+ * Servers included in the cloudflare/skills plugin bundle (Claude Code, Cursor).
+ */
+const BUNDLED = new Set([
+	"cloudflare-api",
+	"cloudflare-docs",
+	"cloudflare-bindings",
+	"cloudflare-builds",
+	"cloudflare-observability",
+]);
+
+/**
+ * Derive a stable server name from a remote URL.
+ *
+ * https://mcp.cloudflare.com/mcp          → cloudflare-api
+ * https://docs.mcp.cloudflare.com/mcp     → cloudflare-docs
+ * https://ai-gateway.mcp.cloudflare.com   → cloudflare-ai-gateway
+ */
+function nameFromUrl(url: string): string {
+	const { hostname } = new URL(url);
+	// hostname: "mcp.cloudflare.com" or "{sub}.mcp.cloudflare.com"
+	const sub = hostname.replace(/\.mcp\.cloudflare\.com$/, "");
+	return sub === "mcp" ? "cloudflare-api" : `cloudflare-${sub}`;
+}
+
+// Use only the streamable-http remotes to get one entry per logical server.
+const servers = (card?.data.remotes ?? [])
+	.filter((r) => r.type === "streamable-http")
+	.map((r) => nameFromUrl(r.url));
 ---
 
 <ul class="agent-simple-list">
 	{
-		SERVERS.map((s) => (
+		servers.map((name) => (
 			<li class="agent-simple-item">
 				<span class="agent-simple-name">
-					{s.name}
-					{showBundled && s.bundled && (
+					{name}
+					{showBundled && BUNDLED.has(name) && (
 						<span
 							class="agent-simple-tag"
 							title="Included in the cloudflare/skills plugin"
@@ -122,7 +93,9 @@ const SERVERS: McpServer[] = [
 						</span>
 					)}
 				</span>
-				<span class="agent-simple-desc">{s.description}</span>
+				<span class="agent-simple-desc">
+					{DESCRIPTIONS[name] ?? ""}
+				</span>
 			</li>
 		))
 	}

--- a/src/components/agent-setup/PlatformAccessSection.astro
+++ b/src/components/agent-setup/PlatformAccessSection.astro
@@ -1,84 +1,43 @@
 ---
-// Shared "Cloudflare platform access" content for every agent detail page.
-//
-// Renders the four <PlatformAccessDetails> cards in a consistent order:
-//   1. Cloudflare Skills  — what they are + links to GitHub and agent Skills docs
-//   2. MCP servers        — description + <McpServerList> + links to GitHub / catalog
-//   3. Wrangler CLI       — agent-specific body via `wrangler` slot (fallback copy is generic)
-//   4. Agent-friendly docs — agent-specific body via `docs` slot (fallback copy is generic)
-//
-// Install commands are intentionally NOT repeated here — they already appear in
-// each agent's Quick start.
-//
-// Uses a bespoke <PlatformAccessDetails> component rather than the site-wide
-// <Details>. This lets us use higher-specificity selectors to beat Starlight's
-// default `.sl-markdown-content details` prose styling WITHOUT needing a
-// `.not-content` wrapper — so inline <code>, hyperlinks, and other prose
-// elements inside the body keep their normal Starlight theming.
 import PlatformAccessDetails from "./PlatformAccessDetails.astro";
 import McpServerList from "./McpServerList.astro";
 import SkillsList from "./SkillsList.astro";
-
-interface Props {
-	agentName: string;
-	/**
-	 * If the agent doesn't yet support Agent Skills, set to false to hide the
-	 * Skills card entirely.
-	 */
-	skillsSupported?: boolean;
-	/** Optional extra paragraph shown above the Skills list. */
-	skillsExtraHtml?: string;
-	/** Optional extra paragraph shown above the MCP server list. */
-	mcpExtraHtml?: string;
-}
-
-const {
-	agentName,
-	skillsSupported = true,
-	skillsExtraHtml,
-	mcpExtraHtml,
-} = Astro.props;
 ---
 
 <div class="agent-setup-platform-access">
 	<p class="agent-platform-lede">
-		The ways {agentName} reaches Cloudflare. Expand any section to learn more.
+		Expand any section to learn more.
 	</p>
 
-	{
-		skillsSupported && (
-			<PlatformAccessDetails header="Cloudflare Skills">
-				<p class="agent-platform-hint">
-					Persistent platform context that teaches {agentName} how Cloudflare
-					works.
-				</p>
-				<p>
-					Skills are instructions the agent loads on demand. The{" "}
-					<a
-						href="https://github.com/cloudflare/skills"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						cloudflare/skills
-					</a>{" "}
-					bundle ships eight Skills covering every layer of the platform &mdash;
-					so the agent knows your conventions without you re-explaining them.
-				</p>
-				{skillsExtraHtml && <p set:html={skillsExtraHtml} />}
-				<SkillsList />
-			</PlatformAccessDetails>
-		)
-	}
+	<PlatformAccessDetails header="Cloudflare Skills">
+		<p class="agent-platform-hint">
+			Persistent platform context that teaches the agent how Cloudflare works.
+		</p>
+		<p>
+			Skills are instructions the agent loads on demand. The{" "}
+			<a
+				href="https://github.com/cloudflare/skills"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				cloudflare/skills
+			</a>{" "}
+			bundle covers every layer of the platform &mdash; so the agent knows your
+			conventions without you re-explaining them.
+		</p>
+		<SkillsList />
+	</PlatformAccessDetails>
 
 	<PlatformAccessDetails header="MCP servers">
 		<p class="agent-platform-hint">
-			Live access to the Cloudflare API, docs, and observability from inside {
-				agentName
-			}.
+			Live access to the Cloudflare API, docs, and observability.
 		</p>
 		<p>
-			MCP servers give {agentName} typed tools to call into Cloudflare at runtime.
-			The{" "}
+			MCP servers provide typed tools to call into Cloudflare at runtime. There
+			are two options: <a href="/agents/api-reference/codemode/">Code Mode</a> —
+			a single server that covers the entire Cloudflare API (2,500+ endpoints in
+			~1,000 tokens) — or a set of focused, domain-specific servers hosted in
+			the{" "}
 			<a
 				href="https://github.com/cloudflare/mcp-server-cloudflare"
 				target="_blank"
@@ -86,37 +45,33 @@ const {
 			>
 				cloudflare/mcp-server-cloudflare
 			</a>{" "}
-			repo hosts all of them; the full catalog is also in the{" "}
+			repo. The full catalog is also in the{" "}
 			<a href="/agents/model-context-protocol/mcp-servers-for-cloudflare/">
 				MCP servers for Cloudflare
 			</a>{" "}
-			docs. The API server alone exposes 2,500+ endpoints in ~1,000 tokens via <a
-				href="/agents/api-reference/codemode/">Code Mode</a
-			>.
+			docs.
 		</p>
-		{mcpExtraHtml && <p set:html={mcpExtraHtml} />}
-		<McpServerList showBundled={agentName === "Claude Code" || agentName === "Cursor"} />
+		<McpServerList />
 	</PlatformAccessDetails>
 
 	<PlatformAccessDetails header="Wrangler CLI">
-		<slot name="wrangler">
-			<p class="agent-platform-hint">
-				Local dev, deploys, and Workers-specific commands.
-			</p>
-			<p>
-				{agentName} runs <a href="/workers/wrangler/">Wrangler</a> for local development,
-				deploys, and product-specific commands like <code
-					>wrangler d1 migrations apply</code
-				> or <code>wrangler tail</code>. The bundled <strong>wrangler</strong> Skill
-				teaches the agent when to reach for it.
-			</p>
-		</slot>
+		<p class="agent-platform-hint">
+			Local dev, deploys, and Workers-specific commands.
+		</p>
+		<p>
+			Use <a href="/workers/wrangler/">Wrangler</a> for local development,
+			deploys, and product-specific commands like{" "}
+			<code>wrangler d1 migrations apply</code> or <code>wrangler tail</code>.
+			The bundled <strong>wrangler</strong> Skill teaches the agent when to reach
+			for it.
+		</p>
 		<aside class="agent-platform-note">
 			<p class="agent-platform-note-title">What&rsquo;s next</p>
 			<p>
-				The unified <code>cf</code> CLI is in technical preview &mdash; a next-generation
-				CLI that covers every Cloudflare product with consistent verbs and ergonomic
-				output for agents. Try it with <code>npx cf</code>. <a
+				The unified <code>cf</code> CLI is in technical preview &mdash; a
+				next-generation CLI that covers every Cloudflare product with consistent
+				verbs and ergonomic output for agents. Try it with <code>npx cf</code>.{" "}
+				<a
 					href="https://blog.cloudflare.com/cf-cli-local-explorer/"
 					target="_blank"
 					rel="noopener noreferrer">Read the announcement &rarr;</a
@@ -126,43 +81,36 @@ const {
 	</PlatformAccessDetails>
 
 	<PlatformAccessDetails header="Agent-friendly docs">
-		<slot name="docs">
-			<p class="agent-platform-hint">
-				Token-efficient references you can point {agentName} at.
-			</p>
-			<p>
-				Append <code>/index.md</code> to any Cloudflare docs URL for a clean markdown
-				version. Every top-level product section also has its own <code
-					>llms.txt</code
-				> — a page index sized for a single context window. A few useful ones:
-			</p>
-			<ul class="agent-platform-resources">
-				<li>
-					<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> &mdash; directory
-					of every Cloudflare product.
-				</li>
-				<li>
-					<a href="/workers/llms.txt"
-						>developers.cloudflare.com/workers/llms.txt</a
-					>
-				</li>
-				<li>
-					<a href="/agents/llms.txt"
-						>developers.cloudflare.com/agents/llms.txt</a
-					>
-				</li>
-				<li>
-					<a href="/r2/llms.txt">developers.cloudflare.com/r2/llms.txt</a>
-				</li>
-				<li>
-					<a href="/d1/llms.txt">developers.cloudflare.com/d1/llms.txt</a>
-				</li>
-			</ul>
-			<p>
-				For a full overview of how these docs are structured for agents, refer
-				to the{" "}
-				<a href="/style-guide/ai-tooling/">AI tooling guide</a>.
-			</p>
-		</slot>
+		<p class="agent-platform-hint">
+			Token-efficient references optimized for agents.
+		</p>
+		<p>
+			Append <code>/index.md</code> to any Cloudflare docs URL for a clean
+			markdown version. Every top-level product section also has its own{" "}
+			<code>llms.txt</code> — a page index sized for a single context window. A
+			few useful ones:
+		</p>
+		<ul class="agent-platform-resources">
+			<li>
+				<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> &mdash;
+				directory of every Cloudflare product.
+			</li>
+			<li>
+				<a href="/workers/llms.txt">developers.cloudflare.com/workers/llms.txt</a>
+			</li>
+			<li>
+				<a href="/agents/llms.txt">developers.cloudflare.com/agents/llms.txt</a>
+			</li>
+			<li>
+				<a href="/r2/llms.txt">developers.cloudflare.com/r2/llms.txt</a>
+			</li>
+			<li>
+				<a href="/d1/llms.txt">developers.cloudflare.com/d1/llms.txt</a>
+			</li>
+		</ul>
+		<p>
+			For a full overview of how these docs are structured for agents, refer to
+			the <a href="/style-guide/ai-tooling/">AI tooling guide</a>.
+		</p>
 	</PlatformAccessDetails>
 </div>

--- a/src/components/agent-setup/SkillsList.astro
+++ b/src/components/agent-setup/SkillsList.astro
@@ -1,66 +1,18 @@
 ---
-// Simple list of Cloudflare Skills shipped by the cloudflare/skills plugin.
-// Renders each Skill as an orange name followed by a short description.
-//
-// Descriptions are copied verbatim from the upstream README at
-// https://github.com/cloudflare/skills. Keep this list in sync with that file
-// when new Skills are added.
+import { getCollection } from "astro:content";
 
-interface Skill {
-	name: string;
-	description: string;
-}
+const skills = await getCollection("cloudflare-skills-manifest");
 
-const SKILLS: Skill[] = [
-	{
-		name: "cloudflare",
-		description:
-			"Comprehensive platform skill covering Workers, Pages, storage (KV, D1, R2), AI (Workers AI, Vectorize, Agents SDK), networking (Tunnel, Spectrum), security (WAF, DDoS), and IaC (Terraform, Pulumi).",
-	},
-	{
-		name: "agents-sdk",
-		description:
-			"Building stateful AI agents with state, scheduling, RPC, MCP servers, email, and streaming chat.",
-	},
-	{
-		name: "durable-objects",
-		description:
-			"Stateful coordination (chat rooms, games, booking), RPC, SQLite, alarms, WebSockets.",
-	},
-	{
-		name: "sandbox-sdk",
-		description:
-			"Secure code execution for AI code execution, code interpreters, CI/CD systems, and interactive dev environments.",
-	},
-	{
-		name: "wrangler",
-		description:
-			"Deploying and managing Workers, KV, R2, D1, Vectorize, Queues, Workflows.",
-	},
-	{
-		name: "web-perf",
-		description:
-			"Auditing Core Web Vitals (FCP, LCP, TBT, CLS), render-blocking resources, network chains.",
-	},
-	{
-		name: "building-mcp-server-on-cloudflare",
-		description:
-			"Building remote MCP servers with tools, OAuth, and deployment.",
-	},
-	{
-		name: "building-ai-agent-on-cloudflare",
-		description:
-			"Building AI agents with state, WebSockets, and tool integration.",
-	},
-];
+// Sort alphabetically so the order is stable and deterministic
+skills.sort((a, b) => a.id.localeCompare(b.id));
 ---
 
 <ul class="agent-simple-list">
 	{
-		SKILLS.map((s) => (
+		skills.map((s) => (
 			<li class="agent-simple-item">
-				<span class="agent-simple-name">{s.name}</span>
-				<span class="agent-simple-desc">{s.description}</span>
+				<span class="agent-simple-name">{s.data.name}</span>
+				<span class="agent-simple-desc">{s.data.description}</span>
 			</li>
 		))
 	}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -30,7 +30,7 @@ import {
 	partialsSchema,
 	streamSchema,
 	cloudflareSkillSchema,
-	mcpServerCardSchema,
+	mcpServerSchema,
 } from "~/schemas";
 
 function contentLoader(name: string) {
@@ -147,12 +147,15 @@ export const collections = {
 		}),
 		schema: cloudflareSkillSchema,
 	}),
-	"cloudflare-mcp-server-card": defineCollection({
-		loader: middlecacheLoader("v1/cloudflare-mcps/server-card.json", {
+	"cloudflare-mcps-manifest": defineCollection({
+		loader: middlecacheLoader("v1/cloudflare-mcps/mcps-manifest.json", {
 			parser: (fileContent: string) => {
-				return { "cloudflare-mcp": JSON.parse(fileContent) };
+				const data = JSON.parse(fileContent) as {
+					servers: Array<{ name: string; description: string; url: string }>;
+				};
+				return Object.fromEntries(data.servers.map((s) => [s.url, s]));
 			},
 		}),
-		schema: mcpServerCardSchema,
+		schema: mcpServerSchema,
 	}),
 };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,6 +9,8 @@ import { skillsLoader } from "astro-skills";
 import { productAvailabilityCollectionConfig } from "./content/collections/product-availability";
 import { granularControlApplicationsCollectionConfig } from "./content/collections/granular-control-applications";
 
+import { middlecacheLoader } from "./util/custom-loaders";
+
 import {
 	appsSchema,
 	catalogModelsSchema,
@@ -27,6 +29,8 @@ import {
 	fieldsSchema,
 	partialsSchema,
 	streamSchema,
+	cloudflareSkillSchema,
+	mcpServerCardSchema,
 } from "~/schemas";
 
 function contentLoader(name: string) {
@@ -131,5 +135,24 @@ export const collections = {
 	),
 	skills: defineCollection({
 		loader: skillsLoader({ base: "./skills" }),
+	}),
+	"cloudflare-skills-manifest": defineCollection({
+		loader: middlecacheLoader("v1/cloudflare-skills/skills-manifest.json", {
+			parser: (fileContent: string) => {
+				const data = JSON.parse(fileContent) as {
+					skills: Array<{ name: string; description: string; files: string[] }>;
+				};
+				return Object.fromEntries(data.skills.map((s) => [s.name, s]));
+			},
+		}),
+		schema: cloudflareSkillSchema,
+	}),
+	"cloudflare-mcp-server-card": defineCollection({
+		loader: middlecacheLoader("v1/cloudflare-mcps/server-card.json", {
+			parser: (fileContent: string) => {
+				return { "cloudflare-mcp": JSON.parse(fileContent) };
+			},
+		}),
+		schema: mcpServerCardSchema,
 	}),
 };

--- a/src/content/docs/agent-setup/claude-code.mdx
+++ b/src/content/docs/agent-setup/claude-code.mdx
@@ -57,54 +57,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Cloudflare platform access
 
-<PlatformAccess agentName="Claude Code">
-	<Fragment slot="wrangler">
-		<div class="agent-platform-hint">
-			Local dev, deploys, and Workers-specific commands.
-		</div>
-		<p>
-			Claude Code uses <a href="/workers/wrangler/">Wrangler</a> directly in the
-			terminal for local dev, deploys, and commands like <code>wrangler d1 migrations apply</code>
-			or <code>wrangler tail</code>. The bundled <strong>wrangler</strong> Skill teaches
-			Claude exactly when to reach for it.
-		</p>
-	</Fragment>
-
-<Fragment slot="docs">
-	<div class="agent-platform-hint">
-		Token-efficient references you can point Claude at.
-	</div>
-	<p>
-		Claude Code automatically sends <code>Accept: text/markdown</code> when fetching
-		Cloudflare docs, so it gets the clean markdown version by default. Every top-level
-		product section also has its own <code>llms.txt</code> — a page index sized for
-		a single context window. A few useful ones:
-	</p>
-	<ul class="agent-platform-resources">
-		<li>
-			<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> — directory of
-			every Cloudflare product.
-		</li>
-		<li>
-			<a href="/workers/llms.txt">developers.cloudflare.com/workers/llms.txt</a>
-		</li>
-		<li>
-			<a href="/agents/llms.txt">developers.cloudflare.com/agents/llms.txt</a>
-		</li>
-		<li>
-			<a href="/r2/llms.txt">developers.cloudflare.com/r2/llms.txt</a>
-		</li>
-		<li>
-			<a href="/d1/llms.txt">developers.cloudflare.com/d1/llms.txt</a>
-		</li>
-	</ul>
-	<p>
-		For a full overview of how these docs are structured for agents, refer to the{" "}
-		<a href="/style-guide/ai-tooling/">AI tooling guide</a>.
-	</p>
-</Fragment>
-
-</PlatformAccess>
+<PlatformAccess />
 
 ## Example prompts
 

--- a/src/content/docs/agent-setup/codex.mdx
+++ b/src/content/docs/agent-setup/codex.mdx
@@ -63,50 +63,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Cloudflare platform access
 
-<PlatformAccess agentName="Codex">
-	<Fragment slot="wrangler">
-		<div class="agent-platform-hint">Sandbox-safe local dev and deploys.</div>
-		<p>
-			Codex runs in a sandboxed environment — it can safely execute <a href="/workers/wrangler/">Wrangler</a>
-			commands without affecting your host system. The bundled <strong>wrangler</strong>
-			Skill teaches Codex which commands to run for deploys, migrations, and log tailing.
-		</p>
-	</Fragment>
-
-    <Fragment slot="docs">
-    	<div class="agent-platform-hint">
-    		Codex also browses the web — pair with the docs MCP server.
-    	</div>
-    	<p>
-    		Codex supports web browsing natively. Combined with the docs MCP server, you
-    		get both fast indexed lookups and live browsing when needed. For offline or
-    		preloaded context:
-    	</p>
-    	<ul class="agent-platform-resources">
-    		<li>
-    			<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> — directory of
-    			every Cloudflare product.
-    		</li>
-    		<li>
-    			<a href="/workers/llms.txt">developers.cloudflare.com/workers/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/agents/llms.txt">developers.cloudflare.com/agents/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/r2/llms.txt">developers.cloudflare.com/r2/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/d1/llms.txt">developers.cloudflare.com/d1/llms.txt</a>
-    		</li>
-    	</ul>
-    	<p>
-    		For a full overview of how these docs are structured for agents, refer to the{" "}
-    		<a href="/style-guide/ai-tooling/">AI tooling guide</a>.
-    	</p>
-    </Fragment>
-
-</PlatformAccess>
+<PlatformAccess />
 
 ## Example prompts
 

--- a/src/content/docs/agent-setup/cursor.mdx
+++ b/src/content/docs/agent-setup/cursor.mdx
@@ -44,51 +44,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Cloudflare platform access
 
-<PlatformAccess agentName="Cursor">
-	<Fragment slot="wrangler">
-		<div class="agent-platform-hint">
-			Local dev, deploys, and Workers-specific commands.
-		</div>
-		<p>
-			Cursor's integrated terminal runs <a href="/workers/wrangler/">Wrangler</a> for
-			local dev and deploys. The bundled <strong>wrangler</strong> Skill teaches Composer
-			when to call CLI commands vs. the MCP API.
-		</p>
-	</Fragment>
-
-    <Fragment slot="docs">
-    	<div class="agent-platform-hint">
-    		Token-efficient references for Composer context.
-    	</div>
-    	<p>
-    		Add Cloudflare docs to Composer context by @-mentioning files in your repo.
-    		For a global reference, point Composer at:
-    	</p>
-    	<ul class="agent-platform-resources">
-    		<li>
-    			<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> — directory of
-    			every Cloudflare product.
-    		</li>
-    		<li>
-    			<a href="/workers/llms.txt">developers.cloudflare.com/workers/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/agents/llms.txt">developers.cloudflare.com/agents/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/r2/llms.txt">developers.cloudflare.com/r2/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/d1/llms.txt">developers.cloudflare.com/d1/llms.txt</a>
-    		</li>
-    	</ul>
-    	<p>
-    		For a full overview of how these docs are structured for agents, refer to the{" "}
-    		<a href="/style-guide/ai-tooling/">AI tooling guide</a>.
-    	</p>
-    </Fragment>
-
-</PlatformAccess>
+<PlatformAccess />
 
 ## Example prompts
 

--- a/src/content/docs/agent-setup/github-copilot.mdx
+++ b/src/content/docs/agent-setup/github-copilot.mdx
@@ -55,66 +55,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Cloudflare platform access
 
-<PlatformAccess
-	agentName="GitHub Copilot"
-	skillsExtraHtml="Copilot supports Agent Skills in VS Code agent mode, the Copilot CLI, and the cloud agent. Skills are not used for inline code completion &mdash; switch Copilot Chat to agent mode to unlock them."
->
-	<Fragment slot="wrangler">
-		<div class="agent-platform-hint">
-			Copilot's deploy story runs through CI, not a local CLI.
-		</div>
-		<p>
-			Unlike terminal agents, Copilot does not have its own CLI that runs Wrangler
-			directly. Instead, ask Copilot to generate a GitHub Actions workflow that runs
-			<a href="/workers/wrangler/">Wrangler</a> on every push — GitHub's ecosystem
-			is Copilot's native turf.
-		</p>
-		<p>
-			You will also want to add <code>CLOUDFLARE_API_TOKEN</code> and <code>CLOUDFLARE_ACCOUNT_ID</code>
-			as repository secrets. Copilot knows this pattern and will prompt you if you
-			forget.
-		</p>
-	</Fragment>
-
-<Fragment slot="docs">
-	<div class="agent-platform-hint">
-		Pair Skills with repository custom instructions.
-	</div>
-	<p>
-		Skills load Cloudflare expertise on demand — use a <code>.github/copilot-instructions.md</code>
-		file for repository-wide conventions that should apply to every task (coding
-		standards, preferred libraries, project layout). GitHub recommends <a href="https://docs.github.com/en/copilot/concepts/agents/about-agent-skills#skills-versus-custom-instructions" target="_blank" rel="noopener noreferrer">both together</a>: instructions for the always-on basics, Skills for the situational
-		depth.
-	</p>
-	<ul class="agent-platform-resources">
-		<li>
-			<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> — directory of
-			every Cloudflare product.
-		</li>
-		<li>
-			<a href="/workers/llms.txt">developers.cloudflare.com/workers/llms.txt</a>
-		</li>
-		<li>
-			<a href="/agents/llms.txt">developers.cloudflare.com/agents/llms.txt</a>
-		</li>
-		<li>
-			<a href="/r2/llms.txt">developers.cloudflare.com/r2/llms.txt</a>
-		</li>
-		<li>
-			<a href="/d1/llms.txt">developers.cloudflare.com/d1/llms.txt</a>
-		</li>
-		<li>
-			<a href="/workers/prompt.txt">/workers/prompt.txt</a> — Cloudflare's own Workers
-			context prompt, useful to include inside <code>copilot-instructions.md</code>.
-		</li>
-	</ul>
-	<p>
-		For a full overview of how these docs are structured for agents, refer to the{" "}
-		<a href="/style-guide/ai-tooling/">AI tooling guide</a>.
-	</p>
-</Fragment>
-
-</PlatformAccess>
+<PlatformAccess />
 
 ## Example prompts
 

--- a/src/content/docs/agent-setup/opencode.mdx
+++ b/src/content/docs/agent-setup/opencode.mdx
@@ -81,50 +81,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Cloudflare platform access
 
-<PlatformAccess agentName="OpenCode">
-	<Fragment slot="wrangler">
-		<div class="agent-platform-hint">
-			Local dev, deploys, and Workers-specific commands.
-		</div>
-		<p>
-			OpenCode runs <a href="/workers/wrangler/">Wrangler</a> directly in the terminal.
-			The bundled <strong>wrangler</strong> Skill teaches it when to reach for CLI
-			commands vs. the MCP API.
-		</p>
-	</Fragment>
-
-<Fragment slot="docs">
-	<div class="agent-platform-hint">
-		OpenCode requests markdown docs automatically.
-	</div>
-	<p>
-	OpenCode is one of the few agents that <a href="https://blog.cloudflare.com/agent-readiness/" target="_blank" rel="noopener noreferrer">sends <code>Accept: text/markdown</code> by default</a> when fetching Cloudflare docs, so it always gets the clean markdown version without any configuration. Useful URLs to reference explicitly:
-	</p>
-	<ul class="agent-platform-resources">
-		<li>
-			<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> — directory of
-			every Cloudflare product.
-		</li>
-		<li>
-			<a href="/workers/llms.txt">developers.cloudflare.com/workers/llms.txt</a>
-		</li>
-		<li>
-			<a href="/agents/llms.txt">developers.cloudflare.com/agents/llms.txt</a>
-		</li>
-		<li>
-			<a href="/r2/llms.txt">developers.cloudflare.com/r2/llms.txt</a>
-		</li>
-		<li>
-			<a href="/d1/llms.txt">developers.cloudflare.com/d1/llms.txt</a>
-		</li>
-	</ul>
-	<p>
-		For a full overview of how these docs are structured for agents, refer to the{" "}
-		<a href="/style-guide/ai-tooling/">AI tooling guide</a>.
-	</p>
-</Fragment>
-
-</PlatformAccess>
+<PlatformAccess />
 
 ## Example prompts
 

--- a/src/content/docs/agent-setup/windsurf.mdx
+++ b/src/content/docs/agent-setup/windsurf.mdx
@@ -55,49 +55,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 ## Cloudflare platform access
 
-<PlatformAccess agentName="Windsurf">
-	<Fragment slot="wrangler">
-		<div class="agent-platform-hint">
-			Run deploys and platform commands from the integrated terminal.
-		</div>
-		<p>
-			Cascade runs <a href="/workers/wrangler/">Wrangler</a> in Windsurf's integrated
-			terminal. The bundled <strong>wrangler</strong> Skill teaches Cascade when to
-			reach for commands like <code>wrangler deploy</code> or <code>wrangler tail</code>.
-		</p>
-	</Fragment>
-
-    <Fragment slot="docs">
-    	<div class="agent-platform-hint">Use @-mentions and llms.txt to preload context.</div>
-    	<p>
-    		Cascade works best when you explicitly <code>@</code>-mention files and paste
-    		URLs. Useful Cloudflare docs URLs to reference:
-    	</p>
-    	<ul class="agent-platform-resources">
-    		<li>
-    			<a href="/llms.txt">developers.cloudflare.com/llms.txt</a> — directory of
-    			every Cloudflare product.
-    		</li>
-    		<li>
-    			<a href="/workers/llms.txt">developers.cloudflare.com/workers/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/agents/llms.txt">developers.cloudflare.com/agents/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/r2/llms.txt">developers.cloudflare.com/r2/llms.txt</a>
-    		</li>
-    		<li>
-    			<a href="/d1/llms.txt">developers.cloudflare.com/d1/llms.txt</a>
-    		</li>
-    	</ul>
-    	<p>
-    		For a full overview of how these docs are structured for agents, refer to the{" "}
-    		<a href="/style-guide/ai-tooling/">AI tooling guide</a>.
-    	</p>
-    </Fragment>
-
-</PlatformAccess>
+<PlatformAccess />
 
 ## Example prompts
 

--- a/src/pages/agent-setup/index.astro
+++ b/src/pages/agent-setup/index.astro
@@ -4,6 +4,7 @@ import type { StarlightPageProps } from "@astrojs/starlight/props";
 import CatalogWithFilter from "~/components/agent-setup/CatalogWithFilter.astro";
 import AgentComparison from "~/components/agent-setup/AgentComparison.astro";
 import AgentPrimer from "~/components/agent-setup/AgentPrimer.astro";
+import CloudflareToolsBanner from "~/components/agent-setup/CloudflareToolsBanner.astro";
 import { AGENTS } from "~/components/agent-setup/agents";
 
 import "~/styles/agent-setup.css";
@@ -14,7 +15,7 @@ const props = {
 	frontmatter: {
 		title: "Agent setup",
 		description:
-			"Install an agent of your choice, connect skills and MCP servers, and start deploying to Cloudflare — all from your editor or terminal.",
+			"Cloudflare provides Skills and MCP servers so your agent can seamlessly build on the Cloudflare platform. Pick an agent below to get started.",
 		template: "splash",
 	},
 	hideBreadcrumbs: true,
@@ -26,6 +27,19 @@ const props = {
 		Install an agent of your choice, connect Skills and MCP servers, and start
 		deploying to Cloudflare — all from your editor or terminal.
 	</p>
+
+	<div class="agent-setup-section" style="margin-top: 3rem;">
+		<div class="agent-setup-section-header">
+			<h2>Tools for agents</h2>
+			<p>Cloudflare is built for agents. Give yours the tools to deploy, manage, and scale on the world's fastest network.</p>
+		</div>
+		<CloudflareToolsBanner />
+	</div>
+
+	<div class="agent-setup-section-header">
+		<h2>Pick your agent</h2>
+		<p>Select an agent to get step-by-step setup instructions.</p>
+	</div>
 
 	<CatalogWithFilter agents={agents} />
 

--- a/src/pages/agent-setup/index.astro
+++ b/src/pages/agent-setup/index.astro
@@ -4,7 +4,6 @@ import type { StarlightPageProps } from "@astrojs/starlight/props";
 import CatalogWithFilter from "~/components/agent-setup/CatalogWithFilter.astro";
 import AgentComparison from "~/components/agent-setup/AgentComparison.astro";
 import AgentPrimer from "~/components/agent-setup/AgentPrimer.astro";
-import CloudflareToolsBanner from "~/components/agent-setup/CloudflareToolsBanner.astro";
 import { AGENTS } from "~/components/agent-setup/agents";
 
 import "~/styles/agent-setup.css";
@@ -24,17 +23,9 @@ const props = {
 
 <StarlightPage {...props}>
 	<p class="agent-setup-lede">
-		Install an agent of your choice, connect Skills and MCP servers, and start
+		Install an agent of your choice, connect Cloudflare <a href="https://github.com/cloudflare/skills" target="_blank" rel="noopener noreferrer">Skills &nearr;</a> and <a href="https://github.com/cloudflare/mcp" target="_blank" rel="noopener noreferrer">MCP servers &nearr;</a>, and start
 		deploying to Cloudflare — all from your editor or terminal.
 	</p>
-
-	<div class="agent-setup-section" style="margin-top: 3rem;">
-		<div class="agent-setup-section-header">
-			<h2>Tools for agents</h2>
-			<p>Cloudflare is built for agents. Give yours the tools to deploy, manage, and scale on the world's fastest network.</p>
-		</div>
-		<CloudflareToolsBanner />
-	</div>
 
 	<div class="agent-setup-section-header">
 		<h2>Pick your agent</h2>

--- a/src/schemas/cloudflare-mcp-server-card.ts
+++ b/src/schemas/cloudflare-mcp-server-card.ts
@@ -1,34 +1,7 @@
 import { z } from "astro/zod";
 
-const mcpRemoteSchema = z.object({
-	url: z.url(),
-	type: z.enum(["streamable-http", "sse"]),
-	headers: z
-		.array(
-			z.object({
-				name: z.string(),
-				description: z.string().optional(),
-				// server-card.json uses both camelCase and snake_case variants
-				isRequired: z.boolean().optional(),
-				isSecret: z.boolean().optional(),
-				is_required: z.boolean().optional(),
-				is_secret: z.boolean().optional(),
-			}),
-		)
-		.optional(),
-});
-
-export const mcpServerCardSchema = z.object({
+export const mcpServerSchema = z.object({
 	name: z.string(),
-	version: z.string(),
-	title: z.string(),
 	description: z.string(),
-	websiteUrl: z.url().optional(),
-	repository: z
-		.object({
-			url: z.url(),
-			source: z.string(),
-		})
-		.optional(),
-	remotes: z.array(mcpRemoteSchema),
+	url: z.url(),
 });

--- a/src/schemas/cloudflare-mcp-server-card.ts
+++ b/src/schemas/cloudflare-mcp-server-card.ts
@@ -1,0 +1,34 @@
+import { z } from "astro/zod";
+
+const mcpRemoteSchema = z.object({
+	url: z.url(),
+	type: z.enum(["streamable-http", "sse"]),
+	headers: z
+		.array(
+			z.object({
+				name: z.string(),
+				description: z.string().optional(),
+				// server-card.json uses both camelCase and snake_case variants
+				isRequired: z.boolean().optional(),
+				isSecret: z.boolean().optional(),
+				is_required: z.boolean().optional(),
+				is_secret: z.boolean().optional(),
+			}),
+		)
+		.optional(),
+});
+
+export const mcpServerCardSchema = z.object({
+	name: z.string(),
+	version: z.string(),
+	title: z.string(),
+	description: z.string(),
+	websiteUrl: z.url().optional(),
+	repository: z
+		.object({
+			url: z.url(),
+			source: z.string(),
+		})
+		.optional(),
+	remotes: z.array(mcpRemoteSchema),
+});

--- a/src/schemas/cloudflare-skills-manifest.ts
+++ b/src/schemas/cloudflare-skills-manifest.ts
@@ -1,0 +1,7 @@
+import { z } from "astro/zod";
+
+export const cloudflareSkillSchema = z.object({
+	name: z.string(),
+	description: z.string(),
+	files: z.array(z.string()),
+});

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,5 +1,7 @@
 export * from "./apps";
 export * from "./base";
+export * from "./cloudflare-skills-manifest";
+export * from "./cloudflare-mcp-server-card";
 export * from "./catalog-models";
 export * from "./changelog";
 export * from "./release-notes";

--- a/src/styles/agent-setup.css
+++ b/src/styles/agent-setup.css
@@ -52,6 +52,73 @@
 	display: inline;
 }
 
+/* ─── Cloudflare tools banner ─── */
+.cf-banner {
+	margin: 0;
+}
+
+
+
+.cf-banner-items {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 0.625rem;
+}
+
+@media (max-width: 640px) {
+	.cf-banner-items {
+		grid-template-columns: 1fr;
+	}
+}
+
+.cf-banner-item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.375rem;
+	padding: 0.875rem 1rem;
+	border: 1px solid var(--color-cl1-gray-8);
+	border-radius: 10px;
+}
+
+:root[data-theme="dark"] .cf-banner-item {
+	border-color: var(--color-cl1-gray-2);
+}
+
+.cf-banner-item-title {
+	font-size: 0.9375rem;
+	font-weight: 600;
+	margin: 0;
+}
+
+.cf-banner-item-desc {
+	font-size: 0.8125rem;
+	line-height: 1.55;
+	color: var(--color-cl1-gray-5);
+	margin: 0;
+	flex: 1;
+}
+
+:root[data-theme="dark"] .cf-banner-item-desc {
+	color: var(--color-cl1-gray-6);
+}
+
+.cf-banner-item-desc a,
+.cf-banner-item-links a {
+	color: var(--sl-color-text-accent);
+	text-decoration: none;
+}
+
+.cf-banner-item-desc a:hover,
+.cf-banner-item-links a:hover {
+	text-decoration: underline;
+}
+
+.cf-banner-item-links {
+	font-size: 0.8125rem;
+	margin-top: auto;
+	padding-top: 0.125rem;
+}
+
 /* ─── Landing page hero ─── */
 .agent-setup-lede {
 	font-size: 1.0625rem;
@@ -63,6 +130,18 @@
 
 :root[data-theme="dark"] .agent-setup-lede {
 	color: var(--color-cl1-gray-7);
+}
+
+.agent-setup-lede-highlight {
+	color: var(--sl-color-text);
+	font-weight: 600;
+	background: color-mix(in srgb, var(--color-cl1-orange-5) 10%, transparent);
+	padding: 0.05em 0.3em;
+	border-radius: 4px;
+}
+
+:root[data-theme="dark"] .agent-setup-lede-highlight {
+	background: color-mix(in srgb, var(--color-cl1-orange-5) 15%, transparent);
 }
 
 /* ─── Agent cards (modernized) ─── */
@@ -907,6 +986,7 @@
 	font-weight: 700;
 	letter-spacing: -0.02em;
 	margin-bottom: 0.5rem;
+	color: var(--sl-color-white);
 }
 
 .agent-setup-section-header p {
@@ -1476,22 +1556,10 @@
 	border: 1px solid var(--color-cl1-gray-8);
 	border-radius: 12px;
 	background: var(--sl-color-bg);
-	transition:
-		border-color 0.2s ease,
-		transform 0.2s ease;
-}
-
-.agent-primer-type:hover {
-	border-color: var(--color-cl1-orange-6);
-	transform: translateY(-2px);
 }
 
 :root[data-theme="dark"] .agent-primer-type {
 	border-color: var(--color-cl1-gray-2);
-}
-
-:root[data-theme="dark"] .agent-primer-type:hover {
-	border-color: var(--color-cl1-orange-5);
 }
 
 .agent-primer-type-icon {

--- a/src/styles/agent-setup.css
+++ b/src/styles/agent-setup.css
@@ -132,6 +132,15 @@
 	color: var(--color-cl1-gray-7);
 }
 
+.agent-setup-lede a {
+	color: var(--sl-color-text-accent);
+	text-decoration: none;
+}
+
+.agent-setup-lede a:hover {
+	text-decoration: underline;
+}
+
 .agent-setup-lede-highlight {
 	color: var(--sl-color-text);
 	font-weight: 600;

--- a/src/styles/agent-setup.css
+++ b/src/styles/agent-setup.css
@@ -2236,6 +2236,8 @@
 	border-bottom: none;
 }
 
+
+
 :root[data-theme="dark"] .agent-simple-item {
 	border-color: var(--color-cl1-gray-2);
 	background: color-mix(in srgb, var(--color-cl1-gray-1) 50%, transparent);
@@ -2255,6 +2257,18 @@
 
 :root[data-theme="dark"] .agent-simple-desc {
 	color: var(--color-cl1-gray-6);
+}
+
+.agent-simple-url {
+	display: block;
+	font-family: var(--sl-font-mono, ui-monospace, monospace);
+	font-size: 0.7375rem;
+	color: var(--color-cl1-gray-6);
+	margin-top: 0.125rem;
+}
+
+:root[data-theme="dark"] .agent-simple-url {
+	color: var(--color-cl1-gray-4);
 }
 
 /* "bundled" tag shown on MCP servers that ship with the skills plugin. */
@@ -2278,6 +2292,8 @@
 	background: color-mix(in srgb, var(--color-cl1-orange-1) 30%, transparent);
 	border-color: var(--color-cl1-orange-2);
 }
+
+
 
 /* ────────────────────────────────────────────────────────────────────
    Agent detail page — Build agents ON Cloudflare footer callout

--- a/src/styles/agent-setup.css
+++ b/src/styles/agent-setup.css
@@ -57,8 +57,6 @@
 	margin: 0;
 }
 
-
-
 .cf-banner-items {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
@@ -2236,8 +2234,6 @@
 	border-bottom: none;
 }
 
-
-
 :root[data-theme="dark"] .agent-simple-item {
 	border-color: var(--color-cl1-gray-2);
 	background: color-mix(in srgb, var(--color-cl1-gray-1) 50%, transparent);
@@ -2292,8 +2288,6 @@
 	background: color-mix(in srgb, var(--color-cl1-orange-1) 30%, transparent);
 	border-color: var(--color-cl1-orange-2);
 }
-
-
 
 /* ────────────────────────────────────────────────────────────────────
    Agent detail page — Build agents ON Cloudflare footer callout


### PR DESCRIPTION
### Summary

Follow-up improvements to the agent-setup pages:

- **Manifest-driven lists** — Skills and MCP server lists are now populated from `middlecache` manifests (`v1/cloudflare-skills/skills-manifest.json` and `v1/cloudflare-mcps/mcps-manifest.json`) via two new Astro content collections, replacing hardcoded arrays. New servers and skills appear automatically on the next build.
- **MCP list UX** — Code Mode is pinned first with a chip, server URLs are shown inline, and the copy clarifies Code Mode vs domain-specific servers.
- **Static `PlatformAccessSection`** — Removed all props, slots, and agent-name interpolations. The component is now fully hardcoded and shared identically across all six agent pages. Each page reduced to `<PlatformAccess />`.
- **Landing page** — Removed the "Tools for agents" section; lede now links to `github.com/cloudflare/skills` and `github.com/cloudflare/mcp` with external link arrows.

## Images
<img width="1117" height="780" alt="Screenshot 2026-04-23 at 3 23 58 PM" src="https://github.com/user-attachments/assets/3bfcf752-49a5-4a43-bd8b-2d503bee3db1" />
<img width="1118" height="829" alt="Screenshot 2026-04-23 at 3 24 40 PM" src="https://github.com/user-attachments/assets/e9a73272-f78f-4507-b6f9-afd0698f0a3e" />

