### PR TITLE
[Radar] Add release note for signature agent URL on bot details

### DIFF
--- a/src/content/release-notes/radar.yaml
+++ b/src/content/release-notes/radar.yaml
@@ -3,6 +3,11 @@ link: "/radar/release-notes/"
 productName: Radar
 productLink: "/radar/"
 entries:
+  - publish_date: "2026-04-24"
+    title: Add signature agent URL to bot details
+    description: |-
+      * Added `signatureAgentUrl` field to the [bot details](/api/resources/radar/subresources/bots/methods/get/) API endpoint. For agents verified via [Web Bot Auth](/bots/reference/bot-verification/web-bot-auth/), this field contains the URL to the agent's HTTP Message Signatures key directory. It is `null` for bots not verified via request signature.
+      * Added signature agent URL to the [bot detail page](https://radar.cloudflare.com/bots/directory) on Radar, with a modal to inspect the key directory JSON content.
   - publish_date: "2026-04-01"
     title: Promote Routing to a dedicated section with sub-pages
     description: |-


### PR DESCRIPTION
## Summary

- Add release note entry for the new `signatureAgentUrl` field on the Radar bot details API endpoint and the corresponding UI changes on the bot detail page


<img width="786" height="247" alt="image" src="https://github.com/user-attachments/assets/c607be4b-b939-4afd-a051-0e092f4fd799" />
