### PR TITLE
[Cloudflare One] Add supported dashboard languages to general FAQ

### DIFF
--- a/src/content/docs/cloudflare-one/faq/general-faq.mdx
+++ b/src/content/docs/cloudflare-one/faq/general-faq.mdx
@@ -51,7 +51,7 @@ The Cloudflare dashboard is available in the following languages:
 - 简体中文 (Mandarin Chinese, Simplified)
 - 繁體中文 (Mandarin Chinese, Traditional)
 
-To change your dashboard language, select your user icon and choose a language from the dropdown.
+To change your dashboard language, refer to [Profile settings](/fundamentals/user-profiles/customize-account/#language).
 
 ## What data localization services are supported?
 

--- a/src/content/docs/cloudflare-one/faq/general-faq.mdx
+++ b/src/content/docs/cloudflare-one/faq/general-faq.mdx
@@ -36,6 +36,23 @@ These browsers are supported:
 - Chrome (current release, last release)
 - Safari (current release, last release)
 
+## What languages does the Cloudflare dashboard support?
+
+The Cloudflare dashboard is available in the following languages:
+
+- Deutsch (German)
+- English
+- Español (Spanish)
+- Français (French)
+- Italiano (Italian)
+- 日本語 (Japanese)
+- 한국어 (Korean)
+- Português (Portuguese)
+- 简体中文 (Mandarin Chinese, Simplified)
+- 繁體中文 (Mandarin Chinese, Traditional)
+
+To change your dashboard language, go to **Profile** > **Settings** > **Language**. For more information, refer to [Profile settings](/fundamentals/user-profiles/customize-account/).
+
 ## What data localization services are supported?
 
 Cloudflare Zero Trust can be used with the Data Localization Suite to ensure that traffic is only inspected in the regions you choose. For more information refer to [Use Zero Trust with Data Localization Suite](/data-localization/how-to/zero-trust/).

--- a/src/content/docs/cloudflare-one/faq/general-faq.mdx
+++ b/src/content/docs/cloudflare-one/faq/general-faq.mdx
@@ -51,7 +51,7 @@ The Cloudflare dashboard is available in the following languages:
 - 简体中文 (Mandarin Chinese, Simplified)
 - 繁體中文 (Mandarin Chinese, Traditional)
 
-To change your dashboard language, go to **Profile** > **Settings** > **Language**. For more information, refer to [Profile settings](/fundamentals/user-profiles/customize-account/).
+To change your dashboard language, select your user icon and choose a language from the dropdown.
 
 ## What data localization services are supported?
 


### PR DESCRIPTION
Adds a new FAQ entry listing the ten languages the Cloudflare dashboard supports. The profile settings page mentions you can change language but does not list which languages are available.

- Add "What languages does the Cloudflare dashboard support?" Q&A
- List all 10 languages with native names and English translations
- Link to the profile settings page for instructions on changing language