### PR TITLE
[Workers AI] Add Inworld TTS 2 model

### DIFF
--- a/src/content/catalog-models/inworld-tts-2.json
+++ b/src/content/catalog-models/inworld-tts-2.json
@@ -1,0 +1,372 @@
+{
+	"model_id": "inworld/tts-2",
+	"provider_id": "inworld",
+	"name": "Inworld TTS 2",
+	"description": "Inworld's most powerful and expressive text-to-speech model. Builds on TTS 1.5 with rich expressive speech, real-time latency, natural language steering (e.g. [whisper], [say excitedly]), and stronger multilingual support across 15 production languages plus 90+ experimental languages.",
+	"task": "Text-to-Speech",
+	"tags": [
+		"TTS",
+		"Speech Synthesis",
+		"Low Latency",
+		"Multilingual",
+		"Natural Language Steering",
+		"Expressive"
+	],
+	"context_length": null,
+	"max_output_tokens": null,
+	"schema_version": "1.0.0",
+	"examples": [
+		{
+			"name": "Simple Speech",
+			"description": "Generate speech with default settings",
+			"input": {
+				"text": "Hello! Welcome to Cloudflare AI Gateway. Let me show you what we can do.",
+				"voice_id": "Dennis",
+				"output_format": "mp3",
+				"temperature": 1,
+				"timestamp_type": "none"
+			},
+			"output": {
+				"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/simple-speech.mp3"
+			},
+			"raw_response": {
+				"state": "Completed",
+				"result": {
+					"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/simple-speech.mp3"
+				},
+				"gatewayMetadata": {
+					"keySource": "Unified"
+				}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'inworld/tts-2',\n  {\n    text: 'Hello! Welcome to Cloudflare AI Gateway. Let me show you what we can do.',\n    voice_id: 'Dennis',\n    output_format: 'mp3',\n    temperature: 1,\n    timestamp_type: 'none',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+				}
+			]
+		},
+		{
+			"name": "Natural Language Steering",
+			"description": "Direct the voice with bracketed natural-language cues for emotion, pace, and style.",
+			"input": {
+				"text": "[speak with excitement] I'm really excited about Inworld's new model. Have you tried out the steering capabilities? It's pretty cool!",
+				"voice_id": "Dennis",
+				"output_format": "mp3",
+				"temperature": 1,
+				"timestamp_type": "none"
+			},
+			"output": {
+				"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/natural-language-steering.mp3"
+			},
+			"raw_response": {
+				"state": "Completed",
+				"result": {
+					"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/natural-language-steering.mp3"
+				},
+				"gatewayMetadata": {
+					"keySource": "Unified"
+				}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'inworld/tts-2',\n  {\n    text: \"[speak with excitement] I'm really excited about Inworld's new model. Have you tried out the steering capabilities? It's pretty cool!\",\n    voice_id: 'Dennis',\n    output_format: 'mp3',\n    temperature: 1,\n    timestamp_type: 'none',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+				}
+			]
+		},
+		{
+			"name": "Whisper",
+			"description": "Use steering tags to whisper",
+			"input": {
+				"text": "[whisper] This is a secret just between us.",
+				"voice_id": "Dennis",
+				"output_format": "mp3",
+				"temperature": 1,
+				"timestamp_type": "none"
+			},
+			"output": {
+				"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/whisper.mp3"
+			},
+			"raw_response": {
+				"state": "Completed",
+				"result": {
+					"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/whisper.mp3"
+				},
+				"gatewayMetadata": {
+					"keySource": "Unified"
+				}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'inworld/tts-2',\n  {\n    text: '[whisper] This is a secret just between us.',\n    voice_id: 'Dennis',\n    output_format: 'mp3',\n    temperature: 1,\n    timestamp_type: 'none',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+				}
+			]
+		},
+		{
+			"name": "High Quality Audio",
+			"description": "Higher sample rate for studio quality",
+			"input": {
+				"text": "This recording is generated at studio quality for the best possible listening experience.",
+				"voice_id": "Dennis",
+				"output_format": "mp3",
+				"sample_rate": 48000,
+				"temperature": 1,
+				"timestamp_type": "none"
+			},
+			"output": {
+				"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/high-quality-audio.mp3"
+			},
+			"raw_response": {
+				"state": "Completed",
+				"result": {
+					"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/high-quality-audio.mp3"
+				},
+				"gatewayMetadata": {
+					"keySource": "Unified"
+				}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'inworld/tts-2',\n  {\n    text: 'This recording is generated at studio quality for the best possible listening experience.',\n    voice_id: 'Dennis',\n    output_format: 'mp3',\n    sample_rate: 48000,\n    temperature: 1,\n    timestamp_type: 'none',\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+				}
+			]
+		},
+		{
+			"name": "With Text Normalization",
+			"description": "Expand numbers and abbreviations before synthesis",
+			"input": {
+				"text": "The meeting is at 3:30 PM on Jan 15th, 2026. Please confirm by calling 555-0123.",
+				"voice_id": "Dennis",
+				"output_format": "mp3",
+				"temperature": 1,
+				"timestamp_type": "none",
+				"apply_text_normalization": true
+			},
+			"output": {
+				"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/with-text-normalization.mp3"
+			},
+			"raw_response": {
+				"state": "Completed",
+				"result": {
+					"audio": "https://pub-04a6d208d361438ea01b797e6973bd19.r2.dev/catalog/inworld__tts-2/with-text-normalization.mp3"
+				},
+				"gatewayMetadata": {
+					"keySource": "Unified"
+				}
+			},
+			"code_snippets": [
+				{
+					"label": "typescript",
+					"language": "typescript",
+					"code": "const response = await env.AI.run(\n  'inworld/tts-2',\n  {\n    text: 'The meeting is at 3:30 PM on Jan 15th, 2026. Please confirm by calling 555-0123.',\n    voice_id: 'Dennis',\n    output_format: 'mp3',\n    temperature: 1,\n    timestamp_type: 'none',\n    apply_text_normalization: true,\n  },\n  {\n    gateway: { id: 'default' },\n  }\n)\nconsole.log(response)"
+				}
+			]
+		}
+	],
+	"supports_async": false,
+	"external_info": "https://docs.inworld.ai/tts/realtime-tts-2-preview",
+	"terms": "https://inworld.ai/terms",
+	"cover_image_url": "https://pub-26f1392c1b674324be6786695bd72257.r2.dev/inworld/tts-2.png",
+	"metadata": {
+		"Languages": "15 production + 90+ experimental",
+		"Steering": "Natural language"
+	},
+	"created_at": "2026-05-04 22:13:05",
+	"default_example": null,
+	"code_snippets": [],
+	"zdr": false,
+	"zdr_comment": null,
+	"schema": {
+		"input": {
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"properties": {
+				"text": {
+					"description": "The text to be synthesized into speech. Maximum input of 2,000 characters.",
+					"type": "string",
+					"maxLength": 2000
+				},
+				"voice_id": {
+					"description": "The ID of the voice to use for synthesizing speech. Defaults to Dennis.",
+					"default": "Dennis",
+					"type": "string",
+					"enum": [
+						"Loretta",
+						"Darlene",
+						"Marlene",
+						"Hank",
+						"Evelyn",
+						"Celeste",
+						"Pippa",
+						"Tessa",
+						"Liam",
+						"Callum",
+						"Hamish",
+						"Abby",
+						"Graham",
+						"Rupert",
+						"Mortimer",
+						"Snik",
+						"Anjali",
+						"Saanvi",
+						"Arjun",
+						"Claire",
+						"Oliver",
+						"Simon",
+						"Elliot",
+						"James",
+						"Serena",
+						"Gareth",
+						"Vinny",
+						"Lauren",
+						"Jessica",
+						"Ethan",
+						"Tyler",
+						"Jason",
+						"Chloe",
+						"Veronica",
+						"Victoria",
+						"Miranda",
+						"Sebastian",
+						"Victor",
+						"Malcolm",
+						"Nate",
+						"Brian",
+						"Amina",
+						"Kelsey",
+						"Derek",
+						"Evan",
+						"Kayla",
+						"Jake",
+						"Grant",
+						"Tristan",
+						"Nadia",
+						"Selene",
+						"Marcus",
+						"Riley",
+						"Damon",
+						"Cedric",
+						"Mia",
+						"Naomi",
+						"Jonah",
+						"Levi",
+						"Avery",
+						"Brandon",
+						"Conrad",
+						"Bianca",
+						"Lucian",
+						"Trevor",
+						"Alex",
+						"Ashley",
+						"Craig",
+						"Deborah",
+						"Dennis",
+						"Edward",
+						"Elizabeth",
+						"Hades",
+						"Julia",
+						"Pixie",
+						"Mark",
+						"Olivia",
+						"Priya",
+						"Ronald",
+						"Sarah",
+						"Shaun",
+						"Theodore",
+						"Timothy",
+						"Wendy",
+						"Dominus",
+						"Hana",
+						"Clive",
+						"Carter",
+						"Blake",
+						"Luna",
+						"Reed",
+						"Duncan",
+						"Felix",
+						"Eleanor",
+						"Sophie"
+					]
+				},
+				"output_format": {
+					"description": "The output format for the audio. Supported formats are mp3, opus, wav, and flac. Defaults to mp3.",
+					"default": "mp3",
+					"type": "string",
+					"enum": [
+						"mp3",
+						"opus",
+						"wav",
+						"flac"
+					]
+				},
+				"bit_rate": {
+					"description": "Bits per second of the audio. Only for compressed audio formats (mp3, opus). The default is 128,000.",
+					"type": "integer",
+					"minimum": -9007199254740991,
+					"maximum": 9007199254740991
+				},
+				"sample_rate": {
+					"description": "The synthesis sample rate in hertz. Accepts: 8000, 16000, 22050, 24000, 32000, 44100, 48000. The default is 48,000.",
+					"type": "integer",
+					"minimum": -9007199254740991,
+					"maximum": 9007199254740991
+				},
+				"speaking_rate": {
+					"description": "Speaking rate/speed, in the range [0.5, 1.5]. The default is 1.0. We recommend using values above 0.8 to ensure high quality.",
+					"type": "number",
+					"minimum": 0.5,
+					"maximum": 1.5
+				},
+				"temperature": {
+					"description": "Determines the degree of randomness when sampling audio tokens. Defaults to 1.0. Accepts values between 0 (exclusive) and 2 (inclusive). Higher values = more expressive, lower values = more deterministic.",
+					"default": 1,
+					"type": "number",
+					"minimum": 0.01,
+					"maximum": 2
+				},
+				"timestamp_type": {
+					"description": "Controls timestamp metadata returned with the audio. \"word\" returns word-level timing, \"character\" returns character-level timing. Note: adds latency. Defaults to none.",
+					"default": "none",
+					"type": "string",
+					"enum": [
+						"none",
+						"word",
+						"character"
+					]
+				},
+				"apply_text_normalization": {
+					"description": "When enabled, text normalization expands numbers, dates, times, and abbreviations before converting to speech. Turning this off may reduce latency.",
+					"type": "boolean"
+				}
+			},
+			"required": [
+				"text",
+				"voice_id",
+				"output_format",
+				"temperature",
+				"timestamp_type"
+			],
+			"additionalProperties": false
+		},
+		"output": {
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"properties": {
+				"audio": {
+					"description": "URL to the generated audio file",
+					"type": "string"
+				}
+			},
+			"required": [
+				"audio"
+			],
+			"additionalProperties": false
+		}
+	}
+}


### PR DESCRIPTION
Adds the Inworld TTS 2 catalog model entry, generated via `bin/fetch-catalog-models.ts`.

Inworld's most powerful and expressive TTS model - builds on TTS 1.5 with rich expressive speech, real-time latency, natural-language steering (`[whisper]`, `[say excitedly]`, etc.), and stronger multilingual support across 15 production and 90+ experimental languages.

- New file: `src/content/catalog-models/inworld-tts-2.json`
- Includes schema, voice list, and five example invocations (simple speech, natural-language steering, whisper, high-quality audio, text normalization)