### PR TITLE
[Registrar] Add 5 new docs pages from April 2026 support case gap analysis

### DIFF
--- a/src/content/docs/registrar/account-options/email-verification.mdx
+++ b/src/content/docs/registrar/account-options/email-verification.mdx
@@ -1,0 +1,122 @@
+---
+pcx_content_type: how-to
+title: Email verification
+sidebar:
+  order: 10
+products:
+  - registrar
+description: Understand ICANN registrant email verification requirements and how to resolve domain suspensions.
+---
+
+import { DashButton } from "~/components";
+
+## Overview
+
+ICANN requires that the registrant email address associated with every domain registration is verified. If you do not complete verification within the required timeframe, your domain may be suspended and your website and email will stop working.
+
+This page explains how the verification process works, what happens if you miss it, and how to restore a suspended domain.
+
+## How verification works
+
+When you register a new domain, transfer a domain to Cloudflare, or update your registrant contact email, a verification email is sent to the registrant email address on file.
+
+- **Who sends it**: For most TLDs, the email comes from `noreply@emailverification.info`. This is a legitimate third-party verification service used by Cloudflare's backend registrar (Key-Systems/CentralNic). It is not phishing.
+- **Deadline**: You must verify within **15 days** of receiving the email.
+- **What to do**: Open the email and select the verification link. No login is required.
+
+:::caution
+
+The verification email comes from `noreply@emailverification.info`, not from Cloudflare. Check your spam or junk folder if you do not see it in your inbox.
+
+:::
+
+## What happens if you do not verify
+
+If the registrant email is not verified within 15 days:
+
+1. The domain is placed in a **serverHold** status at the registry.
+2. The domain's nameservers are replaced with `ns1.emailverification.info` and `ns2.emailverification.info`.
+3. Your website stops resolving. Visitors see an error page or no response.
+4. Email delivery to addresses on the domain stops working.
+
+This is an automated process required by ICANN. Cloudflare does not control when the hold is applied.
+
+## How to check if your domain is affected
+
+If your website or email suddenly stops working and you did not make any changes, check whether your nameservers were changed:
+
+```bash
+dig NS example.com +short
+```
+
+If the output shows `ns1.emailverification.info` and `ns2.emailverification.info` instead of your assigned Cloudflare nameservers, your domain has been suspended due to incomplete email verification.
+
+You can also check by running a WHOIS lookup and looking for `serverHold` in the domain status.
+
+## How to resolve a suspended domain
+
+### Step 1 — Verify your registrant email
+
+1. Check your inbox (and spam folder) for an email from `noreply@emailverification.info`.
+2. Select the verification link in the email.
+3. If the link has expired or you cannot find the email, proceed to Step 2.
+
+### Step 2 — Resend the verification email
+
+1. In the Cloudflare dashboard, go to **Domain Registration** &gt; **Manage Domains**.
+
+    <DashButton url="/?to=/:account/registrar/domains" />
+
+2. Find the affected domain and select **Manage**.
+3. Go to the **Contacts** tab.
+4. Verify that the registrant email address is correct.
+5. If a **Resend verification** option is available, select it.
+
+If you do not see a resend option in the dashboard, contact Cloudflare support and request that the verification email be resent.
+
+### Step 3 — Wait for nameserver restoration
+
+After successful verification, the nameservers are automatically restored to your assigned Cloudflare nameservers. This typically takes **1 to 24 hours** but may take longer depending on DNS TTL values and registry processing times.
+
+## Common issues
+
+### Typo in registrant email
+
+If you entered an incorrect email address during registration, you will never receive the verification email. To fix this:
+
+1. Update the registrant contact email through **Domain Registration** &gt; **Manage Domains** &gt; **Contacts**.
+2. A new verification email will be sent to the corrected address.
+3. Complete verification using the new email.
+
+:::note
+
+Updating the registrant email triggers a Change of Registrant (COR) process for some TLDs. You may need to approve the change from both the old and new email addresses. If the old email is inaccessible, contact support.
+
+:::
+
+### Verification email going to spam
+
+Emails from `@emailverification.info` are frequently filtered as spam. Add `noreply@emailverification.info` to your email allowlist or safe sender list. Check your spam, junk, and promotions folders.
+
+### Domain using same email domain as the registered domain
+
+If your registrant email uses the same domain that was suspended (for example, `admin@example.com` for the domain `example.com`), you will not receive the verification email because the domain's email is no longer working.
+
+To resolve this, update the registrant contact email to an address on a different domain (such as a Gmail or other external email), then complete verification.
+
+### Verification link returns an error
+
+If the verification link returns an error such as `Invalid attribute value` or `Invalid trigger code`, the verification token has expired. Contact Cloudflare support to request a new verification email.
+
+## TLD-specific verification requirements
+
+Some TLDs have additional verification requirements beyond standard ICANN email verification:
+
+| TLD | Additional requirements |
+| --- | --- |
+| `.ca` | CIRA (Canadian Internet Registration Authority) requires registrant verification. Failure to verify results in `serverHold` and nameserver replacement. |
+| `.mx` | NIC Mexico may require separate verification through a third-party service. |
+| `.nz` | The `.nz` registry sends verification through `@emailverification.info`. |
+| `.us` | Registrants must meet usTLD Nexus requirements. WHOIS privacy is not available. |
+
+For `.ca` domains specifically, refer to [.ca domains](/registrar/top-level-domains/ca-domains/) for detailed CIRA verification steps.

