### PR TITLE
Tagging AppSec Docs sections, 2026 05 pt1

### DIFF
--- a/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
+++ b/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
@@ -7,6 +7,8 @@ title: Endpoint labeling service
 sidebar:
   order: 2
   label: Labeling service
+tags:
+  - GraphQL
 ---
 
 import {

--- a/src/content/docs/api-shield/reference/terraform.mdx
+++ b/src/content/docs/api-shield/reference/terraform.mdx
@@ -4,6 +4,8 @@ title: Terraform
 description: Configure API Shield resources with Terraform, including endpoints and schemas.
 products:
   - api-shield
+tags:
+  - Terraform
 
 ---
 

--- a/src/content/docs/api-shield/security/authentication-posture.mdx
+++ b/src/content/docs/api-shield/security/authentication-posture.mdx
@@ -6,6 +6,8 @@ products:
 title: Authentication Posture
 sidebar:
   order: 9
+tags:
+  - Authentication
 ---
 
 import {

--- a/src/content/docs/api-shield/security/graphql-protection/api.mdx
+++ b/src/content/docs/api-shield/security/graphql-protection/api.mdx
@@ -10,6 +10,8 @@ sidebar:
 head:
   - tag: title
     content: Configure GraphQL malicious query protection
+tags:
+  - GraphQL
 ---
 
 Use the [Cloudflare GraphQL API](/analytics/graphql-api/getting-started/) to gather data about your GraphQL API’s current usage and configure Cloudflare’s GraphQL malicious query protection to log or block malicious queries.

--- a/src/content/docs/api-shield/security/jwt-validation/api.mdx
+++ b/src/content/docs/api-shield/security/jwt-validation/api.mdx
@@ -10,6 +10,8 @@ sidebar:
 head:
   - tag: title
     content: Configure JWT validation via the API
+tags:
+  - JSON web token (JWT)
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/api-shield/security/jwt-validation/index.mdx
+++ b/src/content/docs/api-shield/security/jwt-validation/index.mdx
@@ -6,6 +6,8 @@ products:
   - api-shield
 sidebar:
   order: 6
+tags:
+  - JSON web token (JWT)
 ---
 
 import {

--- a/src/content/docs/api-shield/security/jwt-validation/jwt-worker.mdx
+++ b/src/content/docs/api-shield/security/jwt-validation/jwt-worker.mdx
@@ -9,6 +9,9 @@ sidebar:
 head:
   - tag: title
     content: Configure the Worker for JWT validation
+tags:
+  - JSON web token (JWT)
+  - JavaScript
 ---
 
 import { Steps } from "~/components"

--- a/src/content/docs/api-shield/security/jwt-validation/transform-rules.mdx
+++ b/src/content/docs/api-shield/security/jwt-validation/transform-rules.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Enhance Transform Rules with JWT claims
+tags:
+  - JSON web token (JWT)
 ---
 
 import { Steps, DashButton } from "~/components"

--- a/src/content/docs/api-shield/security/mtls/configure.mdx
+++ b/src/content/docs/api-shield/security/mtls/configure.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Configure mTLS
+tags:
+  - mTLS
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/api-shield/security/mtls/index.mdx
+++ b/src/content/docs/api-shield/security/mtls/index.mdx
@@ -6,6 +6,8 @@ products:
   - api-shield
 sidebar:
   order: 7
+tags:
+  - mTLS
 
 ---
 

--- a/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
+++ b/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
@@ -7,6 +7,8 @@ products:
 sidebar:
   order: 8
   label: robots.txt setting
+tags:
+  - AI
 ---
 
 import { Tabs, TabItem, Steps, DashButton } from "~/components";

--- a/src/content/docs/bots/concepts/bot/index.mdx
+++ b/src/content/docs/bots/concepts/bot/index.mdx
@@ -9,6 +9,8 @@ sidebar:
 learning_center:
   title: What is a bot?
   link: https://www.cloudflare.com/learning/bots/what-is-a-bot/
+tags:
+  - AI
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/bots/reference/bot-verification/web-bot-auth.mdx
+++ b/src/content/docs/bots/reference/bot-verification/web-bot-auth.mdx
@@ -7,6 +7,8 @@ products:
 sidebar:
   order: 2
   label: Web Bot Auth
+tags:
+  - Authentication
 ---
 
 import { GlossaryTooltip, Steps } from "~/components";

--- a/src/content/docs/bots/reference/machine-learning-models.mdx
+++ b/src/content/docs/bots/reference/machine-learning-models.mdx
@@ -6,6 +6,8 @@ products:
   - bots
 sidebar:
   order: 3
+tags:
+  - AI
 
 ---
 

--- a/src/content/docs/bots/reference/sample-terms.mdx
+++ b/src/content/docs/bots/reference/sample-terms.mdx
@@ -6,6 +6,8 @@ products:
   - bots
 sidebar:
   order: 5
+tags:
+  - AI
 
 ---
 

--- a/src/content/docs/bots/troubleshooting/wordpress-loopback-issue.mdx
+++ b/src/content/docs/bots/troubleshooting/wordpress-loopback-issue.mdx
@@ -6,6 +6,8 @@ products:
   - bots
 sidebar:
   order: 2
+tags:
+  - WordPress
 ---
 
 import { Tabs, TabItem, Steps, Render, DashButton } from "~/components";

--- a/src/content/docs/bots/workers-templates/delay-action.mdx
+++ b/src/content/docs/bots/workers-templates/delay-action.mdx
@@ -4,6 +4,9 @@ title: Delay action
 description: Use a Worker to add configurable delays to requests with low bot scores.
 products:
   - bots
+tags:
+  - TypeScript
+  - JavaScript
 ---
 
 import { TypeScriptExample } from "~/components";

--- a/src/content/docs/client-side-security/best-practices/deploy-rules-in-production.mdx
+++ b/src/content/docs/client-side-security/best-practices/deploy-rules-in-production.mdx
@@ -7,6 +7,8 @@ sidebar:
   order: 3
   label: Deploy rules in production
 description: Safe practices for deploying and updating content security rules.
+tags:
+  - CSP
 ---
 
 :::note

--- a/src/content/docs/client-side-security/detection/monitor-connections-scripts.mdx
+++ b/src/content/docs/client-side-security/detection/monitor-connections-scripts.mdx
@@ -6,6 +6,8 @@ products:
   - client-side-security
 sidebar:
   order: 2
+tags:
+  - Cookies
 ---
 
 import {

--- a/src/content/docs/client-side-security/faq.mdx
+++ b/src/content/docs/client-side-security/faq.mdx
@@ -7,6 +7,9 @@ products:
 sidebar:
   order: 8
   label: FAQ
+tags:
+  - Headers
+  - CSP
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/client-side-security/how-it-works/index.mdx
+++ b/src/content/docs/client-side-security/how-it-works/index.mdx
@@ -11,6 +11,9 @@ description:
   Cloudflare's client-side security tracks resources (such as scripts)
   loaded by your website visitors and provides alerts when it detects
   new, changed, or malicious resources.
+tags:
+  - Headers
+  - CSP
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/client-side-security/how-it-works/malicious-script-detection.mdx
+++ b/src/content/docs/client-side-security/how-it-works/malicious-script-detection.mdx
@@ -8,6 +8,8 @@ sidebar:
 description: Cloudflare analyzes the JavaScript code of the scripts loaded by
   your website visitors, using threat intelligence and machine learning (including LLMs)
   to detect malicious behavior.
+tags:
+  - LLM
 ---
 
 :::note

--- a/src/content/docs/client-side-security/reference/csp-header.mdx
+++ b/src/content/docs/client-side-security/reference/csp-header.mdx
@@ -6,6 +6,9 @@ products:
   - client-side-security
 sidebar:
   order: 10
+tags:
+  - Headers
+  - CSP
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/client-side-security/reference/pci-dss.mdx
+++ b/src/content/docs/client-side-security/reference/pci-dss.mdx
@@ -7,6 +7,8 @@ products:
 sidebar:
   order: 4
   label: PCI DSS compliance
+tags:
+  - Compliance
 ---
 
 You can use Cloudflare's client-side security for PCI DSS v4's client-side security requirements (items 6.4.3 and 11.6.1).

--- a/src/content/docs/client-side-security/rules/create-dashboard.mdx
+++ b/src/content/docs/client-side-security/rules/create-dashboard.mdx
@@ -7,6 +7,8 @@ sidebar:
   order: 2
   label: Create in the dashboard
 description: Learn how to create a content security rule in the Cloudflare dashboard.
+tags:
+  - CSP
 ---
 
 import { Tabs, TabItem, Render } from "~/components";

--- a/src/content/docs/client-side-security/rules/csp-directives.mdx
+++ b/src/content/docs/client-side-security/rules/csp-directives.mdx
@@ -7,6 +7,9 @@ sidebar:
   order: 6
 head: []
 description: CSP directives supported by content security rules
+tags:
+  - Headers
+  - CSP
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/client-side-security/rules/index.mdx
+++ b/src/content/docs/client-side-security/rules/index.mdx
@@ -10,6 +10,9 @@ sidebar:
 description:
   Use content security rules to define the resources (scripts) allowed
   on your applications.
+tags:
+  - Headers
+  - CSP
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/client-side-security/rules/violations.mdx
+++ b/src/content/docs/client-side-security/rules/violations.mdx
@@ -7,6 +7,9 @@ sidebar:
   order: 4
   label: Rule violations
 description: Cloudflare reports any violations to your content security rules.
+tags:
+  - GraphQL
+  - CSP
 ---
 
 import { Details, Render, GlossaryTooltip } from "~/components";

--- a/src/content/docs/client-side-security/troubleshooting.mdx
+++ b/src/content/docs/client-side-security/troubleshooting.mdx
@@ -7,6 +7,10 @@ products:
   - client-side-security
 sidebar:
   order: 10
+tags:
+  - Headers
+  - CSP
+  - Debugging
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/cloudflare-challenges/challenge-types/challenge-pages/additional-configuration.mdx
+++ b/src/content/docs/cloudflare-challenges/challenge-types/challenge-pages/additional-configuration.mdx
@@ -4,6 +4,9 @@ title: Additional configuration
 description: Customize challenge pages with multi-language support, branding, and text options.
 products:
   - cloudflare-challenges
+tags:
+  - CSP
+  - Headers
 sidebar:
   order: 6
 ---

--- a/src/content/docs/cloudflare-challenges/challenge-types/challenge-pages/challenge-passage.mdx
+++ b/src/content/docs/cloudflare-challenges/challenge-types/challenge-pages/challenge-passage.mdx
@@ -4,6 +4,8 @@ title: Challenge Passage
 description: Set a time period during which visitors do not have to solve repeat challenges.
 products:
   - cloudflare-challenges
+tags:
+  - Cookies
 sidebar:
   order: 3
 ---

--- a/src/content/docs/cloudflare-challenges/challenge-types/challenge-pages/detect-response.mdx
+++ b/src/content/docs/cloudflare-challenges/challenge-types/challenge-pages/detect-response.mdx
@@ -4,6 +4,9 @@ title: Detect a Challenge Page response
 description: Use the cf-mitigated header to identify challenge page responses in fetch and XHR requests.
 products:
   - cloudflare-challenges
+tags:
+  - Headers
+  - JavaScript
 sidebar:
   order: 4
 ---

--- a/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
+++ b/src/content/docs/cloudflare-challenges/challenge-types/javascript-detections.mdx
@@ -4,6 +4,9 @@ title: JavaScript Detections
 description: Client-side JavaScript challenges that run on every request to identify automated traffic.
 products:
   - cloudflare-challenges
+tags:
+  - JavaScript
+  - CSP
 sidebar:
   order: 3
 ---

--- a/src/content/docs/cloudflare-challenges/concepts/clearance.mdx
+++ b/src/content/docs/cloudflare-challenges/concepts/clearance.mdx
@@ -4,6 +4,8 @@ title: Clearance
 description: How cf_clearance cookies prove a visitor passed a Cloudflare challenge.
 products:
   - cloudflare-challenges
+tags:
+  - Cookies
 sidebar:
   order: 2
 ---

--- a/src/content/docs/cloudflare-challenges/reference/supported-languages.mdx
+++ b/src/content/docs/cloudflare-challenges/reference/supported-languages.mdx
@@ -4,6 +4,8 @@ title: Supported languages
 description: Languages supported by Cloudflare challenge pages, detected via navigator.language.
 products:
   - cloudflare-challenges
+tags:
+  - Localization
 sidebar:
   order: 5
 ---

--- a/src/content/docs/cloudflare-challenges/troubleshooting/challenge-solve-issues.mdx
+++ b/src/content/docs/cloudflare-challenges/troubleshooting/challenge-solve-issues.mdx
@@ -4,6 +4,8 @@ pcx_content_type: troubleshooting
 description: Fix challenge loops, unsupported browser errors, and other solve failures.
 products:
   - cloudflare-challenges
+tags:
+  - Debugging
 sidebar:
   order: 2
 

--- a/src/content/docs/cloudflare-challenges/troubleshooting/index.mdx
+++ b/src/content/docs/cloudflare-challenges/troubleshooting/index.mdx
@@ -4,6 +4,8 @@ title: Troubleshooting
 description: Resolve common issues with Cloudflare challenges, including loops and proxied hostnames.
 products:
   - cloudflare-challenges
+tags:
+  - Debugging
 sidebar:
   order: 4
   label: Common issues

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
@@ -4,6 +4,8 @@ pcx_content_type: troubleshooting
 description: Resolve common issues with custom hostnames, certificates, and rate limits.
 products:
   - cloudflare-for-saas
+tags:
+  - Debugging
 sidebar:
   order: 3
 head:

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works.mdx
@@ -4,6 +4,8 @@ title: How it works
 description: How O2O routes traffic through two Cloudflare zones for SaaS provider configurations.
 products:
   - cloudflare-for-saas
+tags:
+  - DNS
 sidebar:
   order: 1
 head:

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/certificate-signing-requests.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/certificate-signing-requests.mdx
@@ -3,6 +3,8 @@ title: Certificate signing requests (CSRs)
 pcx_content_type: tutorial
 products:
   - cloudflare-for-saas
+tags:
+  - TLS
 sidebar:
   order: 7
 head:

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/index.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/index.mdx
@@ -4,6 +4,8 @@ pcx_content_type: concept
 description: Upload your own TLS certificates for custom hostnames that require custom key material.
 products:
   - cloudflare-for-saas
+tags:
+  - TLS
 sidebar:
   order: 5
 ---

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/uploading-certificates.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/uploading-certificates.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Learn how to manage custom certificates for your Cloudflare for SaaS custom hostnames.
 products:
   - cloudflare-for-saas
+tags:
+  - TLS
 sidebar:
   order: 6
 head:

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Delegate domain control validation to Cloudflare for automated certificate issuance.
 products:
   - cloudflare-for-saas
+tags:
+  - DNS
 sidebar:
   order: 1
 head:

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http.mdx
@@ -4,6 +4,8 @@ title: HTTP
 description: Validate domain ownership by placing a DCV token on your customer origin.
 products:
   - cloudflare-for-saas
+tags:
+  - TLS
 sidebar:
   order: 3
 head:

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting.mdx
@@ -4,6 +4,8 @@ title: Troubleshooting
 description: Resolve certificate validation issues including high-risk domains and CA errors.
 products:
   - cloudflare-for-saas
+tags:
+  - Debugging
 sidebar:
   order: 6
 head:

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt.mdx
@@ -4,6 +4,9 @@ title: TXT
 description: Validate domain ownership with a TXT DNS record for certificate issuance.
 products:
   - cloudflare-for-saas
+tags:
+  - TLS
+  - DNS
 sidebar:
   order: 2
 head:

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/secure-with-access.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/secure-with-access.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Control access to custom hostnames using Cloudflare Access identity and device policies.
 products:
   - cloudflare-for-saas
+tags:
+  - Authentication
 sidebar:
   order: 4
 head:

--- a/src/content/docs/cloudflare-for-platforms/workers-for-platforms/reference/platform-examples.mdx
+++ b/src/content/docs/cloudflare-for-platforms/workers-for-platforms/reference/platform-examples.mdx
@@ -6,6 +6,9 @@ sidebar:
 description: REST API and TypeScript SDK examples for deploying Workers programmatically.
 products:
   - cloudflare-for-platforms
+tags:
+  - REST API
+  - TypeScript
 ---
 
 import {

--- a/src/content/docs/data-localization/faq.mdx
+++ b/src/content/docs/data-localization/faq.mdx
@@ -4,6 +4,8 @@ title: FAQs
 description: Answers to common questions about the Data Localization Suite and GDPR compliance.
 products:
   - data-localization
+tags:
+  - Compliance
 structured_data: true
 sidebar:
   order: 9

--- a/src/content/docs/data-localization/geo-key-manager.mdx
+++ b/src/content/docs/data-localization/geo-key-manager.mdx
@@ -4,6 +4,9 @@ title: Geo Key Manager
 description: Control the geographic storage location of your private SSL/TLS keys.
 products:
   - data-localization
+tags:
+  - TLS
+  - Compliance
 sidebar:
   order: 4
 

--- a/src/content/docs/data-localization/index.mdx
+++ b/src/content/docs/data-localization/index.mdx
@@ -4,6 +4,8 @@ pcx_content_type: overview
 description: Control where your data is inspected, processed, and stored with the Data Localization Suite.
 products:
   - data-localization
+tags:
+  - Compliance
 sidebar:
   order: 1
 head:

--- a/src/content/docs/data-localization/metadata-boundary/faq.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/faq.mdx
@@ -3,6 +3,8 @@ pcx_content_type: faq
 title: FAQs
 products:
   - data-localization
+tags:
+  - Compliance
 structured_data: true
 sidebar:
   order: 6

--- a/src/content/docs/data-localization/metadata-boundary/faq.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/faq.mdx
@@ -5,6 +5,7 @@ products:
   - data-localization
 tags:
   - Compliance
+  - Privacy
 structured_data: true
 sidebar:
   order: 6

--- a/src/content/docs/data-localization/metadata-boundary/graphql-datasets.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/graphql-datasets.mdx
@@ -4,6 +4,9 @@ title: GraphQL datasets
 description: GraphQL Analytics API fields that respect Customer Metadata Boundary configuration.
 products:
   - data-localization
+tags:
+  - GraphQL
+  - Analytics
 sidebar:
   order: 3
 ---

--- a/src/content/docs/data-localization/metadata-boundary/index.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/index.mdx
@@ -6,6 +6,7 @@ products:
   - data-localization
 tags:
   - Compliance
+  - Privacy
 sidebar:
   order: 5
 ---

--- a/src/content/docs/data-localization/metadata-boundary/index.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/index.mdx
@@ -4,6 +4,8 @@ title: Customer Metadata Boundary
 description: Restrict where customer traffic metadata and logs are stored by region.
 products:
   - data-localization
+tags:
+  - Compliance
 sidebar:
   order: 5
 ---

--- a/src/content/docs/data-localization/metadata-boundary/logpush-datasets.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/logpush-datasets.mdx
@@ -4,6 +4,8 @@ title: Logpush datasets
 description: Logpush datasets that support Customer Metadata Boundary by region.
 products:
   - data-localization
+tags:
+  - Logging
 sidebar:
   order: 4
 ---

--- a/src/content/docs/data-localization/region-support.mdx
+++ b/src/content/docs/data-localization/region-support.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Supported regions for Geo Key Manager, Regional Services, and Customer Metadata Boundary.
 products:
   - data-localization
+tags:
+  - Compliance
 sidebar:
   order: 2
 head:

--- a/src/content/docs/data-localization/regional-services/http-requests.mdx
+++ b/src/content/docs/data-localization/regional-services/http-requests.mdx
@@ -6,6 +6,7 @@ products:
   - data-localization
 tags:
   - TLS
+  - Privacy
 sidebar:
   order: 2
 ---

--- a/src/content/docs/data-localization/regional-services/http-requests.mdx
+++ b/src/content/docs/data-localization/regional-services/http-requests.mdx
@@ -4,6 +4,8 @@ title: Default HTTP Privacy
 description: How Cloudflare encrypts and processes HTTP requests across its global network.
 products:
   - data-localization
+tags:
+  - TLS
 sidebar:
   order: 2
 ---

--- a/src/content/docs/data-localization/regional-services/index.mdx
+++ b/src/content/docs/data-localization/regional-services/index.mdx
@@ -4,6 +4,8 @@ title: Regional Services
 description: Choose which data centers decrypt and service HTTPS traffic for your hostnames.
 products:
   - data-localization
+tags:
+  - Compliance
 sidebar:
   order: 6
 ---

--- a/src/content/docs/dmarc-management/dns-lookup-limits.mdx
+++ b/src/content/docs/dmarc-management/dns-lookup-limits.mdx
@@ -7,6 +7,8 @@ sidebar:
   order: 4
 head: []
 description: Review number of DNS lookups on your SPF records
+tags:
+  - DNS
 ---
 
 An [SPF record](https://www.cloudflare.com/learning/dns/dns-records/dns-spf-record/) lists which servers are authorized to send email for your domain. SPF records can reference other domains and services (for example, using `include:` or `mx` mechanisms), and each such reference requires a separate DNS lookup to verify. The [SPF specification (RFC 7208)](https://www.rfc-editor.org/rfc/rfc7208.html) limits the total number of these lookups to 10 per SPF check. If your SPF record exceeds this limit, receiving mail servers may treat the SPF check as a permanent error and reject or flag your emails.

--- a/src/content/docs/dmarc-management/enable.mdx
+++ b/src/content/docs/dmarc-management/enable.mdx
@@ -8,6 +8,8 @@ sidebar:
   order: 2
   badge:
     text: Beta
+tags:
+  - DNS
 
 ---
 

--- a/src/content/docs/dmarc-management/index.mdx
+++ b/src/content/docs/dmarc-management/index.mdx
@@ -7,6 +7,9 @@ head:
   - tag: title
     content: Overview
 description: Stop brand impersonation.
+tags:
+  - DNS
+  - Phishing
 ---
 
 import { Description, Plan, RelatedProduct } from "~/components";

--- a/src/content/docs/dmarc-management/security-records.mdx
+++ b/src/content/docs/dmarc-management/security-records.mdx
@@ -10,6 +10,8 @@ head:
     content: Configure email security records
 description: Learn how to configure SPF records, DKIM records, and DMARC records
   in your Cloudflare account to help improve email security.
+tags:
+  - DNS
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/dmarc-management/statistics.mdx
+++ b/src/content/docs/dmarc-management/statistics.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Review DMARC statistics
+tags:
+  - DNS
 
 ---
 

--- a/src/content/docs/key-transparency/api/auditor-information.mdx
+++ b/src/content/docs/key-transparency/api/auditor-information.mdx
@@ -4,6 +4,8 @@ title: Auditor
 description: Retrieve auditor public keys and verify epoch signatures.
 products:
   - key-transparency
+tags:
+  - REST API
 sidebar:
   order: 1
 ---

--- a/src/content/docs/key-transparency/api/epochs.mdx
+++ b/src/content/docs/key-transparency/api/epochs.mdx
@@ -4,6 +4,9 @@ title: Epochs
 description: Query epoch digests, audit proofs, and publication constraints.
 products:
   - key-transparency
+tags:
+  - REST API
+  - mTLS
 sidebar:
   order: 3
 ---

--- a/src/content/docs/key-transparency/api/namespaces.mdx
+++ b/src/content/docs/key-transparency/api/namespaces.mdx
@@ -4,6 +4,9 @@ title: Namespaces
 description: Create and manage namespaces representing logs monitored by the Cloudflare Auditor.
 products:
   - key-transparency
+tags:
+  - REST API
+  - mTLS
 sidebar:
   order: 2
 ---

--- a/src/content/docs/key-transparency/index.mdx
+++ b/src/content/docs/key-transparency/index.mdx
@@ -4,6 +4,8 @@ pcx_content_type: overview
 description: Secure public key distribution in end-to-end encrypted messaging systems.
 products:
   - key-transparency
+tags:
+  - Privacy
 sidebar:
   order: 1
 head:

--- a/src/content/docs/key-transparency/monitor-the-auditor/index.mdx
+++ b/src/content/docs/key-transparency/monitor-the-auditor/index.mdx
@@ -4,6 +4,8 @@ title: Monitor the Auditor
 description: Verify Key Transparency audit proofs locally using the Plexi CLI tool.
 products:
   - key-transparency
+tags:
+  - CLI
 sidebar:
   order: 2
 ---


### PR DESCRIPTION
### Summary
Adding tags to frontmatter based on tags.ts allowlist. This PR focuses on 8 AppSec docs sections, adding tags to 68 files.
Updated the tags.ts allowlist with 1 new tag in this batch, and merged before submitting PR.

### Documentation checklist
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.