### PR TITLE
docs: add Dynatrace to Logpush third-party integrations

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/third-party/dynatrace.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/third-party/dynatrace.mdx
@@ -1,0 +1,7 @@
+---
+pcx_content_type: how-to
+title: Dynatrace
+external_link: https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-ingestion/lma-push-logs-with-cloudflare
+sidebar:
+  order: 4
+---


### PR DESCRIPTION
## Summary

Adds Dynatrace to the [Logpush third-party integrations](https://developers.cloudflare.com/logs/logpush/logpush-job/enable-destinations/third-party/) page.

Dynatrace has published their Cloudflare Logpush integration guide at:
https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-ingestion/lma-push-logs-with-cloudflare

The guide covers configuration via the Cloudflare dashboard and via API, and was published in October 2025.

## Testing

No functional changes — this is a frontmatter-only file that follows the same pattern as the existing entries (Axiom, Taegis, Exabeam), using `external_link` to point to Dynatrace-hosted documentation.