### PR TITLE
LOGPUSH: clarify that Administrator role requires Cloudflare Zero Trust PII add-on for Logpush

### DIFF
--- a/src/content/docs/logs/logpush/permissions.mdx
+++ b/src/content/docs/logs/logpush/permissions.mdx
@@ -35,6 +35,12 @@ The **Administrator Read only** and **Log Share Reader** roles only have access 
 
 To view, create, update, or delete Logpush jobs for Zero Trust datasets (Access, Gateway, and DEX) users must have both the `Logs Edit` and `Zero Trust: PII Read` permissions.
 
+:::note
+
+The **Administrator** role includes `Logs Edit` but does not include `Zero Trust: PII Read`. A Super Administrator must explicitly assign the **Cloudflare Zero Trust PII** role as an add-on to any user who needs to manage Logpush jobs for Zero Trust datasets. Refer to [Zero Trust roles and permissions](/cloudflare-one/roles-permissions/) for more information.
+
+:::
+
 If you encounter the error `reading job for product '<product>' is not allowed (1004)`, this indicates that the API token you are using does not have the required permissions. Ensure your token or user account has both permissions listed above.
 
 For more details, refer to the [Logpush Permission Update for Zero Trust Datasets](https://developers.cloudflare.com/changelog/2025-11-05-logpush-permissions-update/).


### PR DESCRIPTION
### Summary

Adds a note to the Logpush permissions page clarifying that the Administrator role does not include the `Zero Trust: PII Read` permission required to manage Logpush jobs for Zero Trust datasets (Gateway, Access, DEX). A Super Administrator must explicitly assign the Cloudflare Zero Trust PII role as an add-on.

This gap in the docs is a common support pain point - users with the Administrator role hit the "missing required permissions" error when attempting to create ZT Logpush jobs, with no clear explanation of why.

Triggering ticket: `01924878`

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
