### PR TITLE
[1.1.1.1] ELI5 on DNS over HTTPS root-level files

### DIFF
--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/dns-over-https-client.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/dns-over-https-client.mdx
@@ -8,7 +8,7 @@ products:
   - 1.1.1.1
 ---
 
-Several DoH clients are available for connecting to 1.1.1.1.
+A DoH client is software that runs on your device and sends DNS queries to a resolver like 1.1.1.1 over an encrypted HTTPS connection. Once configured, the client handles DNS resolution for your device or network.
 
 ## Cloudflare WARP client
 
@@ -16,7 +16,7 @@ Refer to [WARP client](/warp-client/) for guidance on WARP modes and get-started
 
 ## DNSCrypt-Proxy
 
-The [DNSCrypt-Proxy](https://dnscrypt.info) 2.0+ supports DoH out of the box. It supports both 1.1.1.1 and other services. It also includes more advanced features, such as load balancing and local filtering.
+[DNSCrypt-Proxy](https://dnscrypt.info) 2.0+ supports DoH out of the box. It supports both 1.1.1.1 and other services. It also includes more advanced features, such as load balancing and local filtering.
 
 1. [Install DNSCrypt-Proxy](https://github.com/jedisct1/dnscrypt-proxy/wiki/installation).
 
@@ -36,7 +36,7 @@ The [DNSCrypt-Proxy](https://dnscrypt.info) 2.0+ supports DoH out of the box. It
    server_names = ['cloudflare', 'cloudflare-ipv6']
    ```
 
-4. Make sure that nothing else is running on `localhost:53`, and check that everything works as expected:
+4. Make sure that nothing else is running on `localhost:53` (port `53` is the standard DNS port on your local machine), and check that everything works as expected:
 
    ```sh
    dnscrypt-proxy -resolve cloudflare-dns.com
@@ -52,4 +52,4 @@ The [DNSCrypt-Proxy](https://dnscrypt.info) 2.0+ supports DoH out of the box. It
    Resolver IP:    172.68.140.217
    ```
 
-5. Register it as a system service according to the [DNSCrypt-Proxy installation instructions](https://github.com/jedisct1/dnscrypt-proxy/wiki/installation).
+5. Register it as a system service so that it starts automatically when your device boots. Follow the [DNSCrypt-Proxy installation instructions](https://github.com/jedisct1/dnscrypt-proxy/wiki/installation).

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/dns-over-https-client.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/dns-over-https-client.mdx
@@ -8,7 +8,7 @@ products:
   - 1.1.1.1
 ---
 
-A DoH client is software that runs on your device and sends DNS queries to a resolver like 1.1.1.1 over an encrypted HTTPS connection. Once configured, the client handles DNS resolution for your device or network.
+A DoH client is a software that runs on your device and sends DNS queries to a resolver like 1.1.1.1 over an encrypted HTTPS connection. Once configured, the client handles DNS resolution for your device or network.
 
 ## Cloudflare WARP client
 

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/encrypted-dns-browsers.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/encrypted-dns-browsers.mdx
@@ -7,13 +7,13 @@ title: Configure DoH on your browser
 slug: 1.1.1.1/encryption/dns-over-https/encrypted-dns-browsers
 ---
 
-Several browsers support DNS over HTTPS (DoH), a protocol that encrypts your connection to 1.1.1.1 to protect your DNS queries from privacy intrusions and tampering.
+Several browsers support DNS over HTTPS (DoH), which encrypts your DNS queries to protect them from monitoring and tampering.
 
 Some browsers might already have this setting enabled.
 
 :::note
 
-To use 1.1.1.1 For Families, follow the steps below but, instead of choosing the default 1.1.1.1 option, refer to [Set up](/1.1.1.1/setup/#dns-over-https-doh) and specify the URL you want to use.
+[1.1.1.1 for Families](/1.1.1.1/setup/#1111-for-families) provides additional filtering to block malware, phishing, or adult content. To use it, follow the steps below but, instead of choosing the default 1.1.1.1 option, refer to [Set up](/1.1.1.1/setup/#dns-over-https-doh) and specify the URL you want to use.
 :::
 
 ## Mozilla Firefox

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/index.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/index.mdx
@@ -12,6 +12,10 @@ sidebar:
 
 import { DirectoryListing } from "~/components";
 
-With DNS over HTTPS (DoH), DNS queries and responses are encrypted and sent via the HTTP, HTTP/2 and HTTP/3 protocols. DoH ensures that attackers cannot forge or alter DNS traffic. DoH uses port 443, which is the standard HTTPS traffic port, to wrap the DNS query in an HTTPS request. DNS queries and responses are camouflaged within other HTTPS traffic, since it all comes and goes from the same port.
+DNS over HTTPS (DoH) encrypts DNS queries by wrapping them inside regular HTTPS requests. This prevents attackers from forging or altering your DNS traffic.
+
+DoH sends DNS traffic over port `443` — the default port for HTTPS web traffic. Because DoH queries use the same port and protocol as normal web browsing, they are difficult to distinguish from other HTTPS traffic on the network.
+
+DoH supports the HTTP, HTTP/2, and HTTP/3 protocols.
 
 <DirectoryListing />


### PR DESCRIPTION
### Summary

ELI5 pass on the three root-level MDX files in `/1.1.1.1/encryption/dns-over-https/`. These pages explain DoH concepts, client setup, and browser configuration for a broad audience that includes IT admins and privacy-conscious non-developers.

**Key changes:**

- **`index.mdx` (DoH overview):** Split a dense single-paragraph explanation into three focused paragraphs — what DoH does, why port 443 matters, and protocol support. Replaced "camouflaged within other HTTPS traffic" with a concrete explanation of why sharing port 443 makes DoH traffic hard to distinguish.
- **`dns-over-https-client.mdx` (client tutorial):** Added a two-sentence opener defining what a DoH client is and what role it plays. Added parenthetical explaining `localhost:53`. Expanded "register as a system service" to explain what that means (starts on boot).
- **`encrypted-dns-browsers.mdx` (browser how-to):** Fixed "encrypts your connection to 1.1.1.1" → "encrypts your DNS queries" (more precise). Added a brief definition and link for 1.1.1.1 for Families with the canonical description (malware, phishing, adult content).

All changes were run through an adversarial fact-check review. No structural reorganization — all original code examples, procedural steps, and links are preserved.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
