### PR TITLE
Reword D1 introduction removing hyperbole that does not apply

### DIFF
--- a/src/content/docs/d1/index.mdx
+++ b/src/content/docs/d1/index.mdx
@@ -13,13 +13,18 @@ products:
   - d1
 ---
 
-import { CardGrid, Description, Feature, LinkTitleCard, Plan, RelatedProduct } from "~/components"
+import {
+	CardGrid,
+	Description,
+	Feature,
+	LinkTitleCard,
+	Plan,
+	RelatedProduct,
+} from "~/components";
 
 <Description>
 
-
 Create new serverless SQL databases to query from your Workers and Pages projects.
-
 
 </Description>
 
@@ -27,36 +32,51 @@ Create new serverless SQL databases to query from your Workers and Pages project
 
 D1 is Cloudflare's managed, serverless database with SQLite's SQL semantics, built-in disaster recovery, and Worker and HTTP API access.
 
-D1 is designed for horizontal scale out across multiple, smaller (10 GB) databases, such as per-user, per-tenant or per-entity databases. D1 allows you to build applications with thousands of databases at no extra cost for isolating with multiple databases. D1 pricing is based only on query and storage costs.
+D1 allows you to create thousands of databases at no extra cost for isolation, perfect for scaling out application vibe-coding platforms. D1 pricing is based only on query and storage costs.
 
 Create your first D1 database by [following the Get started guide](/d1/get-started/), learn how to [import data into a database](/d1/best-practices/import-export-data/), and how to [interact with your database](/d1/worker-api/) directly from [Workers](/workers/) or [Pages](/pages/functions/bindings/#d1-databases).
 
-***
+---
 
 ## Features
 
-<Feature header="Create your first D1 database" href="/d1/get-started/" cta="Create your D1 database">
-
-Create your first D1 database, establish a schema, import data and query D1 directly from an application [built with Workers](/workers/).
-
-
+<Feature
+	header="Create your first D1 database"
+	href="/d1/get-started/"
+	cta="Create your D1 database"
+>
+	Create your first D1 database, establish a schema, import data and query D1
+	directly from an application [built with Workers](/workers/).
 </Feature>
 
-<Feature header="SQLite" href="/d1/sql-api/sql-statements/" cta="Execute SQL queries">
-
-Execute SQL with SQLite's SQL compatibility and D1 Client API.
-
-
+<Feature
+	header="SQLite"
+	href="/d1/sql-api/sql-statements/"
+	cta="Execute SQL queries"
+>
+	Execute SQL with SQLite's SQL compatibility and D1 Client API.
 </Feature>
 
-<Feature header="Time Travel" href="/d1/reference/time-travel/" cta="Learn about Time Travel">
-
-Time Travel is D1’s approach to backups and point-in-time-recovery, and allows you to restore a database to any minute within the last 30 days.
-
-
+<Feature
+	header="Time Travel"
+	href="/d1/reference/time-travel/"
+	cta="Learn about Time Travel"
+>
+	Time Travel is D1’s approach to backups and point-in-time-recovery, and allows
+	you to restore a database to any minute within the last 30 days.
 </Feature>
 
-***
+<Feature
+	header="Global Read Replication"
+	href="/d1/best-practices/read-replication/"
+	cta="Scale with Read Replicas"
+>
+	D1 read replication can lower latency for read queries and scale read
+	throughput by adding read-only database copies, called read replicas, across
+	regions globally closer to clients.
+</Feature>
+
+---
 
 ## Related products
 
@@ -64,44 +84,61 @@ Time Travel is D1’s approach to backups and point-in-time-recovery, and allows
 
 Build serverless applications and deploy instantly across the globe for exceptional performance, reliability, and scale.
 
-
 </RelatedProduct>
 
 <RelatedProduct header="Pages" href="/pages/" product="pages">
 
 Deploy dynamic front-end applications in record time.
 
-
 </RelatedProduct>
 
-***
+---
 
 ## More resources
 
 <CardGrid>
 
 <LinkTitleCard title="Pricing" href="/d1/platform/pricing/" icon="seti:shell">
-Learn about D1's pricing and how to estimate your usage.
+	Learn about D1's pricing and how to estimate your usage.
 </LinkTitleCard>
 
 <LinkTitleCard title="Limits" href="/d1/platform/limits/" icon="document">
-Learn about what limits D1 has and how to work within them.
+	Learn about what limits D1 has and how to work within them.
 </LinkTitleCard>
 
-<LinkTitleCard title="Community projects" href="/d1/reference/community-projects/" icon="pen">
-Browse what developers are building with D1.
+<LinkTitleCard
+	title="Community projects"
+	href="/d1/reference/community-projects/"
+	icon="pen"
+>
+	Browse what developers are building with D1.
 </LinkTitleCard>
 
-<LinkTitleCard title="Storage options" href="/workers/platform/storage-options/" icon="document">
-Learn more about the storage and database options you can build on with Workers.
+<LinkTitleCard
+	title="Storage options"
+	href="/workers/platform/storage-options/"
+	icon="document"
+>
+	Learn more about the storage and database options you can build on with
+	Workers.
 </LinkTitleCard>
 
-<LinkTitleCard title="Developer Discord" href="https://discord.cloudflare.com" icon="discord">
-Connect with the Workers community on Discord to ask questions, show what you are building, and discuss the platform with other developers.
+<LinkTitleCard
+	title="Developer Discord"
+	href="https://discord.cloudflare.com"
+	icon="discord"
+>
+	Connect with the Workers community on Discord to ask questions, show what you
+	are building, and discuss the platform with other developers.
 </LinkTitleCard>
 
-<LinkTitleCard title="@CloudflareDev" href="https://x.com/cloudflaredev" icon="x.com">
-Follow @CloudflareDev on Twitter to learn about product announcements, and what is new in Cloudflare Developer Platform.
+<LinkTitleCard
+	title="@CloudflareDev"
+	href="https://x.com/cloudflaredev"
+	icon="x.com"
+>
+	Follow @CloudflareDev on Twitter to learn about product announcements, and
+	what is new in Cloudflare Developer Platform.
 </LinkTitleCard>
 
 </CardGrid>


### PR DESCRIPTION
### Summary

Remove phrase that creates confusion very often with our users ([see example in Discord](https://discord.com/channels/595317990191398933/992060581832032316/1493621386500112496)) since they cannot create thousands D1 DBs and attach them to their Worker easily.

Also, try to bring the content closer to <https://workers.cloudflare.com/product/d1>, and add a CTA for D1 read replication.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