--- a/src/content/docs/registrar/account-options/refunds-and-cancellations.mdx
+++ b/src/content/docs/registrar/account-options/refunds-and-cancellations.mdx
@@ -1,0 +1,77 @@
+---
+pcx_content_type: reference
+title: Refunds and cancellations
+sidebar:
+  order: 9
+products:
+  - registrar
+description: Understand the refund and cancellation policy for Cloudflare Registrar domain registrations.
+---
+
+import { DashButton } from "~/components";
+
+## Domain registration refund policy
+
+Domain registrations through Cloudflare Registrar are generally **non-refundable**. When you register or renew a domain, Cloudflare pays the registry fee on your behalf, and that payment cannot be reversed.
+
+However, some domains may be eligible for cancellation and refund during the **Add Grace Period (AGP)**.
+
+## Add Grace Period (AGP)
+
+ICANN provides a short window after initial registration during which a domain can be deleted and the registration fee refunded. This is called the Add Grace Period.
+
+- **Duration**: 5 days from the date of registration for most gTLDs (`.com`, `.net`, `.org`, and similar).
+- **Eligibility**: Only applies to **new registrations**, not renewals or transfers.
+- **How it works**: If you contact Cloudflare support within the AGP window, Cloudflare can delete the registration at the registry and refund your payment.
+- **Not all TLDs support AGP**: Some country-code TLDs (such as `.uk`, `.ca`, `.ai`) do not offer an Add Grace Period or have different rules. Check with support if you are unsure.
+
+:::note
+
+AGP refunds are processed at Cloudflare's discretion and are subject to registry policies. If the domain has been used (DNS records configured, traffic served, or email routed), the refund request may be denied.
+
+:::
+
+### How to request an AGP refund
+
+1. Open a support case within 5 days of the registration date.
+2. Include the domain name, your account email, and the reason for cancellation.
+3. Confirm that you want the domain deleted. This action is irreversible — the domain will become available for anyone to register.
+
+## Renewals are non-refundable
+
+Once a domain renewal is processed, it cannot be reversed or refunded. This applies to both manual renewals and automatic renewals.
+
+To avoid unwanted renewal charges:
+
+1. In the Cloudflare dashboard, go to the **Manage domains** page.
+
+    <DashButton url="/?to=/:account/registrar/domains" />
+
+2. Find the domain and turn off the **Auto-renew** toggle.
+
+:::caution
+
+Disable auto-renew at least 30 days before the expiration date. Cloudflare begins auto-renewal attempts approximately 30 days prior to expiration.
+
+:::
+
+## Transfers are non-refundable
+
+Domain transfers include a one-year registration extension. Once the transfer is complete and the year has been added, the transfer fee cannot be refunded.
+
+## Common scenarios
+
+| Scenario | Refund eligible? | Action |
+| --- | --- | --- |
+| Registered wrong domain (typo) within 5 days | Possibly, via AGP | Contact support immediately |
+| Registered wrong domain after 5 days | No | Register the correct domain separately |
+| Auto-renewal you did not want | No | Disable auto-renew for future cycles |
+| Transfer completed but you changed your mind | No | Transfer out to another registrar if needed |
+| Registration failed but payment was captured | Yes | Payment is automatically voided or refunded within 5-7 business days. Contact support if not resolved. |
+| Duplicate charge for same domain | Yes | Contact support with both invoice numbers |
+
+## Tips to avoid unwanted charges
+
+- **Double-check the domain name** before confirming your purchase. Typos in domain names cannot be corrected after registration.
+- **Review auto-renew settings** periodically, especially for domains you no longer need.
+- **Set calendar reminders** for domains approaching their renewal date if you want to make a decision before auto-renew triggers.

