### PR TITLE
Clarify correct active attribute mapping for Entra ID SCIM

### DIFF
--- a/src/content/docs/fundamentals/account/account-security/scim-setup/index.mdx
+++ b/src/content/docs/fundamentals/account/account-security/scim-setup/index.mdx
@@ -34,7 +34,15 @@ Expectations for user lifecycle management with SCIM:
 | Retain user in account but with no permissions | Remove the user from all role groups but leave them assigned to the SCIM application. They will be an account member with only the role Minimal Account Access. |
 
 :::note
-Dashboard SCIM handles group membership and user account lifecycle through separate services. Removing a user from a SCIM group updates their group membership in Cloudflare but has no effect on their account membership. Account membership removal requires the identity provider to send `active: false` in a `PATCH /Users` or `PUT /Users` request. Ensure your IdP is configured with the `active` attribute mapping. For Microsoft Entra ID, refer to [Provision with Microsoft Entra](/fundamentals/account/account-security/scim-setup/entra/).
+Dashboard SCIM handles group membership and user account lifecycle through separate
+services. Removing a user from a SCIM group updates their group membership in
+Cloudflare but has no effect on their account membership. Account membership removal
+requires the identity provider to send `active: false` in a `PATCH /Users` or
+`PUT /Users` request.
+For Microsoft Entra ID, ensure the `active` attribute mapping uses the default
+`IsSoftDeleted` expression (`Switch([IsSoftDeleted], , "False", "True", "True", "False")`).
+Using `accountEnabled` as the source will not trigger deprovisioning when a user is
+removed from a group. Refer to [Provision with Microsoft Entra](/fundamentals/account/account-security/scim-setup/entra/).
 :::
 
 ## Limitations


### PR DESCRIPTION
The existing note is vague about which attribute mapping is required. This update explicitly specifies the default Microsoft `IsSoftDeleted` expression and warns against using `accountEnabled`, which does not trigger deprovisioning on group removal.

Context: ESCALATION-678