### PR TITLE
[Fundamentals] Add dashboard keyboard shortcuts reference page

### DIFF
--- a/src/content/docs/fundamentals/reference/dashboard-keyboard-shortcuts.mdx
+++ b/src/content/docs/fundamentals/reference/dashboard-keyboard-shortcuts.mdx
@@ -1,0 +1,47 @@
+---
+title: Dashboard keyboard shortcuts
+description: Use keyboard shortcuts to navigate and take actions in the Cloudflare dashboard without leaving your keyboard.
+pcx_content_type: reference
+products:
+  - fundamentals
+sidebar:
+  order: 5
+---
+
+The Cloudflare dashboard supports keyboard shortcuts so you can navigate, switch context, and take common actions without leaving your keyboard. Press `?` anywhere in the dashboard to open the shortcuts reference modal.
+
+Keyboard shortcuts can be disabled by visiting your [profile settings](https://dash.cloudflare.com/profile/settings).
+
+## Navigation shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| `g h` | Go to Home |
+| `g a` | Go to account overview |
+| `g z` | Go to zone overview |
+| `g p` | Go to your profile |
+| `g w` | Go to Workers & Pages |
+| `g o` | Go to Zero Trust |
+| `g b` | Go to billing |
+| `g 1` – `g 5` | Go to a recent or pinned item (by position in sidebar) |
+| `t →` | Move to the next tab |
+| `t ←` | Move to the previous tab |
+| `p →` | Move to the next page of a table |
+| `p ←` | Move to the previous page of a table |
+
+## Action shortcuts
+
+| Shortcut | Action |
+| --- | --- |
+| `/` | Open quick search |
+| `?` | Show keyboard shortcuts |
+| `s a` | Switch account |
+| `s z` | Switch zone |
+| `s .` | Star or unstar the current zone |
+| `p .` | Pin or unpin the current page |
+| `t s` | Toggle the sidebar open or closed |
+| `t m` | Expand or collapse all sidebar menus |
+| `t a` | Toggle Ask AI sidebar |
+| `d .` | Toggle dark mode |
+| `c u` | Copy the current URL |
+| `c d` | Copy a deep link URL |


### PR DESCRIPTION
### Summary

Adds a reference page for dashboard keyboard shortcuts at `/fundamentals/reference/keyboard-shortcuts/`. Covers navigation and action shortcuts available in the Cloudflare dashboard.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
