### PR TITLE
fix: update RHEL/CentOS install command for Mesh nodes

### DIFF
--- a/src/content/partials/cloudflare-one/mesh/install-node.mdx
+++ b/src/content/partials/cloudflare-one/mesh/install-node.mdx
@@ -23,7 +23,7 @@ sudo warp-cli connector new <TOKEN> && sudo warp-cli connect
 <TabItem label="RedHat / CentOS">
 
 ```sh
-sudo rpm -ivh https://pkg.cloudflareclient.com/cloudflare-release-el8.rpm &&
+curl -fsSl https://pkg.cloudflareclient.com/cloudflare-warp-ascii.repo | sudo tee /etc/yum.repos.d/cloudflare-warp.repo &&
 sudo yum install -y cloudflare-warp &&
 printf 'net.ipv4.ip_forward = 1\nnet.ipv6.conf.all.forwarding = 1\nnet.ipv6.conf.all.accept_ra = 2\n' | sudo tee /etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf &&
 sudo sysctl --system


### PR DESCRIPTION
## Summary

Replaces the deprecated `cloudflare-release-el8.rpm` package install with the current repo-based method per https://pkg.cloudflareclient.com/#rhel.

## Change

`src/content/partials/cloudflare-one/mesh/install-node.mdx` (RedHat/CentOS tab):

**Before:**
```sh
sudo rpm -ivh https://pkg.cloudflareclient.com/cloudflare-release-el8.rpm
```

**After:**
```sh
curl -fsSl https://pkg.cloudflareclient.com/cloudflare-warp-ascii.repo | sudo tee /etc/yum.repos.d/cloudflare-warp.repo
```

The old RPM method is deprecated and the public key requires updating for installs before 2025-09-12.