### PR TITLE
[1.1.1.1] ELI5 on DoH API request reference pages

### DIFF
--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json.mdx
@@ -13,9 +13,9 @@ The DNS over HTTPS JSON format does not have a formal RFC, which means behavior 
 For critical use cases, it is recommended to use the [DNS over HTTPS wireformat](/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat/), which is defined in [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html).
 :::
 
-Cloudflare's DNS over HTTPS endpoint also supports JSON format for querying DNS data. For lack of an agreed upon JSON schema for DNS over HTTPS in the Internet Engineering Task Force (IETF), Cloudflare has chosen to follow the same schema as Google's DNS over HTTPS resolver.
+Cloudflare's DNS over HTTPS endpoint also supports JSON format for querying DNS data. There is no agreed-upon JSON schema for DNS over HTTPS in the IETF, so Cloudflare has chosen to follow the same schema as Google's DNS over HTTPS resolver.
 
-JSON formatted queries are sent using a `GET` request. When making requests using `GET`, the DNS query is encoded into the URL. The client should include an HTTP `Accept` request header field with a MIME type of `application/dns-json` to indicate that the client is able to accept a JSON response from the DNS over HTTPS resolver.
+JSON formatted queries are sent using a `GET` request. When making requests using `GET`, the DNS query is encoded into the URL. Include an HTTP `Accept` request header with a MIME type of `application/dns-json` to indicate that the client can accept a JSON response.
 
 ## Supported parameters
 

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json.mdx
@@ -13,7 +13,7 @@ The DNS over HTTPS JSON format does not have a formal RFC, which means behavior 
 For critical use cases, it is recommended to use the [DNS over HTTPS wireformat](/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat/), which is defined in [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html).
 :::
 
-Cloudflare's DNS over HTTPS endpoint also supports JSON format for querying DNS data. There is no agreed-upon JSON schema for DNS over HTTPS in the IETF, so Cloudflare has chosen to follow the same schema as Google's DNS over HTTPS resolver.
+Cloudflare's DNS over HTTPS endpoint also supports JSON format for querying DNS data. There is no agreed-upon JSON schema for DNS over HTTPS in the Internet Engineering Task Force (IETF), so Cloudflare has chosen to follow the same schema as Google's DNS over HTTPS resolver.
 
 JSON formatted queries are sent using a `GET` request. When making requests using `GET`, the DNS query is encoded into the URL. Include an HTTP `Accept` request header with a MIME type of `application/dns-json` to indicate that the client can accept a JSON response.
 

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat.mdx
@@ -12,7 +12,7 @@ slug: 1.1.1.1/encryption/dns-over-https/make-api-requests/dns-wireformat
 
 Cloudflare respects DNS wireformat as defined in [RFC 1035](https://www.rfc-editor.org/rfc/rfc1035.html).
 
-    To send queries using DNS wireformat, set the header `accept: application/dns-message`, or `content-type: application/dns-message` if using `POST` to indicate the media type of the query.
+To send queries using DNS wireformat, set the header `accept: application/dns-message`, or `content-type: application/dns-message` if using `POST` to indicate the media type of the query.
 
 Queries using DNS wireformat can be sent using `POST` or `GET`.
 

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/index.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/index.mdx
@@ -34,7 +34,7 @@ Refer to [DNS wireformat](/1.1.1.1/encryption/dns-over-https/make-api-requests/d
 
 ## Send multiple questions in a query
 
-Each DNS query maps to exactly one HTTP request. To send multiple queries concurrently, use HTTP/2 or HTTP/3, which support multiplexing multiple requests over a single connection.
+Each DNS query maps to exactly one HTTP request. To send multiple queries concurrently, use HTTP/2 or HTTP/3, which supports multiplexing multiple requests over a single connection.
 
 HTTP/2 is the minimum recommended version of HTTP for use with DoH. This is not specific to 1.1.1.1, but rather how DoH operates per [RFC 8484](https://datatracker.ietf.org/doc/html/rfc8484#section-5.2).
 

--- a/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/index.mdx
+++ b/src/content/docs/1.1.1.1/encryption/dns-over-https/make-api-requests/index.mdx
@@ -20,7 +20,7 @@ https://cloudflare-dns.com/dns-query
 
 ## HTTP method
 
-Cloudflare's DNS-over-HTTPS (DOH) endpoint supports `POST` and `GET` for DNS wireformat, and `GET` for JSON format.
+Cloudflare's DNS over HTTPS (DoH) endpoint supports `POST` and `GET` for DNS wireformat, and `GET` for JSON format.
 
 When making requests using `POST`, the DNS query is included as the message body of the HTTP request, and the MIME type (`application/dns-message`) is sent in the `Content-Type` request header. Cloudflare will use the message body of the HTTP request as sent by the client, so the message body should not be encoded.
 
@@ -34,9 +34,9 @@ Refer to [DNS wireformat](/1.1.1.1/encryption/dns-over-https/make-api-requests/d
 
 ## Send multiple questions in a query
 
-Sending more than one question when making requests depends on the HTTP version used, as each DNS query maps to exactly one HTTP request. HTTP/2 and HTTP/3 have multiplexing capabilities, allowing multiple requests to start concurrently. HTTP/2 is, in fact, the minimum recommended version of HTTP for use with DNS over HTTPS (DoH). This behavior is not specific to 1.1.1.1, but rather how DoH operates.
+Each DNS query maps to exactly one HTTP request. To send multiple queries concurrently, use HTTP/2 or HTTP/3, which support multiplexing multiple requests over a single connection.
 
-You can learn more about how DoH works in RFC 8484, more specifically [the HTTP layer requirements](https://datatracker.ietf.org/doc/html/rfc8484#section-5.2).
+HTTP/2 is the minimum recommended version of HTTP for use with DoH. This is not specific to 1.1.1.1, but rather how DoH operates per [RFC 8484](https://datatracker.ietf.org/doc/html/rfc8484#section-5.2).
 
 Example request:
 


### PR DESCRIPTION
### Summary

Light ELI5 pass on the three reference pages in `/1.1.1.1/encryption/dns-over-https/make-api-requests/`. These are developer-focused API references, so changes are minimal and surgical — only fixing genuine clarity and formatting issues.

**Key changes:**

- **`index.mdx`:** Restructured the "Send multiple questions" section — the key constraint ("one query = one HTTP request") now leads the paragraph instead of being buried mid-sentence. Removed "in fact" filler. Moved RFC 8484 citation inline. Normalized "DNS-over-HTTPS (DOH)" → "DNS over HTTPS (DoH)" for consistency with the rest of the docs.
- **`dns-json.mdx`:** Simplified a convoluted sentence structure ("For lack of an agreed upon JSON schema..." → "There is no agreed-upon JSON schema...so Cloudflare..."). Tightened the Accept header instruction to imperative voice. Preserved original "has chosen to follow" tense for the Google schema claim.
- **`dns-wireformat.mdx`:** Fixed a formatting bug where an instructional paragraph (line 15) had 4-space indentation, causing it to render as a code block instead of prose.

All changes verified through adversarial fact-check review — no factual claims were added, removed, or contradicted. All code examples, tables, and technical details preserved unchanged.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
