### PR TITLE
[Access] Remove beta badge from MCP server portals

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -9,8 +9,6 @@ tags:
 sidebar:
   order: 1
   label: MCP server portals
-  badge:
-    text: Beta
 ---
 
 import { Render, Tabs, TabItem, APIRequest } from "~/components";


### PR DESCRIPTION
## Summary

Removes the sidebar Beta badge from the MCP server portals documentation page. MCP server portals are now GA.