### PR TITLE
[Docs] Fix changelog preview links

### DIFF
--- a/bin/post-preview-url-comment/index.node.test.ts
+++ b/bin/post-preview-url-comment/index.node.test.ts
@@ -50,12 +50,14 @@ describe("filenameToPath", () => {
 	test("changelog", () => {
 		expect(
 			filenameToPath("src/content/changelog/workers/2025-02-05-title.mdx"),
-		).toEqual("changelog/2025-02-05-title/");
+		).toEqual("changelog/post/2025-02-05-title/");
 	});
 
 	test("changelog base", () => {
 		expect(
 			`${DOCS_BASE_URL}/${filenameToPath("src/content/changelog/workers/2025-02-05-title.mdx")}`,
-		).toEqual("https://developers.cloudflare.com/changelog/2025-02-05-title/");
+		).toEqual(
+			"https://developers.cloudflare.com/changelog/post/2025-02-05-title/",
+		);
 	});
 });

--- a/bin/post-preview-url-comment/util.ts
+++ b/bin/post-preview-url-comment/util.ts
@@ -11,7 +11,9 @@ export const filenameToPath = (filename: string) => {
 	const changelogIdx = segments.findIndex((s) => s === "changelog");
 
 	if (changelogIdx !== -1) {
-		segments.splice(changelogIdx + 1, 1);
+		// Remove the product subfolder and insert "post" so that
+		// changelog/waf/2025-01-15 becomes changelog/post/2025-01-15
+		segments.splice(changelogIdx + 1, 1, "post");
 	}
 
 	return segments


### PR DESCRIPTION
This PR updates the preview URL comment bot to generate correct changelog preview links. 

Changelog entry URLs now include `/post/` in the path (e.g., `/changelog/post/2025-02-05-title/` instead of `/changelog/2025-02-05-title/`), matching the actual site routing. 

Example of the existing issue (the before/after links for the scheduled changes return `404`; for the other page there are redirects that make them work):
https://github.com/cloudflare/cloudflare-docs/pull/30370#issuecomment-4331934281

Only changelog paths are affected — docs preview links remain unchanged.
