### PR TITLE
remove unused catalog:build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"scripts": {
 		"preinstall": "pnpx only-allow pnpm",
 		"astro": "astro",
-		"catalog:build": "tsx bin/fetch-catalog-models.ts",
 		"prebuild": "tsx bin/fetch-skills.ts",
 		"build": "export NODE_OPTIONS='--max-old-space-size=8192' || set NODE_OPTIONS=\"--max-old-space-size=8192\" && astro build",
 		"typegen:worker": "wrangler types ./worker/worker-configuration.d.ts",


### PR DESCRIPTION
Removes the `catalog:build` npm script alias from `package.json`.

The script wrapped `tsx bin/fetch-catalog-models.ts`, but nothing in the repo invokes it (no CI, docs, or other scripts reference `catalog:build`). The underlying `bin/fetch-catalog-models.ts` is unchanged and can still be run directly with `tsx` per the usage instructions in the file header.

- Removes the unused `catalog:build` entry from `package.json` scripts