### PR TITLE
Add changelog: Structured error responses for Cloudflare 5xx errors

### DIFF
--- a/src/content/changelog/fundamentals/2026-04-20-structured-responses-for-5xx-errors.mdx
+++ b/src/content/changelog/fundamentals/2026-04-20-structured-responses-for-5xx-errors.mdx
@@ -1,0 +1,50 @@
+---
+title: Structured error responses for Cloudflare 5xx errors
+description: "Cloudflare-generated 5xx error responses now return structured JSON and Markdown when agents request them, with RFC 9457 compliance and Retry-After headers on retryable codes."
+products:
+  - fundamentals
+date: 2026-04-20
+---
+
+Cloudflare-generated 5xx error responses now return structured JSON and Markdown when agents request them, matching the format already available for 1xxx errors. Responses follow [RFC 9457 (Problem Details for HTTP APIs)](https://www.rfc-editor.org/rfc/rfc9457) and include a `Retry-After` HTTP header on retryable codes.
+
+## Changes
+
+**5xx coverage.** Ten Cloudflare-generated error codes (500, 502, 504, 520-526) now serve structured responses. These are errors Cloudflare itself generates when it cannot reach or understand the origin server — origin-generated 5xx responses that Cloudflare passes through are not affected.
+
+**Fault attribution.** The `error_category` field tells agents where the fault lies:
+
+- `origin` (502, 504, 520-524) — the origin server is responsible. Transient; retry with the backoff in `retry_after`.
+- `cloudflare` (500) — Cloudflare's fault, not the website or the request. Short retry.
+- `ssl` (525, 526) — the origin's TLS configuration is broken. Do not retry.
+
+**Retry-After header.** Retryable codes (500, 502, 504, 520-524) include a `Retry-After` HTTP header matching the `retry_after` body field. Non-retryable codes (525, 526) do not include the header.
+
+## Negotiation behavior
+
+| Request header sent                             | Response format                                |
+| ----------------------------------------------- | ---------------------------------------------- |
+| `Accept: application/json`                      | JSON (`application/json` content type)         |
+| `Accept: application/problem+json`              | JSON (`application/problem+json` content type) |
+| `Accept: application/json, text/markdown;q=0.9` | JSON                                           |
+| `Accept: text/markdown`                         | Markdown                                       |
+| `Accept: text/markdown, application/json`       | Markdown (equal `q`, first-listed wins)        |
+| `Accept: */*`                                   | HTML (default)                                 |
+
+## Availability
+
+Available now for all zones on all plans.
+
+## Get started
+
+```bash
+curl -s --compressed -H "Accept: application/json" -A "TestAgent/1.0" -H "Accept-Encoding: gzip, deflate" "<YOUR_DOMAIN>/cdn-cgi/error/522" | jq .
+```
+
+```bash
+curl -s --compressed -D - -o /dev/null -H "Accept: application/json" -A "TestAgent/1.0" -H "Accept-Encoding: gzip, deflate" "<YOUR_DOMAIN>/cdn-cgi/error/521" | grep -i retry-after
+```
+
+References:
+- [RFC 9457 — Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457)
+- [Cloudflare 5xx error documentation](/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/)

--- a/src/content/changelog/fundamentals/2026-04-27-structured-responses-for-5xx-errors.mdx
+++ b/src/content/changelog/fundamentals/2026-04-27-structured-responses-for-5xx-errors.mdx
@@ -37,9 +37,13 @@ Available now for all zones on all plans.
 
 ## Get started
 
+Get JSON response for error 522:
+
 ```bash
 curl -s --compressed -H "Accept: application/json" -A "TestAgent/1.0" -H "Accept-Encoding: gzip, deflate" "<YOUR_DOMAIN>/cdn-cgi/error/522" | jq .
 ```
+
+Check presence of the `Retry-After` HTTP header associated with the JSON response for error 521:
 
 ```bash
 curl -s --compressed -D - -o /dev/null -H "Accept: application/json" -A "TestAgent/1.0" -H "Accept-Encoding: gzip, deflate" "<YOUR_DOMAIN>/cdn-cgi/error/521" | grep -i retry-after

--- a/src/content/changelog/fundamentals/2026-04-27-structured-responses-for-5xx-errors.mdx
+++ b/src/content/changelog/fundamentals/2026-04-27-structured-responses-for-5xx-errors.mdx
@@ -3,7 +3,7 @@ title: Structured error responses for Cloudflare 5xx errors
 description: "Cloudflare-generated 5xx error responses now return structured JSON and Markdown when agents request them, with RFC 9457 compliance and Retry-After headers on retryable codes."
 products:
   - fundamentals
-date: 2026-04-20
+date: 2026-04-27
 ---
 
 Cloudflare-generated 5xx error responses now return structured JSON and Markdown when agents request them, matching the format already available for 1xxx errors. Responses follow [RFC 9457 (Problem Details for HTTP APIs)](https://www.rfc-editor.org/rfc/rfc9457) and include a `Retry-After` HTTP header on retryable codes.

--- a/src/content/changelog/fundamentals/2026-04-27-structured-responses-for-5xx-errors.mdx
+++ b/src/content/changelog/fundamentals/2026-04-27-structured-responses-for-5xx-errors.mdx
@@ -10,7 +10,7 @@ Cloudflare-generated 5xx error responses now return structured JSON and Markdown
 
 ## Changes
 
-**5xx coverage.** Ten Cloudflare-generated error codes (500, 502, 504, 520-526) now serve structured responses. These are errors Cloudflare itself generates when it cannot reach or understand the origin server — origin-generated 5xx responses that Cloudflare passes through are not affected.
+**5xx coverage.** Ten Cloudflare-generated error codes (500, 502, 504, 520-526) now serve structured responses. These are errors Cloudflare itself generates when it cannot reach or understand the origin server. Origin-generated 5xx responses that Cloudflare passes through are not affected.
 
 **Fault attribution.** The `error_category` field tells agents where the fault lies:
 


### PR DESCRIPTION
## Summary

Adds changelog entry for structured JSON/Markdown responses on Cloudflare-generated 5xx errors (500, 502, 504, 520-526).

Feature shipped in FL2 MR FLPROD-1704, live in production since 2026-04-20. Includes RFC 9457 compliance, fault attribution via `error_category`, and `Retry-After` headers on retryable codes.

Related: PR #29000 (1xxx Retry-After changelog, merged)