### PR TITLE
[1.1.1.1] ELI5 on setup files

### DIFF
--- a/src/content/docs/1.1.1.1/setup/android.mdx
+++ b/src/content/docs/1.1.1.1/setup/android.mdx
@@ -15,11 +15,11 @@ slug: 1.1.1.1/setup/android
 
 import { Details, Render } from "~/components";
 
-[1.1.1.1: Faster Internet](https://play.google.com/store/apps/details?id=com.cloudflare.onedotonedotonedotone) is the preferred method of setting up 1.1.1.1 DNS resolver and 1.1.1.1 for Families. It allows you to automatically configure your phone to use 1.1.1.1 on any network you connect to.
+The [1.1.1.1: Faster Internet](https://play.google.com/store/apps/details?id=com.cloudflare.onedotonedotonedotone) app is the recommended way to set up 1.1.1.1 on Android. It automatically configures your phone to use 1.1.1.1 on any network you connect to.
 
 The app also allows you to enable encryption for DNS queries or enable [WARP mode](/warp-client/), which keeps all your HTTP traffic private and secure, including your DNS queries to 1.1.1.1.
 
-You can select between the options available in the app settings. By default, 1.1.1.1: Faster Internet is configured to WARP mode.
+You can select between these options in the app settings. By default, the app uses WARP mode.
 
 ## Set up 1.1.1.1: Faster Internet
 
@@ -41,12 +41,12 @@ Your connection to the Internet and your DNS queries are now protected.
 
 ### Android 11 or later
 
-Android 11 or later versions support both DNS over TLS (DoT) and DNS over HTTPS (DoH).
+Android 11 and later support encrypted DNS through a feature called Private DNS, which uses DNS over TLS (DoT). When you configure Private DNS, your device uses that DNS resolver on all networks — including cellular — without needing per-network configuration.
 
 1. Go to **Settings** > **Network & internet**.
 2. Select **Advanced** > **Private DNS**.
 3. Select the **Private DNS provider hostname** option.
-4. Depending on what you want to configure, use one of the following DNS hostnames or [IP addresses](/1.1.1.1/ip-addresses/) and select **Save**.
+4. Enter one of the following hostnames and select **Save**.
 
   <Details header="Use 1.1.1.1 resolver">
 
@@ -83,12 +83,12 @@ Or the corresponding IP address if your device requires it:
 
 ### Android 9 or 10
 
-Android 9 and Android 10 support DNS over TLS to secure your queries through encryption. In Android, this option is called Private DNS. It prevents your queries from being tracked, modified or surveilled by third-parties. Unlike previous versions of Android, this method also ensures 1.1.1.1 does not need to be configured for each new Wi-Fi network your smartphone joins.
+Android 9 and 10 support DNS over TLS through a feature called Private DNS. When you configure Private DNS, your device encrypts DNS queries and uses the configured resolver on all networks, including cellular.
 
 1. Go to **Settings** > **Network & internet**.
 2. Select **Advanced** > **Private DNS**.
 3. Select the **Private DNS provider hostname** option.
-4. Enter `one.one.one.one` and select **Save**. Or consider the following options if you want to use 1.1.1.1 for Families.
+4. Enter `one.one.one.one` and select **Save**. Or use one of the following hostnames if you want to use 1.1.1.1 for Families.
 
   <Details header="Block malware with 1.1.1.1 for Families">
 
@@ -123,6 +123,6 @@ Before making changes, take note of any DNS addresses you might have and save th
 5. Change the IP Settings to **Static**.
 6. <Render file="all-ipv4" product="1.1.1.1" />
 7. <Render file="all-ipv6" product="1.1.1.1" />
-8. Select **Save**. You may need to disconnect from the Wi-Fi and reconnect for the changes to take place.
+8. Select **Save**. You may need to disconnect from the Wi-Fi and reconnect for the changes to take effect.
 
 <Render file="captive-portals" product="1.1.1.1" />

--- a/src/content/docs/1.1.1.1/setup/azure.mdx
+++ b/src/content/docs/1.1.1.1/setup/azure.mdx
@@ -14,8 +14,10 @@ slug: 1.1.1.1/setup/azure
 
 import { Render } from "~/components";
 
+These steps configure 1.1.1.1 as the DNS resolver for an Azure Virtual Network (VNet). This applies to all resources in the VNet, including virtual machines.
+
 1. Log in to your Azure portal.
 2. From the Azure portal side menu, select **Virtual Networks**.
-3. Navigate to the virtual network associated with your virtual machine (VM).
+3. Select the virtual network you want to configure.
 4. Select **DNS Servers** > **Custom**, and add two entries: <Render file="ipv4" product="1.1.1.1" />
 5. Select **Save**.

--- a/src/content/docs/1.1.1.1/setup/gaming-consoles.mdx
+++ b/src/content/docs/1.1.1.1/setup/gaming-consoles.mdx
@@ -14,6 +14,8 @@ slug: 1.1.1.1/setup/gaming-consoles
 
 import { Render } from "~/components";
 
+The steps below configure your gaming console to use 1.1.1.1 instead of the default DNS resolver provided by your ISP.
+
 ## PS4
 
 1. Go to **Settings** > **Network** > **Set Up Internet Connection**.
@@ -31,7 +33,7 @@ import { Render } from "~/components";
 
 1. Open the Network screen by pressing the Xbox button on your controller.
 2. Go to **Settings** > **Network** > **Network Settings**.
-3. Next, go to **Advanced Settings** > **DNS Settings**.
+3. Go to **Advanced Settings** > **DNS Settings**.
 4. Select **Manual**.
 5. Set **Primary DNS** and **Secondary DNS** to: <Render file="ipv4" product="1.1.1.1" />
 6. If you have the option to add more DNS servers, you can add the IPv6 addresses as well: <Render file="ipv6" product="1.1.1.1" />

--- a/src/content/docs/1.1.1.1/setup/google-cloud.mdx
+++ b/src/content/docs/1.1.1.1/setup/google-cloud.mdx
@@ -14,21 +14,21 @@ slug: 1.1.1.1/setup/google-cloud
 
 import { Render } from "~/components";
 
-Google Cloud supports configuring [outbound server policy](https://cloud.google.com/dns/docs/server-policies-overview#dns-server-policy-out) within Cloud DNS. Policies are applied per Virtual Private Cloud (VPC) network, and will affect all resources within that VPC network, including any existing virtual machines.
+Google Cloud lets you configure custom DNS servers at the Virtual Private Cloud (VPC) network level using [outbound server policies](https://cloud.google.com/dns/docs/server-policies-overview#dns-server-policy-out) in Cloud DNS. When you create an outbound server policy, all resources in that VPC network — including existing virtual machines — use the specified DNS servers.
 
 :::note
 
-If you are using [Cloudflare Zero Trust](/cloudflare-one/), you can choose assigned [locations](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/) to apply custom [DNS policies](/cloudflare-one/traffic-policies/dns-policies/) via Gateway.
+If you are using [Cloudflare Zero Trust](/cloudflare-one/), you can assign [locations](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/) to apply custom [DNS policies](/cloudflare-one/traffic-policies/dns-policies/) via Gateway. This gives you more granular filtering control than 1.1.1.1 for Families.
 
 :::
 
-To configure 1.1.1.1 for your Google Cloud VPC network(s):
+To configure 1.1.1.1 for your Google Cloud VPC network:
 
 1. Open the [Google Cloud Console](https://console.cloud.google.com).
-2. Navigate to **Network Services** > **Cloud DNS** and select [**DNS Server Policies**](https://console.cloud.google.com/net-services/dns/policies).
+2. Go to **Network Services** > **Cloud DNS** and select [**DNS Server Policies**](https://console.cloud.google.com/net-services/dns/policies).
 3. Select **Create Policy**.
-4. Provide a name for your Policy (such as `cloudflare-1-1-1-1`) and select associated VPC network or networks.
-5. Under **Alternate DNS servers**, select **Add Item** and type: <Render file="ipv4" product="1.1.1.1" />
+4. Enter a name for your policy (for example, `cloudflare-1-1-1-1`) and select the VPC networks to apply it to.
+5. Under **Alternate DNS servers**, select **Add Item** and enter: <Render file="ipv4" product="1.1.1.1" />
 6. Select **Create**.
 
-DNS requests within the configured VPC network(s) will now use 1.1.1.1.
+DNS requests within the configured VPC networks will now use 1.1.1.1.

--- a/src/content/docs/1.1.1.1/setup/google-cloud.mdx
+++ b/src/content/docs/1.1.1.1/setup/google-cloud.mdx
@@ -18,7 +18,7 @@ Google Cloud lets you configure custom DNS servers at the Virtual Private Cloud 
 
 :::note
 
-If you are using [Cloudflare Zero Trust](/cloudflare-one/), you can assign [locations](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/) to apply custom [DNS policies](/cloudflare-one/traffic-policies/dns-policies/) via Gateway. This gives you more granular filtering control than 1.1.1.1 for Families.
+If you are using [Cloudflare Zero Trust](/cloudflare-one/), you can assign [locations](/cloudflare-one/networks/resolvers-and-proxies/dns/locations/) to apply custom [DNS policies](/cloudflare-one/traffic-policies/dns-policies/) via Gateway.
 
 :::
 

--- a/src/content/docs/1.1.1.1/setup/index.mdx
+++ b/src/content/docs/1.1.1.1/setup/index.mdx
@@ -16,9 +16,9 @@ products:
 
 import { Details, DirectoryListing, Render } from "~/components";
 
-By default, the [DNS server](https://www.cloudflare.com/learning/dns/what-is-dns/) your devices use is provided by your Internet service provider (ISP). Some [ISPs and network equipment providers](/1.1.1.1/infrastructure/network-operators/) partner with Cloudflare to add safer browsing to their offerings.
+By default, your devices use a [DNS server](https://www.cloudflare.com/learning/dns/what-is-dns/) provided by your Internet service provider (ISP). You can change this to use 1.1.1.1 instead, which gives you faster and more private DNS resolution. Some [ISPs and network equipment providers](/1.1.1.1/infrastructure/network-operators/) already partner with Cloudflare to offer this.
 
-If your providers are not currently using Cloudflare, you can change the DNS settings on your device or router as detailed in the following instructions.
+If your provider does not use Cloudflare, follow the instructions for your device or router below.
 
 <Details header="Device or router specific guides">
 
@@ -26,15 +26,15 @@ If your providers are not currently using Cloudflare, you can change the DNS set
 
 </Details>
 
-You can also set up [1.1.1.1 for Families](#1111-for-families) for an added layer of protection on your home network against malware and adult content. 1.1.1.1 for Families leverages Cloudflare's global network to ensure that it is fast and secure around the world, and includes the same [strong privacy guarantees](/1.1.1.1/privacy/public-dns-resolver/) that Cloudflare committed to when launching 1.1.1.1.
+You can also set up [1.1.1.1 for Families](#1111-for-families) for additional protection against malware and adult content on your home network. 1.1.1.1 for Families uses the same [privacy commitments](/1.1.1.1/privacy/public-dns-resolver/) as the standard 1.1.1.1 resolver.
 
 ---
 
 ## 1.1.1.1 for Families
 
-1.1.1.1 for Families categorizes destinations on the Internet based on the potential threat they pose regarding malware, phishing, or other types of security risks.
+1.1.1.1 for Families automatically blocks DNS queries to domains associated with malware, phishing, or (optionally) adult content.
 
-1.1.1.1 for Families has two default options:
+1.1.1.1 for Families has two options:
 
 <Details header='Block malware'>
 
@@ -58,28 +58,26 @@ Use the following DNS resolvers to block malware and adult content:
 
 </Details>
 
-Cloudflare returns `0.0.0.0` if the [fully qualified domain name (FQDN)](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) or IP in a DNS query is classified as malicious.
+When a queried domain is classified as malicious, Cloudflare returns the address `0.0.0.0` instead of the real address. This prevents your device from connecting to the blocked site.
 
 :::note[Domain miscategorization]
 
-If you are using 1.1.1.1 for Families and see a domain that you believe is miscategorized, [fill in this form](https://radar.cloudflare.com/categorization-feedback/) to bring it to our attention. Your submission will remain anonymous.
-
-We review these submissions to improve Cloudflare’s categorization.
+If you are using 1.1.1.1 for Families and a domain is incorrectly blocked or allowed, [submit feedback](https://radar.cloudflare.com/categorization-feedback/) to help improve Cloudflare's categorization. Your submission is anonymous.
 
 :::
 
 ### Test 1.1.1.1 for Families
 
-After configuring 1.1.1.1 for Families, you can test if it is working as intended with the following URLs:
+After configuring 1.1.1.1 for Families, verify that filtering is working with the following test URLs:
 
-- [https://malware.testcategory.com/](https://malware.testcategory.com/): Use this to test if 1.1.1.1 for Families is blocking known malware addresses correctly.
-- [https://nudity.testcategory.com/](https://nudity.testcategory.com/): Use this to test if 1.1.1.1 for Families is blocking known adult content and malware addresses correctly.
+- [https://malware.testcategory.com/](https://malware.testcategory.com/) — Tests whether known malware domains are blocked.
+- [https://nudity.testcategory.com/](https://nudity.testcategory.com/) — Tests whether adult content and malware domains are blocked.
 
 ### DNS over HTTPS (DoH)
 
-If you have a DoH-compliant client, such as a compatible router, you can set up 1.1.1.1 for Families to encrypt your DNS queries over HTTPS. This prevents spoofing and tracking by malicious actors, advertisers, ISPs, and others. For more information on DoH, refer to the [Learning Center article on DNS encryption](https://www.cloudflare.com/learning/dns/dns-over-tls/).
+DNS over HTTPS (DoH) encrypts your DNS queries by sending them as HTTPS requests. This prevents anyone between your device and the resolver — such as your ISP or a network attacker — from seeing which domains you look up. For more information, refer to the [Learning Center article on DNS encryption](https://www.cloudflare.com/learning/dns/dns-over-tls/).
 
-To configure an encrypted DoH connection to 1.1.1.1 for Families, type one of the following URLs into the appropriate field of your DoH-compliant client:
+To configure an encrypted DoH connection to 1.1.1.1 for Families, enter one of the following URLs in your DoH-compatible client or router:
 
 <Details header="Block malware">
 
@@ -99,9 +97,9 @@ https://family.cloudflare-dns.com/dns-query
 
 ### DNS over TLS (DoT)
 
-1.1.1.1 for Families also supports DoT if you have a compliant client, such as a compatible DoT router. DoT allows you to encrypt your DNS queries, protecting you from spoofing, malicious actors, and others. You can learn more about DoT in the [Learning Center article on DNS encryption](https://www.cloudflare.com/learning/dns/dns-over-tls/).
+DNS over TLS (DoT) encrypts DNS queries using TLS on a dedicated port (`853`). Like DoH, it prevents eavesdropping on your DNS traffic. For more information, refer to the [Learning Center article on DNS encryption](https://www.cloudflare.com/learning/dns/dns-over-tls/).
 
-To configure an encrypted DoT connection to 1.1.1.1 for Families, type one of the following URLs into the appropriate field of your DoT-compliant client:
+To configure an encrypted DoT connection to 1.1.1.1 for Families, enter one of the following hostnames in your DoT-compatible client or router:
 
 <Details header="Block malware">
 

--- a/src/content/docs/1.1.1.1/setup/ios.mdx
+++ b/src/content/docs/1.1.1.1/setup/ios.mdx
@@ -14,11 +14,11 @@ slug: 1.1.1.1/setup/ios
 
 import { Render } from "~/components";
 
-[1.1.1.1: Faster Internet](https://apps.apple.com/us/app/1-1-1-1-faster-internet/id1423538627) is the preferred method of setting up 1.1.1.1 DNS resolver and 1.1.1.1 for Families in iOS devices. It allows you to automatically configure your phone to use 1.1.1.1 on any network you connect to, and solves iOS inability of using an alternative DNS resolver in cellular connections.
+The [1.1.1.1: Faster Internet](https://apps.apple.com/us/app/1-1-1-1-faster-internet/id1423538627) app is the recommended way to set up 1.1.1.1 on iOS. It automatically configures your device to use 1.1.1.1 on any network you connect to, including cellular networks (which cannot use a custom DNS resolver through manual iOS settings alone).
 
 The app also allows you to enable encryption for DNS queries or enable [WARP mode](/warp-client/), which keeps all your HTTP traffic private and secure, including your DNS queries to 1.1.1.1.
 
-You can select between the options available in the app's settings. By default, 1.1.1.1: Faster Internet is configured to WARP mode.
+You can select between these options in the app settings. By default, the app uses WARP mode.
 
 ## Set up 1.1.1.1: Faster Internet
 
@@ -38,7 +38,7 @@ You can select between the options available in the app's settings. By default, 
 
 :::note
 
-If you configure 1.1.1.1 manually, you will have to do it for every Wi-Fi network your device connects to. This method does not work for cellular connections.
+Manual configuration only applies to the Wi-Fi network you are currently connected to. You will need to repeat these steps for each new Wi-Fi network. This method does not work for cellular connections.
 
 :::
 

--- a/src/content/docs/1.1.1.1/setup/linux.mdx
+++ b/src/content/docs/1.1.1.1/setup/linux.mdx
@@ -17,17 +17,17 @@ import { Render } from "~/components";
 
 Before you begin, take note of any DNS addresses you might have set up, and save them in a safe place in case you need to use them later.
 
-Consider the sections below to set up 1.1.1.1 using either the [command line interface (CLI)](#use-command-line-interface-cli) or a [graphical user interface (GUI)](#use-graphical-user-interface-gui) of your preference.
+You can configure 1.1.1.1 using the [command line](#use-command-line-interface-cli) or a [graphical interface](#use-graphical-user-interface-gui).
 
 ## Use command line interface (CLI)
 
-Choose whether you want to use 1.1.1.1 or 1.1.1.1 For Families, and replace `1.1.1.1` with the corresponding [IPv4 or IPv6 address](/1.1.1.1/ip-addresses/) accordingly.
+If you want to use 1.1.1.1 for Families instead of the standard resolver, replace `1.1.1.1` in the examples below with the corresponding [IPv4 or IPv6 address](/1.1.1.1/ip-addresses/).
 
 ### `resolv.conf`
 
-Usually, `/etc/resolv.conf` is where you can configure the resolver IPs that your system is using.
+On most Linux distributions, `/etc/resolv.conf` controls which DNS resolver the system uses.
 
-In that case, you can use the following one-line command to specify `1.1.1.1` as your DNS resolver and `1.0.0.1` as backup:
+To set `1.1.1.1` as your DNS resolver with `1.0.0.1` as a backup:
 
 ```sh
 echo -e "nameserver 1.1.1.1\nnameserver 1.0.0.1" | sudo tee /etc/resolv.conf
@@ -35,14 +35,14 @@ echo -e "nameserver 1.1.1.1\nnameserver 1.0.0.1" | sudo tee /etc/resolv.conf
 
 :::caution
 
-Note that other systems, such as dynamic host configuration protocol (DHCP), may automatically write to `/etc/resolv.conf` and change that configuration. In those cases, consider changing your network settings or DHCP to use `1.1.1.1`.
+Some services — such as DHCP clients or `NetworkManager` — automatically overwrite `/etc/resolv.conf` when your network connection changes. If your DNS settings revert after a reboot or reconnection, configure 1.1.1.1 in your network manager or DHCP client instead.
 :::
 
-Alternatively, you can use an editor (`nano` or `vim`, for example) to manually edit the file.
+You can also edit `/etc/resolv.conf` manually with a text editor like `nano` or `vim`.
 
 ### `systemd-resolved`
 
-If you use `systemd-resolved` utility and the resolver IPs configuration is in `/etc/systemd/resolved.conf`, consider the steps below:
+If your system uses `systemd-resolved` to manage DNS, edit the configuration file at `/etc/systemd/resolved.conf`:
 
 1. Run the following command, replacing `<EDITOR>` with your preferred editor.
 
@@ -57,7 +57,7 @@ sudo <EDITOR> /etc/systemd/resolved.conf
 DNS=1.1.1.1
 ```
 
-To use DNS over TLS, add `#one.one.one.one` and set `DNSOverTLS` to `yes`, as in the following example:
+To use DNS over TLS, append `#one.one.one.one` after the IP address (this tells `systemd-resolved` which hostname to use for TLS verification) and set `DNSOverTLS` to `yes`:
 
 ```txt
 [Resolve]
@@ -70,7 +70,7 @@ DNSOverTLS=yes
 ### GNOME
 
 1. Go to **Show Applications** > **Settings** > **Network**.
-2. Select the adapter you want to configure — like your Ethernet adapter or Wi-Fi card — and select the **Settings** button.
+2. Select the adapter you want to configure — such as your Ethernet adapter or Wi-Fi card — and select the **Settings** button.
 3. On the **IPv4** tab > **DNS** section, disable the **Automatic** toggle.
 4. <Render file="all-ipv4" product="1.1.1.1" />
 5. Go to **IPv6**.

--- a/src/content/docs/1.1.1.1/setup/macos.mdx
+++ b/src/content/docs/1.1.1.1/setup/macos.mdx
@@ -14,6 +14,8 @@ slug: 1.1.1.1/setup/macos
 
 import { Render } from "~/components";
 
+These steps configure 1.1.1.1 as the DNS resolver for a specific network service (such as Wi-Fi or Ethernet) on your Mac.
+
 Take note of any DNS addresses you might have set up, and save them in a safe place in case you need to use them later.
 
 1. Go to **System Settings**. You can find it by pressing `CMD + Space` on your keyboard and typing `System Settings`.

--- a/src/content/docs/1.1.1.1/setup/router.mdx
+++ b/src/content/docs/1.1.1.1/setup/router.mdx
@@ -14,6 +14,8 @@ slug: 1.1.1.1/setup/router
 
 import { Render } from "~/components";
 
+Configuring 1.1.1.1 on your router applies the DNS setting to every device on your network. You do not need to change DNS settings on individual phones, computers, or other devices.
+
 1. Go to the **IP address** used to access your router's admin console in your browser.
    - Linksys and Asus routers typically use `http://192.168.1.1` or `http://router.asus.com` (for ASUS).
    - Netgear routers typically use `http://192.168.1.1` or `http://routerlogin.net`.
@@ -33,10 +35,10 @@ import { Render } from "~/components";
 
 7. Save the updated settings.
 
-## Using DNS-Over-TLS on OpenWrt
+## Use DNS over TLS on OpenWrt
 
-It is possible to encrypt DNS traffic out from your router using DNS-over-TLS if it is running OpenWrt. For more details, see our blog post on the topic: [Adding DNS-Over-TLS support to OpenWrt (LEDE) with Unbound](https://blog.cloudflare.com/dns-over-tls-for-openwrt/).
+If your router runs OpenWrt, you can encrypt DNS traffic using DNS over TLS. For setup instructions, refer to [Adding DNS-Over-TLS support to OpenWrt (LEDE) with Unbound](https://blog.cloudflare.com/dns-over-tls-for-openwrt/).
 
 ## FRITZ!Box
 
-Starting with [FRITZ!OS 7.20](https://en.avm.de/press/press-releases/2020/07/fritzos-720-more-performance-convenience-security/), DNS over TLS is supported, see [Configuring different DNS servers in the FRITZ!Box](https://en.avm.de/service/knowledge-base/dok/FRITZ-Box-7590/165_Configuring-different-DNS-servers-in-the-FRITZ-Box/).
+Starting with [FRITZ!OS 7.20](https://en.avm.de/press/press-releases/2020/07/fritzos-720-more-performance-convenience-security/), DNS over TLS is supported. Refer to [Configuring different DNS servers in the FRITZ!Box](https://en.avm.de/service/knowledge-base/dok/FRITZ-Box-7590/165_Configuring-different-DNS-servers-in-the-FRITZ-Box/).

--- a/src/content/docs/1.1.1.1/setup/windows.mdx
+++ b/src/content/docs/1.1.1.1/setup/windows.mdx
@@ -21,11 +21,11 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
 1. Select the **Start menu** > **Settings**.
 2. On **Network and Internet**, select **Change Adapter Options**.
 3. Right-click on the Ethernet or Wi-Fi network you are connected to and select **Properties**.
-4. Choose **Internet Protocol Version 4**.
+4. Select **Internet Protocol Version 4**.
 5. Select **Properties** > **Use the following DNS server addresses**.
 6. <Render file="all-ipv4" product="1.1.1.1" />
 7. Select **OK**.
-8. Go to **Internet Protocol Version 6**.
+8. Select **Internet Protocol Version 6**.
 9. Select **Properties** > **Use the following DNS server addresses**.
 10. <Render file="all-ipv6" product="1.1.1.1" />
 11. Select **OK**.
@@ -35,7 +35,7 @@ Take note of any DNS addresses you might have set up, and save them in a safe pl
 Take note of any DNS addresses you might have set up, and save them in a safe place in case you need to use them later.
 
 1. Select the **Start menu** > **Settings**.
-2. On **Network and Internet**, choose the adapter you want to configure - like your Ethernet adapter or Wi-Fi card.
+2. On **Network and Internet**, select the adapter you want to configure — such as your Ethernet adapter or Wi-Fi card.
 3. Scroll to **DNS server assignment** and select **Edit**.
 4. Select the **Automatic (DHCP)** drop-down menu > **Manual**.
 5. Select the **IPv4** toggle to turn it on.


### PR DESCRIPTION
### Summary

ELI5 clarity pass on all 10 pages in `/1.1.1.1/setup/`. These are how-to pages that a broad audience follows (home users, gamers, sysadmins, cloud engineers), so the goal is to add context before steps without changing the procedures themselves.

Key patterns addressed across the pages:
- **Missing context before procedures** — Added brief intros explaining *why* you would do this and *what changes* on your device. For example, the router page now explains that configuring at the router level applies to all devices on the network. The index page now explains why you would switch from your ISP's resolver.
- **Undefined jargon** — "Private DNS" (Android) now explains it uses DoT and applies across all networks. The `#one.one.one.one` syntax in `systemd-resolved` now explains its purpose (TLS hostname verification). DoH and DoT sections now briefly explain what encryption does before diving into configuration URLs.
- **Marketing language** — "leverages Cloudflare's global network" and "strong privacy guarantees" in the index replaced with direct references to the privacy policy page. "Categorizes destinations on the Internet based on the potential threat they pose" simplified to "blocks DNS queries to domains associated with malware, phishing, or adult content."
- **Clarity on blocking mechanism** — Explained that `0.0.0.0` responses prevent the device from connecting to the blocked site (previously just stated the return value with no user-facing consequence).
- **Bug fix** — Corrected an existing inaccuracy in android.mdx: Android 11's Private DNS uses DoT only, not DoH (DoH support was added in Android 13). The original text already had this error; this PR fixes it.

All changes went through an adversarial fact-check review. Three flagged claims were corrected: reverted "encrypts all traffic" back to original "HTTP traffic" wording (WARP split-tunnel configs exist), removed an unsourced gaming performance claim, and fixed the Android DoH version claim.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
