### PR TITLE
[Workers AI] Tab example response into output and raw response, refresh catalog

### DIFF
--- a/src/components/models/ExampleCard.astro
+++ b/src/components/models/ExampleCard.astro
@@ -1,5 +1,6 @@
 ---
 import { Code, Tabs, TabItem } from "~/components";
+import OutputBody from "~/components/models/OutputBody.astro";
 import type { ModelExample, CodeSnippet } from "~/schemas/catalog-models";
 
 interface Props {
@@ -13,19 +14,46 @@ const { example, fallbackSnippets, layout = "side-by-side" } = Astro.props;
 const snippets = example.code_snippets ?? fallbackSnippets ?? [];
 const hasSnippets = snippets.length > 0;
 
-const rawImageUrl = example.output?.image ?? example.output?.image_url;
+const output = example.output;
+
+// Text output (e.g. LLM responses): { text: "..." } or { response: "..." }.
+const rawText = output?.text ?? output?.response;
+const textOutput = typeof rawText === "string" ? rawText : undefined;
+
+const rawImageUrl = output?.image ?? output?.image_url;
 const imageUrl = typeof rawImageUrl === "string" ? rawImageUrl : undefined;
-const hasImage = !!imageUrl;
 
-const rawVideoUrl = example.output?.video ?? example.output?.video_url;
+// Some models return an `images` array of URLs.
+const rawImages = output?.images;
+const imageUrls = Array.isArray(rawImages)
+	? rawImages.filter((v): v is string => typeof v === "string")
+	: [];
+
+const rawVideoUrl = output?.video ?? output?.video_url;
 const videoUrl = typeof rawVideoUrl === "string" ? rawVideoUrl : undefined;
-const hasVideo = !!videoUrl;
 
-const rawAudioUrl = example.output?.audio ?? example.output?.audio_url;
+const rawAudioUrl = output?.audio ?? output?.audio_url;
 const audioUrl = typeof rawAudioUrl === "string" ? rawAudioUrl : undefined;
-const hasAudio = !!audioUrl;
 
+const hasImage = !!imageUrl || imageUrls.length > 0;
+const hasVideo = !!videoUrl;
+const hasAudio = !!audioUrl;
+const hasText = !!textOutput;
 const hasMedia = hasImage || hasVideo || hasAudio;
+
+// The Output tab has renderable content if we detected any known shape above.
+const hasOutput = hasText || hasMedia;
+const hasRawResponse = !!example.raw_response;
+const hasResponse = hasOutput || hasRawResponse;
+
+const rawResponseJson = hasRawResponse
+	? JSON.stringify(example.raw_response, null, 2)
+	: "";
+
+// Only enable the side-by-side layout when a code block and renderable media
+// are both present — text-only or JSON-only responses stack better vertically.
+const sideBySide =
+	layout === "side-by-side" && hasSnippets && hasResponse && hasMedia;
 
 const languageMap: Record<string, string> = {
 	typescript: "ts",
@@ -55,12 +83,7 @@ function getLabel(label: string): string {
 }
 ---
 
-<div
-	class:list={[
-		"example-card",
-		{ "side-by-side": layout === "side-by-side" && hasMedia && hasSnippets },
-	]}
->
+<div class:list={["example-card", { "side-by-side": sideBySide }]}>
 	{
 		hasSnippets && (
 			<div class="example-code">
@@ -80,64 +103,43 @@ function getLabel(label: string): string {
 	}
 
 	{
-		hasMedia && (
-			<div class="example-output">
-				<span class="example-output-label">
-					Response
-					<span class="example-status-badge">200</span>
-				</span>
-				{hasImage && (
-					<img src={imageUrl} alt={example.name} loading="lazy" />
-				)}
-				{hasVideo && (
-					<video src={videoUrl} controls preload="metadata">
-						<track kind="captions" />
-					</video>
-				)}
-				{hasAudio && (
-					<audio src={audioUrl} controls preload="metadata">
-						<track kind="captions" />
-					</audio>
+		hasResponse && (
+			<div class="example-response">
+				{hasOutput && hasRawResponse ? (
+					<Tabs>
+						<TabItem label="Output">
+							<OutputBody
+								alt={example.name}
+								textOutput={textOutput}
+								imageUrl={imageUrl}
+								imageUrls={imageUrls}
+								videoUrl={videoUrl}
+								audioUrl={audioUrl}
+							/>
+						</TabItem>
+						<TabItem label="Raw response">
+							<Code code={rawResponseJson} lang="json" />
+						</TabItem>
+					</Tabs>
+				) : hasOutput ? (
+					<OutputBody
+						alt={example.name}
+						textOutput={textOutput}
+						imageUrl={imageUrl}
+						imageUrls={imageUrls}
+						videoUrl={videoUrl}
+						audioUrl={audioUrl}
+					/>
+				) : (
+					<Code code={rawResponseJson} lang="json" />
 				)}
 			</div>
 		)
 	}
 
 	{
-		!hasMedia && !hasSnippets && example.output && (
-			<Tabs>
-				<TabItem label="Input">
-					<Code code={JSON.stringify(example.input, null, 4)} lang="json" />
-				</TabItem>
-				<TabItem label="Output">
-					<Code code={JSON.stringify(example.output, null, 4)} lang="json" />
-				</TabItem>
-			</Tabs>
-		)
-	}
-
-	{
-		!hasMedia && !hasSnippets && !example.output && example.input && (
+		!hasResponse && !hasSnippets && example.input && (
 			<Code code={JSON.stringify(example.input, null, 4)} lang="json" />
-		)
-	}
-
-	{
-		!hasMedia && hasSnippets && example.output && (
-			<details class="example-io">
-				<summary>Input / Output JSON</summary>
-				<Tabs>
-					<TabItem label="Input">
-						<Code code={JSON.stringify(example.input, null, 4)} lang="json" />
-					</TabItem>
-					<TabItem label="Output">
-						<Code
-							code={JSON.stringify(example.output, null, 4)}
-							lang="json"
-						/>
-					</TabItem>
-				</Tabs>
-			</details>
 		)
 	}
 </div>
@@ -206,53 +208,17 @@ function getLabel(label: string): string {
 		overflow: auto;
 	}
 
-	.example-output {
+	.example-response {
 		display: flex;
 		flex-direction: column;
 		gap: 1rem;
 		margin-top: 0;
+		min-width: 0;
 	}
 
-	.example-card.side-by-side .example-output {
+	.example-card.side-by-side .example-response {
 		position: sticky;
 		top: 5rem;
 		align-self: start;
-	}
-
-	.example-output-label {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		height: 1.875rem; /* matches starlight tab bar height (~30px) */
-		font-size: 0.875rem;
-		font-weight: 600;
-		color: var(--sl-color-gray-10);
-		border-bottom: 2px solid var(--sl-color-gray-5);
-	}
-
-	.example-status-badge {
-		font-size: 0.75rem;
-		font-weight: 700;
-		font-family: var(--sl-font-mono);
-		color: var(--sl-color-green);
-		border: 1px solid var(--sl-color-green);
-		border-radius: 0.25rem;
-		padding: 0 0.3rem;
-		line-height: 1.4;
-	}
-
-	.example-output img,
-	.example-output video {
-		width: 100%;
-		border-radius: 0.5rem;
-		border: 1px solid var(--sl-color-gray-5);
-	}
-
-	.example-output audio {
-		width: 100%;
-	}
-
-	.example-io {
-		grid-column: 1 / -1;
 	}
 </style>

--- a/src/components/models/ExampleCard.astro
+++ b/src/components/models/ExampleCard.astro
@@ -118,7 +118,9 @@ function getLabel(label: string): string {
 							/>
 						</TabItem>
 						<TabItem label="Raw response">
-							<Code code={rawResponseJson} lang="json" />
+							<div class="example-raw-response">
+								<Code code={rawResponseJson} lang="json" />
+							</div>
 						</TabItem>
 					</Tabs>
 				) : hasOutput ? (
@@ -131,7 +133,9 @@ function getLabel(label: string): string {
 						audioUrl={audioUrl}
 					/>
 				) : (
-					<Code code={rawResponseJson} lang="json" />
+					<div class="example-raw-response">
+						<Code code={rawResponseJson} lang="json" />
+					</div>
 				)}
 			</div>
 		)
@@ -220,5 +224,12 @@ function getLabel(label: string): string {
 		position: sticky;
 		top: 5rem;
 		align-self: start;
+	}
+
+	/* Cap raw response JSON height — streaming arrays and verbose provider
+	   payloads can run hundreds of lines. */
+	.example-raw-response :global(.expressive-code pre) {
+		max-height: 32rem;
+		overflow: auto;
 	}
 </style>

--- a/src/components/models/ExampleCard.astro
+++ b/src/components/models/ExampleCard.astro
@@ -226,10 +226,22 @@ function getLabel(label: string): string {
 		align-self: start;
 	}
 
-	/* Cap raw response JSON height — streaming arrays and verbose provider
-	   payloads can run hundreds of lines. */
-	.example-raw-response :global(.expressive-code pre) {
+	/* Cap raw response JSON to match the Output text panel height exactly.
+	   Expressive Code wraps the code block in a <figure> with its own margins
+	   and frame chrome; we zero those out and cap the outer figure so the
+	   two tabs render at the same overall size. */
+	.example-raw-response :global(.expressive-code) {
+		margin: 0;
+	}
+	.example-raw-response :global(.expressive-code figure) {
+		margin: 0;
 		max-height: 32rem;
+		display: flex;
+		flex-direction: column;
+	}
+	.example-raw-response :global(.expressive-code pre) {
+		flex: 1;
+		min-height: 0;
 		overflow: auto;
 	}
 </style>

--- a/src/components/models/ExampleCard.astro
+++ b/src/components/models/ExampleCard.astro
@@ -17,8 +17,14 @@ const hasSnippets = snippets.length > 0;
 const output = example.output;
 
 // Text output (e.g. LLM responses): { text: "..." } or { response: "..." }.
+// Some examples provide streaming-style chunks as a string array.
 const rawText = output?.text ?? output?.response;
-const textOutput = typeof rawText === "string" ? rawText : undefined;
+const textOutput =
+	typeof rawText === "string"
+		? rawText
+		: Array.isArray(rawText)
+			? rawText.filter((v): v is string => typeof v === "string").join("")
+			: undefined;
 
 const rawImageUrl = output?.image ?? output?.image_url;
 const imageUrl = typeof rawImageUrl === "string" ? rawImageUrl : undefined;

--- a/src/components/models/ExampleCard.astro
+++ b/src/components/models/ExampleCard.astro
@@ -18,13 +18,15 @@ const output = example.output;
 
 // Text output (e.g. LLM responses): { text: "..." } or { response: "..." }.
 // Some examples provide streaming-style chunks as a string array.
-const rawText = output?.text ?? output?.response;
-const textOutput =
-	typeof rawText === "string"
-		? rawText
-		: Array.isArray(rawText)
-			? rawText.filter((v): v is string => typeof v === "string").join("")
-			: undefined;
+function toTextOutput(value: unknown): string | undefined {
+	if (typeof value === "string") return value;
+	if (Array.isArray(value)) {
+		return value.filter((v): v is string => typeof v === "string").join("");
+	}
+	return undefined;
+}
+
+const textOutput = toTextOutput(output?.text ?? output?.response);
 
 const rawImageUrl = output?.image ?? output?.image_url;
 const imageUrl = typeof rawImageUrl === "string" ? rawImageUrl : undefined;

--- a/src/components/models/OutputBody.astro
+++ b/src/components/models/OutputBody.astro
@@ -23,14 +23,13 @@ const {
 	{imageUrl && <img src={imageUrl} alt={alt} loading="lazy" />}
 	{imageUrls.map((url) => <img src={url} alt={alt} loading="lazy" />)}
 	{
-		videoUrl && (
-			<video src={videoUrl} controls preload="metadata" />
-		)
+		/* AI-generated outputs do not ship caption tracks. */
+		/* eslint-disable-next-line astro/jsx-a11y/media-has-caption */
+		videoUrl && <video src={videoUrl} controls preload="metadata" />
 	}
 	{
-		audioUrl && (
-			<audio src={audioUrl} controls preload="metadata" />
-		)
+		/* eslint-disable-next-line astro/jsx-a11y/media-has-caption */
+		audioUrl && <audio src={audioUrl} controls preload="metadata" />
 	}
 </div>
 

--- a/src/components/models/OutputBody.astro
+++ b/src/components/models/OutputBody.astro
@@ -24,16 +24,12 @@ const {
 	{imageUrls.map((url) => <img src={url} alt={alt} loading="lazy" />)}
 	{
 		videoUrl && (
-			<video src={videoUrl} controls preload="metadata">
-				<track kind="captions" />
-			</video>
+			<video src={videoUrl} controls preload="metadata" />
 		)
 	}
 	{
 		audioUrl && (
-			<audio src={audioUrl} controls preload="metadata">
-				<track kind="captions" />
-			</audio>
+			<audio src={audioUrl} controls preload="metadata" />
 		)
 	}
 </div>

--- a/src/components/models/OutputBody.astro
+++ b/src/components/models/OutputBody.astro
@@ -1,0 +1,74 @@
+---
+interface Props {
+	alt: string;
+	textOutput?: string;
+	imageUrl?: string;
+	imageUrls?: string[];
+	videoUrl?: string;
+	audioUrl?: string;
+}
+
+const {
+	alt,
+	textOutput,
+	imageUrl,
+	imageUrls = [],
+	videoUrl,
+	audioUrl,
+} = Astro.props;
+---
+
+<div class="example-output-body">
+	{textOutput && <pre class="example-text">{textOutput}</pre>}
+	{imageUrl && <img src={imageUrl} alt={alt} loading="lazy" />}
+	{imageUrls.map((url) => <img src={url} alt={alt} loading="lazy" />)}
+	{
+		videoUrl && (
+			<video src={videoUrl} controls preload="metadata">
+				<track kind="captions" />
+			</video>
+		)
+	}
+	{
+		audioUrl && (
+			<audio src={audioUrl} controls preload="metadata">
+				<track kind="captions" />
+			</audio>
+		)
+	}
+</div>
+
+<style>
+	.example-output-body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.example-text {
+		margin: 0;
+		padding: 0.75rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.5rem;
+		background: var(--sl-color-bg-inline-code);
+		color: var(--sl-color-white);
+		font-family: var(--sl-font);
+		font-size: 0.875rem;
+		line-height: 1.5;
+		white-space: pre-wrap;
+		word-break: break-word;
+		max-height: 32rem;
+		overflow: auto;
+	}
+
+	.example-output-body :global(img),
+	.example-output-body :global(video) {
+		width: 100%;
+		border-radius: 0.5rem;
+		border: 1px solid var(--sl-color-gray-5);
+	}
+
+	.example-output-body :global(audio) {
+		width: 100%;
+	}
+</style>

--- a/src/schemas/catalog-models.ts
+++ b/src/schemas/catalog-models.ts
@@ -15,6 +15,9 @@ export const modelExampleSchema = z.object({
 	description: z.string().optional(),
 	input: z.record(z.string(), z.unknown()),
 	output: z.record(z.string(), z.unknown()).optional(),
+	// Full provider response as returned by the upstream API. Shape varies by
+	// provider, so we accept any object and render it as JSON in the UI.
+	raw_response: z.record(z.string(), z.unknown()).optional(),
 	code_snippets: codeSnippetSchema.array().optional(),
 });
 

--- a/src/schemas/catalog-models.ts
+++ b/src/schemas/catalog-models.ts
@@ -16,8 +16,11 @@ export const modelExampleSchema = z.object({
 	input: z.record(z.string(), z.unknown()),
 	output: z.record(z.string(), z.unknown()).optional(),
 	// Full provider response as returned by the upstream API. Shape varies by
-	// provider, so we accept any object and render it as JSON in the UI.
-	raw_response: z.record(z.string(), z.unknown()).optional(),
+	// provider — streaming responses are arrays of chunks, non-streaming are
+	// objects. Rendered as JSON in the UI regardless of shape.
+	raw_response: z
+		.union([z.record(z.string(), z.unknown()), z.array(z.unknown())])
+		.optional(),
 	code_snippets: codeSnippetSchema.array().optional(),
 });
 


### PR DESCRIPTION
### Summary

Two changes to the AI catalog model presentation:

**Component: tab the example response into Output and Raw response**

Mirrors the dashboard's model detail view (`stratus`). When an example has both `output` and `raw_response`, the response area becomes tabs: **Output** (rendered text/image/video/audio) and **Raw response** (the full provider JSON). Examples with only one side render that side directly without tabs.

Also adds text rendering for `output.text` / `output.response` (previously these fell into a collapsed JSON dump) and support for `output.images` arrays.

- Adds `raw_response` to the catalog-models schema (`z.record(z.string(), z.unknown()).optional()`).
- Factors the media rendering into a small `OutputBody.astro` sub-component.

**Catalog refresh**

Refreshes the catalog-model JSON files from the Unified Catalog API. Picks up the new `raw_response` payloads the component now uses.
