### PR TITLE
[Workflows] Removing note that steps can retry infinitely

### DIFF
--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -71,7 +71,7 @@ const defaultConfig: WorkflowStepConfig = {
 
 When providing your own `StepConfig`, you can configure:
 
-- The total number of attempts to make for a step (accepts `Infinity` for unlimited retries)
+- The total number of attempts to make for a step (limited to 10,000 retries per step)
 - The delay between attempts (accepts both `number` (ms) or a human-readable format)
 - What backoff algorithm to apply between each attempt: any of `constant`, `linear`, or `exponential`
 - When to timeout (in duration) before considering the step as failed (including during a retry attempt, as the timeout is set per attempt)


### PR DESCRIPTION
### Summary

Step retries limited to 10k steps

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
