### PR TITLE
Fix @cloudflare/vitest-pool-workers in tsconfig

### DIFF
--- a/src/content/docs/durable-objects/examples/testing-with-durable-objects.mdx
+++ b/src/content/docs/durable-objects/examples/testing-with-durable-objects.mdx
@@ -152,7 +152,7 @@ Create a `test/tsconfig.json` to configure TypeScript for your tests:
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
 		"moduleResolution": "bundler",
-		"types": ["@cloudflare/vitest-pool-workers"]
+		"types": ["@cloudflare/vitest-pool-workers/types"]
 	},
 	"include": ["./**/*.ts", "../src/worker-configuration.d.ts"]
 }

--- a/src/content/docs/workers/testing/vitest-integration/migration-guides/migrate-from-miniflare-2.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/migration-guides/migrate-from-miniflare-2.mdx
@@ -71,7 +71,7 @@ If you are using TypeScript, update your `tsconfig.json` to include the correct 
       "types": [
 				...
 -       "vitest-environment-miniflare/globals"
-+       "@cloudflare/vitest-pool-workers"
++       "@cloudflare/vitest-pool-workers/types"
       ]
     },
   }

--- a/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/write-your-first-test.mdx
@@ -94,7 +94,7 @@ You should also add the output of `wrangler types` to the `include` array so tha
 		"compilerOptions": {
 			"moduleResolution": "bundler",
 			"types": [
-				"@cloudflare/vitest-pool-workers", // provides `cloudflare:test` and `cloudflare:workers` types
+				"@cloudflare/vitest-pool-workers/types", // provides `cloudflare:test` and `cloudflare:workers` types
 			],
 		},
 		"include": [


### PR DESCRIPTION
### Summary

The test-specific types from `@cloudflare/vitest-pool-workers` are available at `@cloudflare/vitest-pool-workers/types`, not `@cloudflare/vitest-pool-workers`. Aligning it to the actual usage in this repo: https://github.com/cloudflare/cloudflare-docs/blob/production/worker/tsconfig.json

