### PR TITLE
[SSL] PQC docs cleanup: tighten Cloudflare One page, agentless terminology

### DIFF
--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-and-zero-trust.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-and-zero-trust.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: reference
-description: Use post-quantum cryptography with Cloudflare One Client and Cloudflare Tunnel.
+description: Use post-quantum cryptography with Cloudflare One on-ramps and off-ramps.
 products:
   - ssl
 title: Post-quantum cryptography in Cloudflare One
@@ -13,11 +13,12 @@ tags:
 
 [Cloudflare One](/cloudflare-one/) replaces legacy corporate security perimeters with Cloudflare's global network, making access to the Internet and to corporate resources faster and safer for teams around the world.
 
-Organizations can obtain end-to-end post-quantum encryption of their private network traffic by sending it over Cloudflare One's post-quantum on-ramps and off-ramps. This protects traffic with post-quantum encryption to prevent [harvest-now, decrypt-later](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later) attacks, even if the individual applications are not yet upgraded to post-quantum encryption. In a harvest-now, decrypt-later attack, an adversary harvests data now and decrypts it in the future, when more powerful quantum computers come online.
+Organizations can obtain end-to-end post-quantum encryption of their private network traffic by sending it over Cloudflare One's post-quantum on-ramps and off-ramps. This protects traffic against [harvest-now, decrypt-later](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later) attacks even if the individual applications are not yet upgraded to post-quantum encryption.
 
 Post-quantum encryption is offered in all major Cloudflare One network configurations, including the following on-ramps:
 
