### PR TITLE
[AI Gateway] Document BYOK authentication and Unified API for Amazon …

### DIFF
--- a/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
@@ -185,7 +185,7 @@ AI Gateway provides a [Unified API](/ai-gateway/usage/chat-completion/) that let
 https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions
 ```
 
-### cURL with BYOK
+### cURL
 
 With BYOK configured, specify the model using the `aws-bedrock/{model}` format:
 
@@ -228,23 +228,4 @@ const response = await client.chat.completions.create({
 console.log(response.choices[0].message.content);
 ```
 
-### Anthropic SDK with BYOK
 
-```python
-import anthropic
-
-client = anthropic.Anthropic(
-    base_url="https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat",
-    api_key="{CF_AIG_TOKEN}",
-)
-
-message = client.messages.create(
-    model="aws-bedrock/anthropic.claude-3-haiku-20240307-v1:0",
-    max_tokens=256,
-    messages=[
-        {"role": "user", "content": "What is Cloudflare?"}
-    ],
-)
-
-print(message.content)
-```

--- a/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
@@ -6,32 +6,112 @@ products:
   - ai-gateway
 ---
 
+import { Details, Tabs, TabItem } from "~/components";
+
 [Amazon Bedrock](https://aws.amazon.com/bedrock/) allows you to build and scale generative AI applications with foundation models.
 
 ## Endpoint
 
 ```txt
-https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock`
+https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock
 ```
 
 ## Prerequisites
 
-When making requests to Amazon Bedrock, ensure you have the following:
+When making requests to Amazon Bedrock, you will need:
 
-- Your AI Gateway Account ID.
-- Your AI Gateway gateway name.
-- An active Amazon Bedrock API token.
-- The name of the Amazon Bedrock model you want to use.
+- AI Gateway account ID
+- AI Gateway gateway name
+- AWS credentials (`accessKeyId`, `secretAccessKey`, and `region`) with permissions for Amazon Bedrock
+- The name of the Amazon Bedrock model you want to use
 
-## Make a request
+## URL structure
 
-When making requests to Amazon Bedrock, replace `https://bedrock-runtime.us-east-1.amazonaws.com/` in the URL you're currently using with `https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/`, then add the model you want to run at the end of the URL.
+When making requests to Amazon Bedrock, replace `https://bedrock-runtime.us-east-1.amazonaws.com/` in the URL you are currently using with `https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/`, then append the model you want to use.
 
-With Bedrock, you will need to sign the URL before you make requests to AI Gateway. You can try using the [`aws4fetch`](https://github.com/mhart/aws4fetch) SDK.
+For example, to invoke the Anthropic Claude model in `us-east-1`:
+
+```txt
+https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/model/anthropic.claude-3-haiku-20240307-v1:0/invoke
+```
+
+## Authenticating with Amazon Bedrock
+
+Amazon Bedrock uses [AWS Signature Version 4 (SigV4)](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html) to authenticate API requests. Unlike providers such as OpenAI or Anthropic that use a simple API key, AWS requires each request to be cryptographically signed with your credentials.
+
+AI Gateway handles this complexity for you. When you store your AWS credentials using BYOK, the gateway automatically signs each request before forwarding it to AWS.
+
+### Authentication methods comparison
+
+| Method | `cf-aig-authorization` header | `Authorization` header | Signing |
+| --- | --- | --- | --- |
+| **BYOK (Recommended)** | `Bearer {CF_AIG_TOKEN}` | Not needed | Gateway signs automatically |
+| **Client-side signing** | `Bearer {CF_AIG_TOKEN}` | Pre-signed AWS headers | You sign with `aws4fetch` or AWS SDK |
+
+:::caution[Do not confuse the headers]
+`cf-aig-authorization` authenticates your request to AI Gateway. When using BYOK, you do not need to include any AWS authorization headers because AI Gateway signs the request for you.
+:::
+
+### Option 1: BYOK (Recommended)
+
+The recommended approach is to store your AWS credentials using AI Gateway's [Bring Your Own Keys (BYOK)](/ai-gateway/configuration/bring-your-own-keys/) feature. This keeps your credentials secure and eliminates the need for client-side request signing.
+
+1. In the Cloudflare dashboard, go to **AI** > **AI Gateway** > your gateway > **Provider Keys**.
+2. Select **Add API Key** and choose **Amazon Bedrock** as the provider.
+3. Enter your AWS credentials as a JSON object with the following structure:
+
+   ```json
+   {
+   	"accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+   	"secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+   	"region": "us-east-1"
+   }
+   ```
+
+4. Select **Save**.
+
+If you are using temporary credentials from AWS STS (for example, from assuming an IAM role), include the `sessionToken` field:
+
+```json
+{
+	"accessKeyId": "ASIAIOSFODNN7EXAMPLE",
+	"secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	"region": "us-east-1",
+	"sessionToken": "FwoGZXIvYXdzEBY..."
+}
+```
+
+With BYOK configured, you only need to include the `cf-aig-authorization` header in your requests. AI Gateway handles the AWS SigV4 signing automatically.
+
+### Option 2: Client-side signing
+
+If you prefer to sign requests yourself, you can use the [`aws4fetch`](https://github.com/mhart/aws4fetch) library or any AWS SDK to sign the request before sending it through AI Gateway. Refer to the [client-side signing example](#client-side-signing-with-aws4fetch) below.
 
 ## Examples
 
-### Use `aws4fetch` SDK with TypeScript
+### cURL with BYOK
+
+With BYOK configured, requests are simple — no AWS signing required:
+
+```bash
+curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/model/anthropic.claude-3-haiku-20240307-v1:0/invoke" \
+  -H "cf-aig-authorization: Bearer {CF_AIG_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is Cloudflare?"
+      }
+    ],
+    "max_tokens": 256,
+    "anthropic_version": "bedrock-2023-05-31"
+  }'
+```
+
+### Client-side signing with aws4fetch
+
+If you are not using BYOK, you must sign the request before sending it through AI Gateway. The following example uses the `aws4fetch` library in a Cloudflare Worker:
 
 ```typescript
 import { AwsClient } from "aws4fetch";
@@ -47,51 +127,39 @@ export default {
 		env: Env,
 		ctx: ExecutionContext,
 	): Promise<Response> {
-		// replace with your configuration
 		const cfAccountId = "{account_id}";
 		const gatewayName = "{gateway_id}";
 		const region = "us-east-1";
 
-		// added as secrets (https://developers.cloudflare.com/workers/configuration/secrets/)
-		const accessKey = env.accessKey;
-		const secretKey = env.secretAccessKey;
-
 		const awsClient = new AwsClient({
-			accessKeyId: accessKey,
-			secretAccessKey: secretKey,
+			accessKeyId: env.accessKey,
+			secretAccessKey: env.secretAccessKey,
 			region: region,
 			service: "bedrock",
 		});
 
-		const requestBodyString = JSON.stringify({
-			inputText: "What does ethereal mean?",
+		const body = JSON.stringify({
+			messages: [{ role: "user", content: "What does ethereal mean?" }],
+			max_tokens: 256,
+			anthropic_version: "bedrock-2023-05-31",
 		});
 
-		const stockUrl = new URL(
-			`https://bedrock-runtime.${region}.amazonaws.com/model/amazon.titan-embed-text-v1/invoke`,
-		);
+		// Sign against the original AWS URL
+		const awsUrl = `https://bedrock-runtime.${region}.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1:0/invoke`;
 
-		const headers = {
-			"Content-Type": "application/json",
-		};
-
-		// sign the original request
-		const presignedRequest = await awsClient.sign(stockUrl.toString(), {
+		const presignedRequest = await awsClient.sign(awsUrl, {
 			method: "POST",
-			headers: headers,
-			body: requestBodyString,
+			headers: { "Content-Type": "application/json" },
+			body: body,
 		});
 
-		// Gateway Url
-		const gatewayUrl = new URL(
-			`https://gateway.ai.cloudflare.com/v1/${cfAccountId}/${gatewayName}/aws-bedrock/bedrock-runtime/${region}/model/amazon.titan-embed-text-v1/invoke`,
-		);
+		// Send through AI Gateway
+		const gatewayUrl = `https://gateway.ai.cloudflare.com/v1/${cfAccountId}/${gatewayName}/aws-bedrock/bedrock-runtime/${region}/model/anthropic.claude-3-haiku-20240307-v1:0/invoke`;
 
-		// make the request through the gateway url
 		const response = await fetch(gatewayUrl, {
 			method: "POST",
 			headers: presignedRequest.headers,
-			body: requestBodyString,
+			body: body,
 		});
 
 		if (
@@ -105,4 +173,78 @@ export default {
 		return new Response("Invalid response", { status: 500 });
 	},
 };
+```
+
+## Using the Unified API (OpenAI compatible)
+
+AI Gateway provides a [Unified API](/ai-gateway/usage/chat-completion/) that lets you use the OpenAI chat completions format with Bedrock models. This means you can use OpenAI or Anthropic SDKs to access models running on Bedrock without changing your request format.
+
+### Endpoint
+
+```txt
+https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions
+```
+
+### cURL with BYOK
+
+With BYOK configured, specify the model using the `aws-bedrock/{model}` format:
+
+```bash
+curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions" \
+  -H "cf-aig-authorization: Bearer {CF_AIG_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "aws-bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is Cloudflare?"
+      }
+    ]
+  }'
+```
+
+### OpenAI SDK with BYOK
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+	apiKey: "{CF_AIG_TOKEN}",
+	baseURL:
+		"https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat",
+});
+
+const response = await client.chat.completions.create({
+	model: "aws-bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+	messages: [
+		{
+			role: "user",
+			content: "What is Cloudflare?",
+		},
+	],
+});
+
+console.log(response.choices[0].message.content);
+```
+
+### Anthropic SDK with BYOK
+
+```python
+import anthropic
+
+client = anthropic.Anthropic(
+    base_url="https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat",
+    api_key="{CF_AIG_TOKEN}",
+)
+
+message = client.messages.create(
+    model="aws-bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+    max_tokens=256,
+    messages=[
+        {"role": "user", "content": "What is Cloudflare?"}
+    ],
+)
+
+print(message.content)
 ```

--- a/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
@@ -91,7 +91,7 @@ If you prefer to sign requests yourself, you can use the [`aws4fetch`](https://g
 
 ### cURL with BYOK
 
-With BYOK configured, requests are simple — no AWS signing required:
+With your AWS credentials [stored as a provider key](/ai-gateway/configuration/bring-your-own-keys/), requests are simple — no AWS signing required:
 
 ```bash
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/model/anthropic.claude-3-haiku-20240307-v1:0/invoke" \
@@ -187,7 +187,7 @@ https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/compl
 
 ### cURL
 
-With BYOK configured, specify the model using the `aws-bedrock/{model}` format:
+With your AWS credentials [stored as a provider key](/ai-gateway/configuration/bring-your-own-keys/), specify the model using the `aws-bedrock/{model}` format:
 
 ```bash
 curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions" \
@@ -204,7 +204,7 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat
   }'
 ```
 
-### OpenAI SDK with BYOK
+### OpenAI SDK
 
 ```javascript
 import OpenAI from "openai";

--- a/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
@@ -32,7 +32,7 @@ When making requests to Amazon Bedrock, replace `https://bedrock-runtime.us-east
 For example, to invoke the Anthropic Claude model in `us-east-1`:
 
 ```txt
-https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/model/anthropic.claude-3-haiku-20240307-v1:0/invoke
+https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke
 ```
 
 ## Authenticating with Amazon Bedrock
@@ -94,7 +94,7 @@ If you prefer to sign requests yourself, you can use the [`aws4fetch`](https://g
 With your AWS credentials [stored as a provider key](/ai-gateway/configuration/bring-your-own-keys/), requests are simple — no AWS signing required:
 
 ```bash
-curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/model/anthropic.claude-3-haiku-20240307-v1:0/invoke" \
+curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/aws-bedrock/bedrock-runtime/us-east-1/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke" \
   -H "cf-aig-authorization: Bearer {CF_AIG_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -145,7 +145,7 @@ export default {
 		});
 
 		// Sign against the original AWS URL
