### PR TITLE
Fix npm create command for Sandbox Bridge manually deployment guide

### DIFF
--- a/src/content/docs/sandbox/bridge/index.mdx
+++ b/src/content/docs/sandbox/bridge/index.mdx
@@ -48,7 +48,7 @@ If you prefer to deploy step by step, scaffold the project and deploy manually.
 1. Scaffold the bridge project:
 
 	```sh
-	npm create cloudflare sandbox-bridge --template=cloudflare/sandbox-sdk/bridge/worker
+	npm create cloudflare -- sandbox-bridge --template=cloudflare/sandbox-sdk/bridge/worker
 	cd sandbox-bridge
 	```
 


### PR DESCRIPTION
### Summary

The documented `npm create` command didn't pass the `--template` option to the underlying script. This PR add the end of options delimiter to ensure the provided template is automatically used when the command is run. Without this the user needs to restate the template. This change is in-keeping with the command displayed on the Sandbox "Getting started" page.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
