### PR TITLE
[Cloudflare WAN, Magic Transit] Add IPv6 support row to Unified Routing beta limitations

### DIFF
--- a/src/content/partials/networking-services/reference/traffic-steering.mdx
+++ b/src/content/partials/networking-services/reference/traffic-steering.mdx
@@ -279,6 +279,7 @@ The following limitations apply to accounts using Unified Routing mode. This lis
 | Cloudflare Advanced Network Firewall features: IP Lists, ASN Lists, Threat Intel Lists, IDS, Rate Limiting, SIP, Managed Rulesets | Not yet supported |
 | Gateway filtering rules | Not supported on traffic where both the onramp and offramp is IPsec/GRE/CNI |
 | Load Balancer | Public-to-private use case is supported to IPsec/GRE/CNI destinations. Private-to-private use case does not yet support Cloudflare Source IPs |
+| IPv6 Support | IPv6 is supported for IPsec and GRE. Basic Network Firewall support for IPv6 is limited to src/dst IP filtering |
 
 ### Enroll in the Unified Routing beta
 


### PR DESCRIPTION
### Summary

Adds a new "IPv6 Support" row to the Unified Routing beta limitations table in the shared Traffic steering reference. The row clarifies that IPv6 is supported for IPsec and GRE under Unified Routing, but Network Firewall support for IPv6 is currently limited to source/destination IP filtering.

This partial is shared between Cloudflare WAN and Magic Transit, so the new row appears on both products' Traffic steering pages.

PCX-21814

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).