### PR TITLE
feat: add llms-txt-directive-md to markdown pages

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -155,6 +155,7 @@ export default defineConfig({
 				MarkdownContent: "./src/components/overrides/MarkdownContent.astro",
 				Sidebar: "./src/components/overrides/Sidebar.astro",
 				PageTitle: "./src/components/overrides/PageTitle.astro",
+				SkipLink: "./src/components/overrides/SkipLink.astro",
 				TableOfContents: "./src/components/overrides/TableOfContents.astro",
 			},
 			sidebar,

--- a/src/components/LlmsTxtDirective.astro
+++ b/src/components/LlmsTxtDirective.astro
@@ -11,8 +11,8 @@ const llmsTxt = productPrefix
 ---
 
 <blockquote class="llms-txt-directive" aria-hidden="true">
-Documentation Index
-Fetch the complete documentation index at: {llmsTxt}
+Documentation Index<br/>
+Fetch the complete documentation index at: {llmsTxt}<br/>
 Use this file to discover all available pages before exploring further.
 </blockquote>
 

--- a/src/components/LlmsTxtDirective.astro
+++ b/src/components/LlmsTxtDirective.astro
@@ -11,9 +11,9 @@ const llmsTxt = productPrefix
 ---
 
 <blockquote class="llms-txt-directive" aria-hidden="true">
-	<p><strong>Documentation Index</strong></p>
-	<p>Fetch the complete documentation index at: {llmsTxt}</p>
-	<p>Use this file to discover all available pages before exploring further.</p>
+Documentation Index
+Fetch the complete documentation index at: {llmsTxt}
+Use this file to discover all available pages before exploring further.
 </blockquote>
 
 <style>

--- a/src/components/LlmsTxtDirective.astro
+++ b/src/components/LlmsTxtDirective.astro
@@ -1,0 +1,33 @@
+---
+const { entry } = Astro.locals.starlightRoute;
+const base =
+	Astro.site?.toString().replace(/\/$/, "") ??
+	"https://developers.cloudflare.com";
+
+const productPrefix = entry.id !== "index" ? entry.id.split("/")[0] : null;
+const llmsTxt = productPrefix
+	? `${base}/${productPrefix}/llms.txt`
+	: `${base}/llms.txt`;
+---
+
+<blockquote class="llms-txt-directive" aria-hidden="true">
+	<p><strong>Documentation Index</strong></p>
+	<p>Fetch the complete documentation index at: {llmsTxt}</p>
+	<p>Use this file to discover all available pages before exploring further.</p>
+</blockquote>
+
+<style>
+	/* Visually hidden from human readers but present in DOM for AI agents.
+	   Uses clip-rect (not display:none) so the element survives HTML-to-markdown conversion. */
+	.llms-txt-directive {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+</style>

--- a/src/components/overrides/SkipLink.astro
+++ b/src/components/overrides/SkipLink.astro
@@ -1,0 +1,27 @@
+---
+import LlmsTxtDirective from "../LlmsTxtDirective.astro";
+---
+
+<LlmsTxtDirective />
+<a href="#_top">{Astro.locals.t("skipLink.label")}</a>
+
+<style>
+	@layer starlight.core {
+		a {
+			clip: rect(0, 0, 0, 0);
+			position: fixed;
+			top: 0.75rem;
+			inset-inline-start: 0.75rem;
+		}
+		a:focus {
+			clip: unset;
+			z-index: var(--sl-z-index-skiplink);
+			display: block;
+			padding: 0.5rem 1rem;
+			text-decoration: none;
+			color: var(--sl-color-text-invert);
+			background-color: var(--sl-color-text-accent);
+			box-shadow: var(--sl-shadow-lg);
+		}
+	}
+</style>


### PR DESCRIPTION
### Summary

Adds a visually-hidden `llms-txt-directive-md` blockquote to every page. This directive is placed at the very top of the `<body>` — before the header — so it appears first in converted markdown.

The directive points agents to the product-scoped `llms.txt` (e.g. `https://developers.cloudflare.com/workers/llms.txt`) or the global `https://developers.cloudflare.com/llms.txt` on root pages. This copies the approach used by [Claude Code's documentation](https://code.claude.com/docs/en/overview.md) and satisfies the [`llms-txt-directive-md` check](https://agentdocsspec.com/spec/#llms-txt-directive-md) in the Agent-Friendly Documentation Spec.

The existing `AgentDirective` in the `<header>` is unchanged. That one exists to be not included in markdown, this new one exists purposefully to be included in markdown.

Follows the same pattern as claude code docs: https://code.claude.com/docs/en/overview.md

### Images

<img width="1627" height="401" alt="1" src="https://github.com/user-attachments/assets/d7c2782d-33b7-4ced-a81c-b4a9f7d2d2fc" />