-- Clientless (browser-only)
+- Agentless [browser access to Cloudflare-proxied applications](#agentless-cloudflare-access) (including self-hosted apps behind Cloudflare Access)
+- Agentless [browser on-ramp to Cloudflare Gateway](#secure-web-gateway) via [proxy endpoints](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/)
 - [Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) (on the end-user device)
 - [Cloudflare IPsec](/cloudflare-wan/reference/gre-ipsec-tunnels/) on-ramp
 
@@ -28,57 +29,57 @@ And off-ramps:
 
 For traffic that egresses to the public Internet, [Cloudflare Gateway](/cloudflare-one/traffic-policies/http-policies/) also provides post-quantum encryption as a Secure Web Gateway (SWG).
 
-All of these network configurations use the post-quantum key agreement algorithm ML-KEM-768 deployed alongside classical Elliptic Curve Diffie-Hellman (ECDH), where the symmetric key used to encrypt network traffic is derived by mixing the results of the ML-KEM key agreement and the ECDH key agreement. This is also known as hybrid ML-KEM. In this hybrid approach, ML-KEM provides protection against quantum harvest-now, decrypt-later attacks, while ECDH provides protection against non-quantum adversaries.
+These on-ramps and off-ramps all use [hybrid post-quantum key agreement](/ssl/post-quantum-cryptography/#hybrid-key-agreement).
 
 ![Overview diagram of post-quantum Cloudflare One network configurations showing on-ramps and off-ramps](~/assets/images/ssl/pqc-cloudflare-one-overview.png)
 
-The following sections describe a few network configurations in detail.
+The sample configurations below illustrate how Cloudflare One's post-quantum on-ramps and off-ramps fit together for several common use cases. For the broader status of post-quantum support across all Cloudflare products and connections, refer to [PQC in Cloudflare products](/ssl/post-quantum-cryptography/pqc-cloudflare-products/).
 
-## Agentless Cloudflare Access
+## Browser to self-hosted application {/* agentless-cloudflare-access */}
 
-You can use [Cloudflare Access](/cloudflare-one/access-controls/policies/) [self-hosted applications](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) in an agentless configuration to protect your organization's Internet traffic to internal web applications. Refer to the [learning path](/learning-paths/clientless-access/initial-setup/) for detailed guidance.
+A common configuration is browser access to a [self-hosted application](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) that is exposed to Cloudflare's network via a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/). This is often combined with [Cloudflare Access](/cloudflare-one/access-controls/policies/) for identity-based policy enforcement; refer to the [agentless access learning path](/learning-paths/clientless-access/initial-setup/) for guidance.
 
-Even if the applications themselves have not yet migrated to post-quantum (PQ) cryptography, they will be protected against quantum threats.
+Even if the application itself has not yet migrated to post-quantum cryptography, traffic to it will be protected against harvest-now, decrypt-later attacks.
 
-![Diagram of how post-quantum cryptography works in clientless connections to Access applications](~/assets/images/ssl/pqc-clientless-access.png).
+![Diagram of how post-quantum cryptography works for browser-based access to a self-hosted application via Cloudflare Tunnel](~/assets/images/ssl/pqc-clientless-access.png).
 
 Here is how it works today:
 
-**1. PQ connection via browser**
+**1. Connection via browser**
 
-As long as the end-user uses a modern web browser that supports post-quantum key agreement (for example, Chrome, Edge, or Firefox), the connection from the device to Cloudflare's network is secured via TLS 1.3 with post-quantum key agreement.
+As long as the end user uses a [modern web browser that supports post-quantum key agreement](/ssl/post-quantum-cryptography/pqc-support/#browsers), the connection from the device to Cloudflare's network is secured via TLS 1.3 with post-quantum key agreement.
 
-**2. PQ within Cloudflare's global network**
+**2. Within Cloudflare's global network**
 
 If the user and origin server are geographically distant, then the user's traffic will enter Cloudflare's global network in one geographic location (such as Frankfurt), and exit at another (such as San Francisco). As this traffic moves from one data center to another inside Cloudflare's global network, these hops through the network are secured via TLS 1.3 with post-quantum key agreement.
 
-**3. PQ Cloudflare Tunnel**
+**3. Cloudflare Tunnel**
 
-Customers establish a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) from their data center or public cloud — where their corporate web application is hosted — to Cloudflare's network. This tunnel is secured using TLS 1.3 with post-quantum key agreement, safeguarding it from [harvest-now, decrypt-later attacks](https://en.wikipedia.org/wiki/Harvest_now,_decrypt_later).
+Customers establish a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) from their data center or public cloud — where their corporate web application is hosted — to Cloudflare's network. This tunnel is secured using TLS 1.3 with post-quantum key agreement.
 
-Putting it together, Cloudflare Access can provide end-to-end quantum safety for accessing corporate HTTPS applications, without requiring customers to upgrade the security of corporate web applications.
+This configuration provides end-to-end post-quantum protection for browser access to corporate HTTPS applications without requiring customers to upgrade the security of the applications themselves.
 
 ## Cloudflare One Client
 
-[Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) (formerly WARP) tunnels traffic over a post-quantum (PQ) MASQUE tunnel using TLS 1.3 with hybrid ML-KEM from the end-user device to Cloudflare's global network. The following is an example network configuration with a Cloudflare One Client on-ramp and a Cloudflare Tunnel off-ramp.
+[Cloudflare One Client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) (formerly WARP) tunnels traffic from the end-user device to Cloudflare's global network. The following is an example network configuration with a Cloudflare One Client on-ramp and a Cloudflare Tunnel off-ramp.
 
 ![Diagram of post-quantum network configuration using Cloudflare One Client on-ramp and Cloudflare Tunnel off-ramp](~/assets/images/ssl/pqc-cloudflare-one-client.png)
 
 _Note: Labels in this image may reflect a previous product name._
 
-**1. PQ connection via Cloudflare One Client**
+**1. Connection via Cloudflare One Client**
 
 The Cloudflare One Client uses the MASQUE protocol to connect from the device to Cloudflare's global network, using TLS 1.3 with hybrid ML-KEM.
 
-**2. PQ within Cloudflare's global network**
+**2. Within Cloudflare's global network**
 
-If the user and origin server are geographically distant, then the user's traffic will enter Cloudflare's global network in one geographic location (such as Frankfurt), and exit at another (such as San Francisco). As this traffic moves from one data center to another inside Cloudflare's global network, these hops through the network are secured via TLS 1.3 with post-quantum key agreement.
+The traffic then travels across Cloudflare's global network over TLS 1.3 with hybrid ML-KEM.
 
-**3. PQ Cloudflare Tunnel**
+**3. Cloudflare Tunnel**
 
-[Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) already supports post-quantum key agreement.
+[Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) supports post-quantum key agreement.
 
-With this network configuration, traffic is encapsulated in quantum-encrypted tunnels, effectively mitigating the risk of harvest-now, decrypt-later attacks without requiring individual upgrades of networks or applications. This provides comprehensive protection for any protocol that can be sent through these tunnels, not just for HTTPS.
+With this network configuration, traffic is encapsulated in tunnels protected with post-quantum encryption without requiring individual upgrades of networks or applications. This provides comprehensive protection for any protocol that can be sent through these tunnels, not just for HTTPS.
 
 ## Cloudflare IPsec
 
@@ -86,15 +87,15 @@ The following is a sample network configuration that uses the Cloudflare One Cli
 
 ![Diagram of post-quantum network configuration using Cloudflare One Client on-ramp to Cloudflare One Appliance off-ramp](~/assets/images/ssl/pqc-cloudflare-ipsec.png)
 
-**1. PQ connection via Cloudflare One Client**
+**1. Connection via Cloudflare One Client**
 
-The Cloudflare One Client uses the MASQUE protocol to connect from the device to Cloudflare's global network, using TLS 1.3 with hybrid ML-KEM.
+The Cloudflare One Client uses the MASQUE protocol, as described in the [Cloudflare One Client](#cloudflare-one-client) section above.
 
-**2. PQ within Cloudflare's global network**
+**2. Within Cloudflare's global network**
 
 The traffic then travels across Cloudflare's global network over TLS 1.3 with hybrid ML-KEM.
 
-**3. PQ Cloudflare IPsec with Cloudflare One Appliance**
+**3. Cloudflare IPsec with Cloudflare One Appliance**
 
 Traffic leaves the Cloudflare network over a post-quantum Cloudflare IPsec link that is terminated at a Cloudflare One Appliance. The Cloudflare One Appliance uses a non-IKE keying protocol built into the control plane, secured with TLS, that establishes the keys used to encrypt dataplane traffic in the IPsec ESP protocol. From Appliance version 2026.2.0, the control plane establishes keys over TLS 1.3 protected with hybrid ML-KEM.
 
@@ -108,18 +109,18 @@ The hybrid key agreement is negotiated using ML-KEM as an additional Key Exchang
 
 A [secure web gateway (SWG)](https://www.cloudflare.com/learning/access-management/what-is-a-secure-web-gateway/) is used to secure access to third-party websites on the public Internet by intercepting and inspecting TLS traffic.
 
-[Cloudflare Gateway](/cloudflare-one/traffic-policies/http-policies/) is now a [quantum-safe SWG for HTTPS traffic](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#post-quantum-support). As long as the third-party website that is being inspected supports post-quantum key agreement, then Cloudflare's SWG also supports post-quantum key agreement. This is true regardless of the on-ramp that you use to get to Cloudflare's network, and only requires the use of a browser that supports post-quantum key agreement.
+[Cloudflare Gateway](/cloudflare-one/traffic-policies/http-policies/) [supports post-quantum cryptography for HTTPS traffic](/cloudflare-one/traffic-policies/http-policies/tls-decryption/#post-quantum-support). As long as the third-party website that is being inspected supports post-quantum key agreement, Cloudflare's SWG also supports post-quantum key agreement.
 
 ![Diagram of how post-quantum cryptography works with Cloudflare's Secure Web Gateway](~/assets/images/ssl/pqc-secure-web-gateway.png).
 
 Cloudflare Gateway's HTTPS filtering feature involves two post-quantum TLS connections, as follows:
 
-**1. PQ connection via browsers**
+**1. Connection from the client to Gateway**
 
-A TLS connection is initiated from the user's browser to a data center in Cloudflare's network that performs the TLS inspection. As long as the end-user uses a modern web browser that supports post-quantum key agreement (for example, Chrome, Edge, or Firefox), this connection is secured by TLS 1.3 with post-quantum key agreement.
+A [modern web browser that supports post-quantum key agreement](/ssl/post-quantum-cryptography/pqc-support/#browsers) connects to Gateway via the [Agentless via proxy endpoints](/ssl/post-quantum-cryptography/pqc-cloudflare-products/#agentless-via-proxy-endpoints) on-ramp. The connection is secured by TLS 1.3 with post-quantum key agreement.
 
-Any traffic that on-ramps to the SWG via the Cloudflare One Client is protected with hybrid ML-KEM, even if the web browser itself does not yet support post-quantum cryptography. This is due to the post-quantum MASQUE tunnel that the Cloudflare One Client establishes to Cloudflare's global network. The same is true of traffic that on-ramps to the SWG using the Cloudflare One Appliance, which establishes a Cloudflare IPsec tunnel protected by post-quantum encryption.
+The [Cloudflare One Client](#cloudflare-one-client) and [Cloudflare IPsec](#cloudflare-ipsec) on-ramps described in the sections above can also route traffic to Gateway with post-quantum protection.
 
-**2. PQ connection to the origin server**
+**2. Connection from Gateway to the origin server**
 
-A TLS connection is initiated from a data center in Cloudflare's network to the origin server, which is typically controlled by a third party. The connection from Cloudflare's SWG currently supports post-quantum key agreement, as long as the third-party's origin server also already supports post-quantum key agreement. You can test this out by using https://pq.cloudflareresearch.com/ as your third-party origin server.
+A TLS connection is initiated from a data center in Cloudflare's network to the origin server, which is typically controlled by a third party. The connection from Cloudflare's SWG supports post-quantum key agreement, as long as the third-party origin server also supports post-quantum key agreement. You can test this out by using https://pq.cloudflareresearch.com/ as your third-party origin server.

--- a/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
+++ b/src/content/docs/ssl/post-quantum-cryptography/pqc-support.mdx
@@ -40,7 +40,7 @@ Browsers are grouped by the underlying rendering engine and TLS stack. Browsers 
 - **Signatures:** 📝 Planned via [Merkle Tree Certificates](https://datatracker.ietf.org/doc/draft-ietf-plants-merkle-tree-certs/)
 - **Reference:** [Chrome](https://www.google.com/chrome/), [Cultivating a robust and efficient quantum-safe HTTPS](https://security.googleblog.com/2026/02/cultivating-robust-and-efficient.html)
 
-Chrome is not planning to add traditional X.509 post-quantum certificates to the public Chrome Root Store. Instead, Chrome is developing MTCs in the IETF PLANTS working group, currently in a feasibility study phase with Cloudflare.
+Chrome is not planning to add standard X.509 post-quantum certificates to the public Chrome Root Store. Instead, Chrome is developing MTCs in the IETF PLANTS working group, currently in a feasibility study phase with Cloudflare.
 
 #### Edge
 


### PR DESCRIPTION
### Summary

Tightens the [PQC and Cloudflare One](https://developers.cloudflare.com/ssl/post-quantum-cryptography/pqc-and-zero-trust/) page: removes redundant content, fixes imprecise phrasing, and aligns terminology with [PR #30537](https://github.com/cloudflare/cloudflare-docs/pull/30537).

**`pqc-and-zero-trust.mdx`**

- **Intro**: link to the canonical [hybrid key agreement](https://developers.cloudflare.com/ssl/post-quantum-cryptography/#hybrid-key-agreement) section instead of restating the construction inline; drop the duplicated harvest-now-decrypt-later explanation (keep the term as a Wikipedia link). Clarify the lead-in for the worked examples ("sample configurations").
- **Terminology**: switch from `clientless` to `agentless` to match current docs convention. Update the page description and image alt text.
- **Browsers**: replace inline lists (`Chrome, Edge, Firefox`) with a link to [Browsers](https://developers.cloudflare.com/ssl/post-quantum-cryptography/pqc-support/#browsers), which also lists Safari.
- **Imprecise phrasing**: replace `quantum-encrypted`, `quantum threats`, `quantum safety`, and `quantum-safe SWG` with `protected with post-quantum encryption`, `harvest-now decrypt-later attacks`, `post-quantum protection`, and `supports post-quantum cryptography`.
- **Section rename**: rename `Agentless Cloudflare Access` to `Browser to self-hosted application` since the cryptographic flow shown (browser TLS, Cloudflare Tunnel) does not depend on Cloudflare Access; Access is now described as an optional identity-policy layer on top. Pin the existing slug (`#agentless-cloudflare-access`) so links from other pages continue to resolve.
- **Split overloaded bullet**: split the `Agentless (browser-only)` on-ramp bullet into two distinct bullets covering agentless browser access to Cloudflare-proxied applications (Visitor-to-Cloudflare flow) and the agentless browser on-ramp to Cloudflare Gateway via proxy endpoints (separate Gateway-stack flow).
- **Step heading style**: drop the `PQ ` prefix from numbered step headings (the entire page is about PQ).
- **Deduplication**: simplify repeated `Within Cloudflare's global network` paragraphs to a one-liner in the Cloudflare One Client and Cloudflare IPsec sections (the full Frankfurt-to-San-Francisco illustration remains in the first walkthrough). Drop the duplicated `Connection via Cloudflare One Client` step and the redundant intro sentence in the Cloudflare One Client section.
- **SWG step 1**: trim to match the diagram, which only illustrates the browser on-ramp. Cloudflare One Client and Cloudflare IPsec are mentioned briefly as alternative post-quantum on-ramps via pointers to their walkthroughs above. Replace `Cloudflare One Appliance` with `Cloudflare IPsec` as the on-ramp name (the actual on-ramp is the IPsec tunnel; the Appliance is one way to establish it).
- **Other**: remove spurious harvest-now-decrypt-later mentions in the narrative steps and the "Putting it together" sentence in the browser-to-self-hosted-application section.

**`pqc-support.mdx`**

- Replace `traditional X.509 post-quantum certificates` with `standard X.509 post-quantum certificates` in the Chrome MTC discussion, since `traditional` is ambiguous in this context. Addresses [#30142 (comment)](https://github.com/cloudflare/cloudflare-docs/pull/30142#discussion_r3182393847).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
