### PR TITLE
[AI Gateway] fix dynamic routing JSON element schemas

### DIFF
--- a/src/content/docs/ai-gateway/features/dynamic-routing/json-configuration.mdx
+++ b/src/content/docs/ai-gateway/features/dynamic-routing/json-configuration.mdx
@@ -49,13 +49,15 @@ Evaluates a condition based on request parameters and routes the request accordi
   - `true`: Forwards request to provided element if condition evaluates to true
   - `false`: Forwards request to provided element if condition evaluates to false
 
+`conditions` supports MongoDB-like operators such as `$eq`, `$ne`, `$in`, `$and`, and `$or`.
+
 ```json
 {
 	"id": "<id>",
 	"type": "conditional",
 	"properties": {
 		"conditions": {
-			"metadata.plan": { "$eq": "free" } // Supports MongoDB-like operators
+			"metadata.plan": { "$eq": "free" }
 		}
 	},
 	"outputs": {
@@ -71,7 +73,7 @@ Routes requests probabilistically across multiple outputs, useful for A/B testin
 
 - **Inputs**: Request
 - **Outputs**: Up to 5 named percentage outputs
-  - Each output has a fractional probability and the values must total 100%
+  - Each output key (for example, `"10%"`) is the probability for that branch, and the keys must sum to 100%
 
 ```json
 {

--- a/src/content/docs/ai-gateway/features/dynamic-routing/json-configuration.mdx
+++ b/src/content/docs/ai-gateway/features/dynamic-routing/json-configuration.mdx
@@ -54,7 +54,7 @@ Evaluates a condition based on request parameters and routes the request accordi
 	"id": "<id>",
 	"type": "conditional",
 	"properties": {
-		"condition": {
+		"conditions": {
 			"metadata.plan": { "$eq": "free" } // Supports MongoDB-like operators
 		}
 	},
@@ -70,9 +70,8 @@ Evaluates a condition based on request parameters and routes the request accordi
 Routes requests probabilistically across multiple outputs, useful for A/B testing and gradual rollouts.
 
 - **Inputs**: Request
-- **Outputs**: Up to 5 named percentage outputs, plus an optional `else` fallback
-  - Each output has a fractional probability (must total 100%)
-  - `else` output handles remaining percentage if other branches don't sum to 100%
+- **Outputs**: Up to 5 named percentage outputs
+  - Each output has a fractional probability and the values must total 100%
 
 ```json
 {
@@ -80,8 +79,8 @@ Routes requests probabilistically across multiple outputs, useful for A/B testin
 	"type": "percentage",
 	"outputs": {
 		"10%": { "elementId": "<id>" },
-		"50%": { "elementId": "<id>" },
-		"else": { "elementId": "<id>" }
+		"40%": { "elementId": "<id>" },
+		"50%": { "elementId": "<id>" }
 	}
 }
 ```
@@ -100,19 +99,17 @@ Apply limits based on request metadata. Supports both count-based and cost-based
 - `limitType`: "count" or "cost"
 - `key`: Request field to use for rate limiting (e.g. "metadata.user_id")
 - `limit`: Maximum allowed requests/cost
-- `interval`: Time window in seconds
-- `technique`: "sliding" or "fixed" window
+- `window`: Time window in seconds
 
 ```json
 {
 	"id": "<id>",
-	"type": "rate_limit",
+	"type": "rate",
 	"properties": {
 		"limitType": "count",
 		"key": "metadata.user_id",
 		"limit": 100,
-		"interval": 3600,
-		"technique": "sliding"
+		"window": 3600
 	},
 	"outputs": {
 		"success": { "elementId": "node_model_workers_ai" },
@@ -159,11 +156,12 @@ Executes inference using a specified model and provider with configurable timeou
 Marks the end of a route. Returns the last successful model response, or an error if no model response was generated.
 
 - **Inputs**: Request
-- **Outputs**: None
+- **Outputs**: None (provide an empty `outputs` object)
 
 ```json
 {
 	"id": "<id>",
-	"type": "end"
+	"type": "end",
+	"outputs": {}
 }
 ```


### PR DESCRIPTION
The example JSON on `/ai-gateway/features/dynamic-routing/json-configuration/` does not match the REST API schema for `POST /accounts/{account_id}/ai-gateway/gateways/{gateway_id}/routes`. Following the doc as-written produces 400s (and in two cases, silent property drops).

I confirmed each of these against the live API on a test account today:

- `conditional` properties: `condition` is silently dropped; the API only knows `conditions`.
- `percentage`: `else` is rejected (`code 7001 Invalid` on `outputs.else`). The remaining named outputs must total 100%.
- `rate`: the type discriminator is `rate`, not `rate_limit` (`Expected 'start' | 'conditional' | 'percentage' | 'rate' | 'model' | 'end'`). The time field is `window`, not `interval`. `technique` is silently dropped.
- `end`: the API requires an `outputs` field (`code 7001 Required` on `outputs`). An empty object is accepted.

Updates the five JSON examples and surrounding prose so that copying them into a `curl` against the API succeeds.