### PR TITLE
update Rust Workers documentation for latest runtime

### DIFF
--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -184,7 +184,8 @@ To get the right JavaScript that `wasm-bindgen` emits:
 For example:
 
 ```rust
-use web_sys::{Request, Response, Url};
+use web_sys::{Request, Response};
+
 
 #[wasm_bindgen(js_name = "fetch", js_namespace = "default")]
 pub async fn fetch(request: Request, env: JsValue) -> Result<Response, JsValue> {

--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -170,38 +170,27 @@ This interoperability is achieved using [`wasm-bindgen`](https://wasm-bindgen.gi
 
 :::note
 
-If you are using `wasm-bindgen` without `workers-rs` / `worker-build`, then you will need to patch the JavaScript that it emits. This is because when you import a `wasm` file in Workers, you get a `WebAssembly.Module` instead of a `WebAssembly.Instance` for performance and security reasons.
+If you are using `wasm-bindgen` without `workers-rs` / `worker-build`, then you will need to use the `--target module` option which outputs for _Source Phase Imports_ syntax output. This is to ensure you get a `WebAssembly.Module` instead of a `WebAssembly.Instance` when importing in Workers for performance and security reasons.
 
-To patch the JavaScript that `wasm-bindgen` emits:
+To get the right JavaScript that `wasm-bindgen` emits:
 
-1. Run `wasm-pack build --target bundler` as you normally would.
-2. Patch the JavaScript file that it produces (the following code block assumes the file is called `mywasmlib.js`):
+1. Ensure the latest `wasm-bindgen`, `js-sys`, `wasm-bindgen-futures` and `web-sys` in the Cargo.toml file with a `[lib]` `crate-type: ["cdylib"]`.
+2. Ensure handlers are defined using the correct `wasm-bindgen` namespace, as required by JS workers (like the example below).
+3. Run `cargo build --target wasm32-unknown-unknown`
+4. Then run `wasm-bindgen target/wasm32-unknown-unknown/debug/rustworker.wasm --target module --out-dir build`
+5. Point the `wrangler.toml` main field at the `build/rustworker.js` generated entry point.
+
+For example:
 
 ```js
-import * as imports from "./mywasmlib_bg.js";
+use web_sys::{Request, Response, Url};
 
-// switch between both syntax for node and for workerd
-import wkmod from "./mywasmlib_bg.wasm";
-import * as nodemod from "./mywasmlib_bg.wasm";
-if (typeof process !== "undefined" && process.release.name === "node") {
-	imports.__wbg_set_wasm(nodemod);
-} else {
-	const instance = new WebAssembly.Instance(wkmod, {
-		"./mywasmlib_bg.js": imports,
-	});
-	imports.__wbg_set_wasm(instance.exports);
+#[wasm_bindgen(js_name = "fetch", js_namespace = "default")]
+pub async fn fetch(request: Request, env: JsValue) -> Result<Response, JsValue> {
+  let name = "test";
+  Response::new_with_opt_str(Some(&format!("Hello {}", name)))
 }
-
-export * from "./mywasmlib_bg.js";
 ```
-
-3. In your Worker entrypoint, import the function and use it directly:
-
-```js
-import { myFunction } from "path/to/mylib.js";
-```
-
-:::
 
 ### Async (`wasm-bindgen-futures`)
 
@@ -218,6 +207,26 @@ To run the resulting Wasm binary on Workers, `workers-rs` includes a build tool 
 3. Outputs a directory structure that Wrangler can use to bundle and deploy the final Worker.
 
 `worker-build` is invoked by default in the template project using a custom build command specified in the `wrangler.toml` file.
+
+### Panic Handling
+
+It is recommended to build Rust Workers with support for panic unwind to avoid Rust panics erroring the entire Wasm runtime.
+
+This can be achieved with the `--panic-unwind` flag for `worker-build` (https://github.com/cloudflare/workers-rs#panic-recovery-with---panic-unwind).
+
+### CPU Limits
+
+To handle CPU limits, use the `worker::signals::is_near_cpu_limit()` method [provided by](https://github.com/cloudflare/workers-rs#cpu-limits) the `worker` crate.
+
+Whenever implementing a hot loop that might exhaust resources leading to a hard termination, it is advisable to check for this signal in that hot loop to avoid losing application state:
+
+```rs
+pub fn do_work () {
+    while !signals::is_near_cpu_limit() {
+        // hot loop
+    }
+}
+```
 
 ### Binary Size (`wasm-opt`)
 

--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -184,8 +184,8 @@ To get the right JavaScript that `wasm-bindgen` emits:
 For example:
 
 ```rust
+use wasm_bindgen::prelude::*;
 use web_sys::{Request, Response};
-
 
 #[wasm_bindgen(js_name = "fetch", js_namespace = "default")]
 pub async fn fetch(request: Request, env: JsValue) -> Result<Response, JsValue> {

--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -214,7 +214,7 @@ To run the resulting Wasm binary on Workers, `workers-rs` includes a build tool 
 
 It is recommended to build Rust Workers with support for panic unwind to avoid Rust panics erroring the entire Wasm runtime.
 
-This can be achieved with the `--panic-unwind` flag for `worker-build` (https://github.com/cloudflare/workers-rs#panic-recovery-with---panic-unwind).
+This can be achieved with the `--panic-unwind` flag for `worker-build` (refer to [Panic Recovery](https://github.com/cloudflare/workers-rs#panic-recovery-with---panic-unwind)).
 
 ### CPU Limits
 

--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -174,7 +174,8 @@ If you are using `wasm-bindgen` without `workers-rs` / `worker-build`, then you 
 
 To get the right JavaScript that `wasm-bindgen` emits:
 
-1. Ensure the latest `wasm-bindgen`, `js-sys`, `wasm-bindgen-futures` and `web-sys` in the Cargo.toml file with a `[lib]` `crate-type: ["cdylib"]`.
+1. Ensure the latest `wasm-bindgen`, `js-sys`, `wasm-bindgen-futures` and `web-sys` in the `Cargo.toml` file with a `[lib]` `crate-type: ["cdylib"]`.
+
 2. Ensure handlers are defined using the correct `wasm-bindgen` namespace, as required by JS workers (like the example below).
 3. Run `cargo build --target wasm32-unknown-unknown`
 4. Then run `wasm-bindgen target/wasm32-unknown-unknown/debug/rustworker.wasm --target module --out-dir build`

--- a/src/content/docs/workers/languages/rust/index.mdx
+++ b/src/content/docs/workers/languages/rust/index.mdx
@@ -182,7 +182,7 @@ To get the right JavaScript that `wasm-bindgen` emits:
 
 For example:
 
-```js
+```rust
 use web_sys::{Request, Response, Url};
 
 #[wasm_bindgen(js_name = "fetch", js_namespace = "default")]
@@ -191,6 +191,8 @@ pub async fn fetch(request: Request, env: JsValue) -> Result<Response, JsValue> 
   Response::new_with_opt_str(Some(&format!("Hello {}", name)))
 }
 ```
+
+:::
 
 ### Async (`wasm-bindgen-futures`)
 


### PR DESCRIPTION
### Summary

This updates the Rust Workers documentation to the latest project guidance.

In particular adding mentions of the panic unwind support, and CPU limit handling recently implemented.

In the process we also update the manual wasm-bindgen instructions which have a better alternative these days too.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
