### PR TITLE
[Audit Logs] Clarify view actions are not currently captured

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
+++ b/src/content/docs/fundamentals/account/account-security/audit-logs.mdx
@@ -244,9 +244,9 @@ The actor represents who performed the action. It includes identity attributes l
 
 ### Action
 
-The action field captures the nature of the event and whether it was successful. It includes a high-level type (e.g., `view`, `create`, `update`, `delete`), a specific description (such as `SSO_LOGIN`), the timestamp of when the action occurred, and the result (`success` or `failure`).
+The action field captures the nature of the event and whether it was successful. It includes a high-level type (e.g., `create`, `update`, `delete`), a specific description (such as `SSO_LOGIN`), the timestamp of when the action occurred, and the result (`success` or `failure`).
 
-All `GET` requests are captured as `view` actions in Audit Logs.
+`view` actions correspond to `GET` requests. These are defined in the schema but not currently captured in Audit Logs. Selective `GET` logging for sensitive read operations is planned for a future release.
 
 ### Account
 


### PR DESCRIPTION
### Summary

Corrects a stale claim in the Audit Logs v2 reference. The page previously stated that all `GET` requests are captured as `view` actions, but `view` is currently only defined in the schema — selective `GET` logging is planned for a future release. Also removes `view` from the example list of high-level action types in the same section to keep the two paragraphs consistent.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
