### PR TITLE
[DLP] Document PII Record profile behavior

### DIFF
--- a/src/content/changelog/dlp/2026-04-28-pii-record-profile.mdx
+++ b/src/content/changelog/dlp/2026-04-28-pii-record-profile.mdx
@@ -1,8 +1,9 @@
 ---
-title: "Detect PII records with a new predefined DLP profile"
-description: "A new predefined DLP profile detects records that contain multiple types of personal data, reducing false positives from isolated matches."
-date: "2026-04-28"
-products: [dlp]
+title: Detect PII records with a new predefined DLP profile
+description: A new predefined DLP profile detects records that contain multiple types of personal data, reducing false positives from isolated matches.
+date: 2026-04-28
+products: 
+  - dlp
 ---
 
 Cloudflare DLP now includes a new predefined profile designed to detect PII records that contain multiple types of personal data: **Personally Identifiable Information (PII) Record**.

--- a/src/content/changelog/dlp/2026-04-28-pii-record-profile.mdx
+++ b/src/content/changelog/dlp/2026-04-28-pii-record-profile.mdx
@@ -1,0 +1,29 @@
+---
+title: "Detect PII records with a new predefined DLP profile"
+description: "A new predefined DLP profile detects records that contain multiple types of personal data, reducing false positives from isolated matches."
+date: "2026-04-28"
+products: [dlp]
+---
+
+Cloudflare DLP now includes a new predefined profile designed to detect PII records that contain multiple types of personal data: **Personally Identifiable Information (PII) Record**.
+
+Most predefined and custom DLP profiles match when any enabled detection entry matches. The **Personally Identifiable Information (PII) Record** profile is different. It only matches when at least three unique detection entries are found in close proximity, which reduces false positives from standalone values that may not represent a real PII record.
+
+Detection entries included in the profile:
+
+- AU Passport Number
+- American Express Card Number
+- Diners Club Card Number
+- Driver's License Number
+- Email Address
+- Full Name
+- Mailing Address
+- Mastercard Card Number
+- US Individual Tax Identification Number (ITIN)
+- US Passport Number
+- US Phone Number
+- Union Pay Card Number
+- United States SSN Numeric Detection
+- Visa Card Number
+
+For more information, refer to [predefined DLP profiles](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/).

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles.mdx
@@ -12,7 +12,7 @@ tags:
 
 import { Render } from "~/components";
 
-Cloudflare Zero Trust provides predefined DLP profiles for common types of sensitive data. Some profiles include built-in validation checks that increase detection accuracy. You can also configure [advanced settings](/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings/) for predefined profiles.
+Cloudflare Zero Trust provides predefined DLP profiles for common types of sensitive data. Some profiles include built-in validation checks to increase detection accuracy. Others use profile-specific matching logic to reduce false positives. You can also configure [advanced settings](/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings/) for predefined profiles.
 
 ## AI Prompt
 
@@ -87,6 +87,29 @@ The following diagnosis and medication names are checked for surrounding ASCII c
 - FDA active ingredients
 - FDA drug names
 - ICD-10 FY2023 short descriptions
+
+## Personally Identifiable Information (PII) Record
+
+The **Personally Identifiable Information (PII) Record** predefined profile is designed to detect records that contain multiple types of personal data. Unlike most predefined and custom DLP profiles, this profile matches only when at least three unique detection entries are found in close proximity.
+
+This behavior helps reduce false positives from isolated matches.
+
+The profile includes the following detection entries:
+
+- AU Passport Number
+- American Express Card Number
+- Diners Club Card Number
+- Driver's License Number
+- Email Address
+- Full Name
+- Mailing Address
+- Mastercard Card Number
+- US Individual Tax Identification Number (ITIN)
+- US Passport Number
+- US Phone Number
+- Union Pay Card Number
+- United States SSN Numeric Detection
+- Visa Card Number
 
 ## Social Security, Insurance, Tax, and Identifier Numbers
 

--- a/src/content/partials/cloudflare-one/data-loss-prevention/predefined-profile.mdx
+++ b/src/content/partials/cloudflare-one/data-loss-prevention/predefined-profile.mdx
@@ -4,5 +4,7 @@
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Data loss prevention** > **Profiles**.
 2. Choose a [predefined profile](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/) and select **Edit**.
-3. Enable one or more **Detection entries** according to your preferences. The DLP Profile matches using the OR logical operator — if multiple entries are enabled, your data needs to match only one of the entries.
+3. Enable one or more **Detection entries** according to your preferences.
 4. Select **Save profile**.
+
+Most predefined profiles match when any enabled detection entry matches. The **Personally Identifiable Information (PII) Record** profile is an exception and requires at least three unique detection entries in close proximity before the profile matches.


### PR DESCRIPTION
## Summary
- add a predefined profiles section for the Personally Identifiable Information (PII) Record profile
- document that the PII Record profile uses profile-specific matching logic and list its included detection entries
- update the predefined profile setup guidance to clarify that most profiles match when any enabled detection entry matches
- add a DLP changelog entry announcing the new predefined PII Record profile

## Files Changed
- `src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles.mdx`
- `src/content/partials/cloudflare-one/data-loss-prevention/predefined-profile.mdx`
- `src/content/changelog/dlp/2026-04-28-pii-record-profile.mdx`

## Validation
- earlier file-level validation passed via `npm run check`
- the clean branch could not re-run `npm run check` locally because the repo now expects `pnpm` and `pnpm` is not installed in this environment
- `npm run build` is currently blocked by an unrelated existing docs issue on `/cloudflare-one/data-loss-prevention/dlp-settings` with invalid frontmatter tag `Configuration`