### PR TITLE
[Artifacts] Improve get-started guide for Workers

### DIFF
--- a/src/content/docs/artifacts/api/errors.mdx
+++ b/src/content/docs/artifacts/api/errors.mdx
@@ -1,0 +1,68 @@
+---
+title: Errors
+description: Error codes returned by the Artifacts REST API and Workers binding.
+pcx_content_type: reference
+sidebar:
+  order: 4
+head:
+  - tag: title
+    content: Errors · Artifacts
+products:
+  - artifacts
+---
+
+import { Type } from "~/components";
+
+The Artifacts REST API and Workers binding return errors with a numeric code and message. Use the error code to identify the failure type and decide how to retry or surface the error.
+
+## Error codes
+
+| Name | Code | Description |
+|------|------|-------------|
+| `ALREADY_EXISTS` | 10201 | The target repository already exists in the namespace. |
+| `NOT_FOUND` | 10200 | The repository or remote resource does not exist. |
+| `IMPORT_IN_PROGRESS` | 10302 | The repository is still being imported and is not yet available. |
+| `FORK_IN_PROGRESS` | 10303 | The repository is still being forked and is not yet available. |
+| `INVALID_INPUT` | 10100 | A request parameter is missing, malformed, or outside the accepted range. |
+| `INVALID_REPO_NAME` | 10101 | The repository name does not meet naming requirements. |
+| `INVALID_TTL` | 10103 | The token TTL is outside the allowed range (60–31,536,000 seconds). |
+| `INVALID_URL` | 10104 | The source URL does not point to a valid git repository. |
+| `REMOTE_AUTH_REQUIRED` | 10106 | The remote repository requires authentication. |
+| `UPSTREAM_UNAVAILABLE` | 10401 | The remote git server could not be reached. |
+| `MEMORY_LIMIT` | 10402 | The operation exceeds service memory limits. |
+| `INTERNAL_ERROR` | 10400 | An unexpected internal error occurred. |
+
+## REST API error format
+
+REST API errors use the standard Cloudflare v4 envelope:
+
+```ts
+export interface ApiError {
+	code: number;
+	message: string;
+	documentation_url?: string;
+	source?: {
+		pointer?: string;
+	};
+}
+```
+
+- `code`: The numeric error code from the table above.
+- `message`: A human-readable description of the error.
+- `documentation_url`: A link to relevant documentation, if available.
+- `source.pointer`: The request field that caused the error, when applicable.
+
+## Workers binding errors
+
+When using the Workers binding, errors are thrown as exceptions. Catch binding errors and map them to the same codes for consistent handling:
+
+```ts
+try {
+	const repo = await env.ARTIFACTS.create(repoName);
+} catch (err) {
+	const message = err instanceof Error ? err.message : String(err);
+	// Map known messages to error codes, or treat as INTERNAL_ERROR.
+}
+```
+
+Binding error messages contain the same descriptive text as REST API errors. Parse the message to identify the specific failure, or treat unknown errors as `INTERNAL_ERROR`.

--- a/src/content/docs/artifacts/api/errors.mdx
+++ b/src/content/docs/artifacts/api/errors.mdx
@@ -13,7 +13,7 @@ products:
 
 import { Type } from "~/components";
 
-The Artifacts REST API and Workers binding return errors with a numeric code and message. Use the error code to identify the failure type and decide how to retry or surface the error.
+This is a list of Artifacts errors. 
 
 ## Error codes
 
@@ -31,38 +31,3 @@ The Artifacts REST API and Workers binding return errors with a numeric code and
 | `UPSTREAM_UNAVAILABLE` | 10401 | The remote git server could not be reached. |
 | `MEMORY_LIMIT` | 10402 | The operation exceeds service memory limits. |
 | `INTERNAL_ERROR` | 10400 | An unexpected internal error occurred. |
