### PR TITLE
chore: remove NODE_OPTIONS heap size arg from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"preinstall": "pnpx only-allow pnpm",
 		"astro": "astro",
 		"prebuild": "tsx bin/fetch-skills.ts",
-		"build": "export NODE_OPTIONS='--max-old-space-size=8192' || set NODE_OPTIONS=\"--max-old-space-size=8192\" && astro build",
+		"build": "astro build",
 		"typegen:worker": "wrangler types ./worker/worker-configuration.d.ts",
 		"check": "pnpm run check:astro && pnpm run check:worker",
 		"check:astro": "astro check",


### PR DESCRIPTION
### Summary

Removes the `NODE_OPTIONS='--max-old-space-size=8192'` heap size override from the `build` script in `package.json`. Node.js 24 (the project's required runtime) ships with improved memory management and generally does not need a manual heap cap. Removing this keeps the build script simple and avoids masking any genuine OOM issues that the runtime's own GC should handle.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->
