### PR TITLE
[Cloudflare One] ELI5 on Logs/Dashboard Logs/Gateway Activity/

### DIFF
--- a/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/index.mdx
@@ -10,7 +10,7 @@ sidebar:
 description: Review DNS queries, network traffic, and HTTP requests inspected by Gateway.
 ---
 
-import { Render, GlossaryTooltip, DirectoryListing, DashButton } from "~/components";
+import { Render, GlossaryTooltip, DirectoryListing } from "~/components";
 
 Gateway activity logs record the DNS queries, Network packets, and HTTP requests inspected by Gateway. You can also download encrypted [SSH command logs](/cloudflare-one/insights/logs/dashboard-logs/ssh-command-logs/) for sessions proxied by Gateway.
 

--- a/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/index.mdx
@@ -10,7 +10,7 @@ sidebar:
 description: Review DNS queries, network traffic, and HTTP requests inspected by Gateway.
 ---
 
-import { Render, GlossaryTooltip, DirectoryListing } from "~/components";
+import { Render, GlossaryTooltip, DirectoryListing, DashButton } from "~/components";
 
 Gateway activity logs record the DNS queries, Network packets, and HTTP requests inspected by Gateway. You can also download encrypted [SSH command logs](/cloudflare-one/insights/logs/dashboard-logs/ssh-command-logs/) for sessions proxied by Gateway.
 
@@ -28,7 +28,7 @@ Gateway logs show the public IP address in the **Source IP** field. Private IP a
 
 To view Gateway activity logs:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Insights** > **Logs**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Insights** > **Logs**.
 2. Choose a type of Gateway log:
 	- **DNS query logs**
 	- **Network logs**
@@ -49,7 +49,8 @@ By default, Gateway logs all events, including DNS queries and HTTP requests tha
 
 To customize what Gateway logs:
 
