### PR TITLE
[Workflows] Document restart-from-step option

### DIFF
--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -171,7 +171,7 @@ await instance.restart(); // Returns Promise<void>
 
 Restarting an instance will immediately cancel any in-progress steps, erase any intermediate state, and treat the Workflow as if it was run for the first time.
 
-You can also restart an instance from a specific step instead of from the beginning. Refer to [`restart`](/workflows/build/workers-api/#restart) in the Workers API reference for details.
+To restart an instance from a specific step instead of the beginning, refer to [`restart`](/workflows/build/workers-api/#restart) in the Workers API reference.
 
 ### Trigger a Workflow from another Workflow
 

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -171,6 +171,8 @@ await instance.restart(); // Returns Promise<void>
 
 Restarting an instance will immediately cancel any in-progress steps, erase any intermediate state, and treat the Workflow as if it was run for the first time.
 
+You can also restart an instance from a specific step instead of from the beginning. Refer to [`restart`](/workflows/build/workers-api/#restart) in the Workers API reference for details.
+
 ### Trigger a Workflow from another Workflow
 
 You can create a new Workflow instance from within a step of another Workflow. The parent Workflow will not block waiting for the child Workflow to complete — it continues execution immediately after the child instance is successfully created.

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -518,7 +518,7 @@ Resume a paused Workflow instance.
 Restart a Workflow instance from the beginning, or from a specific step.
 
 - <code>restart(options?: WorkflowInstanceRestartOptions): Promise&lt;void&gt;</code>
-  - `options` - optional properties that control where the instance restarts from.
+  - `options` - optional properties that control from where the instance restarts.
 
 ```ts
 let instance = await env.MY_WORKFLOW.get("abc-123");

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -479,21 +479,13 @@ declare abstract class WorkflowInstance {
 	 */
 	public terminate(): Promise<void>;
 	/**
-	 * Restart the instance. Pass `options.from` to restart from a specific step.
+	 * Restart the instance from the beginning, or from a specific step.
 	 */
 	public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
 	/**
 	 * Returns the current status of the instance.
 	 */
 	public status(): Promise<InstanceStatus>;
-}
-
-interface WorkflowInstanceRestartOptions {
-	from?: {
-		name: string;
-		count?: number;
-		type?: "do" | "sleep" | "waitForEvent";
-	};
 }
 ```
 
@@ -526,16 +518,53 @@ Resume a paused Workflow instance.
 Restart a Workflow instance from the beginning, or from a specific step.
 
 - <code>restart(options?: WorkflowInstanceRestartOptions): Promise&lt;void&gt;</code>
+  - `options` - optional properties that control where the instance restarts from.
 
 ```ts
 let instance = await env.MY_WORKFLOW.get("abc-123");
 
-await instance.restart(); // From the beginning
-await instance.restart({ from: { name: "aggregate" } }); // From a specific step
-await instance.restart({ from: { name: "process", count: 3 } }); // 3rd occurrence
+// Restart the instance from the beginning.
+await instance.restart();
+
+// Restart the instance from the step named "aggregate".
+await instance.restart({ from: { name: "aggregate" } });
+
+// Restart the instance from the third call to a step named "process".
+await instance.restart({ from: { name: "process", count: 3 } });
 ```
 
-When restarting from a step, all earlier steps replay from cache; the target step and everything after it re-execute. `from.name` is required; `from.count` (1-based, defaults to `1`) targets a specific occurrence when the name repeats; `from.type` (`"do" | "sleep" | "waitForEvent"`) disambiguates when the same name is used across kinds. Throws if the step is not found in the instance's execution history.
+When restarting from a specific step, the cached results of every earlier step are reused, while the target step and any steps that follow it run again. The call throws an error if no step matching `from` is found in the instance's execution history.
+
+#### WorkflowInstanceRestartOptions
+
+```ts
+interface WorkflowInstanceRestartOptions {
+	/**
+	 * The step to restart the instance from.
+	 * If omitted, the instance restarts from the beginning.
+	 */
+	from?: {
+		/**
+		 * The name of the step.
+		 */
+		name: string;
+		/**
+		 * The 1-based index of the step, used when multiple steps share the same name and type. Defaults to 1 (the first occurrence).
+		 */
+		count?: number;
+		/**
+		 * The step type. Use this to disambiguate when the same name is shared across step types. Defaults to "do".
+		 */
+		type?: "do" | "sleep" | "waitForEvent";
+	};
+}
+```
+
+The `from` object identifies the step to restart from. Only `name` is required; `count` and `type` are only needed when the same step name appears more than once in the run.
+
+- `name` - the name of the step.
+- `count` - the 1-based index of the step, used when multiple steps share the same name and type (for example, inside a loop). Defaults to `1` (the first occurrence). Corresponds to `step.count` in the [step context](/workflows/build/step-context/).
+- `type` - the step type (`"do"`, `"sleep"`, or `"waitForEvent"`). Defaults to `"do"`. Use this when the same name is shared across different step types.
 
 ### terminate
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -479,13 +479,21 @@ declare abstract class WorkflowInstance {
 	 */
 	public terminate(): Promise<void>;
 	/**
-	 * Restart the instance.
+	 * Restart the instance. Pass `options.from` to restart from a specific step.
 	 */
-	public restart(): Promise<void>;
+	public restart(options?: WorkflowInstanceRestartOptions): Promise<void>;
 	/**
 	 * Returns the current status of the instance.
 	 */
 	public status(): Promise<InstanceStatus>;
+}
+
+interface WorkflowInstanceRestartOptions {
+	from?: {
+		name: string;
+		count?: number;
+		type?: "do" | "sleep" | "waitForEvent";
+	};
 }
 ```
 
@@ -515,9 +523,19 @@ Resume a paused Workflow instance.
 
 ### restart
 
-Restart a Workflow instance.
+Restart a Workflow instance from the beginning, or from a specific step.
 
-- <code>restart(): Promise&lt;void&gt;</code>
+- <code>restart(options?: WorkflowInstanceRestartOptions): Promise&lt;void&gt;</code>
+
+```ts
+let instance = await env.MY_WORKFLOW.get("abc-123");
+
+await instance.restart(); // From the beginning
+await instance.restart({ from: { name: "aggregate" } }); // From a specific step
+await instance.restart({ from: { name: "process", count: 3 } }); // 3rd occurrence
+```
+
+When restarting from a step, all earlier steps replay from cache; the target step and everything after it re-execute. `from.name` is required; `from.count` (1-based, defaults to `1`) targets a specific occurrence when the name repeats; `from.type` (`"do" | "sleep" | "waitForEvent"`) disambiguates when the same name is used across kinds. Throws if the step is not found in the instance's execution history.
 
 ### terminate
 


### PR DESCRIPTION
### Summary

Adds the optional `from` parameter to `WorkflowInstance.restart()` in the Workers API reference, with a brief cross-link from the trigger-workflows page.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
