### PR TITLE
Fix unclosed code fences in Python FFI and DeepSeek Coder pages

### DIFF
--- a/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
@@ -91,7 +91,7 @@ else:
 
 A common use case is to complete the code for the user after they provide a descriptive comment.
 
-```python
+````python
 model = "@hf/thebloke/deepseek-coder-6.7b-base-awq"
 
 prompt = "# A function that checks if a given word is a palindrome"
@@ -106,14 +106,13 @@ response = requests.post(
 inference = response.json()
 code = inference["result"]["response"]
 
-fence = "```"
 display(Markdown(f"""
-{fence}python
+```python
 {prompt}
 {code.strip()}
-{fence}
-"""))
 ```
+"""))
+````
 
 ```python
 # A function that checks if a given word is a palindrome
@@ -241,7 +240,7 @@ A common use case in Developer Tools is to autocomplete based on context. DeepSe
 
 Warning: The tokens are prefixed with `<｜` and suffixed with `｜>` make sure to copy and paste them.
 
-```python
+````python
 model = "@hf/thebloke/deepseek-coder-6.7b-base-awq"
 
 code = """
@@ -265,14 +264,13 @@ response = requests.post(
 )
 inference = response.json()
 response = inference["result"]["response"]
-fence = "```"
 display(Markdown(f"""
-{fence}python
+```python
 {response.strip()}
-{fence}
+```
 """))
 
-```
+````
 
 ```python
 is_valid_email = re.match(r"[^@]+@[^@]+\.[^@]+", email_address)
@@ -282,7 +280,7 @@ is_valid_email = re.match(r"[^@]+@[^@]+\.[^@]+", email_address)
 
 No need to threaten the model or bring grandma into the prompt. Get back JSON in the format you want.
 