-1. In [Cloudflare](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
+
 2. Under **Traffic logging** > **Log traffic activity**, choose your preference for DNS, Network, and HTTP logs.
 
 These settings only apply to logs displayed in Cloudflare One. Logpush data is unaffected.
@@ -304,7 +305,7 @@ Enhanced file detection is an optional feature that extracts more file informati
 
 To turn on enhanced file detection:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings**.
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. In **Proxy and inspection settings**, turn on **Inspect HTTPS requests with TLS decryption**.
 3. In **Policy settings**, turn on **Allow enhanced file detection**.
 

--- a/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/index.mdx
@@ -12,7 +12,7 @@ description: Review DNS queries, network traffic, and HTTP requests inspected by
 
 import { Render, GlossaryTooltip, DirectoryListing } from "~/components";
 
-Gateway activity logs show the individual DNS queries, Network packets, and HTTP requests inspected by Gateway. You can also download encrypted [SSH command logs](/cloudflare-one/insights/logs/dashboard-logs/ssh-command-logs/) for sessions proxied by Gateway.
+Gateway activity logs record the DNS queries, Network packets, and HTTP requests inspected by Gateway. You can also download encrypted [SSH command logs](/cloudflare-one/insights/logs/dashboard-logs/ssh-command-logs/) for sessions proxied by Gateway.
 
 Enterprise users can generate more detailed logs with [Logpush](/cloudflare-one/insights/logs/logpush/).
 
@@ -20,7 +20,7 @@ Enterprise users can generate more detailed logs with [Logpush](/cloudflare-one/
 
 :::note[Private source IP substitution]
 
-Gateway logs will only show the public IP address for the **Source IP** field. Private IP addresses are substituted by a public IP address via network address translation (NAT).
+Gateway logs show the public IP address in the **Source IP** field. Private IP addresses are translated to public addresses via network address translation (NAT). To see the user's original private IP, refer to the **Source internal IP** field in the DNS, Network, or HTTP log details below.
 
 :::
 
@@ -45,9 +45,14 @@ To view Gateway activity logs:
 
 ## Selective logging
 
-By default, Gateway logs all events, including DNS queries and HTTP requests that are allowed and not a risk. You can choose to disable logs or only log blocked requests. To customize what type of events are recorded, log in to [Cloudflare One](https://one.dash.cloudflare.com/) and go to **Traffic policies** > **Traffic settings**. Under **Traffic logging** > **Log traffic activity**, indicate your DNS, Network, and HTTP log preferences.
+By default, Gateway logs all events, including DNS queries and HTTP requests that are allowed and not a risk. You can choose to disable logging entirely or only log blocked requests.
 
-These settings will only apply to logs displayed in Cloudflare One. Logpush data is unaffected.
+To customize what Gateway logs:
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings**.
+2. Under **Traffic logging** > **Log traffic activity**, choose your preference for DNS, Network, and HTTP logs.
+
+These settings only apply to logs displayed in Cloudflare One. Logpush data is unaffected.
 
 ## DNS logs
 
@@ -147,9 +152,9 @@ These settings will only apply to logs displayed in Cloudflare One. Logpush data
 ## Network logs
 
 :::caution[Failed connection logs]
-Gateway will only log TCP traffic with completed connections. If a connection is not complete (such as a TCP SYN with no SYN ACK), Gateway will not log this traffic in network logs.
+Gateway only logs TCP connections that were successfully established. If a connection is not complete (such as a TCP SYN with no SYN ACK), Gateway does not record it in network logs.
 
-Gateway can log failed connections in [network session logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/). These logs are available for Enterprise users via [Logpush](/cloudflare-one/insights/logs/logpush/) or [GraphQL](/cloudflare-one/insights/analytics/gateway/#graphql-queries).
+To log failed connections, use [network session logs](/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions/). These logs are available for Enterprise users via [Logpush](/cloudflare-one/insights/logs/logpush/) or [GraphQL](/cloudflare-one/insights/analytics/gateway/#graphql-queries).
 :::
 
 ### Explanation of the fields
@@ -211,7 +216,7 @@ Gateway can log failed connections in [network session logs](/logs/logpush/logpu
 
 :::note
 
-When an HTTP request results in an error, Gateway logs the first 512 bytes of the request for 30 days for internal troubleshooting. Otherwise, Gateway does not log HTTP bodies.
+Gateway does not log HTTP bodies. The exception is error requests: when an HTTP request results in an error, Gateway logs the first 512 bytes of the request for 30 days for internal troubleshooting.
 
 :::
 
@@ -295,7 +300,7 @@ When an HTTP request results in an error, Gateway logs the first 512 bytes of th
 
 ### Enhanced file detection
 
-Enhanced file detection is an optional feature to extract more file information from HTTP traffic. When turned on, Gateway will read file information from the HTTP body rather than the HTTP headers to provide greater accuracy and reliability. This feature may have a minor impact on performance for file-heavy organizations.
+Enhanced file detection is an optional feature that extracts more file information from HTTP traffic. When turned on, Gateway reads file information from the HTTP body rather than the HTTP headers, providing greater accuracy and reliability. This feature may have a minor impact on performance for file-heavy organizations.
 
 To turn on enhanced file detection:
 
@@ -305,10 +310,13 @@ To turn on enhanced file detection:
 
 ### Isolate requests
 
-When a user creates an [isolation policy](/cloudflare-one/remote-browser-isolation/isolation-policies/), Gateway logs the initial request that triggers isolation as an Isolate action. Because this request is not isolated yet, the `is_isolated` field will return `false`. Zero Trust then securely returns the result to the user in an isolated browser. Gateway will log all subsequent requests in the isolated browser with the action (such as Allow or Block), and the `is_isolated` field will return `true`.
+When a user creates an [isolation policy](/cloudflare-one/remote-browser-isolation/isolation-policies/), Gateway logs isolation-related requests in two stages:
+
+1. **Initial request** — The request that triggers isolation is logged with an Isolate action. Because this request is not yet isolated, the `is_isolated` field returns `false`.
+2. **Subsequent requests** — After Zero Trust returns the result to the user in an isolated browser, Gateway logs all subsequent requests in the isolated browser with the action (such as Allow or Block), and the `is_isolated` field returns `true`.
 
 ## Limitations
 
-If a connection closes before Gateway inspects and filters the traffic, Gateway will log the traffic with an Unknown action.
+If a connection closes before Gateway inspects and filters the traffic, Gateway logs the event with an Unknown action.
 
-Gateway activity logs are not available in the dashboard if you turn on the [Customer Metadata Boundary (CMB)](/data-localization/metadata-boundary/) within Cloudflare Data Localization Suite (DLS). Enterprise users using CMB can still export logs via [Logpush](/cloudflare-one/insights/logs/logpush/). For more information, refer to [DLS product compatibility](/data-localization/compatibility/#zero-trust).
+Gateway activity logs are not available in the dashboard if you turn on the [Customer Metadata Boundary (CMB)](/data-localization/metadata-boundary/) within Cloudflare Data Localization Suite (DLS). CMB restricts where customer traffic metadata and logs are stored by region. Enterprise users with CMB turned on can still export logs via [Logpush](/cloudflare-one/insights/logs/logpush/). For more information, refer to [DLS product compatibility](/data-localization/compatibility/#zero-trust).

--- a/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/index.mdx
+++ b/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/index.mdx
@@ -49,7 +49,7 @@ By default, Gateway logs all events, including DNS queries and HTTP requests tha
 
 To customize what Gateway logs:
 
-1. In [Cloudflare One](https://one.dash.cloudflare.com/), go to **Traffic policies** > **Traffic settings**.
+1. In [Cloudflare](https://dash.cloudflare.com/), go to **Zero Trust** > **Traffic policies** > **Traffic settings**.
 2. Under **Traffic logging** > **Log traffic activity**, choose your preference for DNS, Network, and HTTP logs.
 
 These settings only apply to logs displayed in Cloudflare One. Logpush data is unaffected.

--- a/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/manage-pii.mdx
+++ b/src/content/docs/cloudflare-one/insights/logs/dashboard-logs/gateway-logs/manage-pii.mdx
@@ -10,9 +10,12 @@ sidebar:
   order: 1
 ---
 
-Cloudflare Gateway gives you multiple ways to safely handle your employees' personally identifiable information (PII). By default, PII is redacted from Gateway Activity logs for all permission roles except the Super Administrator and users with the [Cloudflare Zero Trust PII role](/cloudflare-one/roles-permissions/#cloudflare-zero-trust-pii) assigned to them. Only the Super Administrator can assign roles and determine who has permission to view PII. Redacting PII does not affect the way PII is captured in logs as the data is simply hidden and no information is lost.
+Cloudflare Gateway gives you multiple ways to safely handle your employees' personally identifiable information (PII) in activity logs:
 
-To add or remove the Cloudflare Zero Trust PII role for a user in your organization, refer to [Roles](/fundamentals/manage-members/roles/). Alternatively, you can choose to [exclude PII](#exclude-pii) from Gateway activity logs for all users.
+- **Redact PII** (default) — PII is stored in logs but hidden from view. Only the Super Administrator and users with the [Cloudflare Zero Trust PII role](/cloudflare-one/roles-permissions/#cloudflare-zero-trust-pii) can view redacted PII. The underlying data is preserved — redaction only controls who can see it.
+- **[Exclude PII](#exclude-pii)** — PII is not stored in logs at all. No user, including the Super Administrator, can retrieve it.
+
+Only the Super Administrator can assign roles and determine who has permission to view PII. To add or remove the Cloudflare Zero Trust PII role for a user in your organization, refer to [Roles](/fundamentals/manage-members/roles/).
 
 ## Types of PII
 
@@ -28,7 +31,13 @@ Cloudflare Gateway can log the following types of PII:
 
 ## Exclude PII
 
-Turning on the setting to exclude PII means Cloudflare Gateway will log activity without storing any employee PII. Changes to this setting will not change PII storage of any previous logs. This means if the setting is turned on and then turned off, there will be no PII data for logs captured while this setting was turned on. The PII data will be unavailable to all roles within your Zero Trust organization, including the Super Administrator.
+When you exclude PII, Gateway logs activity without storing any employee PII. This differs from the default redaction behavior — excluded PII is not stored and cannot be retrieved by any role, including the Super Administrator.
+
+:::caution
+Excluding PII is irreversible for the period it is active. If you turn on this setting and later turn it off, logs captured while the setting was on will permanently lack PII data.
+:::
+
+Changes to this setting do not affect PII already stored in previous logs.
 
 To turn on the setting to exclude PII:
 


### PR DESCRIPTION
## Summary

- Improve clarity of prose sections in Gateway activity logs and Manage PII pages (ELI5 pass)
- All changes are to explanatory prose — reference tables are untouched

## Gateway activity logs (`index.mdx`)

- **Opening paragraph** — Tighten verb ("record" vs "show the individual")
- **NAT note** — Add cross-reference to the **Source internal IP** field so readers know where to find private IPs
- **Selective logging** — Break dense paragraph into intro + numbered steps for scannability
- **Failed connection logs** — Add plain-language lead-in ("successfully established") before TCP handshake details
- **HTTP logs note** — Reorder to state general rule first ("does not log HTTP bodies"), then exception
- **Enhanced file detection** — Tighten prose; no net-new claims
- **Isolate requests** — Break single dense paragraph into two-stage numbered list (counterintuitive `is_isolated` behavior is clearer this way)
- **Limitations** — Add one-sentence inline context for Customer Metadata Boundary (CMB)

## Manage PII (`manage-pii.mdx`)

- **Opening** — Restructure into explicit two-mode list (Redact vs Exclude) so the page's core concept is immediately visible
- **Exclude PII** — Surface irreversibility warning in a `:::caution` callout; separate "previous logs unaffected" into its own sentence
- Remove style-guide-violating "simply"