--- a/src/content/docs/registrar/nameserver-changes.mdx
+++ b/src/content/docs/registrar/nameserver-changes.mdx
@@ -1,0 +1,74 @@
+---
+pcx_content_type: troubleshooting
+title: Troubleshoot unexpected nameserver changes
+sidebar:
+  order: 10
+products:
+  - registrar
+description: Understand why your nameservers changed to emailverification.info and how to fix it.
+---
+
+If your domain's nameservers were unexpectedly changed to `ns1.emailverification.info` and `ns2.emailverification.info`, your domain has been suspended due to incomplete registrant email verification. This is not a security breach or unauthorized change.
+
+## Why this happens
+
+ICANN requires that every domain registrant verify their email address. Cloudflare's backend registrar (Key-Systems/CentralNic) enforces this requirement by replacing your nameservers with verification parking servers when verification is not completed within the required timeframe (typically 15 days).
+
+When this happens:
+
+- Your domain's authoritative nameservers change to `ns1.emailverification.info` and `ns2.emailverification.info`.
+- Your website and any services depending on DNS (including email) stop working.
+- Your Cloudflare dashboard may still show the correct nameservers, but public DNS resolvers use the registry-level delegation, which now points elsewhere.
+
+## How to confirm the issue
+
+Run the following command to check your domain's current nameservers at the registry level:
+
+```bash
+dig NS example.com +short
+```
+
+If the output shows:
+
+```txt
+ns1.emailverification.info.
+ns2.emailverification.info.
+```
+
+Your domain has been suspended due to incomplete email verification. Your Cloudflare zone configuration is intact — only the registry-level delegation was changed.
+
+## How to fix it
+
+1. **Find the verification email**. Check your inbox and spam folder for an email from `noreply@emailverification.info`. This is the legitimate verification sender, not phishing.
+
+2. **Select the verification link**. No login is required. After verification, the nameservers are restored automatically.
+
+3. **If the email is missing or expired**, contact Cloudflare support to request a new verification email. Include the domain name and your account email.
+
+4. **If your registrant email has a typo**, update the registrant contact email first through **Domain Registration** &gt; **Manage Domains** &gt; **Contacts**, then complete verification with the corrected address.
+
+5. **Wait for restoration**. After successful verification, the nameservers are restored to your assigned Cloudflare nameservers. This typically takes 1 to 24 hours depending on DNS TTL values and registry processing.
+
+## Affected TLDs
+
+All TLDs managed through Key-Systems/CentralNic can be affected, but the following TLDs are most commonly impacted because their registries enforce verification particularly strictly:
+
+| TLD | Verification sender | Notes |
+| --- | --- | --- |
+| `.ca` | `noreply@emailverification.info` | CIRA requires additional registrant verification beyond ICANN |
+| `.mx` | `noreply@emailverification.info` | NIC Mexico enforces verification through Key-Systems |
+| `.nz` | `noreply@emailverification.info` | Verification handled by third-party service |
+| `.com`, `.net`, `.org` | `noreply@emailverification.info` | Standard ICANN verification |
+
+## Prevention
+
+- **Use a reliable email address** for your registrant contact — one that you check regularly and that is on a different domain than the one you are registering.
+- **Add `noreply@emailverification.info` to your safe sender list** to prevent verification emails from being filtered as spam.
+- **Complete verification promptly** when you receive the email. Do not wait until the deadline.
+- **Avoid using your registered domain's email** as the registrant contact email. If the domain is suspended, you will not be able to receive the verification email needed to unsuspend it.
+
+## Related resources
+
+- [Email verification](/registrar/account-options/email-verification/) — Full guide to the ICANN verification process.
+- [.ca domains](/registrar/top-level-domains/ca-domains/) — CIRA-specific verification requirements.
+- [Domain contact updates](/registrar/account-options/domain-contact-updates/) — How to update your registrant email address.

