### PR TITLE
[Flagship] Use array form for binding configuration

### DIFF
--- a/src/content/docs/flagship/binding/index.mdx
+++ b/src/content/docs/flagship/binding/index.mdx
@@ -20,10 +20,12 @@ Workers access Flagship through a binding that you add to your Wrangler configur
 
 ```jsonc
 {
-	"flagship": {
-		"binding": "FLAGS",
-		"app_id": "<APP_ID>",
-	},
+	"flagship": [
+		{
+			"binding": "FLAGS",
+			"app_id": "<APP_ID>",
+		},
+	],
 }
 ```
 

--- a/src/content/docs/flagship/configuration.mdx
+++ b/src/content/docs/flagship/configuration.mdx
@@ -20,10 +20,12 @@ Add the `flagship` block to your Wrangler configuration file with a binding name
 
 ```jsonc
 {
-	"flagship": {
-		"binding": "FLAGS",
-		"app_id": "<APP_ID>",
-	},
+	"flagship": [
+		{
+			"binding": "FLAGS",
+			"app_id": "<APP_ID>",
+		},
+	],
 }
 ```
 

--- a/src/content/docs/flagship/get-started.mdx
+++ b/src/content/docs/flagship/get-started.mdx
@@ -37,10 +37,12 @@ Add the Flagship binding in your Wrangler configuration file so your Worker can 
 
 ```jsonc
 {
-	"flagship": {
-		"binding": "FLAGS",
-		"app_id": "<APP_ID>",
-	},
+	"flagship": [
+		{
+			"binding": "FLAGS",
+			"app_id": "<APP_ID>",
+		},
+	],
 }
 ```
 


### PR DESCRIPTION
### Summary

Updates the Flagship binding configuration examples across three pages to use the array form consistently. Previously, single-binding examples used an object ("flagship": { ... }), but the correct shape is always an array ("flagship": [{ ... }]), matching how Wrangler parses the binding.
### Screenshots (optional)

NA

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
