### PR TITLE
Make the Help dropdown and Light/Dark Mode dropdown UI consistent

### DIFF
--- a/src/components/ThemeSelectDropdown.astro
+++ b/src/components/ThemeSelectDropdown.astro
@@ -1,0 +1,286 @@
+---
+// The button is static HTML rendered by Astro — no hydration, no flash.
+// An is:inline script reads localStorage synchronously before first paint
+// to patch the icon and label in-place (same technique as Starlight's ThemeSelect).
+//
+// The dropdown menu is a React component (ThemeSelectMenu.tsx) that is lazily
+// imported only when the user clicks the button. By that point React is already
+// loaded and hydration is irrelevant — there is nothing to hydrate.
+---
+
+<starlight-theme-select>
+	{/* Hidden select keeps StarlightThemeProvider.updatePickers() working */}
+	<select aria-hidden="true" tabindex="-1" style="display:none">
+		<option value="light">Light</option>
+		<option value="dark">Dark</option>
+		<option value="auto" selected>Auto</option>
+	</select>
+
+	<button
+		id="theme-toggle"
+		aria-haspopup="listbox"
+		aria-expanded="false"
+		aria-label="Theme: Auto"
+		class="theme-toggle"
+	>
+		<span class="theme-toggle-inner">
+			<span class="theme-icon-slot" aria-hidden="true">
+				{/* Desktop/auto icon — patched synchronously by is:inline script */}
+				<svg
+					class="theme-icon"
+					stroke="currentColor"
+					fill="currentColor"
+					stroke-width="0"
+					viewBox="0 0 256 256"
+					xmlns="http://www.w3.org/2000/svg"
+					><path
+						d="M208,36H48A28,28,0,0,0,20,64V172a28,28,0,0,0,28,28h68v12H96a12,12,0,0,0,0,24h64a12,12,0,0,0,0-24H140V200h68a28,28,0,0,0,28-28V64A28,28,0,0,0,208,36ZM48,60H208a4,4,0,0,1,4,4v72H44V64A4,4,0,0,1,48,60ZM208,176H48a4,4,0,0,1-4-4V160H212v12A4,4,0,0,1,208,176Z"
+					></path></svg
+				>
+			</span>
+			<span class="theme-label">Auto</span>
+		</span>
+		<span class="theme-caret" aria-hidden="true">
+			<svg
+				class="caret-icon"
+				stroke="currentColor"
+				fill="currentColor"
+				stroke-width="0"
+				viewBox="0 0 256 256"
+				xmlns="http://www.w3.org/2000/svg"
+				><path
+					d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"
+				></path></svg
+			>
+		</span>
+	</button>
+</starlight-theme-select>
+
+{
+	/* Runs synchronously before paint — reads localStorage and patches the button DOM */
+}
+<script is:inline>
+	(function () {
+		const storageKey = "starlight-theme";
+		const stored = typeof localStorage !== "undefined" && localStorage.getItem(storageKey);
+		const theme = stored === "light" || stored === "dark" ? stored : "auto";
+
+		const labels = { light: "Light", dark: "Dark", auto: "Auto" };
+
+		const iconPaths = {
+			light:
+				"M116,36V20a12,12,0,0,1,24,0V36a12,12,0,0,1-24,0Zm80,92a68,68,0,1,1-68-68A68.07,68.07,0,0,1,196,128Zm-24,0a44,44,0,1,0-44,44A44.05,44.05,0,0,0,172,128ZM51.51,68.49a12,12,0,1,0,17-17l-12-12a12,12,0,0,0-17,17Zm0,119-12,12a12,12,0,0,0,17,17l12-12a12,12,0,1,0-17-17ZM196,72a12,12,0,0,0,8.49-3.51l12-12a12,12,0,0,0-17-17l-12,12A12,12,0,0,0,196,72Zm8.49,115.51a12,12,0,0,0-17,17l12,12a12,12,0,0,0,17-17ZM48,128a12,12,0,0,0-12-12H20a12,12,0,0,0,0,24H36A12,12,0,0,0,48,128Zm80,80a12,12,0,0,0-12,12v16a12,12,0,0,0,24,0V220A12,12,0,0,0,128,208Zm108-92H220a12,12,0,0,0,0,24h16a12,12,0,0,0,0-24Z",
+			dark: "M236.37,139.4a12,12,0,0,0-12-3A84.07,84.07,0,0,1,119.6,31.59a12,12,0,0,0-15-15A108.86,108.86,0,0,0,49.69,55.07,108,108,0,0,0,136,228a107.09,107.09,0,0,0,64.93-21.69,108.86,108.86,0,0,0,38.44-54.94A12,12,0,0,0,236.37,139.4Zm-49.88,47.74A84,84,0,0,1,68.86,69.51,84.93,84.93,0,0,1,92.27,48.29Q92,52.13,92,56A108.12,108.12,0,0,0,200,164q3.87,0,7.71-.27A84.79,84.79,0,0,1,186.49,187.14Z",
+			auto: "M208,36H48A28,28,0,0,0,20,64V172a28,28,0,0,0,28,28h68v12H96a12,12,0,0,0,0,24h64a12,12,0,0,0,0-24H140V200h68a28,28,0,0,0,28-28V64A28,28,0,0,0,208,36ZM48,60H208a4,4,0,0,1,4,4v72H44V64A4,4,0,0,1,48,60ZM208,176H48a4,4,0,0,1-4-4V160H212v12A4,4,0,0,1,208,176Z",
+		};
+
+		document
+			.querySelectorAll("starlight-theme-select")
+			.forEach(function (picker) {
+				const select = picker.querySelector("select");
+				if (select) select.value = theme;
+
+				const iconPath = picker.querySelector(".theme-icon path");
+				if (iconPath) iconPath.setAttribute("d", iconPaths[theme]);
+
+				const label = picker.querySelector(".theme-label");
+				if (label) label.textContent = labels[theme];
+
+				const btn = picker.querySelector("#theme-toggle");
+				if (btn) btn.setAttribute("aria-label", "Theme: " + labels[theme]);
+			});
+	})();
+</script>
+
+<script>
+	import { createElement } from "react";
+	import { createRoot } from "react-dom/client";
+	import type { Theme } from "./ThemeSelectMenu";
+
+	const storageKey = "starlight-theme";
+
+	const labels: Record<Theme, string> = {
+		light: "Light",
+		dark: "Dark",
+		auto: "Auto",
+	};
+
+	const iconPaths: Record<Theme, string> = {
+		light:
+			"M116,36V20a12,12,0,0,1,24,0V36a12,12,0,0,1-24,0Zm80,92a68,68,0,1,1-68-68A68.07,68.07,0,0,1,196,128Zm-24,0a44,44,0,1,0-44,44A44.05,44.05,0,0,0,172,128ZM51.51,68.49a12,12,0,1,0,17-17l-12-12a12,12,0,0,0-17,17Zm0,119-12,12a12,12,0,0,0,17,17l12-12a12,12,0,1,0-17-17ZM196,72a12,12,0,0,0,8.49-3.51l12-12a12,12,0,0,0-17-17l-12,12A12,12,0,0,0,196,72Zm8.49,115.51a12,12,0,0,0-17,17l12,12a12,12,0,0,0,17-17ZM48,128a12,12,0,0,0-12-12H20a12,12,0,0,0,0,24H36A12,12,0,0,0,48,128Zm80,80a12,12,0,0,0-12,12v16a12,12,0,0,0,24,0V220A12,12,0,0,0,128,208Zm108-92H220a12,12,0,0,0,0,24h16a12,12,0,0,0,0-24Z",
+		dark: "M236.37,139.4a12,12,0,0,0-12-3A84.07,84.07,0,0,1,119.6,31.59a12,12,0,0,0-15-15A108.86,108.86,0,0,0,49.69,55.07,108,108,0,0,0,136,228a107.09,107.09,0,0,0,64.93-21.69,108.86,108.86,0,0,0,38.44-54.94A12,12,0,0,0,236.37,139.4Zm-49.88,47.74A84,84,0,0,1,68.86,69.51,84.93,84.93,0,0,1,92.27,48.29Q92,52.13,92,56A108.12,108.12,0,0,0,200,164q3.87,0,7.71-.27A84.79,84.79,0,0,1,186.49,187.14Z",
+		auto: "M208,36H48A28,28,0,0,0,20,64V172a28,28,0,0,0,28,28h68v12H96a12,12,0,0,0,0,24h64a12,12,0,0,0,0-24H140V200h68a28,28,0,0,0,28-28V64A28,28,0,0,0,208,36ZM48,60H208a4,4,0,0,1,4,4v72H44V64A4,4,0,0,1,48,60ZM208,176H48a4,4,0,0,1-4-4V160H212v12A4,4,0,0,1,208,176Z",
+	};
+
+	function parseTheme(theme: unknown): Theme {
+		return theme === "auto" || theme === "dark" || theme === "light"
+			? theme
+			: "auto";
+	}
+
+	function loadTheme(): Theme {
+		return parseTheme(
+			typeof localStorage !== "undefined" && localStorage.getItem(storageKey),
+		);
+	}
+
+	function storeTheme(theme: Theme): void {
+		if (typeof localStorage !== "undefined") {
+			localStorage.setItem(
+				storageKey,
+				theme === "light" || theme === "dark" ? theme : "",
+			);
+		}
+	}
+
+	function getPreferredColorScheme(): "light" | "dark" {
+		return matchMedia("(prefers-color-scheme: light)").matches
+			? "light"
+			: "dark";
+	}
+
+	function applyTheme(theme: Theme): void {
+		document.documentElement.dataset.theme =
+			theme === "auto" ? getPreferredColorScheme() : theme;
+		storeTheme(theme);
+		if ((window as any).StarlightThemeProvider) {
+			(window as any).StarlightThemeProvider.updatePickers(theme);
+		}
+	}
+
+	function updateButton(picker: Element, theme: Theme) {
+		const select = picker.querySelector("select");
+		if (select) select.value = theme;
+
+		const iconPath = picker.querySelector(".theme-icon path");
+		if (iconPath) iconPath.setAttribute("d", iconPaths[theme]);
+
+		const label = picker.querySelector(".theme-label");
+		if (label) label.textContent = labels[theme];
+
+		const btn = picker.querySelector<HTMLElement>("#theme-toggle");
+		if (btn) btn.setAttribute("aria-label", `Theme: ${labels[theme]}`);
+	}
+
+	document.querySelectorAll("starlight-theme-select").forEach((picker) => {
+		const toggle = picker.querySelector<HTMLButtonElement>("#theme-toggle");
+		if (!toggle) return;
+
+		// React root for the dropdown — created once on first click, reused after.
+		let menuContainer: HTMLDivElement | null = null;
+		let root: ReturnType<typeof createRoot> | null = null;
+		let isOpen = false;
+
+		function renderMenu(open: boolean) {
+			isOpen = open;
+			toggle!.setAttribute("aria-expanded", String(open));
+
+			if (!open) {
+				if (root) root.render(null);
+				return;
+			}
+
+			if (!menuContainer) {
+				menuContainer = document.createElement("div");
+				document.body.appendChild(menuContainer);
+				root = createRoot(menuContainer);
+			}
+
+			// Lazy-import ThemeSelectMenu only on first open.
+			import("./ThemeSelectMenu").then(({ default: ThemeSelectMenu }) => {
+				root!.render(
+					createElement(ThemeSelectMenu, {
+						anchor: toggle!,
+						onSelect(theme: Theme) {
+							applyTheme(theme);
+							updateButton(picker, theme);
+							renderMenu(false);
+						},
+					}),
+				);
+			});
+		}
+
+		toggle.addEventListener("click", () => renderMenu(!isOpen));
+
+		document.addEventListener("mousedown", (e) => {
+			if (isOpen && !picker.contains(e.target as Node)) {
+				renderMenu(false);
+			}
+		});
+
+		document.addEventListener("keydown", (e) => {
+			if (isOpen && e.key === "Escape") renderMenu(false);
+		});
+
+		// React to system color scheme changes when set to auto.
+		matchMedia("(prefers-color-scheme: light)").addEventListener(
+			"change",
+			() => {
+				if (loadTheme() === "auto") {
+					document.documentElement.dataset.theme = getPreferredColorScheme();
+				}
+			},
+		);
+	});
+</script>
+
+<style>
+	.theme-toggle {
+		display: flex;
+		height: 2.25rem;
+		width: 100%;
+		cursor: pointer;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.375rem;
+		border-radius: 0.5rem;
+		background: transparent;
+		border: none;
+		padding: 0 0.75rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--color-header-text);
+		transition:
+			color 150ms,
+			background-color 150ms;
+	}
+
+	.theme-toggle:hover {
+		background-color: var(--color-header-fill);
+		color: var(--color-header-hover-text);
+	}
+
+	.theme-toggle-inner {
+		display: flex;
+		flex: 1;
+		align-items: center;
+		gap: 0.375rem;
+	}
+
+	.theme-icon-slot {
+		display: flex;
+		align-items: center;
+		color: var(--color-header-text-subtle);
+	}
+
+	.theme-toggle:hover .theme-icon-slot,
+	.theme-toggle:hover .theme-caret {
+		color: var(--color-header-hover-text);
+	}
+
+	.theme-icon {
+		width: 0.875rem;
+		height: 0.875rem;
+	}
+
+	.theme-caret {
+		flex-shrink: 0;
+		color: var(--color-header-text-subtle);
+	}
+
+	.caret-icon {
+		width: 0.625rem;
+		height: 0.625rem;
+	}
+</style>