--- a/src/content/docs/registrar/registration-errors.mdx
+++ b/src/content/docs/registrar/registration-errors.mdx
@@ -1,0 +1,112 @@
+---
+pcx_content_type: troubleshooting
+title: Troubleshoot domain registration errors
+sidebar:
+  order: 9
+products:
+  - registrar
+description: Fix common errors when registering a new domain through Cloudflare Registrar.
+---
+
+import { DashButton } from "~/components";
+
+If you encounter an error while registering a new domain through Cloudflare Registrar, use this guide to identify the cause and resolve the issue.
+
+## Registration temporarily blocked
+
+**Error message**: `This domain registration is temporarily blocked. Please wait a few minutes and try again.`
+
+This is the most common registration error. It can be caused by:
+
+- **Fraud prevention checks**: Cloudflare's automated systems flagged the transaction for review. This can happen with new accounts, new payment methods, or unusual purchase patterns.
+- **Recent payment failure**: If a previous payment attempt failed (card declined, PayPal error), the system may temporarily block further attempts on the same domain.
+- **Rate limiting**: Too many registration attempts in a short period.
+
+### How to resolve
+
+1. Wait 15 to 30 minutes, then try again.
+2. If the error persists, try a different payment method (switch between credit card and PayPal, or use a different card).
+3. Verify that your billing address matches the address on file with your payment provider.
+4. Clear your browser cache or try in an incognito/private window.
+5. If the error continues after multiple attempts over several hours, contact Cloudflare support.
+
+## Payment declined
+
+**Error message**: `We're sorry, there was a payment error. Your card was declined.`
+
+Your payment method was rejected during checkout. Common causes:
+
+- **Incorrect billing details**: The name, address, or ZIP code does not match what your bank has on file.
+- **Card issuer block**: Some banks block international transactions or online purchases by default. Contact your bank to authorize the Cloudflare charge.
+- **Insufficient funds or credit limit**: Verify your account balance.
+- **Expired card**: Check that the expiration date and CVV are correct.
+- **Previously declined card**: If you accidentally rejected a payment confirmation on your phone or banking app, the card may remain in a declined state for that merchant. Contact your bank to clear the block, or use a different card.
+
+### Address validation failures
+
+If the checkout form rejects your address with a message like `cannot find your address`, try the following:
+
+1. Use the exact format your bank has on file (including apartment numbers, suite numbers, and abbreviations).
+2. Omit special characters from the street name.
+3. Try a shorter version of your address (for example, `123 Main St` instead of `123 Main Street, Suite 200`).
+4. If you are outside the United States, verify that you selected the correct country.
+
+## Registration failed but payment was captured
+
+**Error message** (via email): `Registration of [domain] unsuccessful`
+
+In some cases, your payment is processed but the registration fails at the registry level. This can happen due to:
+
+- Temporary communication errors between Cloudflare and the domain registry (such as Verisign for `.com`).
+- Registry maintenance or technical difficulties.
+- The domain was registered by another party between the time you started checkout and the time the registration was submitted.
+
+### What happens to your payment
+
+- If the charge shows as **pending** on your bank statement, it will typically be voided automatically within 5 to 7 business days.
+- If the charge was fully captured, Cloudflare will issue a refund. Contact support if the refund does not appear within 7 business days.
+
+### What to do
+
+1. Wait 24 to 48 hours and try registering the domain again. Most registry failures are temporary.
+2. Check whether the domain appears in your **Domain Registration** page. If it shows with a `registrationFailed` status, the zone may need to be cleaned up before you can retry.
+3. If the domain still shows as unavailable in your account but is available at other registrars, contact support to clear the failed registration state.
+
+## Domain shows unavailable but is not registered
+
+If you search for a domain and Cloudflare says it is unavailable, but a WHOIS lookup shows the domain is not registered:
+
+- **Registry propagation delay**: The registry may take a few hours to update availability after a previous registration attempt or expiration. Wait and try again.
+- **Previous failed registration**: A failed registration attempt in your account may still be holding the domain in a reserved state. Contact support to release it.
+- **Premium domain**: Some domains are classified as premium by the registry and may not be available at standard pricing. Cloudflare does not currently support premium domain registration for all TLDs.
+
+## Registration failed with invalid nameservers
+
+After purchasing a domain, the dashboard shows **Invalid nameservers** and the domain is stuck in **Pending** status.
+
+This typically means the registration completed at the registry, but the nameserver delegation was not properly set. Since the domain is registered through Cloudflare, the nameservers should be configured automatically.
+
+### How to resolve
+
+1. Wait up to 24 hours. Nameserver propagation can take time, especially for newer TLDs.
+2. If the domain remains in **Pending** status after 24 hours, contact support. The Cloudflare Registrar team can re-sync the nameserver delegation at the registry level.
+
+## Domain shows as registered but not in your account
+
+If you paid for a domain and received a charge confirmation, but the domain does not appear in your **Domain Registration** page:
+
+1. Verify you are logged into the correct Cloudflare account. Check the account email in the top-right corner of the dashboard.
+2. Check your email for a registration confirmation or failure notification from Cloudflare.
+3. Go to **Billing** &gt; **Invoices** to verify the payment was processed.
+
+    <DashButton url="/?to=/:account/billing" />
+
+4. If payment was processed but the domain is missing, contact support with your invoice number.
+
+## Unsupported TLD
+
+**Error message**: `[domain] cannot be registered as Cloudflare does not yet support the "[extension]" extension.`
+
+Cloudflare Registrar supports over 400 TLDs, but not all extensions are available. If you need a TLD that Cloudflare does not support, you will need to register it through another registrar. You can still use Cloudflare for DNS, CDN, and security services by [adding the domain](/fundamentals/manage-domains/add-site/) and updating nameservers at your registrar.
+
+For a list of supported TLDs, refer to [Top Level Domains supported](/registrar/top-level-domains/).

