### PR TITLE
Changelog entry for removing Support drop-down in global navigation header

### DIFF
--- a/src/content/changelog/support/2026-04-28-direct-support-navigation.mdx
+++ b/src/content/changelog/support/2026-04-28-direct-support-navigation.mdx
@@ -12,7 +12,7 @@ This change ensures that when you need help, you spend less time navigating the 
 
 ### What changed?
 
-* **Previous behavior**: Clicking **? Support** opened a dropdown menu with various links (Help Center, Cloudflare Community, etc.).
-* **New behavior**: Clicking **Support** immediately redirects your current tab to the Support Portal.
+* **Previous behavior**: Selecting **? Support** opened a dropdown menu with various links (Help Center, Cloudflare Community, etc.).
+* **New behavior**: Selecting **Support** immediately redirects your current tab to the Support Portal.
 
 To learn more about the resources available to you, refer to the [Cloudflare Support documentation](https://developers.cloudflare.com/support/contacting-cloudflare-support/).

--- a/src/content/changelog/support/2026-04-28-direct-support-navigation.mdx
+++ b/src/content/changelog/support/2026-04-28-direct-support-navigation.mdx
@@ -1,0 +1,18 @@
+---
+title: Direct access to Support from the dashboard
+description: The Support button now links directly to the support portal, removing the intermediate dropdown menu for faster assistance.
+date: 2026-04-28
+---
+
+## Direct access to Support from the dashboard
+
+The **Support** button in the dashboard global navigation header now takes you directly to the [Cloudflare Support Portal](https://support.cloudflare.com), eliminating the previous dropdown menu.
+
+This change ensures that when you need help, you spend less time navigating the UI and more time getting the answers you need.
+
+### What changed?
+
+* **Previous behavior**: Clicking **? Support** opened a dropdown menu with various links (Help Center, Cloudflare Community, etc.).
+* **New behavior**: Clicking **Support** immediately redirects your current tab to the Support Portal.
+
+To learn more about the resources available to you, refer to the [Cloudflare Support documentation](https://developers.cloudflare.com/support/contacting-cloudflare-support/).


### PR DESCRIPTION
### Summary

Changelog item for removing support dropdown => a direct link to /support

