### PR TITLE
chore: group non-major dependabot updates into weekly Tuesday PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,16 @@ updates:
     commit-message:
       prefix: "[Docs Site] "
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
     assignees:
       - "kodster28"
     reviewers:
-      - "kodster28"
+      - "cloudflare/content-engineering"
+    groups:
+      non-major:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"


### PR DESCRIPTION
### Summary

Switches Dependabot from daily individual PRs to a single grouped PR every Tuesday covering all non-major (minor + patch) npm updates. Major version bumps continue to get individual PRs (Dependabot default). Also moves the reviewer from an individual username to the `@cloudflare/content-engineering` team.
