### PR TITLE
docs: document TZ=UTC default for wrangler dev local runtime

### DIFF
--- a/src/content/docs/workers/development-testing/index.mdx
+++ b/src/content/docs/workers/development-testing/index.mdx
@@ -59,6 +59,7 @@ By default, running `wrangler dev` / `vite dev` (when using the [Vite plugin](/w
 
 - Your Worker code runs on your local machine.
 - All resources your Worker is bound to in your [Wrangler configuration](/workers/wrangler/configuration/) are simulated locally.
+- The local `workerd` runtime runs with `TZ=UTC` so that `Date` and `Intl` APIs inside your Worker observe UTC, matching the production Cloudflare runtime regardless of your machine's timezone.
 
 ### Bindings during local development
 

--- a/src/content/docs/workers/wrangler/commands/workers.mdx
+++ b/src/content/docs/workers/wrangler/commands/workers.mdx
@@ -143,6 +143,10 @@ None of the options for this command are required. Many of these options can be 
 
 `wrangler dev` is a way to [locally test](/workers/development-testing/) your Worker while developing. With `wrangler dev` running, send HTTP requests to `localhost:8787` and your Worker should execute as expected. You will also see `console.log` messages and exceptions appearing in your terminal.
 
+:::note
+`wrangler dev` runs the local `workerd` runtime with `TZ=UTC` to match the production Cloudflare runtime. `Date` and `Intl` APIs inside your Worker observe UTC during local development, regardless of your machine's timezone.
+:::
+
 ---
 
 ## `deploy`


### PR DESCRIPTION
### Summary

Documents the new `TZ=UTC` default for the local Workers runtime, introduced in [cloudflare/workers-sdk#13776](https://github.com/cloudflare/workers-sdk/pull/13776) (closes [cloudflare/workers-sdk#8106](https://github.com/cloudflare/workers-sdk/issues/8106)).

Cloudflare's production runtime runs Workers with `TZ=UTC`, but Miniflare previously inherited the host machine's timezone, causing dev/prod drift in `Date` and `Intl` behaviour. Local development now matches production by default — this PR updates the docs to reflect that.

Two small additions:
- Add a third bullet to the **Defaults** list on the [Development & testing](https://developers.cloudflare.com/workers/development-testing/) page.
- Add a `:::note` callout under `wrangler dev` on the [Workers commands](https://developers.cloudflare.com/workers/wrangler/commands/workers/#dev) page.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry? — N/A; this documents an existing in-flight change to local dev behaviour. The workers-sdk PR will produce a Wrangler/Miniflare changelog entry.
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes. — N/A; not a new page.
- [ ] Files which have changed name or location have been allocated redirects. — N/A; no renames or moves.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->