-		const awsUrl = `https://bedrock-runtime.${region}.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1:0/invoke`;
+		const awsUrl = `https://bedrock-runtime.${region}.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke`;
 
 		const presignedRequest = await awsClient.sign(awsUrl, {
 			method: "POST",
@@ -154,7 +154,7 @@ export default {
 		});
 
 		// Send through AI Gateway
-		const gatewayUrl = `https://gateway.ai.cloudflare.com/v1/${cfAccountId}/${gatewayName}/aws-bedrock/bedrock-runtime/${region}/model/anthropic.claude-3-haiku-20240307-v1:0/invoke`;
+		const gatewayUrl = `https://gateway.ai.cloudflare.com/v1/${cfAccountId}/${gatewayName}/aws-bedrock/bedrock-runtime/${region}/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke`;
 
 		const response = await fetch(gatewayUrl, {
 			method: "POST",
@@ -194,7 +194,7 @@ curl "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat
   -H "cf-aig-authorization: Bearer {CF_AIG_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "aws-bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+    "model": "aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
     "messages": [
       {
         "role": "user",
@@ -216,7 +216,7 @@ const client = new OpenAI({
 });
 
 const response = await client.chat.completions.create({
-	model: "aws-bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+	model: "aws-bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
 	messages: [
 		{
 			role: "user",

--- a/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/bedrock.mdx
@@ -177,7 +177,7 @@ export default {
 
 ## Using the Unified API (OpenAI compatible)
 
-AI Gateway provides a [Unified API](/ai-gateway/usage/chat-completion/) that lets you use the OpenAI chat completions format with Bedrock models. This means you can use OpenAI or Anthropic SDKs to access models running on Bedrock without changing your request format.
+AI Gateway provides a [Unified API](/ai-gateway/usage/chat-completion/) that lets you use the OpenAI chat completions format with Bedrock models. This is currently supported for **Anthropic Claude** and **Amazon Nova** model families. You can use the OpenAI SDK to access these models running on Bedrock without changing your request format.
 
 ### Endpoint
 


### PR DESCRIPTION
…Bedrock

The existing Bedrock docs only showed client-side SigV4 signing, which confused customers into thinking they had to sign requests themselves. This rewrites the page to document BYOK as the recommended auth method and adds Unified API (OpenAI compat) examples so users can access Bedrock models via OpenAI/Anthropic SDKs.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
