### PR TITLE
docs(cache): cache resposne rules support versioning

### DIFF
--- a/src/content/changelog/cache/2026-04-27-cache-response-rules-zone-versioning.mdx
+++ b/src/content/changelog/cache/2026-04-27-cache-response-rules-zone-versioning.mdx
@@ -1,0 +1,25 @@
+---
+title: Cache Response Rules now support zone versioning
+description: Cache Response Rules can now be versioned with Version Management, allowing you to test response-phase cache settings across environments before promoting to production.
+products:
+  - cache
+date: 2026-04-27
+---
+
+Cache Response Rules now work with [Version Management](/version-management/). You can version response-phase cache settings and promote them through environments, just like Cache Rules and other supported configurations.
+
+## What changed
+
+Previously, Cache Response Rules were excluded from zone versioning. Any response-phase rule you created applied globally across all environments with no way to test changes in staging first. Cache Rules already supported versioning, but the response phase, where you modify `Cache-Control` directives, manage cache tags, and strip headers, did not.
+
+Cache Response Rules are now fully integrated with Version Management. You can create or modify response-phase rules within a version, and those changes stay scoped to that version until promoted.
+
+## Benefits
+
+- **Safe rollout of cache behavior changes**: Test response-phase rules in a staging environment before promoting to production. Catch unintended caching side effects early.
+- **Parity with Cache Rules**: Cache Response Rules now follow the same versioning workflow as Cache Rules, so you can manage all cache configuration through a single promotion pipeline.
+- **Independent environment control**: Run different response-phase cache settings per environment. For example, strip `Set-Cookie` headers in staging to validate cacheability without affecting production traffic.
+
+## Get started
+
+Configure Cache Response Rules in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/:zone/caching/cache-rules) under **Caching** > **Cache Rules**, or via the [Rulesets API](/ruleset-engine/rulesets-api/). For more details, refer to the [Cache Response Rules documentation](/cache/how-to/cache-response-rules/) and the [Version Management documentation](/version-management/).

--- a/src/content/docs/cache/how-to/cache-response-rules/index.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/index.mdx
@@ -63,4 +63,4 @@ In this case, the Cache Response Rule takes precedence. Cloudflare caches the as
 
 - If you strip last modified then Smart Edge Revalidation will be turned off.
 - Cache Response Rules ignore [`1xx` HTTP response status codes](/support/troubleshooting/http-status-codes/1xx-informational/) as they are treated as informational responses.
-- Currently, Cache Response Rules do not work with [Version Management](/version-management/).
+- Cache Response Rules can be versioned. Refer to the [Version Management](/version-management/) documentation for more information.

--- a/src/content/partials/version-management/product-limitations.mdx
+++ b/src/content/partials/version-management/product-limitations.mdx
@@ -34,12 +34,6 @@ Version Management does not currently support or have limited support for the fo
 
 </Details>
 
-<Details header="Cache Response Rules">
-
-- [Cache Response Rules](/cache/how-to/cache-response-rules/) do not work with Version Management.
-
-</Details>
-
 <Details header="Workers Cache API">
 
 - [Workers Cache API](/workers/runtime-apis/cache/) does not work with Version Management.

--- a/src/content/release-notes/version-management.yaml
+++ b/src/content/release-notes/version-management.yaml
@@ -3,6 +3,11 @@ link: "/version-management/changelog/"
 productName: Version Management
 productLink: "/version-management/"
 entries:
+  - publish_date: "2026-04-27"
+    title: "Support for Cache Response Rules"
+    description: |-
+      - Version Management now supports versioning for [Cache Response Rules](/cache/how-to/cache-response-rules/).
+
   - publish_date: "2024-02-26"
     title: "Support for API Shield"
     description: |-


### PR DESCRIPTION
### Summary

This commit includes changes to:

1. The Cloudflare changelog
2. Cache Response Rules how-to
3. Version Management updates

### Screenshots (optional)


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
