### PR TITLE
[WAF, Turnstile, Bots] Add protect forms from spam and abuse solution guide

### DIFF
--- a/src/content/docs/use-cases/solutions/discover-secure-api-endpoints.mdx
+++ b/src/content/docs/use-cases/solutions/discover-secure-api-endpoints.mdx
@@ -13,7 +13,7 @@ tags:
   - REST API
   - Security
 sidebar:
-  label: Secure API endpoints (Free, Pro, Business)
+  label: Secure API endpoints
 ---
 
 import { Render, Steps, Tabs, TabItem, DashButton } from "~/components";
@@ -22,9 +22,7 @@ Once your API is in production and receiving traffic, you need to decide which e
 
 The core workflow uses [Cloudflare Application Security](/waf/) (also known as Web Application Firewall or WAF) features, [SSL/TLS](/ssl/) settings, and [bot detection](/bots/), all available on Free, Pro, and Business plans. Enterprise callouts cover [API Shield](/api-shield/) capabilities for teams that need schema validation, JSON Web Token (JWT) validation, and sequence analysis.
 
-:::note
-Most procedures in this guide are configured per domain or [zone](/fundamentals/concepts/accounts-and-zones/#zones). Select your domain in the Cloudflare dashboard before starting.
-:::
+<Render file="domain-scope-note" product="use-cases" />
 
 ## Know what you are exposing
 

--- a/src/content/docs/use-cases/solutions/encrypt-all-keep-site-secure.mdx
+++ b/src/content/docs/use-cases/solutions/encrypt-all-keep-site-secure.mdx
@@ -6,7 +6,7 @@ products:
   - ssl
   - client-side-security
 sidebar:
-  label: Enforce HTTPS (Free, Pro, Business)
+  label: Enforce HTTPS
 ---
 
 import { DashButton, Render, Steps, TabItem, Tabs } from "~/components";
@@ -21,9 +21,7 @@ HTTPS on Cloudflare involves two separate connections: visitor to Cloudflare, an
 
 The core workflow is available on Free, Pro, and Business plans.
 
-:::note
-Most procedures in this guide are configured per domain. Select your domain in the Cloudflare dashboard before starting. Client-side security is the exception, as it is configured at the account level.
-:::
+<Render file="domain-scope-note" product="use-cases" params={{ exception: "Client-Side Security is the exception: it is configured at the account level." }} />
 
 ## Configure your SSL/TLS encryption mode
 

--- a/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
+++ b/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
@@ -1,0 +1,255 @@
+---
+pcx_content_type: solution-guide
+title: Protect your forms from spam and abuse (Free, Pro, and Business)
+description: Block spam submissions, fake account creation, and card testing on your web forms using a layered defense.
+products:
+  - turnstile
+  - waf
+  - bots
+  - client-side-security
+sidebar:
+  label: Protect your forms from spam and abuse
+---
+
+import { Render, Steps, DashButton } from "~/components";
+
+When your site has forms that accept user input, you need to decide how to verify that visitors are human, how aggressively to limit repeated submissions, and which request patterns to block outright. The core workflow uses features available on all plans. Pro and Business plan features are included as callouts.
+
+<Render file="domain-scope-note" product="use-cases" params={{ exception: "Turnstile is the exception: widgets are configured at the account level." }} />
+
+## Add Turnstile to your forms
+
+Turnstile verifies visitors are human without visible challenges. This guide uses Managed mode, which automatically chooses between a non-interactive or checkbox challenge based on visitor risk level. For other widget modes, refer to [Widget types](/turnstile/concepts/widget/).
+
+Adding Turnstile involves three steps: create a widget in the dashboard, add the client-side snippet to your form page, and validate the token on your server before processing the submission.
+
+### Create a Turnstile widget
+
+<Render file="create-widget-dashboard" product="turnstile" />
+
+Store the sitekey and secret key. You will use the sitekey in the client-side snippet and the secret key for server-side validation.
+
+### Add the client-side snippet
+
+Add the Turnstile script and widget div to each form you want to protect. Replace `<YOUR-SITE-KEY>` with the sitekey from the previous step.
+
+```html
+<form id="contact-form" action="/submit" method="POST">
+  <input type="text" name="name" placeholder="Name" required />
+  <input type="email" name="email" placeholder="Email" required />
+  <textarea name="message" placeholder="Message" required></textarea>
+  <div class="cf-turnstile" data-sitekey="<YOUR-SITE-KEY>"></div>
+  <button type="submit">Submit</button>
+</form>
+
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+```
+
+The widget renders in the form and generates a token when the visitor passes verification. The token is included in the form submission as the `cf-turnstile-response` field.
+
+### Validate the token on your server
+
+Server-side validation is required. The client-side widget alone does not protect your forms because attackers can submit directly to your form endpoint. Tokens can only be validated once.
+
+Call the Siteverify API before processing any form submission:
+
+```js title="server.js"
+const SECRET_KEY = "your-secret-key";
+
+async function validateTurnstile(token, remoteip) {
+  try {
+    const response = await fetch(
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          secret: SECRET_KEY,
+          response: token,
+          remoteip: remoteip,
+        }),
+      },
+    );
+
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error("Turnstile validation error:", error);
+    return { success: false, "error-codes": ["internal-error"] };
+  }
+}
+```
+
+Replace `"your-secret-key"` with your Turnstile secret key. The endpoint returns a JSON object with a `success` field. Only process the form submission if `success` is `true`.
+
+For validation examples in PHP, Python, Java, and C#, refer to [Validate the token](/turnstile/get-started/server-side-validation/).
+
+## Rate limit form submission endpoints
+
+Some abuse scripts skip the browser entirely and POST directly to your form endpoints. Application Security [rate limiting rules](/waf/rate-limiting-rules/) catch these requests because client-side verification only runs in a browser.
+
+### Find your baseline request rate
+
+Before creating a rate limiting rule, check the normal submission rate for your form endpoints. Your rate limit threshold should be above this baseline to avoid blocking legitimate traffic.
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Analytics** page.
+
+   <DashButton url="/?to=/:account/:zone/security/analytics" />
+
+2. In the **Traffic** tab, select a time period with non-peak traffic.
+
+3. Use the **Add filter** button to narrow results to your form endpoint traffic.
+
+4. Note the typical request rate per IP address. Your rate limit should be above this baseline.
+
+</Steps>
+
+:::note[Enterprise: Request rate analysis]
+The **Request rate analysis** tab in Security Analytics displays request rate distributions for your top unique clients. For details, refer to [Find appropriate rate limit](/waf/rate-limiting-rules/find-rate-limit/).
+:::
+
+### Create a rate limiting rule
+
+Create a rule that limits how many times a single IP address can submit to your form endpoint within a given period. Adjust the path, threshold, and period for your site.
+
+<Render file="create-rate-limiting-rule" product="waf" params={{ ruleName: "Rate limit contact form submissions", expression: '(http.request.uri.path eq "/contact" and http.request.method eq "POST")', expressionHelp: 'Replace "/contact" with your form endpoint path.', threshold: "5" }} />
+
+:::note
+Rate limiting rule parameters (counting characteristics, periods, number of rules) vary by plan. For the full availability matrix, refer to [Rate limiting rules](/waf/rate-limiting-rules/#availability).
+:::
+
+### Configure a custom response for blocked requests (Pro and above)
+
+Instead of showing the default Cloudflare error page when a rate limit is reached, you can configure a custom response. For details, refer to [Create a rate limiting rule in the dashboard](/waf/rate-limiting-rules/create-zone-dashboard/#configure-a-custom-response-for-blocked-requests).
+
+## Add Application Security rules for known abuse patterns
+
+Rate limiting alone does not catch targeted attack patterns like SQL injection or cross-site scripting (XSS) in form fields. Application Security [custom rules](/waf/custom-rules/) and [managed rulesets](/waf/managed-rules/) let you block these specific patterns targeting your form endpoints. Custom rules run before rate limiting rules and managed rulesets in the [execution order](/waf/feature-interoperability/).
+
+### Challenge non-bot requests to form endpoints
+
+Create a custom rule that challenges POST requests to your form endpoints from sources that are not verified bots.
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Security rules** page.
+
+   <DashButton url="/?to=/:account/:zone/security/security-rules" />
+
+2. Select **Create rule** > **Custom rules**.
+
+3. Enter a name for the rule (for example, "Challenge spam form submissions").
+
+4. Under **When incoming requests match**, select **Edit expression** and enter:
+
+   ```txt
+   (http.request.uri.path eq "/contact" and http.request.method eq "POST" and not cf.client.bot)
+   ```
+
+   Replace `/contact` with your form endpoint path. The `not cf.client.bot` clause exempts verified bots (such as search engine crawlers) from the rule.
+
+5. Under **Then take action**, select _Managed Challenge_.
+
+   Start with Managed Challenge to observe which requests are flagged before switching to Block.
+
+6. Select **Deploy**.
+
+</Steps>
+
+After deploying, review [Security Events](/waf/analytics/security-events/) to check whether the rule is matching legitimate traffic. If legitimate users are being challenged, narrow the expression or switch to a less aggressive action.
+
+:::note[Pro plans and above: Managed rulesets]
+The [Cloudflare Managed Ruleset](/waf/managed-rules/reference/cloudflare-managed-ruleset/) protects against common web attack patterns, including form-based injection attacks (SQL injection, XSS). Verify the ruleset is deployed on the **Security rules** page under **Managed rules**. For plan availability, refer to [Managed Rules](/waf/managed-rules/#availability).
+:::
+
+## Turn on bot protection
+
+Bot Fight Mode challenges requests that match known bot patterns across your entire domain. It is available on all plans and requires no configuration beyond turning it on.
+
+<Render file="enable-bfm" product="bots" />
+
+Bot Fight Mode protects your entire domain without endpoint restrictions. You cannot create exceptions using custom rules to bypass Bot Fight Mode.
+
+:::note[Pro, Business, and Enterprise]
+[Super Bot Fight Mode](/bots/get-started/super-bot-fight-mode/) provides more granular controls. You can configure how your domain responds to different categories of bot traffic (definitely automated, likely automated, verified bots) and create exceptions using custom rules with the Skip action. Enterprise customers with [Bot Management](/bots/get-started/bot-management/) can use `cf.bot_management.score` in custom rule expressions for path-specific bot protection.
+:::
+
+## Monitor your form endpoints
+
+After deploying Turnstile, rate limiting rules, and Application Security rules, monitor your form endpoints to verify your rules are working and to detect new attack patterns.
+
+### Review Security Events
+
+[Security Events](/waf/analytics/security-events/) shows requests that Cloudflare security products acted on or flagged, including blocks, challenges, and skips. Filter by your form endpoint paths to see what is being blocked and what is getting through. A high volume of blocked or challenged requests to your form paths confirms the rules are active.
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Analytics** page.
+
+   <DashButton url="/?to=/:account/:zone/security/analytics" />
+
+2. Select the **Events** tab.
+
+3. Use the **Add filter** button to narrow results to your form endpoint traffic.
+
+4. Review the sampled logs. For each event, check:
+
+   - **Action taken**: Whether the request was blocked, challenged, or allowed
+   - **Source**: The rule or feature that triggered the action
+   - **IP address**: Whether a single IP is generating many events
+   - **URI path**: Whether requests target your form endpoints specifically
+
+</Steps>
+
+If legitimate users are being challenged, narrow the rule expression or switch to a less aggressive action.
+
+### Set up security event alerts
+
+Configure a notification to receive alerts when there is an unusual spike in security events on your domain.
+
+For alert types, trigger thresholds, and setup instructions, refer to [Alerts for security events](/waf/reference/alerts/).
+
+### Turn on client-side resource monitoring
+
+If a third-party script is injected into your form page, it can exfiltrate submitted data, including payment information. Client-Side Security monitors third-party scripts on your pages for changes and potential supply chain attacks.
+
+To enable monitoring:
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Security Settings** page.
+
+   <DashButton url="/?to=/:account/:zone/security/settings" />
+
+2. (Optional) Filter by **Client-side abuse**.
+
+3. Turn on **Continuous script monitoring**.
+
+</Steps>
+
+After enabling, review detected scripts on the **Web assets** page under the **Client-side resources** tab to identify any unexpected scripts on your form pages. For the full setup workflow, refer to [Get started with client-side security](/client-side-security/get-started/).
+
+## Related resources
+
+**Turnstile**
+
+- [Get started with Turnstile](/turnstile/get-started/) — create widgets, add the client snippet, and validate tokens
+- [Validate the token](/turnstile/get-started/server-side-validation/) — server-side validation examples in multiple languages
+- [Integrate Turnstile, WAF, and Bot Management](/turnstile/tutorials/integrating-turnstile-waf-and-bot-management/) — tutorial combining all three products for login protection
+
+**Application Security**
+
+- [Custom rules](/waf/custom-rules/) — create rules targeting specific request patterns
+- [Rate limiting rules](/waf/rate-limiting-rules/) — protect endpoints from high-volume abuse
+- [Security features interoperability](/waf/feature-interoperability/) — execution order and interaction between security features
+
+**Bots**
+
+- [Bot Fight Mode](/bots/get-started/bot-fight-mode/) — challenge requests matching bot patterns on Free plans
+- [Super Bot Fight Mode](/bots/get-started/super-bot-fight-mode/) — granular bot controls for Pro and above
+
+**Client-Side Security**
+
+- [Get started with client-side security](/client-side-security/get-started/) — enable monitoring and review detected scripts

--- a/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
+++ b/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
@@ -152,7 +152,7 @@ Create a custom rule that challenges POST requests to your form endpoints from s
 
 5. Under **Then take action**, select _Managed Challenge_.
 
-   Start with Managed Challenge to observe which requests are flagged before switching to Block.
+   Start with _Managed Challenge_ to observe which requests are flagged before switching to _Block_.
 
 6. Select **Deploy**.
 

--- a/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
+++ b/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
@@ -13,7 +13,7 @@ sidebar:
 
 import { Render, Steps, DashButton } from "~/components";
 
-When your site has forms that accept user input, you need to decide how to verify that visitors are human, how aggressively to limit repeated submissions, and which request patterns to block outright. The core workflow uses features available on all plans. Pro and Business plan features are included as callouts.
+Contact, registration, and checkout forms are common targets for automated abuse. This guide covers form protection: verifying that visitors are human, limiting repeated submissions, and blocking known attack patterns. The core workflow uses features available on all plans. Pro and Business plan features are included as callouts.
 
 <Render file="domain-scope-note" product="use-cases" params={{ exception: "Turnstile is the exception: widgets are configured at the account level." }} />
 
@@ -105,6 +105,8 @@ Before creating a rate limiting rule, check the normal submission rate for your 
 4. Note the typical request rate per IP address. Your rate limit should be above this baseline.
 
 </Steps>
+
+If you do not have enough traffic data to establish a baseline, start with a conservative threshold and adjust based on Security Events after deployment.
 
 :::note[Enterprise: Request rate analysis]
 The **Request rate analysis** tab in Security Analytics displays request rate distributions for your top unique clients. For details, refer to [Find appropriate rate limit](/waf/rate-limiting-rules/find-rate-limit/).

--- a/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
+++ b/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
@@ -31,7 +31,7 @@ Store the sitekey and secret key. You will use the sitekey in the client-side sn
 
 ### Add the client-side snippet
 
-Add the Turnstile script and widget div to each form you want to protect. Replace `<YOUR-SITE-KEY>` with the sitekey from the previous step.
+Add the Turnstile script and widget `div` element to each form you want to protect. Replace `<YOUR-SITE-KEY>` with the sitekey from the previous step.
 
 ```html
 <form id="contact-form" action="/submit" method="POST">

--- a/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
+++ b/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
@@ -98,7 +98,7 @@ Before creating a rate limiting rule, check the normal submission rate for your 
 
    <DashButton url="/?to=/:account/:zone/security/analytics" />
 
-2. In the **Traffic** tab, select a time period with non-peak traffic.
+2. In the **Traffic** tab, select a time period with non-peak traffic, or with the lowest visitor activity.
 
 3. Use the **Add filter** button to narrow results to your form endpoint traffic.
 

--- a/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
+++ b/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
@@ -80,7 +80,7 @@ async function validateTurnstile(token, remoteip) {
 }
 ```
 
-Replace `"your-secret-key"` with your Turnstile secret key. The endpoint returns a JSON object with a `success` field. Only process the form submission if `success` is `true`.
+Replace `"<YOUR-SECRET-KEY>"` with your Turnstile secret key. The endpoint returns a JSON object with a `success` field. Only process the form submission if `success` is `true`.
 
 For validation examples in PHP, Python, Java, and C#, refer to [Validate the token](/turnstile/get-started/server-side-validation/).
 

--- a/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
+++ b/src/content/docs/use-cases/solutions/protect-sensitive-forms-fraud-abuse.mdx
@@ -54,7 +54,7 @@ Server-side validation is required. The client-side widget alone does not protec
 Call the Siteverify API before processing any form submission:
 
 ```js title="server.js"
-const SECRET_KEY = "your-secret-key";
+const SECRET_KEY = "<YOUR-SECRET-KEY>";
 
 async function validateTurnstile(token, remoteip) {
   try {

--- a/src/content/docs/use-cases/solutions/stop-account-takeover-attacks.mdx
+++ b/src/content/docs/use-cases/solutions/stop-account-takeover-attacks.mdx
@@ -119,7 +119,7 @@ The widget renders inside the `div` and produces a token when the visitor passes
 
 Before processing the form submission, send the token to the Turnstile siteverify endpoint to confirm the visitor passed the challenge.
 ```js title="server.js"
-const SECRET_KEY = "your-secret-key";
+const SECRET_KEY = "<YOUR-SECRET-KEY>";
 
 async function validateTurnstile(token, remoteip) {
 	try {
@@ -147,7 +147,7 @@ async function validateTurnstile(token, remoteip) {
 }
 ```
 
-Replace `"your-secret-key"` with your Turnstile secret key. The endpoint returns a JSON object with a `success` field. Only process the form submission if `success` is `true`.
+Replace `"<YOUR-SECRET-KEY>"` with your Turnstile secret key. The endpoint returns a JSON object with a `success` field. Only process the form submission if `success` is `true`.
 
 For additional fraud detection, Turnstile supports [Ephemeral IDs](/turnstile/tutorials/fraud-detection-with-ephemeral-ids/) that provide a unique, temporary identifier for each visitor session without storing personal data.
 

--- a/src/content/docs/use-cases/solutions/stop-account-takeover-attacks.mdx
+++ b/src/content/docs/use-cases/solutions/stop-account-takeover-attacks.mdx
@@ -8,7 +8,7 @@ products:
   - turnstile
   - waf
 sidebar:
-  label: Stop account takeover (Free, Pro, Business)
+  label: Stop account takeover
 ---
 
 import {
@@ -20,9 +20,7 @@ import {
 
 When your site has login pages, you need to decide how to verify that visitors are human, how aggressively to limit failed attempts, and which request patterns to block. This guide covers five stages: enforce HTTPS, turn on bot protection, add [Turnstile](/turnstile/) to your login form, create Application Security [rate limiting rules](/waf/rate-limiting-rules/) and [custom rules](/waf/custom-rules/) for suspicious patterns, and monitor for ongoing attacks using [SSL/TLS](/ssl/) transport security and [Cloudflare bot solutions](/bots/). The core workflow covers features available on Free, Pro, and Business plans. Enterprise features such as leaked credentials custom detection locations and Bot Management custom rules are included as callouts.
 
-:::note
-Most procedures in this guide are configured per domain. Select your domain in the Cloudflare dashboard before starting. Turnstile is the exception. It is configured at the account level.
-:::
+<Render file="domain-scope-note" product="use-cases" params={{ exception: "Turnstile is the exception: widgets are configured at the account level." }} />
 
 ## Enforce HTTPS to protect credentials in transit
 
@@ -174,45 +172,17 @@ The following example creates a rate limiting rule that issues a Managed Challen
 Managed Challenge and other [challenge types](/cloudflare-challenges/challenge-types/challenge-pages/) require an HTML response to render. They do not work for non-HTML responses such as AJAX/XHR requests, which are common on login endpoints that use single-page applications (SPAs) or API-based authentication. If your login flow uses AJAX, consider using [Turnstile Pre-Clearance](/turnstile/additional-configuration/pre-clearance-support/) instead.
 :::
 
-<Steps>
+<Render file="create-rate-limiting-rule" product="waf" params={{ ruleName: "Rate limit login endpoint", expression: 'http.host eq "example.com" and http.request.uri.path eq "/login" and http.request.method eq "POST"', expressionHelp: 'Replace `example.com` with your domain and `/login` with your login endpoint path.', threshold: "5" }} />
 
-1. In the Cloudflare dashboard, go to the **Security rules** page.
+:::note
+(Optional) To count only failed login attempts instead of all matching requests, Business plan and above users can add a separate counting expression under **Increment counter when**:
 
-   <DashButton url="/?to=/:account/:zone/security/security-rules" />
+```txt
+http.request.uri.path eq "/login" and http.request.method eq "POST" and http.response.code in {401 403}
+```
 
-2. Select **Create rule** and choose **Rate limiting rules**.
-
-3. Enter a name for the rule (for example, "Rate limit login endpoint").
-
-4. Under **When incoming requests match**, enter the following expression:
-
-   ```txt
-   http.host eq "example.com" and http.request.uri.path eq "/login" and http.request.method eq "POST"
-   ```
-
-   Replace `example.com` with your domain and `/login` with your login endpoint path.
-
-5. Under **With the same characteristics**, verify that _IP_ is selected. On Free plans, this is preset to _IP_.
-
-6. Under **When rate exceeds**, enter _5_ for **Requests** and select a value for **Period**. On Free plans, select _10 seconds_. Pro and above plans offer additional periods. For available values by plan, refer to [Rate limiting parameters](/waf/rate-limiting-rules/parameters/).
-
-7. Under **Then take action**, select an action from the **Choose action** dropdown. On Free plans, select _Block_. On Pro and above, _Managed Challenge_ is recommended as it allows legitimate users who trigger the limit to pass by completing a challenge.
-
-8. Under **For duration**, select a duration for the action. On Free plans, select _10 seconds_. Pro and above plans offer longer durations. This is how long the action applies after the rate limit is triggered.
-
-9. Select **Deploy**.
-
-   :::note
-   (Optional) To count only failed login attempts instead of all matching requests, Business plan and above users can add a separate counting expression under **Increment counter when**:
-
-   ```txt
-   http.request.uri.path eq "/login" and http.request.method eq "POST" and http.response.code in {401 403}
-   ```
-
-   This counts requests based on the response status code. Successful logins (200) do not increment the counter.
-   :::
-
-</Steps>
+This counts requests based on the response status code. Successful logins (200) do not increment the counter.
+:::
 
 :::note[Advanced Rate Limiting (Enterprise)]
 Enterprise customers with Advanced Rate Limiting can rate limit by characteristics beyond IP address, which is useful when attackers distribute attempts across many IP addresses. For available characteristics and plan availability, refer to [Rate limiting parameters](/waf/rate-limiting-rules/parameters/).

--- a/src/content/docs/use-cases/solutions/stop-malicious-bots.mdx
+++ b/src/content/docs/use-cases/solutions/stop-malicious-bots.mdx
@@ -7,12 +7,14 @@ products:
   - bots
   - turnstile
 sidebar:
-  label: Block bots (Free, Pro, Business)
+  label: Block bots
 ---
 
 import { Tabs, TabItem, Steps, Render, DashButton } from "~/components";
 
-The right defense against malicious bot traffic depends on the traffic patterns on your site and your plan. This guide covers a layered approach using [Cloudflare Bots](/bots/), [Cloudflare Application Security](/waf/) (also known as Web Application Firewall or WAF), and [Turnstile](/turnstile/), from baseline protection to targeted custom rules. The core workflow uses features on Free, Pro, and Business plans, with callouts for Enterprise options. Most settings in this guide are configured per domain. [Select a domain](https://dash.cloudflare.com/) in the Cloudflare dashboard before following the steps below.
+The right defense against malicious bot traffic depends on the traffic patterns on your site and your plan. This guide covers a layered approach using [Cloudflare Bots](/bots/), [Cloudflare Application Security](/waf/) (also known as Web Application Firewall or WAF), and [Turnstile](/turnstile/), from baseline protection to targeted custom rules. The core workflow uses features on Free, Pro, and Business plans, with callouts for Enterprise options.
+
+<Render file="domain-scope-note" product="use-cases" params={{ exception: "Turnstile is the exception: widgets are configured at the account level." }} />
 
 ## Review your bot traffic
 

--- a/src/content/partials/use-cases/domain-scope-note.mdx
+++ b/src/content/partials/use-cases/domain-scope-note.mdx
@@ -1,6 +1,6 @@
 ---
 params:
-  - exception
+  - exception?
 ---
 
 :::note

--- a/src/content/partials/use-cases/domain-scope-note.mdx
+++ b/src/content/partials/use-cases/domain-scope-note.mdx
@@ -1,0 +1,8 @@
+---
+params:
+  - exception
+---
+
+:::note
+Most procedures in this guide are configured per domain or [zone](/fundamentals/concepts/accounts-and-zones/#zones). Select your domain in the Cloudflare dashboard before starting. {props.exception ?? ""}
+:::

--- a/src/content/partials/waf/create-rate-limiting-rule.mdx
+++ b/src/content/partials/waf/create-rate-limiting-rule.mdx
@@ -1,0 +1,35 @@
+---
+params:
+  - ruleName
+  - expression
+  - expressionHelp
+  - threshold
+---
+
+import { Steps, DashButton } from "~/components";
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Security rules** page.
+
+   <DashButton url="/?to=/:account/:zone/security/security-rules" />
+
+2. Select **Create rule** and choose **Rate limiting rules**.
+
+3. Enter a name for the rule (for example, "{props.ruleName}").
+
+4. Under **When incoming requests match**, select **Edit expression** and enter: <code>{props.expression}</code>
+
+   {props.expressionHelp}
+
+5. Under **With the same characteristics**, verify that _IP_ is selected. On Free plans, this is preset to _IP_.
+
+6. Under **When rate exceeds**, enter _{props.threshold}_ for **Requests** and select a value for **Period**. On Free plans, select _10 seconds_. Pro and above plans offer additional periods. For available values by plan, refer to [Rate limiting parameters](/waf/rate-limiting-rules/parameters/).
+
+7. Under **Then take action**, select an action from the **Choose action** dropdown. On Free plans, select _Block_. On Pro and above, _Managed Challenge_ is recommended because it allows legitimate users who trigger the limit to pass by completing a challenge.
+
+8. Under **For duration**, select a duration for the action. On Free plans, select _10 seconds_. Pro and above plans offer longer durations. This is how long the action applies after the rate limit is triggered.
+
+9. Select **Deploy**.
+
+</Steps>


### PR DESCRIPTION
### Summary

New solution guide for PCX-21348: protect public forms from spam and abuse using Turnstile, WAF rate limiting, custom rules, Bot Fight Mode, and Client-Side Security. Targets Free, Pro, and Business plans with plan-gated callouts for higher-tier features.

Also creates two shared partials and updates all existing solution guides to use them:

- `waf/create-rate-limiting-rule` — parameterized rate limiting rule creation procedure with plan-aware steps (action, period, duration, characteristics). Used by the forms guide and account takeover guide.
- `use-cases/domain-scope-note` — shared "configured per domain or zone" callout with optional exception param. Used by all 5 solution guides.

Removes plan tier from sidebar labels across all solution guides (plan tier stays in the page title).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