--- a/src/components/ThemeSelectDropdown.tsx
+++ b/src/components/ThemeSelectDropdown.tsx
@@ -1,0 +1,186 @@
+import {
+	FloatingPortal,
+	autoUpdate,
+	offset,
+	shift,
+	useClick,
+	useDismiss,
+	useFloating,
+	useInteractions,
+} from "@floating-ui/react";
+import { useEffect, useRef, useState } from "react";
+import {
+	PiCaretDownBold,
+	PiDesktopBold,
+	PiMoonBold,
+	PiSunBold,
+} from "react-icons/pi";
+
+type Theme = "auto" | "dark" | "light";
+
+const storageKey = "starlight-theme";
+
+const themeOptions: {
+	value: Theme;
+	label: string;
+	Icon: React.ComponentType<{ className?: string }>;
+}[] = [
+	{ value: "light", label: "Light", Icon: PiSunBold },
+	{ value: "dark", label: "Dark", Icon: PiMoonBold },
+	{ value: "auto", label: "Auto", Icon: PiDesktopBold },
+];
+
+function parseTheme(theme: unknown): Theme {
+	return theme === "auto" || theme === "dark" || theme === "light"
+		? theme
+		: "auto";
+}
+
+function loadTheme(): Theme {
+	return parseTheme(
+		typeof localStorage !== "undefined" && localStorage.getItem(storageKey),
+	);
+}
+
+function storeTheme(theme: Theme): void {
+	if (typeof localStorage !== "undefined") {
+		localStorage.setItem(
+			storageKey,
+			theme === "light" || theme === "dark" ? theme : "",
+		);
+	}
+}
+
+function getPreferredColorScheme(): "light" | "dark" {
+	return matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+function applyTheme(theme: Theme): void {
+	document.documentElement.dataset.theme =
+		theme === "auto" ? getPreferredColorScheme() : theme;
+	storeTheme(theme);
+	// Keep any hidden <select> elements in sync so StarlightThemeProvider.updatePickers() works.
+	if (typeof window !== "undefined" && (window as any).StarlightThemeProvider) {
+		(window as any).StarlightThemeProvider.updatePickers(theme);
+	}
+}
+
+export default function ThemeSelectDropdown() {
+	// Start as null so the button renders empty (no label flash) until hydration reads localStorage.
+	const [theme, setTheme] = useState<Theme | null>(null);
+	const [isOpen, setIsOpen] = useState(false);
+	// Hidden select ref so StarlightThemeProvider.updatePickers() can find and update it.
+	const selectRef = useRef<HTMLSelectElement>(null);
+
+	// Initialize from localStorage on mount.
+	useEffect(() => {
+		setTheme(loadTheme());
+
+		// React to system color scheme changes when set to auto.
+		const mq = matchMedia("(prefers-color-scheme: light)");
+		const handleChange = () => {
+			if (loadTheme() === "auto") {
+				document.documentElement.dataset.theme = getPreferredColorScheme();
+			}
+		};
+		mq.addEventListener("change", handleChange);
+		return () => mq.removeEventListener("change", handleChange);
+	}, []);
+
+	// Keep hidden select value in sync with React state.
+	useEffect(() => {
+		if (selectRef.current && theme) {
+			selectRef.current.value = theme;
+		}
+	}, [theme]);
+
+	const { refs, floatingStyles, context } = useFloating({
+		open: isOpen,
+		onOpenChange: setIsOpen,
+		middleware: [shift(), offset(8)],
+		whileElementsMounted: autoUpdate,
+	});
+
+	const click = useClick(context);
+	const dismiss = useDismiss(context);
+
+	const { getReferenceProps, getFloatingProps } = useInteractions([
+		click,
+		dismiss,
+	]);
+
+	function handleSelect(value: Theme) {
+		setTheme(value);
+		applyTheme(value);
+		setIsOpen(false);
+	}
+
+	const current = theme ? themeOptions.find((o) => o.value === theme) : null;
+	const CurrentIcon = current?.Icon;
+
+	return (
+		// Keep starlight-theme-select as the wrapper so StarlightThemeProvider.updatePickers()
+		// can still query it and update the hidden <select>.
+		<starlight-theme-select>
+			{/* Hidden select preserves the StarlightThemeProvider contract */}
+			<select
+				ref={selectRef}
+				defaultValue={theme ?? "auto"}
+				aria-hidden="true"
+				tabIndex={-1}
+				style={{ display: "none" }}
+				onChange={(e) => handleSelect(parseTheme(e.currentTarget.value))}
+			>
+				{themeOptions.map((o) => (
+					<option key={o.value} value={o.value}>
+						{o.label}
+					</option>
+				))}
+			</select>
+
+			{/* Fixed width prevents layout shift as the label changes between "Auto"/"Light"/"Dark" */}
+			<button
+				ref={refs.setReference}
+				{...getReferenceProps()}
+				aria-label={current ? `Theme: ${current.label}` : "Theme"}
+				className="flex h-9 w-full cursor-pointer items-center justify-between gap-1.5 rounded-lg bg-transparent px-3 text-sm font-medium text-[var(--color-header-text)] transition-colors duration-150 hover:bg-[var(--color-header-fill)] hover:text-[var(--color-header-hover-text)]"
+			>
+				<span className="flex flex-1 items-center gap-1.5">
+					{CurrentIcon && (
+						<CurrentIcon className="size-3.5 text-[var(--color-header-text-subtle)]" />
+					)}
+					{current?.label}
+				</span>
+				<span className="shrink-0">
+					<PiCaretDownBold className="size-2.5 text-[var(--color-header-text-subtle)]" />
+				</span>
+			</button>
+
+			{isOpen && (
+				<FloatingPortal>
+					<ul
+						ref={refs.setFloating}
+						style={floatingStyles}
+						{...getFloatingProps()}
+						className="z-50 max-w-64 min-w-44 list-none rounded-lg border border-[var(--color-header-overlay-line)] bg-[var(--color-header-overlay-bg)] p-1 shadow-[0_4px_16px_var(--color-header-overlay-shadow)]"
+					>
+						{themeOptions.map((option) => {
+							const OptionIcon = option.Icon;
+							return (
+								<li key={option.value} className="list-none">
+									<button
+										onClick={() => handleSelect(option.value)}
+										className="flex w-full cursor-pointer items-center gap-2 rounded-md bg-transparent px-2.5 py-1.5 text-left text-sm text-[var(--color-header-text)] transition-colors duration-150 hover:bg-[var(--color-header-fill)] hover:text-[var(--color-header-hover-text)]"
+									>
+										<OptionIcon className="size-3.5 shrink-0 text-[var(--color-header-text-subtle)]" />
+										{option.label}
+									</button>
+								</li>
+							);
+						})}
+					</ul>
+				</FloatingPortal>
+			)}
+		</starlight-theme-select>
+	);
+}

--- a/src/components/ThemeSelectMenu.tsx
+++ b/src/components/ThemeSelectMenu.tsx
@@ -1,0 +1,60 @@
+import {
+	FloatingPortal,
+	autoUpdate,
+	offset,
+	shift,
+	useFloating,
+} from "@floating-ui/react";
+import { PiDesktopBold, PiMoonBold, PiSunBold } from "react-icons/pi";
+
+export type Theme = "auto" | "dark" | "light";
+
+const themeOptions: {
+	value: Theme;
+	label: string;
+	Icon: React.ComponentType<{ className?: string }>;
+}[] = [
+	{ value: "light", label: "Light", Icon: PiSunBold },
+	{ value: "dark", label: "Dark", Icon: PiMoonBold },
+	{ value: "auto", label: "Auto", Icon: PiDesktopBold },
+];
+
+interface Props {
+	anchor: HTMLElement;
+	onSelect: (theme: Theme) => void;
+}
+
+export default function ThemeSelectMenu({ anchor, onSelect }: Props) {
+	const { refs, floatingStyles } = useFloating({
+		open: true,
+		elements: { reference: anchor },
+		middleware: [shift(), offset(8)],
+		whileElementsMounted: autoUpdate,
+	});
+
+	return (
+		<FloatingPortal>
+			<ul
+				ref={refs.setFloating}
+				style={floatingStyles}
+				className="z-50 max-w-64 min-w-44 list-none rounded-lg border border-[var(--color-header-overlay-line)] bg-[var(--color-header-overlay-bg)] p-1 shadow-[0_4px_16px_var(--color-header-overlay-shadow)]"
+				onMouseDown={(e) => e.stopPropagation()}
+			>
+				{themeOptions.map((option) => {
+					const OptionIcon = option.Icon;
+					return (
+						<li key={option.value} className="list-none">
+							<button
+								onClick={() => onSelect(option.value)}
+								className="flex w-full cursor-pointer items-center gap-2 rounded-md bg-transparent px-2.5 py-1.5 text-left text-sm text-[var(--color-header-text)] transition-colors duration-150 hover:bg-[var(--color-header-fill)] hover:text-[var(--color-header-hover-text)]"
+							>
+								<OptionIcon className="size-3.5 shrink-0 text-[var(--color-header-text-subtle)]" />
+								{option.label}
+							</button>
+						</li>
+					);
+				})}
+			</ul>
+		</FloatingPortal>
+	);
+}

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -3,7 +3,7 @@ import LanguageSelect from "@astrojs/starlight/components/LanguageSelect.astro";
 import DocSearch from "@astrojs/starlight-docsearch/DocSearch.astro";
 import SiteTitle from "@astrojs/starlight/components/SiteTitle.astro";
 import HeaderDropdowns from "../HeaderDropdowns.tsx";
-import ThemeSelectDropdown from "../ThemeSelectDropdown.tsx";
+import ThemeSelectDropdown from "../ThemeSelectDropdown.astro";
 import AgentDirective from "../AgentDirective.astro";
 ---
 
@@ -27,7 +27,7 @@ import AgentDirective from "../AgentDirective.astro";
 			>
 				Log in
 			</a>
-			<span class="w-[6rem]"><ThemeSelectDropdown client:idle /></span>
+			<ThemeSelectDropdown />
 			<LanguageSelect />
 		</div>
 	</div>

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -2,9 +2,8 @@
 import LanguageSelect from "@astrojs/starlight/components/LanguageSelect.astro";
 import DocSearch from "@astrojs/starlight-docsearch/DocSearch.astro";
 import SiteTitle from "@astrojs/starlight/components/SiteTitle.astro";
-import ThemeSelect from "@astrojs/starlight/components/ThemeSelect.astro";
-
 import HeaderDropdowns from "../HeaderDropdowns.tsx";
+import ThemeSelectDropdown from "../ThemeSelectDropdown.tsx";
 import AgentDirective from "../AgentDirective.astro";
 ---
 
@@ -28,7 +27,7 @@ import AgentDirective from "../AgentDirective.astro";
 			>
 				Log in
 			</a>
-			<ThemeSelect />
+			<span class="w-[6rem]"><ThemeSelectDropdown client:idle /></span>
 			<LanguageSelect />
 		</div>
 	</div>
@@ -76,7 +75,10 @@ import AgentDirective from "../AgentDirective.astro";
 		line-height: 1;
 		white-space: nowrap;
 		text-decoration: none;
-		transition: color 150ms, background-color 150ms, border-color 150ms;
+		transition:
+			color 150ms,
+			background-color 150ms,
+			border-color 150ms;
 	}
 
 	.header-login {
@@ -109,29 +111,6 @@ import AgentDirective from "../AgentDirective.astro";
 		height: 1.25rem;
 	}
 
