### PR TITLE
[Cloudflare One] Remove beta labels from Authorization proxy and hosted PAC files

### DIFF
--- a/src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx
+++ b/src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx
@@ -8,7 +8,7 @@ date: 2026-04-29
 
 The [Gateway Authorization Proxy](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#authorization-endpoint) and [hosted PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#create-a-hosted-pac-file) are now generally available for all plan types.
 
-Authorization proxy endpoints add an identity-aware option alongside the existing [source IP proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#source-ip-endpoint), using [Cloudflare Access](/cloudflare-one/access-controls/policies/) authentication to verify who a user is before applying Gateway filtering — without installing the WARP client. Cloudflare-hosted PAC files let you create and distribute PAC files directly from Cloudflare One on Cloudflare's global network.
+Authorization proxy endpoints add an identity-aware option alongside the existing [source IP proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#source-ip-endpoint), using [Cloudflare Access](/cloudflare-one/access-controls/policies/) authentication to verify who a user is before applying Gateway filtering — without installing the [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/). Cloudflare-hosted PAC files let you create and distribute PAC files directly from Cloudflare One on Cloudflare's global network.
 
 These features are ideal for environments where deploying a device client is not an option, such as virtual desktops (VDI) or compliance-restricted endpoints.
 

--- a/src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx
+++ b/src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx
@@ -8,7 +8,7 @@ date: 2026-04-29
 
 The [Gateway Authorization Proxy](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#authorization-endpoint) and [hosted PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#create-a-hosted-pac-file) are now generally available for all plan types.
 
-Authorization proxy endpoints replace IP-based authorization with [Cloudflare Access](/cloudflare-one/access-controls/policies/) authentication, verifying who a user is before applying Gateway filtering — without installing the WARP client. Cloudflare-hosted PAC files let you create and distribute PAC files directly from Cloudflare One on Cloudflare's global network.
+Authorization proxy endpoints add an identity-aware option alongside the existing [source IP proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#source-ip-endpoint), using [Cloudflare Access](/cloudflare-one/access-controls/policies/) authentication to verify who a user is before applying Gateway filtering — without installing the WARP client. Cloudflare-hosted PAC files let you create and distribute PAC files directly from Cloudflare One on Cloudflare's global network.
 
 These features are ideal for environments where deploying a device client is not an option, such as virtual desktops (VDI), mergers and acquisitions, or compliance-restricted endpoints.
 

--- a/src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx
+++ b/src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx
@@ -10,6 +10,6 @@ The [Gateway Authorization Proxy](/cloudflare-one/networks/resolvers-and-proxies
 
 Authorization proxy endpoints add an identity-aware option alongside the existing [source IP proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#source-ip-endpoint), using [Cloudflare Access](/cloudflare-one/access-controls/policies/) authentication to verify who a user is before applying Gateway filtering — without installing the WARP client. Cloudflare-hosted PAC files let you create and distribute PAC files directly from Cloudflare One on Cloudflare's global network.
 
-These features are ideal for environments where deploying a device client is not an option, such as virtual desktops (VDI), mergers and acquisitions, or compliance-restricted endpoints.
+These features are ideal for environments where deploying a device client is not an option, such as virtual desktops (VDI) or compliance-restricted endpoints.
 
 To get started, refer to the [proxy endpoints documentation](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/).

--- a/src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx
+++ b/src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx
@@ -1,0 +1,15 @@
+---
+title: Gateway Authorization Proxy and hosted PAC files are now generally available
+description: Authorization proxy endpoints and Cloudflare-hosted PAC files are now generally available for all plan types, enabling identity-aware Gateway policies without a device client.
+products:
+  - gateway
+date: 2026-04-29
+---
+
+The [Gateway Authorization Proxy](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#authorization-endpoint) and [hosted PAC files](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#create-a-hosted-pac-file) are now generally available for all plan types.
+
+Authorization proxy endpoints replace IP-based authorization with [Cloudflare Access](/cloudflare-one/access-controls/policies/) authentication, verifying who a user is before applying Gateway filtering — without installing the WARP client. Cloudflare-hosted PAC files let you create and distribute PAC files directly from Cloudflare One on Cloudflare's global network.
+
+These features are ideal for environments where deploying a device client is not an option, such as virtual desktops (VDI), mergers and acquisitions, or compliance-restricted endpoints.
+
+To get started, refer to the [proxy endpoints documentation](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/).

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices.mdx
@@ -223,7 +223,7 @@ if (
 
 ### Apps with certificate pinning
 
-Some applications and services use certificate pinning to validate connections. These apps reject the Cloudflare-injected certificate used for HTTPS inspection and fail to load when routed through the proxy. Bypass these domains in your PAC file:
+When HTTPS inspection is enabled, applications and services that use certificate pinning reject the Cloudflare-injected certificate and fail to load when routed through the proxy. Bypass these domains in your PAC file:
 
 ```js
 // Bypass certificate-pinned apps
@@ -235,7 +235,7 @@ if (
 }
 ```
 
-When using [authorization endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#authorization-endpoint), bypassing certificate-pinned apps in the PAC file is required. [Do Not Inspect (DNI) policies](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) will not prevent certificate pinning errors on these connections.
+[Do Not Inspect (DNI) policies](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) will not prevent certificate pinning errors on these connections — bypassing certificate-pinned apps in the PAC file is required.
 
 ## Test PAC files
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices.mdx
@@ -221,6 +221,22 @@ if (
 }
 ```
 
+### Apps with certificate pinning
+
+Some applications and services use certificate pinning to validate connections. These apps reject the Cloudflare-injected certificate used for HTTPS inspection and fail to load when routed through the proxy. Bypass these domains in your PAC file:
+
+```js
+// Bypass certificate-pinned apps
+if (
+	shExpMatch(host, "*.example-bank.com") ||
+	shExpMatch(host, "*.example-pinned-app.com")
+) {
+	return "DIRECT";
+}
+```
+
+When using [authorization endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/#authorization-endpoint), bypassing certificate-pinned apps in the PAC file is required. [Do Not Inspect (DNI) policies](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) will not prevent certificate pinning errors on these connections.
+
 ## Test PAC files
 
 ### Test with expected websites

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -508,7 +508,7 @@ Authorization endpoints do not support plaintext HTTP traffic unless the traffic
 
 #### Browser Isolation
 
-Gateway [HTTP Isolate policies](/cloudflare-one/traffic-policies/http-policies/#isolate) are not currently supported with authorization endpoints.
+Gateway [HTTP Isolate policies](/cloudflare-one/traffic-policies/http-policies/#isolate) are not supported with authorization endpoints.
 
 #### Referer header traffic
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -11,7 +11,6 @@ tags:
 ---
 
 import {
-	Badge,
 	Details,
 	GlossaryDefinition,
 	TabItem,
@@ -20,8 +19,6 @@ import {
 } from "~/components";
 
 :::note
-[Authorization endpoints](#authorization-endpoint) and [PAC file hosting](#create-a-hosted-pac-file) are in open beta for all customers.
-
 [Source IP proxy endpoints](#source-ip-endpoint) are only available on Enterprise plans.
 :::
 
@@ -65,7 +62,7 @@ Cloudflare One offers two types of proxy endpoints, each with different authoriz
 
 Once you create a proxy endpoint, you cannot change its type. If you need a different authorization method, you must create a new proxy endpoint.
 
-#### Authorization endpoint <Badge text="Beta" variant="caution" />
+#### Authorization endpoint
 
 Authorization endpoints use [Cloudflare Access](/cloudflare-one/access-controls/policies/) to provide Zero Trust authorization. Users must authenticate through an identity provider and pass Access policies before they can use the proxy endpoint.
 
@@ -251,7 +248,7 @@ A PAC file is a text file written in JavaScript that specifies which traffic sho
 For detailed instructions and examples for creating a PAC file, refer to [PAC file best practices](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices/).
 :::
 
-### Create a hosted PAC file <Badge text="Beta" variant="caution" />
+### Create a hosted PAC file
 
 When you create a PAC file in Cloudflare One, Cloudflare will host it in a publicly accessible Worker. Hosted PAC files are automatically distributed through Cloudflare's global network.
 
@@ -511,7 +508,7 @@ Authorization endpoints do not support plaintext HTTP traffic unless the traffic
 
 #### Browser Isolation
 
-Gateway [HTTP Isolate policies](/cloudflare-one/traffic-policies/http-policies/#isolate) are not currently supported with authorization endpoints during the beta period.
+Gateway [HTTP Isolate policies](/cloudflare-one/traffic-policies/http-policies/#isolate) are not currently supported with authorization endpoints.
 
 #### Referer header traffic
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -496,7 +496,7 @@ Each user who authenticates through an authorization proxy endpoint occupies a [
 
 ### Authorization endpoint limitations
 
-When using [authorization endpoints](#authorization-endpoint), be aware of the following limitations.
+When using [authorization endpoints](#authorization-endpoint), be aware of the following limitations. For configuration guidance on apps with certificate pinning, refer to [PAC file best practices](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices/#apps-with-certificate-pinning).
 
 #### Plaintext HTTP traffic
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -498,10 +498,6 @@ Each user who authenticates through an authorization proxy endpoint occupies a [
 
 When using [authorization endpoints](#authorization-endpoint), be aware of the following limitations.
 
-#### Domain bypassing and certificate pinning
-
-You must bypass domains you do not intend to inspect with your PAC file. Gateway will still apply [Do Not Inspect (DNI) policies](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) when using authorization endpoints, but this will not bypass certificate pinning errors.
-
 #### Plaintext HTTP traffic
 
 Authorization endpoints do not support plaintext HTTP traffic unless the traffic is configured through an [Access application](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) or bypassed with the PAC file.


### PR DESCRIPTION
## Summary

Removes beta labels from the Gateway Authorization Proxy and Cloudflare-hosted PAC files now that both features are generally available, and relocates configuration guidance that was misclassified as a limitation.

## Changes

### `src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx`

- Removed `<Badge text=\"Beta\" variant=\"caution\" />` from the **Authorization endpoint** and **Create a hosted PAC file** headings.
- Removed the open-beta sentence from the top-of-page `:::note` (Enterprise-plans note for source IP endpoints retained).
- Updated the Browser Isolation limitation to drop \"during the beta period\" / \"currently\" wording.
- Removed the **Domain bypassing and certificate pinning** subsection from limitations (it was configuration guidance, not a limitation) and added a cross-reference to the new best-practices subsection.
- Cleaned up the now-unused `Badge` import.

### `src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices.mdx`

- Added a new `### Apps with certificate pinning` subsection under `## Common bypass rules`, alongside the existing Font and Streaming subsections. Includes:
  - A qualifier that the issue applies when HTTPS inspection is enabled.
  - A code example showing how to bypass certificate-pinned apps in a PAC file.
  - A note that DNI policies will not prevent certificate pinning errors.

### `src/content/changelog/gateway/2026-04-29-gateway-authorization-proxy-pac-files-ga.mdx` (new)

- GA announcement entry. Frames authorization proxy as an additive identity-aware option alongside source IP proxy endpoints (not a replacement).
- Uses **Cloudflare One Client** terminology consistent with `index.mdx`.
- The original `2026-03-04-...-open-beta.mdx` entry is preserved as a historical record.

## Validation

- `pnpm exec prettier --check` clean on all modified files.
- No remaining `Badge` / `beta` / `Beta` references in `proxy-endpoints/index.mdx`.
- No broken inbound links to the removed `#domain-bypassing-and-certificate-pinning` anchor.