### PR TITLE
[1.1.1.1] ELI5 on privacy files

### DIFF
--- a/src/content/docs/1.1.1.1/privacy/cloudflare-resolver-firefox.mdx
+++ b/src/content/docs/1.1.1.1/privacy/cloudflare-resolver-firefox.mdx
@@ -11,15 +11,15 @@ slug: 1.1.1.1/privacy/cloudflare-resolver-firefox
 
 ### What is the Cloudflare resolver for Firefox?
 
-Every time you type a web address, such as [www.mozilla.org](http://www.mozilla.org) or [www.firefox.com](http://www.firefox.com), into a web browser, the web browser sends a query to a DNS resolver. If DNS is like the card catalog of the Internet, then a DNS resolver is like a helpful librarian that knows how to use the information from that catalog to track down the exact location of a website. Whenever a resolver receives your query it looks up the IP address associated with the web address that you entered and relays that information to your web browser. “DNS resolution” as this process is referred to, is a crucial component of your Internet experience because without it your web browser would be unable to communicate with the servers that host your favorite websites, since communication requires knowing the IP addresses of those websites.
+When you type a web address like [www.mozilla.org](http://www.mozilla.org) into a browser, the browser sends a DNS query to a resolver. The resolver looks up the IP address associated with that domain and returns it so your browser can connect to the correct server. Without this step, your browser would not know which server to contact.
 
-For most Internet users, the DNS resolver that they use is either the one that comes with the operating system running on their machines or the one that is set by their network provider. In some cases, these resolvers leave a lot to be desired because of their susceptibility to unwanted spying and other security threats.
+Most users rely on a DNS resolver provided by their operating system or network provider. These default resolvers may be vulnerable to eavesdropping or on-path attacks, since DNS queries are typically sent in plaintext.
 
-To counter such threats, Mozilla has partnered with Cloudflare to provide direct DNS resolution from within the Firefox browser using the Cloudflare Resolver for Firefox. What this means is that whenever you select or type a web address in the Firefox browser your DNS lookup request will be sent over a secure channel to the Cloudflare Resolver for Firefox rather than to an unknown DNS resolver, significantly decreasing the odds of any unwanted spying or man in the middle attacks.
+To address this, Mozilla has partnered with Cloudflare to provide DNS resolution directly from within the Firefox browser using the Cloudflare Resolver for Firefox. When this feature is active, Firefox sends DNS queries over a secure channel to the Cloudflare Resolver for Firefox rather than to an unknown DNS resolver, significantly decreasing the odds of unwanted spying or man-in-the-middle attacks.
 
 ### What information does the Cloudflare resolver for Firefox collect?
 
-Any data Cloudflare handles as a result of its resolver for Firefox is as a data processor acting pursuant to Firefox’s data processing instructions. Therefore, the data Cloudflare collects and processes pursuant to its agreement with Firefox is not covered by the [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/). As part of its agreement with Firefox, Cloudflare has agreed to collect only a limited amount of data about the DNS requests that are sent to the Cloudflare Resolver for Firefox via the Firefox browser. Cloudflare will collect only the following information from Firefox users:
+Any data Cloudflare handles as a result of its Resolver for Firefox is as a data processor acting pursuant to Mozilla's data processing instructions. The data Cloudflare collects and processes pursuant to its agreement with Mozilla is not covered by the [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/). As part of its agreement with Mozilla, Cloudflare has agreed to collect only a limited amount of data about the DNS requests sent to the Cloudflare Resolver for Firefox via the Firefox browser. Cloudflare will collect only the following information from Firefox users:
 
 - date
 - dateTime
@@ -53,24 +53,24 @@ Any data Cloudflare handles as a result of its resolver for Firefox is as a data
 - coloID (unique Cloudflare data center ID)
 - metalId (unique Cloudflare data center ID)
 
-All of the above information will be stored briefly as part of Cloudflare’s temporary logs, and then permanently deleted within 24 hours of Cloudflare’s receipt of such information. In addition to the above information, Cloudflare will also collect and store the following information as part of its permanent logs.
+All of the above information is stored in temporary logs and then permanently deleted within 24 hours of Cloudflare's receipt of such information. In addition, Cloudflare stores the following in permanent logs:
 
-- Total number of requests processed by each Cloudflare co-location facility.
+- Total number of requests processed by each Cloudflare data center.
 - Aggregate list of all domain names requested.
 - Samples of domain names queried along with the times of such queries.
 
-Information stored in Cloudflare’s permanent logs will be anonymized and may be held indefinitely by Cloudflare for its own internal research and development purposes.
+Information stored in permanent logs is anonymized and may be held indefinitely by Cloudflare for internal research and development purposes.
 
 ### What is the Cloudflare promise?
 
-Cloudflare understands how important your data is to you, which is why we promise to use the information that we collect from the Cloudflare Resolver for Firefox solely to improve the performance of Cloudflare Resolver for Firefox and to assist us in debugging efforts if an issue arises. In addition to limiting our collection and use of your data, Cloudflare also promises:
+Cloudflare commits to using the information collected from the Cloudflare Resolver for Firefox solely to improve the performance of the Cloudflare Resolver for Firefox and to assist in debugging efforts if an issue arises. In addition to limiting collection and use of data, Cloudflare promises:
 
-- Cloudflare will not retain or sell or transfer to any third party (except as may be required by law) any personal information, IP addresses or other user identifiers from the DNS queries sent from the Firefox browser to the Cloudflare Resolver for Firefox;
+- Cloudflare will not retain or sell or transfer to any third party (except as may be required by law) any personal information, IP addresses, or other user identifiers from the DNS queries sent from the Firefox browser to the Cloudflare Resolver for Firefox.
 
-- Cloudflare will not combine the data that it collects from such queries, with any other Cloudflare or third party data in any way that can be used to identify individual end users;
+- Cloudflare will not combine the data that it collects from such queries with any other Cloudflare or third-party data in any way that can be used to identify individual end users.
 
-- Cloudflare will not sell, license, sublicense, or grant any rights to your data to any other person or entity without Mozilla’s explicit written permission.
+- Cloudflare will not sell, license, sublicense, or grant any rights to your data to any other person or entity without Mozilla's explicit written permission.
 
 ### What about government requests for content blocking?
 
-Cloudflare does not block or filter content through the Cloudflare Resolver for Firefox. As part of its agreement with Mozilla, Cloudflare is providing only direct DNS resolution. If Cloudflare were to receive written requests from law enforcement and government agencies to block access to domains or content through the Cloudflare resolver for Firefox, Cloudflare would, in consultation with Mozilla, exhaust our legal remedies before complying with such a request. We also commit to documenting any government request to block access in our semi-annual transparency report, unless legally prohibited from doing so.
+Cloudflare does not block or filter content through the Cloudflare Resolver for Firefox. As part of its agreement with Mozilla, Cloudflare provides only direct DNS resolution. If Cloudflare were to receive written requests from law enforcement and government agencies to block access to domains or content through the Cloudflare Resolver for Firefox, Cloudflare would, in consultation with Mozilla, exhaust its legal remedies before complying with such a request. We also commit to documenting any government request to block access in our semi-annual transparency report, unless legally prohibited from doing so.

--- a/src/content/docs/1.1.1.1/privacy/cloudflare-resolver-firefox.mdx
+++ b/src/content/docs/1.1.1.1/privacy/cloudflare-resolver-firefox.mdx
@@ -15,11 +15,11 @@ When you type a web address like [www.mozilla.org](http://www.mozilla.org) into 
 
 Most users rely on a DNS resolver provided by their operating system or network provider. These default resolvers may be vulnerable to eavesdropping or on-path attacks, since DNS queries are typically sent in plaintext.
 
-To address this, Mozilla has partnered with Cloudflare to provide DNS resolution directly from within the Firefox browser using the Cloudflare Resolver for Firefox. When this feature is active, Firefox sends DNS queries over a secure channel to the Cloudflare Resolver for Firefox rather than to an unknown DNS resolver, significantly decreasing the odds of unwanted spying or man-in-the-middle attacks.
+To address this, Mozilla has partnered with Cloudflare to provide DNS resolution directly from within the Firefox browser using the Cloudflare resolver for Firefox. When this feature is active, Firefox sends DNS queries over a secure channel to the Cloudflare resolver for Firefox rather than to an unknown DNS resolver, significantly decreasing the odds of unwanted spying or man-in-the-middle attacks.
 
 ### What information does the Cloudflare resolver for Firefox collect?
 
-Any data Cloudflare handles as a result of its Resolver for Firefox is as a data processor acting pursuant to Mozilla's data processing instructions. The data Cloudflare collects and processes pursuant to its agreement with Mozilla is not covered by the [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/). As part of its agreement with Mozilla, Cloudflare has agreed to collect only a limited amount of data about the DNS requests sent to the Cloudflare Resolver for Firefox via the Firefox browser. Cloudflare will collect only the following information from Firefox users:
+Any data Cloudflare handles as a result of its resolver for Firefox is as a data processor acting pursuant to Mozilla's data processing instructions. The data Cloudflare collects and processes pursuant to its agreement with Mozilla is not covered by the [Cloudflare Privacy Policy](https://www.cloudflare.com/privacypolicy/). As part of its agreement with Mozilla, Cloudflare has agreed to collect only a limited amount of data about the DNS requests sent to the Cloudflare resolver for Firefox via the Firefox browser. Cloudflare will collect only the following information from Firefox users:
 
 - date
 - dateTime
@@ -63,9 +63,9 @@ Information stored in permanent logs is anonymized and may be held indefinitely 
 
 ### What is the Cloudflare promise?
 
-Cloudflare commits to using the information collected from the Cloudflare Resolver for Firefox solely to improve the performance of the Cloudflare Resolver for Firefox and to assist in debugging efforts if an issue arises. In addition to limiting collection and use of data, Cloudflare promises:
+Cloudflare commits to using the information collected from the Cloudflare resolver for Firefox solely to improve the performance of the Cloudflare resolver for Firefox and to assist in debugging efforts if an issue arises. In addition to limiting collection and use of data, Cloudflare promises:
 
-- Cloudflare will not retain or sell or transfer to any third party (except as may be required by law) any personal information, IP addresses, or other user identifiers from the DNS queries sent from the Firefox browser to the Cloudflare Resolver for Firefox.
+- Cloudflare will not retain or sell or transfer to any third party (except as may be required by law) any personal information, IP addresses, or other user identifiers from the DNS queries sent from the Firefox browser to the Cloudflare resolver for Firefox.
 
 - Cloudflare will not combine the data that it collects from such queries with any other Cloudflare or third-party data in any way that can be used to identify individual end users.
 
@@ -73,4 +73,4 @@ Cloudflare commits to using the information collected from the Cloudflare Resolv
 
 ### What about government requests for content blocking?
 
-Cloudflare does not block or filter content through the Cloudflare Resolver for Firefox. As part of its agreement with Mozilla, Cloudflare provides only direct DNS resolution. If Cloudflare were to receive written requests from law enforcement and government agencies to block access to domains or content through the Cloudflare Resolver for Firefox, Cloudflare would, in consultation with Mozilla, exhaust its legal remedies before complying with such a request. We also commit to documenting any government request to block access in our semi-annual transparency report, unless legally prohibited from doing so.
+Cloudflare does not block or filter content through the Cloudflare resolver for Firefox. As part of its agreement with Mozilla, Cloudflare provides only direct DNS resolution. If Cloudflare were to receive written requests from law enforcement and government agencies to block access to domains or content through the Cloudflare resolver for Firefox, Cloudflare would, in consultation with Mozilla, exhaust its legal remedies before complying with such a request. We also commit to documenting any government request to block access in our semi-annual transparency report, unless legally prohibited from doing so.

--- a/src/content/docs/1.1.1.1/privacy/cloudflare-resolver-firefox.mdx
+++ b/src/content/docs/1.1.1.1/privacy/cloudflare-resolver-firefox.mdx
@@ -11,9 +11,9 @@ slug: 1.1.1.1/privacy/cloudflare-resolver-firefox
 
 ### What is the Cloudflare resolver for Firefox?
 
-When you type a web address like [www.mozilla.org](http://www.mozilla.org) into a browser, the browser sends a DNS query to a resolver. The resolver looks up the IP address associated with that domain and returns it so your browser can connect to the correct server. Without this step, your browser would not know which server to contact.
+Every time you type a web address, such as [www.mozilla.org](http://www.mozilla.org) or [www.firefox.com](http://www.firefox.com), into a web browser, the web browser sends a query to a DNS resolver. If DNS is like the card catalog of the Internet, then a DNS resolver is like a helpful librarian that knows how to use the information from that catalog to track down the exact location of a website. Whenever a resolver receives your query it looks up the IP address associated with the web address that you entered and relays that information to your web browser. “DNS resolution” as this process is referred to, is a crucial component of your Internet experience because without it your web browser would be unable to communicate with the servers that host your favorite websites, since communication requires knowing the IP addresses of those websites.
 
-Most users rely on a DNS resolver provided by their operating system or network provider. These default resolvers may be vulnerable to eavesdropping or on-path attacks, since DNS queries are typically sent in plaintext.
+For most Internet users, the DNS resolver that they use is either the one that comes with the operating system running on their machines or the one that is set by their network provider. In some cases, these resolvers leave a lot to be desired because of their susceptibility to unwanted spying and other security threats.
 
 To address this, Mozilla has partnered with Cloudflare to provide DNS resolution directly from within the Firefox browser using the Cloudflare resolver for Firefox. When this feature is active, Firefox sends DNS queries over a secure channel to the Cloudflare resolver for Firefox rather than to an unknown DNS resolver, significantly decreasing the odds of unwanted spying or man-in-the-middle attacks.
 

--- a/src/content/docs/1.1.1.1/privacy/index.mdx
+++ b/src/content/docs/1.1.1.1/privacy/index.mdx
@@ -9,8 +9,10 @@ sidebar:
 slug: 1.1.1.1/privacy
 ---
 
-- [1.1.1.1 Public DNS Resolver](/1.1.1.1/privacy/public-dns-resolver/): This document provides details on our collection, use, and disclosure of the information processed by the 1.1.1.1 public DNS resolver. The 1.1.1.1 public DNS resolver service is governed by our [Privacy Policy](https://www.cloudflare.com/privacypolicy/).
+Cloudflare maintains separate privacy commitments depending on how you use 1.1.1.1:
 
-- [Resolver for Firefox](/1.1.1.1/privacy/cloudflare-resolver-firefox/): This document outlines our collection, use, and disclosure of the information processed by the Cloudflare Resolver for Firefox. Any data Cloudflare processes in connection with the Cloudflare Resolver for Firefox is as a data processor acting pursuant to Mozilla’s data processing instructions. Cloudflare Resolver for Firefox is not covered by our main Privacy Policy and is separate from the 1.1.1.1 public DNS resolver.
+- [1.1.1.1 Public DNS Resolver](/1.1.1.1/privacy/public-dns-resolver/): Privacy commitments for the 1.1.1.1 public DNS resolver, including what data Cloudflare collects, uses, retains, and shares. Governed by the Cloudflare [Privacy Policy](https://www.cloudflare.com/privacypolicy/).
 
-- [1.1.1.1 Application](https://www.cloudflare.com/application/privacypolicy/): This policy applies to our collection, use, and disclosure of the information from Cloudflare’s consumer-facing 1.1.1.1 Applications, such as our 1.1.1.1 Application for iOS and Android.
+- [Resolver for Firefox](/1.1.1.1/privacy/cloudflare-resolver-firefox/): Privacy commitments specific to the Cloudflare Resolver for Firefox, where Cloudflare acts as a data processor under Mozilla's instructions. This is separate from the 1.1.1.1 public DNS resolver and is not covered by the main Cloudflare Privacy Policy.
+
+- [1.1.1.1 Application](https://www.cloudflare.com/application/privacypolicy/): Privacy policy for Cloudflare's consumer-facing 1.1.1.1 applications, including the 1.1.1.1 app for iOS and Android.

--- a/src/content/docs/1.1.1.1/privacy/public-dns-resolver.mdx
+++ b/src/content/docs/1.1.1.1/privacy/public-dns-resolver.mdx
@@ -11,43 +11,43 @@ slug: 1.1.1.1/privacy/public-dns-resolver
 
 _Last updated March 27, 2024_
 
-## Cloudflare’s commitment to privacy: 1.1.1.1 Public DNS Resolver
+## Cloudflare's commitment to privacy: 1.1.1.1 Public DNS Resolver
 
 The 1.1.1.1 public DNS resolver is governed by our [Privacy Policy](https://www.cloudflare.com/privacypolicy/). This document provides additional details on our collection, use, and disclosure of the information collected from the 1.1.1.1 public DNS resolver.
 
 ---
 
-Nearly everything on the Internet starts with a DNS request. DNS is the Internet’s directory. Select a link, open an app, send an email, and the first thing your phone or computer does is ask its directory: where can I find this?
+Nearly everything on the Internet starts with a DNS request. DNS is the Internet's directory. Select a link, open an app, send an email, and the first thing your device does is ask a DNS resolver: where can I find this?
 
-Unfortunately, by default, DNS is usually slow and insecure. Your ISP, and anyone else listening in on the Internet, can see every site you visit and every app you use — even if their content is encrypted. Creepily, some DNS providers sell data about your Internet activity or use it to target you with ads.
+By default, most devices use a DNS resolver provided by the Internet service provider (ISP). Some ISPs and third-party DNS providers log your queries, sell data about your Internet activity, or use it to target you with ads. DNS queries are also typically sent in plaintext, which means anyone on the network path between your device and the resolver can see every site you visit and every app you use — even if the content itself is encrypted.
 
-Given the current state of affairs, Cloudflare created a DNS resolver with your privacy and security in mind. Cloudflare, in partnership with APNIC, runs the 1.1.1.1 public resolver, a recursive DNS service that values user privacy and security. DNS requests sent to our public resolver can be sent over a secure channel, significantly decreasing the odds of any unwanted spying or man in the middle attacks.
+Cloudflare built the 1.1.1.1 public DNS resolver to address these problems. In partnership with APNIC, Cloudflare operates 1.1.1.1 as a recursive DNS service designed for privacy and security. DNS requests to 1.1.1.1 can be sent over an [encrypted channel](/1.1.1.1/encryption/), significantly decreasing the odds of unwanted spying or man-in-the-middle attacks.
 
-The 1.1.1.1 public DNS resolver was designed for privacy first, and Cloudflare commits to the following:
+The 1.1.1.1 public DNS resolver was designed for privacy first. Cloudflare commits to the following:
 
-1. Cloudflare will not sell or share Public Resolver users’ personal data with third parties or use personal data from the Public Resolver to target any user with advertisements.
-2. Cloudflare will only retain or use what is being asked, not information that will identify who is asking it. Except for randomly sampled network packets captured from at most 0.05% of all traffic sent to Cloudflare’s network infrastructure, Cloudflare will not retain the source IP from DNS queries to the Public Resolver in non-volatile storage. These randomly sampled packets are solely used for network troubleshooting and DoS mitigation purposes.
-3. A Public Resolver user’s IP address (referred to as the client or source IP address) will not be stored in non-volatile storage. Cloudflare will anonymize source IP addresses via IP truncation methods (last octet for IPv4 and last 80 bits for IPv6). Cloudflare will delete the truncated IP address within 25 hours.
-4. Cloudflare will retain only the limited transaction and debug log data (“Public Resolver Logs”) set forth below, for the legitimate operation of our Public Resolver and research purposes, and Cloudflare will delete the Public Resolver Logs within 25 hours.
+1. Cloudflare will not sell or share Public Resolver users' personal data with third parties or use personal data from the Public Resolver to target any user with advertisements.
+2. Cloudflare will only retain or use what is being asked, not information that will identify who is asking it. Except for randomly sampled network packets captured from at most 0.05% of all traffic sent to Cloudflare's network infrastructure, Cloudflare will not retain the source IP from DNS queries to the Public Resolver in non-volatile storage. These randomly sampled packets are solely used for network troubleshooting and DoS mitigation purposes.
+3. A Public Resolver user's IP address (referred to as the client or source IP address) will not be stored in non-volatile storage. Cloudflare will anonymize source IP addresses via IP truncation methods (last octet for IPv4 and last 80 bits for IPv6). Cloudflare will delete the truncated IP address within 25 hours.
+4. Cloudflare will retain only the limited transaction and debug log data ("Public Resolver Logs") set forth below, for the legitimate operation of our Public Resolver and research purposes, and Cloudflare will delete the Public Resolver Logs within 25 hours.
 5. Cloudflare will not share the Public Resolver Logs with any third parties except for APNIC pursuant to a Research Cooperative Agreement. APNIC will only have limited access to query the anonymized data in the Public Resolver Logs and conduct research related to the operation of the DNS system.
 
-Cloudflare has taken technical steps to ensure that we cannot retain our user’s information.
+Cloudflare has taken technical steps to ensure that we cannot retain our user's information.
 
-We have also retained one of the top four accounting firms to audit our practices and publish a public report confirming we are doing what we said we would. The report is available in the [Certifications and compliance resources](https://www.cloudflare.com/trust-hub/compliance-resources/) page.
+We have also retained one of the top four accounting firms to audit our practices and publish a public report confirming we are doing what we said we would. The report is available on the [Certifications and compliance resources](https://www.cloudflare.com/trust-hub/compliance-resources/) page.
 
 ## Limited data sharing with APNIC
 
-Cloudflare has partnered with [APNIC Labs](https://labs.apnic.net/?p=1127), the regional Internet registry for the Asia-Pacific region to make the 1.1.1.1 IP address the home of the Cloudflare Public DNS Resolver. As part of its mission to ensure a global, open and secure Internet, APNIC conducts research about the functioning and governance of the Internet, which it makes available on its website, located at [www.apnic.net](http://www.apnic.net).
+Cloudflare has partnered with [APNIC Labs](https://labs.apnic.net/?p=1127), the regional Internet registry for the Asia-Pacific region, which provided the 1.1.1.1 IP address for use as a public DNS resolver. As part of its mission to ensure a global, open, and secure Internet, APNIC conducts research about the functioning and governance of the Internet, which it publishes at [www.apnic.net](http://www.apnic.net).
 
-Cloudflare has agreed to provide APNIC with access to some of the anonymized data that Cloudflare collects through the Cloudflare Public DNS Resolver. Specifically, APNIC will be permitted to access query names, query types, resolver location and other metadata via a Cloudflare API that will allow APNIC to study topics like the volume of DDoS attacks launched on the Internet and adoption of IPv6.
+Cloudflare has agreed to provide APNIC with access to some of the anonymized data that Cloudflare collects through the Cloudflare Public DNS Resolver. APNIC can access query names, query types, resolver location, and other metadata via a Cloudflare API. This allows APNIC to study topics like the volume of DDoS attacks on the Internet and adoption of IPv6.
 
-APNIC Labs will use such data for non-profit operational research. As part of Cloudflare’s commitment to privacy, Cloudflare will not provide APNIC with any access to the IP address associated with a client.
+APNIC Labs uses this data for non-profit operational research. As part of Cloudflare's commitment to privacy, Cloudflare will not provide APNIC with any access to the IP address associated with a client.
 
 Aside from APNIC, Cloudflare will not share the Public Resolver Logs with any third party.
 
 ## Data in public resolver logs
 
-The Public Resolver Logs we store consist entirely of the following fields:
+The Public Resolver Logs consist of the following fields:
 
 - answerData type
 - answerData
@@ -89,7 +89,7 @@ The Public Resolver Logs we store consist entirely of the following fields:
 - srcIPVersion
 - validationState
 
-Additionally, recursive resolvers perform outgoing queries to various authoritative nameservers in the DNS hierarchy that are logged in subrequest fields. These logs are used for the operation and debugging of our public DNS resolver service.
+Additionally, the resolver performs outgoing queries to authoritative nameservers in the DNS hierarchy. These queries are logged in subrequest fields and are used for the operation and debugging of the Public DNS Resolver service.
 
 The following subrequest data is included in the Public Resolver Logs:
 
@@ -105,24 +105,24 @@ The following subrequest data is included in the Public Resolver Logs:
 - subrequest.recordData
 - subrequest.error
 
-Except for the limited sampled data from the Public Resolver Logs (which do not include truncated IP addresses) used to generate the aggregated data described below, all of the Public Resolver Logs are deleted within 25 hours of Cloudflare’s receipt of such information.
+Except for limited sampled data from the Public Resolver Logs (which do not include truncated IP addresses) used to generate the aggregations described below, all Public Resolver Logs are deleted within 25 hours.
 
-Cloudflare may make the following aggregations:
+Cloudflare may produce the following aggregations:
 
-- Total number of queries with different protocol settings (for example, tcp/udp/dnssec) by Cloudflare data centers.
-- Response code/time quantiles with different protocol settings by Cloudflare data centers.
-- Total Number of Requests Processed by Cloudflare data centers.
-- Aggregate List of All Domain Names Requested and aggregate number of requests and timestamp of first time requested by region.
-- Number of unique clients, queries over IPv4, queries over IPv6, queries with the RD bit set, queries asking for DNSSEC, number of bogus, valid, and invalid DNSSEC answers, queries by type, number of answers with each response code, response time quantiles (e.g. 50 percentile), response TTL, and number of cached answers per minute, per day, per protocol (HTTPS/UDP/TCP/TLS), per region, per Cloudflare data center, and per Autonomous System Number.
-- Number of queries, number of queries with EDNS, number of bytes and time in answers quantiles (e.g. 50 percentile) by day, month, Cloudflare data center, and by IPv4 vs IPv6.
-- Number of queries, response codes and response code quantiles (e.g. 50 percentile) by day, region, name and type.
+- Total number of queries with different protocol settings (for example, TCP/UDP/DNSSEC) by Cloudflare data center.
+- Response code and response time quantiles with different protocol settings by Cloudflare data center.
+- Total number of requests processed by Cloudflare data center.
+- Aggregate list of all domain names requested, with aggregate request count and timestamp of first request by region.
+- Number of unique clients, queries over IPv4, queries over IPv6, queries with the RD bit set, queries asking for DNSSEC, number of bogus, valid, and invalid DNSSEC answers, queries by type, number of answers with each response code, response time quantiles (for example, 50th percentile), response TTL, and number of cached answers per minute, per day, per protocol (HTTPS/UDP/TCP/TLS), per region, per Cloudflare data center, and per Autonomous System Number.
+- Number of queries, number of queries with EDNS, number of bytes and time in answers quantiles (for example, 50th percentile) by day, month, Cloudflare data center, and by IPv4 versus IPv6.
+- Number of queries, response codes and response code quantiles (for example, 50th percentile) by day, region, name, and type.
 
-Cloudflare may store the data described above indefinitely in order to power Cloudflare Radar and assist Cloudflare in improving Cloudflare services, such as, enhancing the overall performance of the Cloudflare Resolver and identifying security threats.
+Cloudflare may store this aggregated data indefinitely to power Cloudflare Radar and to improve Cloudflare services, such as enhancing the overall performance of the Cloudflare Resolver and identifying security threats.
 
 ## What about requests for content blocking?
 
 Cloudflare does not block or filter any content through the 1.1.1.1 Public DNS Resolver, which is designed for direct, fast DNS resolution, not for blocking or filtering content. Cloudflare does block and filter malware and adult content through 1.1.1.1 for Families, which is designed to help individuals protect their home networks.
 
-In general, Cloudflare views government or civil requests to block content at the DNS level as ineffective, inefficient, and overboard. Because such a block would apply globally to all users of the resolver, regardless of where they are located, it would affect end users outside of the blocking government’s jurisdiction. A government request to block content through a globally available public recursive resolver like the 1.1.1.1 Public DNS Resolver and 1.1.1.1 for Families should therefore be evaluated as a request to block content globally.
+In general, Cloudflare views government or civil requests to block content at the DNS level as ineffective, inefficient, and overboard. Because such a block would apply globally to all users of the resolver, regardless of where they are located, it would affect end users outside of the blocking government's jurisdiction. A government request to block content through a globally available public recursive resolver like the 1.1.1.1 Public DNS Resolver and 1.1.1.1 for Families should therefore be evaluated as a request to block content globally.
 
 Given the broad extraterritorial effect, if Cloudflare were to receive written requests from law enforcement and government agencies to block access to domains or content through the 1.1.1.1 Public DNS Resolver or to block access to domains or content through 1.1.1.1 for Families that is outside the scope of the filtering in that product, Cloudflare would pursue its legal remedies before complying with such a request. We also commit to documenting any government request to block access in our semi-annual transparency report, unless legally prohibited from doing so.


### PR DESCRIPTION
### Summary

ELI5 clarity pass on all 3 pages in `/1.1.1.1/privacy/`. These are privacy commitment and policy pages, so edits are conservative — the goal is to improve readability without changing the meaning of any legal commitments.

Key changes:
- **index.mdx** — Added an intro sentence explaining that different privacy commitments apply depending on how you use 1.1.1.1. Shortened bullet descriptions to focus on what each page covers rather than repeating legal boilerplate.
- **public-dns-resolver.mdx** — Rewrote the intro paragraphs: replaced "Creepily, some DNS providers" with neutral factual language; replaced "phone or computer" with "device"; added a link to the encryption page; replaced `e.g.` with "for example" throughout; clarified that the resolver performs outgoing queries to authoritative nameservers (not "recursive resolvers"). Preserved all 5 numbered privacy commitments verbatim. Added an Oxford comma after "open" in the APNIC section. Replaced "Specifically, APNIC will be permitted to" with a shorter formulation while keeping the "some of" qualifier and "has agreed to provide" commitment language.
- **cloudflare-resolver-firefox.mdx** — Broke apart a 100+ word run-on sentence explaining DNS into 3 clear sentences. Preserved all legal commitment language verbatim, including "permanently deleted within 24 hours of Cloudflare's receipt," "solely to improve the performance of," and "has agreed to collect only." Changed "Firefox's data processing instructions" to "Mozilla's data processing instructions" (Mozilla is the legal entity).

All changes went through an adversarial fact-check review that flagged 4 high-severity and 7 medium-severity issues — all related to preserving the precise legal meaning of privacy commitments. Every flagged issue was fixed before the commit. The most notable corrections: reverted "prevents" back to original "significantly decreasing the odds" language, restored "some of" in the APNIC data-sharing scope, and restored "the performance of" in the Firefox resolver promise.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
