### PR TITLE
[Billing] Add Instant Bank Payments via Link documentation

### DIFF
--- a/src/content/docs/billing/index.mdx
+++ b/src/content/docs/billing/index.mdx
@@ -7,42 +7,134 @@ head:
   - tag: title
     content: Overview
 description: Manage billing and subscriptions for your account.
+products:
+  - billing
 ---
 
-Welcome to the Cloudflare Billing and Payment Help Center! Here you will find answers to some of the most common and impactful issues facing our customers today. Most current issues revolve around:
+import { CardGrid, LinkTitleCard } from "~/components";
 
-* Payment failures
-* Outstanding balances
-* Subscription renewals
-* Cancellation requests
-* Updating payment methods
-* Understanding billing cycles
+Cloudflare bills on a recurring cycle for each domain on your account — every 30 days for monthly plans or annually for yearly plans. Plans and add-on services are billed separately, and some products use [usage-based billing](/billing/understand/usage-based-billing/). You can pay with Visa, Mastercard, American Express, Discover, PayPal, Apple Pay, Google Pay, Stripe Link, or UnionPay.
 
-An overview of these issues can be found below:
+## Get started
 
-## Failed Plan Modifications
+Set up your billing profile and payment methods.
 
-You may receive an error when attempting to purchase a product, pay a balance or change a paid plan. Review the following guides for possible solutions:
+<CardGrid>
 
-* [Resolve a payment failure](/billing/troubleshoot-failed-payments/)
-* [Resolve the zone cannot be upgraded error](/billing/resolve-zone-cannot-be-ugpraded/)
-* [Resolve "You cannot modify this subscription"](/billing/resolve-you-cannot-modify-this-subscription/)
+<LinkTitleCard title="Create billing profile" href="/billing/get-started/create-billing-profile/">
+Add a payment method to your Cloudflare account and configure your billing profile.
+</LinkTitleCard>
 
-If the problems above do not apply to you, there are intermittent issues with subscription upgrades, downgrades, and cancellations. This may result in billing charges being applied without the subscription level being updated. In these instances, you should [contact support](/support/contacting-cloudflare-support/).
+<LinkTitleCard title="Update billing information" href="/billing/get-started/update-billing-info/">
+Change your payment method, billing address, or billing email address.
+</LinkTitleCard>
 
-## Cannot update or remove payment methods
+</CardGrid>
 
-You should be able to add, update, and remove payment methods in your account. If you are seeing difficulties doing this, refer to the following guides for possible solutions:
+## Manage
 
-* [Update billing information](/billing/update-billing-info/)
-* [Resolve "Cannot remove payment method"](/billing/resolve-cannot-remove-payment-method/)
+Change plans, view invoices, monitor usage, and manage subscriptions.
 
-If the solutions above do not apply to you, we have observed reports of being unable to update or add payment methods within the dashboard. In these instances, you should [contact support](/support/contacting-cloudflare-support/).
+<CardGrid>
 
-## Cancellations 
+<LinkTitleCard title="Monitor billable usage" href="/billing/manage/billable-usage/">
+Track daily usage-based costs across your account with the billable usage dashboard.
+</LinkTitleCard>
 
-Cancellations are not processed until the end of the billing period. To understand more, refer to [Cancel Cloudflare subscriptions](/billing/cancel-subscription/).
+<LinkTitleCard title="Budget alerts" href="/billing/manage/budget-alerts/">
+Get notified by email when your usage-based spend crosses a dollar threshold.
+</LinkTitleCard>
 
-## Non-refundable occurrences
+<LinkTitleCard title="Change domain plan" href="/billing/manage/change-plan/">
+Upgrade or downgrade the plan associated with a specific Cloudflare domain.
+</LinkTitleCard>
 
