### PR TITLE
Add link to origin server protection docs in WAF documentation

### DIFF
--- a/src/content/docs/waf/get-started.mdx
+++ b/src/content/docs/waf/get-started.mdx
@@ -248,3 +248,7 @@ Available to Enterprise customers.
 Cloudflare protects your APIs from new and known application attacks and exploits such as SQL injection attacks. API-specific security products extend those protections to the unique risks in APIs such as API discovery and authentication management.
 
 For more information on Cloudflare's API security features, refer to [Cloudflare API Shield](/api-shield/).
+
+### Protect your origin server
+
+For information on how to prevent attackers from discovering or overloading your origin server, refer to [Protect your origin server](/fundamentals/security/protect-your-origin-server/) for a layered approach including proxied DNS, IP allowlisting, and authenticated origin pulls.


### PR DESCRIPTION
### Summary

This PR adds a reference link to origin server protection under the optional next steps of the WAF getting started guide


### Documentation checklist


- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
