### PR TITLE
[Worklows] Update step retry limit on Workflows limits page

### DIFF
--- a/src/content/docs/workflows/reference/limits.mdx
+++ b/src/content/docs/workflows/reference/limits.mdx
@@ -39,6 +39,7 @@ Workflows cannot be deployed to Workers for Platforms namespaces, as Workflows d
 | Maximum length of a Workflow name [^4]                                                        | 64 characters                                                                                    | 64 characters                                                                                             |
 | Maximum length of a Workflow instance ID [^4]                                                 | 100 characters                                                                                   | 100 characters                                                                                            |
 | Maximum number of subrequests per Workflow instance                                           | 50/request                                                                                       | 10,000/request (default) / configurable up to 10 million                                                  |
+| Maximum number of retries per step                                                            | 10,000                                                                                           | 10,000                                                                                                    |
 
 [^2]: Workflow instance state and logs will be retained for 3 days on the Workers Free plan and for 30 days on the Workers Paid plan.
 


### PR DESCRIPTION
### Summary

Adding 10k/step retry limit to Workflows limits page

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
