### PR TITLE
[Pipelines] Add Terraform docs for Pipelines and R2 Data Catalog

### DIFF
--- a/src/content/changelog/pipelines/2026-04-27-terraform-support.mdx
+++ b/src/content/changelog/pipelines/2026-04-27-terraform-support.mdx
@@ -1,0 +1,61 @@
+---
+title: Pipelines and R2 Data Catalog now supported in Terraform
+description: Create and manage  Pipelines and R2 Data Catalog resources using the Cloudflare Terraform provider v5.19.0.
+products:
+  - pipelines
+date: 2026-04-27
+---
+
+[Cloudflare Pipelines](/pipelines/) ingests streaming data via [Workers](/workers/) or HTTP endpoints, transforms it with SQL, and writes it to [R2](/r2/) as Apache Iceberg tables. [R2 Data Catalog](/r2/data-catalog/) manages those Iceberg tables, compaction, and compatibility with query engines like [R2 SQL](/r2-sql/), [Spark](/r2/data-catalog/config-examples/spark-scala/), and [DuckDB](/r2/data-catalog/config-examples/duckdb/).
+
+You can now create and manage both products using Terraform, supported in the [Cloudflare Terraform provider v5.19.0](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs).
+
+This adds four new resources that let you define your entire data pipeline as infrastructure-as-code: a data catalog, a stream for ingestion, a sink that writes to R2 Data Catalog or R2, and a pipeline that connects them with SQL.
+
+The new Terraform resources are:
+
+- [`cloudflare_r2_data_catalog`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_data_catalog) — enable the data catalog on an R2 bucket
+- [`cloudflare_pipeline_stream`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/pipeline_stream) — create a stream that receives events via HTTP or Worker bindings
+- [`cloudflare_pipeline_sink`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/pipeline_sink) — create a sink that writes to R2 Data Catalog or R2
+- [`cloudflare_pipeline`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/pipeline) — create a pipeline with SQL connecting a stream to a sink
+
+Here is a minimal example that creates a stream, an R2 Data Catalog sink, and a pipeline:
+
+```hcl
+resource "cloudflare_pipeline_stream" "my_stream" {
+  account_id = var.cloudflare_account_id
+  name       = "my_stream"
+  format     = { type = "json" }
+  schema = {
+    fields = [{
+      name     = "value"
+      type     = "json"
+      required = true
+    }]
+  }
+  http           = { enabled = true, authentication = false, cors = {} }
+  worker_binding = { enabled = false }
+}
+
+resource "cloudflare_pipeline_sink" "my_sink" {
+  account_id = var.cloudflare_account_id
+  name       = "my_sink"
+  type       = "r2_data_catalog"
+  format     = { type = "parquet" }
+  schema     = { fields = [] }
+  config = {
+    account_id = var.cloudflare_account_id
+    bucket     = "my-pipeline-bucket"
+    table_name = "my_table"
+    token      = var.catalog_token
+  }
+}
+
+resource "cloudflare_pipeline" "my_pipeline" {
+  account_id = var.cloudflare_account_id
+  name       = "my_pipeline"
+  sql        = "INSERT INTO ${cloudflare_pipeline_sink.my_sink.name} SELECT * FROM ${cloudflare_pipeline_stream.my_stream.name}"
+}
+```
+
+For a full end-to-end example that includes R2 bucket creation, data catalog setup, and scoped API token provisioning, refer to the [Pipelines Terraform documentation](/pipelines/reference/terraform/).

--- a/src/content/changelog/pipelines/2026-04-27-terraform-support.mdx
+++ b/src/content/changelog/pipelines/2026-04-27-terraform-support.mdx
@@ -3,7 +3,7 @@ title: Pipelines and R2 Data Catalog now supported in Terraform
 description: Create and manage Pipelines and R2 Data Catalog resources using the Cloudflare Terraform provider v5.19.0.
 products:
   - pipelines
-date: 2026-04-27
+date: 2026-05-04
 ---
 
 [Cloudflare Pipelines](/pipelines/) ingests streaming data via [Workers](/workers/) or HTTP endpoints, transforms it with SQL, and writes it to [R2](/r2/) as Apache Iceberg tables. [R2 Data Catalog](/r2/data-catalog/) manages those Iceberg tables, compaction, and compatibility with query engines like [R2 SQL](/r2-sql/), [Spark](/r2/data-catalog/config-examples/spark-scala/), and [DuckDB](/r2/data-catalog/config-examples/duckdb/).

--- a/src/content/changelog/pipelines/2026-04-27-terraform-support.mdx
+++ b/src/content/changelog/pipelines/2026-04-27-terraform-support.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pipelines and R2 Data Catalog now supported in Terraform
-description: Create and manage  Pipelines and R2 Data Catalog resources using the Cloudflare Terraform provider v5.19.0.
+description: Create and manage Pipelines and R2 Data Catalog resources using the Cloudflare Terraform provider v5.19.0.
 products:
   - pipelines
 date: 2026-04-27