-
-## REST API error format
-
-REST API errors use the standard Cloudflare v4 envelope:
-
-```ts
-export interface ApiError {
-	code: number;
-	message: string;
-	documentation_url?: string;
-	source?: {
-		pointer?: string;
-	};
-}
-```
-
-- `code`: The numeric error code from the table above.
-- `message`: A human-readable description of the error.
-- `documentation_url`: A link to relevant documentation, if available.
-- `source.pointer`: The request field that caused the error, when applicable.
-
-## Workers binding errors
-
-When using the Workers binding, errors are thrown as exceptions. Catch binding errors and map them to the same codes for consistent handling:
-
-```ts
-try {
-	const repo = await env.ARTIFACTS.create(repoName);
-} catch (err) {
-	const message = err instanceof Error ? err.message : String(err);
-	// Map known messages to error codes, or treat as INTERNAL_ERROR.
-}
-```
-
-Binding error messages contain the same descriptive text as REST API errors. Parse the message to identify the specific failure, or treat unknown errors as `INTERNAL_ERROR`.

--- a/src/content/docs/artifacts/api/errors.mdx
+++ b/src/content/docs/artifacts/api/errors.mdx
@@ -11,9 +11,7 @@ products:
   - artifacts
 ---
 
-import { Type } from "~/components";
-
-This is a list of Artifacts errors. 
+This is a list of Artifacts errors.
 
 ## Error codes
 

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -489,7 +489,7 @@ Request body:
 
 - `repo` <Type text="RepoName" /> <MetaInfo text="required" />
 - `scope` <Type text='"read" | "write"' /> <MetaInfo text='optional (default: "write")' />
-- `ttl` <Type text="number" /> <MetaInfo text="optional (seconds, default: 86400)" />
+- `ttl` <Type text="number" /> <MetaInfo text="optional" /> — Token time-to-live in seconds. Minimum 60 (1 minute), maximum 31,536,000 (1 year). Defaults to 86,400 (24 hours).
 
 Response type:
 

--- a/src/content/docs/artifacts/api/workers-binding.mdx
+++ b/src/content/docs/artifacts/api/workers-binding.mdx
@@ -64,6 +64,8 @@ Use namespace methods on `env.ARTIFACTS` to create, list, inspect, import, or de
 - `opts.setDefaultBranch` <Type text="string" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
 
+`create()` returns repo metadata including `name`, `remote`, `defaultBranch`, and an initial token. Save these values if you need them later.
+
 <TypeScriptExample>
 
 ```ts
@@ -85,20 +87,21 @@ async function createRepo(artifacts: Artifacts) {
 
 </TypeScriptExample>
 
-The returned token encodes its expiry directly in the `?expires=` suffix.
-
 ### `get(name)`
 
 - `name` <Type text="RepoName" /> <MetaInfo text="required" />
 - Returns <Type text="Promise<ArtifactsRepo>" />
 - Throws if the repo does not exist or is not ready yet.
 
+`get()` returns a handle to an existing repo. Use the handle to call async methods on the repo, such as `createToken()`, `listTokens()`, `revokeToken()`, and `fork()`.
+
 <TypeScriptExample>
 
 ```ts
 async function getRepoHandle(artifacts: Artifacts) {
 	const repo = await artifacts.get("starter-repo");
-	return repo;
+	const token = await repo.createToken("read", 3600);
+	return token;
 }
 ```
 
@@ -142,6 +145,8 @@ Import a repository from an external git remote.
 - `params.target.opts.readOnly` <Type text="boolean" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
 
+`import()` returns repo metadata including `name`, `remote`, `defaultBranch`, and an initial token. Save the `remote` and `name` values if you need them later.
+
 <TypeScriptExample>
 
 ```ts
