### PR TITLE
Update FIPS 140-2 references to FIPS 140-3

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/index.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/index.mdx
@@ -243,7 +243,7 @@ Configures the protocol used to route IP traffic from the device to Cloudflare G
 **Value**:
 
 - **WireGuard**: Establishes a [WireGuard](https://www.wireguard.com/) connection to Cloudflare. The Cloudflare One Client will encrypt traffic using a non-FIPs compliant cipher suite, `TLS_CHACHA20_POLY1305_SHA256`. When switching from MASQUE to WireGuard, users may lose Internet connectivity if their Wi-Fi network blocks the [ports and IPs](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/firewall/#warp-ingress-ip) required for WireGuard to function.
-- **MASQUE**: (default) Establishes an HTTP/3 connection to Cloudflare. The Cloudflare One Client will encrypt traffic using TLS 1.3 and a [FIPS 140-2](https://csrc.nist.gov/pubs/fips/140-2/upd2/final) compliant cipher suite, `TLS_AES_256_GCM_SHA384`. [Assign a unique IP address to each device](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#assign-a-unique-ip-address-to-each-device) is enabled by default for devices with MASQUE enabled.
+- **MASQUE**: (default) Establishes an HTTP/3 connection to Cloudflare. The Cloudflare One Client will encrypt traffic using TLS 1.3 and a [FIPS 140-3](https://csrc.nist.gov/pubs/fips/140-3/final) compliant cipher suite, `TLS_AES_256_GCM_SHA384`. [Assign a unique IP address to each device](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#assign-a-unique-ip-address-to-each-device) is enabled by default for devices with MASQUE enabled.
 
 For more details on WireGuard versus MASQUE, refer to our [blog post](https://blog.cloudflare.com/zero-trust-warp-with-a-masque).
 

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/tls-decryption.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/tls-decryption.mdx
@@ -121,13 +121,13 @@ Refer to [Post-quantum cryptography](/ssl/post-quantum-cryptography/) to learn m
 
 ## FIPS compliance
 
-By default, TLS decryption can use both TLS version 1.2 and 1.3. However, some environments such as FedRAMP may require cipher suites and TLS versions compliant with FIPS 140-2. FIPS compliance currently requires TLS version 1.2.
+By default, TLS decryption can use both TLS version 1.2 and 1.3. However, some environments such as FedRAMP may require cipher suites and TLS versions compliant with FIPS 140-3. FIPS compliance currently requires TLS version 1.2.
 
 ### Enable FIPS compliance
 
 <Render file="gateway/enable-tls-decryption" product="cloudflare-one" />
 
-3. Select **Enable only cipher suites and TLS versions compliant with FIPS 140-2**.
+3. Select **Enable only cipher suites and TLS versions compliant with FIPS 140-3**.
 
 ### Limitations
 

--- a/src/content/docs/reference-architecture/diagrams/security/fips-140-3.mdx
+++ b/src/content/docs/reference-architecture/diagrams/security/fips-140-3.mdx
@@ -56,7 +56,7 @@ This level makes the physical security requirements more stringent, requiring th
 
 - **Cloudflare Keyless SSL**: A service that allows organizations to use Cloudflare's SSL/TLS protection while keeping their private keys securely stored in their own infrastructure, ensuring private keys remain under their control and never leave their premises, while still benefiting from Cloudflare's DDoS protection and performance optimization features.
 - **Cloudflare Tunnel**: Provides a secure, encrypted connection between Cloudflare's global network and the private infrastructure hosting CloudHSM, protecting data in transit.
-- **Hardware Security module**: A FIPS 140-2 Level 3 compliant HSM that securely manages cryptographic keys. Cloudflare supports a handful of HSMs, including AWS CloudHSM, Azure Key Vault, and Google Cloud KMS.
+- **Hardware Security module**: A FIPS 140-3 Level 3 compliant HSM that securely manages cryptographic keys. Cloudflare supports a handful of HSMs, including AWS CloudHSM, Azure Key Vault, and Google Cloud KMS.
 
 ## Architecture overview
 

--- a/src/content/docs/reference-architecture/diagrams/security/fips-140-3.mdx
+++ b/src/content/docs/reference-architecture/diagrams/security/fips-140-3.mdx
@@ -56,7 +56,7 @@ This level makes the physical security requirements more stringent, requiring th
 
 - **Cloudflare Keyless SSL**: A service that allows organizations to use Cloudflare's SSL/TLS protection while keeping their private keys securely stored in their own infrastructure, ensuring private keys remain under their control and never leave their premises, while still benefiting from Cloudflare's DDoS protection and performance optimization features.
 - **Cloudflare Tunnel**: Provides a secure, encrypted connection between Cloudflare's global network and the private infrastructure hosting CloudHSM, protecting data in transit.
-- **Hardware Security module**: A FIPS 140-3 Level 3 compliant HSM that securely manages cryptographic keys. Cloudflare supports a handful of HSMs, including AWS CloudHSM, Azure Key Vault, and Google Cloud KMS.
+- **Hardware Security module**: A FIPS 140 Level 3 compliant HSM that securely manages cryptographic keys. Cloudflare supports a handful of HSMs, including AWS CloudHSM, Azure Key Vault, and Google Cloud KMS.
 
 ## Architecture overview
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/compliance-status.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/compliance-status.mdx
@@ -1,7 +1,7 @@
 ---
 title: Compliance standards
 pcx_content_type: reference
-description: Cipher suite compliance with FIPS 140-2, PCI DSS, and other standards.
+description: Cipher suite compliance with FIPS 140-3, PCI DSS, and other standards.
 products:
   - ssl
 sidebar:
@@ -35,9 +35,9 @@ Recommended cipher suites for compliance with the [Payment Card Industry Data Se
 
 <Render file="cipher-suites-api-linkout" product="ssl" />
 
-## FIPS-140-2
+## FIPS-140-3
 
-Recommended cipher suites for compliance with the [Federal Information Processing Standard (140-2)](https://csrc.nist.gov/pubs/fips/140-2/upd2/final). Used to approve cryptographic modules.
+Recommended cipher suites for compliance with the [Federal Information Processing Standard (140-3)](https://csrc.nist.gov/pubs/fips/140-3/final). Used to approve cryptographic modules.
 
 <Details header="Cipher suites list">
 

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/api.mdx
@@ -118,7 +118,7 @@ For compliance with PCI DSS, also [enable TLS 1.3](/ssl/edge-certificates/additi
 
 <Render file="ciphers-api-general-notes" product="ssl" />
 
-</TabItem> <TabItem label="fips-140-2">
+</TabItem> <TabItem label="fips-140-3">
 
 <APIRequest
 	path="/zones/{zone_id}/settings/{setting_id}"

--- a/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard.mdx
+++ b/src/content/docs/ssl/edge-certificates/additional-options/cipher-suites/customize-cipher-suites/dashboard.mdx
@@ -24,7 +24,7 @@ import { Render, Details, DashButton } from "~/components";
 When configuring cipher suites via dashboard, you can use three different selection modes:
 
 - **By security level**: allows you to select between the predefined [Cloudflare recommendations](/ssl/edge-certificates/additional-options/cipher-suites/recommendations/) (Modern[^1], Compatible, or Legacy).
-- **By compliance standard**: allows you to select cipher suites grouped according to [industry standards](/ssl/edge-certificates/additional-options/cipher-suites/compliance-status/) (PCI DSS or FIPS-140-2).
+- **By compliance standard**: allows you to select cipher suites grouped according to [industry standards](/ssl/edge-certificates/additional-options/cipher-suites/compliance-status/) (PCI DSS or FIPS-140-3).
 - **Custom**: allows you to individually select the cipher suites you would like to support.
 
 For any of the modes, you should keep in mind the following configuration conditions. If using the **security level** or the **compliance standard** mode, some actions may be blocked and explained referencing these conditions.

--- a/src/content/docs/ssl/keyless-ssl/hardware-security-modules/index.mdx
+++ b/src/content/docs/ssl/keyless-ssl/hardware-security-modules/index.mdx
@@ -15,7 +15,7 @@ In addition to private keys stored on disk, Keyless SSL supports keys stored in 
 
 ## Why use Keyless SSL with an HSM?
 
-Hardware Security Modules (HSMs) facilitate a higher level of protection for your private keys over storing them directly on your key server. The primary responsibility of an HSM is safeguarding private keys and performing operations such as signing or encryption internally. In addition to access control, that means the physical device must offer some degree of tamper-resistance in order to be compliant with government or [industry regulations such as FIPS 140](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-2.pdf).
+Hardware Security Modules (HSMs) facilitate a higher level of protection for your private keys over storing them directly on your key server. The primary responsibility of an HSM is safeguarding private keys and performing operations such as signing or encryption internally. In addition to access control, that means the physical device must offer some degree of tamper-resistance in order to be compliant with government or [industry regulations such as FIPS 140](https://csrc.nist.gov/pubs/fips/140-3/final).
 
 Moreover, many HSMs are also capable of generating keys and producing cryptographically secure randomness. Some are purpose-built to perform cryptographic computations more efficiently.
 


### PR DESCRIPTION
## Summary

Updates all Cloudflare-owned FIPS 140-2 wording to FIPS 140-3 across the docs.

### Files changed

- `cloudflare-one/.../settings/index.mdx` — MASQUE protocol description link and text
- `cloudflare-one/.../tls-decryption.mdx` — FedRAMP/FIPS compliance wording (x2)
- `reference-architecture/.../fips-140-3.mdx` — leftover FIPS 140-2 reference on a FIPS 140-3 page
- `ssl/.../compliance-status.mdx` — frontmatter description, section heading, and NIST link
- `ssl/.../customize-cipher-suites/api.mdx` — tab label
- `ssl/.../customize-cipher-suites/dashboard.mdx` — compliance standard description
- `ssl/.../hardware-security-modules/index.mdx` — NIST PDF URL updated to FIPS 140-3

### Not changed

HSM vendor certification pages (`ibm-cloud-hsm.mdx`, `fortanix-dsm.mdx`, `azure-managed-hsm.mdx`, `azure-dedicated-hsm.mdx`, `google-cloud-hsm.mdx`) — these describe third-party vendor certifications, not Cloudflare's own compliance claims.