### PR TITLE
[Workers] Add redirect guidance to Custom Domains page

### DIFF
--- a/src/content/docs/workers/configuration/routing/custom-domains.mdx
+++ b/src/content/docs/workers/configuration/routing/custom-domains.mdx
@@ -14,7 +14,7 @@ Custom Domains allow you to connect your Worker to a domain or subdomain, withou
 
 Custom Domains are routes to a domain or subdomain (such as `example.com` or `shop.example.com`) within a Cloudflare zone where the Worker is the origin.
 
-Custom Domains are recommended if you want to connect your Worker to the Internet and do not have an application server that you want to always communicate with.  If you do have external dependencies, you can create a `Request` object with the target URI, and use `fetch()` to reach out.
+Custom Domains are recommended if you want to connect your Worker to the Internet and do not have an application server that you want to always communicate with. If you do have external dependencies, you can create a `Request` object with the target URI, and use `fetch()` to reach out.
 
 Custom Domains can stack on top of each other. For example, if you have Worker A attached to `app.example.com` and Worker B attached to `api.example.com`, Worker A can call `fetch()` on `api.example.com` and invoke Worker B.
 
@@ -33,9 +33,7 @@ Custom Domains can be attached to your Worker via the Cloudflare dashboard, [Wra
 
 :::caution
 
-
 You cannot create a Custom Domain on a hostname with an existing CNAME DNS record or on a zone you do not own.
-
 
 :::
 
@@ -77,8 +75,6 @@ To configure a Custom Domain in your [Wrangler configuration file](/workers/wran
 
 To configure multiple Custom Domains:
 
-
-
 <WranglerConfig>
 
 ```jsonc
@@ -106,8 +102,8 @@ On the same zone, if a Worker is attempting to communicate with a target Worker 
 
 For example, consider the following scenario, where both Workers are running on the `example.com` Cloudflare zone:
 
-* `worker-a` running on the [route](/workers/configuration/routing/routes/#set-up-a-route) `auth.example.com/*`.
-* `worker-b` running on the [route](/workers/configuration/routing/routes/#set-up-a-route) `shop.example.com/*`.
+- `worker-a` running on the [route](/workers/configuration/routing/routes/#set-up-a-route) `auth.example.com/*`.
+- `worker-b` running on the [route](/workers/configuration/routing/routes/#set-up-a-route) `shop.example.com/*`.
 
 If `worker-a` sends a fetch request to `worker-b`, the request will fail, because of the limitation on same-zone fetch requests. `worker-a` must have a service binding to `worker-b` for this request to resolve.
 
@@ -115,9 +111,9 @@ If `worker-a` sends a fetch request to `worker-b`, the request will fail, becaus
 export default {
 	fetch(request) {
 		// This will fail
-		return fetch("https://shop.example.com")
-	}
-}
+		return fetch("https://shop.example.com");
+	},
+};
 ```
 
 However, if `worker-b` was instead set up to run on the Custom Domain `shop.example.com`, the fetch request would succeed.
@@ -142,15 +138,15 @@ For example, consider the following workflow:
 ```js title="auth-worker" {8}
 export default {
 	fetch(request) {
-		const url = new URL(request.url)
-		if(url.searchParams.get("auth") !== "SECRET_TOKEN") {
-			return new Response(null, { status: 401 })
+		const url = new URL(request.url);
+		if (url.searchParams.get("auth") !== "SECRET_TOKEN") {
+			return new Response(null, { status: 401 });
 		} else {
 			// This will invoke `api-worker`
-			return fetch(request)
+			return fetch(request);
 		}
-	}
-}
+	},
+};
 ```
 
 ## Certificates
@@ -158,6 +154,22 @@ export default {
 Creating a Custom Domain will also generate an [Advanced Certificate](/ssl/edge-certificates/advanced-certificate-manager/) on your target zone for your target hostname.
 
 These certificates are generated with default settings. To override these settings, delete the generated certificate and create your own certificate in the Cloudflare dashboard. Refer to [Manage advanced certificates](/ssl/edge-certificates/advanced-certificate-manager/manage-certificates/) for instructions.
+
+## Redirect between www and root domain
+
+Because Custom Domains require an exact hostname match, a Worker attached to `example.com` will not receive requests sent to `www.example.com`, and vice versa. To make both versions of your domain work, set up a redirect rule:
+
+- [Redirect from www to root](/rules/url-forwarding/examples/redirect-www-to-root/)
+- [Redirect from root to www](/rules/url-forwarding/examples/redirect-root-to-www/)
+
+You also need a [proxied DNS record](/dns/manage-dns-records/how-to/create-dns-records/) for the hostname you are redirecting _from_, so that Cloudflare can apply the redirect rule.
+
+- For www to root: Add a proxied DNS `A` record for `www` pointing to `192.0.2.0`, or a proxied `AAAA` record pointing to `100::`
+- For root to www: Add a proxied DNS `A` record for your root domain pointing to `192.0.2.0`, or a proxied `AAAA` record pointing to `100::`
+
+:::note
+`192.0.2.0` (A record) and `100::` (AAAA record) are reserved placeholder addresses for [originless setups](/dns/manage-dns-records/how-to/create-dns-records/#originless-setups). Because the DNS record is proxied, requests never reach this address — Cloudflare intercepts them and applies your redirect rule.
+:::
 
 ## Migrate from Routes
 


### PR DESCRIPTION
Adds www-to-root and root-to-www redirect guidance to the Workers Custom Domains page. This was covered in Pages docs but missing from Workers.