### PR TITLE
Fix typo and incorrect step in 2FA docs

### DIFF
--- a/src/content/docs/fundamentals/user-profiles/2fa.mdx
+++ b/src/content/docs/fundamentals/user-profiles/2fa.mdx
@@ -57,9 +57,9 @@ On a Windows device, you may need to set up Windows Hello or register your secur
 
 ## Configure TOTP mobile application authentication
 
-Time-based one-time password (TOTP) authentication works by using an authenticatior app, such as Google Authenticator or Microsoft Authenticator, which generates a secret code shared between the app and a website. When you log in to the website, you enter your username, password, and the secret code generated from the authenticator app. The secret code is only valid for a short period of time, about 30 to 60 seconds, before a new code is generated.
+Time-based one-time password (TOTP) authentication works by using an authenticator app, such as Google Authenticator or Microsoft Authenticator, which generates a secret code shared between the app and a website. When you log in to the website, you enter your username, password, and the secret code generated from the authenticator app. The secret code is only valid for a short period of time, about 30 to 60 seconds, before a new code is generated.
 
-1. Once your security key is plugged in, go to **Profile** > **Authentication**.
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/) and go to **Profile** > **Authentication**.
 2. From **Two-Factor Authentication**, select **Set up**.
 3. Under **Mobile App Authentication**, select **Add**.
 4. Scan the QR code with your mobile device and enter the code from your authenticator application.


### PR DESCRIPTION
1. Fix typo: 'authenticatior' -> 'authenticator' in TOTP section description.
2. Fix incorrect first step in TOTP setup: replaced wrong 'Once your security key is plugged in' instruction (copy-pasted from the Security Keys section) with the correct 'Log in to the Cloudflare dashboard and go to Profile > Authentication' instruction.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
