### PR TITLE
docs: document dashboard session creation for Browser Run

### DIFF
--- a/src/content/docs/browser-run/features/live-view.mdx
+++ b/src/content/docs/browser-run/features/live-view.mdx
@@ -23,6 +23,8 @@ There are three ways to access Live View: through the Cloudflare dashboard, via 
 
 In the Cloudflare dashboard, go to the **Browser Run** page and select the **Live Sessions** tab. This shows all active browser sessions in your account. Expand a session to see its tabs, then select **Open** to open the Live View for that tab.
 
+You can also create a new session directly from the dashboard by selecting **Create Session**. The session starts with Live View open automatically so you can interact with it right away. You can optionally enable [session recording](/browser-run/features/session-recording/) when creating the session.
+
 <DashButton url="/?to=/:account/workers/browser-run" />
 
 ### Hosted UI (any browser)

--- a/src/content/docs/browser-run/features/session-recording.mdx
+++ b/src/content/docs/browser-run/features/session-recording.mdx
@@ -14,7 +14,13 @@ import { Details, InlineBadge, Tabs, TabItem, DashButton } from "~/components";
 
 When browser automation fails or behaves unexpectedly, it can be difficult to understand what happened. Session recording captures DOM changes, mouse and keyboard events, and page navigation as structured JSON events — not a video — so it is lightweight and easy to inspect. Recordings are powered by [rrweb](https://github.com/rrweb-io/rrweb) and are opt-in per session.
 
-## Enable session recording
+## Enable from the dashboard
+
+You can create a session with recording enabled directly from the Cloudflare dashboard. Go to **Browser Run** > **Create Session** and toggle **Session Recording** on. The session starts with [Live View](/browser-run/features/live-view/) so you can interact with it in real time, and the recording is available under **Browser Run** > **Runs** after the session closes.
+
+<DashButton url="/?to=/:account/workers/browser-run" />
+
+## Enable in code
 
 Pass `recording: true` to `puppeteer.launch()` or `playwright.launch()`:
 

--- a/src/content/docs/browser-run/features/session-recording.mdx
+++ b/src/content/docs/browser-run/features/session-recording.mdx
@@ -14,13 +14,15 @@ import { Details, InlineBadge, Tabs, TabItem, DashButton } from "~/components";
 
 When browser automation fails or behaves unexpectedly, it can be difficult to understand what happened. Session recording captures DOM changes, mouse and keyboard events, and page navigation as structured JSON events — not a video — so it is lightweight and easy to inspect. Recordings are powered by [rrweb](https://github.com/rrweb-io/rrweb) and are opt-in per session.
 
-## Enable from the dashboard
+## Enable session recording
+
+### From the dashboard
 
 You can create a session with recording enabled directly from the Cloudflare dashboard. Go to **Browser Run** > **Create Session** and toggle **Session Recording** on. The session starts with [Live View](/browser-run/features/live-view/) so you can interact with it in real time, and the recording is available under **Browser Run** > **Runs** after the session closes.
 
 <DashButton url="/?to=/:account/workers/browser-run" />
 
-## Enable in code
+### In code
 
 Pass `recording: true` to `puppeteer.launch()` or `playwright.launch()`:
 
@@ -83,7 +85,7 @@ export default {
 The recording is finalized when the browser session closes, whether you call `browser.close()` explicitly, the session reaches its idle timeout, or the Worker terminates for any other reason. The recording is not available until after the session ends.
 :::
 
-## Enable with CDP endpoint
+### With the CDP endpoint
 
 When connecting to Browser Run from any environment using the [CDP endpoint](/browser-run/cdp/), add `recording=true` as a query parameter to the WebSocket URL:
 

--- a/src/content/docs/browser-run/get-started.mdx
+++ b/src/content/docs/browser-run/get-started.mdx
@@ -8,11 +8,24 @@ products:
   - browser-run
 ---
 
-import { Render } from "~/components";
+import { DashButton, Render } from "~/components";
 
 Cloudflare Browser Run (formerly Browser Rendering) allows you to programmatically control a headless browser, enabling you to do things like take screenshots, generate PDFs, and perform automated browser tasks. This guide will help you choose the right integration method and get you started with your first project.
 
 <Render file="integration-methods" product="browser-run" />
+
+## Dashboard
+
+The fastest way to try Browser Run is directly from the Cloudflare dashboard — no API token or code required.
+
+1. Go to **Browser Run** in the Cloudflare dashboard.
+2. Select **Create Session**.
+3. Optionally, toggle **Session Recording** to capture a replayable recording of the session.
+4. Your browser session starts immediately with [Live View](/browser-run/features/live-view/), so you can see and interact with it in real time.
+
+After the session closes, any recordings are available under **Browser Run** > **Runs**. To learn more, refer to [Session recording](/browser-run/features/session-recording/).
+
+<DashButton url="/?to=/:account/workers/browser-run" />
 
 ## Quick Actions
 

--- a/src/content/docs/browser-run/get-started.mdx
+++ b/src/content/docs/browser-run/get-started.mdx
@@ -16,7 +16,7 @@ Cloudflare Browser Run (formerly Browser Rendering) allows you to programmatical
 
 ## Dashboard
 
-The fastest way to try Browser Run is directly from the Cloudflare dashboard — no API token or code required.
+You can launch a browser session directly from the Cloudflare dashboard to try Browser Run and see what it can do — no API token or code required. For production use, integrate with [Quick Actions](#quick-actions), [Browser Sessions](#browser-sessions), or the [CDP endpoint](/browser-run/cdp/).
 
 1. Go to **Browser Run** in the Cloudflare dashboard.
 2. Select **Create Session**.

--- a/src/content/docs/browser-run/get-started.mdx
+++ b/src/content/docs/browser-run/get-started.mdx
@@ -8,24 +8,11 @@ products:
   - browser-run
 ---
 
-import { DashButton, Render } from "~/components";
+import { Render } from "~/components";
 
 Cloudflare Browser Run (formerly Browser Rendering) allows you to programmatically control a headless browser, enabling you to do things like take screenshots, generate PDFs, and perform automated browser tasks. This guide will help you choose the right integration method and get you started with your first project.
 
 <Render file="integration-methods" product="browser-run" />
-
-## Dashboard
-
-You can launch a browser session directly from the Cloudflare dashboard to try Browser Run and see what it can do — no API token or code required. For production use, integrate with [Quick Actions](#quick-actions), [Browser Sessions](#browser-sessions), or the [CDP endpoint](/browser-run/cdp/).
-
-1. Go to **Browser Run** in the Cloudflare dashboard.
-2. Select **Create Session**.
-3. Optionally, toggle **Session Recording** to capture a replayable recording of the session.
-4. Your browser session starts immediately with [Live View](/browser-run/features/live-view/), so you can see and interact with it in real time.
-
-After the session closes, any recordings are available under **Browser Run** > **Runs**. To learn more, refer to [Session recording](/browser-run/features/session-recording/).
-
-<DashButton url="/?to=/:account/workers/browser-run" />
 
 ## Quick Actions
 


### PR DESCRIPTION
## Summary

- Add documentation for creating browser sessions directly from the Cloudflare dashboard, with optional session recording
- The dashboard is the lowest-friction way to try Browser Run (no API token or code required), but was previously undocumented

## Changes

### Get Started (`get-started.mdx`)
- Add **Dashboard** as the first integration path, before Quick Actions and Browser Sessions
- Includes numbered steps: go to Browser Run, create session, optionally toggle session recording, interact via Live View

### Session Recording (`features/session-recording.mdx`)
- Add **Enable from the dashboard** section before the existing code examples
- Rename existing "Enable session recording" heading to "Enable in code" for clarity

### Live View (`features/live-view.mdx`)
- Add a paragraph under the Cloudflare dashboard section noting you can create new sessions (not just view existing ones)

## Why this approach
Rather than a standalone "Using the Dashboard" page (which would go stale with UI changes and fragment the user journey), dashboard creation is documented inline where users are already looking: the get-started page for first-time onboarding, and feature pages for feature-specific context.