### PR TITLE
[1.1.1.1] ELI5 on root files

### DIFF
--- a/src/content/docs/1.1.1.1/check.mdx
+++ b/src/content/docs/1.1.1.1/check.mdx
@@ -9,9 +9,9 @@ sidebar:
 slug: 1.1.1.1/check
 ---
 
-After setting up `1.1.1.1`, you can check if you are correctly connected to Cloudflare's resolver.
+After [setting up 1.1.1.1](/1.1.1.1/setup/), you can verify that your DNS queries are going through Cloudflare's resolver.
 
-1. Open a web browser on a configured device (smartphone or computer) or on a device connected to your configured router.
-2. Enter [https://1.1.1.1/help](https://one.one.one.one/help) on the browser address bar.
+1. Open a web browser on a device that you configured to use 1.1.1.1, or on a device connected to a router you configured.
+2. Go to [https://1.1.1.1/help](https://one.one.one.one/help).
 
-Wait for the page to load and run its tests. The page will present you a summary of the type of connection you have to `1.1.1.1`, as well as the Cloudflare data center you are connected to.
+The page runs a series of tests and shows whether your connection to 1.1.1.1 is working. It also displays which Cloudflare data center is serving your requests.

--- a/src/content/docs/1.1.1.1/faq.mdx
+++ b/src/content/docs/1.1.1.1/faq.mdx
@@ -17,11 +17,11 @@ Below you will find answers to our most commonly asked questions. If you cannot 
 
 ## What is 1.1.1.1?
 
-1.1.1.1 is Cloudflare's fast and secure DNS resolver. When you request to visit an application like `cloudflare.com`, your computer needs to know which server to connect you to so that it can load the application. Computers do not know how to do this name to address translation, so they ask a specialized server to do it for them.
+1.1.1.1 is Cloudflare's fast and secure DNS resolver. When you visit a website like `cloudflare.com`, your computer needs to find the IP address of the server that hosts it. Your computer cannot perform this translation on its own, so it sends the request to a DNS resolver.
 
-This specialized server is called a DNS recursive resolver. The resolver's job is to find the address for a given name, like `2400:cb00:2048:1::c629:d7a2` for `cloudflare.com`, and return it to the computer that asked for it.
+A DNS resolver looks up the IP address for a given domain name (for example, `2400:cb00:2048:1::c629:d7a2` for `cloudflare.com`) and returns it to the requesting device.
 
-Computers are configured to talk to specific DNS resolvers, identified by IP address. Usually the configuration is managed by your ISP (like Comcast or AT\&T) if you are on your home or wireless Internet, and by your network administrator if you are connected to the office Internet. You can also change the configured DNS resolver your computer talks to yourself.
+Your device is usually configured to use a DNS resolver chosen by your ISP (such as Comcast or AT&T) for home or wireless Internet, or by your network administrator for office networks. You can change which DNS resolver your device uses at any time. Refer to [Set up 1.1.1.1](/1.1.1.1/setup/) for instructions.
 
 ## How can I check if my computer / smartphone / tablet is connected to 1.1.1.1?
 
@@ -29,33 +29,35 @@ Visit [1.1.1.1/help](https://one.one.one.one/help) to make sure your system is c
 
 ## What do DNS resolvers do?
 
-DNS resolvers are like address books for the Internet. They translate the name of places to addresses so that your browser can figure out how to get there. DNS resolvers do this by working backwards from the top until they find the website you are looking for.
+DNS resolvers are like address books for the Internet. They translate domain names into IP addresses so that your browser knows which server to contact. A resolver does this by working backwards from the top of the domain name hierarchy.
 
-Every resolver knows how to find the invisible `.` at the end of domain names (for example, `cloudflare.com.`). There are [hundreds of root servers](http://www.root-servers.org/) all over the world that host the `.` file, and resolvers are [hard coded to know the IP addresses](http://www.internic.net/domain/named.root) of those servers. Cloudflare itself hosts [that file](http://www.internic.net/domain/root.zone) on all of its servers around the world through a [partnership with ISC](https://blog.cloudflare.com/f-root/).
+Every resolver knows how to find the invisible `.` at the end of domain names (for example, `cloudflare.com.`). There are [hundreds of root servers](http://www.root-servers.org/) all over the world that host the `.` file. Resolvers come preconfigured with the [IP addresses of those root servers](http://www.internic.net/domain/named.root). Cloudflare itself hosts [that file](http://www.internic.net/domain/root.zone) on all of its servers around the world through a [partnership with ISC](https://blog.cloudflare.com/f-root/).
 
-The resolver asks one of the root servers where to find the next link in the chain — the top-level domain (abbreviated to TLD) or domain ending. An example of a TLD is `.com` or `.org`. Luckily, the root servers store the locations of all the TLD servers, so they can return which IP address the DNS resolver should go ask next.
+The resolver asks one of the root servers where to find the next link in the chain — the top-level domain (TLD), which is the domain ending like `.com` or `.org`. The root servers return the address of the TLD server responsible for that ending.
 
-The resolver then asks the TLD's servers where it can find the domain it is looking for. For example, a resolver might ask `.com` where to find `cloudflare.com`. TLDs host a file containing the location of every domain using the TLD.
+The resolver then asks the TLD server where to find the specific domain. For example, a resolver might ask `.com` where to find `cloudflare.com`. The TLD server responds with the address of the authoritative nameserver that holds the records for that domain.
 
-Once the resolver has the final IP address, it returns the answer to the computer that asked.
+Once the resolver has the final IP address, it returns the answer to the device that asked.
 
-This whole system is called the [Domain Name System (DNS)](https://www.cloudflare.com/learning/dns/what-is-dns/). This system includes the servers that host the information (called [authoritative DNS](https://www.cloudflare.com/learning/dns/dns-server-types/)) and the servers that seek the information (the DNS resolvers).
+This whole system is called the [Domain Name System (DNS)](https://www.cloudflare.com/learning/dns/what-is-dns/). It includes the servers that host domain records (called [authoritative DNS servers](https://www.cloudflare.com/learning/dns/dns-server-types/)) and the servers that look up those records on behalf of users (DNS resolvers).
 
 ## Does 1.1.1.1 support ANY?
 
-Cloudflare [stopped supporting the ANY query](https://blog.cloudflare.com/deprecating-dns-any-meta-query-type/) in 2015 as ANY queries are more often used to perpetuate large volumetric attacks against the DNS system than valid use. 1.1.1.1 returns `NOTIMPL` when asked for `qtype==ANY`.
+No. Cloudflare [stopped supporting the ANY query type](https://blog.cloudflare.com/deprecating-dns-any-meta-query-type/) in 2015. The `ANY` query asks a DNS server to return all record types for a domain at once. In practice, `ANY` is more often used to amplify denial-of-service attacks than for legitimate purposes. When 1.1.1.1 receives an `ANY` query, it responds with `NOTIMPL` (not implemented).
 
 ## How does 1.1.1.1 work with DNSSEC?
 
-1.1.1.1 is a DNSSEC validating resolver. 1.1.1.1 sends the `DO` (`DNSSEC OK`) bit on every query to convey to the authoritative server that it wishes to receive signed answers if available. 1.1.1.1 supports the signature algorithms specified in [Supported DNSKEY signature algorithms](/1.1.1.1/encryption/dnskey/).
+DNSSEC (Domain Name System Security Extensions) lets domain owners cryptographically sign their DNS records. A DNSSEC-validating resolver checks these signatures to confirm that a DNS response is authentic and has not been modified.
 
-## ​Does 1.1.1.1 send EDNS Client Subnet header?
+1.1.1.1 is a DNSSEC-validating resolver. On every query, it sends the `DO` (DNSSEC OK) flag to signal that it can accept signed responses. If the authoritative server provides signed records, 1.1.1.1 validates the signatures before returning the answer. 1.1.1.1 supports the signature algorithms listed in [Supported DNSKEY signature algorithms](/1.1.1.1/encryption/dnskey/).
 
-1.1.1.1 is a privacy centric resolver so it does not send any client IP information and does not send the <GlossaryTooltip term="EDNS Client Subnet (ECS)">EDNS Client Subnet (ECS)</GlossaryTooltip> header to authoritative servers. The exception is the single Akamai debug domain `whoami.ds.akahelp.net` to aid in cross-provider debugging. However, Cloudflare does not send ECS to any of Akamai's production domains, such as `akamaihd.net` or similar.
+## Does 1.1.1.1 send EDNS Client Subnet header?
+
+No. 1.1.1.1 is a privacy-focused resolver and does not include client IP information in its queries to authoritative servers. It does not send the <GlossaryTooltip term="EDNS Client Subnet (ECS)">EDNS Client Subnet (ECS)</GlossaryTooltip> header. The only exception is the Akamai debug domain `whoami.ds.akahelp.net`, which is used for cross-provider debugging. Cloudflare does not send ECS to any of Akamai's production domains, such as `akamaihd.net`.
 
 ## Does 1.1.1.1 support IPv6?
 
-1.1.1.1 has full IPv6 support.
+Yes. 1.1.1.1 has full IPv6 support. Refer to [IP addresses](/1.1.1.1/ip-addresses/) for the IPv6 addresses you can use.
 
 ## What is Purge Cache?
 
@@ -63,4 +65,4 @@ Cloudflare [stopped supporting the ANY query](https://blog.cloudflare.com/deprec
 
 ## Can IPs used by 1.1.1.1 be allowlisted?
 
-Authoritative DNS providers may want to allowlist IP's 1.1.1.1 uses to query upstream DNS providers. The comprehensive list of IP's to allowlist is available at [https://www.cloudflare.com/ips/](https://www.cloudflare.com/ips/).
+Authoritative DNS providers may want to allowlist the IP addresses that 1.1.1.1 uses when querying upstream nameservers. The full list of Cloudflare IP addresses is available at [https://www.cloudflare.com/ips/](https://www.cloudflare.com/ips/).

--- a/src/content/docs/1.1.1.1/index.mdx
+++ b/src/content/docs/1.1.1.1/index.mdx
@@ -19,25 +19,27 @@ Speed up your online experience with Cloudflare's public DNS resolver.
 
 <Plan type="all" />
 
-1.1.1.1 is Cloudflare’s public DNS resolver. It offers a fast and private way to browse the Internet. [DNS resolvers](https://www.cloudflare.com/learning/dns/what-is-dns/) translate domains like `cloudflare.com` into the IP addresses necessary to reach the website (like `104.16.123.96`).
+1.1.1.1 is Cloudflare's public [DNS resolver](https://www.cloudflare.com/learning/dns/what-is-dns/). When you type a domain name like `cloudflare.com` into your browser, a DNS resolver translates that name into an IP address (for example, `104.16.123.96`) so your device knows which server to contact.
 
-Unlike most DNS resolvers, 1.1.1.1 does not sell user data to advertisers. 1.1.1.1 has also been measured to be the [fastest DNS resolver available](https://www.dnsperf.com/#!dns-resolvers) — it is deployed in [hundreds of cities worldwide](https://www.cloudflare.com/network/), and has access to the addresses of millions of domain names on the same servers it runs on.
+Most people use the DNS resolver assigned by their Internet Service Provider (ISP). Switching to 1.1.1.1 gives you a faster, more private alternative. Unlike most DNS resolvers, 1.1.1.1 does not sell user data to advertisers.
 
-1.1.1.1 is completely free. Setting it up takes minutes and requires no special software.
+1.1.1.1 has been measured as the [fastest public DNS resolver](https://www.dnsperf.com/#!dns-resolvers). It runs on Cloudflare's network in [hundreds of cities worldwide](https://www.cloudflare.com/network/) and has access to the addresses of millions of domains on the same servers it runs on.
+
+1.1.1.1 is free. Setting it up takes minutes and does not require any special software.
 
 ---
 
 ## Features
 
 <Feature header="1.1.1.1 for Families" href="/1.1.1.1/setup/#1111-for-families">
-	1.1.1.1 for Families has additional protection against malware and adult
-	content.
+	1.1.1.1 for Families adds protection against malware and adult
+	content on top of the standard resolver.
 </Feature>
 
-<Feature header="Encrypted service" href="/1.1.1.1/encryption/">
-	1.1.1.1 offers an encrypted service through DNS over HTTPS (DoH) or DNS over
-	TLS (DoT) for increased security and privacy. You can also access 1.1.1.1 [as
-	a Tor hidden service](/1.1.1.1/additional-options/dns-over-tor/).
+<Feature header="Encrypted DNS" href="/1.1.1.1/encryption/">
+	1.1.1.1 supports DNS over HTTPS (DoH) and DNS over TLS (DoT) to
+	encrypt your DNS queries and prevent eavesdropping. You can also access
+	1.1.1.1 [as a Tor hidden service](/1.1.1.1/additional-options/dns-over-tor/).
 </Feature>
 
 ---
@@ -45,7 +47,7 @@ Unlike most DNS resolvers, 1.1.1.1 does not sell user data to advertisers. 1.1.1
 ## Related products
 
 <RelatedProduct header="WARP Client" href="/warp-client/" product="warp-client">
-	Access the Internet in a more secure and private way.
+	Encrypt all traffic from your device, not only DNS queries.
 </RelatedProduct>
 
 <RelatedProduct header="DNS" href="/dns/" product="dns">

--- a/src/content/docs/1.1.1.1/ip-addresses.mdx
+++ b/src/content/docs/1.1.1.1/ip-addresses.mdx
@@ -13,27 +13,27 @@ slug: 1.1.1.1/ip-addresses
 
 import { Render } from "~/components";
 
-Consider the tables below to know which IPv4 or IPv6 addresses are used by the different Cloudflare DNS resolver offerings.
+Use the addresses below to configure your device or router. Two addresses are provided for each resolver for redundancy.
 
-For detailed guidance refer to [Set up](/1.1.1.1/setup/).
+For step-by-step instructions, refer to [Set up](/1.1.1.1/setup/).
 
 ---
 
 ## 1.1.1.1
 
-1.1.1.1 is Cloudflare’s public DNS resolver. It offers a fast and private way to browse the Internet.
+The standard resolver provides fast, private DNS lookups with no content filtering.
 
 | IPv4                     | IPv6                                               |
 | ------------------------ | -------------------------------------------------- |
 | `1.1.1.1` <br/>`1.0.0.1` | `2606:4700:4700::1111` <br/>`2606:4700:4700::1001` |
 
-Refer to [Encryption](/1.1.1.1/encryption/) to learn how to use 1.1.1.1 in an encrypted way.
+Refer to [Encryption](/1.1.1.1/encryption/) to learn how to encrypt your DNS queries.
 
 ---
 
 ## 1.1.1.1 for Families
 
-1.1.1.1 for Families categorizes destinations on the Internet based on the potential threat they pose regarding malware, phishing, or other types of security risks.
+1.1.1.1 for Families adds automatic filtering to block known malware, phishing, and (optionally) adult content.
 
 For more information, refer to [1.1.1.1 for Families set up](/1.1.1.1/setup/#1111-for-families).
 

--- a/src/content/docs/1.1.1.1/terms-of-use.mdx
+++ b/src/content/docs/1.1.1.1/terms-of-use.mdx
@@ -9,6 +9,6 @@ sidebar:
 slug: 1.1.1.1/terms-of-use
 ---
 
-By using 1.1.1.1 Public DNS Resolver or 1.1.1.1 for Families, you consent to be bound by the [Cloudflare Website and Online Services Terms of Use](https://www.cloudflare.com/website-terms/).
+By using 1.1.1.1 Public DNS Resolver or 1.1.1.1 for Families, you agree to the [Cloudflare Website and Online Services Terms of Use](https://www.cloudflare.com/website-terms/).
 
-If you are an [Internet Service Provider (ISP) or network equipment provider](/1.1.1.1/infrastructure/network-operators/), you agree to provide proper attribution to Cloudflare in accordance with our Trademark Guidelines using our Public DNS Resolver. Please reach out to `resolver@cloudflare.com` for such logo requests.
+If you are an [Internet Service Provider (ISP) or network equipment provider](/1.1.1.1/infrastructure/network-operators/) that integrates 1.1.1.1, you agree to provide proper attribution to Cloudflare in accordance with the Cloudflare Trademark Guidelines. Contact `resolver@cloudflare.com` for logo requests.

--- a/src/content/docs/1.1.1.1/troubleshooting.mdx
+++ b/src/content/docs/1.1.1.1/troubleshooting.mdx
@@ -15,9 +15,11 @@ slug: 1.1.1.1/troubleshooting
 
 import { Render } from "~/components";
 
-This guide will help you diagnose and resolve common issues with Cloudflare's DNS Resolver. Before proceeding with manual troubleshooting steps, you can [verify your connection](/1.1.1.1/check/) to automatically gather relevant information.
+This guide helps you diagnose and resolve common issues with Cloudflare's DNS Resolver. Before proceeding with manual troubleshooting steps, [verify your connection](/1.1.1.1/check/) to automatically gather relevant information.
 
 ## Name resolution issues
+
+If a domain name is not resolving correctly, test DNS resolution against 1.1.1.1 and compare the result to another resolver (such as `8.8.8.8`). The CHAOS TXT queries (`id.server`) identify which Cloudflare server handled your request, which is useful when reporting issues.
 
 ### Linux/macOS
 
@@ -51,11 +53,17 @@ nslookup -class=chaos -type=txt id.server 1.0.0.1
 nslookup -type=txt whoami.cloudflare.com ns3.cloudflare.com
 ```
 
-**Note:** The network information command reveals your IP address. Only include this in reports to Cloudflare if you are comfortable sharing this information.
+:::caution
+
+The network information command reveals your IP address. Only include this in reports to Cloudflare if you are comfortable sharing this information.
+
+:::
 
 For additional analysis, you can generate a [DNSViz](http://dnsviz.net/) report for the domain in question.
 
 ## Connectivity and routing issues
+
+If DNS queries time out or you cannot reach 1.1.1.1 at all, the problem may be a network routing issue between your device and Cloudflare. Run traceroutes to both resolver addresses to identify where packets are being dropped.
 
 Before reporting connectivity issues:
 
@@ -96,6 +104,8 @@ nslookup -vc -class=chaos -type=txt id.server 1.0.0.1
 
 ## DNS-over-TLS (DoT) troubleshooting
 
+DNS over TLS encrypts DNS queries using TLS on port `853`. If your DoT connection is not working, test TLS connectivity and then DNS resolution over TLS.
+
 ### Linux/macOS
 
 ```sh
@@ -114,6 +124,8 @@ Windows does not include a standalone DoT client. You can test TLS connectivity 
 
 ## DNS-over-HTTPS (DoH) troubleshooting
 
+DNS over HTTPS sends DNS queries as HTTPS requests. If your DoH connection is not working, test it by querying the Cloudflare DNS endpoint directly.
+
 ### Linux/macOS
 
 ```sh
@@ -130,7 +142,7 @@ curl -H 'accept: application/dns-json' 'https://cloudflare-dns.com/dns-query?nam
 
 ### First hop failures
 
-If your traceroute fails at the first hop, the issue is likely hardware-related. Your router may have a hardcoded route for 1.1.1.1. When reporting this issue, include:
+If your traceroute fails at the first hop (the first network device after your computer, usually your router), the issue is likely hardware-related. Your router may have a hardcoded route for `1.1.1.1` that conflicts with using it as a DNS resolver. When reporting this issue, include:
 
 - Router make and model
 - ISP name

--- a/src/content/docs/1.1.1.1/upstream-resolution.mdx
+++ b/src/content/docs/1.1.1.1/upstream-resolution.mdx
@@ -9,34 +9,43 @@ sidebar:
 slug: 1.1.1.1/upstream-resolution
 ---
 
-When 1.1.1.1 cannot answer a query from cache, it contacts authoritative nameservers on your behalf. This page describes how 1.1.1.1 selects which nameserver to query, what happens when a nameserver is unreachable, and how the final response is determined.
+When 1.1.1.1 does not have an answer in its cache, it contacts authoritative nameservers on your behalf. Authoritative nameservers are the DNS servers that hold the actual records for a domain. This page describes how 1.1.1.1 selects which nameserver to query, what happens when a nameserver is unreachable, and how the final response is determined.
 
 ## Query name minimization
 
-1.1.1.1 minimizes privacy leakage by only sending the minimal query name to authoritative DNS servers. For example, if a client looks up `foo.bar.example.com`, the only part of the query 1.1.1.1 discloses to `.com` is that it needs to know who is responsible for `example.com`. The zone internals stay hidden.
+When resolving a multi-level domain name like `foo.bar.example.com`, 1.1.1.1 does not reveal the full name to every server in the chain. Instead, it sends only the minimum information each server needs. For example, when asking the `.com` TLD server, 1.1.1.1 only discloses that it needs to find `example.com` — the subdomain parts (`foo.bar`) are not included. This limits the amount of information exposed to intermediary servers and reduces privacy leakage.
 
 ## Root zone
 
-1.1.1.1 upstreams to [locally hosted root zone files](https://blog.cloudflare.com/f-root/) instead of querying remote root servers for every lookup. This reduces latency, lowers privacy leakage, and decreases load on the DNS root server system.
+1.1.1.1 uses [locally hosted copies of the root zone file](https://blog.cloudflare.com/f-root/) instead of querying remote root servers for every lookup. The root zone file contains the addresses of all top-level domain (TLD) servers. By hosting it locally, 1.1.1.1 avoids a network round trip to root servers, which reduces latency, improves privacy, and decreases load on the global DNS root server system.
 
 ## Nameserver selection
 
-When more than one authoritative nameserver is available for a zone (for example, multiple `NS` records at the root, TLD, or delegation level), 1.1.1.1 chooses between them based on measured performance. The resolver tracks per-upstream metrics — including round-trip time (RTT) and response quality — and queries the nameserver that has historically been fastest and most reliable from the data center serving the request.
+Most domains have multiple authoritative nameservers for redundancy. When 1.1.1.1 needs to query one, it chooses based on measured performance. The resolver tracks metrics for each nameserver — including round-trip time (how long a query takes to travel to the server and back) and response quality — then picks the nameserver that has historically been fastest and most reliable from the data center handling your request.
 
-If that nameserver does not answer in time or returns a transient error, 1.1.1.1 retries against another authoritative nameserver for the same zone. Refer to [Retry behavior](#retry-behavior) for details.
+If the selected nameserver does not respond in time or returns an error, 1.1.1.1 retries against a different nameserver for the same zone. Refer to [Retry behavior](#retry-behavior) for details.
 
-A small share of queries is also sent to other candidates so that latency measurements stay current and a previously slow server can be re-evaluated. For more background on the platform that powers this behavior, refer to the [BigPineapple architecture blog post](https://blog.cloudflare.com/big-pineapple-intro/).
+A small percentage of queries are also sent to alternative nameservers so that performance measurements stay current. This allows a previously slow server to be re-evaluated if its performance improves. For more background on the system that powers this selection, refer to the [BigPineapple architecture blog post](https://blog.cloudflare.com/big-pineapple-intro/).
 
 ## Retry behavior
 
-If a chosen upstream nameserver does not respond in time or returns a transient error, 1.1.1.1 retries the query against another authoritative nameserver for the same zone. The temporarily unresponsive server is downranked so that subsequent queries prefer healthier alternatives. It is periodically re-probed to detect recovery.
+If a nameserver does not respond in time or returns a temporary error, 1.1.1.1 retries the query against a different authoritative nameserver for the same zone. The unresponsive server is deprioritized so that subsequent queries prefer healthier alternatives. 1.1.1.1 periodically re-checks deprioritized servers to detect recovery.
 
-Concurrent identical upstream queries are deduplicated so that a single in-flight request serves multiple waiting clients. The exact retry parameters and ranking logic are tuned over time and may change.
+When multiple clients request the same domain at the same time, 1.1.1.1 deduplicates the upstream queries so that a single in-flight request serves all waiting clients. The exact retry timing and ranking logic are tuned over time and may change.
 
 ## Response selection
 
-For a given query, 1.1.1.1 returns only one final answer to the client. When authoritative nameservers disagree, which response is selected depends on whether the upstream responses are authoritative answers or transient failures:
+For a given query, 1.1.1.1 returns only one answer to the client. When authoritative nameservers disagree, which response 1.1.1.1 selects depends on the type of responses received.
 
-- **`NOERROR` (with answer or `NODATA`) versus `NXDOMAIN`:** Both are valid authoritative answers. 1.1.1.1 returns the first valid response it receives and does not query the remaining authoritative nameservers to compare answers. Authoritative nameservers for the same zone are expected to be consistent — if one returns `NXDOMAIN` and another returns `NOERROR` for the same name, that indicates a misconfiguration on the authoritative side, and which answer reaches the client depends on which nameserver was queried.
-- **Timeout versus a valid response:** A timeout is not an answer. 1.1.1.1 retries against another authoritative nameserver and returns the first valid response (`NOERROR`, `NXDOMAIN`, or other) it receives.
-- **`SERVFAIL`, `REFUSED`, or other transient failure versus a valid response:** Transient failures are treated as upstream errors rather than authoritative answers. 1.1.1.1 retries against another authoritative nameserver and returns the first valid response it receives. Only if no authoritative nameserver returns a valid response does 1.1.1.1 return a failure to the client — typically `SERVFAIL`, or `REFUSED` if that is what the authoritative nameservers consistently returned.
+The following DNS response codes are relevant:
+
+- **`NOERROR`** — The query succeeded. The response contains the requested records, or indicates that the name exists but has no records of the requested type (sometimes called `NODATA`).
+- **`NXDOMAIN`** — The domain name does not exist.
+- **`SERVFAIL`** — The nameserver encountered an internal error and could not answer.
+- **`REFUSED`** — The nameserver refused to answer the query.
+
+How 1.1.1.1 handles disagreements between nameservers:
+
+- **`NOERROR` versus `NXDOMAIN`:** Both are valid authoritative answers. 1.1.1.1 returns whichever response it receives first and does not query remaining nameservers to compare. Authoritative nameservers for the same zone are expected to be consistent. If one returns `NXDOMAIN` and another returns `NOERROR` for the same name, that indicates a misconfiguration on the authoritative side.
+- **Timeout versus a valid response:** A timeout is not an answer. 1.1.1.1 retries against another nameserver and returns the first valid response it receives.
+- **`SERVFAIL` or `REFUSED` versus a valid response:** Temporary failures are treated as upstream errors, not authoritative answers. 1.1.1.1 retries against another nameserver and returns the first valid response. Only if all nameservers return errors does 1.1.1.1 return a failure to the client — typically `SERVFAIL`, or `REFUSED` if that is what the nameservers consistently returned.


### PR DESCRIPTION
### Summary

ELI5 clarity pass on all 7 root-level pages in `/1.1.1.1/`. The goal is to make these pages accessible to non-technical readers (IT admins, decision-makers, hobbyists) without losing accuracy for DNS practitioners.

Key patterns addressed across the pages:
- **Undefined jargon** — DNS response codes (`NOERROR`, `NXDOMAIN`, `SERVFAIL`, `REFUSED`), DNSSEC concepts (`DO` bit, validating resolver), CHAOS TXT queries, and QNAME minimization are now defined inline before use.
- **Missing "why"** — Added context for why you would switch DNS resolvers (index), what each troubleshooting section diagnoses (troubleshooting), and why the root zone is hosted locally (upstream-resolution).
- **Awkward phrasing** — Replaced "Consider the tables below to know which..." (ip-addresses), "access to the addresses of millions of domain names on the same servers it runs on" now has a lead-in sentence explaining the mechanism (index).
- **Style fixes** — Converted a bold `**Note:**` to a `:::caution` aside (troubleshooting), added missing cross-links between pages (check → setup, faq → ip-addresses, faq → setup).

All changes went through an adversarial fact-check review. Six flagged claims were corrected before finalizing (details in commit history).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
