### PR TITLE
[Workflows] Add local explorer docs to Workflows page

### DIFF
--- a/src/content/docs/workflows/build/local-development.mdx
+++ b/src/content/docs/workflows/build/local-development.mdx
@@ -82,6 +82,22 @@ npx wrangler workflows instances describe my-workflow <INSTANCE_ID> --local
 
 All commands accept `--port` to target a specific `wrangler dev` session (defaults to `8787`).
 
+## Local Explorer
+
+[Local Explorer](/workers/development-testing/local-explorer/) is a browser-based interface for viewing and managing your local Workflow instances during development. Instead of running CLI commands, you can open Local Explorer in your browser and interact with your Workflows directly.
+
+While a `wrangler dev` session is running, press `e` in your terminal to open Local Explorer, or go to `http://localhost:8787/cdn-cgi/explorer` in your browser.
+
+With Local Explorer you can:
+
+- View all Workflows defined in your project and their instances.
+- Inspect the step history and current status of each instance.
+- Trigger new Workflow runs and send events to running instances.
+- Pause, resume, terminate, and restart instances.
+- Delete specific instances or clear all of them at once.
+
+Local Explorer requires Wrangler version `4.82.1` or later, or [Cloudflare Vite plugin](/workers/vite-plugin/) version `1.32.0` or later.
+
 ## Known Issues
 
 Workflows are not supported as [remote bindings](/workers/development-testing/#remote-bindings) or when using `npx wrangler dev --remote`.


### PR DESCRIPTION
### Summary

We recently launched Local Explorer, which includes an interactive interface for Workflows. This adds documentation to the Workflows "Local development" page informing the existence of this feature for local dev.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
