### PR TITLE
Update Turnstile dummy response example

### DIFF
--- a/src/content/docs/turnstile/troubleshooting/testing.mdx
+++ b/src/content/docs/turnstile/troubleshooting/testing.mdx
@@ -126,10 +126,11 @@ Production secret keys will reject the dummy token. You must also use a dummy se
 {
   "success": true,
   "challenge_ts": "2022-02-28T15:14:30.096Z",
-  "hostname": "localhost",
+  "hostname": "example.com",
   "error-codes": [],
-  "action": "test",
-  "cdata": "test-data"
+  "metadata": {
+    "result_with_testing_key": true
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Updates the Turnstile testing-key validation success response example to match the observed dummy Siteverify response shape.

## Details

The current example shows `action: "test"` and `cdata: "test-data"`. A successful dummy validation response includes `metadata.result_with_testing_key` instead.