@@ -166,8 +171,6 @@ async function importFromGitHub(artifacts: Artifacts) {
 
 </TypeScriptExample>
 
-Imported repos return the same create-style token format. The token encodes its expiry directly in the `?expires=` suffix.
-
 ### `delete(name)`
 
 - `name` <Type text="RepoName" /> <MetaInfo text="required" />
@@ -185,18 +188,7 @@ async function deleteRepo(artifacts: Artifacts) {
 
 ## Repo handle methods
 
-Call `await artifacts.get(name)` to get a repo handle. The handle extends `ArtifactsRepoInfo`, so repo metadata (`id`, `name`, `remote`, `defaultBranch`, etc.) is available directly as properties.
-
-<TypeScriptExample>
-
-```ts
-async function getRemoteUrl(artifacts: Artifacts) {
-	const repo = await artifacts.get("starter-repo");
-	return repo.remote;
-}
-```
-
-</TypeScriptExample>
+Call `await artifacts.get(name)` to get a repo handle. Use the handle to call async methods on the repo.
 
 ### `createToken(scope?, ttl?)`
 
@@ -260,6 +252,8 @@ async function revokeToken(artifacts: Artifacts, tokenOrId: string) {
 - `opts.defaultBranchOnly` <Type text="boolean" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
 
+`fork()` returns metadata for the new repo. Save the `remote` and `name` values if you need them later.
+
 <TypeScriptExample>
 
 ```ts
@@ -300,16 +294,6 @@ export default {
 			});
 		}
 
-		if (request.method === "GET" && url.pathname === "/repos/starter-repo") {
-			const repo = await env.ARTIFACTS.get("starter-repo");
-			return Response.json({
-				id: repo.id,
-				name: repo.name,
-				remote: repo.remote,
-				defaultBranch: repo.defaultBranch,
-			});
-		}
-
 		if (request.method === "POST" && url.pathname === "/tokens") {
 			const repo = await env.ARTIFACTS.get("starter-repo");
 			const token = await repo.createToken("read", 3600);
@@ -317,7 +301,7 @@ export default {
 		}
 
 		return Response.json(
-			{ message: "Use POST /repos, GET /repos/starter-repo, or POST /tokens." },
+			{ message: "Use POST /repos or POST /tokens." },
 			{ status: 404 },
 		);
 	},

--- a/src/content/docs/artifacts/concepts/namespaces.mdx
+++ b/src/content/docs/artifacts/concepts/namespaces.mdx
@@ -10,11 +10,9 @@ products:
 
 import { WranglerConfig } from "~/components";
 
-Artifacts uses namespaces as top-level containers for repositories. Use them to separate repositories by environment, such as `prod`, `staging`, and `dev`, or by tenant and shard.
+Artifacts uses namespaces as top-level containers for repositories. Use them to separate repositories by environment, such as `prod`, `staging`, and `dev`, by tenant, or shard.
 
-You do not create namespaces separately.
-
-Choose a namespace name, then use that name in your Wrangler config or REST API path when you create the first repo. Artifacts creates the namespace implicitly at that point.
+Namespaces are created implicitly — there is no separate step to create one. You choose a namespace name, then reference it in your Wrangler config or REST API path. The first time you create a repository under that name, Artifacts creates the namespace for you automatically.
 
 ## Use namespaces as containers
 

--- a/src/content/docs/artifacts/examples/git-client.mdx
+++ b/src/content/docs/artifacts/examples/git-client.mdx
@@ -8,28 +8,37 @@ products:
   - artifacts
 ---
 
-Use this pattern when you want to discover a repo over the REST API and then hand the returned HTTPS remote to a standard Git client.
+You can use a standard Git client to interact with Artifacts repos. This example walks through clone, but the same approach works for fetch, pull, push, and any other Git operation.
+
+To do this, you need to:
+- Fetch the repo's remote URL from the REST API
+- Mint a short-lived token scoped to that repo
+
+Once you have the remote URL and token, you can use them to run Git commands against the repo. 
 
 This example assumes the repo already exists and that you have a [Cloudflare API token](/fundamentals/api/get-started/create-token/) with **Artifacts** > **Edit**.
 
 ## Fetch the remote and clone the repo
 
-First, fetch the repo metadata from the REST API. Then mint a read token for that repo and use the returned remote with `git clone`.
+Replace the placeholder values with your account ID, API token, and repo name. The script fetches the repo's remote URL from the API, mints a read-only token that expires in one hour, and clones the repo to a local directory.
 
 The example below uses `jq` to extract fields from the JSON responses.
 
 ```bash
+# Set your account details
 export ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
 export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
 export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
 
+# Fetch the repo's remote URL
 REPO_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN")
 
 ARTIFACTS_REMOTE=$(printf '%s' "$REPO_JSON" | jq -r '.result.remote')
 
+# Mint a short-lived read token
 TOKEN_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/tokens" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -37,11 +46,14 @@ TOKEN_JSON=$(curl --silent "$ARTIFACTS_BASE_URL/tokens" \
 
 ARTIFACTS_TOKEN=$(printf '%s' "$TOKEN_JSON" | jq -r '.result.plaintext')
 
+# Clone the repo
 git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" clone "$ARTIFACTS_REMOTE" artifacts-clone
 ```
+You now have a standard Git checkout in `./artifacts-clone`.
 
 This flow is useful when another system owns repo discovery or access control, but your local tooling still expects a normal git remote.
 
+### Authentication
 Treat `ARTIFACTS_TOKEN` as a secret. Keep it out of logs, and prefer `http.extraHeader` over saving credentials in a remote URL.
 
 If you need a self-contained remote URL for a short-lived workflow, extract the token secret and build the authenticated remote only for that command:

--- a/src/content/docs/artifacts/examples/isomorphic-git.mdx
+++ b/src/content/docs/artifacts/examples/isomorphic-git.mdx
@@ -12,7 +12,7 @@ import { Details, PackageManagers, TypeScriptExample } from "~/components";
 
 Use [isomorphic-git](https://isomorphic-git.org/) to run Git operations on Artifacts repos directly from a Cloudflare Worker.
 
-The Artifacts binding creates and manages repos, but it can't read or write files inside them — for that, you need Git. Since Workers don't have a git binary or a local filesystem, `isomorphic-git` fills that gap. It provides Git operations like init, commit, and push as JavaScript function calls, using an in-memory filesystem in place of a real disk.
+The Artifacts binding creates and manages repos, but it cannot read or write files inside them — for that, you need Git. Since Workers do not have a git binary or a local filesystem, `isomorphic-git` fills that gap. It provides Git operations like init, commit, and push as JavaScript function calls, using an in-memory filesystem in place of a real disk.
 
 Use this when your Worker needs to programmatically build and push file trees to an Artifacts repo — for example, an AI agent that generates code and commits it, or an automation that clones a repo, modifies files, and pushes changes back.
 

--- a/src/content/docs/artifacts/examples/isomorphic-git.mdx
+++ b/src/content/docs/artifacts/examples/isomorphic-git.mdx
@@ -10,11 +10,17 @@ products:
 
 import { Details, PackageManagers, TypeScriptExample } from "~/components";
 
-Use [isomorphic-git](https://isomorphic-git.org/) in a Cloudflare Worker when you need Git operations without a Git binary.
+Use [isomorphic-git](https://isomorphic-git.org/) to run Git operations on Artifacts repos directly from a Cloudflare Worker.
 
-This works with Artifacts because Artifacts exposes standard Git smart HTTP remotes. In Workers, pair `isomorphic-git/http/web` with a small in-memory filesystem because the runtime does not expose a local disk.
+The Artifacts binding creates and manages repos, but it can't read or write files inside them — for that, you need Git. Since Workers don't have a git binary or a local filesystem, `isomorphic-git` fills that gap. It provides Git operations like init, commit, and push as JavaScript function calls, using an in-memory filesystem in place of a real disk.
 
-## Install the dependency
+Use this when your Worker needs to programmatically build and push file trees to an Artifacts repo — for example, an AI agent that generates code and commits it, or an automation that clones a repo, modifies files, and pushes changes back.
+
+## Prerequisites
+
+Follow the [Artifacts Workers setup guide](/artifacts/get-started/workers/) to set up a Worker with an Artifacts binding. 
+
+### Install the dependency
 
 Install `isomorphic-git` in your Worker project:
 
@@ -43,17 +49,20 @@ export interface Env {
 
 export default {
 	async fetch(_request: Request, env: Env) {
+		// Create a new Artifacts repo
 		const repoName = `worker-demo-${crypto.randomUUID().slice(0, 8)}`;
 		const created = await env.ARTIFACTS.create(repoName);
 
-		// Artifacts returns art_v1_<secret>?expires=<unix_seconds>.
-		// For Git Basic auth, pass only the secret as the password.
+		// Artifacts tokens include expiry metadata: art_v1_<secret>?expires=<unix_seconds>
+		// Git Basic auth expects only the token secret as the password
 		const tokenSecret = created.token.split("?expires=")[0];
+
+		// Set up an in-memory filesystem and initialize a Git repo
 		const dir = "/workspace";
 		const fs = new MemoryFS();
-
 		await git.init({ fs, dir, defaultBranch: "main" });
 
+		// Write files
 		await fs.promises.writeFile(
 			`${dir}/README.md`,
 			"# Artifacts repo created from a Worker\n",
@@ -63,6 +72,7 @@ export default {
 			'export const message = "hello from Artifacts";\n',
 		);
 
+		// Stage and commit
 		await git.add({ fs, dir, filepath: "README.md" });
 		await git.add({ fs, dir, filepath: "src/index.ts" });
 
@@ -76,6 +86,7 @@ export default {
 			},
 		});
 
+		// Push to the Artifacts remote
 		const push = await git.push({
 			fs,
 			http,

--- a/src/content/docs/artifacts/get-started/rest-api.mdx
+++ b/src/content/docs/artifacts/get-started/rest-api.mdx
@@ -29,11 +29,11 @@ You need:
 - A local `git` client.
 - `jq`, if you want to extract response fields automatically.
 
-For Workers-based access instead of direct HTTP calls, use the [Workers get started guide](/artifacts/get-started/workers/).
+If you want to create and manage repos directly from a Worker (instead of calling the REST API), use the [Workers get started guide](/artifacts/get-started/workers/).
 
 ## 1. Export your environment variables
 
-Set the variables used in the examples:
+Set the following variables using your Cloudflare account ID and Artifacts API token:
 
 ```sh
 export ARTIFACTS_NAMESPACE="default"
@@ -45,7 +45,7 @@ export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUN
 
 Use a unique repo name each time you run this guide.
 
-Artifacts uses Bearer authentication for control-plane requests:
+Artifacts uses Bearer authentication for API requests:
 
 ```txt
 Authorization: Bearer $CLOUDFLARE_API_TOKEN
@@ -82,10 +82,11 @@ The response resembles the following:
 	"messages": []
 }
 ```
+The response includes two values which you will need for Git operations: 
+- `remote`: the Git remote URL for this repo. `<ACCOUNT_ID>` will be your actual Cloudflare account ID. Use this URL for all Git commands (git push, git clone). Note that this uses a different URL than the REST API you used to create the repo.
+- `token`: a short-lived credential for Git operations. The token encodes its expiry directly in the `?expires=` suffix as a Unix timestamp.
 
-The REST control-plane base URL and the returned Git remote use different hosts. Use the exact `result.remote` value for Git operations. The example above uses `<ACCOUNT_ID>` as a placeholder for your Cloudflare account ID.
 
-The returned token encodes its expiry directly in the `?expires=` suffix.
 
 Copy the `remote` and `token` values from `result` into local shell variables:
 

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -104,35 +104,24 @@ Replace `src/index.ts` with the following code:
 <TypeScriptExample filename="src/index.ts">
 
 ```ts
-interface Env {
-	ARTIFACTS: Artifacts;
-}
-
 export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
+	async fetch(request, env) {
 		const url = new URL(request.url);
 
 		if (request.method === "POST" && url.pathname === "/repos") {
 			// Read the repo name from the request body so the route is reusable.
-			const body = (await request.json().catch(() => ({}))) as {
-				name?: string;
-			};
+			const body = await request.json().catch(() => ({}));
+
 			const repoName = body.name ?? "starter-repo";
 
-			try {
-				// Create the repo and return the remote URL plus initial write token.
-				const created = await env.ARTIFACTS.create(repoName);
-				return Response.json({
-					name: created.name,
-					remote: created.remote,
-					token: created.token,
-				});
-			} catch (err) {
-				// Return an error if the repo name is already taken.
-				const message = err instanceof Error ? err.message : String(err);
-				const status = message.includes("already exists") ? 409 : 500;
-				return Response.json({ error: message }, { status });
-			}
+			// Create the repo and return the remote URL plus initial write token.
+			const created = await env.ARTIFACTS.create(repoName);
+
+			return Response.json({
+				name: created.name,
+				remote: created.remote,
+				token: created.token,
+			});
 		}
 
 		return new Response("Use POST /repos to create an Artifacts repo.", {
@@ -140,7 +129,7 @@ export default {
 			headers: { Allow: "POST" },
 		});
 	},
-} satisfies ExportedHandler<Env>;
+};
 ```
 
 </TypeScriptExample>

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -211,7 +211,8 @@ export ARTIFACTS_TOKEN=$(printf '%s' "$RESPONSE" | jq -r '.token')
 
 ## 5. Push your first commit with git
 
-In the previous step, your Worker created an empty Artifacts repo. Now you'll create a local Git repo, add a file, and push it to Artifacts — the same way you'd push to any Git remote.
+In the previous step, your Worker created an empty Artifacts repo. Now you will create a local Git repo, add a file, and push it to Artifacts — the same way you would push to any Git remote.
+
 
 ```sh
 mkdir artifacts-demo

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -172,7 +172,8 @@ curl http://localhost:8787/repos \
   }'
 ```
 
-Your Worker will call `env.ARTIFACTS.create()` and return three values you'll need for Git operations:
+Your Worker will call `env.ARTIFACTS.create()` and return three values you will need for Git operations:
+
 
 ```json
 {

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -119,14 +119,20 @@ export default {
 			};
 			const repoName = body.name ?? "starter-repo";
 
-			// Create the repo and return the remote URL plus initial write token.
-			const created = await env.ARTIFACTS.create(repoName);
-
-			return Response.json({
-				name: created.name,
-				remote: created.remote,
-				token: created.token,
-			});
+			try {
+				// Create the repo and return the remote URL plus initial write token.
+				const created = await env.ARTIFACTS.create(repoName);
+				return Response.json({
+					name: created.name,
+					remote: created.remote,
+					token: created.token,
+				});
+			} catch (err) {
+				// Return an error if the repo name is already taken.
+				const message = err instanceof Error ? err.message : String(err);
+				const status = message.includes("already exists") ? 409 : 500;
+				return Response.json({ error: message }, { status });
+			}
 		}
 
 		return new Response("Use POST /repos to create an Artifacts repo.", {
@@ -139,7 +145,7 @@ export default {
 
 </TypeScriptExample>
 
-This Worker does one job: create an Artifacts repo and return the values your Git client needs next.
+This Worker creates an Artifacts repo and returns the remote URL and token your Git client needs to push and pull.
 
 :::caution[Protect token-issuing routes]
 This example omits authentication so it can focus on the Artifacts flow. In production, authorize the caller before creating repos or returning write tokens.
@@ -153,9 +159,7 @@ Start local development:
 
 <PackageManagers type="exec" pkg="wrangler" args="dev" />
 
-In a second terminal, choose one of the following ways to create a repo through your Worker.
-
-If you rerun this guide, use a different repo name in the request body.
+Then, open a second terminal and send a request to your Worker to create a new Artifacts repo:
 
 <Tabs>
 	<TabItem label="Manual">
@@ -168,7 +172,7 @@ curl http://localhost:8787/repos \
   }'
 ```
 
-The response resembles the following:
+Your Worker will call `env.ARTIFACTS.create()` and return three values you'll need for Git operations:
 
 ```json
 {
@@ -177,10 +181,9 @@ The response resembles the following:
 	"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000"
 }
 ```
-
-Use the exact `remote` value from the response. The example above uses `<ACCOUNT_ID>` as a placeholder for your Cloudflare account ID.
-
-The returned token encodes its expiry directly in the `?expires=` suffix.
+- `name`: the repo name. Must be unique within the namespace.
+- `remote`: the Git remote URL for this repo. `<ACCOUNT_ID>` will be your actual Cloudflare account ID.
+- `token`: a short-lived credential for Git operations. The token encodes its expiry directly in the `?expires=` suffix as a Unix timestamp.
 
 Copy the `remote` and `token` values into local shell variables:
 
@@ -207,7 +210,7 @@ export ARTIFACTS_TOKEN=$(printf '%s' "$RESPONSE" | jq -r '.token')
 
 ## 5. Push your first commit with git
 
-Create a local repository and push it to Artifacts:
+In the previous step, your Worker created an empty Artifacts repo. Now you'll create a local Git repo, add a file, and push it to Artifacts — the same way you'd push to any Git remote.
 
 ```sh
 mkdir artifacts-demo
@@ -220,7 +223,7 @@ git remote add origin "$ARTIFACTS_REMOTE"
 git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" push -u origin main
 ```
 
-This uses the recommended header-based form and keeps the token out of the remote URL.
+The `-c http.extraHeader` flag passes the token as a request header, which keeps it out of your Git config and shell history.
 
 If you need a self-contained remote URL for a short-lived command, build one from the token secret instead:
 
@@ -249,6 +252,11 @@ git clone "$ARTIFACTS_AUTH_REMOTE" artifacts-clone
 ```
 
 ## 7. Deploy your Worker
+
+Switch back to your Worker project directory: 
+```sh
+cd artifacts-worker
+```
 
 Deploy the Worker so you can create repos without running `wrangler dev`:
 

--- a/src/content/docs/artifacts/guides/event-subscriptions.mdx
+++ b/src/content/docs/artifacts/guides/event-subscriptions.mdx
@@ -10,7 +10,7 @@ products:
 
 import { Render } from "~/components";
 
-Artifacts emits structured events for repository lifecycle changes — creates, deletes, forks, imports, and clones. By subscribing to these events through [event subscriptions](/queues/event-subscriptions/), you can consume them from a Worker to build commit-driven automation.
+Artifacts emits structured events for repository lifecycle changes — creates, deletes, forks, imports, pushes, clones, fetches, and token changes. By subscribing to these events through [event subscriptions](/queues/event-subscriptions/), you can consume them from a Worker to build commit-driven automation.
 
 For example:
 - Run custom workflows when a repository is created or imported

--- a/src/content/partials/queues/event-subscriptions/artifacts-events.mdx
+++ b/src/content/partials/queues/event-subscriptions/artifacts-events.mdx
@@ -230,3 +230,57 @@ Triggered when updates are fetched from a repository.
   }
 }
 ```
+
+#### `token.created`
+
+Triggered when a repo-scoped token is created. Includes the token ID, scope, and expiration time.
+
+**Example:**
+
+```json
+{
+  "type": "cf.artifacts.repo.token.created",
+  "source": {
+    "type": "artifacts.repo",
+    "namespace": "default",
+    "repoName": "token-evt-repo"
+  },
+  "payload": {
+    "tokenId": "7ngdf3ww3u84t33x",
+    "scope": "read",
+    "expiresAt": "2026-05-20T16:58:14.548Z"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "0ab4c7b45a39491ba5da2973f3d093a6",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2026-05-20T16:58:14.548Z"
+  }
+}
+```
+
+#### `token.revoked`
+
+Triggered when a repo-scoped token is revoked. Includes the token ID.
+
+**Example:**
+
+```json
+{
+  "type": "cf.artifacts.repo.token.revoked",
+  "source": {
+    "type": "artifacts.repo",
+    "namespace": "default",
+    "repoName": "token-evt-repo"
+  },
+  "payload": {
+    "tokenId": "7ngdf3ww3u84t33x"
+  },
+  "metadata": {
+    "accountId": "f9f79265f388666de8122cfb508d7776",
+    "eventSubscriptionId": "0ab4c7b45a39491ba5da2973f3d093a6",
+    "eventSchemaVersion": 1,
+    "eventTimestamp": "2026-05-20T16:58:14.548Z"
+  }
+}
+```


### PR DESCRIPTION
Improves the Artifacts get-started guide for Workers with clearer explanations and better error handling.

Changes:
- Added try/catch error handling in the Worker code to return 409 Conflict when a repo name already exists
- Improved explanation of what the Worker returns (remote URL, token, and name)
- Added bullet points clarifying the purpose of each returned field
- Added explicit step to switch back to Worker directory before deployment
- Clarified how the token expiry works (Unix timestamp in the query string)
- Improved instructions for using the token with Git (header-based auth keeps token out of shell history and Git config)
- Fixed code indentation to use tabs per codebase style
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
