### PR TITLE
docs: suppress UI chrome from Markdown for Agents output

### DIFF
--- a/src/components/overrides/TableOfContents.astro
+++ b/src/components/overrides/TableOfContents.astro
@@ -38,23 +38,24 @@ const { editUrl } = Astro.locals.starlightRoute;
 	{
 		(showFeedback || showActions) && (
 			<div class="mt-6 flex flex-col gap-5 border-t border-[var(--sidebar-border)] pt-6">
-				<div class="agents-toolkit-container">
-					<AgentsToolkit client:idle />
-				</div>
+				<nav class="agents-toolkit-container" aria-label="Agents toolkit">
+					<AgentsToolkit client:only="react" />
+				</nav>
 
 				{showFeedback && (
 					<div class="feedback-container border-t border-[var(--sidebar-border)] pt-5">
-						<FeedbackPrompt client:idle />
+						<FeedbackPrompt client:only="react" />
 					</div>
 				)}
 
 				{showActions && (
-					<div class="flex flex-col gap-3">
+					<nav class="flex flex-col gap-3" aria-label="Page actions">
 						{editUrl && (
-							<a
-								href={editUrl}
-							class="group flex items-center gap-2.5 rounded-sm text-[13px] text-[var(--sl-color-gray-2)] transition-colors duration-150 ease-out hover:text-[var(--sl-color-white)] focus-visible:ring-2 focus-visible:ring-[var(--sl-color-text-accent)] focus-visible:outline-none"
-						>
+						<a
+							href={editUrl}
+							target="_blank"
+						class="group flex items-center gap-2.5 rounded-sm text-[13px] text-[var(--sl-color-gray-2)] transition-colors duration-150 ease-out hover:text-[var(--sl-color-white)] focus-visible:ring-2 focus-visible:ring-[var(--sl-color-text-accent)] focus-visible:outline-none"
+					>
 							<Icon
 								name="pencil"
 								class="h-3.5 w-3.5"
@@ -63,10 +64,11 @@ const { editUrl } = Astro.locals.starlightRoute;
 							<span>Edit page</span>
 						</a>
 					)}
-					<a
-						href="https://github.com/cloudflare/cloudflare-docs/issues/new/choose"
-						class="group flex items-center gap-2.5 rounded-sm text-[13px] text-[var(--sl-color-gray-2)] transition-colors duration-150 ease-out hover:text-[var(--sl-color-white)] focus-visible:ring-2 focus-visible:ring-[var(--sl-color-text-accent)] focus-visible:outline-none"
-					>
+				<a
+					href="https://github.com/cloudflare/cloudflare-docs/issues/new/choose"
+					target="_blank"
+					class="group flex items-center gap-2.5 rounded-sm text-[13px] text-[var(--sl-color-gray-2)] transition-colors duration-150 ease-out hover:text-[var(--sl-color-white)] focus-visible:ring-2 focus-visible:ring-[var(--sl-color-text-accent)] focus-visible:outline-none"
+				>
 						<Icon
 							name="github"
 							class="h-3.5 w-3.5"
@@ -74,7 +76,7 @@ const { editUrl } = Astro.locals.starlightRoute;
 							/>
 							<span>Report issue</span>
 						</a>
-					</div>
+					</nav>
 				)}
 			</div>
 		)


### PR DESCRIPTION
### Summary

Updates `TableOfContents.astro` to prevent the right-sidebar UI elements (Agents toolkit, feedback prompt, edit/report links) from appearing in the network-layer Markdown for Agents conversion. (`<nav />`'s are ignored)

- Switch `AgentsToolkit` and `FeedbackPrompt` from `client:idle` to `client:only="react"` to prevent SSR HTML from reaching the converter
- Wrap AgentsToolkit in `<nav aria-label="Agents toolkit">`
- Wrap Edit page / Report issue links in `<nav aria-label="Page actions">`
- Add `target="_blank"` to external edit/report links

Does not address the "Skip to content" link — that remains in markdown output as a standard `<a>` element and is acceptable.

## Images
<img width="1300" height="574" alt="1" src="https://github.com/user-attachments/assets/da4b0ee8-da16-4d92-bbae-da44b58cca5d" />
<img width="1309" height="599" alt="2" src="https://github.com/user-attachments/assets/736040df-b513-4e1b-a247-934b3b4aaee0" />