--- a/src/content/docs/registrar/top-level-domains/ca-domains.mdx
+++ b/src/content/docs/registrar/top-level-domains/ca-domains.mdx
@@ -1,0 +1,113 @@
+---
+pcx_content_type: how-to
+title: .ca domains
+sidebar:
+  order: 4
+head:
+  - tag: title
+    content: Learn how to manage a .ca domain with Cloudflare.
+products:
+  - registrar
+description: Manage .ca domains with Cloudflare Registrar, including CIRA verification requirements.
+---
+
+import { DashButton } from "~/components";
+
+## Who can register a .ca domain
+
+`.ca` domains are administered by the Canadian Internet Registration Authority (CIRA). To register a `.ca` domain, you must meet the [Canadian Presence Requirements (CPR)](https://www.cira.ca/en/policy/rules-policies/canadian-presence-requirements-registrants/). Eligible registrants include:
+
+- Canadian citizens or permanent residents (anywhere in the world).
+- Canadian corporations, partnerships, trusts, or associations.
+- Trademark holders with a valid Canadian trademark registration.
+- Official representatives of the Canadian government or its agencies.
+
+During registration, you must select a **legal entity type** (`ca-legal-type`) that describes your eligibility. Common values include:
+
+| Legal type | Description |
+| --- | --- |
+| `CCT` | Canadian citizen |
+| `RES` | Permanent resident |
+| `CCO` | Canadian corporation |
+| `ABO` | Aboriginal peoples |
+| `GOV` | Government entity |
+| `TDM` | Trademark owner (Canada) |
+
+Cloudflare submits this information to CIRA during registration. If the information is incorrect or does not meet CPR, the registration may be rejected or the domain may be suspended.
+
+## CIRA registrant verification
+
+After registering a `.ca` domain, CIRA requires registrant email verification. This is separate from — and in addition to — the standard ICANN verification process.
+
+### How it works
+
+1. CIRA sends a verification email to the registrant email address on file. This email comes from `noreply@emailverification.info`, not from Cloudflare or CIRA directly.
+2. You must select the verification link within the email to confirm your identity.
+3. If you do not complete verification, CIRA places the domain in **serverHold** status.
+
+### What happens if verification is not completed
+
+If the registrant email is not verified:
+
+- The domain's nameservers are changed to `ns1.emailverification.info` and `ns2.emailverification.info`.
+- Your website and email stop working.
+- The domain remains registered to you but is not functional until verification is complete.
+
+This is the same process described in [Email verification](/registrar/account-options/email-verification/), but `.ca` domains are particularly affected because CIRA enforces verification strictly.
+
+### How to resolve a suspended .ca domain
+
+1. Check your inbox and spam folder for an email from `noreply@emailverification.info`.
+2. Select the verification link. If the link has expired, contact Cloudflare support to request a new verification email.
+3. After verification, CIRA restores the nameservers automatically. This can take up to 24 hours.
+
+If your registrant email has a typo or uses the same domain that was suspended, update the registrant contact email first through **Domain Registration** &gt; **Manage Domains** &gt; **Contacts**, then complete verification with the corrected address.
+
+## Transferring .ca domains
+
+### Transfer a .ca domain to Cloudflare
+
+Cloudflare supports inbound transfers of `.ca` domains. The process follows the standard transfer flow with some `.ca`-specific considerations:
+
+1. Ensure your domain is **unlocked** at your current registrar.
+2. Obtain the **authorization code** from your current registrar. CIRA authorization codes are case-sensitive and may contain special characters.
+3. Your domain must be [added to your Cloudflare account](/fundamentals/manage-domains/add-site/) and showing **Active** status before you can initiate the transfer.
+4. Go to the **Transfer domains** page and enter your authorization code.
+
+    <DashButton url="/?to=/:account/registrar/transfer" />
+
+:::note
+
+`.ca` transfers do not add an additional year to the registration. The expiration date remains the same after transfer.
+
+If the authorization code is rejected, request a fresh code from your current registrar. CIRA codes expire after a set period and must be entered exactly as provided, including any special characters.
+
+:::
+
+### Transfer a .ca domain away from Cloudflare
+
+1. In the Cloudflare dashboard, go to **Domain Registration** &gt; **Manage Domains**.
+2. Find the `.ca` domain and select **Manage**.
+3. Select **Configuration** &gt; **Unlock**.
+4. Copy the authorization code and provide it to your new registrar.
+5. Your new registrar will initiate the transfer through CIRA.
+
+## .ca renewal
+
+`.ca` domains renew at the registry list price. Auto-renewal follows the same process as other TLDs — refer to [Renew domains](/registrar/account-options/renew-domains/) for details.
+
+## Troubleshooting
+
+### Authorization code rejected during transfer
+
+- CIRA authorization codes are case-sensitive. Enter the code exactly as provided.
+- Codes expire. If your code was generated more than a few days ago, request a new one.
+- Some registrars format `.ca` auth codes differently. Try entering the code manually rather than copy-pasting to avoid hidden characters.
+
+### Domain stuck in serverHold after verification
+
+If you completed CIRA verification but the domain still shows `serverHold` or the nameservers have not been restored after 24 hours, contact Cloudflare support. The registrar team can check the verification status with the backend registry and push the nameserver update.
+
+### WHOIS shows incorrect registrar
+
+After a transfer, WHOIS may still show the previous registrar (often displayed as `CentralNic Canada Inc` or the previous registrar name). This is normal during the propagation period. WHOIS data typically updates within 24 to 48 hours after a completed transfer.


### PR DESCRIPTION
## Summary

Adds 5 new documentation pages to the Registrar section based on a gap analysis of ~350 April 2026 support cases. These pages address the top documentation gaps driving **46% of total Registrar ticket volume**.

Tracked in [SPM-3500](https://jira.cfdata.org/browse/SPM-3500).

## New pages

| Page | Path | Priority | Est. deflection |
| --- | --- | --- | --- |
| Refunds and cancellations | `/registrar/account-options/refunds-and-cancellations/` | P0 | ~55 cases/mo (16%) |
| Email verification | `/registrar/account-options/email-verification/` | P0 | ~45 cases/mo (13%) |
| Registration errors | `/registrar/registration-errors/` | P0 | ~60 cases/mo (17%) |
| Nameserver changes | `/registrar/nameserver-changes/` | P1 | ~30 cases/mo (9%) |
| .ca domains | `/registrar/top-level-domains/ca-domains/` | P1 | ~12 cases/mo (3%) |

## Context

The top 3 Registrar support case categories in April 2026 had **zero documentation coverage**:

1. **Refund/cancellation requests** (16%) — customers do not know the refund policy, ICANN Add Grace Period, or that registrations are non-refundable
2. **ICANN email verification / domain suspension** (13%) — customers do not recognize emails from `@emailverification.info`, miss them, or have typos preventing verification
3. **Registration blocked / payment failures** (17%) — "temporarily blocked" errors with no troubleshooting guidance

Two additional P1 gaps:
- **Nameserver drift** (9%) — domains silently moved to `emailverification.info` nameservers with no explanation in docs
- **No .ca domain guide** (3%) — `.ca` has CIRA-specific verification requirements not covered anywhere

## Style compliance

- Follows MDX frontmatter conventions (`pcx_content_type`, `products`, `sidebar.order`)
- Uses `DashButton` component for dashboard links
- Uses `:::note` and `:::caution` admonitions (Starlight syntax)
- No contractions, active voice, "select" not "click", "go to" not "navigate"
- Internal links use relative paths without file extensions
- Code blocks specify lowercase language identifiers

## What is NOT in this PR (follow-up)

Modifications to existing pages (troubleshooting, FAQ, renew-domains, inter-account-transfer, whois-redaction, domain-management) are planned as a follow-up PR to keep this review focused on net-new content.