### PR TITLE
[agents/securing-mcp-server] use strict-equality cookie parse (.trim() breaks __Host- prefix)

### DIFF
--- a/src/content/docs/agents/guides/securing-mcp-server.mdx
+++ b/src/content/docs/agents/guides/securing-mcp-server.mdx
@@ -56,14 +56,33 @@ function generateCSRFProtection() {
 	return { token, setCookie };
 }
 
+// IMPORTANT: do NOT use String.prototype.trim() when comparing a cookie name
+// to a prefix like __Host-. JavaScript's .trim() strips Unicode whitespace
+// per ECMAScript § 22.1.3.33 (U+00A0 NBSP, U+2000–U+200A, U+FEFF ZWNBSP, etc.),
+// which defeats the __Host- prefix guarantee: an attacker on a co-site context
+// can set a cookie whose stored name begins with Unicode whitespace (browsers
+// accept it without applying __Host- constraints) that the server then
+// normalizes back to __Host-NAME via .trim().
+// See: https://portswigger.net/research/cookie-chaos
+
+function readExactCookie(header: string, exactName: string): string | null {
+	for (const raw of header.split(";")) {
+		// RFC 6265 inter-pair separator is "; "; strip at most ONE leading
+		// ASCII space. Never String.trim().
+		const piece = raw.startsWith(" ") ? raw.slice(1) : raw;
+		const eqIdx = piece.indexOf("=");
+		if (eqIdx < 0) continue;
+		if (piece.substring(0, eqIdx) !== exactName) continue;
+		return piece.substring(eqIdx + 1);
+	}
+	return null;
+}
+
 // Validate CSRF token on form submission
 function validateCSRFToken(formData: FormData, request: Request) {
 	const tokenFromForm = formData.get("csrf_token");
 	const cookieHeader = request.headers.get("Cookie") || "";
-	const tokenFromCookie = cookieHeader
-		.split(";")
-		.find((c) => c.trim().startsWith("__Host-CSRF_TOKEN="))
-		?.split("=")[1];
+	const tokenFromCookie = readExactCookie(cookieHeader, "__Host-CSRF_TOKEN");
 
 	if (!tokenFromForm || !tokenFromCookie || tokenFromForm !== tokenFromCookie) {
 		throw new Error("CSRF token mismatch");
@@ -221,6 +240,16 @@ The `__Host-` prefix prevents subdomain attacks, which is especially important o
 - Must not have a `Domain` attribute
 
 Without `__Host-`, an attacker controlling `evil.workers.dev` could set cookies for your `mcp-server.workers.dev` domain.
+
+:::caution[The prefix is only as strong as your cookie parser]
+
+The browser enforces the `__Host-` constraints **only for the exact literal name** `__Host-NAME`. A cookie whose browser-stored name begins with Unicode whitespace (e.g. U+00A0 NBSP, U+2000 EN QUAD) is NOT recognized as `__Host-`-prefixed and therefore allows the browser to accept `Domain=` attributes and subdomain-scope cookies.
+
+If your server parses cookies with `String.prototype.trim()`, that Unicode-prefixed cookie will be normalized to `__Host-NAME` server-side and the prefix guarantee is defeated. Use strict-equality cookie-name matching (see the `readExactCookie` helper in the CSRF example above) and never `.trim()` a cookie-name fragment before comparing to a `__Host-` prefix.
+
+See: Gareth Heyes, ["Cookie Chaos: How to bypass __Host and __Secure cookie prefixes"](https://portswigger.net/research/cookie-chaos-how-to-bypass-host-and-secure-cookie-prefixes), PortSwigger Research, 2025.
+
+:::
 
 ### Multiple OAuth flows
 


### PR DESCRIPTION
## Summary

The "Securing MCP servers" guide currently teaches:

```typescript
cookieHeader
  .split(";")
  .find((c) => c.trim().startsWith("__Host-CSRF_TOKEN="))
  ?.split("=")[1];
```

`String.prototype.trim()` strips all Unicode whitespace per ECMAScript § 22.1.3.33 (including U+00A0, U+2000–U+200A, U+202F, U+3000, U+FEFF). Per Gareth Heyes, ["Cookie Chaos: How to bypass __Host and __Secure cookie prefixes"](https://portswigger.net/research/cookie-chaos-how-to-bypass-host-and-secure-cookie-prefixes) (PortSwigger Research, 2025-09-03), Chrome/Firefox/Edge accept cookies whose name begins with Unicode whitespace **without** applying the `__Host-` prefix security constraints.

Combined: an attacker on a co-site context (subdomain XSS, takeover, or Worker-route misconfig) can plant a cookie whose browser-stored name is e.g. ` __Host-CSRF_TOKEN=<attacker_value>` with `Domain=<target-etld+1>`. The server's `.trim()` normalizes it to `__Host-CSRF_TOKEN` and the `__Host-` prefix's subdomain-attack protection (documented in this very page) is defeated.

## Changes

1. Introduces a `readExactCookie(header, exactName)` helper that uses strict equality on the cookie name. It rejects any non-ASCII-whitespace-prefixed variant by comparing the raw `substring(0, eqIdx)` against the exact expected name. As a side-effect it also fixes a truncation bug in the original (`?.split("=")[1]` drops everything after a second `=` in the cookie value).
2. Replaces the vulnerable `.trim()` + `startsWith()` call with the helper.
3. Adds a `:::caution:::` callout in the "Cookie security" section, explaining the `.trim()` / `__Host-` prefix interaction and linking to Heyes 2025 so readers understand the underlying browser-vs-server parser-desync.

## Test plan

- [x] Manual reproduction: `node` script running the EXACT parse code from the current doc against six Unicode whitespace chars (U+2000, U+00A0, U+FEFF, U+0020, U+3000, U+202F) confirms all six trip `.trim()` and extract attacker-controlled values.
- [x] Cloudflare Workers runtime reproduction: minimal Worker under `wrangler dev --local` (workerd), hex dump of `request.headers.get("Cookie")` confirms workerd preserves Unicode whitespace bytes unmodified (`2000 005f 005f 0048 ...`). The .trim()-based extraction then yields the attacker value.
- [x] Proposed `readExactCookie` helper tested: strict-equality comparison rejects Unicode-prefixed variants and accepts only the literal `__Host-NAME`.

## Related

A library-side companion advisory is being coordinated separately against `cloudflare/mcp-server-cloudflare` — `packages/mcp-common/src/workers-oauth-utils.ts` at commit `17a978590595c9beffa4f2fa2e72cfc8f6c49d2d` uses the same vulnerable `.split(';').map(c => c.trim()) + .startsWith('__Host-NAME=')` pattern on lines 105, 565, and 725 (parsing `mcp-approved-clients`, `__Host-CSRF_TOKEN`, and `__Host-CONSENTED_STATE` respectively).

## References

- Gareth Heyes, "Cookie Chaos: How to bypass __Host and __Secure cookie prefixes" — https://portswigger.net/research/cookie-chaos-how-to-bypass-host-and-secure-cookie-prefixes
- ECMAScript § 22.1.3.33 `String.prototype.trim` — Unicode WhiteSpace production
- RFC 6265 §5.4 on cookie-pair inter-pair separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
