### PR TITLE
Add docs for python-process-pth-files compat flag

### DIFF
--- a/src/content/compatibility-flags/python-process-pth-files.md
+++ b/src/content/compatibility-flags/python-process-pth-files.md
@@ -1,0 +1,25 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Process .pth files for Python Workers"
+sort_date: "2026-05-26"
+enable_date: "2026-05-26"
+enable_flag: "python_process_pth_files"
+disable_flag: "disable_python_process_pth_files"
+---
+
+When the `python_process_pth_files` flag is set, Python Workers process `.pth`
+files in the `python_modules/` directory during startup by calling
+[`site.addsitedir()`](https://docs.python.org/3/library/site.html#site.addsitedir)
+on it. This lets packages extend `sys.path` declaratively, for example to add
+subdirectories or register import hooks. Without this flag, `.pth` files in
+`python_modules/` are ignored.
+
+This flag also moves the top-level entropy context managers required by some
+packages out of the runtime and into
+[workers-py](https://github.com/cloudflare/workers-py).
+
+You must use `workers-py` version `1.1.3` or later when this flag is set.


### PR DESCRIPTION
Makes Python workers call `addsitedir()` on the `python_modules` directory, causing their pth files to be processed. Used to move some package top level entropy patches into workers-py 1.1.3. Requires workers-py >= 1.1.3

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