--- a/src/content/docs/pipelines/reference/terraform.mdx
+++ b/src/content/docs/pipelines/reference/terraform.mdx
@@ -1,0 +1,274 @@
+---
+title: Terraform
+pcx_content_type: example
+description: Configure Pipelines and R2 Data Catalog with Terraform using the Cloudflare provider.
+products:
+  - pipelines
+tags:
+  - Terraform
+sidebar:
+  order: 2
+---
+
+import { Details } from "~/components";
+
+This example shows how to configure [Pipelines](/pipelines/) and [R2 Data Catalog](/r2/data-catalog/) with Terraform using the [Cloudflare provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs) (v5.19.0+).
+
+The configuration creates a complete data pipeline: an R2 bucket with the data catalog enabled, a scoped API token for the sink, and the stream, sink, and pipeline resources that ingest JSON data into an [Apache Iceberg](https://iceberg.apache.org/) table.
+
+## Prerequisites
+
+- [Terraform CLI](https://developer.hashicorp.com/terraform/downloads) >= 1.0
+- A Cloudflare account with R2 and Pipelines enabled
+- An API token scoped to your account with the following permissions:
+  - **Pipelines** - Edit
+  - **Workers R2 Storage** - Edit
+  - **Workers R2 Data Catalog** - Edit
+  - **Account API Tokens** - Edit
+
+For general information on using Terraform with Cloudflare, refer to [the Terraform documentation](/terraform/).
+
+## Terraform resources
+
+This example uses the following Cloudflare Terraform resources:
+
+| Resource                                                                                                                            | Description                                                       |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [`cloudflare_r2_bucket`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_bucket)             | Creates an R2 bucket to store pipeline data                       |
+| [`cloudflare_r2_data_catalog`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/r2_data_catalog) | Enables the R2 Data Catalog on a bucket                           |
+| [`cloudflare_pipeline_stream`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/pipeline_stream) | Creates a stream that receives events via HTTP or Worker bindings |
+| [`cloudflare_pipeline_sink`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/pipeline_sink)     | Creates a sink that writes data to R2 Data Catalog or R2          |
+| [`cloudflare_pipeline`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/pipeline)               | Creates a pipeline with SQL that connects a stream to a sink      |
+| [`cloudflare_account_token`](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/account_token)     | Creates a scoped API token for sink authentication                |
+
+## End-to-end example
+
+With [`terraform`](https://developer.hashicorp.com/terraform/downloads) installed, create a directory and the following files.
+
+### 1. Define variables and provider
+
+Create `variables.tf`:
+
+```hcl
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.19"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+variable "cloudflare_api_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "cloudflare_account_id" {
+  type = string
+}
+```
+
+### 2. Create the pipeline resources
+
+Create `main.tf`:
+
+```hcl
+# --- R2 bucket and Data Catalog ---
+
+resource "cloudflare_r2_bucket" "pipeline_bucket" {
+  account_id = var.cloudflare_account_id
+  name       = "my-pipeline-bucket"
+}
+
+resource "cloudflare_r2_data_catalog" "pipeline_catalog" {
+  account_id  = var.cloudflare_account_id
+  bucket_name = cloudflare_r2_bucket.pipeline_bucket.name
+}
+
+# --- Scoped API token for the sink ---
+
+data "cloudflare_account_api_token_permission_groups_list" "r2_bucket_item_write" {
+  account_id = var.cloudflare_account_id
+  name       = "Workers R2 Storage Bucket Item Write"
+}
+
+data "cloudflare_account_api_token_permission_groups_list" "r2_data_catalog_write" {
+  account_id = var.cloudflare_account_id
+  name       = "Workers R2 Data Catalog Write"
+}
+
+resource "cloudflare_account_token" "sink_token" {
+  name       = "pipeline-sink-token"
+  account_id = var.cloudflare_account_id
+
+  policies = [{
+    effect = "allow"
+    permission_groups = [
+      { id = data.cloudflare_account_api_token_permission_groups_list.r2_bucket_item_write.result[0].id },
+      { id = data.cloudflare_account_api_token_permission_groups_list.r2_data_catalog_write.result[0].id },
+    ]
+    resources = jsonencode({
+      "com.cloudflare.api.account.${var.cloudflare_account_id}" = "*"
+    })
+  }]
+}
+
+# --- Stream ---
+
+resource "cloudflare_pipeline_stream" "my_stream" {
+  account_id = var.cloudflare_account_id
+  name       = "my_stream"
+  format = {
+    type = "json"
+  }
+  schema = {
+    fields = [{
+      name     = "value"
+      type     = "json"
+      required = true
+    }]
+  }
+  http = {
+    enabled        = true
+    authentication = false
+    cors           = {}
+  }
+  worker_binding = {
+    enabled = false
+  }
+}
+
+# --- Sink (R2 Data Catalog) ---
+
+resource "cloudflare_pipeline_sink" "my_sink" {
+  account_id = var.cloudflare_account_id
+  name       = "my_sink"
+  type       = "r2_data_catalog"
+  format = {
+    type = "parquet"
+  }
+  schema = {
+    fields = []
+  }
+  config = {
+    account_id = var.cloudflare_account_id
+    bucket     = cloudflare_r2_bucket.pipeline_bucket.name
+    table_name = cloudflare_r2_data_catalog.pipeline_catalog.name
+    token      = cloudflare_account_token.sink_token.value
+  }
+}
+
+# --- Pipeline ---
+
+resource "cloudflare_pipeline" "my_pipeline" {
+  account_id = var.cloudflare_account_id
+  name       = "my_pipeline"
+  sql        = "INSERT INTO ${cloudflare_pipeline_sink.my_sink.name} SELECT * FROM ${cloudflare_pipeline_stream.my_stream.name}"
+}
+```
+
+<Details header="Use an R2 sink instead of R2 Data Catalog">
+
+To write raw Parquet or JSON files to R2 instead of Iceberg tables, replace the sink resource with an R2 sink. This requires R2 S3-compatible credentials instead of a catalog token.
+
+Add variables for S3 credentials to `variables.tf`:
+
+```hcl
+variable "r2_access_key_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "r2_access_key_secret" {
+  type      = string
+  sensitive = true
+}
+```
+
+Replace the sink resource in `main.tf`:
+
+```hcl
+resource "cloudflare_pipeline_sink" "my_sink" {
+  account_id = var.cloudflare_account_id
+  name       = "my_sink"
+  type       = "r2"
+  format = {
+    type = "json"
+  }
+  schema = {
+    fields = []
+  }
+  config = {
+    account_id = var.cloudflare_account_id
+    bucket     = cloudflare_r2_bucket.pipeline_bucket.name
+    credentials = {
+      access_key_id     = var.r2_access_key_id
+      secret_access_key = var.r2_access_key_secret
+    }
+  }
+}
+```
+
+When using an R2 sink, you can remove the `cloudflare_r2_data_catalog`, `cloudflare_account_token`, and the two `cloudflare_account_api_token_permission_groups_list` data sources from your configuration.
+
+</Details>
+
+### 3. Define outputs
+
+Create `outputs.tf`:
+
+```hcl
+output "pipeline_id" {
+  value = cloudflare_pipeline.my_pipeline.id
+}
+
+output "pipeline_status" {
+  value = cloudflare_pipeline.my_pipeline.status
+}
+
+output "stream_endpoint" {
+  value = cloudflare_pipeline_stream.my_stream.endpoint
+}
+
+output "sink_id" {
+  value = cloudflare_pipeline_sink.my_sink.id
+}
+```
+
+### 4. Deploy
+
+Set your environment variables:
+
+```bash
+export TF_VAR_cloudflare_api_token="<YOUR_API_TOKEN>"
+export TF_VAR_cloudflare_account_id="<YOUR_ACCOUNT_ID>"
+```
+
+You can then use `terraform plan` to view the changes and `terraform apply` to apply changes:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+After the apply completes, Terraform outputs the stream endpoint URL. Use it to send data to your pipeline:
+
+```bash
+curl -X POST https://<STREAM_ENDPOINT> \
+  -H "Content-Type: application/json" \
+  -d '[{"value": {"event": "page_view", "user_id": "user_123"}}]'
+```
+
+## Clean up
+
+To remove all resources created by this configuration:
+
+```bash
+terraform destroy
+```

--- a/src/content/docs/pipelines/reference/terraform.mdx
+++ b/src/content/docs/pipelines/reference/terraform.mdx
@@ -18,7 +18,7 @@ The configuration creates a complete data pipeline: an R2 bucket with the data c
 
 ## Prerequisites
 
-- [Terraform CLI](https://developer.hashicorp.com/terraform/downloads) >= 1.0
+- [Terraform CLI](https://developer.hashicorp.com/terraform/downloads) `>= 1.0`
 - A Cloudflare account with R2 and Pipelines enabled
 - An API token scoped to your account with the following permissions:
   - **Pipelines** - Edit

--- a/src/content/docs/pipelines/reference/terraform.mdx
+++ b/src/content/docs/pipelines/reference/terraform.mdx
@@ -249,7 +249,7 @@ export TF_VAR_cloudflare_api_token="<YOUR_API_TOKEN>"
 export TF_VAR_cloudflare_account_id="<YOUR_ACCOUNT_ID>"
 ```
 
-You can then use `terraform plan` to view the changes and `terraform apply` to apply changes:
+You can then use `terraform plan` to view the changes and `terraform apply` to apply them:
 
 ```bash
 terraform init


### PR DESCRIPTION
### Summary

Adds Terraform documentation and a changelog entry for the new Pipelines and R2 Data Catalog Terraform resources, available in the Cloudflare Terraform provider v5.19.0.

**New files:**

| File | Description |
| --- | --- |
| `src/content/docs/pipelines/reference/terraform.mdx` | End-to-end example page showing how to create a complete data pipeline (R2 bucket, data catalog, scoped API token, stream, sink, pipeline) using the Cloudflare Terraform provider. Includes a collapsible section for the R2 sink variant. |
| `src/content/changelog/pipelines/2026-04-27-terraform-support.mdx` | Changelog entry announcing Terraform support with a minimal HCL code example and links to the new docs page. |

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
