### PR TITLE
[DNS] Fix footnotes inside Tabs panels generating duplicate headings

### DIFF
--- a/.semgrep/style-guide-footnotes-in-tabs.yaml
+++ b/.semgrep/style-guide-footnotes-in-tabs.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: style-guide-footnotes-in-tabs
+    languages: [generic]
+    message: >
+      Hover-style footnote syntax found inside a <Tabs> block. It generates a '## Footnotes'
+      heading inside each tab panel; when the same footnote appears in multiple tabs, that
+      heading repeats across tab groups and fails the section-header-quality agent-friendliness
+      check. Use plain text footnotes (<sup>n</sup>) or inline the text instead.
+      (add [skip style guide checks] to commit message to skip)
+    severity: MEDIUM
+    paths:
+      include:
+        - "*.mdx"
+    patterns:
+      - pattern-inside: |
+          <Tabs ...>
+          ... ... ... ... ...
+          </Tabs>
+      - pattern-regex: '\[\^\w+\]'

--- a/src/content/docs/style-guide/formatting/footnotes.mdx
+++ b/src/content/docs/style-guide/formatting/footnotes.mdx
@@ -22,6 +22,10 @@ With this type of footnote, you can add the numbers to the MDX file in any order
 
 The hover ability of this type of footnote is powered by [tippy.js](https://atomiks.github.io/tippyjs/).
 
+:::caution
+Do not use this syntax inside `<Tabs>` blocks or in partials included inside `<Tabs>` blocks. It generates a `## Footnotes` heading inside each tab panel, which repeats across tabs and breaks agent-readable documentation. Use plain text footnotes or inline the text instead.
+:::
+
 ### Plain text footnotes
 
 To add plain text footnotes, use the syntax in this example:
@@ -30,6 +34,6 @@ To add plain text footnotes, use the syntax in this example:
 This is a sentence with a footnote.<sup>1</sup>
 
 <sup>1</sup> A footnote adds details or context.
-
 ```
+
 With this type of footnote, you can add the footnote note anywhere on the page. We recommend adding it to the bottom of the section or table where the footnote is referenced or to the bottom of the page.

--- a/src/content/partials/dns/internal-dns-view-conditions.mdx
+++ b/src/content/partials/dns/internal-dns-view-conditions.mdx
@@ -4,8 +4,8 @@
 ---
 
 - DNS views can be empty, with no [internal zones](/dns/internal-dns/internal-zones/) linked to them.
-- A DNS view cannot contain public DNS zones [^1].
+- A DNS view cannot contain public DNS zones.<sup>1</sup>
 - Each internal DNS zone name must be unique within a given DNS view.
 - Each DNS view name must be unique within a given Cloudflare account.
 
-[^1]: DNS zones that contain public DNS records and are accessible by public resolvers.
+<sup>1</sup> DNS zones that contain public DNS records and are accessible by public resolvers.

--- a/src/content/partials/dns/internal-zones-conditions.mdx
+++ b/src/content/partials/dns/internal-zones-conditions.mdx
@@ -5,8 +5,8 @@
 
 - Internal zones can contain the same [DNS record types](/dns/manage-dns-records/reference/dns-record-types/) that Cloudflare supports for public zones.
 - An internal zone can have the same name as a public zone in the same account.
-- Each internal zone can be linked to multiple [views](/dns/internal-dns/dns-views/).<sup>20</sup>
+- Each internal zone can be linked to multiple [views](/dns/internal-dns/dns-views/).<sup>1</sup>
 - There can be several internal zones with the same name in one account. However, two internal zones with the same name cannot be linked to the same view.
 - Internal zones are not subject to any top-level domain (TLD) restrictions. This means that an internal zone can be created if its TLD is not registered publicly (for example, `xyz.local`), if it is created on the TLD itself (`local`), or even if on the root (`.`).
 
-<sup>20</sup> Logical groupings of internal DNS zones that are referenced by Gateway resolver policies to define how a specific query should be resolved.
+<sup>1</sup> Logical groupings of internal DNS zones that are referenced by Gateway resolver policies to define how a specific query should be resolved.

--- a/src/content/partials/dns/internal-zones-conditions.mdx
+++ b/src/content/partials/dns/internal-zones-conditions.mdx
@@ -5,8 +5,8 @@
 
 - Internal zones can contain the same [DNS record types](/dns/manage-dns-records/reference/dns-record-types/) that Cloudflare supports for public zones.
 - An internal zone can have the same name as a public zone in the same account.
-- Each internal zone can be linked to multiple [views](/dns/internal-dns/dns-views/)[^20].
+- Each internal zone can be linked to multiple [views](/dns/internal-dns/dns-views/).<sup>20</sup>
 - There can be several internal zones with the same name in one account. However, two internal zones with the same name cannot be linked to the same view.
 - Internal zones are not subject to any top-level domain (TLD) restrictions. This means that an internal zone can be created if its TLD is not registered publicly (for example, `xyz.local`), if it is created on the TLD itself (`local`), or even if on the root (`.`).
 
-[^20]: Logical groupings of internal DNS zones that are referenced by Gateway resolver policies to define how a specific query should be resolved.
+<sup>20</sup> Logical groupings of internal DNS zones that are referenced by Gateway resolver policies to define how a specific query should be resolved.


### PR DESCRIPTION
Fixes duplicate `## Footnotes` headings appearing inside Dashboard/API tab panels on the Internal DNS get-started page, which caused the section-header-quality agent-friendliness check to fail.

- Convert `[^20]` and `[^1]` in `internal-zones-conditions` and `internal-dns-view-conditions` partials to plain `<sup>` footnotes
- Add semgrep rule to catch `[^n]` syntax inside `<Tabs>` blocks going forward
- Update footnotes style guide to recommend plain text footnotes and warn against `[^n]` inside `<Tabs>`

## Images

#### Before
<img width="1440" height="568" alt="1" src="https://github.com/user-attachments/assets/9cd0a0fb-2e65-49ec-ba82-5e9fa00a894e" />


