### PR TITLE
[Billing] Add Instant Bank Payments via Link documentation

### DIFF
--- a/src/content/docs/billing/index.mdx
+++ b/src/content/docs/billing/index.mdx
@@ -63,6 +63,18 @@ View, download, and manage your Cloudflare invoices.
 
 </CardGrid>
 
+## Payment methods
+
+Learn about payment methods available for Cloudflare services.
+
+<CardGrid>
+
+<LinkTitleCard title="Instant Bank Payments via Link" href="/billing/payment-methods/instant-bank-payments-link/">
+Pay for Cloudflare services directly from your bank account through Link.
+</LinkTitleCard>
+
+</CardGrid>
+
 ## Understand
 
 Learn how Cloudflare billing works.

--- a/src/content/docs/billing/payment-methods/index.mdx
+++ b/src/content/docs/billing/payment-methods/index.mdx
@@ -1,0 +1,15 @@
+---
+pcx_content_type: navigation
+title: Payment methods
+sidebar:
+  order: 4
+  group:
+    hideIndex: true
+description: Learn about payment methods available for Cloudflare services.
+products:
+  - billing
+---
+
+import { DirectoryListing } from "~/components";
+
+<DirectoryListing />

--- a/src/content/docs/billing/payment-methods/index.mdx
+++ b/src/content/docs/billing/payment-methods/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 4
   group:
     hideIndex: true
-description: Learn about payment methods available for Cloudflare services.
+description: Payment methods available for Cloudflare services.
 products:
   - billing
 ---

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -61,7 +61,7 @@ If a bank payment cannot be processed:
    <DashButton url="/?to=/:account/billing" />
 
 Ensure your bank account has sufficient funds and supports instant payments.
-
+2. **Update payment method**: If the issue persists, update your payment method in billing settings.
 ## FAQ
 
 ### How do I know if I paid via Instant Bank Payments?

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -48,7 +48,7 @@ Card-based Link payments display your card's last four digits, distinguishing th
 2. Go to **Manage Account** > **Billing**.
 
    <DashButton url="/?to=/:account/billing" />
-
+## View your payment history
 3. Select **Invoices** to view your invoice and payment history.
 
 ## What happens if a bank payment fails

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -37,7 +37,7 @@ Bank-based Link payments appear in your billing history with these identifiers:
 | --- | --- |
 | Payment method | `link` |
 | Last four digits | `0000` |
