### PR TITLE
[Cloudflare for SaaS] Clarify validation readiness

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/index.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/index.mdx
@@ -6,7 +6,6 @@ products:
   - cloudflare-for-saas
 sidebar:
   order: 2
-
 ---
 
 import { DirectoryListing } from "~/components";
@@ -22,6 +21,15 @@ If a custom hostname is already on Cloudflare, using the [pre-validation methods
 If minimizing downtime is more important to you, refer to our [pre-validation methods](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/pre-validation/).
 
 If ease of use for your customers is more important, review our [real-time validation methods](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/realtime-validation/).
+
+## Hostname validation and certificate validation
+
+Hostname validation and certificate validation use different tokens and API fields.
+
+- `ownership_verification` and `ownership_verification_http` validate hostname ownership and affect the custom hostname `status`.
+- `ssl.validation_records` validates certificate issuance and affects `ssl.status`.
+
+For production traffic, the hostname should have `status: active`, `ssl.status: active`, and DNS that points to your SaaS target.
 
 ## Limitations
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/validation-status.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/validation-status.mdx
@@ -9,7 +9,6 @@ sidebar:
 head:
   - tag: title
     content: Validation status - Custom Hostname Validation
-
 ---
 
 When you [validate a custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/), that hostname can be in several different statuses.
@@ -22,6 +21,10 @@ When you [validate a custom hostname](/cloudflare-for-platforms/cloudflare-for-s
 | Blocked             | Custom hostname cannot be added to Cloudflare at this time. Custom hostname was likely associated with Cloudflare previously and flagged for abuse.<br/><br/>If you are an Enterprise customer, contact your Customer Success Manager. Otherwise, email `abusereply@cloudflare.com` with the name of the web property and a detailed explanation of your association with this web property. |
 | Moved               | Custom hostname is not active after **Pending** for the entirety of the [Validation Backoff Schedule](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/backoff-schedule/) or it no longer points to the fallback origin.                                                                                                                                     |
 | Deleted             | Custom hostname was deleted from the zone. Occurs when status is **Moved** for more than seven days.                                                                                                                                                                                                                                                                                         |
+
+The custom hostname validation status is separate from the certificate status. In the [Custom hostname details endpoint](/api/resources/custom_hostnames/methods/get/) response, `result.status` tracks hostname activation and `result.ssl.status` tracks certificate issuance and deployment.
+
+A custom hostname is ready for production traffic when `result.status` is `active`, `result.ssl.status` is `active`, and DNS points to your SaaS target. If `result.status` is `active` but `result.ssl.status` is not `active`, Cloudflare has validated the hostname, but the certificate has not completed issuance and deployment.
 
 ## Refresh validation
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http.mdx
@@ -15,17 +15,19 @@ import { Details, Render } from "~/components";
 
 HTTP validation involves adding a DCV token to your customer's origin.
 
+You choose one certificate validation method when you [create a custom hostname](/api/resources/custom_hostnames/methods/create/). The API accepts one `ssl.method` value: `http`, `txt`, or `email`.
+
 ---
 
 ## Non-wildcard custom hostnames
 
-If your custom hostname does not include a wildcard, Cloudflare will always and automatically attempt to complete DCV through [HTTP validation](#http-automatic), even if you have selected **TXT** for your validation method.
+If your custom hostname does not include a wildcard, Cloudflare always attempts to complete DCV through [HTTP validation](#http-automatic) after the hostname points to your SaaS target, even if you have selected **TXT** for your validation method.
 
-This HTTP validation should succeed as long as your customer is pointing to your custom hostname and they do not have any [CAA records](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#certificate-authority-authorization-caa-records) blocking your chosen certificate authority.
+This HTTP validation should succeed as long as your customer's hostname points to your SaaS target and they do not have any [CAA records](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#certificate-authority-authorization-caa-records) blocking your chosen certificate authority.
 
 ## Wildcard custom hostnames
 
-HTTP DCV validation is not allowed for wildcard certificates. You must use [TXT validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt/) instead.
+HTTP DCV validation is not allowed for wildcard certificates. Use [TXT validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt/) instead. You can also configure [Delegated DCV](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv/) to automate TXT-based validation.
 
 ---
 
@@ -36,6 +38,10 @@ HTTP DCV validation is not allowed for wildcard certificates. You must use [TXT 
 If you value simplicity and your customers can handle a few minutes of downtime, you can rely on Cloudflare automatic HTTP validation.
 
 Once you [create a new hostname](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/issue-certificates/) and choose the `http` validation method, all your customers have to do is add a CNAME to your `$CNAME_TARGET` and Cloudflare will take care of the rest.
+
+Automatic HTTP validation works on the fly. After your customer points the hostname to your SaaS target, Cloudflare can serve the CA's HTTP DCV token from the edge and complete certificate validation.
+
+During that period, the hostname may route to Cloudflare before the certificate reaches `ssl.status: active`. If you need the certificate active before your customer changes DNS, use [TXT validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt/) or [Delegated DCV](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv/) instead.
 
 <Details header="What happens after you create the custom hostname">
 
@@ -77,7 +83,10 @@ location "/.well-known/pki-validation/ca3-0052344e54074d9693e89e27486692d6.txt" 
 Once your configuration is live, test that the DCV text file is in place with `curl`:
 
 ```sh
-$ curl "http://http-preval.example.com/.well-known/pki-validation/ca3-0052344e54074d9693e89e27486692d6.txt"
+curl "http://http-preval.example.com/.well-known/pki-validation/ca3-0052344e54074d9693e89e27486692d6.txt"
+```
+
+```txt
 ca3-be794c5f757b468eba805d1a705e44f6
 ```
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/index.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/index.mdx
@@ -16,6 +16,8 @@ import { Render } from "~/components";
 
 <Render file="dcv-definition" product="ssl" /> <br />
 
+When you [create a custom hostname](/api/resources/custom_hostnames/methods/create/), choose one certificate validation method. The API accepts one `ssl.method` value: `http`, `txt`, or `email`.
+
 ## DCV situations
 
 ### Non-wildcard certificates
@@ -40,6 +42,8 @@ If you want to minimize downtime, explore one of the following methods to issue 
 ### Minimize customer effort
 
 If you value simplicity and your customers can handle a few minutes of downtime, you can rely on Cloudflare [automatic HTTP validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/#http-automatic).
+
+Automatic HTTP validation requires the hostname to point to your SaaS target before the CA can fetch the validation token. During that period, the hostname may route to Cloudflare before the certificate reaches `ssl.status: active`.
 
 ## Potential issues
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt.mdx
@@ -15,15 +15,19 @@ import { Render, TabItem, Tabs } from "~/components";
 
 <Render file="txt-validation-definition" product="ssl" /> <br />
 
+You choose one certificate validation method when you [create a custom hostname](/api/resources/custom_hostnames/methods/create/). The API accepts one `ssl.method` value: `http`, `txt`, or `email`.
+
 ## When to use
 
-Generally, you should use TXT-based DCV when you cannot use [HTTP validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/) or [Delegated DCV](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv/).
+Generally, you should use TXT-based DCV when you cannot use [HTTP validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/) or [Delegated DCV](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv/), or when you need the certificate active before your customer changes DNS.
 
 ### Non-wildcard custom hostnames
 
-If your custom hostname does not include a wildcard, Cloudflare will always and automatically attempt to complete DCV through [HTTP validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/#http-automatic), even if you have selected **TXT** for your validation method.
+If your custom hostname does not include a wildcard, Cloudflare always attempts to complete DCV through [HTTP validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/#http-automatic) after the hostname points to your SaaS target, even if you have selected **TXT** for your validation method.
 
-This HTTP validation should succeed as long as your customer is pointing to your custom hostname and they do not have any [CAA records](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#certificate-authority-authorization-caa-records) blocking your chosen certificate authority.
+This HTTP validation should succeed as long as your customer's hostname points to your SaaS target and they do not have any [CAA records](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#certificate-authority-authorization-caa-records) blocking your chosen certificate authority.
+
+This automatic HTTP attempt does not mean that the Create Custom Hostname API accepts both HTTP and TXT validation methods in one request. The `ssl.method` field accepts one value.
 
 ### Wildcard custom hostnames
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/common-api-calls.mdx
@@ -28,14 +28,16 @@ As a SaaS provider, you may want to configure and manage Cloudflare for SaaS [vi
 
 To confirm that a custom hostname is fully configured, check both status fields in the [Custom hostname details endpoint](/api/resources/custom_hostnames/methods/get/) response:
 
-- Top-level `status`: Hostname activation status. This field shows whether Cloudflare has validated and activated the custom hostname.
-- Nested `ssl.status`: Certificate status. This field shows whether the hostname's SSL/TLS certificate has completed issuance and deployment.
+| API field           | What it means                                                                                                          | Ready value |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `result.status`     | Hostname activation status. This field shows whether Cloudflare has validated and activated the custom hostname.       | `active`    |
+| `result.ssl.status` | Certificate status. This field shows whether the hostname's SSL/TLS certificate has completed issuance and deployment. | `active`    |
 
-Treat the custom hostname as ready for production HTTPS when the top-level `status` is `active`, `ssl.status` is `active`, and the customer's DNS points to your CNAME target or apex proxying records.
+Treat the custom hostname as ready for production HTTPS when `result.status` is `active`, `result.ssl.status` is `active`, and the customer's DNS points to your CNAME target or apex proxying target.
 
-If the top-level `status` is `active` but `ssl.status` is not `active`, the hostname is active but its certificate has not completed issuance and deployment. A successful TLS handshake alone does not mean the custom hostname certificate has finished provisioning because Cloudflare may present another matching certificate for that hostname. For more information, refer to [Certificate and hostname priority](/ssl/reference/certificate-and-hostname-priority/).
+If `result.status` is `active` but `result.ssl.status` is not `active`, the hostname is active but its certificate has not completed issuance and deployment. A successful TLS handshake alone does not mean the custom hostname certificate has finished provisioning because Cloudflare may present another matching certificate for that hostname. For more information, refer to [Certificate and hostname priority](/ssl/reference/certificate-and-hostname-priority/).
 
-For non-wildcard custom hostnames, Cloudflare always attempts [HTTP certificate validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/#non-wildcard-custom-hostnames), even if you selected **TXT** validation.
+When you use the [Create custom hostname endpoint](/api/resources/custom_hostnames/methods/create/), choose one `ssl.method` value: `http`, `txt`, or `email`. For non-wildcard custom hostnames, Cloudflare always attempts [HTTP certificate validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/#non-wildcard-custom-hostnames) after the hostname points to your SaaS target, even if you selected **TXT** validation.
 
 ## Fallback origins
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started.mdx
@@ -53,6 +53,23 @@ The CNAME target — optional, but highly encouraged — provides a friendly and
 
 <Render file="get-started-per-hostname" product="cloudflare-for-platforms" />
 
+### Check when a custom hostname is ready
+
+A custom hostname uses separate validation flows for hostname activation and certificate issuance.
+
+| API field           | What it means                                                        | Ready value |
+| ------------------- | -------------------------------------------------------------------- | ----------- |
+| `result.status`     | Cloudflare has validated the hostname and can proxy traffic for it.  | `active`    |
+| `result.ssl.status` | Cloudflare has issued and deployed the certificate for the hostname. | `active`    |
+
+Treat a custom hostname as ready for production traffic when:
+
+- `result.status` is `active`.
+- `result.ssl.status` is `active`.
+- The hostname's DNS record points to your SaaS target.
+
+A successful TLS handshake can happen before `result.ssl.status` changes to `active` if Cloudflare can present another matching certificate. Use the [Custom hostname details endpoint](/api/resources/custom_hostnames/methods/get/) as the source of truth for onboarding state. For more information, refer to [Certificate and hostname priority](/ssl/reference/certificate-and-hostname-priority/).
+
 ### 3. Have customer create CNAME record
 
 To finish the custom hostname setup, your customer needs to set up a CNAME record at their authoritative DNS that points to your [CNAME target](#2-optional-create-cname-target) [^1].

--- a/src/content/partials/cloudflare-for-platforms/get-started-check-statuses.mdx
+++ b/src/content/partials/cloudflare-for-platforms/get-started-check-statuses.mdx
@@ -1,14 +1,13 @@
 ---
 {}
-
 ---
 
 :::caution
 
+Before your customer points DNS to your SaaS target, decide whether hostname validation and certificate validation should happen before or after DNS cutover.
 
-Before your customer does this step, confirm that the hostname's **Certificate status** and **Hostname status** are both **Active**.
+If you need the hostname to be active before DNS cutover, use [hostname pre-validation](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/pre-validation/) and wait until **Hostname status** is **Active**. If you need the certificate to be active before DNS cutover, use [TXT validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt/) or [Delegated DCV](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv/) and wait until **Certificate status** is **Active**.
 
-If not, confirm that you are using a method of [certificate](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/#http-automatic) or [hostnames](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/realtime-validation/) validation that occurs after your customer adds their DNS record.
-
+If you use [automatic HTTP certificate validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http/#http-automatic) or [real-time hostname validation](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/realtime-validation/), validation happens after your customer adds their DNS record. This can create a short downtime window while the hostname activates or the certificate moves to **Active**.
 
 :::


### PR DESCRIPTION
### Summary

Updates the Cloudflare for SaaS hostname and certificate validation docs stacked on https://github.com/cloudflare/cloudflare-docs/pull/30557 to clarify how custom hostname readiness is determined.

The changes explain that production readiness requires `result.status: active`, `result.ssl.status: active`, and DNS pointed at the SaaS target, and clarify HTTP/TXT DCV behavior, wildcard constraints, and downtime avoidance.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
