### PR TITLE
Revise limits for Artifacts operations

### DIFF
--- a/src/content/docs/artifacts/platform/limits.mdx
+++ b/src/content/docs/artifacts/platform/limits.mdx
@@ -10,14 +10,14 @@ products:
 
 Limits that apply to creating, importing, cloning, and pushing Artifacts are detailed below.
 
-These limits cover naming rules and request rates for control-plane and git operations.
+These limits cover naming rules, storage, and request rates for control-plane and Git operations.
 
-| Feature                           | Limit                                                      |
-| --------------------------------- | ---------------------------------------------------------- |
-| Control-plane request rate        | 2,000 requests per 10 seconds                              |
-| Git request rate (per namespace)  | 2,000 requests per 10 seconds                              |
-| Maximum storage per repository    | 10 GB                                                      |
-| Maximum storage per account       | 1 TB (can be raised on request)                            |
-| Maximum number of repositories    | Unlimited                                                  |
-| Maximum number of namespaces      | Unlimited                                                  |
-| Namespace and repo names          | Start with a letter or digit. Remaining characters may include letters, digits, `.`, `_`, and `-`. |
+| Feature                        | Limit                                                                                              |
+| ------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Control-plane request rate     | 2,000 requests per 10 seconds per Artifacts namespace                                              |
+| Git request rate, per repo     | 2,000 requests per 10 seconds per repo                                                             |
+| Maximum storage per repository | 10 GB                                                                                              |
+| Maximum storage per account    | 1 TB (can be raised on request)                                                                    |
+| Maximum number of repositories | No fixed product quota; subject to storage and request-rate limits                                 |
+| Maximum number of namespaces   | Unlimited                                                                                          |
+| Namespace and repo names       | Start with a letter or digit. Remaining characters may include letters, digits, `.`, `_`, and `-`. |

--- a/src/content/docs/artifacts/platform/limits.mdx
+++ b/src/content/docs/artifacts/platform/limits.mdx
@@ -15,9 +15,9 @@ These limits cover naming rules, storage, and request rates for control-plane an
 | Feature                        | Limit                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------- |
 | Control-plane request rate     | 2,000 requests per 10 seconds per Artifacts namespace                                              |
-| Git request rate, per repo     | 2,000 requests per 10 seconds per repo                                                             |
+| Git request rate, per artifact     | 2,000 requests per 10 seconds per artifact                                                             |
 | Maximum storage per repository | 10 GB                                                                                              |
 | Maximum storage per account    | 1 TB (can be raised on request)                                                                    |
-| Maximum number of repositories | No fixed product quota; subject to storage and request-rate limits                                 |
+| Maximum number of repositories | Unlimited                                 |
 | Maximum number of namespaces   | Unlimited                                                                                          |
 | Namespace and repo names       | Start with a letter or digit. Remaining characters may include letters, digits, `.`, `_`, and `-`. |


### PR DESCRIPTION
Updated limits for control-plane and Git operations to include namespace-specific request rates and clarified repository limits.

### Summary

See internal MR, separate rate limit for the namespace from limit per artifact