### PR TITLE
[Agents] Sync SDK docs and onboarding

### DIFF
--- a/src/content/docs/agents/agentic-payments/x402/charge-for-http-content.mdx
+++ b/src/content/docs/agents/agentic-payments/x402/charge-for-http-content.mdx
@@ -58,7 +58,7 @@ With [Bot Management](/bots/), the proxy can charge crawlers while keeping the s
 }
 ```
 
-Requests with a bot score below `bot_score_threshold` are directed to the paywall. Use `except_detection_ids` to allowlist specific crawlers by [detection ID](/ai-crawl-control/reference/bots/).
+Requests with a bot score at or below `bot_score_threshold` are directed to the paywall. Use `except_detection_ids` to allowlist specific crawlers by [detection ID](/ai-crawl-control/reference/bots/).
 
 ## Deploy
 

--- a/src/content/docs/agents/api-reference/agent-tools.mdx
+++ b/src/content/docs/agents/api-reference/agent-tools.mdx
@@ -1,0 +1,223 @@
+---
+title: Agent tools
+description: Run Think and AIChatAgent sub-agents as retained, streaming tools from a parent agent.
+pcx_content_type: reference
+sidebar:
+  order: 6
+products:
+  - agents
+---
+
+import { TypeScriptExample, LinkCard } from "~/components";
+
+Agent tools let one chat agent dispatch another chat-capable sub-agent as part of its work. The child is a real sub-agent with its own Durable Object storage, messages, tools, resumable stream, and drill-in URL. The parent keeps a small run registry so clients can render the child timeline, replay it after refresh, and clean it up later.
+
+Agent tools support `@cloudflare/think` agents and `AIChatAgent` subclasses. `AIChatAgent` children run headlessly through `saveMessages()`, so they should use server-side tools. Browser-provided client tools are not available during an agent-tool turn unless you model that interaction as server-side state or a separate parent-mediated workflow.
+
+## Use an agent as an AI SDK tool
+
+Use `agentTool()` when the parent model should decide when to call the helper.
+
+<TypeScriptExample>
+
+```ts
+import { Think } from "@cloudflare/think";
+import { agentTool } from "agents/agent-tools";
+import { z } from "zod";
+
+export class Researcher extends Think<Env> {
+	getSystemPrompt() {
+		return "Research the user's topic and end with a concise summary.";
+	}
+}
+
+export class Assistant extends Think<Env> {
+	getTools() {
+		return {
+			research: agentTool(Researcher, {
+				description: "Research one topic in depth.",
+				displayName: "Researcher",
+				inputSchema: z.object({
+					query: z.string().min(3),
+				}),
+			}),
+		};
+	}
+}
+```
+
+</TypeScriptExample>
+
+The child can also be an `AIChatAgent`:
+
+<TypeScriptExample>
+
+```ts
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { agentTool } from "agents/agent-tools";
+import { convertToModelMessages, stepCountIs, streamText } from "ai";
+import { z } from "zod";
+
+export class Summarizer extends AIChatAgent<Env> {
+	protected override formatAgentToolInput(input: { text: string }, request) {
+		return {
+			id: `agent-tool-${request.runId}-input`,
+			role: "user",
+			parts: [{ type: "text", text: `Summarize:\n\n${input.text}` }],
+		};
+	}
+
+	async onChatMessage() {
+		const result = streamText({
+			model: this.env.MODEL,
+			messages: await convertToModelMessages(this.messages),
+		});
+		return result.toUIMessageStreamResponse();
+	}
+}
+
+export class Assistant extends AIChatAgent<Env> {
+	async onChatMessage() {
+		const result = streamText({
+			model: this.env.MODEL,
+			messages: await convertToModelMessages(this.messages),
+			tools: {
+				summarize: agentTool(Summarizer, {
+					description: "Summarize long text in a separate retained agent.",
+					inputSchema: z.object({ text: z.string() }),
+				}),
+			},
+			stopWhen: stepCountIs(5),
+		});
+
+		return result.toUIMessageStreamResponse();
+	}
+}
+```
+
+</TypeScriptExample>
+
+The generated tool calls `this.runAgentTool(ChildAgent, ...)`, streams `agent-tool-event` frames on the parent WebSocket, and returns the child summary to the parent model. If the run fails, aborts, or is interrupted, the tool returns a structured failure instead of an empty success value.
+
+## Run an agent tool imperatively
+
+Use `runAgentTool()` for deterministic workflows, scheduled work, HTTP handlers, or fan-out code.
+
+<TypeScriptExample>
+
+```ts
+const [a, b] = await Promise.allSettled([
+	this.runAgentTool(Researcher, {
+		input: { query: "HTTP/3" },
+		parentToolCallId: toolCallId,
+		displayOrder: 0,
+	}),
+	this.runAgentTool(Researcher, {
+		input: { query: "gRPC" },
+		parentToolCallId: toolCallId,
+		displayOrder: 1,
+	}),
+]);
+```
+
+</TypeScriptExample>
+
+`runAgentTool()` is idempotent by `runId`. Passing the same `runId` never starts a duplicate child turn. Completed, failed, aborted, and interrupted runs are retained until you explicitly clear them.
+
+## Render child timelines in React
+
+`useAgentToolEvents()` is a headless hook. It subscribes to the existing parent connection, deduplicates replay/live races, applies child `UIMessageChunk` bodies to message parts, and groups sibling runs by parent tool call ID.
+
+<TypeScriptExample>
+
+```tsx
+import { useAgent, useAgentToolEvents } from "agents/react";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
+
+const agent = useAgent({ agent: "Assistant", name: userId });
+const { messages } = useAgentChat({ agent });
+const agentTools = useAgentToolEvents({ agent });
+
+for (const message of messages) {
+	for (const part of message.parts) {
+		if (part.type === "tool-call") {
+			const runs = agentTools.getRunsForToolCall(part.toolCallId);
+			// Render the child runs beside this tool call.
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+Imperative runs without a parent tool call are available as `agentTools.unboundRuns`.
+
+## Drill in and gate access
+
+Agent tools are normal sub-agents. Connect to a retained child through the parent route:
+
+<TypeScriptExample>
+
+```ts
+useAgent({
+	agent: "Assistant",
+	name: userId,
+	sub: [{ agent: "Researcher", name: runId }],
+});
+```
+
+</TypeScriptExample>
+
+Gate external access with the parent registry so guessed run IDs cannot spawn fresh child facets:
+
+<TypeScriptExample>
+
+```ts
+override async onBeforeSubAgent(_request, child) {
+	if (!this.hasAgentToolRun(child.className, child.name)) {
+		return new Response("Not found", { status: 404 });
+	}
+}
+```
+
+</TypeScriptExample>
+
+## Clear retained runs
+
+Runs and child facets are retained by default for refresh, drill-in, and later inspection. Delete them explicitly when clearing chat history or applying your own retention policy:
+
+<TypeScriptExample>
+
+```ts
+await this.clearAgentToolRuns();
+await this.clearAgentToolRuns({
+	status: ["completed", "error", "aborted", "interrupted"],
+});
+await this.clearAgentToolRuns({ olderThan: Date.now() - 7 * 24 * 60 * 60_000 });
+```
+
+</TypeScriptExample>
+
+If a retained run is still `starting` or `running`, cleanup cancels the child before deleting its facet.
+
+## Example
+
+<LinkCard
+	title="Agents as tools example"
+	href="https://github.com/cloudflare/agents/tree/main/examples/agents-as-tools"
+	description="Run chat-capable sub-agents as retained tools, stream their timelines inline, and drill into child agents."
+/>
+
+## Related
+
+<LinkCard
+	title="Sub-agents"
+	href="/agents/api-reference/sub-agents/"
+	description="Spawn child agents with isolated storage, typed RPC, and nested client routing."
+/>
+
+<LinkCard
+	title="Chat agents"
+	href="/agents/api-reference/chat-agents/"
+	description="Build AI chat interfaces with AIChatAgent and useAgentChat."
+/>

--- a/src/content/docs/agents/api-reference/agent-tools.mdx
+++ b/src/content/docs/agents/api-reference/agent-tools.mdx
@@ -3,7 +3,7 @@ title: Agent tools
 description: Run Think and AIChatAgent sub-agents as retained, streaming tools from a parent agent.
 pcx_content_type: reference
 sidebar:
-  order: 6
+  order: 16
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/agent-tools.mdx
+++ b/src/content/docs/agents/api-reference/agent-tools.mdx
@@ -170,8 +170,6 @@ useAgent({
 
 Gate external access with the parent registry so guessed run IDs cannot spawn fresh child facets:
 
-<TypeScriptExample>
-
 ```ts
 override async onBeforeSubAgent(_request, child) {
 	if (!this.hasAgentToolRun(child.className, child.name)) {
@@ -179,8 +177,6 @@ override async onBeforeSubAgent(_request, child) {
 	}
 }
 ```
-
-</TypeScriptExample>
 
 ## Clear retained runs
 

--- a/src/content/docs/agents/api-reference/agents-api.mdx
+++ b/src/content/docs/agents/api-reference/agents-api.mdx
@@ -32,13 +32,20 @@ Agents require [Cloudflare Durable Objects](/durable-objects/). Refer to [Config
 An Agent is a class that extends the base `Agent` class:
 
 ```ts
-import { Agent } from "agents";
+import { Agent, routeAgentRequest } from "agents";
 
-class MyAgent extends Agent<Env, State> {
+export class MyAgent extends Agent<Env, State> {
 	// Your agent logic
 }
 
-export default MyAgent;
+export default {
+	async fetch(request: Request, env: Env) {
+		return (
+			(await routeAgentRequest(request, env)) ||
+			new Response("Not found", { status: 404 })
+		);
+	},
+} satisfies ExportedHandler<Env>;
 ```
 
 Each Agent can have millions of instances. Each instance is a separate micro-server that runs independently, allowing horizontal scaling. Instances are addressed by a unique identifier (user ID, email, ticket number, etc.).
@@ -82,7 +89,7 @@ flowchart TD
 | --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | **State**             | `setState()`, `onStateChanged()`, `initialState`                                 | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
 | **Callable methods**  | `@callable()` decorator                                                          | [Callable methods](/agents/api-reference/callable-methods/)         |
-| **Scheduling**        | `schedule()`, `scheduleEvery()`, `listSchedules()`, `cancelSchedule()`           | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
+| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getScheduleById()`, `listSchedules()`          | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
 | **Durable execution** | `runFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()`, `keepAliveWhile()` | [Durable execution](/agents/api-reference/durable-execution/)       |
 | **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                             | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
 | **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                         | [WebSockets](/agents/api-reference/websockets/)                     |
@@ -95,7 +102,7 @@ flowchart TD
 | **Context**           | `getCurrentAgent()`                                                              | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
 | **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                | [Observability](/agents/api-reference/observability/)               |
 | **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                              | [Sub-agents](/agents/api-reference/sub-agents/)                     |
-| **Agent tools**       | `agentTool()`, `runAgentTool()`, `useAgentToolEvents()`                          | [Agent tools](/agents/api-reference/agent-tools/)                   |
+| **Agent tools**       | `runAgentTool()`, `clearAgentToolRuns()`, `hasAgentToolRun()`                    | [Agent tools](/agents/api-reference/agent-tools/)                   |
 | **Sessions**          | `Session.create()`, context blocks, compaction, search                           | [Sessions](/agents/api-reference/sessions/)                         |
 | **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions                 | [Think](/agents/api-reference/think/)                               |
 
@@ -118,12 +125,15 @@ For state that needs to sync with clients, use the [State API](/agents/api-refer
 
 ## Client-side API reference
 
-| Feature              | Methods          | Documentation                                                                 |
-| -------------------- | ---------------- | ----------------------------------------------------------------------------- |
-| **WebSocket client** | `AgentClient`    | [Client SDK](/agents/api-reference/client-sdk/)                               |
-| **HTTP client**      | `agentFetch()`   | [Client SDK](/agents/api-reference/client-sdk/#http-requests-with-agentfetch) |
-| **React hook**       | `useAgent()`     | [Client SDK](/agents/api-reference/client-sdk/#react)                         |
-| **Chat hook**        | `useAgentChat()` | [Client SDK](/agents/api-reference/client-sdk/)                               |
+| Feature               | Methods                | Documentation                                                                     |
+| --------------------- | ---------------------- | --------------------------------------------------------------------------------- |
+| **WebSocket client**  | `AgentClient`          | [Client SDK](/agents/api-reference/client-sdk/)                                   |
+| **HTTP client**       | `agentFetch()`         | [Client SDK](/agents/api-reference/client-sdk/#http-requests-with-agentfetch)     |
+| **React hook**        | `useAgent()`           | [Client SDK](/agents/api-reference/client-sdk/#react)                             |
+| **Chat hook**         | `useAgentChat()`       | [Client SDK](/agents/api-reference/client-sdk/)                                   |
+| **Agent tool events** | `useAgentToolEvents()` | [Agent tools](/agents/api-reference/agent-tools/#render-child-timelines-in-react) |
+
+Module-level helper exports include `agentTool()` from `agents/agent-tools`, which converts a Think or `AIChatAgent` subclass into an AI SDK tool definition.
 
 ### Quick example
 

--- a/src/content/docs/agents/api-reference/agents-api.mdx
+++ b/src/content/docs/agents/api-reference/agents-api.mdx
@@ -78,25 +78,26 @@ flowchart TD
 
 ## Server-side API reference
 
-| Feature               | Methods                                                                              | Documentation                                                       |
-| --------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| **State**             | `setState()`, `onStateChanged()`, `initialState`                                     | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
-| **Callable methods**  | `@callable()` decorator                                                              | [Callable methods](/agents/api-reference/callable-methods/)         |
-| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getSchedules()`, `cancelSchedule()`                | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
-| **Durable execution** | `runFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()`, `keepAliveWhile()`     | [Durable execution](/agents/api-reference/durable-execution/)      |
-| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                                 | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
-| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                             | [WebSockets](/agents/api-reference/websockets/)                     |
-| **HTTP/SSE**          | `onRequest()`                                                                        | [HTTP and SSE](/agents/api-reference/http-sse/)                     |
-| **Email**             | `onEmail()`, `replyToEmail()`                                                        | [Email routing](/agents/api-reference/email/)                       |
-| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                                 | [Run Workflows](/agents/api-reference/run-workflows/)               |
-| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                             | [MCP Client API](/agents/api-reference/mcp-client-api/)             |
-| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                               | [Using AI models](/agents/api-reference/using-ai-models/)           |
-| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`                      | [Protocol messages](/agents/api-reference/protocol-messages/)       |
-| **Context**           | `getCurrentAgent()`                                                                  | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
-| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                    | [Observability](/agents/api-reference/observability/)               |
-| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                                  | [Sub-agents](/agents/api-reference/sub-agents/)                    |
-| **Sessions**          | `Session.create()`, context blocks, compaction, search                               | [Sessions](/agents/api-reference/sessions/)                        |
-| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions                     | [Think](/agents/api-reference/think/)                              |
+| Feature               | Methods                                                                          | Documentation                                                       |
+| --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **State**             | `setState()`, `onStateChanged()`, `initialState`                                 | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
+| **Callable methods**  | `@callable()` decorator                                                          | [Callable methods](/agents/api-reference/callable-methods/)         |
+| **Scheduling**        | `schedule()`, `scheduleEvery()`, `listSchedules()`, `cancelSchedule()`           | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
+| **Durable execution** | `runFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()`, `keepAliveWhile()` | [Durable execution](/agents/api-reference/durable-execution/)       |
+| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                             | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
+| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                         | [WebSockets](/agents/api-reference/websockets/)                     |
+| **HTTP/SSE**          | `onRequest()`                                                                    | [HTTP and SSE](/agents/api-reference/http-sse/)                     |
+| **Email**             | `onEmail()`, `replyToEmail()`                                                    | [Email routing](/agents/api-reference/email/)                       |
+| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                             | [Run Workflows](/agents/api-reference/run-workflows/)               |
+| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                         | [MCP Client API](/agents/api-reference/mcp-client-api/)             |
+| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                           | [Using AI models](/agents/api-reference/using-ai-models/)           |
+| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`                  | [Protocol messages](/agents/api-reference/protocol-messages/)       |
+| **Context**           | `getCurrentAgent()`                                                              | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
+| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                | [Observability](/agents/api-reference/observability/)               |
+| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                              | [Sub-agents](/agents/api-reference/sub-agents/)                     |
+| **Agent tools**       | `agentTool()`, `runAgentTool()`, `useAgentToolEvents()`                          | [Agent tools](/agents/api-reference/agent-tools/)                   |
+| **Sessions**          | `Session.create()`, context blocks, compaction, search                           | [Sessions](/agents/api-reference/sessions/)                         |
+| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions                 | [Think](/agents/api-reference/think/)                               |
 
 ## SQL API
 
@@ -149,7 +150,7 @@ function App() {
 For AI chat applications, extend `AIChatAgent` instead of `Agent`:
 
 ```ts
-import { AIChatAgent } from "agents/ai-chat-agent";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 
 class ChatAgent extends AIChatAgent {
 	async onChatMessage(onFinish) {

--- a/src/content/docs/agents/api-reference/browse-the-web.mdx
+++ b/src/content/docs/agents/api-reference/browse-the-web.mdx
@@ -3,7 +3,7 @@ title: Browse the web
 description: Give Agents full Chrome DevTools Protocol access to inspect pages, scrape data, and capture screenshots with Browser Run.
 pcx_content_type: reference
 sidebar:
-  order: 15
+  order: 21
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -627,8 +627,6 @@ Common return values:
 
 Use `ctx.createdAt` to skip stale recoveries:
 
-<TypeScriptExample>
-
 ```ts
 override async onChatRecovery(
 	ctx: ChatRecoveryContext,
@@ -639,8 +637,6 @@ override async onChatRecovery(
 	return {};
 }
 ```
-
-</TypeScriptExample>
 
 #### `continueLastTurn`
 

--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -14,12 +14,14 @@ Build AI-powered chat interfaces with `AIChatAgent` and `useAgentChat`. Messages
 
 ## Overview
 
-The `@cloudflare/ai-chat` package provides two main exports:
+The `@cloudflare/ai-chat` package provides two primary APIs:
 
 | Export         | Import                      | Purpose                                                        |
 | -------------- | --------------------------- | -------------------------------------------------------------- |
 | `AIChatAgent`  | `@cloudflare/ai-chat`       | Server-side agent class with message persistence and streaming |
 | `useAgentChat` | `@cloudflare/ai-chat/react` | React hook for building chat UIs                               |
+
+Advanced helpers are also available from `@cloudflare/ai-chat/react`, `@cloudflare/ai-chat/types`, and `agents/chat`; see [Exports](#exports) for the full package surface.
 
 Built on the [AI SDK](https://ai-sdk.dev) and Cloudflare Durable Objects, you get:
 
@@ -35,7 +37,7 @@ Built on the [AI SDK](https://ai-sdk.dev) and Cloudflare Durable Objects, you ge
 ### Install
 
 ```sh
-npm install @cloudflare/ai-chat agents ai
+npm install @cloudflare/ai-chat agents ai workers-ai-provider
 ```
 
 ### Server
@@ -98,7 +100,7 @@ function Chat() {
 				}}
 			>
 				<input name="input" placeholder="Type a message..." />
-				<button type="submit" disabled={status === "streaming"}>
+				<button type="submit" disabled={status !== "ready"}>
 					Send
 				</button>
 			</form>
@@ -167,10 +169,11 @@ export class ChatAgent extends AIChatAgent {
 	// Limit stored messages (optional)
 	maxPersistedMessages = 200;
 
-	async onChatMessage(onFinish?, options?) {
-		// onFinish: optional callback for streamText (cleanup is automatic)
+	async onChatMessage(onFinish, options?) {
+		// onFinish: callback for streamText (cleanup is automatic)
 		// options.abortSignal: cancel signal
 		// options.body: custom data from client
+		// options.continuation: true for continuation turns
 		// Return a Response (streaming or plain text)
 	}
 }
@@ -227,9 +230,16 @@ export class ChatAgent extends AIChatAgent {
 		// options.requestId — unique identifier for this chat request,
 		// useful for logging and correlating events
 		console.log("Request ID:", options?.requestId);
+
+		if (options?.continuation) {
+			// This turn continues a previous assistant message after a tool result,
+			// continueLastTurn(), or recovery.
+		}
 	}
 }
 ```
+
+`options.continuation` is `true` for automatic continuations after tool results or approvals, calls to `continueLastTurn()`, and recovered turns. Use it to choose a different model, adjust your system prompt, or skip expensive context assembly for continuation turns.
 
 ### `this.messages`
 
@@ -325,7 +335,7 @@ export class ChatAgent extends AIChatAgent {
 | `"queue"` (default)                             | Queue every submission and process in order                                                                                         |
 | `"latest"`                                      | Keep only the latest overlapping submission; superseded submissions still persist their user messages but do not start a model turn |
 | `"merge"`                                       | Queue overlapping submissions, then collapse their trailing user messages into one combined turn before the latest queued turn runs |
-| `"drop"`                                        | Ignore overlapping submissions entirely                                                                                             |
+| `"drop"`                                        | Ignore overlapping submissions entirely. Messages are not persisted.                                                                |
 | `{ strategy: "debounce", debounceMs?: number }` | Trailing-edge latest with a quiet window (default 750ms)                                                                            |
 
 This setting only applies to `sendMessage()` submissions. Regenerations, tool continuations, approvals, clears, and programmatic `saveMessages()` calls keep their existing serialized behavior.
@@ -391,7 +401,7 @@ if (result.status === "aborted") {
 
 ### `onChatResponse`
 
-Called after a chat turn completes and the assistant message has been persisted. The turn lock is released before this hook runs, so it is safe to call `saveMessages` from inside. Fires for all turn completion paths: WebSocket chat requests, `saveMessages`, and auto-continuation.
+Called after a chat turn produces and persists an assistant message. The turn lock is released before this hook runs, so it is safe to call `saveMessages` from inside. Fires for turn paths that persist an assistant message: WebSocket chat requests, `saveMessages`, and auto-continuation. If a turn fails before producing any assistant parts, the error is surfaced through the original request instead.
 
 <TypeScriptExample>
 
@@ -554,6 +564,15 @@ export class ChatAgent extends AIChatAgent {
 If you do not pass `abortSignal` to `streamText`, the LLM call will continue running in the background even after the user cancels. Always forward it when possible.
 :::
 
+Subclasses can also cancel turns from inside the Durable Object:
+
+```ts
+protected abortRequest(requestId: string, reason?: unknown): void
+protected abortAllRequests(): void
+```
+
+Use `abortRequest()` when you know the request ID. Use `abortAllRequests()` for single-purpose helpers that should cancel whatever turn is currently running. Prefer `SaveMessagesOptions.signal` for programmatic turns when you can pass a signal at the call site.
+
 ### Stream recovery
 
 When a Durable Object is evicted mid-stream (code update, inactivity timeout, resource limit), the LLM connection is severed permanently and the in-memory streaming state is lost. `chatRecovery` wraps each chat turn in a [`runFiber()`](/agents/api-reference/durable-execution/), providing automatic `keepAlive` during streaming and a recovery hook on restart.
@@ -649,7 +668,7 @@ protected continueLastTurn(
 ): Promise<SaveMessagesResult>;
 ```
 
-Called automatically by the default recovery path. Can also be called manually from scheduled callbacks or other entry points. The optional `body` parameter merges with the saved `_lastBody`.
+Called automatically by the default recovery path. Can also be called manually from scheduled callbacks or other entry points. The optional `body` parameter overrides the saved request body for this continuation. Pass `options.signal` to cancel the continuation while it is running.
 
 #### Stashing recovery data
 
@@ -737,6 +756,7 @@ function Chat() {
 | ----------------------------- | --------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `agent`                       | `ReturnType<typeof useAgent>`                 | Required | Agent connection from `useAgent`                                                                                         |
 | `onToolCall`                  | `({ toolCall, addToolOutput }) => void`       | —        | Handle client-side tool execution                                                                                        |
+| `tools`                       | `Record<string, AITool>`                      | —        | Advanced: dynamically register client-executed tools from the browser                                                    |
 | `autoContinueAfterToolResult` | `boolean`                                     | `true`   | Auto-continue conversation after client tool results and approvals                                                       |
 | `resume`                      | `boolean`                                     | `true`   | Enable automatic stream resumption on reconnect                                                                          |
 | `body`                        | `object \| () => object`                      | —        | Custom data sent with every request                                                                                      |
@@ -753,7 +773,7 @@ function Chat() {
 | `addToolOutput`           | `({ toolCallId, output }) => void` | Provide output for a client-side tool                                             |
 | `addToolApprovalResponse` | `({ id, approved }) => void`       | Approve or reject a tool requiring approval                                       |
 | `setMessages`             | `(messages \| updater) => void`    | Set messages directly (syncs to server)                                           |
-| `status`                  | `string`                           | `"idle"`, `"submitted"`, `"streaming"`, or `"error"`                              |
+| `status`                  | `string`                           | `"ready"`, `"submitted"`, `"streaming"`, or `"error"`                             |
 | `isStreaming`             | `boolean`                          | `true` while the agent is streaming or waiting on an active client tool           |
 | `isServerStreaming`       | `boolean`                          | `true` while a server-initiated stream or active client-tool phase is in progress |
 | `isToolContinuation`      | `boolean`                          | `true` while an automatic continuation after a tool result or approval is running |
@@ -851,13 +871,13 @@ const { messages, sendMessage } = useAgentChat({
 
 When the LLM invokes `getLocation`, the stream pauses. The `onToolCall` callback fires, your code provides the output, and the conversation continues.
 
+For SDKs or platforms where the browser decides the available tools at runtime, pass a `tools` object to `useAgentChat`. Tools with client-side `execute` functions are serialized and sent to the server automatically. On the server, `options.clientTools` and `createToolsFromClientSchemas()` remain supported for this dynamic tool pattern.
+
 ### Tool approval (human-in-the-loop)
 
 Use `needsApproval` for tools that require user confirmation before executing.
 
 **Server:**
-
-<TypeScriptExample>
 
 ```ts
 tools: {
@@ -873,13 +893,16 @@ tools: {
 }
 ```
 
-</TypeScriptExample>
-
 **Client:**
 
-<TypeScriptExample>
-
 ```ts
+import { getToolName, isToolUIPart } from "ai";
+import {
+	getToolApproval,
+	getToolCallId,
+	getToolPartState,
+} from "@cloudflare/ai-chat/react";
+
 const { messages, addToolApprovalResponse } = useAgentChat({ agent });
 
 // Render pending approvals from message parts
@@ -887,28 +910,33 @@ const { messages, addToolApprovalResponse } = useAgentChat({ agent });
 	messages.map((msg) =>
 		msg.parts
 			.filter(
-				(part) => part.type === "tool" && part.state === "approval-required",
+				(part) =>
+					isToolUIPart(part) && getToolPartState(part) === "waiting-approval",
 			)
 			.map((part) => (
-				<div key={part.toolCallId}>
-					<p>Approve {part.toolName}?</p>
+				<div key={getToolCallId(part)}>
+					<p>Approve {getToolName(part)}?</p>
 					<button
-						onClick={() =>
+						onClick={() => {
+							const approval = getToolApproval(part);
+							if (!approval) return;
 							addToolApprovalResponse({
-								id: part.toolCallId,
+								id: approval.id,
 								approved: true,
-							})
-						}
+							});
+						}}
 					>
 						Approve
 					</button>
 					<button
-						onClick={() =>
+						onClick={() => {
+							const approval = getToolApproval(part);
+							if (!approval) return;
 							addToolApprovalResponse({
-								id: part.toolCallId,
+								id: approval.id,
 								approved: false,
-							})
-						}
+							});
+						}}
 					>
 						Reject
 					</button>
@@ -917,8 +945,6 @@ const { messages, addToolApprovalResponse } = useAgentChat({ agent });
 	);
 }
 ```
-
-</TypeScriptExample>
 
 #### Custom denial messages with `addToolOutput`
 
@@ -1169,7 +1195,7 @@ const { messages } = useAgentChat({ agent, resume: false });
 
 ### Row size protection
 
-SQLite rows have a maximum size of 2 MB. When a message approaches this limit (for example, a tool returning a very large output), `AIChatAgent` automatically compacts the message:
+Workers SQLite rows have a hard maximum size of 2 MB. To stay below that limit, `AIChatAgent` starts compacting a serialized message at roughly 1.8 MB, for example when a tool returns a very large output:
 
 1. **Tool output compaction** — Large tool outputs are replaced with an LLM-friendly summary that instructs the model to suggest re-running the tool
 2. **Text truncation** — If the message is still too large after tool compaction, text parts are truncated with a note
@@ -1540,12 +1566,12 @@ The originating client receives the streaming response. All other clients receiv
 
 ### Exports
 
-| Import path                 | Exports                                                                                                    |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `@cloudflare/ai-chat`       | `AIChatAgent`, `createToolsFromClientSchemas`, `ChatRecoveryContext`, `ChatRecoveryOptions`                |
-| `@cloudflare/ai-chat/react` | `useAgentChat`                                                                                             |
-| `@cloudflare/ai-chat/types` | `MessageType`, `OutgoingMessage`, `IncomingMessage`                                                        |
-| `agents/chat`               | Shared advanced chat primitives such as `SaveMessagesResult`, `SaveMessagesOptions`, and `isReplayChunk()` |
+| Import path                 | Exports                                                                                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@cloudflare/ai-chat`       | `AIChatAgent`, `createToolsFromClientSchemas`, `ClientToolSchema`, `ChatRecoveryContext`, `ChatRecoveryOptions`, lifecycle types                  |
+| `@cloudflare/ai-chat/react` | `useAgentChat`, `extractClientToolSchemas`, `getToolPartState`, `getToolCallId`, `getToolInput`, `getToolOutput`, `getToolApproval`               |
+| `@cloudflare/ai-chat/types` | `MessageType`, `OutgoingMessage`, `IncomingMessage`                                                                                               |
+| `agents/chat`               | Shared advanced chat primitives such as `SaveMessagesResult`, `SaveMessagesOptions`, `CHAT_MESSAGE_TYPES`, `ROW_MAX_BYTES`, and `isReplayChunk()` |
 
 ### WebSocket protocol
 
@@ -1563,21 +1589,22 @@ The chat protocol uses typed JSON messages over WebSocket:
 | `CF_AGENT_MESSAGE_UPDATED`       | Server → Client | Notify of message update    |
 | `CF_AGENT_STREAM_RESUMING`       | Server → Client | Notify of stream resumption |
 | `CF_AGENT_STREAM_RESUME_REQUEST` | Client → Server | Request stream resume check |
+| `CF_AGENT_STREAM_RESUME_ACK`     | Server → Client | Resume stream from a cursor |
+| `CF_AGENT_STREAM_RESUME_NONE`    | Server → Client | No resumable stream exists  |
 
 ## Deprecated APIs
 
 The following APIs are deprecated and will emit a console warning when used. They will be removed in a future release.
 
-| Deprecated                              | Replacement                                   | Notes                                           |
-| --------------------------------------- | --------------------------------------------- | ----------------------------------------------- |
-| `addToolResult({ toolCallId, result })` | `addToolOutput({ toolCallId, output })`       | Renamed for consistency with AI SDK terminology |
-| `createToolsFromClientSchemas()`        | Client tools are now registered automatically | No manual schema conversion needed              |
-| `extractClientToolSchemas()`            | Client tools are now registered automatically | Schemas are sent with tool results              |
-| `detectToolsRequiringConfirmation()`    | Use `needsApproval` on the tool definition    | Approval is now per-tool, not a global filter   |
-| `tools` option on `useAgentChat`        | Define tools in `onChatMessage` on the server | All tool definitions belong on the server       |
-| `toolsRequiringConfirmation` option     | Use `needsApproval` on individual tools       | Per-tool approval replaces global list          |
+| Deprecated                              | Replacement                                | Notes                                           |
+| --------------------------------------- | ------------------------------------------ | ----------------------------------------------- |
+| `addToolResult({ toolCallId, result })` | `addToolOutput({ toolCallId, output })`    | Renamed for consistency with AI SDK terminology |
+| `detectToolsRequiringConfirmation()`    | Use `needsApproval` on the tool definition | Approval is now per-tool, not a global filter   |
+| `toolsRequiringConfirmation` option     | Use `needsApproval` on individual tools    | Per-tool approval replaces global list          |
 
 If you are upgrading from an earlier version, replace deprecated calls with their replacements. The deprecated APIs still work but will be removed in a future major version.
+
+`createToolsFromClientSchemas()`, `extractClientToolSchemas()`, and the `tools` option on `useAgentChat` are still supported for dynamic client-side tools. They are advanced APIs, not deprecated APIs.
 
 ## Next steps
 

--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -1423,7 +1423,7 @@ export class ChatAgent extends AIChatAgent {
 
 </TypeScriptExample>
 
-### Subagent delegation
+### In-process subagent delegation
 
 :::note
 
@@ -1485,7 +1485,7 @@ export class ChatAgent extends AIChatAgent {
 The research agent runs in its own context — its token budget is separate from the orchestrator's. Only the summary goes back to the parent model.
 
 :::note
-`ToolLoopAgent` is best suited for subagents, not as a replacement for `streamText` in `onChatMessage` itself. The main `onChatMessage` benefits from direct access to `this.env`, `this.messages`, and `options.body` — things that a pre-configured `ToolLoopAgent` instance cannot reference.
+`ToolLoopAgent` is best suited for in-process subagents, not as a replacement for `streamText` in `onChatMessage` itself. The main `onChatMessage` benefits from direct access to `this.env`, `this.messages`, and `options.body` — things that a pre-configured `ToolLoopAgent` instance cannot reference.
 :::
 
 #### Streaming progress with preliminary results

--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -366,7 +366,28 @@ await this.saveMessages((messages) => [
 
 </TypeScriptExample>
 
-`saveMessages` returns `{ requestId, status }` where `status` is `"completed"` if the turn ran, or `"skipped"` if the chat was cleared before it started.
+`saveMessages` returns `{ requestId, status }` where `status` is `"completed"` if the turn ran, `"skipped"` if the chat was cleared before it started, or `"aborted"` if an external `AbortSignal` cancelled it before completion.
+
+Pass `options.signal` to cancel a programmatic turn from outside the chat agent. This is useful when a parent tool call needs to cancel a child agent turn without knowing the internally generated request ID:
+
+<TypeScriptExample>
+
+```ts
+const controller = new AbortController();
+
+const result = await this.saveMessages(
+	(messages) => [...messages, syntheticUserMessage],
+	{ signal: controller.signal },
+);
+
+if (result.status === "aborted") {
+	// Partial chunks already streamed are persisted.
+}
+```
+
+</TypeScriptExample>
+
+`continueLastTurn()` accepts the same `options.signal` argument. `AbortSignal` objects cannot cross Durable Object RPC boundaries, so construct the controller inside the Durable Object that calls `saveMessages()` or `continueLastTurn()`. The signal is in memory only; if the Durable Object hibernates mid-turn and `chatRecovery` is enabled, the recovered turn runs without the original signal.
 
 ### `onChatResponse`
 
@@ -556,7 +577,10 @@ Override to implement provider-specific recovery. The default behavior persists 
 <TypeScriptExample>
 
 ```ts
-import type { ChatRecoveryContext, ChatRecoveryOptions } from "@cloudflare/ai-chat";
+import type {
+	ChatRecoveryContext,
+	ChatRecoveryOptions,
+} from "@cloudflare/ai-chat";
 
 export class ChatAgent extends AIChatAgent {
 	override chatRecovery = true;
@@ -586,6 +610,7 @@ export class ChatAgent extends AIChatAgent {
 | `messages`        | `ChatMessage[]`                        | Full conversation history                                             |
 | `lastBody`        | `Record<string, unknown> \| undefined` | The original request body                                             |
 | `lastClientTools` | `ClientToolSchema[] \| undefined`      | Client tool schemas from the original request                         |
+| `createdAt`       | `number`                               | Epoch milliseconds when the interrupted turn started                  |
 
 **`ChatRecoveryOptions`:**
 
@@ -600,12 +625,32 @@ Common return values:
 - `{ continue: false }` — persist partial but do not auto-continue (handle continuation yourself)
 - `{ persist: false, continue: false }` — handle everything yourself (for example, retrieve a completed response from the provider)
 
+Use `ctx.createdAt` to skip stale recoveries:
+
+<TypeScriptExample>
+
+```ts
+override async onChatRecovery(
+	ctx: ChatRecoveryContext,
+): Promise<ChatRecoveryOptions> {
+	if (Date.now() - ctx.createdAt > 2 * 60 * 1000) {
+		return { continue: false };
+	}
+	return {};
+}
+```
+
+</TypeScriptExample>
+
 #### `continueLastTurn`
 
 Appends to the last assistant message by re-calling `onChatMessage` with the saved request body. The response is streamed as a continuation — appended to the existing assistant message, not a new one. No synthetic user message is created.
 
 ```ts
-protected continueLastTurn(body?: Record<string, unknown>): Promise<SaveMessagesResult>;
+protected continueLastTurn(
+	body?: Record<string, unknown>,
+	options?: SaveMessagesOptions,
+): Promise<SaveMessagesResult>;
 ```
 
 Called automatically by the default recovery path. Can also be called manually from scheduled callbacks or other entry points. The optional `body` parameter merges with the saved `_lastBody`.
@@ -679,6 +724,9 @@ function Chat() {
 		addToolApprovalResponse,
 		setMessages,
 		status,
+		isStreaming,
+		isServerStreaming,
+		isToolContinuation,
 	} = useAgentChat({ agent });
 
 	// ...
@@ -701,15 +749,20 @@ function Chat() {
 
 ### Return values
 
-| Property                  | Type                               | Description                                          |
-| ------------------------- | ---------------------------------- | ---------------------------------------------------- |
-| `messages`                | `UIMessage[]`                      | Current conversation messages                        |
-| `sendMessage`             | `(message) => void`                | Send a message                                       |
-| `clearHistory`            | `() => void`                       | Clear conversation (client and server)               |
-| `addToolOutput`           | `({ toolCallId, output }) => void` | Provide output for a client-side tool                |
-| `addToolApprovalResponse` | `({ id, approved }) => void`       | Approve or reject a tool requiring approval          |
-| `setMessages`             | `(messages \| updater) => void`    | Set messages directly (syncs to server)              |
-| `status`                  | `string`                           | `"idle"`, `"submitted"`, `"streaming"`, or `"error"` |
+| Property                  | Type                               | Description                                                                       |
+| ------------------------- | ---------------------------------- | --------------------------------------------------------------------------------- |
+| `messages`                | `UIMessage[]`                      | Current conversation messages                                                     |
+| `sendMessage`             | `(message) => void`                | Send a message                                                                    |
+| `clearHistory`            | `() => void`                       | Clear conversation (client and server)                                            |
+| `addToolOutput`           | `({ toolCallId, output }) => void` | Provide output for a client-side tool                                             |
+| `addToolApprovalResponse` | `({ id, approved }) => void`       | Approve or reject a tool requiring approval                                       |
+| `setMessages`             | `(messages \| updater) => void`    | Set messages directly (syncs to server)                                           |
+| `status`                  | `string`                           | `"idle"`, `"submitted"`, `"streaming"`, or `"error"`                              |
+| `isStreaming`             | `boolean`                          | `true` while the agent is streaming or waiting on an active client tool           |
+| `isServerStreaming`       | `boolean`                          | `true` while a server-initiated stream or active client-tool phase is in progress |
+| `isToolContinuation`      | `boolean`                          | `true` while an automatic continuation after a tool result or approval is running |
+
+Use `isToolContinuation` when your UI should distinguish a fresh user submit from a continuation after a tool result. For example, show a typing indicator only for `status === "submitted" && !isToolContinuation`, while keeping loading controls disabled whenever `isStreaming` is true.
 
 ## Tools
 
@@ -1374,7 +1427,7 @@ export class ChatAgent extends AIChatAgent {
 
 :::note
 
-This section covers **in-process** subagents using the AI SDK's `ToolLoopAgent`. For **Durable Object sub-agents** with their own isolated storage and typed RPC, refer to [Sub-agents](/agents/api-reference/sub-agents/). For streaming full LLM turns through a child agent, refer to [Think: Sub-agent RPC](/agents/api-reference/think/#sub-agent-rpc-and-programmatic-turns).
+This section covers **in-process** subagents using the AI SDK's `ToolLoopAgent`. For **Durable Object sub-agents** with their own isolated storage and typed RPC, refer to [Sub-agents](/agents/api-reference/sub-agents/). To run Think or `AIChatAgent` sub-agents as retained, streaming tools, refer to [Agent tools](/agents/api-reference/agent-tools/).
 
 :::
 
@@ -1491,11 +1544,12 @@ The originating client receives the streaming response. All other clients receiv
 
 ### Exports
 
-| Import path                 | Exports                                             |
-| --------------------------- | --------------------------------------------------- |
-| `@cloudflare/ai-chat`       | `AIChatAgent`, `createToolsFromClientSchemas`, `ChatRecoveryContext`, `ChatRecoveryOptions` |
-| `@cloudflare/ai-chat/react` | `useAgentChat`                                      |
-| `@cloudflare/ai-chat/types` | `MessageType`, `OutgoingMessage`, `IncomingMessage` |
+| Import path                 | Exports                                                                                                    |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `@cloudflare/ai-chat`       | `AIChatAgent`, `createToolsFromClientSchemas`, `ChatRecoveryContext`, `ChatRecoveryOptions`                |
+| `@cloudflare/ai-chat/react` | `useAgentChat`                                                                                             |
+| `@cloudflare/ai-chat/types` | `MessageType`, `OutgoingMessage`, `IncomingMessage`                                                        |
+| `agents/chat`               | Shared advanced chat primitives such as `SaveMessagesResult`, `SaveMessagesOptions`, and `isReplayChunk()` |
 
 ### WebSocket protocol
 

--- a/src/content/docs/agents/api-reference/configuration.mdx
+++ b/src/content/docs/agents/api-reference/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Configure Wrangler bindings, environment variables, and type generation for an Agents SDK project.
+description: Configure Wrangler bindings, environment variables, and type generation for a project using the Agents SDK.
 pcx_content_type: concept
 sidebar:
   order: 3

--- a/src/content/docs/agents/api-reference/durable-execution.mdx
+++ b/src/content/docs/agents/api-reference/durable-execution.mdx
@@ -25,24 +25,24 @@ import { Agent } from "agents";
 import type { FiberRecoveryContext } from "agents";
 
 class MyAgent extends Agent {
-  async doWork() {
-    await this.runFiber("my-task", async (ctx) => {
-      const step1 = await expensiveOperation();
-      ctx.stash({ step1 });
+	async doWork() {
+		await this.runFiber("my-task", async (ctx) => {
+			const step1 = await expensiveOperation();
+			ctx.stash({ step1 });
 
-      const step2 = await anotherExpensiveOperation(step1);
-      this.setState({ ...this.state, result: step2 });
-    });
-  }
+			const step2 = await anotherExpensiveOperation(step1);
+			this.setState({ ...this.state, result: step2 });
+		});
+	}
 
-  async onFiberRecovered(ctx: FiberRecoveryContext) {
-    if (ctx.name !== "my-task") return;
-    const snapshot = ctx.snapshot as { step1: unknown } | null;
-    if (snapshot) {
-      const step2 = await anotherExpensiveOperation(snapshot.step1);
-      this.setState({ ...this.state, result: step2 });
-    }
-  }
+	async onFiberRecovered(ctx: FiberRecoveryContext) {
+		if (ctx.name !== "my-task") return;
+		const snapshot = ctx.snapshot as { step1: unknown } | null;
+		if (snapshot) {
+			const step2 = await anotherExpensiveOperation(snapshot.step1);
+			this.setState({ ...this.state, result: step2 });
+		}
+	}
 }
 ```
 
@@ -66,8 +66,8 @@ Prevents idle eviction by creating a 30-second alarm heartbeat that resets the i
 
 ```ts
 class Agent {
-  keepAlive(): Promise<() => void>;
-  keepAliveWhile<T>(fn: () => Promise<T>): Promise<T>;
+	keepAlive(): Promise<() => void>;
+	keepAliveWhile<T>(fn: () => Promise<T>): Promise<T>;
 }
 ```
 
@@ -75,7 +75,7 @@ class Agent {
 
 ```ts
 const result = await this.keepAliveWhile(async () => {
-  return await slowAPICall();
+	return await slowAPICall();
 });
 ```
 
@@ -84,9 +84,9 @@ For manual control, `keepAlive()` returns a disposer. Always call it when done �
 ```ts
 const dispose = await this.keepAlive();
 try {
-  await longWork();
+	await longWork();
 } finally {
-  dispose();
+	dispose();
 }
 ```
 
@@ -94,7 +94,7 @@ try {
 
 While any `keepAlive` ref is held, an alarm fires every 30 seconds that resets the inactivity timer. When all disposers are called, alarms stop and the DO can go idle naturally.
 
-The heartbeat is invisible to `getSchedules()` — no schedule rows are created. It does not conflict with your own schedules; the alarm system multiplexes all schedules and the keepAlive heartbeat through a single alarm slot.
+The heartbeat is invisible to `listSchedules()` — no schedule rows are created. It does not conflict with your own schedules; the alarm system multiplexes all schedules and the keepAlive heartbeat through a single alarm slot.
 
 ### Configurable interval
 
@@ -102,7 +102,7 @@ Default: 30 seconds. The inactivity timeout is ~70–140 seconds, so 30 seconds 
 
 ```ts
 class MyAgent extends Agent {
-  static options = { keepAliveIntervalMs: 2_000 };
+	static options = { keepAliveIntervalMs: 2_000 };
 }
 ```
 
@@ -125,21 +125,22 @@ Durable execution with checkpointing and recovery.
 
 ```ts
 class Agent {
-  runFiber<T>(name: string, fn: (ctx: FiberContext) => Promise<T>): Promise<T>;
-  stash(data: unknown): void;
-  onFiberRecovered(ctx: FiberRecoveryContext): Promise<void>;
+	runFiber<T>(name: string, fn: (ctx: FiberContext) => Promise<T>): Promise<T>;
+	stash(data: unknown): void;
+	onFiberRecovered(ctx: FiberRecoveryContext): Promise<void>;
 }
 
 type FiberContext = {
-  id: string;
-  stash(data: unknown): void;
-  snapshot: unknown | null;
+	id: string;
+	stash(data: unknown): void;
+	snapshot: unknown | null;
 };
 
 type FiberRecoveryContext = {
-  id: string;
-  name: string;
-  snapshot: unknown | null;
+	id: string;
+	name: string;
+	snapshot: unknown | null;
+	createdAt: number;
 };
 ```
 
@@ -181,6 +182,14 @@ runFiber("work", fn)
 
 Both recovery paths call the same hook. The alarm path is critical for background agents that have no incoming client connections — the persisted alarm wakes the agent on its own.
 
+#### Sub-agents
+
+Fibers also work inside sub-agents. The fiber row and snapshots are stored in the sub-agent's own SQLite database, and `onFiberRecovered()` runs with the sub-agent as `this`.
+
+Sub-agents do not have independent alarm slots, so the top-level parent owns the physical heartbeat. When a sub-agent starts a fiber, the parent stores a small root-side index entry for that facet and fiber ID. Root alarm housekeeping uses that index to route recovery checks back into the owning sub-agent, even if the child has no client connection or incoming RPC.
+
+This keeps recovery local to the child while preserving the single physical alarm slot owned by the parent. A recovered continuation can use `schedule()` from inside the facet; the parent owns the physical alarm and routes the callback back to the child.
+
 #### Error during execution
 
 ```txt
@@ -199,12 +208,12 @@ No automatic retries. Recovery logic belongs in `onFiberRecovered`, where you ha
 ```ts
 // Inline — await the result
 const result = await this.runFiber("work", async (ctx) => {
-  return computeExpensiveThing();
+	return computeExpensiveThing();
 });
 
 // Fire-and-forget — caller does not wait
 void this.runFiber("background", async (ctx) => {
-  await longRunningProcess();
+	await longRunningProcess();
 });
 ```
 
@@ -218,20 +227,20 @@ Each call **fully replaces** the previous snapshot — it is not a merge. Write 
 
 ```ts
 await this.runFiber("research", async (ctx) => {
-  const steps = ["search", "analyze", "synthesize"];
-  const completed: string[] = [];
-  const results: Record<string, unknown> = {};
+	const steps = ["search", "analyze", "synthesize"];
+	const completed: string[] = [];
+	const results: Record<string, unknown> = {};
 
-  for (const step of steps) {
-    results[step] = await executeStep(step);
-    completed.push(step);
+	for (const step of steps) {
+		results[step] = await executeStep(step);
+		completed.push(step);
 
-    ctx.stash({
-      completed,
-      results,
-      pendingSteps: steps.slice(completed.length)
-    });
-  }
+		ctx.stash({
+			completed,
+			results,
+			pendingSteps: steps.slice(completed.length),
+		});
+	}
 });
 ```
 
@@ -247,32 +256,32 @@ Override `onFiberRecovered` to handle interrupted fibers. The default implementa
 
 ```ts
 class ResearchAgent extends Agent {
-  async onFiberRecovered(ctx: FiberRecoveryContext) {
-    if (ctx.name !== "research") return;
+	async onFiberRecovered(ctx: FiberRecoveryContext) {
+		if (ctx.name !== "research") return;
 
-    const snapshot = ctx.snapshot as {
-      completed: string[];
-      results: Record<string, unknown>;
-      pendingSteps: string[];
-    } | null;
+		const snapshot = ctx.snapshot as {
+			completed: string[];
+			results: Record<string, unknown>;
+			pendingSteps: string[];
+		} | null;
 
-    if (snapshot && snapshot.pendingSteps.length > 0) {
-      void this.runFiber("research", async (fiberCtx) => {
-        const { completed, results, pendingSteps } = snapshot;
+		if (snapshot && snapshot.pendingSteps.length > 0) {
+			void this.runFiber("research", async (fiberCtx) => {
+				const { completed, results, pendingSteps } = snapshot;
 
-        for (const step of pendingSteps) {
-          results[step] = await this.executeStep(step);
-          completed.push(step);
+				for (const step of pendingSteps) {
+					results[step] = await this.executeStep(step);
+					completed.push(step);
 
-          fiberCtx.stash({
-            completed,
-            results,
-            pendingSteps: pendingSteps.slice(pendingSteps.indexOf(step) + 1)
-          });
-        }
-      });
-    }
-  }
+					fiberCtx.stash({
+						completed,
+						results,
+						pendingSteps: pendingSteps.slice(pendingSteps.indexOf(step) + 1),
+					});
+				}
+			});
+		}
+	}
 }
 ```
 
@@ -293,10 +302,10 @@ Multiple fibers can run at the same time. Each has its own row in SQLite with it
 
 ```ts
 void this.runFiber("fetch-data", async (ctx) => {
-  /* ... */
+	/* ... */
 });
 void this.runFiber("process-queue", async (ctx) => {
-  /* ... */
+	/* ... */
 });
 ```
 
@@ -332,6 +341,7 @@ Called once per orphaned fiber row on agent restart. Override to implement recov
 - **`ctx.id`** — unique fiber ID
 - **`ctx.name`** — the name passed to `runFiber()`
 - **`ctx.snapshot`** — the last `stash()` data, or `null` if `stash()` was never called
+- **`ctx.createdAt`** — epoch milliseconds when `runFiber()` started. Compare against `Date.now()` to skip recoveries that are too old to replay safely.
 
 ### keepAlive()
 
@@ -345,5 +355,6 @@ Run an async function while keeping the DO alive. Heartbeat starts before `fn` a
 
 - [Long-running agents](/agents/concepts/long-running-agents/) — how fibers compose with schedules, plans, and async operations
 - [Schedule tasks](/agents/api-reference/schedule-tasks/) — `keepAlive` details and the alarm system
+- [Sub-agents](/agents/api-reference/sub-agents/) — durable execution and schedules inside sub-agents
 - [Workflows](/agents/concepts/workflows/) — durable multi-step execution outside the agent
 - [Chat agents](/agents/api-reference/chat-agents/) — `chatRecovery` and `onChatRecovery`

--- a/src/content/docs/agents/api-reference/durable-execution.mdx
+++ b/src/content/docs/agents/api-reference/durable-execution.mdx
@@ -150,13 +150,13 @@ type FiberRecoveryContext = {
 
 ```txt
 runFiber("work", fn)
-  ├─ INSERT row into cf_agents_runs
+  ├─ Persist recovery metadata
   ├─ keepAlive() — heartbeat starts
   ├─ Execute fn(ctx)
-  │    ├─ ctx.stash(data) → UPDATE snapshot in SQLite
-  │    ├─ ctx.stash(data) → UPDATE snapshot in SQLite
+  │    ├─ ctx.stash(data) → persist snapshot
+  │    ├─ ctx.stash(data) → persist snapshot
   │    └─ return result
-  ├─ DELETE row from cf_agents_runs
+  ├─ Delete recovery metadata
   ├─ keepAlive dispose — heartbeat stops
   └─ Return result to caller
 ```
@@ -172,12 +172,12 @@ runFiber("work", fn)
   ├─ Persisted alarm fires → housekeeping check                   [fallback path]
 
   Recovery:
-  ├─ SELECT * FROM cf_agents_runs
-  ├─ For each orphaned row:
+  ├─ Load interrupted fibers from storage
+  ├─ For each interrupted fiber:
   │    ├─ Parse snapshot from JSON
   │    ├─ Call onFiberRecovered(ctx)
-  │    └─ DELETE the row
-  └─ If onFiberRecovered calls runFiber() again → new row, normal execution
+  │    └─ Delete recovery metadata
+  └─ If onFiberRecovered calls runFiber() again → new fiber, normal execution
 ```
 
 Both recovery paths call the same hook. The alarm path is critical for background agents that have no incoming client connections — the persisted alarm wakes the agent on its own.
@@ -186,7 +186,7 @@ Both recovery paths call the same hook. The alarm path is critical for backgroun
 
 Fibers also work inside sub-agents. The fiber row and snapshots are stored in the sub-agent's own SQLite database, and `onFiberRecovered()` runs with the sub-agent as `this`.
 
-Sub-agents do not have independent alarm slots, so the top-level parent owns the physical heartbeat. When a sub-agent starts a fiber, the parent stores a small root-side index entry for that facet and fiber ID. Root alarm housekeeping uses that index to route recovery checks back into the owning sub-agent, even if the child has no client connection or incoming RPC.
+Sub-agents do not have independent alarm slots, so the top-level parent owns the physical heartbeat. When a sub-agent starts a fiber, the parent tracks enough metadata to route recovery checks back into the owning sub-agent, even if the child has no client connection or incoming RPC.
 
 This keeps recovery local to the child while preserving the single physical alarm slot owned by the parent. A recovered continuation can use `schedule()` from inside the facet; the parent owns the physical alarm and routes the callback back to the child.
 

--- a/src/content/docs/agents/api-reference/get-current-agent.mdx
+++ b/src/content/docs/agents/api-reference/get-current-agent.mdx
@@ -21,7 +21,7 @@ All custom methods automatically have full agent context. The framework automati
 <TypeScriptExample>
 
 ```ts
-import { AIChatAgent } from "agents/ai-chat-agent";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 import { getCurrentAgent } from "agents";
 
 export class MyAgent extends AIChatAgent {
@@ -52,7 +52,7 @@ No configuration is required. The framework automatically:
 <TypeScriptExample>
 
 ```ts
-import { AIChatAgent } from "agents/ai-chat-agent";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 import { getCurrentAgent } from "agents";
 import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";
@@ -110,7 +110,7 @@ agent.customMethod();
 <TypeScriptExample>
 
 ```ts
-import { AIChatAgent } from "agents/ai-chat-agent";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";
 
@@ -137,7 +137,7 @@ export class MyAgent extends AIChatAgent {
 <TypeScriptExample>
 
 ```ts
-import { AIChatAgent } from "agents/ai-chat-agent";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 import { getCurrentAgent } from "agents";
 
 async function saveToDatabase(data: any) {
@@ -214,7 +214,7 @@ function getCurrentAgent<T extends Agent>(): {
 <TypeScriptExample>
 
 ```ts
-import { AIChatAgent } from "agents/ai-chat-agent";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 import { getCurrentAgent } from "agents";
 
 export class MyAgent extends AIChatAgent {

--- a/src/content/docs/agents/api-reference/get-current-agent.mdx
+++ b/src/content/docs/agents/api-reference/get-current-agent.mdx
@@ -3,7 +3,7 @@ title: getCurrentAgent()
 description: Access the current Agent context from external utility functions using getCurrentAgent() in the Agents SDK.
 pcx_content_type: concept
 sidebar:
-  order: 17
+  order: 29
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/http-sse.mdx
+++ b/src/content/docs/agents/api-reference/http-sse.mdx
@@ -111,7 +111,7 @@ data: {"count": 42}\n\n
 
 ### With AI SDK
 
-The [AI SDK](https://sdk.vercel.ai/) provides built-in SSE streaming:
+The [AI SDK](https://ai-sdk.dev/) provides built-in SSE streaming:
 
 <TypeScriptExample>
 

--- a/src/content/docs/agents/api-reference/mcp-agent-api.mdx
+++ b/src/content/docs/agents/api-reference/mcp-agent-api.mdx
@@ -5,7 +5,7 @@ description: Build stateful MCP servers on Cloudflare by extending the McpAgent 
 tags:
   - MCP
 sidebar:
-  order: 12
+  order: 25
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/mcp-client-api.mdx
+++ b/src/content/docs/agents/api-reference/mcp-client-api.mdx
@@ -309,6 +309,7 @@ const state = this.getMcpServers();
 for (const tool of state.tools) {
 	console.log(`Tool: ${tool.name}`);
 	console.log(`  From server: ${tool.serverId}`);
+	console.log(`  Title: ${tool.title ?? tool.name}`);
 	console.log(`  Description: ${tool.description}`);
 }
 ```

--- a/src/content/docs/agents/api-reference/mcp-client-api.mdx
+++ b/src/content/docs/agents/api-reference/mcp-client-api.mdx
@@ -5,7 +5,7 @@ pcx_content_type: reference
 tags:
   - MCP
 sidebar:
-  order: 12
+  order: 26
 products:
   - agents
 ---
@@ -353,7 +353,7 @@ for (const [id, server] of Object.entries(state.servers)) {
 
 ### Integration with AI SDK
 
-To use MCP tools with the Vercel AI SDK, use `this.mcp.getAITools()` which converts MCP tools to AI SDK format:
+To use MCP tools with the AI SDK, use `this.mcp.getAITools()` which converts MCP tools to AI SDK format:
 
 <TypeScriptExample>
 

--- a/src/content/docs/agents/api-reference/mcp-handler-api.mdx
+++ b/src/content/docs/agents/api-reference/mcp-handler-api.mdx
@@ -5,7 +5,7 @@ description: Create a stateless MCP server fetch handler for a plain Worker usin
 tags:
   - MCP
 sidebar:
-  order: 12
+  order: 24
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/observability.mdx
+++ b/src/content/docs/agents/api-reference/observability.mdx
@@ -3,7 +3,7 @@ title: Observability
 description: Subscribe to structured Agent events for RPC calls, state changes, schedules, workflows, and MCP connections via diagnostics channels.
 pcx_content_type: concept
 sidebar:
-  order: 18
+  order: 30
 products:
   - agents
 ---
@@ -32,16 +32,16 @@ Every event has these fields:
 
 Events are routed to eight named channels based on their type:
 
-| Channel            | Event types                                                                                                                                                                  | Description                         |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `agents:state`     | `state:update`                                                                                                                                                               | State sync events                   |
-| `agents:rpc`       | `rpc`, `rpc:error`                                                                                                                                                           | RPC method calls and failures       |
-| `agents:message`   | `message:request`, `message:response`, `message:clear`, `message:cancel`, `message:error`, `tool:result`, `tool:approval`                                                    | Chat message and tool lifecycle     |
-| `agents:schedule`  | `schedule:create`, `schedule:execute`, `schedule:cancel`, `schedule:retry`, `schedule:error`, `queue:create`, `queue:retry`, `queue:error`                                   | Scheduled and queued task lifecycle |
-| `agents:lifecycle` | `connect`, `disconnect`, `destroy`                                                                                                                                           | Agent connection and teardown       |
-| `agents:workflow`  | `workflow:start`, `workflow:event`, `workflow:approved`, `workflow:rejected`, `workflow:terminated`, `workflow:paused`, `workflow:resumed`, `workflow:restarted`             | Workflow state transitions          |
-| `agents:mcp`       | `mcp:client:preconnect`, `mcp:client:connect`, `mcp:client:authorize`, `mcp:client:discover`                                                                                 | MCP client operations               |
-| `agents:email`     | `email:receive`, `email:reply`                                                                                                                                               | Email processing                    |
+| Channel            | Event types                                                                                                                                                      | Description                         |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `agents:state`     | `state:update`                                                                                                                                                   | State sync events                   |
+| `agents:rpc`       | `rpc`, `rpc:error`                                                                                                                                               | RPC method calls and failures       |
+| `agents:message`   | `message:request`, `message:response`, `message:clear`, `message:cancel`, `message:error`, `tool:result`, `tool:approval`                                        | Chat message and tool lifecycle     |
+| `agents:schedule`  | `schedule:create`, `schedule:execute`, `schedule:cancel`, `schedule:retry`, `schedule:error`, `queue:create`, `queue:retry`, `queue:error`                       | Scheduled and queued task lifecycle |
+| `agents:lifecycle` | `connect`, `disconnect`, `destroy`                                                                                                                               | Agent connection and teardown       |
+| `agents:workflow`  | `workflow:start`, `workflow:event`, `workflow:approved`, `workflow:rejected`, `workflow:terminated`, `workflow:paused`, `workflow:resumed`, `workflow:restarted` | Workflow state transitions          |
+| `agents:mcp`       | `mcp:client:preconnect`, `mcp:client:connect`, `mcp:client:authorize`, `mcp:client:discover`                                                                     | MCP client operations               |
+| `agents:email`     | `email:receive`, `email:reply`                                                                                                                                   | Email processing                    |
 
 ## Subscribing to events
 

--- a/src/content/docs/agents/api-reference/protocol-messages.mdx
+++ b/src/content/docs/agents/api-reference/protocol-messages.mdx
@@ -3,7 +3,7 @@ title: Protocol messages
 description: Control the identity, state, and MCP protocol messages sent to WebSocket clients on Agent connect.
 pcx_content_type: concept
 sidebar:
-  order: 9
+  order: 27
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/queue-tasks.mdx
+++ b/src/content/docs/agents/api-reference/queue-tasks.mdx
@@ -3,7 +3,7 @@ title: Queue tasks
 description: Add background tasks to a built-in FIFO queue for asynchronous processing within Cloudflare Agents.
 pcx_content_type: concept
 sidebar:
-  order: 11
+  order: 12
 products:
   - agents
 ---
@@ -362,7 +362,6 @@ The queue system works with other Agent SDK features:
 - Tasks are processed sequentially, not in parallel.
 - No priority system (FIFO only).
 - Queue processing happens during agent execution, not as separate background jobs.
-
 
 ## Queue vs Schedule
 

--- a/src/content/docs/agents/api-reference/rag.mdx
+++ b/src/content/docs/agents/api-reference/rag.mdx
@@ -3,7 +3,7 @@ title: Retrieval Augmented Generation
 description: Add RAG to Cloudflare Agents using Vectorize for vector search and the embedded SQL database for context retrieval.
 pcx_content_type: concept
 sidebar:
-  order: 14
+  order: 20
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/readonly-connections.mdx
+++ b/src/content/docs/agents/api-reference/readonly-connections.mdx
@@ -3,7 +3,7 @@ title: Readonly connections
 description: Restrict WebSocket clients to view-only access so they receive state updates without modifying Agent state.
 pcx_content_type: concept
 sidebar:
-  order: 8
+  order: 28
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/retries.mdx
+++ b/src/content/docs/agents/api-reference/retries.mdx
@@ -3,7 +3,7 @@ title: Retries
 description: Retry failed operations with exponential backoff and jitter using the built-in retry system in the Agents SDK.
 pcx_content_type: reference
 sidebar:
-  order: 11
+  order: 13
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/run-workflows.mdx
+++ b/src/content/docs/agents/api-reference/run-workflows.mdx
@@ -3,7 +3,7 @@ title: Run Workflows
 description: Integrate Cloudflare Workflows with Agents for durable, multi-step background processing and failure recovery.
 pcx_content_type: concept
 sidebar:
-  order: 12
+  order: 14
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/schedule-tasks.mdx
+++ b/src/content/docs/agents/api-reference/schedule-tasks.mdx
@@ -1,7 +1,7 @@
 ---
 title: Schedule tasks
 description: Schedule delayed, date-based, cron, and interval tasks on Agents with persistent SQLite-backed execution.
-pcx_content_type: concept
+pcx_content_type: reference
 sidebar:
   order: 10
 products:

--- a/src/content/docs/agents/api-reference/schedule-tasks.mdx
+++ b/src/content/docs/agents/api-reference/schedule-tasks.mdx
@@ -301,7 +301,7 @@ Retrieve a scheduled task by its ID:
 <TypeScriptExample>
 
 ```ts
-const schedule = this.getSchedule(scheduleId);
+const schedule = await this.getScheduleById(scheduleId);
 
 if (schedule) {
 	console.log(
@@ -324,13 +324,13 @@ Query scheduled tasks with optional filters:
 
 ```ts
 // Get all scheduled tasks
-const allSchedules = this.getSchedules();
+const allSchedules = await this.listSchedules();
 
 // Get only cron jobs
-const cronJobs = this.getSchedules({ type: "cron" });
+const cronJobs = await this.listSchedules({ type: "cron" });
 
 // Get tasks in the next hour
-const upcoming = this.getSchedules({
+const upcoming = await this.listSchedules({
 	timeRange: {
 		start: new Date(),
 		end: new Date(Date.now() + 60 * 60 * 1000),
@@ -338,10 +338,10 @@ const upcoming = this.getSchedules({
 });
 
 // Get a specific task by ID
-const specific = this.getSchedules({ id: "abc123" });
+const specific = await this.listSchedules({ id: "abc123" });
 
 // Combine filters
-const upcomingCronJobs = this.getSchedules({
+const upcomingCronJobs = await this.listSchedules({
 	type: "cron",
 	timeRange: {
 		start: new Date(),
@@ -478,7 +478,7 @@ class PollingAgent extends Agent {
 
 	async stopPolling() {
 		// Cancel all polling schedules
-		const schedules = this.getSchedules({ type: "delayed" });
+		const schedules = await this.listSchedules({ type: "delayed" });
 		for (const schedule of schedules) {
 			if (schedule.callback === "poll") {
 				await this.cancelSchedule(schedule.id);
@@ -763,13 +763,33 @@ Schedule a task to run repeatedly at a fixed interval.
 - If callback throws an error, the interval continues
 - Cancel with `cancelSchedule(id)` to stop the entire interval
 
+### `getScheduleById()`
+
+```ts
+async getScheduleById(id: string): Promise<Schedule<unknown> | undefined>
+```
+
+Get a scheduled task by ID. Returns `undefined` if not found. This method works in both top-level agents and sub-agents.
+
+### `listSchedules()`
+
+```ts
+async listSchedules(criteria?: {
+  id?: string;
+  type?: "scheduled" | "delayed" | "cron" | "interval";
+  timeRange?: { start?: Date; end?: Date };
+}): Promise<Schedule<unknown>[]>
+```
+
+Get scheduled tasks matching the criteria. This method works in both top-level agents and sub-agents.
+
 ### `getSchedule()`
 
 ```ts
 getSchedule<T>(id: string): Schedule<T> | undefined
 ```
 
-Get a scheduled task by ID. Returns `undefined` if not found. This method is synchronous.
+Deprecated. Get a scheduled task by ID synchronously. This method only works in top-level agents. Use `await this.getScheduleById(id)` instead.
 
 ### `getSchedules()`
 
@@ -781,7 +801,7 @@ getSchedules<T>(criteria?: {
 }): Schedule<T>[]
 ```
 
-Get scheduled tasks matching the criteria. This method is synchronous.
+Deprecated. Get scheduled tasks matching the criteria synchronously. This method only works in top-level agents. Use `await this.listSchedules(criteria)` instead.
 
 ### `cancelSchedule()`
 
@@ -797,7 +817,7 @@ Cancel a scheduled task. Returns `true` if cancelled, `false` if not found.
 async keepAlive(): Promise<() => void>
 ```
 
-Prevent the Durable Object from being evicted due to inactivity by creating a 30-second heartbeat schedule. Returns a disposer function that cancels the heartbeat when called. The disposer is idempotent — calling it multiple times is safe.
+Prevent the Durable Object from being evicted due to inactivity by holding a 30-second alarm-backed heartbeat reference. Returns a disposer function that releases the heartbeat when called. The disposer is idempotent — calling it multiple times is safe.
 
 Always call the disposer when the work is done — otherwise the heartbeat continues indefinitely.
 
@@ -841,11 +861,12 @@ const result = await this.keepAliveWhile(async () => {
 
 Durable Objects are evicted after a period of inactivity (typically 70-140 seconds with no incoming requests, WebSocket messages, or alarms). During long-running operations — streaming LLM responses, waiting on external APIs, running multi-step computations — the agent can be evicted mid-flight.
 
-`keepAlive()` prevents this by creating a 30-second heartbeat schedule. The internal heartbeat callback is a no-op — the alarm firing itself is what resets the inactivity timer. Because it uses the scheduling system:
+`keepAlive()` prevents this by holding an in-memory heartbeat reference and using the Durable Object alarm system directly. The alarm firing itself resets the inactivity timer.
 
-- The heartbeat does not conflict with your own schedules (the scheduling system multiplexes through a single alarm slot)
-- The heartbeat shows up in `getSchedules()` if you need to inspect it
-- Multiple concurrent `keepAlive()` calls each get their own schedule, so they do not interfere with each other
+- The heartbeat does not conflict with your own schedules because the alarm system multiplexes through a single alarm slot.
+- No schedule rows are created, and the heartbeat is invisible to `listSchedules()`.
+- Multiple concurrent `keepAlive()` calls use a reference count, so one disposer does not release another caller's heartbeat.
+- Inside sub-agents, `keepAlive()` delegates that heartbeat reference to the top-level parent because facets do not have independent alarm slots.
 
 ### Multiple concurrent callers
 
@@ -880,12 +901,6 @@ dispose2(); // Now the agent can go idle
 | Multi-step tool execution                   | Yes                                    |
 | Short request-response handlers             | No — not needed                        |
 | Background work via scheduling or workflows | No — alarms already keep the DO active |
-
-:::note
-
-`keepAlive()` is marked `@experimental` and may change between releases.
-
-:::
 
 ## Limits
 

--- a/src/content/docs/agents/api-reference/sessions.mdx
+++ b/src/content/docs/agents/api-reference/sessions.mdx
@@ -5,7 +5,7 @@ description: Persistent conversation storage with tree-structured messages, cont
 tags:
   - AI
 sidebar:
-  order: 6
+  order: 18
 products:
   - agents
 ---
@@ -102,18 +102,18 @@ const session = new Session(new AgentSessionProvider(this), {
 
 All builder methods return `this` for chaining. Order does not matter — providers are resolved lazily on first use.
 
-| Method | Description |
-| ------ | ----------- |
-| `Session.create(agent)` | Static factory. `agent` is any object with a `sql` tagged template method (your Agent or Durable Object). |
-| `.forSession(sessionId)` | Namespace this session by ID. Required for multi-session isolation when not using `SessionManager`. |
-| `.withContext(label, options?)` | Add a context block. Refer to [Context blocks](#context-blocks). |
-| `.withCachedPrompt(provider?)` | Enable system prompt persistence. The prompt is frozen on first use and survives hibernation and eviction. |
-| `.onCompaction(fn)` | Register a compaction function. Refer to [Compaction](#compaction). |
-| `.compactAfter(tokenThreshold)` | Auto-compact when estimated token count exceeds the threshold. Requires `.onCompaction()`. |
+| Method                          | Description                                                                                                |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `Session.create(agent)`         | Static factory. `agent` is any object with a `sql` tagged template method (your Agent or Durable Object).  |
+| `.forSession(sessionId)`        | Namespace this session by ID. Required for multi-session isolation when not using `SessionManager`.        |
+| `.withContext(label, options?)` | Add a context block. Refer to [Context blocks](#context-blocks).                                           |
+| `.withCachedPrompt(provider?)`  | Enable system prompt persistence. The prompt is frozen on first use and survives hibernation and eviction. |
+| `.onCompaction(fn)`             | Register a compaction function. Refer to [Compaction](#compaction).                                        |
+| `.compactAfter(tokenThreshold)` | Auto-compact when estimated token count exceeds the threshold. Requires `.onCompaction()`.                 |
 
 ## Messages
 
-Messages use the `SessionMessage` type — a minimal shape with `id`, `role`, `parts`, and optional `createdAt`. The Vercel AI SDK's `UIMessage` is structurally compatible and can be passed directly. The session stores messages in a tree structure via `parent_id`, enabling branching conversations.
+Messages use the `SessionMessage` type — a minimal shape with `id`, `role`, `parts`, and optional `createdAt`. The AI SDK's `UIMessage` is structurally compatible and can be passed directly. The session stores messages in a tree structure via `parent_id`, enabling branching conversations.
 
 <TypeScriptExample>
 
@@ -201,12 +201,12 @@ Context blocks are persistent key-value sections injected into the system prompt
 
 There are four provider types, detected by duck-typing:
 
-| Provider | Interface | Behavior | AI tool |
-| -------- | --------- | -------- | ------- |
-| **ContextProvider** | `get()` | Read-only block in system prompt | — |
-| **WritableContextProvider** | `get()` + `set()` | Writable via AI | `set_context` |
-| **SkillProvider** | `get()` + `load()` + `set?()` | On-demand keyed documents. `get()` returns a metadata listing; `load(key)` fetches full content. | `load_context`, `unload_context`, `set_context` |
-| **SearchProvider** | `get()` + `search()` + `set?()` | Full-text searchable entries. `get()` returns a summary; `search(query)` runs FTS5. | `search_context`, `set_context` |
+| Provider                    | Interface                       | Behavior                                                                                         | AI tool                                         |
+| --------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| **ContextProvider**         | `get()`                         | Read-only block in system prompt                                                                 | —                                               |
+| **WritableContextProvider** | `get()` + `set()`               | Writable via AI                                                                                  | `set_context`                                   |
+| **SkillProvider**           | `get()` + `load()` + `set?()`   | On-demand keyed documents. `get()` returns a metadata listing; `load(key)` fetches full content. | `load_context`, `unload_context`, `set_context` |
+| **SearchProvider**          | `get()` + `search()` + `set?()` | Full-text searchable entries. `get()` returns a summary; `search(query)` runs FTS5.              | `search_context`, `set_context`                 |
 
 ### Built-in providers
 
@@ -452,13 +452,13 @@ Context blocks, prompt caching, and compaction settings are propagated to all se
 
 ### Builder methods
 
-| Method | Description |
-| ------ | ----------- |
-| `SessionManager.create(agent)` | Static factory. |
-| `.withContext(label, options?)` | Add context block template for all sessions. |
-| `.withCachedPrompt(provider?)` | Enable prompt persistence for all sessions. |
-| `.onCompaction(fn)` | Register compaction function for all sessions. |
-| `.compactAfter(tokenThreshold)` | Auto-compact threshold for all sessions. |
+| Method                          | Description                                                                                             |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `SessionManager.create(agent)`  | Static factory.                                                                                         |
+| `.withContext(label, options?)` | Add context block template for all sessions.                                                            |
+| `.withCachedPrompt(provider?)`  | Enable prompt persistence for all sessions.                                                             |
+| `.onCompaction(fn)`             | Register compaction function for all sessions.                                                          |
+| `.compactAfter(tokenThreshold)` | Auto-compact threshold for all sessions.                                                                |
 | `.withSearchableHistory(label)` | Add a cross-session searchable history block. The model can search past conversations from any session. |
 
 ### Session lifecycle
@@ -593,7 +593,8 @@ const myWritable: WritableContextProvider = {
 const mySkills: SkillProvider = {
 	get: async () => "- api-ref: API Reference\n- guide: User Guide",
 	load: async (key) => fetchDocument(key),
-	set: async (key, content, description) => saveDocument(key, content, description),
+	set: async (key, content, description) =>
+		saveDocument(key, content, description),
 };
 
 // Search provider (enables search_context tool)
@@ -612,18 +613,42 @@ You can also implement `SessionProvider` to replace the SQLite storage entirely:
 
 ```ts
 const myStorage: SessionProvider = {
-	getMessage(id) { /* ... */ },
-	getHistory(leafId?) { /* ... */ },
-	getLatestLeaf() { /* ... */ },
-	getBranches(messageId) { /* ... */ },
-	getPathLength(leafId?) { /* ... */ },
-	appendMessage(message, parentId?) { /* ... */ },
-	updateMessage(message) { /* ... */ },
-	deleteMessages(messageIds) { /* ... */ },
-	clearMessages() { /* ... */ },
-	addCompaction(summary, fromId, toId) { /* ... */ },
-	getCompactions() { /* ... */ },
-	searchMessages(query, limit) { /* ... */ },
+	getMessage(id) {
+		/* ... */
+	},
+	getHistory(leafId?) {
+		/* ... */
+	},
+	getLatestLeaf() {
+		/* ... */
+	},
+	getBranches(messageId) {
+		/* ... */
+	},
+	getPathLength(leafId?) {
+		/* ... */
+	},
+	appendMessage(message, parentId?) {
+		/* ... */
+	},
+	updateMessage(message) {
+		/* ... */
+	},
+	deleteMessages(messageIds) {
+		/* ... */
+	},
+	clearMessages() {
+		/* ... */
+	},
+	addCompaction(summary, fromId, toId) {
+		/* ... */
+	},
+	getCompactions() {
+		/* ... */
+	},
+	searchMessages(query, limit) {
+		/* ... */
+	},
 };
 ```
 
@@ -633,14 +658,14 @@ const myStorage: SessionProvider = {
 
 All storage is in Durable Object SQLite. Tables are created lazily on first use.
 
-| Table | Purpose |
-| ----- | ------- |
-| `assistant_messages` | Tree-structured messages with `id`, `session_id`, `parent_id`, `role`, `content` (JSON), `created_at` |
-| `assistant_compactions` | Compaction overlays with `summary`, `from_message_id`, `to_message_id` |
-| `assistant_fts` | FTS5 virtual table for message search (porter stemming, unicode tokenization) |
-| `assistant_sessions` | Session registry (SessionManager only) with `name`, `parent_session_id`, `model`, `source`, token/cost counters |
-| `cf_agents_context_blocks` | Persistent context block storage (`AgentContextProvider`) |
-| `cf_agents_search_entries` / `cf_agents_search_fts` | Searchable context entries and FTS5 index (`AgentSearchProvider`) |
+| Table                                               | Purpose                                                                                                         |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `assistant_messages`                                | Tree-structured messages with `id`, `session_id`, `parent_id`, `role`, `content` (JSON), `created_at`           |
+| `assistant_compactions`                             | Compaction overlays with `summary`, `from_message_id`, `to_message_id`                                          |
+| `assistant_fts`                                     | FTS5 virtual table for message search (porter stemming, unicode tokenization)                                   |
+| `assistant_sessions`                                | Session registry (SessionManager only) with `name`, `parent_session_id`, `model`, `source`, token/cost counters |
+| `cf_agents_context_blocks`                          | Persistent context block storage (`AgentContextProvider`)                                                       |
+| `cf_agents_search_entries` / `cf_agents_search_fts` | Searchable context entries and FTS5 index (`AgentSearchProvider`)                                               |
 
 ## Acknowledgments
 

--- a/src/content/docs/agents/api-reference/sub-agents.mdx
+++ b/src/content/docs/agents/api-reference/sub-agents.mdx
@@ -10,14 +10,13 @@ products:
   - agents
 ---
 
-import {
-	TypeScriptExample,
-	WranglerConfig,
-	InlineBadge,
-	LinkCard,
-} from "~/components";
+import { TypeScriptExample, WranglerConfig, LinkCard } from "~/components";
 
 Spawn child agents as co-located Durable Objects with their own isolated SQLite storage. The parent gets a typed RPC stub for calling methods on the child — every public method on the child class is callable as a remote procedure call with Promise-wrapped return types.
+
+Use sub-agents when a single user or entity owns an open-ended set of long-lived agents, such as chats, documents, sessions, shards, or projects. Each sub-agent runs in parallel with its own state while the parent coordinates discovery, access control, and lifecycle.
+
+If you want a parent chat agent to dispatch another chat-capable agent during a single turn and render that child's progress inline, use [Agent tools](/agents/api-reference/agent-tools/). Agent tools are built on sub-agents, but add a parent-side run registry, streaming `agent-tool-event` frames, replay, cancellation, and cleanup.
 
 ## Quick start
 
@@ -50,7 +49,7 @@ Both classes must be exported from the worker entry point. No separate Durable O
 
 ```toml
 compatibility_date = "$today"
-compatibility_flags = ["nodejs_compat", "experimental"]
+compatibility_flags = ["nodejs_compat"]
 
 [[durable_objects.bindings]]
 class_name = "Orchestrator"
@@ -119,6 +118,8 @@ class MyChild extends Agent {
 - The child class must extend `Agent`
 - The child class must be exported from the worker entry point (`export class MyChild extends Agent`)
 - The export name must match the class name — `export { Foo as Bar }` is not supported
+- The parent class must be bound as a Durable Object namespace in `wrangler.jsonc`
+- The child class name cannot be `Sub`, because `/sub/` is reserved as the URL separator for nested routes
 
 ## abortSubAgent
 
@@ -162,6 +163,166 @@ class Agent {
 | `name`    | `string`        | Name of the child to delete                     |
 
 Deletion is transitive — the child's own sub-agents are also deleted.
+
+## Introspection and access control
+
+### `hasSubAgent`
+
+Check whether a child has been spawned and not deleted. This is backed by a framework-maintained SQLite registry.
+
+<TypeScriptExample>
+
+```ts
+if (!this.hasSubAgent(Chat, id)) {
+	return new Response("Not found", { status: 404 });
+}
+```
+
+</TypeScriptExample>
+
+### `listSubAgents`
+
+List spawned sub-agents, optionally filtered by class. Rows are returned in creation order.
+
+<TypeScriptExample>
+
+```ts
+const chats = this.listSubAgents(Chat);
+// [{ className: "Chat", name: "chat-abc", createdAt: 1700000000000 }]
+```
+
+</TypeScriptExample>
+
+### `onBeforeSubAgent`
+
+Override this middleware hook on the parent to gate, mutate, or short-circuit incoming `/sub/` requests before the framework wakes the child. It mirrors `onBeforeConnect` and `onBeforeRequest`.
+
+The hook can return:
+
+| Return value | Effect                                    |
+| ------------ | ----------------------------------------- |
+| `void`       | Forward the original request to the child |
+| `Request`    | Forward a modified request                |
+| `Response`   | Short-circuit and do not wake the child   |
+
+<TypeScriptExample>
+
+```ts
+export class Inbox extends Agent {
+	override async onBeforeSubAgent(_request, { className, name }) {
+		// Strict registry gate: only allow clients to reach chats that were created.
+		if (!this.hasSubAgent(className, name)) {
+			return new Response(`${className} "${name}" not found`, {
+				status: 404,
+			});
+		}
+	}
+}
+```
+
+</TypeScriptExample>
+
+WebSocket upgrade requests flow through this hook the same way as plain HTTP requests. If you return a modified `Request`, preserve the original WebSocket upgrade headers.
+
+## Parent and child identity
+
+Sub-agents know who their parent is through `this.parentPath` and `this.selfPath`.
+
+<TypeScriptExample>
+
+```ts
+// Inside a Chat spawned by Inbox:
+this.parentPath;
+// [{ className: "Inbox", name: "user-123" }]
+
+this.selfPath;
+// [
+//   { className: "Inbox", name: "user-123" },
+//   { className: "Chat", name: "chat-abc" }
+// ]
+```
+
+</TypeScriptExample>
+
+`parentPath` is root-first, so the direct parent is always `parentPath.at(-1)`. Top-level agents have `parentPath === []`.
+
+Use `parentAgent(Cls)` from a sub-agent to get a typed RPC stub to its immediate parent:
+
+<TypeScriptExample>
+
+```ts
+const inbox = await this.parentAgent(Inbox);
+await inbox.recordTurn(this.name, "...");
+```
+
+</TypeScriptExample>
+
+For grandparents and further ancestors, iterate `this.parentPath` and call `getAgentByName()` directly. If the binding name does not match the class name, call `getAgentByName(env.MY_BINDING, this.parentPath.at(-1)!.name)` instead of `parentAgent()`.
+
+## Client routing
+
+### `useAgent({ sub })`
+
+Extend any `useAgent` call with a `sub` chain to connect to a descendant facet:
+
+<TypeScriptExample>
+
+```tsx
+const chat = useAgent({
+	agent: "Inbox",
+	name: userId,
+	sub: [{ agent: "Chat", name: chatId }],
+});
+```
+
+</TypeScriptExample>
+
+The hook builds a URL like `/agents/inbox/user-123/sub/chat/chat-abc` and opens a direct WebSocket to the `Chat` child. Every other `useAgent` feature works as usual: state sync, `stub` calls, `@callable` RPC, and `useAgentChat` on top of the returned socket.
+
+### Custom HTTP routing
+
+For fetch handlers that do their own top-level URL parsing, use `routeSubAgentRequest()` to dispatch a request into a sub-agent from an already-resolved parent stub:
+
+<TypeScriptExample>
+
+```ts
+import { getAgentByName, routeSubAgentRequest } from "agents";
+
+export default {
+	async fetch(request: Request, env: Env) {
+		const url = new URL(request.url);
+		const match = url.pathname.match(/^\/api\/u\/([^/]+)(\/.*)$/);
+		if (!match) return new Response("Not found", { status: 404 });
+
+		const [, userId, rest] = match;
+		const parent = await getAgentByName(env.Inbox, userId);
+		return routeSubAgentRequest(request, parent, { fromPath: rest });
+	},
+};
+```
+
+</TypeScriptExample>
+
+`fromPath` takes the sub-agent tail, such as `/sub/chat/chat-abc`. The helper parses it, runs the parent's `onBeforeSubAgent` hook, and forwards the request into the facet.
+
+### External typed RPC
+
+From inside the parent Durable Object, `this.subAgent(Cls, name)` returns a typed stub. From outside the parent, use `getSubAgentByName()`:
+
+<TypeScriptExample>
+
+```ts
+import { getAgentByName, getSubAgentByName } from "agents";
+
+const inbox = await getAgentByName(env.Inbox, userId);
+const chat = await getSubAgentByName(inbox, Chat, chatId);
+
+await chat.addMessage({ role: "user", content: "hello" });
+```
+
+</TypeScriptExample>
+
+`getSubAgentByName()` returns an RPC-only proxy. Method calls work, but `.fetch()` throws. Use `routeSubAgentRequest()` for HTTP and WebSocket forwarding.
 
 ## Storage isolation
 
@@ -316,24 +477,39 @@ export class Streamer extends Agent {
 
 </TypeScriptExample>
 
-## Limitations
+## Scheduling and durable work
 
-Sub-agents run as facets of the parent Durable Object. Some `Agent` methods are not available in sub-agents:
+Sub-agents can schedule their own callbacks and run durable fibers:
 
-| Method             | Behavior in sub-agent                              |
-| ------------------ | -------------------------------------------------- |
-| `schedule()`       | Throws `"not supported in sub-agents"`             |
-| `cancelSchedule()` | Throws `"not supported in sub-agents"`             |
-| `keepAlive()`      | Throws `"not supported in sub-agents"`             |
-| `setState()`       | Works normally (writes to the child's own storage) |
-| `this.sql`         | Works normally (child's own SQLite)                |
-| `subAgent()`       | Works — sub-agents can spawn their own children    |
+| Method                                  | Behavior in sub-agent                                                      |
+| --------------------------------------- | -------------------------------------------------------------------------- |
+| `schedule()` / `scheduleEvery()`        | Work normally and run callbacks inside the sub-agent                       |
+| `cancelSchedule()`                      | Works for schedules owned by the calling sub-agent                         |
+| `getScheduleById()` / `listSchedules()` | Work and return schedules scoped to the calling sub-agent                  |
+| `keepAlive()` / `keepAliveWhile()`      | Work by delegating the heartbeat to the top-level parent                   |
+| `runFiber()`                            | Works, with fiber rows and snapshots stored in the child's SQLite database |
+| `setState()`                            | Works normally and writes to the child's own storage                       |
+| `this.sql`                              | Works normally and points at the child's own SQLite database               |
+| `subAgent()`                            | Works, so sub-agents can spawn their own children                          |
 
-For scheduled work, have the parent schedule the task and delegate to the sub-agent when the schedule fires.
+The top-level parent still owns the physical Durable Object alarm because facets do not have independent alarm slots. The Agents SDK stores the child owner path with each schedule row, wakes the parent, and routes the callback back into the child. `runFiber()` uses the same pattern: fiber rows and snapshots live in the child's own SQLite database, while the parent keeps a small root-side index so alarm housekeeping can route recovery checks back into idle children.
+
+The older synchronous `getSchedule()` and `getSchedules()` APIs throw inside sub-agents because scheduled rows are stored on the top-level parent. Use `getScheduleById()` and `listSchedules()` instead.
+
+Calling `this.destroy()` inside a sub-agent delegates cleanup to the parent. The parent cancels that sub-agent's parent-owned schedules, removes descendant fiber recovery leases, removes the registry row, and asks the runtime to wipe the child storage. Treat `this.destroy()` as fire-and-forget because the underlying facet deletion can abort the sub-agent isolate before the method returns cleanly.
+
+## Example
+
+<LinkCard
+	title="Multi-session chat example"
+	href="https://github.com/cloudflare/agents/tree/main/examples/multi-ai-chat"
+	description="Build an inbox where each chat is an AIChatAgent sub-agent with isolated state and direct client routing."
+/>
 
 ## Related
 
 - [Think](/agents/api-reference/think/) — `chat()` method for streaming AI turns through sub-agents
 - [Long-running agents](/agents/concepts/long-running-agents/) — sub-agent delegation in the context of multi-week agent lifetimes
 - [Callable methods](/agents/api-reference/callable-methods/) — RPC via `@callable` and service bindings
-- [Chat agents](/agents/api-reference/chat-agents/) — `ToolLoopAgent` for in-process AI SDK sub-calls
+- [Agent tools](/agents/api-reference/agent-tools/) — run Think or `AIChatAgent` sub-agents as retained, streaming tools
+- [Schedule tasks](/agents/api-reference/schedule-tasks/) — scheduling primitives for top-level agents and sub-agents

--- a/src/content/docs/agents/api-reference/sub-agents.mdx
+++ b/src/content/docs/agents/api-reference/sub-agents.mdx
@@ -5,7 +5,7 @@ description: Spawn child agents with isolated storage and typed RPC using subAge
 tags:
   - AI
 sidebar:
-  order: 5
+  order: 15
 products:
   - agents
 ---
@@ -492,11 +492,11 @@ Sub-agents can schedule their own callbacks and run durable fibers:
 | `this.sql`                              | Works normally and points at the child's own SQLite database               |
 | `subAgent()`                            | Works, so sub-agents can spawn their own children                          |
 
-The top-level parent still owns the physical Durable Object alarm because facets do not have independent alarm slots. The Agents SDK stores the child owner path with each schedule row, wakes the parent, and routes the callback back into the child. `runFiber()` uses the same pattern: fiber rows and snapshots live in the child's own SQLite database, while the parent keeps a small root-side index so alarm housekeeping can route recovery checks back into idle children.
+The top-level parent still owns the physical Durable Object alarm because facets do not have independent alarm slots. The Agents SDK records which child owns each scheduled callback or recovery check, wakes the parent, and routes the work back into the child. The callback still runs with the sub-agent as `this`, so it uses the child's state, SQLite storage, and `getCurrentAgent()` context.
 
 The older synchronous `getSchedule()` and `getSchedules()` APIs throw inside sub-agents because scheduled rows are stored on the top-level parent. Use `getScheduleById()` and `listSchedules()` instead.
 
-Calling `this.destroy()` inside a sub-agent delegates cleanup to the parent. The parent cancels that sub-agent's parent-owned schedules, removes descendant fiber recovery leases, removes the registry row, and asks the runtime to wipe the child storage. Treat `this.destroy()` as fire-and-forget because the underlying facet deletion can abort the sub-agent isolate before the method returns cleanly.
+Calling `this.destroy()` inside a sub-agent delegates cleanup to the parent. The parent cancels that sub-agent's schedules, removes recovery metadata for the sub-agent and its descendants, removes the registry entry, and asks the runtime to wipe the child storage. Treat `this.destroy()` as fire-and-forget because deleting the sub-agent can abort its isolate before the method returns cleanly.
 
 ## Example
 

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -875,20 +875,12 @@ beforeTurn(ctx: TurnContext) {
 Called before each AI SDK step in the agentic loop. Think forwards this hook to `streamText` as `prepareStep`, so it receives the AI SDK's full prepare-step context and can return per-step overrides. Use `beforeTurn` for turn-wide assembly and `beforeStep` when the decision depends on the step number or previous step results.
 
 ```ts
-beforeStep(ctx: PrepareStepContext): StepConfig | void | Promise<StepConfig | void>
-```
-
-<TypeScriptExample>
-
-```ts
 beforeStep(ctx: PrepareStepContext): StepConfig | void {
 	if (ctx.stepNumber > 0) {
 		return { activeTools: [] };
 	}
 }
 ```
-
-</TypeScriptExample>
 
 ### beforeToolCall
 

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -5,7 +5,7 @@ description: Opinionated chat agent framework with built-in tools, persistent me
 tags:
   - AI
 sidebar:
-  order: 7
+  order: 17
 products:
   - agents
 ---
@@ -1031,7 +1031,7 @@ Handle approvals on the client with `onToolCall`:
 <TypeScriptExample>
 
 ```ts
-const { messages, sendMessage, addToolResult } = useAgentChat({
+useAgentChat({
 	agent,
 	onToolCall: ({ toolCall }) => {
 		if (toolCall.toolName === "read") {
@@ -1052,13 +1052,13 @@ After a client tool result is received, Think automatically continues the conver
 
 The `messageConcurrency` property controls how overlapping user submits behave when a chat turn is already active.
 
-| Strategy                                        | Behavior                                                                              |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `"queue"`                                       | Queue every submit and process them in order. Default.                                |
-| `"latest"`                                      | Keep only the latest overlapping submit.                                              |
-| `"merge"`                                       | All overlapping user messages remain in history; the model sees them all in one turn. |
-| `"drop"`                                        | Ignore overlapping submits entirely. Messages are not persisted.                      |
-| `{ strategy: "debounce", debounceMs?: number }` | Trailing-edge latest with a quiet window (default 750ms).                             |
+| Strategy                                        | Behavior                                                                                                                            |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `"queue"`                                       | Queue every submit and process them in order. Default.                                                                              |
+| `"latest"`                                      | Keep only the latest overlapping submission; superseded submissions still persist their user messages but do not start a model turn |
+| `"merge"`                                       | Queue overlapping submissions, then collapse their trailing user messages into one combined turn before the latest queued turn runs |
+| `"drop"`                                        | Ignore overlapping submits entirely. Messages are not persisted.                                                                    |
+| `{ strategy: "debounce", debounceMs?: number }` | Trailing-edge latest with a quiet window (default 750ms).                                                                           |
 
 <TypeScriptExample>
 
@@ -1422,7 +1422,7 @@ if (stable) {
 | Package                | Required | Notes                   |
 | ---------------------- | -------- | ----------------------- |
 | `agents`               | yes      | Cloudflare Agents SDK   |
-| `ai`                   | yes      | Vercel AI SDK v6        |
+| `ai`                   | yes      | AI SDK v6               |
 | `zod`                  | yes      | Schema validation (v4)  |
 | `@cloudflare/shell`    | yes      | Workspace filesystem    |
 | `@cloudflare/codemode` | optional | For `createExecuteTool` |

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -171,20 +171,20 @@ Both Think and [`AIChatAgent`](/agents/api-reference/chat-agents/) extend `Agent
 | `configureSession()`    | identity                         | Add context blocks, compaction, search, skills — refer to [Sessions](/agents/api-reference/sessions/) |
 | `messageConcurrency`    | `"queue"`                        | How overlapping submits behave — refer to [Message concurrency](#message-concurrency)                 |
 | `waitForMcpConnections` | `false`                          | Wait for MCP servers before inference                                                                 |
-| `chatRecovery`          | `true`                           | Wrap turns in `runFiber` for durable execution, including sub-agent turns                             |
+| `chatRecovery`          | `true`                           | Wrap WebSocket, programmatic, and continuation turns in `runFiber` for durable execution              |
 
 ## Dynamic configuration
 
-Think accepts a `Config` type parameter for per-instance typed configuration. Configuration is persisted in SQLite and survives hibernation and restarts.
+Think's class generics match `Agent<Env, State, Props>`. Persisted runtime configuration is typed at the `configure<T>()` and `getConfig<T>()` call sites, stored in SQLite, and survives hibernation and restarts.
 
 <TypeScriptExample>
 
 ```ts
 type MyConfig = { modelTier: "fast" | "capable"; theme: string };
 
-export class MyAgent extends Think<Env, MyConfig> {
+export class MyAgent extends Think<Env> {
 	getModel() {
-		const tier = this.getConfig()?.modelTier ?? "fast";
+		const tier = this.getConfig<MyConfig>()?.modelTier ?? "fast";
 		const models = {
 			fast: "@cf/moonshotai/kimi-k2.6",
 			capable: "@cf/meta/llama-4-scout-17b-16e-instruct",
@@ -196,10 +196,10 @@ export class MyAgent extends Think<Env, MyConfig> {
 
 </TypeScriptExample>
 
-| Method                        | Description                                                   |
-| ----------------------------- | ------------------------------------------------------------- |
-| `configure(config: Config)`   | Persist a typed configuration object                          |
-| `getConfig(): Config \| null` | Read the persisted configuration, or null if never configured |
+| Method                      | Description                                                   |
+| --------------------------- | ------------------------------------------------------------- |
+| `configure<T>(config: T)`   | Persist a typed configuration object                          |
+| `getConfig<T>(): T \| null` | Read the persisted configuration, or null if never configured |
 
 Expose configuration to the client via `@callable`:
 
@@ -208,14 +208,14 @@ Expose configuration to the client via `@callable`:
 ```ts
 import { callable } from "agents";
 
-export class MyAgent extends Think<Env, MyConfig> {
+export class MyAgent extends Think<Env> {
 	getModel() {
 		/* ... */
 	}
 
 	@callable()
 	updateConfig(config: MyConfig) {
-		this.configure(config);
+		this.configure<MyConfig>(config);
 	}
 }
 ```
@@ -266,8 +266,8 @@ On every turn, Think merges tools from multiple sources. Later sources override 
 
 1. **Workspace tools** — `read`, `write`, `edit`, `list`, `find`, `grep`, `delete` (built-in)
 2. **`getTools()`** — your custom server-side tools
-3. **Session tools** — `set_context`, `load_context`, `search_context` (from `configureSession`)
-4. **Extension tools** — tools from loaded extensions (prefixed by extension name)
+3. **Extension tools** — tools from loaded extensions (prefixed by extension name)
+4. **Session tools** — `set_context`, `load_context`, `search_context` (from `configureSession`)
 5. **MCP tools** — from connected MCP servers
 6. **Client tools** — from the browser (refer to [Client tools](#client-tools))
 7. **Caller tools** — from `chat()` options when used as a sub-agent
@@ -733,8 +733,8 @@ Think owns the `streamText` call and provides hooks at each stage of the chat tu
 | `configureSession(session)` | Once during `onStart`                         | `Session`                  | yes   |
 | `beforeTurn(ctx)`           | Before `streamText`                           | `TurnConfig` or void       | yes   |
 | `beforeStep(ctx)`           | Before each model step                        | `StepConfig` or void       | yes   |
-| `beforeToolCall(ctx)`       | When model calls a tool                       | `ToolCallDecision` or void | yes   |
-| `afterToolCall(ctx)`        | After tool execution                          | void                       | yes   |
+| `beforeToolCall(ctx)`       | Before a server-side tool executes            | `ToolCallDecision` or void | yes   |
+| `afterToolCall(ctx)`        | After a tool outcome is known                 | void                       | yes   |
 | `onStepFinish(ctx)`         | After each step completes                     | void                       | yes   |
 | `onChunk(ctx)`              | Per streaming chunk                           | void                       | yes   |
 | `onChatResponse(result)`    | After turn completes and message is persisted | void                       | yes   |
@@ -782,31 +782,32 @@ beforeTurn(ctx: TurnContext): TurnConfig | void | Promise<TurnConfig | void>
 
 #### TurnContext
 
-| Field          | Type                      | Description                                                              |
-| -------------- | ------------------------- | ------------------------------------------------------------------------ |
-| `system`       | `string`                  | Assembled system prompt (from context blocks or `getSystemPrompt()`)     |
-| `messages`     | `ModelMessage[]`          | Assembled model messages (truncated, pruned)                             |
-| `tools`        | `ToolSet`                 | Merged tool set (workspace + getTools + session + MCP + client + caller) |
-| `model`        | `LanguageModel`           | The model from `getModel()`                                              |
-| `continuation` | `boolean`                 | Whether this is a continuation turn (auto-continue after tool result)    |
-| `body`         | `Record<string, unknown>` | Custom body fields from the client request                               |
+| Field          | Type                      | Description                                                                           |
+| -------------- | ------------------------- | ------------------------------------------------------------------------------------- |
+| `system`       | `string`                  | Assembled system prompt (from context blocks or `getSystemPrompt()`)                  |
+| `messages`     | `ModelMessage[]`          | Assembled model messages (truncated, pruned)                                          |
+| `tools`        | `ToolSet`                 | Merged tool set (workspace + getTools + extensions + session + MCP + client + caller) |
+| `model`        | `LanguageModel`           | The model from `getModel()`                                                           |
+| `continuation` | `boolean`                 | Whether this is a continuation turn (auto-continue after tool result)                 |
+| `body`         | `Record<string, unknown>` | Custom body fields from the client request                                            |
 
 #### TurnConfig
 
 All fields are optional. Return only what you want to change.
 
-| Field             | Type                      | Description                             |
-| ----------------- | ------------------------- | --------------------------------------- |
-| `model`           | `LanguageModel`           | Override the model for this turn        |
-| `system`          | `string`                  | Override the system prompt              |
-| `messages`        | `ModelMessage[]`          | Override the assembled messages         |
-| `tools`           | `ToolSet`                 | Extra tools to merge (additive)         |
-| `activeTools`     | `string[]`                | Limit which tools the model can call    |
-| `toolChoice`      | `ToolChoice`              | Force a specific tool call              |
-| `maxSteps`        | `number`                  | Override `maxSteps` for this turn       |
-| `sendReasoning`   | `boolean`                 | Send reasoning chunks for this turn     |
-| `output`          | `Output`                  | Request structured output for this turn |
-| `providerOptions` | `Record<string, unknown>` | Provider-specific options               |
+| Field                    | Type                      | Description                             |
+| ------------------------ | ------------------------- | --------------------------------------- |
+| `model`                  | `LanguageModel`           | Override the model for this turn        |
+| `system`                 | `string`                  | Override the system prompt              |
+| `messages`               | `ModelMessage[]`          | Override the assembled messages         |
+| `tools`                  | `ToolSet`                 | Extra tools to merge (additive)         |
+| `activeTools`            | `string[]`                | Limit which tools the model can call    |
+| `toolChoice`             | `ToolChoice`              | Force a specific tool call              |
+| `maxSteps`               | `number`                  | Override `maxSteps` for this turn       |
+| `sendReasoning`          | `boolean`                 | Send reasoning chunks for this turn     |
+| `output`                 | `Output`                  | Request structured output for this turn |
+| `providerOptions`        | `Record<string, unknown>` | Provider-specific options               |
+| `experimental_telemetry` | `object`                  | AI SDK telemetry settings for this turn |
 
 #### Examples
 
@@ -884,64 +885,93 @@ beforeStep(ctx: PrepareStepContext): StepConfig | void {
 
 ### beforeToolCall
 
-Called when the model produces a tool call. Only fires for server-side tools (tools with `execute`).
-
-:::note
-
-`beforeToolCall` currently fires as an observation hook — after tool execution, via `onStepFinish` data. The `block` and `substitute` actions in `ToolCallDecision` are defined in the types but are not yet functional. For now, use this hook for logging and analytics.
-
-:::
+Called before a server-side tool's `execute` function runs. Think wraps each server-side tool so the hook can allow, modify, block, or substitute the call before the model receives the tool result.
 
 ```ts
-beforeToolCall(ctx: ToolCallContext) {
-	console.log(`Tool called: ${ctx.toolName}`, ctx.args);
+beforeToolCall(ctx: ToolCallContext): ToolCallDecision | void {
+	if (ctx.toolName === "delete" && this.isReadOnlyMode) {
+		return { action: "block", reason: "delete is disabled in read-only mode" };
+	}
+
+	if (ctx.toolName === "weather") {
+		const cached = this.weatherCache.get(JSON.stringify(ctx.input));
+		if (cached) return { action: "substitute", output: cached };
+	}
 }
 ```
 
-| Field      | Type                      | Description                   |
-| ---------- | ------------------------- | ----------------------------- |
-| `toolName` | `string`                  | Name of the tool being called |
-| `args`     | `Record<string, unknown>` | Arguments the model provided  |
+| Field         | Type                       | Description                                |
+| ------------- | -------------------------- | ------------------------------------------ |
+| `toolName`    | `string`                   | Name of the tool being called              |
+| `input`       | `unknown`                  | Input the model provided                   |
+| `toolCallId`  | `string`                   | ID for this tool call                      |
+| `messages`    | `ModelMessage[]`           | Messages visible at tool execution time    |
+| `abortSignal` | `AbortSignal \| undefined` | Signal that aborts if the turn is canceled |
+
+Return a `ToolCallDecision` to control execution:
+
+| Decision                           | Behavior                                                      |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `void` or `{ action: "allow" }`    | Run the original tool with the original input                 |
+| `{ action: "allow", input }`       | Run the original tool with modified input                     |
+| `{ action: "block", reason }`      | Skip the original tool and return `reason` as the tool result |
+| `{ action: "substitute", output }` | Skip the original tool and return `output` as the tool result |
+
+If a wrapped tool returns an `AsyncIterable` for preliminary tool results, Think collapses the iterable to its final yielded value after `beforeToolCall` runs. If you need true preliminary streaming from that tool, avoid intercepting it with `beforeToolCall`.
 
 ### afterToolCall
 
-Called after a tool executes.
+Called after a tool outcome is known. This includes real executions, blocked calls, substituted calls, and thrown tool errors.
 
 ```ts
 afterToolCall(ctx: ToolCallResultContext) {
+	if (!ctx.success) return;
+
 	this.env.ANALYTICS.writeDataPoint({
 		blobs: [ctx.toolName],
-		doubles: [JSON.stringify(ctx.result).length],
+		doubles: [JSON.stringify(ctx.output).length],
 	});
 }
 ```
 
-| Field      | Type                      | Description                        |
-| ---------- | ------------------------- | ---------------------------------- |
-| `toolName` | `string`                  | Name of the tool that was called   |
-| `args`     | `Record<string, unknown>` | Arguments the tool was called with |
-| `result`   | `unknown`                 | The result returned by the tool    |
+| Field        | Type             | Description                                          |
+| ------------ | ---------------- | ---------------------------------------------------- |
+| `toolName`   | `string`         | Name of the tool that was called                     |
+| `input`      | `unknown`        | Input the model provided                             |
+| `toolCallId` | `string`         | ID for this tool call                                |
+| `messages`   | `ModelMessage[]` | Messages visible at tool execution time              |
+| `durationMs` | `number`         | Tool execution duration in milliseconds              |
+| `success`    | `boolean`        | Whether the model received a successful tool outcome |
+| `output`     | `unknown`        | Present when `success` is `true`                     |
+| `error`      | `unknown`        | Present when `success` is `false`                    |
+
+For blocked and substituted tool calls, `success` is `true` because the model receives a valid tool result. Only thrown errors from the original tool execution surface as `success: false`.
 
 ### onStepFinish
 
-Called after each step completes in the agentic loop. A step is one `streamText` iteration — the model generates text, optionally calls tools, and the step ends.
+Called after each step completes in the agentic loop. `StepContext` is the AI SDK's step-finish event, so it includes the full step record: generated text, reasoning, files, sources, typed tool calls and results, usage, warnings, request and response metadata, and provider metadata.
 
 ```ts
 onStepFinish(ctx: StepContext) {
 	console.log(
-		`Step ${ctx.stepType}: ${ctx.usage.inputTokens}in/${ctx.usage.outputTokens}out`,
+		`Step ${ctx.stepNumber} (${ctx.finishReason}): ` +
+			`${ctx.usage.inputTokens}in/${ctx.usage.outputTokens}out`,
 	);
 }
 ```
 
-| Field          | Type                                       | Description                 |
-| -------------- | ------------------------------------------ | --------------------------- |
-| `stepType`     | `"initial" \| "continue" \| "tool-result"` | Why the step ran            |
-| `text`         | `string`                                   | Text generated in this step |
-| `toolCalls`    | `unknown[]`                                | Tool calls made             |
-| `toolResults`  | `unknown[]`                                | Tool results received       |
-| `finishReason` | `string`                                   | Why the step ended          |
-| `usage`        | `{ inputTokens, outputTokens }`            | Token usage for this step   |
+| Field              | Description                                       |
+| ------------------ | ------------------------------------------------- |
+| `stepNumber`       | Zero-based index of the step                      |
+| `text`             | Text generated in this step                       |
+| `reasoning`        | Reasoning parts emitted by the model              |
+| `files`            | Files generated during the step                   |
+| `sources`          | Citations or sources used by the model            |
+| `toolCalls`        | Typed tool calls made in this step                |
+| `toolResults`      | Typed tool results received in this step          |
+| `finishReason`     | Why the step ended                                |
+| `usage`            | Token usage, including cache and reasoning tokens |
+| `providerMetadata` | Provider-specific metadata                        |
 
 ### onChunk
 
@@ -949,9 +979,9 @@ Called for each streaming chunk. High-frequency — fires per token. Use for str
 
 ### onChatResponse
 
-Called after a chat turn completes and the assistant message has been persisted. The turn lock is released before this hook runs, so it is safe to call `saveMessages` or other methods from inside.
+Called after a chat turn produces and persists an assistant message. The turn lock is released before this hook runs, so it is safe to call `saveMessages` or other methods from inside.
 
-Fires for all turn completion paths: WebSocket, sub-agent RPC, `saveMessages`, and auto-continuation.
+Fires for all turn paths that persist an assistant message: WebSocket, sub-agent RPC, `saveMessages`, and auto-continuation. If a turn fails before producing any assistant parts, `onChatError` handles the error instead.
 
 ```ts
 onChatResponse(result: ChatResponseResult) {
@@ -982,18 +1012,18 @@ onChatError(error: unknown) {
 
 ## Client tools
 
-Think supports tools that execute in the browser. The client sends tool schemas in the chat request body, Think merges them with server tools, and when the LLM calls a client tool, the call is routed to the client for execution.
+Think supports tools that execute in the browser. The client sends serializable tool schemas in the chat request body, Think merges them with server tools, and when the LLM calls a client tool, the call is routed to the client for execution.
 
 ### Defining client tools
 
-On the client, pass `clientTools` to `useAgentChat`:
+For dynamic client-side tools, pass `tools` to `useAgentChat`. Tools with an `execute` function are registered with the server as client-executed tools:
 
 <TypeScriptExample>
 
 ```ts
 const { messages, sendMessage } = useAgentChat({
 	agent,
-	clientTools: {
+	tools: {
 		getUserTimezone: {
 			description: "Get the user's timezone from their browser",
 			parameters: {},
@@ -1016,20 +1046,25 @@ const { messages, sendMessage } = useAgentChat({
 
 Client tools are tools without an `execute` function on the server — they only have a schema. When the LLM produces a tool call for one, Think routes it to the client.
 
+For most apps, prefer defining tools on the server and using `onToolCall` for browser-only execution. The `tools` option is most useful for SDKs or platforms where the browser decides the available tool surface at runtime.
+
 ### Approval flow
 
-Handle approvals on the client with `onToolCall`:
+Handle browser-side tool execution on the client with `onToolCall`:
 
 <TypeScriptExample>
 
 ```ts
 useAgentChat({
 	agent,
-	onToolCall: ({ toolCall }) => {
+	onToolCall: async ({ toolCall, addToolOutput }) => {
 		if (toolCall.toolName === "read") {
-			return { approve: true };
+			const result = await readFromBrowser(toolCall.input);
+			addToolOutput({
+				toolCallId: toolCall.toolCallId,
+				output: result,
+			});
 		}
-		// Others go through the UI approval flow
 	},
 });
 ```
@@ -1072,6 +1107,10 @@ export class SearchAgent extends Think<Env> {
 
 Think broadcasts streaming responses to all connected WebSocket clients. When multiple browser tabs are connected to the same agent, all tabs see the streamed response in real time. Tool call states (pending, result, approval) are broadcast to all tabs.
 
+## Agent tools
+
+Use [Agent tools](/agents/api-reference/agent-tools/) when a parent chat agent should run a Think sub-agent as a retained, streaming tool. The parent uses `agentTool()` or `runAgentTool()` from `agents/agent-tools`; the child Think instance keeps its own messages, tools, resumable stream, and storage.
+
 ## Sub-agent RPC and programmatic turns
 
 Think works as both a top-level agent and a sub-agent. When used as a sub-agent, the `chat()` method runs a full turn and streams events via a callback.
@@ -1088,11 +1127,11 @@ async chat(
 
 #### StreamCallback
 
-| Method           | When it fires                                                   |
-| ---------------- | --------------------------------------------------------------- |
-| `onEvent(json)`  | For each streaming chunk (JSON-serialized `UIMessageChunk`)     |
-| `onDone()`       | After the turn completes and the assistant message is persisted |
-| `onError(error)` | On error during the turn (if not provided, the error is thrown) |
+| Method             | When it fires                                                   |
+| ------------------ | --------------------------------------------------------------- |
+| `onEvent(json)`    | For each streaming chunk (JSON-serialized `UIMessageChunk`)     |
+| `onDone()`         | After the turn completes and the assistant message is persisted |
+| `onError(message)` | On error during the turn (if not provided, the error is thrown) |
 
 #### ChatOptions
 
@@ -1282,7 +1321,7 @@ async onChatResponse(result: ChatResponseResult) {
 
 ### continueLastTurn
 
-Resume the last assistant turn without injecting a new user message. Useful after tool results are received or after recovery from an interruption.
+Run another model call after the latest assistant message without injecting a new user message. Think persists the result as a new assistant message with `continuation: true`; it does not append chunks to the existing assistant message.
 
 ```ts
 protected async continueLastTurn(
@@ -1292,6 +1331,17 @@ protected async continueLastTurn(
 ```
 
 Returns `{ requestId, status: "skipped" }` if the last message is not an assistant message. The optional `body` parameter overrides the stored body for this continuation. Pass `options.signal` to cancel the continuation while it is running.
+
+### abortRequest and abortAllRequests
+
+Cancel in-flight chat turns from inside the Durable Object:
+
+```ts
+protected abortRequest(requestId: string, reason?: unknown): void
+protected abortAllRequests(): void
+```
+
+Use `abortRequest()` when you know the request ID. Use `abortAllRequests()` for single-purpose helpers that should cancel whatever turn is currently running. Prefer `SaveMessagesOptions.signal` for programmatic turns when you can pass a signal at the call site.
 
 ### Chat recovery
 
@@ -1406,7 +1456,9 @@ if (stable) {
 | `@cloudflare/think`                  | `Think`, `Session`, `Workspace` — main class and re-exports   |
 | `@cloudflare/think/tools/workspace`  | `createWorkspaceTools()` — for custom storage backends        |
 | `@cloudflare/think/tools/execute`    | `createExecuteTool()` — sandboxed code execution via codemode |
+| `@cloudflare/think/tools/browser`    | `createBrowserTools()` — Chrome DevTools Protocol tools       |
 | `@cloudflare/think/tools/extensions` | `createExtensionTools()` — LLM-driven extension loading       |
+| `@cloudflare/think/tools/sandbox`    | `createSandboxTools()` — placeholder export; returns no tools |
 | `@cloudflare/think/extensions`       | `ExtensionManager`, `HostBridgeLoopback` — extension runtime  |
 
 ## Peer dependencies

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -41,7 +41,7 @@ import { routeAgentRequest } from "agents";
 export class MyAgent extends Think<Env> {
 	getModel() {
 		return createWorkersAI({ binding: this.env.AI })(
-			"@cf/moonshotai/kimi-k2.5",
+			"@cf/moonshotai/kimi-k2.6",
 		);
 	}
 }
@@ -109,7 +109,7 @@ function Chat() {
 
 ```toml
 compatibility_date = "$today"
-compatibility_flags = ["nodejs_compat", "experimental"]
+compatibility_flags = ["nodejs_compat"]
 
 [ai]
 binding = "AI"
@@ -167,10 +167,11 @@ Both Think and [`AIChatAgent`](/agents/api-reference/chat-agents/) extend `Agent
 | `getSystemPrompt()`     | `"You are a helpful assistant."` | System prompt (fallback when no context blocks)                                                       |
 | `getTools()`            | `{}`                             | AI SDK `ToolSet` for the agentic loop                                                                 |
 | `maxSteps`              | `10`                             | Max tool-call rounds per turn                                                                         |
+| `sendReasoning`         | `true`                           | Send reasoning chunks to chat clients                                                                 |
 | `configureSession()`    | identity                         | Add context blocks, compaction, search, skills — refer to [Sessions](/agents/api-reference/sessions/) |
 | `messageConcurrency`    | `"queue"`                        | How overlapping submits behave — refer to [Message concurrency](#message-concurrency)                 |
 | `waitForMcpConnections` | `false`                          | Wait for MCP servers before inference                                                                 |
-| `chatRecovery`          | `true`                           | Wrap turns in `runFiber` for durable execution                                                        |
+| `chatRecovery`          | `true`                           | Wrap turns in `runFiber` for durable execution, including sub-agent turns                             |
 
 ## Dynamic configuration
 
@@ -185,7 +186,7 @@ export class MyAgent extends Think<Env, MyConfig> {
 	getModel() {
 		const tier = this.getConfig()?.modelTier ?? "fast";
 		const models = {
-			fast: "@cf/moonshotai/kimi-k2.5",
+			fast: "@cf/moonshotai/kimi-k2.6",
 			capable: "@cf/meta/llama-4-scout-17b-16e-instruct",
 		};
 		return createWorkersAI({ binding: this.env.AI })(models[tier]);
@@ -731,6 +732,7 @@ Think owns the `streamText` call and provides hooks at each stage of the chat tu
 | --------------------------- | --------------------------------------------- | -------------------------- | ----- |
 | `configureSession(session)` | Once during `onStart`                         | `Session`                  | yes   |
 | `beforeTurn(ctx)`           | Before `streamText`                           | `TurnConfig` or void       | yes   |
+| `beforeStep(ctx)`           | Before each model step                        | `StepConfig` or void       | yes   |
 | `beforeToolCall(ctx)`       | When model calls a tool                       | `ToolCallDecision` or void | yes   |
 | `afterToolCall(ctx)`        | After tool execution                          | void                       | yes   |
 | `onStepFinish(ctx)`         | After each step completes                     | void                       | yes   |
@@ -748,12 +750,16 @@ configureSession()          ← once at startup, not per-turn
 beforeTurn()                ← inspect assembled context, override model/tools/prompt
       │
   ┌── streamText ───────────────────────────────────┐
+  │   beforeStep()                                  │
+  │       │                                         │
   │   onChunk()  onChunk()  onChunk()  ...          │
   │       │                                         │
   │   beforeToolCall()  →  tool executes            │
   │                        afterToolCall()           │
   │       │                                         │
   │   onStepFinish()                                │
+  │       │                                         │
+  │   beforeStep()                                  │
   │       │                                         │
   │   onChunk()  onChunk()  ...                     │
   │       │                                         │
@@ -789,16 +795,18 @@ beforeTurn(ctx: TurnContext): TurnConfig | void | Promise<TurnConfig | void>
 
 All fields are optional. Return only what you want to change.
 
-| Field             | Type                      | Description                          |
-| ----------------- | ------------------------- | ------------------------------------ |
-| `model`           | `LanguageModel`           | Override the model for this turn     |
-| `system`          | `string`                  | Override the system prompt           |
-| `messages`        | `ModelMessage[]`          | Override the assembled messages      |
-| `tools`           | `ToolSet`                 | Extra tools to merge (additive)      |
-| `activeTools`     | `string[]`                | Limit which tools the model can call |
-| `toolChoice`      | `ToolChoice`              | Force a specific tool call           |
-| `maxSteps`        | `number`                  | Override `maxSteps` for this turn    |
-| `providerOptions` | `Record<string, unknown>` | Provider-specific options            |
+| Field             | Type                      | Description                             |
+| ----------------- | ------------------------- | --------------------------------------- |
+| `model`           | `LanguageModel`           | Override the model for this turn        |
+| `system`          | `string`                  | Override the system prompt              |
+| `messages`        | `ModelMessage[]`          | Override the assembled messages         |
+| `tools`           | `ToolSet`                 | Extra tools to merge (additive)         |
+| `activeTools`     | `string[]`                | Limit which tools the model can call    |
+| `toolChoice`      | `ToolChoice`              | Force a specific tool call              |
+| `maxSteps`        | `number`                  | Override `maxSteps` for this turn       |
+| `sendReasoning`   | `boolean`                 | Send reasoning chunks for this turn     |
+| `output`          | `Output`                  | Request structured output for this turn |
+| `providerOptions` | `Record<string, unknown>` | Provider-specific options               |
 
 #### Examples
 
@@ -831,6 +839,56 @@ beforeTurn(ctx: TurnContext) {
 	}
 }
 ```
+
+Hide reasoning for internal continuation turns:
+
+```ts
+beforeTurn(ctx: TurnContext) {
+	if (ctx.continuation) {
+		return { sendReasoning: false };
+	}
+}
+```
+
+Force structured output for a turn:
+
+```ts
+import { Output } from "ai";
+import { z } from "zod";
+
+const ResultSchema = z.object({ severity: z.enum(["low", "high"]) });
+
+beforeTurn(ctx: TurnContext) {
+	if (ctx.body?.mode === "structured-answer") {
+		return {
+			output: Output.object({ schema: ResultSchema }),
+			activeTools: [],
+		};
+	}
+}
+```
+
+`output` is a turn-level setting only. The AI SDK's `prepareStep` does not accept an `output` override, so `beforeStep` cannot toggle structured output on a single step.
+
+### beforeStep
+
+Called before each AI SDK step in the agentic loop. Think forwards this hook to `streamText` as `prepareStep`, so it receives the AI SDK's full prepare-step context and can return per-step overrides. Use `beforeTurn` for turn-wide assembly and `beforeStep` when the decision depends on the step number or previous step results.
+
+```ts
+beforeStep(ctx: PrepareStepContext): StepConfig | void | Promise<StepConfig | void>
+```
+
+<TypeScriptExample>
+
+```ts
+beforeStep(ctx: PrepareStepContext): StepConfig | void {
+	if (ctx.stepNumber > 0) {
+		return { activeTools: [] };
+	}
+}
+```
+
+</TypeScriptExample>
 
 ### beforeToolCall
 
@@ -1145,10 +1203,13 @@ async saveMessages(
 	messages:
 		| UIMessage[]
 		| ((current: UIMessage[]) => UIMessage[] | Promise<UIMessage[]>),
+	options?: SaveMessagesOptions,
 ): Promise<SaveMessagesResult>
 ```
 
-Returns `{ requestId, status }` where `status` is `"completed"` or `"skipped"`.
+Returns `{ requestId, status }` where `status` is `"completed"`, `"skipped"`, or `"aborted"`.
+
+Pass `options.signal` to cancel a programmatic turn from the Durable Object that starts it. `AbortSignal` cannot cross Durable Object RPC boundaries, and the signal is not persisted across hibernation.
 
 #### Static messages
 
@@ -1234,10 +1295,11 @@ Resume the last assistant turn without injecting a new user message. Useful afte
 ```ts
 protected async continueLastTurn(
 	body?: Record<string, unknown>,
+	options?: SaveMessagesOptions,
 ): Promise<SaveMessagesResult>
 ```
 
-Returns `{ requestId, status: "skipped" }` if the last message is not an assistant message. The optional `body` parameter overrides the stored body for this continuation.
+Returns `{ requestId, status: "skipped" }` if the last message is not an assistant message. The optional `body` parameter overrides the stored body for this continuation. Pass `options.signal` to cancel the continuation while it is running.
 
 ### Chat recovery
 
@@ -1299,6 +1361,7 @@ export class MyAgent extends Think<Env> {
 | `messages`        | `UIMessage[]`              | Current conversation history              |
 | `lastBody`        | `Record<string, unknown>?` | Body from the interrupted turn            |
 | `lastClientTools` | `ClientToolSchema[]?`      | Client tools from the interrupted turn    |
+| `createdAt`       | `number`                   | Epoch milliseconds when the turn started  |
 
 #### ChatRecoveryOptions
 
@@ -1308,6 +1371,8 @@ export class MyAgent extends Think<Env> {
 | `continue` | `boolean?` | Whether to auto-continue with a new turn         |
 
 With `persist: true`, the partial message is saved. With `continue: true`, Think calls `continueLastTurn()` after the agent reaches a stable state.
+
+Use `ctx.createdAt` to skip stale recoveries. For example, if the interrupted turn is older than a few minutes, return `{ continue: false }` so the partial response is preserved without starting an old continuation.
 
 ### Stability detection
 
@@ -1365,6 +1430,14 @@ if (stable) {
 ## Acknowledgments
 
 Think's design is inspired by [Pi](https://pi.dev).
+
+## Example
+
+<LinkCard
+	title="Assistant example"
+	href="https://github.com/cloudflare/agents/tree/main/examples/assistant"
+	description="Explore a multi-session Think assistant with sub-agent routing, shared workspace, MCP, chat recovery, and GitHub OAuth."
+/>
 
 ## Related
 

--- a/src/content/docs/agents/api-reference/using-ai-models.mdx
+++ b/src/content/docs/agents/api-reference/using-ai-models.mdx
@@ -5,7 +5,7 @@ pcx_content_type: concept
 tags:
   - AI
 sidebar:
-  order: 13
+  order: 19
 products:
   - agents
 ---
@@ -22,7 +22,7 @@ import {
 
 Agents can call AI models from any provider. [Workers AI](/workers-ai/) is built in and requires no API keys. You can also use [OpenAI](https://platform.openai.com/docs/quickstart?language=javascript), [Anthropic](https://docs.anthropic.com/en/api/client-sdks#typescript), [Google Gemini](https://ai.google.dev/gemini-api/docs/openai), or any service that exposes an OpenAI-compatible API.
 
-The [AI SDK](https://sdk.vercel.ai/docs/introduction) provides a unified interface across all of these providers, and is what `AIChatAgent` and the starter template use under the hood. You can also use the model routing features in [AI Gateway](/ai-gateway/) to route across providers, eval responses, and manage rate limits.
+The [AI SDK](https://ai-sdk.dev/docs/introduction) provides a unified interface across all of these providers, and is what `AIChatAgent` and the starter template use under the hood. You can also use the model routing features in [AI Gateway](/ai-gateway/) to route across providers, eval responses, and manage rate limits.
 
 ## Calling AI Models
 
@@ -183,7 +183,7 @@ Visit the [AI Gateway documentation](/ai-gateway/) to learn how to configure a g
 
 ## AI SDK
 
-The [AI SDK](https://sdk.vercel.ai/docs/introduction) provides a unified API for text generation, tool calling, structured responses, and more. It works with any provider that has an AI SDK adapter, including Workers AI via [`workers-ai-provider`](https://www.npmjs.com/package/workers-ai-provider).
+The [AI SDK](https://ai-sdk.dev/docs/introduction) provides a unified API for text generation, tool calling, structured responses, and more. It works with any provider that has an AI SDK adapter, including Workers AI via [`workers-ai-provider`](https://www.npmjs.com/package/workers-ai-provider).
 
 <PackageManagers pkg="ai workers-ai-provider" />
 

--- a/src/content/docs/agents/api-reference/voice.mdx
+++ b/src/content/docs/agents/api-reference/voice.mdx
@@ -3,7 +3,7 @@ title: Voice agents
 description: Build real-time voice agents with speech-to-text, text-to-speech, and conversation persistence over WebSocket.
 pcx_content_type: reference
 sidebar:
-  order: 16
+  order: 22
 products:
   - agents
 ---

--- a/src/content/docs/agents/api-reference/voice.mdx
+++ b/src/content/docs/agents/api-reference/voice.mdx
@@ -21,13 +21,13 @@ Build real-time voice agents with speech-to-text, text-to-speech, and conversati
 
 `@cloudflare/voice` provides two server-side mixins and matching client libraries:
 
-| Export | Import | Purpose |
-| --- | --- | --- |
-| `withVoice` | `@cloudflare/voice` | Full voice agent: STT, LLM, TTS, persistence |
-| `withVoiceInput` | `@cloudflare/voice` | STT-only: transcription without response |
-| `useVoiceAgent` | `@cloudflare/voice/react` | React hook for `withVoice` agents |
-| `useVoiceInput` | `@cloudflare/voice/react` | React hook for `withVoiceInput` agents |
-| `VoiceClient` | `@cloudflare/voice/client` | Framework-agnostic client |
+| Export           | Import                     | Purpose                                      |
+| ---------------- | -------------------------- | -------------------------------------------- |
+| `withVoice`      | `@cloudflare/voice`        | Full voice agent: STT, LLM, TTS, persistence |
+| `withVoiceInput` | `@cloudflare/voice`        | STT-only: transcription without response     |
+| `useVoiceAgent`  | `@cloudflare/voice/react`  | React hook for `withVoice` agents            |
+| `useVoiceInput`  | `@cloudflare/voice/react`  | React hook for `withVoiceInput` agents       |
+| `VoiceClient`    | `@cloudflare/voice/client` | Framework-agnostic client                    |
 
 Built on Cloudflare Durable Objects, you get:
 
@@ -176,10 +176,10 @@ The client receives `transcript_interim` messages with partial results as the us
 
 Set providers as class properties. Class field initializers run after `super()`, so `this.env` is available.
 
-| Property | Type | Required | Description |
-| --- | --- | --- | --- |
-| `transcriber` | `Transcriber` | Yes | Continuous per-call STT provider |
-| `tts` | `TTSProvider` | Yes | Text-to-speech |
+| Property      | Type          | Required | Description                      |
+| ------------- | ------------- | -------- | -------------------------------- |
+| `transcriber` | `Transcriber` | Yes      | Continuous per-call STT provider |
+| `tts`         | `TTSProvider` | Yes      | Text-to-speech                   |
 
 <TypeScriptExample>
 
@@ -224,12 +224,12 @@ Return a `string`, `AsyncIterable<string>`, or `ReadableStream` for streaming re
 
 ```ts
 export class MyAgent extends VoiceAgent<Env> {
-  transcriber = new WorkersAIFluxSTT(this.env.AI);
-  tts = new WorkersAITTS(this.env.AI);
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new WorkersAITTS(this.env.AI);
 
-  async onTurn(transcript: string, context: VoiceTurnContext) {
-    return "You said: " + transcript;
-  }
+	async onTurn(transcript: string, context: VoiceTurnContext) {
+		return "You said: " + transcript;
+	}
 }
 ```
 
@@ -244,27 +244,27 @@ import { streamText } from "ai";
 import { createWorkersAI } from "workers-ai-provider";
 
 export class MyAgent extends VoiceAgent<Env> {
-  transcriber = new WorkersAIFluxSTT(this.env.AI);
-  tts = new WorkersAITTS(this.env.AI);
+	transcriber = new WorkersAIFluxSTT(this.env.AI);
+	tts = new WorkersAITTS(this.env.AI);
 
-  async onTurn(transcript: string, context: VoiceTurnContext) {
-    const workersai = createWorkersAI({ binding: this.env.AI });
+	async onTurn(transcript: string, context: VoiceTurnContext) {
+		const workersai = createWorkersAI({ binding: this.env.AI });
 
-    const result = streamText({
-      model: workersai("@cf/moonshotai/kimi-k2.5"),
-      system: "You are a helpful voice assistant. Keep responses concise.",
-      messages: [
-        ...context.messages.map(m => ({
-          role: m.role as "user" | "assistant",
-          content: m.content,
-        })),
-        { role: "user", content: transcript },
-      ],
-      abortSignal: context.signal,
-    });
+		const result = streamText({
+			model: workersai("@cf/moonshotai/kimi-k2.6"),
+			system: "You are a helpful voice assistant. Keep responses concise.",
+			messages: [
+				...context.messages.map((m) => ({
+					role: m.role as "user" | "assistant",
+					content: m.content,
+				})),
+				{ role: "user", content: transcript },
+			],
+			abortSignal: context.signal,
+		});
 
-    return result.textStream;
-  }
+		return result.textStream;
+	}
 }
 ```
 
@@ -272,30 +272,30 @@ export class MyAgent extends VoiceAgent<Env> {
 
 The `context` object provides:
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `connection` | `Connection` | The WebSocket connection |
-| `messages` | `Array<{ role: string; content: string }>` | Conversation history from SQLite |
-| `signal` | `AbortSignal` | Aborted on interrupt or disconnect |
+| Field        | Type                                       | Description                        |
+| ------------ | ------------------------------------------ | ---------------------------------- |
+| `connection` | `Connection`                               | The WebSocket connection           |
+| `messages`   | `Array<{ role: string; content: string }>` | Conversation history from SQLite   |
+| `signal`     | `AbortSignal`                              | Aborted on interrupt or disconnect |
 
 ### Lifecycle hooks
 
-| Method | Description |
-| --- | --- |
-| `beforeCallStart(connection)` | Return `false` to reject the call |
-| `onCallStart(connection)` | Called after a call is accepted |
-| `onCallEnd(connection)` | Called when a call ends |
-| `onInterrupt(connection)` | Called when user interrupts during playback |
+| Method                        | Description                                 |
+| ----------------------------- | ------------------------------------------- |
+| `beforeCallStart(connection)` | Return `false` to reject the call           |
+| `onCallStart(connection)`     | Called after a call is accepted             |
+| `onCallEnd(connection)`       | Called when a call ends                     |
+| `onInterrupt(connection)`     | Called when user interrupts during playback |
 
 ### Pipeline hooks
 
 Intercept and transform data at each pipeline stage. Return `null` to skip the current utterance.
 
-| Method | Receives | Can skip? |
-| --- | --- | --- |
-| `afterTranscribe(transcript, connection)` | STT text | Yes |
-| `beforeSynthesize(text, connection)` | Text before TTS | Yes |
-| `afterSynthesize(audio, text, connection)` | Audio after TTS | Yes |
+| Method                                     | Receives        | Can skip? |
+| ------------------------------------------ | --------------- | --------- |
+| `afterTranscribe(transcript, connection)`  | STT text        | Yes       |
+| `beforeSynthesize(text, connection)`       | Text before TTS | Yes       |
+| `afterSynthesize(audio, text, connection)` | Audio after TTS | Yes       |
 
 <TypeScriptExample>
 
@@ -325,13 +325,13 @@ export class MyAgent extends VoiceAgent<Env> {
 
 ### Convenience methods
 
-| Method | Description |
-| --- | --- |
-| `speak(connection, text)` | Synthesize and send audio to one connection |
-| `speakAll(text)` | Synthesize and send audio to all connections |
-| `forceEndCall(connection)` | Programmatically end a call |
-| `saveMessage(role, text)` | Persist a message to conversation history |
-| `getConversationHistory()` | Retrieve conversation history from SQLite |
+| Method                     | Description                                  |
+| -------------------------- | -------------------------------------------- |
+| `speak(connection, text)`  | Synthesize and send audio to one connection  |
+| `speakAll(text)`           | Synthesize and send audio to all connections |
+| `forceEndCall(connection)` | Programmatically end a call                  |
+| `saveMessage(role, text)`  | Persist a message to conversation history    |
+| `getConversationHistory()` | Retrieve conversation history from SQLite    |
 
 ### Configuration options
 
@@ -349,11 +349,11 @@ const VoiceAgent = withVoice(Agent, {
 
 </TypeScriptExample>
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `historyLimit` | `number` | `20` | Max messages loaded for context |
-| `audioFormat` | `string` | `"mp3"` | Audio format sent to client |
-| `maxMessageCount` | `number` | `1000` | Max messages stored in SQLite |
+| Option            | Type     | Default | Description                     |
+| ----------------- | -------- | ------- | ------------------------------- |
+| `historyLimit`    | `number` | `20`    | Max messages loaded for context |
+| `audioFormat`     | `string` | `"mp3"` | Audio format sent to client     |
+| `maxMessageCount` | `number` | `1000`  | Max messages stored in SQLite   |
 
 ## Server API: `withVoiceInput`
 
@@ -426,12 +426,12 @@ const {
 
 #### Tuning options
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `silenceThreshold` | `number` | `0.04` | RMS below this is silence |
-| `silenceDurationMs` | `number` | `500` | Silence duration before `end_of_speech` (ms) |
-| `interruptThreshold` | `number` | `0.05` | RMS to detect speech during playback |
-| `interruptChunks` | `number` | `2` | Consecutive high-RMS chunks to trigger interrupt |
+| Option               | Type     | Default | Description                                      |
+| -------------------- | -------- | ------- | ------------------------------------------------ |
+| `silenceThreshold`   | `number` | `0.04`  | RMS below this is silence                        |
+| `silenceDurationMs`  | `number` | `500`   | Silence duration before `end_of_speech` (ms)     |
+| `interruptThreshold` | `number` | `0.05`  | RMS to detect speech during playback             |
+| `interruptChunks`    | `number` | `2`     | Consecutive high-RMS chunks to trigger interrupt |
 
 Changing tuning options triggers a client reconnect (the connection key includes them).
 
@@ -459,9 +459,7 @@ function Dictation() {
 	return (
 		<div>
 			<textarea
-				value={
-					transcript + (interimTranscript ? " " + interimTranscript : "")
-				}
+				value={transcript + (interimTranscript ? " " + interimTranscript : "")}
 				readOnly
 			/>
 			<button onClick={isListening ? stop : start}>
@@ -507,25 +505,25 @@ client.disconnect();
 
 ### Events
 
-| Event | Data type | Description |
-| --- | --- | --- |
-| `statuschange` | `VoiceStatus` | Pipeline state changed |
-| `transcriptchange` | `TranscriptMessage[]` | Transcript updated |
-| `interimtranscript` | `string \| null` | Interim transcript from streaming STT |
-| `metricschange` | `VoicePipelineMetrics` | Pipeline timing metrics |
-| `audiolevelchange` | `number` | Mic audio level (0–1) |
-| `connectionchange` | `boolean` | WebSocket connected/disconnected |
-| `mutechange` | `boolean` | Mute state changed |
-| `error` | `string \| null` | Error occurred |
-| `custommessage` | `unknown` | Non-voice message from server |
+| Event               | Data type              | Description                           |
+| ------------------- | ---------------------- | ------------------------------------- |
+| `statuschange`      | `VoiceStatus`          | Pipeline state changed                |
+| `transcriptchange`  | `TranscriptMessage[]`  | Transcript updated                    |
+| `interimtranscript` | `string \| null`       | Interim transcript from streaming STT |
+| `metricschange`     | `VoicePipelineMetrics` | Pipeline timing metrics               |
+| `audiolevelchange`  | `number`               | Mic audio level (0–1)                 |
+| `connectionchange`  | `boolean`              | WebSocket connected/disconnected      |
+| `mutechange`        | `boolean`              | Mute state changed                    |
+| `error`             | `string \| null`       | Error occurred                        |
+| `custommessage`     | `unknown`              | Non-voice message from server         |
 
 ### Advanced options
 
-| Option | Type | Description |
-| --- | --- | --- |
-| `transport` | `VoiceTransport` | Custom transport (default: WebSocket via PartySocket) |
-| `audioInput` | `VoiceAudioInput` | Custom mic capture (default: built-in AudioWorklet) |
-| `preferredFormat` | `VoiceAudioFormat` | Hint for server audio format (advisory only) |
+| Option            | Type               | Description                                           |
+| ----------------- | ------------------ | ----------------------------------------------------- |
+| `transport`       | `VoiceTransport`   | Custom transport (default: WebSocket via PartySocket) |
+| `audioInput`      | `VoiceAudioInput`  | Custom mic capture (default: built-in AudioWorklet)   |
+| `preferredFormat` | `VoiceAudioFormat` | Hint for server audio format (advisory only)          |
 
 ## Providers
 
@@ -533,11 +531,11 @@ client.disconnect();
 
 No API keys required — use your Workers AI binding:
 
-| Class | Type | Default model | Recommended for |
-| --- | --- | --- | --- |
-| `WorkersAIFluxSTT` | Continuous STT | `@cf/deepgram/flux` | `withVoice` |
+| Class               | Type           | Default model         | Recommended for  |
+| ------------------- | -------------- | --------------------- | ---------------- |
+| `WorkersAIFluxSTT`  | Continuous STT | `@cf/deepgram/flux`   | `withVoice`      |
 | `WorkersAINova3STT` | Continuous STT | `@cf/deepgram/nova-3` | `withVoiceInput` |
-| `WorkersAITTS` | TTS | `@cf/deepgram/aura-1` | Both |
+| `WorkersAITTS`      | TTS            | `@cf/deepgram/aura-1` | Both             |
 
 <TypeScriptExample>
 
@@ -575,11 +573,11 @@ export class CustomAgent extends VoiceAgent<Env> {
 
 ### Third-party providers
 
-| Package | Class | Description |
-| --- | --- | --- |
-| `@cloudflare/voice-deepgram` | `DeepgramSTT` | Continuous STT |
-| `@cloudflare/voice-elevenlabs` | `ElevenLabsTTS` | High-quality TTS |
-| `@cloudflare/voice-twilio` | `TwilioAdapter` | Telephony (phone calls) |
+| Package                        | Class           | Description             |
+| ------------------------------ | --------------- | ----------------------- |
+| `@cloudflare/voice-deepgram`   | `DeepgramSTT`   | Continuous STT          |
+| `@cloudflare/voice-elevenlabs` | `ElevenLabsTTS` | High-quality TTS        |
+| `@cloudflare/voice-twilio`     | `TwilioAdapter` | Telephony (phone calls) |
 
 **ElevenLabs TTS:**
 

--- a/src/content/docs/agents/concepts/long-running-agents.mdx
+++ b/src/content/docs/agents/concepts/long-running-agents.mdx
@@ -80,29 +80,29 @@ Throughout this doc, we build up a project manager agent that:
 import { Agent } from "agents";
 
 type ProjectState = {
-  name: string;
-  status: "planning" | "active" | "review" | "complete";
-  tasks: Task[];
-  plan: Plan | null;
+	name: string;
+	status: "planning" | "active" | "review" | "complete";
+	tasks: Task[];
+	plan: Plan | null;
 };
 
 type Task = {
-  id: string;
-  title: string;
-  status: "pending" | "in_progress" | "blocked" | "complete";
-  assignee?: string;
-  dueDate?: string;
-  completedAt?: number;
-  externalJobId?: string;
+	id: string;
+	title: string;
+	status: "pending" | "in_progress" | "blocked" | "complete";
+	assignee?: string;
+	dueDate?: string;
+	completedAt?: number;
+	externalJobId?: string;
 };
 
 export class ProjectManager extends Agent<ProjectState> {
-  initialState: ProjectState = {
-    name: "",
-    status: "planning",
-    tasks: [],
-    plan: null
-  };
+	initialState: ProjectState = {
+		name: "",
+		status: "planning",
+		tasks: [],
+		plan: null,
+	};
 }
 ```
 
@@ -112,13 +112,13 @@ The `Plan` type is introduced in [Planning as a durability strategy](#planning-a
 
 A hibernated agent can be woken by any of these sources:
 
-| Wake source              | How it works                                                                                                                                                           | Example                                 |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| **HTTP request**         | Any request to the agent's URL triggers `onRequest()`                                                                                                                  | A webhook from GitHub                   |
-| **WebSocket connection** | A client connects, triggering `onConnect()`                                                                                                                            | A team member opens the dashboard       |
+| Wake source              | How it works                                                                                                                                                             | Example                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
+| **HTTP request**         | Any request to the agent's URL triggers `onRequest()`                                                                                                                    | A webhook from GitHub                   |
+| **WebSocket connection** | A client connects, triggering `onConnect()`                                                                                                                              | A team member opens the dashboard       |
 | **RPC call**             | Another Worker or agent calls a method via [service binding](/workers/runtime-apis/bindings/service-bindings/) or [`@callable`](/agents/api-reference/callable-methods/) | A coordinator agent delegates a task    |
-| **Scheduled alarm**      | A stored schedule fires, triggering your callback                                                                                                                      | Daily standup reminder at 9am           |
-| **Email**                | An inbound email triggers `onEmail()`                                                                                                                                  | A team member replies to a status email |
+| **Scheduled alarm**      | A stored schedule fires, triggering your callback                                                                                                                        | Daily standup reminder at 9am           |
+| **Email**                | An inbound email triggers `onEmail()`                                                                                                                                    | A team member replies to a status email |
 
 The pattern extends naturally to any event source that can reach a Worker — anything from telephony webhooks to chat platform bots. An external signal arrives, the platform wakes the agent, and the agent handles it.
 
@@ -126,42 +126,42 @@ The agent does not need to be "started" or "deployed" separately for each wake s
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async onStart() {
-    // Daily deadline check at 9am UTC — idempotent, safe across restarts
-    await this.schedule(
-      "0 9 * * *",
-      "checkDeadlines",
-      {},
-      {
-        idempotent: true
-      }
-    );
+	async onStart() {
+		// Daily deadline check at 9am UTC — idempotent, safe across restarts
+		await this.schedule(
+			"0 9 * * *",
+			"checkDeadlines",
+			{},
+			{
+				idempotent: true,
+			},
+		);
 
-    // Progress sync every 30 minutes
-    await this.scheduleEvery(1800, "syncProgress");
-  }
+		// Progress sync every 30 minutes
+		await this.scheduleEvery(1800, "syncProgress");
+	}
 
-  async onRequest(request: Request): Promise<Response> {
-    const url = new URL(request.url);
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
 
-    if (url.pathname.endsWith("/github-webhook")) {
-      const event = await request.json();
-      await this.handleGitHubEvent(event);
-      return new Response("OK");
-    }
+		if (url.pathname.endsWith("/github-webhook")) {
+			const event = await request.json();
+			await this.handleGitHubEvent(event);
+			return new Response("OK");
+		}
 
-    return Response.json({
-      project: this.state.name,
-      status: this.state.status
-    });
-  }
+		return Response.json({
+			project: this.state.name,
+			status: this.state.status,
+		});
+	}
 
-  async checkDeadlines() {
-    /* ... find overdue tasks, broadcast alerts ... */
-  }
-  async syncProgress() {
-    /* ... check on sub-agents, update task statuses ... */
-  }
+	async checkDeadlines() {
+		/* ... find overdue tasks, broadcast alerts ... */
+	}
+	async syncProgress() {
+		/* ... check on sub-agents, update task statuses ... */
+	}
 }
 ```
 
@@ -173,22 +173,22 @@ Sometimes an agent needs to do work that takes longer than the idle eviction win
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async generateProjectPlan(goal: string) {
-    const result = await this.keepAliveWhile(async () => {
-      const plan = await this.callLLM(`Create a project plan for: ${goal}`);
-      const tasks = await this.callLLM(
-        `Break this into tasks: ${JSON.stringify(plan)}`
-      );
-      return { plan, tasks };
-    });
+	async generateProjectPlan(goal: string) {
+		const result = await this.keepAliveWhile(async () => {
+			const plan = await this.callLLM(`Create a project plan for: ${goal}`);
+			const tasks = await this.callLLM(
+				`Break this into tasks: ${JSON.stringify(plan)}`,
+			);
+			return { plan, tasks };
+		});
 
-    this.setState({
-      ...this.state,
-      status: "active",
-      plan: result.plan,
-      tasks: result.tasks
-    });
-  }
+		this.setState({
+			...this.state,
+			status: "active",
+			plan: result.plan,
+			tasks: result.tasks,
+		});
+	}
 }
 ```
 
@@ -197,9 +197,9 @@ export class ProjectManager extends Agent<ProjectState> {
 ```ts
 const dispose = await this.keepAlive();
 try {
-  await longWork();
+	await longWork();
 } finally {
-  dispose();
+	dispose();
 }
 ```
 
@@ -207,12 +207,12 @@ try {
 
 `keepAlive` is for work measured in minutes, not hours. For truly long-running operations, use a different strategy:
 
-| Duration         | Strategy                                                                     |
-| ---------------- | ---------------------------------------------------------------------------- |
-| Seconds          | Normal request handling                                                      |
-| Minutes          | `keepAlive()` / `keepAliveWhile()`                                           |
-| Minutes to hours | [Workflows](/agents/concepts/workflows/)                                     |
-| Hours to days    | Async pattern: start job, hibernate, wake on completion                      |
+| Duration         | Strategy                                                |
+| ---------------- | ------------------------------------------------------- |
+| Seconds          | Normal request handling                                 |
+| Minutes          | `keepAlive()` / `keepAliveWhile()`                      |
+| Minutes to hours | [Workflows](/agents/concepts/workflows/)                |
+| Hours to days    | Async pattern: start job, hibernate, wake on completion |
 
 ## Surviving crashes: fibers and recovery
 
@@ -222,32 +222,32 @@ An agent can be evicted at any time — a deploy, a platform restart, or hitting
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async executeTask(task: Task) {
-    await this.runFiber(`task:${task.id}`, async (ctx) => {
-      const resources = await this.gatherResources(task);
-      ctx.stash({ phase: "prepared", resources, task });
+	async executeTask(task: Task) {
+		await this.runFiber(`task:${task.id}`, async (ctx) => {
+			const resources = await this.gatherResources(task);
+			ctx.stash({ phase: "prepared", resources, task });
 
-      const result = await this.runSubAgent(task, resources);
-      ctx.stash({ phase: "executed", result, task });
+			const result = await this.runSubAgent(task, resources);
+			ctx.stash({ phase: "executed", result, task });
 
-      await this.updateTaskStatus(task.id, "complete", result);
-    });
-  }
+			await this.updateTaskStatus(task.id, "complete", result);
+		});
+	}
 
-  async onFiberRecovered(ctx: FiberRecoveryContext) {
-    if (!ctx.name.startsWith("task:")) return;
-    const { phase, task } = ctx.snapshot as { phase: string; task: Task };
+	async onFiberRecovered(ctx: FiberRecoveryContext) {
+		if (!ctx.name.startsWith("task:")) return;
+		const { phase, task } = ctx.snapshot as { phase: string; task: Task };
 
-    if (phase === "prepared") {
-      await this.executeTask(task);
-    } else if (phase === "executed") {
-      await this.updateTaskStatus(
-        task.id,
-        "complete",
-        (ctx.snapshot as { result: unknown }).result
-      );
-    }
-  }
+		if (phase === "prepared") {
+			await this.executeTask(task);
+		} else if (phase === "executed") {
+			await this.updateTaskStatus(
+				task.id,
+				"complete",
+				(ctx.snapshot as { result: unknown }).result,
+			);
+		}
+	}
 }
 ```
 
@@ -271,35 +271,35 @@ The project manager starts a CI pipeline for a task. The pipeline takes 20 minut
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async startCIPipeline(task: Task) {
-    const response = await fetch("https://ci.example.com/api/pipelines", {
-      method: "POST",
-      body: JSON.stringify({
-        repo: "org/project",
-        branch: "main",
-        callback_url: `${this.url}/ci-callback?taskId=${task.id}`
-      })
-    });
+	async startCIPipeline(task: Task) {
+		const response = await fetch("https://ci.example.com/api/pipelines", {
+			method: "POST",
+			body: JSON.stringify({
+				repo: "org/project",
+				branch: "main",
+				callback_url: `${this.url}/ci-callback?taskId=${task.id}`,
+			}),
+		});
 
-    const { pipelineId } = await response.json();
-    this.updateTask(task.id, {
-      status: "in_progress",
-      externalJobId: pipelineId
-    });
-  }
+		const { pipelineId } = await response.json();
+		this.updateTask(task.id, {
+			status: "in_progress",
+			externalJobId: pipelineId,
+		});
+	}
 
-  async onRequest(request: Request): Promise<Response> {
-    const url = new URL(request.url);
-    if (url.pathname.endsWith("/ci-callback")) {
-      const taskId = url.searchParams.get("taskId");
-      const result = await request.json();
-      this.updateTask(taskId, {
-        status: result.status === "success" ? "complete" : "blocked"
-      });
-      return new Response("OK");
-    }
-    // ... other routes
-  }
+	async onRequest(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		if (url.pathname.endsWith("/ci-callback")) {
+			const taskId = url.searchParams.get("taskId");
+			const result = await request.json();
+			this.updateTask(taskId, {
+				status: result.status === "success" ? "complete" : "blocked",
+			});
+			return new Response("OK");
+		}
+		// ... other routes
+	}
 }
 ```
 
@@ -309,43 +309,43 @@ Not every external service supports callbacks. When the project manager submits 
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async startVideoGeneration(task: Task) {
-    const response = await fetch("https://video-api.example.com/generate", {
-      method: "POST",
-      body: JSON.stringify({ prompt: task.title })
-    });
-    const { jobId } = await response.json();
-    this.updateTask(task.id, { status: "in_progress", externalJobId: jobId });
-    await this.schedule(60, "pollExternalJob", {
-      taskId: task.id,
-      jobId,
-      attempt: 1
-    });
-  }
+	async startVideoGeneration(task: Task) {
+		const response = await fetch("https://video-api.example.com/generate", {
+			method: "POST",
+			body: JSON.stringify({ prompt: task.title }),
+		});
+		const { jobId } = await response.json();
+		this.updateTask(task.id, { status: "in_progress", externalJobId: jobId });
+		await this.schedule(60, "pollExternalJob", {
+			taskId: task.id,
+			jobId,
+			attempt: 1,
+		});
+	}
 
-  async pollExternalJob(payload: {
-    taskId: string;
-    jobId: string;
-    attempt: number;
-  }) {
-    const response = await fetch(
-      `https://video-api.example.com/status/${payload.jobId}`
-    );
-    const status = await response.json();
+	async pollExternalJob(payload: {
+		taskId: string;
+		jobId: string;
+		attempt: number;
+	}) {
+		const response = await fetch(
+			`https://video-api.example.com/status/${payload.jobId}`,
+		);
+		const status = await response.json();
 
-    if (status.state === "complete" || status.state === "failed") {
-      this.updateTask(payload.taskId, {
-        status: status.state === "complete" ? "complete" : "blocked"
-      });
-      return;
-    }
+		if (status.state === "complete" || status.state === "failed") {
+			this.updateTask(payload.taskId, {
+				status: status.state === "complete" ? "complete" : "blocked",
+			});
+			return;
+		}
 
-    const nextDelay = Math.min(60 * payload.attempt, 600);
-    await this.schedule(nextDelay, "pollExternalJob", {
-      ...payload,
-      attempt: payload.attempt + 1
-    });
-  }
+		const nextDelay = Math.min(60 * payload.attempt, 600);
+		await this.schedule(nextDelay, "pollExternalJob", {
+			...payload,
+			attempt: payload.attempt + 1,
+		});
+	}
 }
 ```
 
@@ -355,25 +355,25 @@ A production deployment involves multiple steps that must each retry independent
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async startDeployment(task: Task) {
-    const instanceId = await this.runWorkflow("DEPLOY_WORKFLOW", {
-      taskId: task.id,
-      environment: "production"
-    });
-    this.updateTask(task.id, {
-      status: "in_progress",
-      externalJobId: instanceId
-    });
-  }
+	async startDeployment(task: Task) {
+		const instanceId = await this.runWorkflow("DEPLOY_WORKFLOW", {
+			taskId: task.id,
+			environment: "production",
+		});
+		this.updateTask(task.id, {
+			status: "in_progress",
+			externalJobId: instanceId,
+		});
+	}
 
-  async onWorkflowComplete(
-    workflowName: string,
-    instanceId: string,
-    result?: unknown
-  ) {
-    const task = this.state.tasks.find((t) => t.externalJobId === instanceId);
-    if (task) this.updateTask(task.id, { status: "complete" });
-  }
+	async onWorkflowComplete(
+		workflowName: string,
+		instanceId: string,
+		result?: unknown,
+	) {
+		const task = this.state.tasks.find((t) => t.externalJobId === instanceId);
+		if (task) this.updateTask(task.id, { status: "complete" });
+	}
 }
 ```
 
@@ -391,10 +391,10 @@ Three approaches work today:
 
 ```ts
 ctx.stash({
-  task: "Waiting for CI results",
-  onSuccess: "Mark task complete, move to next step in plan",
-  onFailure: "Notify team, schedule retry in 1 hour",
-  relevantContext: { taskId, planStep: 3 }
+	task: "Waiting for CI results",
+	onSuccess: "Mark task complete, move to next step in plan",
+	onFailure: "Notify team, schedule retry in 1 hour",
+	relevantContext: { taskId, planStep: 3 },
 });
 ```
 
@@ -408,87 +408,87 @@ A structured plan is not just useful for showing progress to users — it is a d
 
 ```ts
 type Plan = {
-  goal: string;
-  steps: PlanStep[];
-  currentStep: number;
-  createdAt: string;
-  updatedAt: string;
+	goal: string;
+	steps: PlanStep[];
+	currentStep: number;
+	createdAt: string;
+	updatedAt: string;
 };
 
 type PlanStep = {
-  id: string;
-  description: string;
-  status: "pending" | "in_progress" | "complete" | "failed" | "skipped";
-  result?: unknown;
+	id: string;
+	description: string;
+	status: "pending" | "in_progress" | "complete" | "failed" | "skipped";
+	result?: unknown;
 };
 
 export class ProjectManager extends Agent<ProjectState> {
-  async createPlan(goal: string) {
-    const steps = await this.keepAliveWhile(async () => {
-      return this.callLLM(`
+	async createPlan(goal: string) {
+		const steps = await this.keepAliveWhile(async () => {
+			return this.callLLM(`
         Break down this project goal into concrete steps.
         Return a JSON array of { id, description } objects.
         Goal: ${goal}
       `);
-    });
+		});
 
-    this.setState({
-      ...this.state,
-      plan: {
-        goal,
-        steps: steps.map((s: { id: string; description: string }) => ({
-          ...s,
-          status: "pending" as const
-        })),
-        currentStep: 0,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      }
-    });
+		this.setState({
+			...this.state,
+			plan: {
+				goal,
+				steps: steps.map((s: { id: string; description: string }) => ({
+					...s,
+					status: "pending" as const,
+				})),
+				currentStep: 0,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+		});
 
-    await this.schedule(0, "executeNextStep");
-  }
+		await this.schedule(0, "executeNextStep");
+	}
 
-  async executeNextStep() {
-    const { plan } = this.state;
-    if (!plan || plan.currentStep >= plan.steps.length) {
-      this.setState({ ...this.state, status: "complete" });
-      return;
-    }
+	async executeNextStep() {
+		const { plan } = this.state;
+		if (!plan || plan.currentStep >= plan.steps.length) {
+			this.setState({ ...this.state, status: "complete" });
+			return;
+		}
 
-    const step = plan.steps[plan.currentStep];
+		const step = plan.steps[plan.currentStep];
 
-    try {
-      const result = await this.keepAliveWhile(() => this.executeStep(step));
+		try {
+			const result = await this.keepAliveWhile(() => this.executeStep(step));
 
-      const updatedSteps = plan.steps.map((s) =>
-        s.id === step.id ? { ...s, status: "complete" as const, result } : s
-      );
-      this.setState({
-        ...this.state,
-        plan: {
-          ...plan,
-          steps: updatedSteps,
-          currentStep: plan.currentStep + 1,
-          updatedAt: new Date().toISOString()
-        }
-      });
+			const updatedSteps = plan.steps.map((s) =>
+				s.id === step.id ? { ...s, status: "complete" as const, result } : s,
+			);
+			this.setState({
+				...this.state,
+				plan: {
+					...plan,
+					steps: updatedSteps,
+					currentStep: plan.currentStep + 1,
+					updatedAt: new Date().toISOString(),
+				},
+			});
 
-      await this.schedule(0, "executeNextStep");
-    } catch (error) {
-      const updatedSteps = plan.steps.map((s) =>
-        s.id === step.id ? { ...s, status: "failed" as const } : s
-      );
-      this.setState({
-        ...this.state,
-        plan: {
-          ...plan,
-          steps: updatedSteps,
-          updatedAt: new Date().toISOString()
-        }
-      });
-    }
-  }
+			await this.schedule(0, "executeNextStep");
+		} catch (error) {
+			const updatedSteps = plan.steps.map((s) =>
+				s.id === step.id ? { ...s, status: "failed" as const } : s,
+			);
+			this.setState({
+				...this.state,
+				plan: {
+					...plan,
+					steps: updatedSteps,
+					updatedAt: new Date().toISOString(),
+				},
+			});
+		}
+	}
 }
 ```
 
@@ -506,23 +506,25 @@ A project manager does not do everything itself. It delegates specialized work t
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async delegateTask(task: Task) {
-    const researcher = await this.subAgent(
-      ResearchAgent,
-      `research-${task.id}`
-    );
+	async delegateTask(task: Task) {
+		const researcher = await this.subAgent(
+			ResearchAgent,
+			`research-${task.id}`,
+		);
 
-    const findings = await researcher.research(task.title);
+		const findings = await researcher.research(task.title);
 
-    this.updateTask(task.id, { status: "complete" });
-    return findings;
-  }
+		this.updateTask(task.id, { status: "complete" });
+		return findings;
+	}
 }
 ```
 
-Sub-agents are independent Durable Objects. They have their own state, their own schedules, and their own lifecycle. The parent does not need to stay alive while the sub-agent works — it can start the work, hibernate, and be woken by a callback or scheduled check.
+Sub-agents have their own state, schedules, durable fibers, and lifecycle. They are colocated under the parent, but each child stores its own SQLite data and runs callbacks with the child as `this`.
 
-For the full `subAgent()` API — typed RPC stubs, abort, delete, storage isolation, and limitations — refer to [Sub-agents](/agents/api-reference/sub-agents/). For AI-specific sub-agent streaming (running full LLM turns through a child agent), refer to [Think: Sub-agent RPC](/agents/api-reference/think/#sub-agent-rpc-and-programmatic-turns).
+Because facets do not have independent alarm slots, the top-level parent owns the physical Durable Object alarm. The Agents SDK records which sub-agent owns each schedule or fiber recovery lease, wakes the parent, and routes the callback back into the child. The parent does not need to stay active while the sub-agent works — it can start the work, hibernate, and be woken by the child-owned schedule or recovery check.
+
+For the full `subAgent()` API — typed RPC stubs, client routing, access control, storage isolation, and alarm-backed APIs — refer to [Sub-agents](/agents/api-reference/sub-agents/). For AI-specific sub-agent streaming (running full LLM turns through a child agent), refer to [Think: Sub-agent RPC](/agents/api-reference/think/#sub-agent-rpc-and-programmatic-turns).
 
 ## Recovering interrupted LLM streams
 
@@ -533,32 +535,35 @@ For chat-oriented agents built on `AIChatAgent`, this is an even sharper problem
 ```ts
 import { AIChatAgent } from "@cloudflare/ai-chat";
 import type {
-  ChatRecoveryContext,
-  ChatRecoveryOptions
+	ChatRecoveryContext,
+	ChatRecoveryOptions,
 } from "@cloudflare/ai-chat";
 
 class ProjectChat extends AIChatAgent<Env> {
-  override chatRecovery = true;
+	override chatRecovery = true;
 
-  override async onChatRecovery(
-    ctx: ChatRecoveryContext
-  ): Promise<ChatRecoveryOptions> {
-    // ctx.partialText    — text generated before eviction
-    // ctx.recoveryData   — whatever you stashed via this.stash()
-    // ctx.messages        — full conversation history
-    return {};
-  }
+	override async onChatRecovery(
+		ctx: ChatRecoveryContext,
+	): Promise<ChatRecoveryOptions> {
+		// ctx.partialText    — text generated before eviction
+		// ctx.recoveryData   — whatever you stashed via this.stash()
+		// ctx.messages        — full conversation history
+		// ctx.createdAt       — when the interrupted turn started
+		return {};
+	}
 }
 ```
 
 The right recovery strategy depends on the LLM provider:
 
-| Provider               | Strategy                            | How it works                                                                 | Token cost |
-| ---------------------- | ----------------------------------- | ---------------------------------------------------------------------------- | ---------- |
-| Workers AI             | Continue from partial               | `continueLastTurn()` — model continues via assistant prefill                 | Low        |
-| OpenAI (Responses API) | Retrieve completed response         | Stash `responseId` during streaming, retrieve on recovery                    | Zero       |
-| Anthropic              | Synthetic continuation              | Persist partial, send a synthetic user message asking the model to continue  | Medium     |
+| Provider               | Strategy                            | How it works                                                                  | Token cost |
+| ---------------------- | ----------------------------------- | ----------------------------------------------------------------------------- | ---------- |
+| Workers AI             | Continue from partial               | `continueLastTurn()` — model continues via assistant prefill                  | Low        |
+| OpenAI (Responses API) | Retrieve completed response         | Stash `responseId` during streaming, retrieve on recovery                     | Zero       |
+| Anthropic              | Synthetic continuation              | Persist partial, send a synthetic user message asking the model to continue   | Medium     |
 | Other                  | Try prefill, fall back to synthetic | `continueLastTurn()` if the provider supports it, synthetic message otherwise | Varies     |
+
+Use `ctx.createdAt` to suppress stale recoveries. For example, if a recovered chat turn is older than a few minutes, you may persist the partial answer but skip automatic continuation to avoid surprising the user with an old response.
 
 ## Managing state over time
 
@@ -570,31 +575,31 @@ Schedule periodic cleanup to prune old data and archive completed work:
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async onStart() {
-    await this.schedule("0 0 * * *", "housekeeping", {}, { idempotent: true });
-  }
+	async onStart() {
+		await this.schedule("0 0 * * *", "housekeeping", {}, { idempotent: true });
+	}
 
-  async housekeeping() {
-    const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
-    const toArchive = this.state.tasks.filter(
-      (t) => t.status === "complete" && (t.completedAt ?? 0) < cutoff
-    );
-    for (const task of toArchive) {
-      this
-        .sql`INSERT INTO archived_tasks (id, data) VALUES (${task.id}, ${JSON.stringify(task)})`;
-    }
-    this.setState({
-      ...this.state,
-      tasks: this.state.tasks.filter(
-        (t) => !toArchive.some((a) => a.id === t.id)
-      )
-    });
+	async housekeeping() {
+		const cutoff = Date.now() - 30 * 24 * 60 * 60 * 1000;
+		const toArchive = this.state.tasks.filter(
+			(t) => t.status === "complete" && (t.completedAt ?? 0) < cutoff,
+		);
+		for (const task of toArchive) {
+			this
+				.sql`INSERT INTO archived_tasks (id, data) VALUES (${task.id}, ${JSON.stringify(task)})`;
+		}
+		this.setState({
+			...this.state,
+			tasks: this.state.tasks.filter(
+				(t) => !toArchive.some((a) => a.id === t.id),
+			),
+		});
 
-    this.deleteWorkflows({
-      status: ["complete", "errored"],
-      createdBefore: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-    });
-  }
+		this.deleteWorkflows({
+			status: ["complete", "errored"],
+			createdBefore: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+		});
+	}
 }
 ```
 
@@ -614,17 +619,17 @@ A long-running agent eventually completes its purpose. The project ships, the in
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
-  async completeProject() {
-    const schedules = this.getSchedules();
-    for (const schedule of schedules) {
-      await this.cancelSchedule(schedule.id);
-    }
+	async completeProject() {
+		const schedules = await this.listSchedules();
+		for (const schedule of schedules) {
+			await this.cancelSchedule(schedule.id);
+		}
 
-    this.setState({ ...this.state, status: "complete" });
+		this.setState({ ...this.state, status: "complete" });
 
-    // All SQLite data, schedules, and state are permanently deleted
-    await this.destroy();
-  }
+		// All SQLite data, schedules, and state are permanently deleted
+		await this.destroy();
+	}
 }
 ```
 
@@ -651,17 +656,17 @@ The project manager agent uses both: schedules for its own rhythms (daily standu
 
 Long-running agents on Cloudflare are not long-running processes. They are durable entities that wake, work, and sleep — potentially over weeks or months. The key primitives:
 
-| Primitive                              | Purpose                                       |
-| -------------------------------------- | --------------------------------------------- |
-| **`setState()` / `this.sql`**          | Persist state across activations              |
-| **`schedule()` / `scheduleEvery()`**   | Wake the agent at future times                |
-| **`keepAlive()` / `keepAliveWhile()`** | Prevent eviction during active work           |
-| **`runFiber()` / `stash()`**           | Checkpoint and recover long tasks             |
-| **`chatRecovery`**            | Recover interrupted LLM streams               |
-| **`onRequest()` / `onEmail()` / RPC**  | Wake on external events                       |
-| **`runWorkflow()`**                    | Delegate heavyweight multi-step work          |
-| **`subAgent()`**                       | Delegate specialized work to child agents     |
-| **Structured plans in state**          | Enable recovery, visibility, and re-planning  |
+| Primitive                              | Purpose                                      |
+| -------------------------------------- | -------------------------------------------- |
+| **`setState()` / `this.sql`**          | Persist state across activations             |
+| **`schedule()` / `scheduleEvery()`**   | Wake the agent at future times               |
+| **`keepAlive()` / `keepAliveWhile()`** | Prevent eviction during active work          |
+| **`runFiber()` / `stash()`**           | Checkpoint and recover long tasks            |
+| **`chatRecovery`**                     | Recover interrupted LLM streams              |
+| **`onRequest()` / `onEmail()` / RPC**  | Wake on external events                      |
+| **`runWorkflow()`**                    | Delegate heavyweight multi-step work         |
+| **`subAgent()`**                       | Delegate specialized work to child agents    |
+| **Structured plans in state**          | Enable recovery, visibility, and re-planning |
 
 For the project manager agent, these compose into an agent that:
 

--- a/src/content/docs/agents/concepts/long-running-agents.mdx
+++ b/src/content/docs/agents/concepts/long-running-agents.mdx
@@ -12,6 +12,14 @@ products:
 
 Build agents that persist for days, weeks, or months — surviving restarts, waking on demand, and managing work that spans far longer than any single request.
 
+The short version:
+
+- Agents are durable identities, not always-on processes.
+- State, SQL data, schedules, and fiber checkpoints survive hibernation and restarts.
+- In-memory variables, timers, open fetches, and local closures do not survive eviction.
+- Use `keepAlive()` for active work measured in minutes, `runFiber()` when work needs recovery, and Workflows for heavyweight multi-step jobs.
+- Use sub-agents when one parent coordinates many long-lived child contexts.
+
 ## Why Cloudflare for long-running agents
 
 Agents spend most of their time waiting. Waiting for user input (seconds to days), LLM responses (seconds to minutes), tool results (seconds to hours), human approvals (hours to days), or scheduled wake-ups (minutes to months). On a traditional VM or container, you pay for all that idle time. An agent that is 99% dormant and 1% active still costs you 100% of a server.

--- a/src/content/docs/agents/concepts/memory.mdx
+++ b/src/content/docs/agents/concepts/memory.mdx
@@ -16,6 +16,14 @@ Agents need memory to be useful over time. Without it, every conversation starts
 
 The [Session API](/agents/api-reference/sessions/) provides the memory layer for agents built on the Cloudflare Agents SDK. It manages two kinds of memory: **conversation history** (the messages and tool calls that make up a session) and **context memory** (persistent blocks injected into the system prompt that the agent can read, write, search, and load).
 
+Use this page when you need more than simple synced state or flat chat history. For small UI state, use [Store and sync state](/agents/api-reference/store-and-sync-state/). For basic chat persistence, `AIChatAgent` stores messages for you. For opinionated long-term memory, Think builds on Session and context blocks.
+
+:::caution[Experimental]
+
+The Session memory APIs currently use `agents/experimental/memory/session`. The concepts are stable, but import paths and details may change before graduation.
+
+:::
+
 ## Conversation history
 
 The most fundamental type of memory is the conversation itself: the messages between the user and the agent, the tool calls the agent made, and the results it received. The Session stores all of this in a tree-structured message history backed by a Session Provider, defaulting to SQLite.
@@ -27,9 +35,9 @@ import { Session } from "agents/experimental/memory/session";
 
 // Append messages as the conversation progresses
 await session.appendMessage({
-  id: `user-${crypto.randomUUID()}`,
-  role: "user",
-  parts: [{ type: "text", text: "What's the status of the deployment?" }]
+	id: `user-${crypto.randomUUID()}`,
+	role: "user",
+	parts: [{ type: "text", text: "What's the status of the deployment?" }],
 });
 
 // Read the full conversation history
@@ -71,15 +79,14 @@ A coding assistant might have a soul that defines its personality and constraint
 ```ts
 import { Session } from "agents/experimental/memory/session";
 
-const session = Session.create(this)
-  .withContext("soul", {
-    provider: {
-      get: async () =>
-        "You are a senior TypeScript engineer. You write concise, " +
-        "well-tested code. You prefer composition over inheritance. " +
-        "When you are unsure, you say so rather than guessing."
-    }
-  });
+const session = Session.create(this).withContext("soul", {
+	provider: {
+		get: async () =>
+			"You are a senior TypeScript engineer. You write concise, " +
+			"well-tested code. You prefer composition over inheritance. " +
+			"When you are unsure, you say so rather than guessing.",
+	},
+});
 ```
 
 </TypeScriptExample>
@@ -89,15 +96,14 @@ Or load it from R2 so you can update the agent's personality without redeploying
 <TypeScriptExample>
 
 ```ts
-const session = Session.create(this)
-  .withContext("soul", {
-    provider: {
-      get: async () => {
-        const obj = await env.CONFIG_BUCKET.get("soul.md");
-        return obj ? obj.text() : "You are a helpful assistant.";
-      }
-    }
-  });
+const session = Session.create(this).withContext("soul", {
+	provider: {
+		get: async () => {
+			const obj = await env.CONFIG_BUCKET.get("soul.md");
+			return obj ? obj.text() : "You are a helpful assistant.";
+		},
+	},
+});
 ```
 
 </TypeScriptExample>
@@ -112,14 +118,14 @@ Think of this as a scratchpad the agent maintains for itself, a place to jot dow
 
 ```ts
 const session = Session.create(this)
-  .withContext("memory", {
-    description: "Important facts learned during conversation",
-    maxTokens: 1100
-  })
-  .withContext("todos", {
-    description: "Task list, track what needs to be done and what is complete",
-    maxTokens: 2000
-  });
+	.withContext("memory", {
+		description: "Important facts learned during conversation",
+		maxTokens: 1100,
+	})
+	.withContext("todos", {
+		description: "Task list, track what needs to be done and what is complete",
+		maxTokens: 2000,
+	});
 ```
 
 </TypeScriptExample>
@@ -159,11 +165,11 @@ The built-in `AgentSearchProvider` uses Durable Object SQLite with FTS5 as defau
 ```ts
 import { AgentSearchProvider } from "agents/experimental/memory/session";
 
-const session = Session.create(this)
-  .withContext("knowledge", {
-    description: "Searchable knowledge base, search for relevant information before answering",
-    provider: new AgentSearchProvider(this)
-  });
+const session = Session.create(this).withContext("knowledge", {
+	description:
+		"Searchable knowledge base, search for relevant information before answering",
+	provider: new AgentSearchProvider(this),
+});
 ```
 
 </TypeScriptExample>
@@ -173,23 +179,23 @@ But you can implement your own provider backed by any search mechanism:
 <TypeScriptExample>
 
 ```ts
-const session = Session.create(this)
-  .withContext("knowledge", {
-    description: "Searchable knowledge base",
-    provider: {
-      get: async () => "Product documentation and FAQs",
-      search: async (query) => {
-        // Use Vectorize, an external API, whatever you need
-        const results = await env.VECTORIZE_INDEX.query(
-          await generateEmbedding(query), { topK: 5 }
-        );
-        return results.matches.map(m => m.metadata.text).join("\n\n");
-      },
-      set: async (key, content) => {
-        // Index new content
-      }
-    }
-  });
+const session = Session.create(this).withContext("knowledge", {
+	description: "Searchable knowledge base",
+	provider: {
+		get: async () => "Product documentation and FAQs",
+		search: async (query) => {
+			// Use Vectorize, an external API, whatever you need
+			const results = await env.VECTORIZE_INDEX.query(
+				await generateEmbedding(query),
+				{ topK: 5 },
+			);
+			return results.matches.map((m) => m.metadata.text).join("\n\n");
+		},
+		set: async (key, content) => {
+			// Index new content
+		},
+	},
+});
 ```
 
 </TypeScriptExample>
@@ -240,23 +246,24 @@ The built-in `R2SkillProvider` stores skills in a Cloudflare R2 bucket. Each ski
 import { Session, R2SkillProvider } from "agents/experimental/memory/session";
 
 const session = Session.create(this)
-  .withContext("soul", {
-    provider: {
-      get: async () => [
-        "You are a helpful assistant with access to skills.",
-        "When a user asks you to do something, check the SKILLS section",
-        "for a relevant skill and use load_context to load it.",
-      ].join("\n")
-    }
-  })
-  .withContext("memory", {
-    description: "Learned facts",
-    maxTokens: 1100
-  })
-  .withContext("skills", {
-    provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" })
-  })
-  .withCachedPrompt();
+	.withContext("soul", {
+		provider: {
+			get: async () =>
+				[
+					"You are a helpful assistant with access to skills.",
+					"When a user asks you to do something, check the SKILLS section",
+					"for a relevant skill and use load_context to load it.",
+				].join("\n"),
+		},
+	})
+	.withContext("memory", {
+		description: "Learned facts",
+		maxTokens: 1100,
+	})
+	.withContext("skills", {
+		provider: new R2SkillProvider(env.SKILLS_BUCKET, { prefix: "skills/" }),
+	})
+	.withCachedPrompt();
 ```
 
 </TypeScriptExample>
@@ -293,7 +300,7 @@ To add descriptions (shown in the metadata listing), set custom metadata on the 
 
 ```ts
 await env.SKILLS_BUCKET.put("skills/api-ref", content, {
-  customMetadata: { description: "API Reference documentation" }
+	customMetadata: { description: "API Reference documentation" },
 });
 ```
 
@@ -309,39 +316,39 @@ You can back skills with any storage by implementing the `SkillProvider` interfa
 import type { SkillProvider } from "agents/experimental/memory/session";
 
 class DatabaseSkillProvider implements SkillProvider {
-  private db: D1Database;
+	private db: D1Database;
 
-  constructor(db: D1Database) {
-    this.db = db;
-  }
+	constructor(db: D1Database) {
+		this.db = db;
+	}
 
-  async get(): Promise<string | null> {
-    const rows = await this.db
-      .prepare("SELECT key, description FROM skills ORDER BY key")
-      .all();
-    if (rows.results.length === 0) return null;
-    return rows.results
-      .map(r => `- ${r.key}${r.description ? `: ${r.description}` : ""}`)
-      .join("\n");
-  }
+	async get(): Promise<string | null> {
+		const rows = await this.db
+			.prepare("SELECT key, description FROM skills ORDER BY key")
+			.all();
+		if (rows.results.length === 0) return null;
+		return rows.results
+			.map((r) => `- ${r.key}${r.description ? `: ${r.description}` : ""}`)
+			.join("\n");
+	}
 
-  async load(key: string): Promise<string | null> {
-    const row = await this.db
-      .prepare("SELECT content FROM skills WHERE key = ?")
-      .bind(key)
-      .first();
-    return row ? (row.content as string) : null;
-  }
+	async load(key: string): Promise<string | null> {
+		const row = await this.db
+			.prepare("SELECT content FROM skills WHERE key = ?")
+			.bind(key)
+			.first();
+		return row ? (row.content as string) : null;
+	}
 
-  async set(key: string, content: string, description?: string): Promise<void> {
-    await this.db
-      .prepare(
-        "INSERT INTO skills (key, content, description) VALUES (?, ?, ?) " +
-        "ON CONFLICT(key) DO UPDATE SET content = ?, description = ?"
-      )
-      .bind(key, content, description ?? null, content, description ?? null)
-      .run();
-  }
+	async set(key: string, content: string, description?: string): Promise<void> {
+		await this.db
+			.prepare(
+				"INSERT INTO skills (key, content, description) VALUES (?, ?, ?) " +
+					"ON CONFLICT(key) DO UPDATE SET content = ?, description = ?",
+			)
+			.bind(key, content, description ?? null, content, description ?? null)
+			.run();
+	}
 }
 ```
 
@@ -351,13 +358,13 @@ The Session detects the `load()` method via duck-typing and generates the approp
 
 #### Skills vs other memory types
 
-| Aspect | Skills | Writable context | Searchable context |
-| ------ | ------ | ---------------- | ------------------ |
-| **In system prompt** | Metadata listing only | Full content | Summary count |
-| **Access pattern** | Load whole document by key | Always visible | Search by query |
-| **Best for** | Large documents, reference material | Short notes, preferences | Large collections of small entries |
-| **Context cost** | Low (until loaded) | Proportional to content | Low (until searched) |
-| **Agent writes?** | Optional (if `set` implemented) | Yes (via `set_context`) | Yes (via `set_context`) |
+| Aspect               | Skills                              | Writable context         | Searchable context                 |
+| -------------------- | ----------------------------------- | ------------------------ | ---------------------------------- |
+| **In system prompt** | Metadata listing only               | Full content             | Summary count                      |
+| **Access pattern**   | Load whole document by key          | Always visible           | Search by query                    |
+| **Best for**         | Large documents, reference material | Short notes, preferences | Large collections of small entries |
+| **Context cost**     | Low (until loaded)                  | Proportional to content  | Low (until searched)               |
+| **Agent writes?**    | Optional (if `set` implemented)     | Yes (via `set_context`)  | Yes (via `set_context`)            |
 
 The key distinction: skills are **lazy**. They cost nearly nothing in the system prompt until the agent decides it needs one. This makes them ideal for large reference material where only a subset is relevant to any given conversation.
 
@@ -372,10 +379,10 @@ const sessionTools = await session.tools();
 const allTools = { ...sessionTools, ...myApplicationTools };
 
 const result = streamText({
-  model: myModel,
-  system: await session.freezeSystemPrompt(),
-  messages: await convertToModelMessages(session.getHistory()),
-  tools: allTools
+	model: myModel,
+	system: await session.freezeSystemPrompt(),
+	messages: await convertToModelMessages(session.getHistory()),
+	tools: allTools,
 });
 ```
 
@@ -385,13 +392,13 @@ const result = streamText({
 
 The Session generates tools dynamically based on what provider types are present:
 
-| Tool | Generated when | What it does |
-| ---- | -------------- | ------------ |
-| **`set_context`** | Any writable, skill, or search block exists | Writes content to a named block. For writable blocks, replaces or appends. For skill/search blocks, writes a keyed entry. |
-| **`load_context`** | Any skill block exists | Loads full content of a document by key into the agent's context. |
-| **`unload_context`** | Any skill block exists | Frees context space by removing a previously loaded document. The document remains available for re-loading. |
-| **`search_context`** | Any search block exists | Full-text search within a searchable block. Returns the top results ranked by relevance. |
-| **`session_search`** | Using `SessionManager` | Searches across all sessions (cross-conversation search). |
+| Tool                 | Generated when                              | What it does                                                                                                              |
+| -------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **`set_context`**    | Any writable, skill, or search block exists | Writes content to a named block. For writable blocks, replaces or appends. For skill/search blocks, writes a keyed entry. |
+| **`load_context`**   | Any skill block exists                      | Loads full content of a document by key into the agent's context.                                                         |
+| **`unload_context`** | Any skill block exists                      | Frees context space by removing a previously loaded document. The document remains available for re-loading.              |
+| **`search_context`** | Any search block exists                     | Full-text search within a searchable block. Returns the top results ranked by relevance.                                  |
+| **`session_search`** | Using `SessionManager`                      | Searches across all sessions (cross-conversation search).                                                                 |
 
 The tools include descriptions and parameter schemas that tell the LLM which blocks are available and what they are for. The agent decides when and how to use them based on the conversation.
 
@@ -446,11 +453,11 @@ This means the system prompt stays stable throughout a multi-step tool-use turn,
 
 ```ts
 const session = Session.create(this)
-  .withContext("soul", {
-    provider: { get: async () => "You are a helpful assistant." }
-  })
-  .withContext("memory", { description: "Learned facts", maxTokens: 1100 })
-  .withCachedPrompt(); // Persist the frozen prompt across hibernation
+	.withContext("soul", {
+		provider: { get: async () => "You are a helpful assistant." },
+	})
+	.withContext("memory", { description: "Learned facts", maxTokens: 1100 })
+	.withCachedPrompt(); // Persist the frozen prompt across hibernation
 
 // During a conversation turn:
 const system = await session.freezeSystemPrompt(); // Same value every call
@@ -495,15 +502,17 @@ The key points:
 import { createCompactFunction } from "agents/experimental/memory/utils/compaction-helpers";
 
 const session = Session.create(this)
-  .withContext("memory", { maxTokens: 1100 })
-  .onCompaction(createCompactFunction({
-    summarize: (prompt) =>
-      generateText({ model: myModel, prompt }).then(r => r.text),
-    protectHead: 3,
-    tailTokenBudget: 20000,
-    minTailMessages: 2
-  }))
-  .compactAfter(100_000); // Auto-compact when token estimate exceeds threshold
+	.withContext("memory", { maxTokens: 1100 })
+	.onCompaction(
+		createCompactFunction({
+			summarize: (prompt) =>
+				generateText({ model: myModel, prompt }).then((r) => r.text),
+			protectHead: 3,
+			tailTokenBudget: 20000,
+			minTailMessages: 2,
+		}),
+	)
+	.compactAfter(100_000); // Auto-compact when token estimate exceeds threshold
 ```
 
 </TypeScriptExample>
@@ -533,19 +542,19 @@ const truncated = truncateOlderMessages(history);
 ## Related
 
 <LinkCard
-  title="Session API reference"
-  href="/agents/api-reference/sessions/"
-  description="Full API reference for Session, covering messages, context blocks, compaction, search, tools, and custom providers."
+	title="Session API reference"
+	href="/agents/api-reference/sessions/"
+	description="Full API reference for Session, covering messages, context blocks, compaction, search, tools, and custom providers."
 />
 
 <LinkCard
-  title="Store and sync state"
-  href="/agents/api-reference/store-and-sync-state/"
-  description="setState() for simpler key-value persistence and real-time sync."
+	title="Store and sync state"
+	href="/agents/api-reference/store-and-sync-state/"
+	description="setState() for simpler key-value persistence and real-time sync."
 />
 
 <LinkCard
-  title="Think"
-  href="/agents/api-reference/think/"
-  description="Opinionated chat agent with built-in Session integration via configureSession()."
+	title="Think"
+	href="/agents/api-reference/think/"
+	description="Opinionated chat agent with built-in Session integration via configureSession()."
 />

--- a/src/content/docs/agents/concepts/tools.mdx
+++ b/src/content/docs/agents/concepts/tools.mdx
@@ -12,6 +12,18 @@ products:
 
 Tools enable AI systems to interact with external services and perform actions. They provide a structured way for agents and workflows to invoke APIs, manipulate data, and integrate with external systems. Tools form the bridge between AI decision-making capabilities and real-world actions.
 
+## Tools on Cloudflare Agents
+
+Cloudflare Agents support several tool patterns. Choose the smallest one that fits the job:
+
+| Pattern           | Use when                                                                                  | Start here                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Server-side tools | The tool can run entirely in the Worker, such as fetching an API or querying SQL          | [Chat agents](/agents/api-reference/chat-agents/#server-side-tools) |
+| Client-side tools | The tool needs browser APIs such as geolocation, clipboard, or local storage              | [Chat agents](/agents/api-reference/chat-agents/#client-side-tools) |
+| Human approvals   | The tool is sensitive and needs a user decision before it runs                            | [Human-in-the-loop](/agents/concepts/human-in-the-loop/)            |
+| MCP tools         | You want to expose or consume tools through the Model Context Protocol                    | [Model Context Protocol](/agents/model-context-protocol/)           |
+| Agent tools       | You want a chat agent to run another chat-capable sub-agent as a retained, streaming tool | [Agent tools](/agents/api-reference/agent-tools/)                   |
+
 ### Understanding tools
 
 In an AI system, tools are typically implemented as function calls that the AI can use to accomplish specific tasks. For example, a travel booking agent might have tools for:

--- a/src/content/docs/agents/concepts/workflows.mdx
+++ b/src/content/docs/agents/concepts/workflows.mdx
@@ -18,14 +18,14 @@ import { TypeScriptExample, LinkCard } from "~/components";
 
 Agents and Workflows have complementary strengths:
 
-| Capability              | Agents                     | Workflows                      |
-| ----------------------- | -------------------------- | ------------------------------ |
-| Execution model         | Can run indefinitely       | Run to completion              |
-| Real-time communication | WebSockets, HTTP streaming | Not supported                  |
-| State persistence       | Built-in SQL database      | Step-level persistence         |
-| Failure handling        | Application-defined        | Automatic retries and recovery |
-| External events         | Direct handling            | Pause and wait for events      |
-| User interaction        | Direct (chat, UI)          | Through Agent callbacks        |
+| Capability              | Agents                                   | Workflows                      |
+| ----------------------- | ---------------------------------------- | ------------------------------ |
+| Execution model         | Long-lived identity that wakes on events | Run to completion              |
+| Real-time communication | WebSockets, HTTP streaming               | Not supported                  |
+| State persistence       | Built-in SQL database                    | Step-level persistence         |
+| Failure handling        | Application-defined                      | Automatic retries and recovery |
+| External events         | Direct handling                          | Pause and wait for events      |
+| User interaction        | Direct (chat, UI)                        | Through Agent callbacks        |
 
 Agents can loop, branch, and interact directly with users. Workflows execute steps sequentially with guaranteed delivery and can pause for days waiting for approvals or external data.
 

--- a/src/content/docs/agents/getting-started/build-a-chat-agent.mdx
+++ b/src/content/docs/agents/getting-started/build-a-chat-agent.mdx
@@ -17,6 +17,8 @@ Build a chat agent that streams AI responses, calls server-side tools, executes 
 
 **Time:** ~15 minutes
 
+This tutorial starts from a minimal Hello World Worker so you can see each moving part. If you want a complete starter app with the same core pieces already wired together, start with the [quick start](/agents/getting-started/quick-start/) and then return here to understand how the chat pieces fit together.
+
 **Prerequisites:**
 
 - Node.js 18+

--- a/src/content/docs/agents/getting-started/index.mdx
+++ b/src/content/docs/agents/getting-started/index.mdx
@@ -10,19 +10,36 @@ products:
   - agents
 ---
 
-import { DirectoryListing } from "~/components";
+import { DirectoryListing, LinkCard } from "~/components";
 
-Start building agents that can remember context and make decisions. This guide walks you through creating your first agent and understanding how they work.
+Start building agents that can remember context, communicate with users, and act on their own. Pick the path that matches what you want to build first.
 
-Agents maintain state across conversations and can execute workflows. Use them for customer support automation, personal assistants, or interactive experiences.
+## Choose a path
 
-## What you will learn
+<LinkCard
+	title="Quick start"
+	href="/agents/getting-started/quick-start/"
+	description="Build a small stateful counter agent and learn the core Agent, state, and client SDK model."
+/>
 
-Building with agents involves understanding a few core concepts:
+<LinkCard
+	title="Build a chat agent"
+	href="/agents/getting-started/build-a-chat-agent/"
+	description="Build a streaming AI chat agent with Workers AI, server tools, client tools, and approvals."
+/>
 
-- **State management**: How agents remember information across interactions.
-- **Decision making**: How agents analyze requests and choose actions.
-- **Tool integration**: How agents access external APIs and data sources.
-- **Conversation flow**: How agents maintain context and personality.
+<LinkCard
+	title="Add Agents to an existing project"
+	href="/agents/getting-started/add-to-existing-project/"
+	description="Install the Agents SDK into an existing Workers application and wire up routing."
+/>
+
+<LinkCard
+	title="Testing your Agents"
+	href="/agents/getting-started/testing-your-agent/"
+	description="Write tests with Vitest and the Workers test pool."
+/>
+
+## All getting started pages
 
 <DirectoryListing />

--- a/src/content/docs/agents/getting-started/prompting.mdx
+++ b/src/content/docs/agents/getting-started/prompting.mdx
@@ -5,7 +5,7 @@ external_link: /workers/get-started/prompting/
 sidebar:
   order: 5
 head: []
-description: Use the Workers "mega prompt" to build a Agents using your preferred AI tools and/or IDEs. The prompt understands the Agents SDK APIs, best practices and guidelines, and makes it easier to build valid Agents and Workers.
+description: Use the Workers "mega prompt" to build Agents using your preferred AI tools and IDEs. The prompt understands the Agents SDK APIs, best practices, and guidelines, and makes it easier to build valid Agents and Workers.
 products:
   - agents
 ---

--- a/src/content/docs/agents/getting-started/quick-start.mdx
+++ b/src/content/docs/agents/getting-started/quick-start.mdx
@@ -32,7 +32,7 @@ Build AI agents that persist, think, and act. Agents run on Cloudflare's global 
 Then install dependencies and start the dev server:
 
 ```sh
-cd my-agent
+cd agents-starter
 npm install
 npm run dev
 ```

--- a/src/content/docs/agents/getting-started/testing-your-agent.mdx
+++ b/src/content/docs/agents/getting-started/testing-your-agent.mdx
@@ -69,20 +69,20 @@ describe("make a request to my Agent", () => {
 	// Unit testing approach
 	it("responds with state", async () => {
 		// Provide a valid URL that your Worker can use to route to your Agent
-		// If you are using routeAgentRequest, this will be /agent/:agent/:name
+		// If you are using routeAgentRequest, this will be /agents/:agent/:name
 		const request = new Request<unknown, IncomingRequestCfProperties>(
-			"http://example.com/agent/my-agent/agent-123",
+			"http://example.com/agents/my-agent/agent-123",
 		);
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, env, ctx);
 		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchObject({ hello: "from your agent" });
+		expect(await response.json()).toEqual({ hello: "from your agent" });
 	});
 
 	it("also responds with state", async () => {
-		const request = new Request("http://example.com/agent/my-agent/agent-123");
+		const request = new Request("http://example.com/agents/my-agent/agent-123");
 		const response = await exports.default.fetch(request);
-		expect(await response.text()).toMatchObject({ hello: "from your agent" });
+		expect(await response.json()).toEqual({ hello: "from your agent" });
 	});
 });
 ```
@@ -92,12 +92,12 @@ describe("make a request to my Agent", () => {
 Running tests is done using the `vitest` CLI:
 
 ```sh
-$ npm run test
+npm run test
 # or run vitest directly
-$ npx vitest
+npx vitest
 ```
 
-```sh output
+```txt
   MyAgent
     ✓ should return a greeting (1 ms)
 
@@ -111,10 +111,10 @@ Review the [documentation on testing](/workers/testing/vitest-integration/write-
 You can also run an Agent locally using the `wrangler` CLI:
 
 ```sh
-$ npx wrangler dev
+npx wrangler dev
 ```
 
-```sh output
+```txt
 Your Worker and resources are simulated locally via Miniflare. For more information, see: https://developers.cloudflare.com/workers/testing/local-development.
 
 Your worker has access to the following bindings:

--- a/src/content/docs/agents/guides/build-a-voice-agent.mdx
+++ b/src/content/docs/agents/guides/build-a-voice-agent.mdx
@@ -106,7 +106,7 @@ export class MyVoiceAgent extends VoiceAgent<Env> {
 		const workersAi = createWorkersAI({ binding: this.env.AI });
 
 		const result = streamText({
-			model: workersAi("@cf/moonshotai/kimi-k2.5"),
+			model: workersAi("@cf/moonshotai/kimi-k2.6"),
 			system:
 				"You are a helpful voice assistant. Keep responses concise — you are being spoken aloud.",
 			messages: [
@@ -191,9 +191,7 @@ function App() {
 					{status === "idle" ? "Start Call" : "End Call"}
 				</button>
 				{status !== "idle" && (
-					<button onClick={toggleMute}>
-						{isMuted ? "Unmute" : "Mute"}
-					</button>
+					<button onClick={toggleMute}>{isMuted ? "Unmute" : "Mute"}</button>
 				)}
 			</div>
 
@@ -211,8 +209,8 @@ function App() {
 
 			{metrics && (
 				<p>
-					LLM: {metrics.llm_ms}ms | TTS: {metrics.tts_ms}ms | First
-					audio: {metrics.first_audio_ms}ms
+					LLM: {metrics.llm_ms}ms | TTS: {metrics.tts_ms}ms | First audio:{" "}
+					{metrics.first_audio_ms}ms
 				</p>
 			)}
 		</div>

--- a/src/content/docs/agents/guides/cross-domain-authentication.mdx
+++ b/src/content/docs/agents/guides/cross-domain-authentication.mdx
@@ -299,7 +299,7 @@ export class SecureAgent extends Agent {
 <LinkCard
 	title="GitHub OAuth agent example"
 	href="https://github.com/cloudflare/agents/tree/main/examples/auth-agent"
-	description="Protect an Agents app with GitHub OAuth, HTTP-only cookies, and server-owned Durable Object routing."
+	description="Protect an app built with Agents using GitHub OAuth, HTTP-only cookies, and server-owned Durable Object routing."
 />
 
 <LinkCard

--- a/src/content/docs/agents/guides/cross-domain-authentication.mdx
+++ b/src/content/docs/agents/guides/cross-domain-authentication.mdx
@@ -297,6 +297,12 @@ export class SecureAgent extends Agent {
 />
 
 <LinkCard
+	title="GitHub OAuth agent example"
+	href="https://github.com/cloudflare/agents/tree/main/examples/auth-agent"
+	description="Protect an Agents app with GitHub OAuth, HTTP-only cookies, and server-owned Durable Object routing."
+/>
+
+<LinkCard
 	title="Agents API"
 	href="/agents/api-reference/agents-api/"
 	description="Complete API reference for the Agents SDK."

--- a/src/content/docs/agents/guides/remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/remote-mcp-server.mdx
@@ -271,9 +271,11 @@ npx wrangler secret put GITHUB_CLIENT_ID
 npx wrangler secret put GITHUB_CLIENT_SECRET
 ```
 
-    ```
-    npx wrangler secret put COOKIE_ENCRYPTION_KEY # add any random string here e.g. openssl rand -hex 32
-    ```
+```sh
+npx wrangler secret put COOKIE_ENCRYPTION_KEY
+```
+
+Use any random string for `COOKIE_ENCRYPTION_KEY`, for example the output of `openssl rand -hex 32`.
 
     :::caution
     When you create the first secret, Wrangler will ask if you want to create a new Worker. Submit "Y" to create a new Worker and save the secret.

--- a/src/content/docs/agents/index.mdx
+++ b/src/content/docs/agents/index.mdx
@@ -34,6 +34,8 @@ Most AI applications today are stateless — they process a request, return a re
 
 Each agent runs on a [Durable Object](/durable-objects/) — a stateful micro-server with its own SQL database, WebSocket connections, and scheduling. Deploy once and Cloudflare runs your agents across its global network, scaling to tens of millions of instances. No infrastructure to manage, no sessions to reconstruct, no state to externalize.
 
+The mental model is simple: define a TypeScript class, give each real-world thing a stable name, and route requests or WebSocket connections to that named instance. The instance wakes when something happens, reads its durable state, does work, and hibernates when idle.
+
 ### Get started
 
 Three commands to a running agent. No API keys required — the starter uses [Workers AI](/workers-ai/) by default.

--- a/src/content/docs/agents/index.mdx
+++ b/src/content/docs/agents/index.mdx
@@ -67,8 +67,8 @@ The starter includes streaming AI chat, server-side and client-side tools, human
 - **Act on their own** — [Schedule tasks](/agents/api-reference/schedule-tasks/) on a delay, at a specific time, or on a cron. Agents can wake themselves up, do work, and go back to sleep — without a user present.
 - **Browse the web** — Give your agents [browser tools](/agents/api-reference/browse-the-web/) powered by the Chrome DevTools Protocol to scrape, screenshot, debug, and interact with web pages.
 - **Talk to users** — Build real-time [voice agents](/agents/api-reference/voice/) with speech-to-text, text-to-speech, and conversation persistence — audio streams over WebSocket.
-- **Orchestrate work** — Run multi-step [workflows](/agents/api-reference/run-workflows/) with automatic retries, or coordinate across multiple agents.
-- **React to events** — Handle [inbound email](/agents/api-reference/email/), HTTP requests, WebSocket messages, and state changes — all from the same class.
+- **Orchestrate work** — Run multi-step [workflows](/agents/api-reference/run-workflows/) with automatic retries, coordinate across [sub-agents](/agents/api-reference/sub-agents/), or run chat-capable [agent tools](/agents/api-reference/agent-tools/) with retained streaming timelines.
+- **React to events** — Handle [inbound email](/agents/api-reference/email/) (see the [email agent example](https://github.com/cloudflare/agents/tree/main/examples/email-agent)), HTTP requests, WebSocket messages, and state changes — all from the same class.
 
 ### How it works
 

--- a/src/content/docs/agents/model-context-protocol/tools.mdx
+++ b/src/content/docs/agents/model-context-protocol/tools.mdx
@@ -16,6 +16,18 @@ MCP tools are functions that an [MCP server](/agents/model-context-protocol/) ex
 
 Tools are defined using the `@modelcontextprotocol/sdk` package. The Agents SDK handles transport and lifecycle; the tool definitions are the same regardless of whether you use [`createMcpHandler`](/agents/api-reference/mcp-handler-api/) or [`McpAgent`](/agents/api-reference/mcp-agent-api/).
 
+:::note[Experimental WebMCP adapter]
+
+The Agents SDK also includes the experimental `agents/experimental/webmcp` adapter for bridging `McpAgent` tools to Chrome's native `navigator.modelContext` API. This API is under active development and may change between releases.
+
+:::
+
+<LinkCard
+	title="WebMCP example"
+	href="https://github.com/cloudflare/agents/tree/main/examples/webmcp"
+	description="Bridge MCP tools from a Cloudflare McpAgent into Chrome's experimental WebMCP API."
+/>
+
 ## Defining tools
 
 Use `server.tool()` to register a tool on an `McpServer` instance. Each tool has a name, a description (used by the LLM to decide when to call it), an input schema defined with [Zod](https://zod.dev), and a handler function.

--- a/src/content/docs/agents/patterns.mdx
+++ b/src/content/docs/agents/patterns.mdx
@@ -13,7 +13,7 @@ import { GitHubCode } from "~/components";
 
 This page lists and defines common patterns for implementing AI agents, based on [Anthropic's patterns for building effective agents](https://www.anthropic.com/research/building-effective-agents).
 
-Code samples use the [AI SDK](https://sdk.vercel.ai/docs/foundations/agents), running in [Durable Objects](/durable-objects).
+Code samples use the [AI SDK](https://ai-sdk.dev/docs/foundations/agents), running in [Durable Objects](/durable-objects).
 
 ## Prompt Chaining
 


### PR DESCRIPTION
### Summary

Updates the Agents docs to reflect recent SDK work and make the section easier to follow for both human readers and coding agents.

This PR adds a dedicated Agent tools reference page, updates the existing API reference pages for sub-agents, chat agents, Think, scheduling, durable execution, MCP, voice, and examples, and tightens the onboarding path so readers can choose between the stateful counter quick start, the chat-agent tutorial, and existing-project setup.

It also includes an editorial sweep to reduce implementation-detail leakage, clarify terminology around Durable Object sub-agents versus in-process AI SDK subagents, fix stale import paths and model names, and correct small copy/paste issues in testing, OAuth setup, payment gating, and AI SDK links.

Notable areas covered:

- Adds `src/content/docs/agents/api-reference/agent-tools.mdx` for retained, streaming sub-agent tool runs.
- Updates sub-agent docs for routing, access control, `onBeforeSubAgent`, client hooks, scheduling, durable fibers, and cleanup behavior.
- Updates chat/Think docs for cancellation, recovery metadata, client streaming flags, turn/step configuration, and agent-tool guidance.
- Clarifies scheduling and durable execution wording while keeping storage/alarm internals out of the main reader path.
- Reworks getting-started and concept intros for a clearer learning path.

### Screenshots (optional)

<!-- TODO: add screenshots or deploy preview notes before requesting review -->

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.

### Validation

- `ReadLints` on `src/content/docs/agents`: no linter errors.
- `pnpm exec prettier --check` on edited formatter-stable Agents docs: passed.
- `pnpm run check`: fails on existing repo-level TypeScript issues unrelated to this PR:
  - `vitest.config.ts`: `@cloudflare/vitest-pool-workers` type file is not a module.
  - `src/components/ModelCatalog.tsx`: missing `@base-ui/react/*` modules and implicit `any` diagnostics.
