### PR TITLE
[DNS] Add note explaining reserved IP addresses in originless setups

### DIFF
--- a/src/content/docs/dns/manage-dns-records/how-to/create-dns-records.mdx
+++ b/src/content/docs/dns/manage-dns-records/how-to/create-dns-records.mdx
@@ -120,7 +120,7 @@ If you need a placeholder address for an originless setup (also referred to as p
 This allows you to route requests using products such as [Redirect Rules](/rules/url-forwarding/), [Page Rules](/rules/page-rules/), or [Workers](/workers/).
 
 :::note
-The addresses `192.0.2.0` and `100::` come from IP ranges reserved for documentation and testing ([RFC 5737](https://www.rfc-editor.org/rfc/rfc5737) and [RFC 6666](https://www.rfc-editor.org/rfc/rfc6666)). They are guaranteed to never route to a real server, which makes them safe to use as placeholder values. Because the DNS record is proxied, Cloudflare intercepts the request before it reaches the dummy address.
+The address `192.0.2.0` comes from an IPv4 range reserved for documentation ([RFC 5737](https://www.rfc-editor.org/rfc/rfc5737)), and `100::` comes from the IPv6 discard prefix `0100::/64` ([RFC 6666](https://www.rfc-editor.org/rfc/rfc6666)). Neither address is expected to route to a real server on properly configured networks, which makes them safe to use as placeholder values. Because the DNS record is proxied, Cloudflare intercepts the request before it reaches the origin address.
 :::
 
 ---

--- a/src/content/docs/dns/manage-dns-records/how-to/create-dns-records.mdx
+++ b/src/content/docs/dns/manage-dns-records/how-to/create-dns-records.mdx
@@ -119,6 +119,10 @@ If you need a placeholder address for an originless setup (also referred to as p
 
 This allows you to route requests using products such as [Redirect Rules](/rules/url-forwarding/), [Page Rules](/rules/page-rules/), or [Workers](/workers/).
 
+:::note
+The addresses `192.0.2.0` and `100::` come from IP ranges reserved for documentation and testing ([RFC 5737](https://www.rfc-editor.org/rfc/rfc5737) and [RFC 6666](https://www.rfc-editor.org/rfc/rfc6666)). They are guaranteed to never route to a real server, which makes them safe to use as placeholder values. Because the DNS record is proxied, Cloudflare intercepts the request before it reaches the dummy address.
+:::
+
 ---
 
 ## Further guidance


### PR DESCRIPTION
### Summary

Adds a note to the [originless setups](https://developers.cloudflare.com/dns/manage-dns-records/how-to/create-dns-records/#originless-setups) section explaining why `192.0.2.0` and `100::` are safe to use as placeholder addresses. The existing text mentions "reserved" addresses but does not explain what that means — this note links to the relevant RFCs and clarifies that Cloudflare's proxy intercepts requests before they reach the dummy address.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