-In accordance with the Cloudflare Billing Policy, be aware that some [Non-Refundable occurrences](/billing/billing-policy/#non-refundable-occurrences) cannot be refunded and you should not contact support to request refunds for these.
+<LinkTitleCard title="Cancel subscriptions" href="/billing/manage/cancel-subscription/">
+Cancel Cloudflare plans, add-ons, or subscriptions.
+</LinkTitleCard>
+
+<LinkTitleCard title="Pay an outstanding balance" href="/billing/manage/pay-invoices-overdue-balances/">
+Pay overdue invoices and resolve outstanding balances on your account.
+</LinkTitleCard>
+
+<LinkTitleCard title="Invoices" href="/billing/manage/invoices/">
+View, download, and manage your Cloudflare invoices.
+</LinkTitleCard>
+
+</CardGrid>
+
+## Payment methods
+
+Learn about payment methods available for Cloudflare services.
+
+<CardGrid>
+
+<LinkTitleCard title="Instant Bank Payments via Link" href="/billing/payment-methods/instant-bank-payments-link/">
+Pay for Cloudflare services directly from your bank account through Link.
+</LinkTitleCard>
+
+</CardGrid>
+
+## Understand
+
+Learn how Cloudflare billing works.
+
+<CardGrid>
+
+<LinkTitleCard title="How billing works" href="/billing/understand/how-billing-works/">
+Understand the billing lifecycle, charge types, and how to read your Cloudflare invoice.
+</LinkTitleCard>
+
+<LinkTitleCard title="Preview services" href="/billing/understand/preview-services/">
+Try certain products and features for 30 days as a contracted customer.
+</LinkTitleCard>
+
+<LinkTitleCard title="Billing policy" href="/billing/understand/billing-policy/">
+Understand refund policies, payment methods, and subscription terms.
+</LinkTitleCard>
+
+<LinkTitleCard title="Usage-based billing" href="/billing/understand/usage-based-billing/">
+Learn how usage-based charges work for products like Workers and other metered services.
+</LinkTitleCard>
+
+<LinkTitleCard title="How charges accrue" href="/billing/understand/how-charges-accrue/">
+Follow a request through Cloudflare and see which products generate charges at each stage.
+</LinkTitleCard>
+
+<LinkTitleCard title="Sales tax" href="/billing/understand/sales-tax/">
+Understand how Cloudflare collects sales tax based on your billing address.
+</LinkTitleCard>
+
+</CardGrid>
+
+## Troubleshoot
+
+Resolve payment failures, invoice issues, and error messages.
+
+<CardGrid>
+
+<LinkTitleCard title="Error reference" href="/billing/troubleshoot/error-reference/">
+Quick lookup table for common billing error messages and how to fix them.
+</LinkTitleCard>
+
+<LinkTitleCard title="Resolve a payment failure" href="/billing/troubleshoot/troubleshoot-failed-payments/">
+Fix errors when purchasing products, changing subscriptions, or paying invoices.
+</LinkTitleCard>
+
+<LinkTitleCard title="Troubleshoot invoices" href="/billing/troubleshoot/troubleshoot-invoices/">
+Resolve issues with invoice data, billing contacts, or missing invoices.
+</LinkTitleCard>
+
+<LinkTitleCard title="Resolve the zone cannot be upgraded error" href="/billing/troubleshoot/resolve-zone-cannot-be-upgraded/">
+Fix errors when upgrading a domain or purchasing a subscription.
+</LinkTitleCard>
+
+<LinkTitleCard title="Resolve &quot;you cannot modify this subscription&quot;" href="/billing/troubleshoot/resolve-you-cannot-modify-this-subscription/">
+Fix errors when cancelling or modifying a subscription that is already scheduled for cancellation.
+</LinkTitleCard>
+
+<LinkTitleCard title="Resolve &quot;cannot remove payment method&quot;" href="/billing/troubleshoot/resolve-cannot-remove-payment-method/">
+Fix errors when attempting to remove a payment method linked to active subscriptions.
+</LinkTitleCard>
+
+</CardGrid>

--- a/src/content/docs/billing/payment-methods/index.mdx
+++ b/src/content/docs/billing/payment-methods/index.mdx
@@ -1,0 +1,15 @@
+---
+pcx_content_type: navigation
+title: Payment methods
+sidebar:
+  order: 4
+  group:
+    hideIndex: true
+description: Learn about payment methods available for Cloudflare services.
+products:
+  - billing
+---
+
+import { DirectoryListing } from "~/components";
+
+<DirectoryListing />

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -1,0 +1,88 @@
+---
+title: Instant Bank Payments via Link
+pcx_content_type: concept
+sidebar:
+  order: 1
+  description: Pay for Cloudflare services directly from your bank account through Link
+description: Understand Instant Bank Payments via Link for Cloudflare services.
+products:
+  - billing
+---
+
+import { DashButton } from "~/components";
+
+Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudflare services directly from your bank account. Link is a one-click checkout wallet that remembers your payment details. If you already have a bank account saved in Link, it appears as a payment option at checkout. If not, you can connect one during the checkout flow.
+
+## How Instant Bank Payments works
+
+1. **Checkout** - Cloudflare presents your saved Link payment methods. You can also connect your bank with Link if not already set up.
+2. **Select bank account** - Your bank account appears as a payment option alongside your existing cards.
+3. **Confirm payment** - Select your bank account and confirm.
+4. **Processing** - The payment is authenticated and processed on your behalf.
+
+After your first Link authentication, your bank account is available for future purchases without re-entering details.
+
+:::note
+Instant Bank Payments is an additional payment option. Your existing cards remain available at checkout.
+:::
+
+## Eligibility
+
+Instant Bank Payments via Link is available to US-based self-serve accounts across all Cloudflare products. You can connect your bank account through Link during checkout.
+
+## Identifying bank payments
+
+Bank-based Link payments appear in your billing history with these identifiers:
+
+| Field | Value |
+| --- | --- |
+| Payment method | `link` |
+| Last four digits | `0000` |
+
+Card-based Link payments display your card's last four digits, distinguishing them from bank payments.
+
+## Viewing your payment history
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/).
+2. Go to **Manage Account** > **Billing**.
+
+   <DashButton url="/?to=/:account/billing" />
+
+3. Select **Invoices** to view your invoice and payment history.
+
+## What happens if a bank payment fails
+
+If a bank payment cannot be processed:
+
+1. **Retry or switch** - You are prompted to select a different payment method. You can retry with the same bank account or choose a card.
+2. **Update payment method** - If the issue persists, update your payment method in billing settings.
+
+   <DashButton url="/?to=/:account/billing" />
+
+Ensure your bank account has sufficient funds and supports instant payments.
+
+## FAQ
+
+### How do I know if I paid via Instant Bank Payments?
+
+Your billing history shows the payment method as `link` with last four digits `0000`. Card-based Link payments show your card's actual last four digits.
+
+### Is my bank account secure?
+
+Your bank credentials are stored in the Link wallet using encryption and multi-factor authentication. Your raw bank details are never shared with Cloudflare or other merchants.
+
+### Can I still pay with a card?
+
+Yes. Instant Bank Payments is an additional option. Cards saved in Link or added manually remain available at checkout.
+
+### Is there any difference in processing time?
+
+No. Bank payments through Link process in the same checkout flow as card payments. Your purchase is confirmed immediately.
+
+### Can I remove my bank account from Link?
+
+Yes. Manage your saved payment methods through the [Link wallet](https://link.co/). Removing a bank account does not affect previously completed payments.
+
+### What if I think I was charged incorrectly?
+
+[Contact Cloudflare support](/support/contacting-cloudflare-support/) with your invoice number and payment details.


### PR DESCRIPTION
## Summary

Adds Instant Bank Payments via Link documentation and a new **Payment methods** section to the billing docs.

Supersedes #30422 (closed due to merge conflict from workflow file scope issue).

## Changes

- New section: `billing/payment-methods/` with navigation index
- New page: `src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx`
- Updated `billing/index.mdx` with Payment methods card grid
- Covers: how it works, eligibility, payment identification, payment failures, FAQ

## Related

- SHIP-14077
- Changelog PR: #30428
- Internal wiki: https://wiki.cfdata.org/spaces/BILL/pages/1396655722

## Checklist

- [x] Content is technically accurate
- [x] New Payment methods section follows existing billing docs structure (matches manage/, understand/, troubleshoot/ pattern)
- [x] Uses MDX components (DashButton) consistent with other billing pages
- [x] Cloudflare voice guidelines applied (density, direct tone, no anti-patterns)
- [x] No internal metrics disclosed (cost savings, auth rates, addressable volume excluded)
- [x] No Stripe references in customer-facing content