### PR TITLE
Workers AI: kimi updates

### DIFF
--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -34,7 +34,7 @@ const ModelCatalog = ({
 
 	// List of model names to pin at the top
 	const pinnedModelNames = [
-		"@cf/moonshotai/kimi-k2.5",
+		"@cf/moonshotai/kimi-k2.6",
 		"@cf/zai-org/glm-4.7-flash",
 		"@cf/openai/gpt-oss-120b",
 		"@cf/meta/llama-4-scout-17b-16e-instruct",

--- a/src/content/workers-ai-models/kimi-k2.5.json
+++ b/src/content/workers-ai-models/kimi-k2.5.json
@@ -13,23 +13,11 @@
     "properties": [
         {
             "property_id": "async_queue",
-            "value": "true"
+            "value": "false"
         },
         {
             "property_id": "context_window",
             "value": "256000"
-        },
-        {
-            "property_id": "function_calling",
-            "value": "true"
-        },
-        {
-            "property_id": "reasoning",
-            "value": "true"
-        },
-        {
-            "property_id": "vision",
-            "value": "true"
         },
         {
             "property_id": "price",
@@ -40,16 +28,32 @@
                     "currency": "USD"
                 },
                 {
-                    "unit": "per M cached input tokens",
-                    "price": 0.1,
+                    "unit": "per M output tokens",
+                    "price": 3,
                     "currency": "USD"
                 },
                 {
-                    "unit": "per M output tokens",
-                    "price": 3.0,
+                    "unit": "per M cached input tokens",
+                    "price": 0.1,
                     "currency": "USD"
                 }
             ]
+        },
+        {
+            "property_id": "function_calling",
+            "value": "true"
+        },
+        {
+            "property_id": "reasoning",
+            "value": "true"
+        },
+        {
+            "property_id": "terms",
+            "value": "https://github.com/MoonshotAI/Kimi-K2.5/blob/master/LICENSE"
+        },
+        {
+            "property_id": "vision",
+            "value": "true"
         }
     ],
     "schema": {


### PR DESCRIPTION
## Summary

Updates Kimi K2.5 model schema and pins K2.6 in the model catalog.

## Changes

- Remove batch support (`async_queue: true → false`) from Kimi K2.5
- Pin Kimi K2.6 instead of K2.6 in model catalog