### PR TITLE
Update errors documentation by removing Snippets reference

### DIFF
--- a/src/content/docs/rules/snippets/errors.mdx
+++ b/src/content/docs/rules/snippets/errors.mdx
@@ -71,9 +71,3 @@ The name you define when creating a Snippet will be used as the Snippet ID and c
 ### Resolution
 
 To change the name of your Snippet, create a new Snippet and delete the old one.
-
----
-
-## Other runtime errors
-
-Snippets share some error codes with Workers, namely errors in the `11xx` range. For more information on these errors, refer to [Errors and exceptions](/workers/observability/errors/).

--- a/src/content/docs/workers/observability/errors.mdx
+++ b/src/content/docs/workers/observability/errors.mdx
@@ -31,7 +31,6 @@ When a Worker running in production has an error that prevents it from returning
 
 Other `11xx` errors generally indicate a problem with the Workers runtime itself. Refer to the [status page](https://www.cloudflarestatus.com) if you are experiencing an error.
 
-Errors in the `11xx` range can also be related with [Snippets](/rules/snippets/).
 
 ### Loop limit
 


### PR DESCRIPTION
Removed mention of Snippets related to 11xx errors.

"Errors in the `11xx` range can also be related with Snippets"

We notice this is one line which customer pointed is actually contradicting with other docs. https://developers.cloudflare.com/workers/observability/errors/#error-pages-generated-by-workers

Actually Snippet errors only follow 12xx 
11xx belongs to workers only.
For reference:
Worker error 1101: https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1101/ Snippet error codes: https://developers.cloudflare.com/rules/snippets/errors/

Also, confirmed in wiki
https://wiki.cfdata.org/spaces/ERE/pages/1357492857/Spec+for+MR5313#SpecforMR5313-Appendix%3ASummarytable

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
