### PR TITLE
Session recording: document multi-tab viewing and fix DashButton URL

### DIFF
--- a/src/content/dash-routes/core-manually-defined.json
+++ b/src/content/dash-routes/core-manually-defined.json
@@ -15,6 +15,11 @@
 		"parent": ["Compute & AI"]
 	},
 	{
+		"deeplink": "/?to=/:account/workers/browser-run/runs",
+		"name": "Browser Run Runs",
+		"parent": ["Compute & AI"]
+	},
+	{
 		"deeplink": "/?to=/:account/mesh",
 		"name": "Mesh",
 		"parent": ["Networking"]

--- a/src/content/docs/browser-run/features/session-recording.mdx
+++ b/src/content/docs/browser-run/features/session-recording.mdx
@@ -134,14 +134,19 @@ A successful response looks similar to the following:
 	"sessionId": "e26d4660-5b78-4761-b82f-c6b5bad5a925",
 	"duration": 4380,
 	"events": {
-		"target-1": []
+		"target-1": [],
+		"target-2": []
 	}
 }
 ```
 
+The keys in `events` (such as `target-1`, `target-2`) are [CDP targets](https://chromedevtools.github.io/devtools-protocol/tot/Target/). In the context of session recording, each target typically corresponds to a browser tab. A session that opened multiple tabs will have one target per tab, and each target's value is an independent rrweb event array for that tab.
+
 ## Replay a recording
 
-The `events` values in the API response are standard rrweb event arrays. You can pass them directly to [`rrweb-player`](https://github.com/rrweb-io/rrweb/tree/master/packages/rrweb-player) to self-host a replay UI with a timeline scrubber and playback controls.
+Each value in `events` is a standard rrweb event array and can be passed directly to [`rrweb-player`](https://github.com/rrweb-io/rrweb/tree/master/packages/rrweb-player) to self-host a replay UI with a timeline scrubber and playback controls.
+
+Tabs replay independently — to replay a multi-tab session, render one player per target, or build a UI that lets the user switch between targets (similar to the tab selector in the dashboard recording viewer).
 
 ## Limits
 

--- a/src/content/docs/browser-run/features/session-recording.mdx
+++ b/src/content/docs/browser-run/features/session-recording.mdx
@@ -112,9 +112,11 @@ The recording is only available after the browser session closes. CDP sessions t
 
 ## View recordings
 
-After a session closes, its recording is available in the Cloudflare dashboard under **Browser Run** > **Runs**. Select a session to open the recording viewer, where you can scrub through the timeline and replay what happened during the session.
+After a session closes, its recording is available in the Cloudflare dashboard under **Browser Run** > **Runs**. Select the recording icon next to a session to open the recording viewer, where you can scrub through the timeline and replay what happened during the session.
 
-<DashButton url="/?to=/:account/workers/browser-run/logs" />
+If a session opened multiple tabs, the recording viewer shows a tab selector dropdown in the top-right corner of the replay area. Use it to switch between the recorded tabs and view the activity for each one individually.
+
+<DashButton url="/?to=/:account/workers/browser-run/runs" />
 
 ## Retrieve a recording via API
 


### PR DESCRIPTION
- Clarify that users select the recording icon to open the viewer
- Add info about the tab selector dropdown for multi-tab sessions
- Fix DashButton URL from /logs to /runs

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
