### PR TITLE
perf: reduce Workers AI model page HTML payload size

### DIFF
--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from "react";
 import ModelInfo from "./models/ModelInfo";
 import ModelBadges from "./models/ModelBadges";
 import { authorData } from "./models/data";
-import type { ResolvedModel } from "~/util/model-types";
+import type { ModelCardData } from "~/util/model-types";
 import { getModelAuthor } from "~/util/model-helpers";
 import { setSearchParams } from "~/util/url";
 import {
@@ -22,7 +22,7 @@ const ModelCatalog = ({
 	models,
 	basePath = "/ai/models",
 }: {
-	models: ResolvedModel[];
+	models: ModelCardData[];
 	basePath?: string;
 }) => {
 	const [filters, setFilters] = useState<Filters>({

--- a/src/components/models/ModelBadges.tsx
+++ b/src/components/models/ModelBadges.tsx
@@ -1,5 +1,5 @@
 import type { WorkersAIModelsSchema } from "~/schemas";
-import type { ResolvedModel } from "~/util/model-types";
+import type { ModelCardData, ResolvedModel } from "~/util/model-types";
 import { CAPABILITY_PROPERTIES } from "~/util/model-properties";
 
 const CATEGORY_BADGE: Record<string, string> = {
@@ -7,7 +7,7 @@ const CATEGORY_BADGE: Record<string, string> = {
 	platform: "caution", // orange
 };
 
-type ModelType = WorkersAIModelsSchema | ResolvedModel;
+type ModelType = WorkersAIModelsSchema | ResolvedModel | ModelCardData;
 
 const ModelBadges = ({ model }: { model: ModelType }) => {
 	const badges = model.properties.flatMap(({ property_id, value }) => {

--- a/src/components/models/ModelDetailPage.astro
+++ b/src/components/models/ModelDetailPage.astro
@@ -341,30 +341,75 @@ const starlightPageProps = {
 			<>
 				<h2 id="Parameters">Parameters</h2>
 
-				<div class="space-y-3">
-					{model.apiModes.map((mode) => (
-						<details class="group rounded-lg border border-gray-200 p-0 py-3 dark:border-gray-700">
-							<summary class="cursor-pointer px-8 font-medium text-gray-900 dark:text-gray-100">
-								<span>{mode.name}</span>
-								{mode.description && (
-									<span class="text-sm font-normal text-gray-500 dark:text-gray-400">
-										— {mode.description}
-									</span>
-								)}
-							</summary>
-							<div class="border-t border-gray-200 p-4 pb-1 dark:border-gray-700">
-								<Tabs syncKey={`schema-${mode.id}`}>
-									<TabItem label="Input">
-										<SchemaDisplay schema={mode.input} title="Input" />
-									</TabItem>
-									<TabItem label="Output">
-										<SchemaDisplay schema={mode.output} title="Output" />
-									</TabItem>
-								</Tabs>
+				{/*
+				 * Render input schema once (shared across all modes), then
+				 * render per-mode output sections. This avoids duplicating the
+				 * processed SchemaRowData tree in the HTML for every mode.
+				 *
+				 * Sync and streaming always share the same input; batch may differ.
+				 * We detect shared input by comparing JSON serialisation.
+				 */}
+				{(() => {
+					// Detect which modes share the same input as the first mode
+					const firstInputJson = JSON.stringify(model.apiModes[0].input);
+					const allInputsIdentical = model.apiModes.every(
+						(mode) => JSON.stringify(mode.input) === firstInputJson,
+					);
+
+					return allInputsIdentical ? (
+						<>
+							{/* Input rendered once */}
+							<h3 class="mt-4! mb-2! text-base font-semibold">Input</h3>
+							<SchemaDisplay schema={model.apiModes[0].input} title="Input" />
+
+							{/* Output per mode */}
+							<h3 class="mt-6! mb-2! text-base font-semibold">Output</h3>
+							<div class="space-y-3">
+								{model.apiModes.map((mode) => (
+									<details class="group rounded-lg border border-gray-200 p-0 py-3 dark:border-gray-700">
+										<summary class="cursor-pointer px-8 font-medium text-gray-900 dark:text-gray-100">
+											<span>{mode.name}</span>
+											{mode.description && (
+												<span class="text-sm font-normal text-gray-500 dark:text-gray-400">
+													— {mode.description}
+												</span>
+											)}
+										</summary>
+										<div class="border-t border-gray-200 p-4 pb-1 dark:border-gray-700">
+											<SchemaDisplay schema={mode.output} title="Output" />
+										</div>
+									</details>
+								))}
 							</div>
-						</details>
-					))}
-				</div>
+						</>
+					) : (
+						/* Inputs differ (e.g. batch has different input) — show per-mode tabs */
+						<div class="space-y-3">
+							{model.apiModes.map((mode) => (
+								<details class="group rounded-lg border border-gray-200 p-0 py-3 dark:border-gray-700">
+									<summary class="cursor-pointer px-8 font-medium text-gray-900 dark:text-gray-100">
+										<span>{mode.name}</span>
+										{mode.description && (
+											<span class="text-sm font-normal text-gray-500 dark:text-gray-400">
+												— {mode.description}
+											</span>
+										)}
+									</summary>
+									<div class="border-t border-gray-200 p-4 pb-1 dark:border-gray-700">
+										<Tabs syncKey={`schema-${mode.id}`}>
+											<TabItem label="Input">
+												<SchemaDisplay schema={mode.input} title="Input" />
+											</TabItem>
+											<TabItem label="Output">
+												<SchemaDisplay schema={mode.output} title="Output" />
+											</TabItem>
+										</Tabs>
+									</div>
+								</details>
+							))}
+						</div>
+					);
+				})()}
 
 				<h2 id="API-Schemas">API Schemas (Raw)</h2>
 				<div class="space-y-3">

--- a/src/components/models/ModelDetailPage.astro
+++ b/src/components/models/ModelDetailPage.astro
@@ -158,6 +158,14 @@ const hasSupportedLanguages = model.name === "@cf/deepgram/nova-3";
 const hasSchema =
 	model.schema.input && Object.keys(model.schema.input).length > 0;
 
+// Base path for the static schema JSON endpoints.
+// workers-ai models use the short slug (last segment of model name).
+// catalog models use the full slug as-is (may be multi-segment, e.g. "openai/gpt-5.4-mini").
+const schemaBasePath =
+	model.dataSource === "legacy"
+		? `/workers-ai/models/${model.name.split("/").at(-1)}`
+		: `/ai/models/${model.slug}`;
+
 const authorName = author?.name ?? authorId;
 const pageTitle = `${displayName} (${authorName}) · Cloudflare AI docs`;
 
@@ -180,7 +188,7 @@ const starlightPageProps = {
 			? { depth: 2, slug: "Examples", text: "Examples" }
 			: false,
 		hasSchema ? { depth: 2, slug: "Parameters", text: "Parameters" } : false,
-		hasSchema ? { depth: 2, slug: "API-Schemas", text: "API Schemas" } : false,
+		hasSchema ? { depth: 2, slug: "API-Schemas", text: "API Schemas (Raw)" } : false,
 	].filter((v) => Boolean(v)) as MarkdownHeading[],
 	hideTitle: true,
 } as StarlightPageProps;
@@ -412,39 +420,29 @@ const starlightPageProps = {
 				})()}
 
 				<h2 id="API-Schemas">API Schemas (Raw)</h2>
-				<div class="space-y-3">
-					{model.apiModes.map((mode) => (
-						<details class="group rounded-lg border border-gray-200 p-0 py-3 dark:border-gray-700">
-							<summary class="cursor-pointer px-8 font-medium text-gray-900 dark:text-gray-100">
-								<span>{mode.name}</span>
-								{mode.description && (
-									<span class="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
-										— {mode.description}
-									</span>
-								)}
-							</summary>
-							<div class="px-4 py-2">
-								<Tabs syncKey={`raw-schema-${mode.id}`}>
-									<TabItem label="Input">
-										<div class="[&_pre]:max-h-[500px] [&_pre]:overflow-y-scroll">
-											<Code
-												code={JSON.stringify(mode.input, null, 2)}
-												lang="json"
-											/>
-										</div>
-									</TabItem>
-									<TabItem label="Output">
-										<div class="[&_pre]:max-h-[500px] [&_pre]:overflow-y-scroll">
-											<Code
-												code={JSON.stringify(mode.output, null, 2)}
-												lang="json"
-											/>
-										</div>
-									</TabItem>
-								</Tabs>
-							</div>
-						</details>
-					))}
+				<div class="not-content grid grid-cols-1 gap-2 sm:grid-cols-2">
+					{model.apiModes.flatMap((mode) => [
+						<div class="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-1.5 dark:border-gray-700">
+							<span class="text-sm">
+								<span class="font-medium text-gray-900 dark:text-gray-100">{mode.name}</span>
+								<span class="ml-2 text-gray-500 dark:text-gray-400">Input</span>
+							</span>
+							<span class="flex items-center gap-1">
+								<a href={`${schemaBasePath}/${mode.id}-input.json`} target="_blank" rel="noopener noreferrer" title="Open" class="flex h-7 w-7 items-center justify-center rounded text-gray-400 no-underline hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a>
+								<a href={`${schemaBasePath}/${mode.id}-input.json`} download={`${mode.id}-input.json`} title="Download" class="flex h-7 w-7 items-center justify-center rounded text-gray-400 no-underline hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></a>
+							</span>
+						</div>,
+						<div class="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-1.5 dark:border-gray-700">
+							<span class="text-sm">
+								<span class="font-medium text-gray-900 dark:text-gray-100">{mode.name}</span>
+								<span class="ml-2 text-gray-500 dark:text-gray-400">Output</span>
+							</span>
+							<span class="flex items-center gap-1">
+								<a href={`${schemaBasePath}/${mode.id}-output.json`} target="_blank" rel="noopener noreferrer" title="Open" class="flex h-7 w-7 items-center justify-center rounded text-gray-400 no-underline hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a>
+								<a href={`${schemaBasePath}/${mode.id}-output.json`} download={`${mode.id}-output.json`} title="Download" class="flex h-7 w-7 items-center justify-center rounded text-gray-400 no-underline hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></a>
+							</span>
+						</div>,
+					])}
 				</div>
 			</>
 		) : (
@@ -482,25 +480,23 @@ const starlightPageProps = {
 						</TabItem>
 					</Tabs>
 
-					<h2 id="API-Schemas">API Schemas</h2>
-					<Tabs syncKey="schema-tab">
-						<TabItem label="Input">
-							<div class="[&_pre]:max-h-[500px] [&_pre]:overflow-y-auto">
-								<Code
-									code={JSON.stringify(model.schema.input, null, 2)}
-									lang="json"
-								/>
-							</div>
-						</TabItem>
-						<TabItem label="Output">
-							<div class="[&_pre]:max-h-[500px] [&_pre]:overflow-y-auto">
-								<Code
-									code={JSON.stringify(model.schema.output, null, 2)}
-									lang="json"
-								/>
-							</div>
-						</TabItem>
-					</Tabs>
+					<h2 id="API-Schemas">API Schemas (Raw)</h2>
+					<div class="not-content grid grid-cols-1 gap-2 sm:grid-cols-2">
+						<div class="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-1.5 dark:border-gray-700">
+							<span class="text-sm font-medium text-gray-900 dark:text-gray-100">Input</span>
+							<span class="flex items-center gap-1">
+								<a href={`${schemaBasePath}/schema-input.json`} target="_blank" rel="noopener noreferrer" title="Open" class="flex h-7 w-7 items-center justify-center rounded text-gray-400 no-underline hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a>
+								<a href={`${schemaBasePath}/schema-input.json`} download="schema-input.json" title="Download" class="flex h-7 w-7 items-center justify-center rounded text-gray-400 no-underline hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></a>
+							</span>
+						</div>
+						<div class="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-1.5 dark:border-gray-700">
+							<span class="text-sm font-medium text-gray-900 dark:text-gray-100">Output</span>
+							<span class="flex items-center gap-1">
+								<a href={`${schemaBasePath}/schema-output.json`} target="_blank" rel="noopener noreferrer" title="Open" class="flex h-7 w-7 items-center justify-center rounded text-gray-400 no-underline hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a>
+								<a href={`${schemaBasePath}/schema-output.json`} download="schema-output.json" title="Download" class="flex h-7 w-7 items-center justify-center rounded text-gray-400 no-underline hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></a>
+							</span>
+						</div>
+					</div>
 				</>
 			)
 		)

--- a/src/components/models/ModelInfo.tsx
+++ b/src/components/models/ModelInfo.tsx
@@ -1,9 +1,9 @@
 import type { WorkersAIModelsSchema } from "~/schemas";
-import type { ResolvedModel } from "~/util/model-types";
+import type { ModelCardData, ResolvedModel } from "~/util/model-types";
 import { getModelAuthor } from "~/util/model-helpers";
 import { authorData } from "./data";
 
-type ModelType = WorkersAIModelsSchema | ResolvedModel;
+type ModelType = WorkersAIModelsSchema | ResolvedModel | ModelCardData;
 
 const ModelInfo = ({ model }: { model: ModelType }) => {
 	const authorId = getModelAuthor(model.name);

--- a/src/components/models/SchemaDisplay.astro
+++ b/src/components/models/SchemaDisplay.astro
@@ -422,14 +422,14 @@ const variantRows =
 				variants={variantRows}
 				schemaId={schemaId}
 				hideRequired={hideRequired}
-				client:load
+				client:visible
 			/>
 		) : rows.length === 0 ? (
 			<p class="text-sm text-gray-500 dark:text-gray-400">
 				No parameters defined.
 			</p>
 		) : (
-			<SchemaTreeView rows={rows} schemaId={schemaId} hideRequired={hideRequired} client:load />
+			<SchemaTreeView rows={rows} schemaId={schemaId} hideRequired={hideRequired} client:visible />
 		)
 	}
 </div>

--- a/src/pages/ai/models/[...schema].json.ts
+++ b/src/pages/ai/models/[...schema].json.ts
@@ -1,0 +1,45 @@
+import type { APIRoute, GetStaticPaths, InferGetStaticPropsType } from "astro";
+import { getResolvedModels } from "~/util/model-resolver";
+import { detectApiModes } from "~/util/model-schema";
+
+export const getStaticPaths = (async () => {
+	const models = await getResolvedModels();
+	const paths = [];
+
+	for (const model of models) {
+		// Catalog models use the full slug as the URL path segment
+		// (e.g. "openai/gpt-5.4-mini"), matching /ai/models/[...name].astro
+		const slug = model.slug;
+		const modes = detectApiModes(model.schema);
+
+		if (modes) {
+			for (const mode of modes) {
+				paths.push({
+					params: { schema: `${slug}/${mode.id}-input` },
+					props: { schema: mode.input },
+				});
+				paths.push({
+					params: { schema: `${slug}/${mode.id}-output` },
+					props: { schema: mode.output },
+				});
+			}
+		} else {
+			paths.push({
+				params: { schema: `${slug}/schema-input` },
+				props: { schema: model.schema.input },
+			});
+			paths.push({
+				params: { schema: `${slug}/schema-output` },
+				props: { schema: model.schema.output },
+			});
+		}
+	}
+
+	return paths;
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+export const GET: APIRoute<Props> = ({ props }) => {
+	return Response.json(props.schema);
+};

--- a/src/pages/ai/models/index.astro
+++ b/src/pages/ai/models/index.astro
@@ -1,10 +1,10 @@
 ---
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import ModelCatalog from "~/components/ModelCatalog.tsx";
-import { getResolvedModels } from "~/util/model-resolver";
+import { getResolvedModels, toModelCardData } from "~/util/model-resolver";
 import { Aside } from "~/components";
 
-const models = await getResolvedModels();
+const models = (await getResolvedModels()).map(toModelCardData);
 ---
 
 <StarlightPage frontmatter={{ title: "Models", tableOfContents: false }}>

--- a/src/pages/workers-ai/models/[...schema].json.ts
+++ b/src/pages/workers-ai/models/[...schema].json.ts
@@ -1,0 +1,45 @@
+import type { APIRoute, GetStaticPaths, InferGetStaticPropsType } from "astro";
+import { getLegacyModels } from "~/util/model-resolver";
+import { detectApiModes } from "~/util/model-schema";
+
+export const getStaticPaths = (async () => {
+	const models = await getLegacyModels();
+	const paths = [];
+
+	for (const model of models) {
+		// Short slug is the last segment of the model name, matching the
+		// URL structure used by /workers-ai/models/[...name].astro
+		const slug = model.name.split("/").at(-1)!;
+		const modes = detectApiModes(model.schema);
+
+		if (modes) {
+			for (const mode of modes) {
+				paths.push({
+					params: { schema: `${slug}/${mode.id}-input` },
+					props: { schema: mode.input },
+				});
+				paths.push({
+					params: { schema: `${slug}/${mode.id}-output` },
+					props: { schema: mode.output },
+				});
+			}
+		} else {
+			paths.push({
+				params: { schema: `${slug}/schema-input` },
+				props: { schema: model.schema.input },
+			});
+			paths.push({
+				params: { schema: `${slug}/schema-output` },
+				props: { schema: model.schema.output },
+			});
+		}
+	}
+
+	return paths;
+}) satisfies GetStaticPaths;
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+export const GET: APIRoute<Props> = ({ props }) => {
+	return Response.json(props.schema);
+};

--- a/src/pages/workers-ai/models/index.astro
+++ b/src/pages/workers-ai/models/index.astro
@@ -1,10 +1,10 @@
 ---
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import ModelCatalog from "~/components/ModelCatalog.tsx";
-import { getLegacyModels } from "~/util/model-resolver";
+import { getLegacyModels, toModelCardData } from "~/util/model-resolver";
 import { Aside } from "~/components";
 
-const models = await getLegacyModels();
+const models = (await getLegacyModels()).map(toModelCardData);
 ---
 
 <StarlightPage

--- a/src/util/model-properties.ts
+++ b/src/util/model-properties.ts
@@ -57,9 +57,7 @@ export function hasProperty(properties: Property[], id: string): boolean {
 }
 
 /** Get all unique capability labels across a set of models. */
-export function getAllCapabilityLabels(
-	models: WithProperties[],
-): string[] {
+export function getAllCapabilityLabels(models: WithProperties[]): string[] {
 	return [...new Set(models.flatMap((m) => getCapabilities(m.properties)))];
 }
 

--- a/src/util/model-properties.ts
+++ b/src/util/model-properties.ts
@@ -7,6 +7,14 @@ type PropertyDef = {
 	category: PropertyCategory;
 };
 
+/** Minimal shape required for property-related utilities. */
+type WithProperties = {
+	properties: Array<{
+		property_id: string;
+		value: string | Array<Record<string, unknown>>;
+	}>;
+};
+
 /**
  * Boolean properties surfaced as badges and sidebar filters.
  *
@@ -50,14 +58,14 @@ export function hasProperty(properties: Property[], id: string): boolean {
 
 /** Get all unique capability labels across a set of models. */
 export function getAllCapabilityLabels(
-	models: WorkersAIModelsSchema[],
+	models: WithProperties[],
 ): string[] {
 	return [...new Set(models.flatMap((m) => getCapabilities(m.properties)))];
 }
 
 /** Get all unique labels for a given category across a set of models. */
 export function getLabelsByCategory(
-	models: WorkersAIModelsSchema[],
+	models: WithProperties[],
 	category: PropertyCategory,
 ): string[] {
 	const categoryProps = Object.entries(CAPABILITY_PROPERTIES)

--- a/src/util/model-resolver.ts
+++ b/src/util/model-resolver.ts
@@ -2,11 +2,11 @@ import { getCollection } from "astro:content";
 import type { CatalogModelsSchema } from "~/schemas/catalog-models";
 import type { WorkersAIModelsSchema } from "~/schemas/workers-ai-models";
 
-import type { ApiMode, ResolvedModel } from "./model-types";
+import type { ApiMode, ModelCardData, ResolvedModel } from "./model-types";
 
 // Re-export client-safe helpers and types for convenience
 export { getModelAuthor } from "./model-helpers";
-export type { ResolvedModel, ApiMode } from "./model-types";
+export type { ResolvedModel, ApiMode, ModelCardData } from "./model-types";
 
 /**
  * Detect and split a model's schema into logical API modes.
@@ -315,4 +315,31 @@ export async function getLegacyModels(): Promise<ResolvedModel[]> {
 	return legacyModels
 		.filter((entry) => !catalogSlugs.has(entry.data.name))
 		.map((entry) => legacyToResolved(entry.data));
+}
+
+/**
+ * Project a ResolvedModel to ModelCardData, stripping heavy fields
+ * (schema, apiModes, codeSnippets, examples, metadata, etc.) that are
+ * not needed by the catalog index pages. This avoids serializing
+ * megabytes of JSON Schema data into the page HTML as island props.
+ */
+export function toModelCardData(model: ResolvedModel): ModelCardData {
+	return {
+		name: model.name,
+		modelId: model.modelId,
+		slug: model.slug,
+		displayName: model.displayName,
+		description: model.description,
+		task: model.task,
+		tags: model.tags,
+		contextLength: model.contextLength,
+		maxOutputTokens: model.maxOutputTokens,
+		supportsAsync: model.supportsAsync,
+		id: model.id,
+		source: model.source,
+		created_at: model.created_at,
+		properties: model.properties,
+		dataSource: model.dataSource,
+		hosting: model.hosting,
+	};
 }

--- a/src/util/model-resolver.ts
+++ b/src/util/model-resolver.ts
@@ -2,117 +2,13 @@ import { getCollection } from "astro:content";
 import type { CatalogModelsSchema } from "~/schemas/catalog-models";
 import type { WorkersAIModelsSchema } from "~/schemas/workers-ai-models";
 
-import type { ApiMode, ModelCardData, ResolvedModel } from "./model-types";
+import type { ModelCardData, ResolvedModel } from "./model-types";
+import { detectApiModes } from "./model-schema";
 
 // Re-export client-safe helpers and types for convenience
 export { getModelAuthor } from "./model-helpers";
-export type { ResolvedModel, ApiMode, ModelCardData } from "./model-types";
-
-/**
- * Detect and split a model's schema into logical API modes.
- * Handles common patterns like:
- * - Sync vs Batch (anyOf with requests array)
- * - Prompt vs Messages input formats
- * - JSON vs Streaming output
- */
-function detectApiModes(schema: {
-	input: Record<string, unknown>;
-	output: Record<string, unknown>;
-}): ApiMode[] | undefined {
-	const { input, output } = schema;
-	const modes: ApiMode[] = [];
-
-	// Check for anyOf/oneOf at the input level
-	const inputVariants =
-		(input.anyOf as Record<string, unknown>[]) ||
-		(input.oneOf as Record<string, unknown>[]);
-
-	// Check for anyOf/oneOf at the output level
-	const outputVariants =
-		(output.anyOf as Record<string, unknown>[]) ||
-		(output.oneOf as Record<string, unknown>[]);
-
-	if (!inputVariants || inputVariants.length === 0) {
-		// No variants to split - return undefined to use combined schema
-		return undefined;
-	}
-
-	// Find batch input (has "requests" property)
-	const batchInputIndex = inputVariants.findIndex((v) => {
-		const props = v.properties as Record<string, unknown> | undefined;
-		return props && "requests" in props;
-	});
-
-	// Find sync input (not batch)
-	const syncInputIndex = inputVariants.findIndex(
-		(_, i) => i !== batchInputIndex,
-	);
-
-	// Find JSON output (contentType: application/json or has properties)
-	const jsonOutputIndex =
-		outputVariants?.findIndex((v) => {
-			return (
-				v.contentType === "application/json" ||
-				(v.type === "object" && v.properties)
-			);
-		}) ?? -1;
-
-	// Find streaming output (type: string, or format: binary for SSE)
-	const streamOutputIndex =
-		outputVariants?.findIndex((v) => {
-			return v.type === "string" || v.format === "binary";
-		}) ?? -1;
-
-	// Build sync mode
-	if (syncInputIndex !== -1) {
-		const syncInput = inputVariants[syncInputIndex];
-		const syncOutput =
-			jsonOutputIndex !== -1 && outputVariants
-				? outputVariants[jsonOutputIndex]
-				: output;
-
-		modes.push({
-			id: "sync",
-			name: "Synchronous",
-			description: "Send a request and receive a complete response",
-			input: syncInput,
-			output: syncOutput,
-		});
-
-		// Build streaming mode (same input as sync, different output)
-		if (streamOutputIndex !== -1 && outputVariants) {
-			modes.push({
-				id: "streaming",
-				name: "Streaming",
-				description:
-					"Send a request with `stream: true` and receive server-sent events",
-				input: syncInput,
-				output: outputVariants[streamOutputIndex],
-			});
-		}
-	}
-
-	// Build batch mode
-	if (batchInputIndex !== -1) {
-		const batchInput = inputVariants[batchInputIndex];
-		// Batch typically uses the same JSON output format
-		const batchOutput =
-			jsonOutputIndex !== -1 && outputVariants
-				? outputVariants[jsonOutputIndex]
-				: output;
-
-		modes.push({
-			id: "batch",
-			name: "Batch",
-			description: "Send multiple requests in a single API call",
-			input: batchInput,
-			output: batchOutput,
-		});
-	}
-
-	// Only return modes if we found meaningful splits
-	return modes.length > 1 ? modes : undefined;
-}
+export type { ResolvedModel, ModelCardData } from "./model-types";
+export type { ApiMode } from "./model-types";
 
 /**
  * Convert catalog model to resolved model format.

--- a/src/util/model-schema.ts
+++ b/src/util/model-schema.ts
@@ -1,0 +1,115 @@
+/**
+ * Schema utilities for Workers AI models.
+ * Extracted here so they can be shared between model-resolver.ts (build-time)
+ * and the static JSON endpoint pages without circular imports.
+ */
+
+import type { ApiMode } from "./model-types";
+
+/**
+ * Detect and split a model's schema into logical API modes.
+ * Handles common patterns like:
+ * - Sync vs Batch (anyOf with requests array)
+ * - Prompt vs Messages input formats
+ * - JSON vs Streaming output
+ *
+ * Returns undefined when the schema has no meaningful splits (flat schema).
+ */
+export function detectApiModes(schema: {
+	input: Record<string, unknown>;
+	output: Record<string, unknown>;
+}): ApiMode[] | undefined {
+	const { input, output } = schema;
+	const modes: ApiMode[] = [];
+
+	// Check for anyOf/oneOf at the input level
+	const inputVariants =
+		(input.anyOf as Record<string, unknown>[]) ||
+		(input.oneOf as Record<string, unknown>[]);
+
+	// Check for anyOf/oneOf at the output level
+	const outputVariants =
+		(output.anyOf as Record<string, unknown>[]) ||
+		(output.oneOf as Record<string, unknown>[]);
+
+	if (!inputVariants || inputVariants.length === 0) {
+		// No variants to split - return undefined to use combined schema
+		return undefined;
+	}
+
+	// Find batch input (has "requests" property)
+	const batchInputIndex = inputVariants.findIndex((v) => {
+		const props = v.properties as Record<string, unknown> | undefined;
+		return props && "requests" in props;
+	});
+
+	// Find sync input (not batch)
+	const syncInputIndex = inputVariants.findIndex(
+		(_, i) => i !== batchInputIndex,
+	);
+
+	// Find JSON output (contentType: application/json or has properties)
+	const jsonOutputIndex =
+		outputVariants?.findIndex((v) => {
+			return (
+				v.contentType === "application/json" ||
+				(v.type === "object" && v.properties)
+			);
+		}) ?? -1;
+
+	// Find streaming output (type: string, or format: binary for SSE)
+	const streamOutputIndex =
+		outputVariants?.findIndex((v) => {
+			return v.type === "string" || v.format === "binary";
+		}) ?? -1;
+
+	// Build sync mode
+	if (syncInputIndex !== -1) {
+		const syncInput = inputVariants[syncInputIndex];
+		const syncOutput =
+			jsonOutputIndex !== -1 && outputVariants
+				? outputVariants[jsonOutputIndex]
+				: output;
+
+		modes.push({
+			id: "sync",
+			name: "Synchronous",
+			description: "Send a request and receive a complete response",
+			input: syncInput,
+			output: syncOutput,
+		});
+
+		// Build streaming mode (same input as sync, different output)
+		if (streamOutputIndex !== -1 && outputVariants) {
+			modes.push({
+				id: "streaming",
+				name: "Streaming",
+				description:
+					"Send a request with `stream: true` and receive server-sent events",
+				input: syncInput,
+				output: outputVariants[streamOutputIndex],
+			});
+		}
+	}
+
+	// Build batch mode
+	if (batchInputIndex !== -1) {
+		const batchInput = inputVariants[batchInputIndex];
+		// Batch typically uses the same JSON output format
+		const batchOutput =
+			jsonOutputIndex !== -1 && outputVariants
+				? outputVariants[jsonOutputIndex]
+				: output;
+
+		modes.push({
+			id: "batch",
+			name: "Batch",
+			description: "Send multiple requests in a single API call",
+			input: batchInput,
+			output: batchOutput,
+		});
+	}
+
+	// Only return modes if we found meaningful splits
+	return modes.length > 1 ? modes : undefined;
+}

--- a/src/util/model-types.ts
+++ b/src/util/model-types.ts
@@ -6,6 +6,38 @@
 import type { CodeSnippet, ModelExample } from "~/schemas/catalog-models";
 
 /**
+ * Slimmed model type for the catalog index pages.
+ * Only includes the fields needed to render model cards and run filters.
+ * schema, apiModes, codeSnippets, examples, metadata, etc. are stripped
+ * to avoid serializing megabytes of JSON Schema data into the page HTML.
+ */
+export interface ModelCardData {
+	name: string;
+	modelId: string;
+	slug: string;
+	displayName: string;
+	description: string;
+	task: {
+		id: string;
+		name: string;
+		description: string;
+	};
+	tags: string[];
+	contextLength?: number;
+	maxOutputTokens?: number;
+	supportsAsync: boolean;
+	id: string;
+	source: number;
+	created_at?: string;
+	properties: Array<{
+		property_id: string;
+		value: string | Array<Record<string, unknown>>;
+	}>;
+	dataSource: "catalog" | "legacy";
+	hosting: "proxied" | "hosted";
+}
+
+/**
  * Represents a distinct API mode for a model (e.g., sync, streaming, batch).
  * Each mode has its own input/output schema derived from the combined schema.
  */


### PR DESCRIPTION
### Summary

The `/workers-ai/models/` and `/ai/models/` pages were exceeding the 2 MB markdown content-negotiation limit used by agents, and were unnecessarily large for all clients.

| Change | Detail | Saving |
| --- | --- | --- |
| Slim `ModelCatalog` props | Added `ModelCardData` type that strips `schema`, `apiModes`, `codeSnippets`, `examples`, `metadata`, and other heavy fields before serialising into the island. The catalog only needs name, task, description, properties, and a few scalars for filtering/rendering. | ~1.76 MB per index page |
| `client:visible` on schema islands | Changed `client:load` → `client:visible` on `SchemaTreeView` and `SchemaVariantSelector`. The schema section is below the fold on every detail page; React was hydrating it immediately on load regardless. | Defers React runtime cost until scroll |
| Deduplicate input schema on multi-mode pages | On models with sync + streaming `apiModes`, both modes share identical input. Previously the processed `SchemaRowData` tree was serialised into island props twice. Now input is rendered once with per-mode output sections shown separately. | ~145 KB per affected detail page |
| Static JSON schema endpoints | The "API Schemas (Raw)" section used `<Code code={JSON.stringify(...)} lang="json" />` which inflated 227 KB of raw JSON into ~1.95 MB of syntax-highlighted HTML (8.6× ratio). Replaced with static `.json` files served at e.g. `/workers-ai/models/gemma-4-26b-a4b-it/sync-input.json` and a compact card UI with open/download icon buttons. | ~1.95 MB per detail page |

| Page | Before | After |
| --- | --- | --- |
| `/workers-ai/models/` index | ~2.85 MB | ~1.0 MB |
| `/ai/models/` index | similar | ~1.0 MB |
| `/workers-ai/models/gemma-4-26b-a4b-it/` | ~3.1 MB | ~1.15 MB |

The raw schemas are also now directly accessible and linkable as JSON files, usable by `curl`, `jq`, agents, and API clients.
