### PR TITLE
[Workers] Add Local Explorer changelog entry

### DIFF
--- a/src/content/changelog/workers/2026-04-13-local-explorer.mdx
+++ b/src/content/changelog/workers/2026-04-13-local-explorer.mdx
@@ -1,0 +1,33 @@
+---
+title: Local Explorer for local resource data
+description: Browse, edit, and programmatically access local resource data during development with a new browser UI and OpenAPI-powered REST API.
+products:
+  - workers
+date: 2026-04-13
+---
+
+Local Explorer is a browser-based interface and REST API for viewing and editing local resource data during development. It removes the need to write throwaway scripts or dig through `.wrangler/state` to understand what data your Worker has stored locally.
+
+Local Explorer is available in Wrangler 4.82.1+ and the Cloudflare Vite plugin 1.32.0+. Start a local development session and press `e` in your terminal, or navigate to `/cdn-cgi/explorer` on your local dev server.
+
+## Supported resources
+
+Local Explorer supports five resource types and works across multiple workers running locally:
+
+- **[KV](/kv/)** — Browse keys, view values and metadata, create, update, and delete key-value pairs.
+- **[R2](/r2/)** — List objects, view metadata, upload files, and delete objects. Supports directory views and multi-select.
+- **[D1](/d1/)** — Browse tables and rows, run arbitrary SQL queries, and edit schemas in a full data studio.
+- **[Durable Objects](/durable-objects/)** (SQLite storage) — Browse individual object SQLite tables, run SQL queries, and edit schemas.
+- **[Workflows](/workflows/)** — List instances, view status and step history, trigger new runs, and pause, resume, restart, or terminate instances.
+
+## OpenAPI-powered REST API
+
+Local Explorer exposes a REST API at `/cdn-cgi/explorer/api` that provides programmatic access to the same operations available in the browser. The root endpoint returns an [OpenAPI specification](https://www.openapis.org/) describing all available endpoints, parameters, and response formats.
+
+```sh
+curl http://localhost:8787/cdn-cgi/explorer/api
+```
+
+Point an AI coding agent at `/cdn-cgi/explorer/api` and it can discover and interact with your local resources without manual setup. This enables iterative development loops where an agent can populate test data in KV or D1, inspect Durable Object state, trigger Workflow runs, or upload files to R2.
+
+For more details, refer to the [Local Explorer documentation](/workers/development-testing/local-explorer/).


### PR DESCRIPTION
## Summary

- Adds a changelog entry for Local Explorer, a new browser UI and REST API for viewing and editing local resource data during development
- Covers supported resources (KV, R2, D1, Durable Objects, Workflows) and the OpenAPI-powered API for use with AI coding agents