-	:global(starlight-theme-select > label > select) {
-		line-height: 1.25rem;
-		margin: 1px;
-		color: var(--color-header-text-subtle);
-	}
-
-	:global(
-		starlight-theme-select > label > select:focus,
-		starlight-theme-select > label > select:focus-visible
-	) {
-		margin: 1px;
-		outline-offset: -4px;
-	}
-
-	:global(starlight-theme-select > label > .label-icon) {
-		left: 8%;
-		color: var(--color-header-text-subtle);
-	}
-
-	:global(starlight-theme-select > label > .caret) {
-		left: 75%;
-	}
-
 	#right-group {
 		display: none;
 		align-items: center;
@@ -151,7 +130,10 @@ import AgentDirective from "../AgentDirective.astro";
 			height: 2.25rem;
 			border-color: var(--color-header-line);
 			color: var(--color-header-text-subtle);
-			transition: color 150ms, background-color 150ms, border-color 150ms;
+			transition:
+				color 150ms,
+				background-color 150ms,
+				border-color 150ms;
 		}
 
 		#docsearch :global(.DocSearch-Button:hover) {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -39,3 +39,15 @@ interface ModelContext {
 interface Navigator {
 	readonly modelContext?: ModelContext;
 }
+
+// Allow the starlight-theme-select custom element to be used in React JSX.
+declare namespace React {
+	namespace JSX {
+		interface IntrinsicElements {
+			"starlight-theme-select": React.DetailedHTMLProps<
+				React.HTMLAttributes<HTMLElement>,
+				HTMLElement
+			>;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

### Before:
The **Help** dropdown menu and the light / dark mode dropdown did not match:

| Dark | Light |
| :---: | :---: |
| <img width="392" height="310" alt="CleanShot 2026-05-04 at 14 19 40@2x" src="https://github.com/user-attachments/assets/43050091-6275-467d-a161-2d74c3c1b683" /> | <img width="392" height="310" alt="CleanShot 2026-05-04 at 14 19 30@2x" src="https://github.com/user-attachments/assets/ee377367-a594-4ed3-941d-cfe740f98bc7" /> |
| <img width="730" height="456" alt="CleanShot 2026-05-04 at 14 19 18@2x" src="https://github.com/user-attachments/assets/a6f2f771-f3f8-43c1-b1ed-98232cc37900" /> | <img width="730" height="456" alt="CleanShot 2026-05-04 at 14 19 27@2x" src="https://github.com/user-attachments/assets/00b16191-6cf0-4e06-818f-0708712c9a2c" /> |

### After:

The items were displayed differently because the Gelp dropdown implemented a React dropdown menu. The light/dark mode dropdown utilized a standard HTML `select`. 

This PR moves the light/dark mode dropdown to a React dropdown (`ThemeSelectDropdown`) that matches the help menu  and replaces the Starlight `ThemeSelect` component.

I kept a hidden `select` input within the new React component so that the code continues to leverage the pre-existing JavaScript listener and `StarlightThemeProvider`.

## Screenshots

| Dark | Light |
| :---: | :---: |
| <img width="898" height="622" alt="CleanShot 2026-05-04 at 14 12 12@2x" src="https://github.com/user-attachments/assets/cf5f30eb-4332-445b-937e-c623b8aa1453" /> | <img width="898" height="622" alt="CleanShot 2026-05-04 at 14 12 27@2x" src="https://github.com/user-attachments/assets/32e2717b-ff43-4f6a-8899-8f4fe79414eb" /> |
| <img width="898" height="622" alt="CleanShot 2026-05-04 at 14 12 04@2x" src="https://github.com/user-attachments/assets/f4a77a30-1208-418c-8ff0-7b23b594640b" /> | <img width="898" height="622" alt="CleanShot 2026-05-04 at 14 12 25@2x" src="https://github.com/user-attachments/assets/a88d8169-2509-4b2a-877d-a5213dd197d5" /> |

In the video, the content flash signals a page refresh:
https://github.com/user-attachments/assets/79ffe65f-fda5-47a3-84ba-a39a4e5e9fd9
