### PR TITLE
fix: normalize external_link paths to lowercase in sitemap filter

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -78,7 +78,7 @@ async function getExternalLinkPaths(dir: string): Promise<Set<string>> {
 				rel = rel.replace(/\.(mdx|md)$/, "");
 				rel = rel.replace(/\/index$/, "/");
 				if (!rel.endsWith("/")) rel += "/";
-				paths.add(rel);
+				paths.add(rel.toLowerCase());
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`getExternalLinkPaths()` in `astro.config.ts` builds paths directly from filesystem filenames. For files with uppercase names like `D1.mdx` and `R2.mdx`, it produced paths like `/workers/runtime-apis/bindings/D1/` — but Astro lowercases all generated URLs, so the sitemap contains `/workers/runtime-apis/bindings/d1/`.

The sitemap filter's `externalLinkPaths.has(pathname)` check was therefore case-sensitive and missing these two pages, so they leaked into the sitemap despite having `external_link` frontmatter and a `noindex` meta tag.

**Fix:** call `.toLowerCase()` on the path before adding it to the exclusion set.

**Affected pages that were incorrectly included in the sitemap:**
- `/workers/runtime-apis/bindings/d1/` (file: `D1.mdx`)
- `/workers/runtime-apis/bindings/r2/` (file: `R2.mdx`)

These pages were flagged as `js-redirect` failures in the afdocs audit for the Workers product.