### PR TITLE
[Analytics][WAF] Document firewall events dataset retention (SPM-3071)

### DIFF
--- a/src/content/docs/analytics/graphql-api/tutorials/querying-firewall-events.mdx
+++ b/src/content/docs/analytics/graphql-api/tutorials/querying-firewall-events.mdx
@@ -190,20 +190,13 @@ https://api.cloudflare.com/client/v4/graphql \
 
 ## Retention and query window
 
-`firewallEventsAdaptive` has different retention limits from the datasets that back [Security Analytics](/waf/analytics/security-analytics/). Queries that exceed the retention window return an error similar to the following:
+The `firewallEventsAdaptive` dataset, which powers [Security Events](/waf/analytics/security-events/), has different data retention limits from the datasets used in [Security Analytics](/waf/analytics/security-analytics/#limits). Queries that exceed the data retention window return an error similar to the following:
 
 ```txt
 cannot request data older than 2678400s
 ```
 
-The value 2,678,400 seconds (31 days) is the the maximum query window for the dataset. The retention limits per plan are the following:
-
-| Plan       | Historical time (how far back you can query) | Max query window (span of a single query) |
-| ---------- | -------------------------------------------- | ----------------------------------------- |
-| Free       | 24 hours                                     | 24 hours                                  |
-| Pro        | 24 hours                                     | 24 hours                                  |
-| Business   | 3 days                                       | 3 days                                    |
-| Enterprise | 30 days                                      | 31 days                                   |
+For more information on the limits per plan for the `firewallEventsAdaptive` dataset, refer to [Security Events](/waf/analytics/security-events/#availability).
 
 To discover the exact limits for your zone programmatically, query the `settings` node:
 

--- a/src/content/docs/analytics/graphql-api/tutorials/querying-firewall-events.mdx
+++ b/src/content/docs/analytics/graphql-api/tutorials/querying-firewall-events.mdx
@@ -196,7 +196,7 @@ https://api.cloudflare.com/client/v4/graphql \
 cannot request data older than 2678400s
 ```
 
-The value `2678400` seconds equals 31 days — the maximum query window for the dataset. Retention limits per plan:
+The value 2,678,400 seconds (31 days) is the the maximum query window for the dataset. The retention limits per plan are the following:
 
 | Plan       | Historical time (how far back you can query) | Max query window (span of a single query) |
 | ---------- | -------------------------------------------- | ----------------------------------------- |

--- a/src/content/docs/analytics/graphql-api/tutorials/querying-firewall-events.mdx
+++ b/src/content/docs/analytics/graphql-api/tutorials/querying-firewall-events.mdx
@@ -188,4 +188,46 @@ https://api.cloudflare.com/client/v4/graphql \
 #=> }
 ```
 
+## Retention and query window
+
+`firewallEventsAdaptive` has different retention limits from the datasets that back [Security Analytics](/waf/analytics/security-analytics/). Queries that exceed the retention window return an error similar to the following:
+
+```txt
+cannot request data older than 2678400s
+```
+
+The value `2678400` seconds equals 31 days — the maximum query window for the dataset. Retention limits per plan:
+
+| Plan       | Historical time (how far back you can query) | Max query window (span of a single query) |
+| ---------- | -------------------------------------------- | ----------------------------------------- |
+| Free       | 24 hours                                     | 24 hours                                  |
+| Pro        | 24 hours                                     | 24 hours                                  |
+| Business   | 3 days                                       | 3 days                                    |
+| Enterprise | 30 days                                      | 31 days                                   |
+
+To discover the exact limits for your zone programmatically, query the `settings` node:
+
+```graphql
+{
+	viewer {
+		zones(filter: { zoneTag: "<CLOUDFLARE_ZONE_TAG>" }) {
+			settings {
+				firewallEventsAdaptive {
+					maxDuration
+					maxPageSize
+					notOlderThan
+				}
+				httpRequestsAdaptive {
+					maxDuration
+					maxPageSize
+					notOlderThan
+				}
+			}
+		}
+	}
+}
+```
+
+For more on the `settings` node, refer to [Settings node](/analytics/graphql-api/features/discovery/settings/).
+
 [^1]: Refer to [Configure an Analytics API token](/analytics/graphql-api/getting-started/authentication/api-token-auth/) for more information on configuration and permissions.

--- a/src/content/docs/waf/analytics/security-analytics.mdx
+++ b/src/content/docs/waf/analytics/security-analytics.mdx
@@ -216,4 +216,12 @@ Currently, changing the time frame or the applied filters while showing raw logs
 
 ## Sampling
 
-The Security Analytics dashboard uses [sampled data](/analytics/graphql-api/sampling/), except when showing raw logs. If you query Security Analytics data through the [GraphQL Analytics API](/analytics/graphql-api/), the primary underlying datasets are `httpRequestsAdaptiveGroups` and `httpRequestsAdaptive`. For more information, refer to [Datasets (tables)](/analytics/graphql-api/features/data-sets/).
+The Security Analytics dashboard uses [sampled data](/analytics/graphql-api/sampling/), except when showing raw logs.
+
+## Query using GraphQL
+
+If you query Security Analytics data through the [GraphQL Analytics API](/analytics/graphql-api/), the primary underlying datasets are `httpRequestsAdaptiveGroups` and `httpRequestsAdaptive`. For more information, refer to [Datasets (tables)](/analytics/graphql-api/features/data-sets/).
+
+## Limits
+
+The data retention (historical time) and maximum query window vary per Cloudflare plan and per dataset. For a comparison of data retention and maximum query window of the datasets supporting Security Events and Security Analytics, refer to [Security Events](/waf/analytics/security-events/#limits).

--- a/src/content/docs/waf/analytics/security-analytics.mdx
+++ b/src/content/docs/waf/analytics/security-analytics.mdx
@@ -224,4 +224,8 @@ If you query Security Analytics data through the [GraphQL Analytics API](/analyt
 
 ## Limits
 
-The data retention (historical time) and maximum query window vary per Cloudflare plan and per dataset. For a comparison of data retention and maximum query window of the datasets supporting Security Events and Security Analytics, refer to [Security Events](/waf/analytics/security-events/#limits).
+The data retention (historical time) and maximum query window of the datasets supporting Security Analytics differ from the dataset that powers [Security Events](/waf/analytics/security-events/#query-using-graphql).
+
+The following tables show the different limits per Cloudflare plan:
+
+<Render file="analytics-dataset-limits" product="waf" />

--- a/src/content/docs/waf/analytics/security-events.mdx
+++ b/src/content/docs/waf/analytics/security-events.mdx
@@ -184,3 +184,17 @@ Security Events currently has these limitations:
 - The Cloudflare dashboard may show an inaccurate number of events per page. Data queries are highly optimized, but this means that pagination may not always work because the source data may have been sampled. The GraphQL Analytics API does not have this pagination issue.
 
 - Triggered [OWASP rules](/waf/managed-rules/reference/owasp-core-ruleset/) appear in the Security Events page under **Additional logs**, but they are not included in exported JSON files.
+
+## Sampling
+
+Security Events uses [sampled data](/analytics/graphql-api/sampling/). If you query Security Events data through the [GraphQL Analytics API](/analytics/graphql-api/), the underlying dataset is `firewallEventsAdaptive`. For more information, refer to [Datasets (tables)](/analytics/graphql-api/features/data-sets/).
+
+The retention and query window for `firewallEventsAdaptive` differ from the datasets that power [Security Analytics](/waf/analytics/security-analytics/). The following table shows the limits per plan:
+
+|                                                                | Free     | Pro      | Business | Enterprise |
+| -------------------------------------------------------------- | -------- | -------- | -------- | ---------- |
+| **Security Events** (`firewallEventsAdaptive`) historical time | 24 hours | 24 hours | 3 days   | 30 days    |
+| **Security Analytics** (`httpRequestsAdaptive`) retention      | 7 days   | 7 days   | 31 days  | 90 days    |
+| **Security Analytics** (`httpRequestsAdaptive`) query window   | 1 day    | 7 days   | 31 days  | 31 days    |
+
+For more information on querying these datasets, refer to [Querying Firewall Events with GraphQL](/analytics/graphql-api/tutorials/querying-firewall-events/).

--- a/src/content/docs/waf/analytics/security-events.mdx
+++ b/src/content/docs/waf/analytics/security-events.mdx
@@ -179,7 +179,7 @@ The generated report will reflect all applied filters.
 
 Security Events currently has these limitations:
 
-- Security Events may use sampled data to improve performance. If your search uses sampled data, Security Events might not display all events and filters might not return the expected results. To display more events, select a smaller time frame (a narrower time range reduces the volume of data, which reduces or eliminates sampling).
+- Security Events may use sampled data to improve performance. Refer to [Sampling](#sampling) for more information.
 
 - The Cloudflare dashboard may show an inaccurate number of events per page. Data queries are highly optimized, but this means that pagination may not always work because the source data may have been sampled. The GraphQL Analytics API does not have this pagination issue.
 
@@ -187,14 +187,26 @@ Security Events currently has these limitations:
 
 ## Sampling
 
-Security Events uses [sampled data](/analytics/graphql-api/sampling/). If you query Security Events data through the [GraphQL Analytics API](/analytics/graphql-api/), the underlying dataset is `firewallEventsAdaptive`. For more information, refer to [Datasets (tables)](/analytics/graphql-api/features/data-sets/).
+Security Events may use [sampled data](/analytics/graphql-api/sampling/). If your search uses sampled data, Security Events might not display all events and filters might not return the expected results. To display more events, select a smaller time frame (a narrower time range reduces the volume of data, which reduces or eliminates sampling).
 
-The retention and query window for `firewallEventsAdaptive` differ from the datasets that power [Security Analytics](/waf/analytics/security-analytics/). The following table shows the limits per plan:
+## Query using GraphQL
 
-|                                                                | Free     | Pro      | Business | Enterprise |
-| -------------------------------------------------------------- | -------- | -------- | -------- | ---------- |
-| **Security Events** (`firewallEventsAdaptive`) historical time | 24 hours | 24 hours | 3 days   | 30 days    |
-| **Security Analytics** (`httpRequestsAdaptive`) retention      | 7 days   | 7 days   | 31 days  | 90 days    |
-| **Security Analytics** (`httpRequestsAdaptive`) query window   | 1 day    | 7 days   | 31 days  | 31 days    |
+If you query Security Events data through the [GraphQL Analytics API](/analytics/graphql-api/), the underlying dataset is `firewallEventsAdaptive`. For more information, refer to [Datasets (tables)](/analytics/graphql-api/features/data-sets/).
 
-For more information on querying these datasets, refer to [Querying Firewall Events with GraphQL](/analytics/graphql-api/tutorials/querying-firewall-events/).
+For more information on querying the `firewallEventsAdaptive` dataset, refer to [Querying Firewall Events with GraphQL](/analytics/graphql-api/tutorials/querying-firewall-events/).
+
+## Limits
+
+The retention and query window for the `firewallEventsAdaptive` dataset differ from the datasets that power [Security Analytics](/waf/analytics/security-analytics/#sampling).
+
+The following tables show the different limits per Cloudflare plan:
+
+| Data retention (historical time) for...     | Free     | Pro      | Business | Enterprise |
+| ------------------------------------------- | -------- | -------- | -------- | ---------- |
+| Security Events (`firewallEventsAdaptive`)  | 24 hours | 24 hours | 3 days   | 30 days    |
+| Security Analytics (`httpRequestsAdaptive`) | 7 days   | 7 days   | 31 days  | 90 days    |
+
+| Maximum query window for...                 | Free     | Pro      | Business | Enterprise |
+| ------------------------------------------- | -------- | -------- | -------- | ---------- |
+| Security Events (`firewallEventsAdaptive`)  | 24 hours | 24 hours | 3 days   | 31 days    |
+| Security Analytics (`httpRequestsAdaptive`) | 24 hours | 7 days   | 31 days  | 31 days    |

--- a/src/content/docs/waf/analytics/security-events.mdx
+++ b/src/content/docs/waf/analytics/security-events.mdx
@@ -11,6 +11,7 @@ sidebar:
 import {
 	FeatureTable,
 	GlossaryTooltip,
+	Render,
 	Steps,
 	Tabs,
 	TabItem,
@@ -201,12 +202,4 @@ The retention and query window for the `firewallEventsAdaptive` dataset differ f
 
 The following tables show the different limits per Cloudflare plan:
 
-| Data retention (historical time) for...     | Free     | Pro      | Business | Enterprise |
-| ------------------------------------------- | -------- | -------- | -------- | ---------- |
-| Security Events (`firewallEventsAdaptive`)  | 24 hours | 24 hours | 3 days   | 30 days    |
-| Security Analytics (`httpRequestsAdaptive`) | 7 days   | 7 days   | 31 days  | 90 days    |
-
-| Maximum query window for...                 | Free     | Pro      | Business | Enterprise |
-| ------------------------------------------- | -------- | -------- | -------- | ---------- |
-| Security Events (`firewallEventsAdaptive`)  | 24 hours | 24 hours | 3 days   | 31 days    |
-| Security Analytics (`httpRequestsAdaptive`) | 24 hours | 7 days   | 31 days  | 31 days    |
+<Render file="analytics-dataset-limits" product="waf" />

--- a/src/content/partials/waf/analytics-dataset-limits.mdx
+++ b/src/content/partials/waf/analytics-dataset-limits.mdx
@@ -1,0 +1,13 @@
+---
+{}
+---
+
+| Data retention (historical time) for...     | Free     | Pro      | Business | Enterprise |
+| ------------------------------------------- | -------- | -------- | -------- | ---------- |
+| Security Events (`firewallEventsAdaptive`)  | 24 hours | 24 hours | 3 days   | 30 days    |
+| Security Analytics (`httpRequestsAdaptive`) | 7 days   | 7 days   | 31 days  | 90 days    |
+
+| Maximum query window for...                 | Free     | Pro      | Business | Enterprise |
+| ------------------------------------------- | -------- | -------- | -------- | ---------- |
+| Security Events (`firewallEventsAdaptive`)  | 24 hours | 24 hours | 3 days   | 31 days    |
+| Security Analytics (`httpRequestsAdaptive`) | 24 hours | 7 days   | 31 days  | 31 days    |

--- a/src/content/plans/index.json
+++ b/src/content/plans/index.json
@@ -1616,11 +1616,18 @@
 					"ent": "Yes"
 				},
 				"historical_data": {
-					"title": "Historical time",
+					"title": "Historical time (data retention)",
 					"free": "Up to the last 24 hours",
 					"pro": "Up to the last 24 hours",
 					"biz": "Up to the last 3 days",
 					"ent": "Up to the last 30 days"
+				},
+				"i_max_query_window": {
+					"title": "Max query window",
+					"free": "24 hours",
+					"pro": "24 hours",
+					"biz": "3 days",
+					"ent": "31 days"
 				},
 				"export_records": {
 					"title": "Export report",
@@ -1651,18 +1658,18 @@
 					"ent": "Yes"
 				},
 				"retention": {
-					"title": "Retention",
-					"free": "7",
-					"pro": "7",
-					"biz": "31",
-					"ent": "90"
+					"title": "Historical time (data retention)",
+					"free": "Up to the last 7 days",
+					"pro": "Up to the last 7 days",
+					"biz": "Up to the last 31 days",
+					"ent": "Up to the last 90 days"
 				},
 				"query_window": {
-					"title": "Query window",
-					"free": "1",
-					"pro": "7",
-					"biz": "31",
-					"ent": "31"
+					"title": "Max query window",
+					"free": "24 hours",
+					"pro": "7 days",
+					"biz": "31 days",
+					"ent": "31 days"
 				}
 			}
 		},


### PR DESCRIPTION
## Summary

- Add a Sampling section to the Security Events page covering the
  underlying GraphQL dataset (firewallEventsAdaptive) and how its
  retention compares to the datasets that back Security Analytics.
- Add a Retention and query window section to the firewall events
  GraphQL tutorial covering the
  "cannot request data older than 2678400s" error and the settings
  node query for per-zone limits.

SPM-3071