-## Identify bank payments
+
 Card-based Link payments display your card's last four digits, distinguishing them from bank payments.
 
 ## View your payment history

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -1,0 +1,88 @@
+---
+title: Instant Bank Payments via Link
+pcx_content_type: concept
+sidebar:
+  order: 1
+  description: Pay for Cloudflare services directly from your bank account through Link
+description: Understand Instant Bank Payments via Link for Cloudflare services.
+products:
+  - billing
+---
+
+import { DashButton } from "~/components";
+
+Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudflare services directly from your bank account. Link is a one-click checkout wallet that remembers your payment details. If you already have a bank account saved in Link, it appears as a payment option at checkout. If not, you can connect one during the checkout flow.
+
+## How Instant Bank Payments works
+
+1. **Checkout** - Cloudflare presents your saved Link payment methods. You can also connect your bank with Link if not already set up.
+2. **Select bank account** - Your bank account appears as a payment option alongside your existing cards.
+3. **Confirm payment** - Select your bank account and confirm.
+4. **Processing** - The payment is authenticated and processed on your behalf.
+
+After your first Link authentication, your bank account is available for future purchases without re-entering details.
+
+:::note
+Instant Bank Payments is an additional payment option. Your existing cards remain available at checkout.
+:::
+
+## Eligibility
+
+Instant Bank Payments via Link is available to US-based self-serve accounts across all Cloudflare products. You can connect your bank account through Link during checkout.
+
+## Identifying bank payments
+
+Bank-based Link payments appear in your billing history with these identifiers:
+
+| Field | Value |
+| --- | --- |
+| Payment method | `link` |
+| Last four digits | `0000` |
+
+Card-based Link payments display your card's last four digits, distinguishing them from bank payments.
+
+## Viewing your payment history
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/).
+2. Go to **Manage Account** > **Billing**.
+
+   <DashButton url="/?to=/:account/billing" />
+
+3. Select **Invoices** to view your invoice and payment history.
+
+## What happens if a bank payment fails
+
+If a bank payment cannot be processed:
+
+1. **Retry or switch** - You are prompted to select a different payment method. You can retry with the same bank account or choose a card.
+2. **Update payment method** - If the issue persists, update your payment method in billing settings.
+
+   <DashButton url="/?to=/:account/billing" />
+
+Ensure your bank account has sufficient funds and supports instant payments.
+
+## FAQ
+
+### How do I know if I paid via Instant Bank Payments?
+
+Your billing history shows the payment method as `link` with last four digits `0000`. Card-based Link payments show your card's actual last four digits.
+
+### Is my bank account secure?
+
+Your bank credentials are stored in the Link wallet using encryption and multi-factor authentication. Your raw bank details are never shared with Cloudflare or other merchants.
+
+### Can I still pay with a card?
+
+Yes. Instant Bank Payments is an additional option. Cards saved in Link or added manually remain available at checkout.
+
+### Is there any difference in processing time?
+
+No. Bank payments through Link process in the same checkout flow as card payments. Your purchase is confirmed immediately.
+
+### Can I remove my bank account from Link?
+
+Yes. Manage your saved payment methods through the [Link wallet](https://link.co/). Removing a bank account does not affect previously completed payments.
+
+### What if I think I was charged incorrectly?
+
+[Contact Cloudflare support](/support/contacting-cloudflare-support/) with your invoice number and payment details.

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -15,7 +15,7 @@ Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudf
 Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudflare services directly from your bank account. Link is a one-click checkout wallet that remembers your payment details. If you already have a bank account saved in Link, it appears as a payment option at checkout. If not, you can connect one during the checkout flow.
 
 ## How Instant Bank Payments works
-
+1. **Checkout**: Cloudflare presents your saved Link payment methods. You can also connect your bank with Link if not already set up.
 2. **Select bank account**: Your bank account appears as a payment option alongside your existing cards.
 2. **Select bank account** - Your bank account appears as a payment option alongside your existing cards.
 3. **Confirm payment** - Select your bank account and confirm.

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -56,7 +56,7 @@ Card-based Link payments display your card's last four digits, distinguishing th
 If a bank payment cannot be processed:
 
 1. **Retry or switch** - You are prompted to select a different payment method. You can retry with the same bank account or choose a card.
-2. **Update payment method** - If the issue persists, update your payment method in billing settings.
+## Failed bank payments
 
    <DashButton url="/?to=/:account/billing" />
 

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -3,7 +3,8 @@ title: Instant Bank Payments via Link
 pcx_content_type: concept
 sidebar:
   order: 1
-  description: Pay for Cloudflare services directly from your bank account through Link
+sidebar:
+  order: 1
 description: Understand Instant Bank Payments via Link for Cloudflare services.
 products:
   - billing

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -72,15 +72,15 @@ Your bank credentials are stored in the Link wallet using encryption and multi-f
 
 ### Card payment availability
 
-Yes. Instant Bank Payments is an additional option. Cards saved in Link or added manually remain available at checkout.
+Instant Bank Payments is an additional option. Cards saved in Link or added manually remain available at checkout.
 
 ### Processing time
 
-No difference. Bank payments through Link process in the same checkout flow as card payments. Your purchase is confirmed immediately.
+Bank payments through Link process in the same checkout flow as card payments. Your purchase is confirmed immediately.
 
 ### Bank account removal
 
-Yes. Manage your saved payment methods through the [Link wallet](https://link.co/). Removing a bank account does not affect previously completed payments.
+You can manage your saved payment methods, including bank accounts, through the [Link wallet](https://link.co/). Removing a bank account does not affect previously completed payments.
 
 ### Incorrect charges
 

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -37,7 +37,7 @@ Bank-based Link payments appear in your billing history with these identifiers:
 | --- | --- |
 | Payment method | `link` |
 | Last four digits | `0000` |
-
+## Identify bank payments
 Card-based Link payments display your card's last four digits, distinguishing them from bank payments.
 
 ## View your payment history

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -58,7 +58,7 @@ If a bank payment cannot be processed:
 1. **Retry or switch** - You are prompted to select a different payment method. You can retry with the same bank account or choose a card.
 ## Failed bank payments
 
-   <DashButton url="/?to=/:account/billing" />
+1. **Retry or switch**: You are prompted to select a different payment method. You can retry with the same bank account or choose a card.
 
 Ensure your bank account has sufficient funds and supports instant payments.
 2. **Update payment method**: If the issue persists, update your payment method in billing settings.

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -16,7 +16,7 @@ Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudf
 
 ## How Instant Bank Payments works
 
-1. **Checkout** - Cloudflare presents your saved Link payment methods. You can also connect your bank with Link if not already set up.
+2. **Select bank account**: Your bank account appears as a payment option alongside your existing cards.
 2. **Select bank account** - Your bank account appears as a payment option alongside your existing cards.
 3. **Confirm payment** - Select your bank account and confirm.
 4. **Processing** - The payment is authenticated and processed on your behalf.

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -11,7 +11,7 @@ products:
 ---
 
 import { DashButton } from "~/components";
-
+Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudflare services directly from your bank account. Link is a one-click checkout wallet that stores your payment details. If you already have a bank account saved in Link, it appears as a payment option at checkout. If not, you can connect one during the checkout flow.
 Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudflare services directly from your bank account. Link is a one-click checkout wallet that remembers your payment details. If you already have a bank account saved in Link, it appears as a payment option at checkout. If not, you can connect one during the checkout flow.
 
 ## How Instant Bank Payments works

--- a/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
+++ b/src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx
@@ -3,23 +3,21 @@ title: Instant Bank Payments via Link
 pcx_content_type: concept
 sidebar:
   order: 1
-sidebar:
-  order: 1
 description: Understand Instant Bank Payments via Link for Cloudflare services.
 products:
   - billing
 ---
 
 import { DashButton } from "~/components";
+
 Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudflare services directly from your bank account. Link is a one-click checkout wallet that stores your payment details. If you already have a bank account saved in Link, it appears as a payment option at checkout. If not, you can connect one during the checkout flow.
-Instant Bank Payments (IBP) via [Link](https://link.co/) lets you pay for Cloudflare services directly from your bank account. Link is a one-click checkout wallet that remembers your payment details. If you already have a bank account saved in Link, it appears as a payment option at checkout. If not, you can connect one during the checkout flow.
 
 ## How Instant Bank Payments works
+
 1. **Checkout**: Cloudflare presents your saved Link payment methods. You can also connect your bank with Link if not already set up.
 2. **Select bank account**: Your bank account appears as a payment option alongside your existing cards.
-2. **Select bank account** - Your bank account appears as a payment option alongside your existing cards.
-3. **Confirm payment** - Select your bank account and confirm.
-4. **Processing** - The payment is authenticated and processed on your behalf.
+3. **Confirm payment**: Select your bank account and confirm.
+4. **Processing**: The payment is authenticated and processed on your behalf.
 
 After your first Link authentication, your bank account is available for future purchases without re-entering details.
 
@@ -31,7 +29,7 @@ Instant Bank Payments is an additional payment option. Your existing cards remai
 
 Instant Bank Payments via Link is available to US-based self-serve accounts across all Cloudflare products. You can connect your bank account through Link during checkout.
 
-## Identifying bank payments
+## Identify bank payments
 
 Bank-based Link payments appear in your billing history with these identifiers:
 
@@ -42,48 +40,48 @@ Bank-based Link payments appear in your billing history with these identifiers:
 
 Card-based Link payments display your card's last four digits, distinguishing them from bank payments.
 
-## Viewing your payment history
+## View your payment history
 
 1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/).
 2. Go to **Manage Account** > **Billing**.
 
    <DashButton url="/?to=/:account/billing" />
-## View your payment history
+
 3. Select **Invoices** to view your invoice and payment history.
 
-## What happens if a bank payment fails
+## Failed bank payments
 
 If a bank payment cannot be processed:
 
-1. **Retry or switch** - You are prompted to select a different payment method. You can retry with the same bank account or choose a card.
-## Failed bank payments
-
 1. **Retry or switch**: You are prompted to select a different payment method. You can retry with the same bank account or choose a card.
+2. **Update payment method**: If the issue persists, update your payment method in billing settings.
+
+   <DashButton url="/?to=/:account/billing" />
 
 Ensure your bank account has sufficient funds and supports instant payments.
-2. **Update payment method**: If the issue persists, update your payment method in billing settings.
+
 ## FAQ
 
-### How do I know if I paid via Instant Bank Payments?
+### Payment identification
 
 Your billing history shows the payment method as `link` with last four digits `0000`. Card-based Link payments show your card's actual last four digits.
 
-### Is my bank account secure?
+### Bank account security
 
 Your bank credentials are stored in the Link wallet using encryption and multi-factor authentication. Your raw bank details are never shared with Cloudflare or other merchants.
 
-### Can I still pay with a card?
+### Card payment availability
 
 Yes. Instant Bank Payments is an additional option. Cards saved in Link or added manually remain available at checkout.
 
-### Is there any difference in processing time?
+### Processing time
 
-No. Bank payments through Link process in the same checkout flow as card payments. Your purchase is confirmed immediately.
+No difference. Bank payments through Link process in the same checkout flow as card payments. Your purchase is confirmed immediately.
 
-### Can I remove my bank account from Link?
+### Bank account removal
 
 Yes. Manage your saved payment methods through the [Link wallet](https://link.co/). Removing a bank account does not affect previously completed payments.
 
-### What if I think I was charged incorrectly?
+### Incorrect charges
 
 [Contact Cloudflare support](/support/contacting-cloudflare-support/) with your invoice number and payment details.


### PR DESCRIPTION
## Summary

Adds Instant Bank Payments via Link documentation and a new **Payment methods** section to the billing docs.

Supersedes #30469, #30434, and #30422.

## Changes

- New section: `billing/payment-methods/` with navigation index
- New page: `src/content/docs/billing/payment-methods/instant-bank-payments-link.mdx`
- Updated `billing/index.mdx` with Payment methods card grid (between Manage and Understand)
- Covers: how it works, eligibility, payment identification, payment failures, FAQ

## Related

- SHIP-14077
- Changelog PR: #30428
- Internal wiki: https://wiki.cfdata.org/spaces/BILL/pages/1396655722

## Checklist

- [x] Content is technically accurate
- [x] New Payment methods section follows existing billing docs structure (matches manage/, understand/, troubleshoot/ pattern)
- [x] Uses MDX components (DashButton) consistent with other billing pages
- [x] Cloudflare voice guidelines applied (density, direct tone, no anti-patterns)
- [x] No internal metrics disclosed (cost savings, auth rates, addressable volume excluded)
- [x] No Stripe references in customer-facing content