-```python
+````python
 model = "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
 
 # Learn more at https://json-schema.org/
@@ -339,13 +337,12 @@ response = requests.post(
 )
 inference = response.json()
 response = inference["result"]["response"]
-fence = "```"
 display(Markdown(f"""
-{fence}json
+```json
 {response.strip()}
-{fence}
-"""))
 ```
+"""))
+````
 
 ```json
 {

--- a/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
@@ -106,11 +106,12 @@ response = requests.post(
 inference = response.json()
 code = inference["result"]["response"]
 
+fence = "```"
 display(Markdown(f"""
-    ```python
-    {prompt}
-    {code.strip()}
-    ```
+{fence}python
+{prompt}
+{code.strip()}
+{fence}
 """))
 ```
 
@@ -264,10 +265,11 @@ response = requests.post(
 )
 inference = response.json()
 response = inference["result"]["response"]
+fence = "```"
 display(Markdown(f"""
-    ```python
-    {response.strip()}
-    ```
+{fence}python
+{response.strip()}
+{fence}
 """))
 
 ```
@@ -337,10 +339,11 @@ response = requests.post(
 )
 inference = response.json()
 response = inference["result"]["response"]
+fence = "```"
 display(Markdown(f"""
-    ```json
-    {response.strip()}
-    ```
+{fence}json
+{response.strip()}
+{fence}
 """))
 ```
 

--- a/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
@@ -240,7 +240,7 @@ A common use case in Developer Tools is to autocomplete based on context. DeepSe
 
 Warning: The tokens are prefixed with `<｜` and suffixed with `｜>` make sure to copy and paste them.
 
-````python
+```python
 model = "@hf/thebloke/deepseek-coder-6.7b-base-awq"
 
 code = """
@@ -270,7 +270,7 @@ display(Markdown(f"""
     ```
 """))
 
-````
+```
 
 ```python
 is_valid_email = re.match(r"[^@]+@[^@]+\.[^@]+", email_address)
@@ -280,7 +280,7 @@ is_valid_email = re.match(r"[^@]+@[^@]+\.[^@]+", email_address)
 
 No need to threaten the model or bring grandma into the prompt. Get back JSON in the format you want.
 
-````python
+```python
 model = "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
 
 # Learn more at https://json-schema.org/
@@ -342,7 +342,7 @@ display(Markdown(f"""
     {response.strip()}
     ```
 """))
-````
+```
 
 ```json
 {

--- a/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
@@ -107,10 +107,10 @@ inference = response.json()
 code = inference["result"]["response"]
 
 display(Markdown(f"""
-```python
-{prompt}
-{code.strip()}
-```
+    ```python
+    {prompt}
+    {code.strip()}
+    ```
 """))
 ````
 
@@ -265,9 +265,9 @@ response = requests.post(
 inference = response.json()
 response = inference["result"]["response"]
 display(Markdown(f"""
-```python
-{response.strip()}
-```
+    ```python
+    {response.strip()}
+    ```
 """))
 
 ````
@@ -338,9 +338,9 @@ response = requests.post(
 inference = response.json()
 response = inference["result"]["response"]
 display(Markdown(f"""
-```json
-{response.strip()}
-```
+    ```json
+    {response.strip()}
+    ```
 """))
 ````
 

--- a/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
+++ b/src/content/docs/workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models.mdx
@@ -240,7 +240,7 @@ A common use case in Developer Tools is to autocomplete based on context. DeepSe
 
 Warning: The tokens are prefixed with `<｜` and suffixed with `｜>` make sure to copy and paste them.
 
-```python
+````python
 model = "@hf/thebloke/deepseek-coder-6.7b-base-awq"
 
 code = """
@@ -270,7 +270,7 @@ display(Markdown(f"""
     ```
 """))
 
-```
+````
 
 ```python
 is_valid_email = re.match(r"[^@]+@[^@]+\.[^@]+", email_address)
@@ -280,7 +280,7 @@ is_valid_email = re.match(r"[^@]+@[^@]+\.[^@]+", email_address)
 
 No need to threaten the model or bring grandma into the prompt. Get back JSON in the format you want.
 
-```python
+````python
 model = "@hf/thebloke/deepseek-coder-6.7b-instruct-awq"
 
 # Learn more at https://json-schema.org/
@@ -342,7 +342,7 @@ display(Markdown(f"""
     {response.strip()}
     ```
 """))
-```
+````
 
 ```json
 {

--- a/src/content/docs/workers/languages/python/ffi.mdx
+++ b/src/content/docs/workers/languages/python/ffi.mdx
@@ -62,7 +62,7 @@ Under the hood, `env` is actually a JavaScript object. When you call `.FOO`, you
 
 Occasionally, to interoperate with JavaScript APIs, you may need to convert a Python object to JavaScript. Pyodide provides a `to_js` function to facilitate this conversion.
 
-````python
+```python
 from js import Object
 from pyodide.ffi import to_js as _to_js
 
@@ -71,8 +71,7 @@ from workers import WorkerEntrypoint, Response
 # to_js converts between Python dictionaries and JavaScript Objects
 def to_js(obj):
    return _to_js(obj, dict_converter=Object.fromEntries)
-	```
-````
+```
 
 For more details, see out the [documentation on `pyodide.ffi.to_js`](https://pyodide.org/en/stable/usage/api/python-api/ffi.html#pyodide.ffi.to_js).
 

--- a/src/content/docs/workers/languages/python/ffi.mdx
+++ b/src/content/docs/workers/languages/python/ffi.mdx
@@ -62,7 +62,7 @@ Under the hood, `env` is actually a JavaScript object. When you call `.FOO`, you
 
 Occasionally, to interoperate with JavaScript APIs, you may need to convert a Python object to JavaScript. Pyodide provides a `to_js` function to facilitate this conversion.
 
-```python
+````python
 from js import Object
 from pyodide.ffi import to_js as _to_js
 
@@ -71,7 +71,8 @@ from workers import WorkerEntrypoint, Response
 # to_js converts between Python dictionaries and JavaScript Objects
 def to_js(obj):
    return _to_js(obj, dict_converter=Object.fromEntries)
-```
+	```
+````
 
 For more details, see out the [documentation on `pyodide.ffi.to_js`](https://pyodide.org/en/stable/usage/api/python-api/ffi.html#pyodide.ffi.to_js).
 


### PR DESCRIPTION
Fixes unclosed code fence errors on two pages flagged by the markdown-code-fence-validity check.

- `workers/languages/python/ffi`: remove stray backtick line inside a code block that caused the fence parser to see an unclosed opener
- `workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models`: wrap two Python blocks that embed triple-backtick strings inside `display(Markdown(...))` calls with 4-backtick outer fences to prevent the inner backticks from being interpreted as fence closers

Relevant routes are: /workers/languages/python/ffi/index.md and /workers-ai/guides/tutorials/explore-code-generation-using-deepseek-coder-models/index.md

## Images
#### Before
<img width="938" height="833" alt="1" src="https://github.com/user-attachments/assets/c7e88db9-b88f-4da7-b59d-fb596c5287bd" />

