### PR TITLE
[workers] Fixed body schema  for 'Set environment variables' http API request

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/api-reference.mdx
+++ b/src/content/docs/workers/ci-cd/builds/api-reference.mdx
@@ -242,10 +242,8 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/trigg
   --header "Content-Type: application/json" \
   --request PATCH \
   --data '{
-    "variables": [
-      {"key": "NODE_ENV", "value": "production", "type": "text"},
-      {"key": "API_KEY", "value": "prod-secret-key", "type": "secret"}
-    ]
+    "NODE_ENV": { "value": "production", "is_secret": false },
+    "API_KEY": { "value": "prod-secret-key", "is_secret": true }
   }'
 ```
 
@@ -257,10 +255,8 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/{account_id}/builds/trigg
   --header "Content-Type: application/json" \
   --request PATCH \
   --data '{
-    "variables": [
-      {"key": "NODE_ENV", "value": "development", "type": "text"},
-      {"key": "API_KEY", "value": "dev-secret-key", "type": "secret"}
-    ]
+    "NODE_ENV": { "value": "production", "is_secret": false },
+    "API_KEY": { "value": "prod-secret-key", "is_secret": true }
   }'
 ```
 


### PR DESCRIPTION
Running the documentation this example patch operation returns the error `Invalid request body`. It succeeded when using the body payload schema used by dashboard:

 https://github.com/cloudflare/cloudflare-docs/blob/da1e525ce2ba7e55b5f7a0f25bf153cf152105c7/src/content/docs/workers/ci-cd/builds/api-reference.mdx?plain=1#L240-L265

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
