### PR TITLE
Add Codex example for Sandbox SDK

### DIFF
--- a/src/content/docs/sandbox/tutorials/codex.mdx
+++ b/src/content/docs/sandbox/tutorials/codex.mdx
@@ -19,7 +19,8 @@ Build a Worker that takes a repository URL and a task description and uses Sandb
 
 <Render file="prereqs" product="workers" />
 
-You'll also need:
+You will also need:
+
 
 - An [OpenAI API key](https://platform.openai.com/api-keys) for Codex
 - [Docker](https://www.docker.com/) running locally

--- a/src/content/docs/sandbox/tutorials/codex.mdx
+++ b/src/content/docs/sandbox/tutorials/codex.mdx
@@ -1,0 +1,128 @@
+---
+title: Run Codex on a Sandbox
+pcx_content_type: tutorial
+sidebar:
+  order: 1
+description: Use OpenAI Codex to implement a task in your GitHub repository.
+reviewed: 2026-04-29
+products:
+  - sandbox
+---
+
+import { Render, PackageManagers } from "~/components";
+
+Build a Worker that takes a repository URL and a task description and uses Sandbox SDK to run OpenAI Codex to implement your task.
+
+**Time to complete:** 5 minutes
+
+## Prerequisites
+
+<Render file="prereqs" product="workers" />
+
+You'll also need:
+
+- An [OpenAI API key](https://platform.openai.com/api-keys) for Codex
+- [Docker](https://www.docker.com/) running locally
+
+## 1. Create your project
+
+Create a new Sandbox SDK project:
+
+<PackageManagers
+	type="create"
+	pkg="cloudflare@latest"
+	args={
+		"codex-sandbox --template=cloudflare/sandbox-sdk/examples/codex"
+	}
+/>
+
+```sh
+cd codex-sandbox
+```
+
+## 2. Set up local environment variables
+
+Create a `.dev.vars` file in your project root for local development:
+
+```sh
+echo "OPENAI_API_KEY=your_api_key_here" > .dev.vars
+```
+
+Replace `your_api_key_here` with your actual API key from the [OpenAI Platform](https://platform.openai.com/api-keys).
+
+:::note
+The `.dev.vars` file is automatically gitignored and only used during local development with `npm run dev`.
+:::
+
+## 3. Test locally
+
+Start the development server:
+
+```sh
+npm run dev
+```
+
+:::note
+First run builds the Docker container (2-3 minutes). Subsequent runs are much faster.
+:::
+
+Test with curl:
+
+```sh
+curl -X POST http://localhost:8787/ \
+  -d '{
+    "repo": "https://github.com/cloudflare/agents",
+    "task": "remove the emojis from the readme"
+  }'
+```
+
+Response:
+
+```json
+{
+	"logs": "Removed the brain emoji from the README title. The heading now reads \"# Cloudflare Agents\" instead of \"# 🧠 Cloudflare Agents\".",
+	"diff": "diff --git a/README.md b/README.md\nindex 9296ac9..027c218 100644\n--- a/README.md\n+++ b/README.md\n@@ -1,4 +1,4 @@\n-# 🧠 Cloudflare Agents\n+# Cloudflare Agents\n \n ![npm install agents](assets/npm-install-agents.svg)\n "
+}
+```
+
+## 4. Deploy
+
+Deploy your Worker:
+
+```sh
+npx wrangler deploy
+```
+
+Then set your OpenAI API key as a production secret:
+
+```sh
+npx wrangler secret put OPENAI_API_KEY
+```
+
+Paste your API key from the [OpenAI Platform](https://platform.openai.com/api-keys) when prompted.
+
+:::caution
+After first deployment, wait 2-3 minutes for container provisioning. Check status with `npx wrangler containers list`.
+:::
+
+## What you built
+
+You created an API that:
+
+- Accepts a repository URL and natural language task descriptions
+- Creates a Sandbox and clones the repository into it
+- Kicks off Codex in non-interactive mode to implement the given task
+- Returns Codex's output and changes
+
+## Next steps
+
+- [Analyze data with AI](/sandbox/tutorials/analyze-data-with-ai/) - Add pandas and matplotlib for data analysis
+- [Code Interpreter API](/sandbox/api/interpreter/) - Use the built-in code interpreter instead of exec
+- [Streaming output](/sandbox/guides/streaming-output/) - Show real-time execution progress
+- [API reference](/sandbox/api/) - Explore all available methods
+
+## Related resources
+
+- [OpenAI Codex documentation](https://developers.openai.com/codex)
+- [Codex non-interactive mode](https://developers.openai.com/codex/noninteractive)
+- [Workers AI](/workers-ai/) - Use Cloudflare's built-in models


### PR DESCRIPTION
### Summary
Add a new tutorial covering how to run OpenAI Codex (https://developers.openai.com/codex) on a Cloudflare Sandbox. Mirrors the existing Run Claude Code on a Sandbox (https://developers.cloudflare.com/sandbox/tutorials/claude-code/) tutorial so users have a comparable 5-minute starting point for OpenAI's coding agent: clone a repo into a sandbox, run codex exec in non-interactive mode against a task description, and get the resulting logs and git diff back.
Pairs with the companion example at https://github.com/cloudflare/sandbox-sdk/examples/codex, which the tutorial pulls in as a create-cloudflare template.

### Documentation checklist
- [x] The change adheres to the documentation style guide (https://developers.cloudflare.com/style-guide/).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
