### PR TITLE
Tagging AppSec docs sections, 2026 05 pt2

### DIFF
--- a/src/content/docs/bots/account-abuse-protection.mdx
+++ b/src/content/docs/bots/account-abuse-protection.mdx
@@ -4,6 +4,8 @@ title: Account Abuse Protection (Early Access)
 description: Detect and block automated abuse on login and registration endpoints.
 products:
   - bots
+tags:
+  - Account takeover
 sidebar:
   order: 6
   label: Account Abuse Protection

--- a/src/content/docs/bots/additional-configurations/block-ai-bots.mdx
+++ b/src/content/docs/bots/additional-configurations/block-ai-bots.mdx
@@ -6,6 +6,7 @@ products:
   - bots
 tags:
   - AI
+  - Scraping
 sidebar:
   order: 6
   label: Block AI Bots

--- a/src/content/docs/bots/additional-configurations/detection-ids/account-takeover-detections.mdx
+++ b/src/content/docs/bots/additional-configurations/detection-ids/account-takeover-detections.mdx
@@ -4,6 +4,8 @@ title: Account takeover detections
 description: Detection IDs for identifying and mitigating automated account takeover attacks.
 products:
   - bots
+tags:
+  - Account takeover
 sidebar:
   order: 3
 ---

--- a/src/content/docs/bots/additional-configurations/detection-ids/scraping-detections.mdx
+++ b/src/content/docs/bots/additional-configurations/detection-ids/scraping-detections.mdx
@@ -4,6 +4,8 @@ title: Scraping detections
 description: Detection IDs for identifying volumetric scraping attacks by ASN and fingerprint.
 products:
   - bots
+tags:
+  - Scraping
 sidebar:
   order: 3
 ---

--- a/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
+++ b/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
@@ -4,6 +4,9 @@ title: robots.txt setting
 description: Manage a robots.txt file to direct AI bot operators on content scraping permissions.
 products:
   - bots
+tags:
+  - Scraping
+  - AI
 sidebar:
   order: 8
   label: robots.txt setting

--- a/src/content/docs/bots/reference/sample-terms.mdx
+++ b/src/content/docs/bots/reference/sample-terms.mdx
@@ -4,6 +4,9 @@ title: Sample terms
 description: Example Terms of Service language for restricting AI bots and data scraping.
 products:
   - bots
+tags:
+  - Scraping
+  - AI
 sidebar:
   order: 5
 

--- a/src/content/docs/bots/reference/sample-terms.mdx
+++ b/src/content/docs/bots/reference/sample-terms.mdx
@@ -4,9 +4,6 @@ title: Sample terms
 description: Example Terms of Service language for restricting AI bots and data scraping.
 products:
   - bots
-tags:
-  - Scraping
-  - AI
 sidebar:
   order: 5
 

--- a/src/content/docs/dns/dns-firewall/analytics.mdx
+++ b/src/content/docs/dns/dns-firewall/analytics.mdx
@@ -9,6 +9,7 @@ sidebar:
 tags:
   - Analytics
   - GraphQL
+  - Logging
 ---
 
 import { Badge, FeatureTable, Details, DashButton } from "~/components";

--- a/src/content/docs/dns/dns-firewall/faq.mdx
+++ b/src/content/docs/dns/dns-firewall/faq.mdx
@@ -4,6 +4,8 @@ pcx_content_type: faq
 description: Find answers to common questions about Cloudflare's DNS Firewall, including cache behavior, EDNS support, and setting PTR records.
 products:
   - dns-firewall
+tags:
+  - Caching
 sidebar:
   order: 4
   label: FAQ

--- a/src/content/docs/dns/dns-firewall/index.mdx
+++ b/src/content/docs/dns/dns-firewall/index.mdx
@@ -4,6 +4,8 @@ title: DNS Firewall
 description: Protect and accelerate authoritative nameservers with DNS-level caching and DDoS mitigation.
 products:
   - dns-firewall
+tags:
+  - Caching
 sidebar:
   order: 15
 

--- a/src/content/docs/security-center/app-security-reports.mdx
+++ b/src/content/docs/security-center/app-security-reports.mdx
@@ -4,6 +4,8 @@ pcx_content_type: concept
 description: View account-wide application security reports covering WAF, bots, DDoS, and API Shield.
 products:
   - security-center
+tags:
+  - Analytics
 sidebar:
   order: 6
   badge:

--- a/src/content/docs/security-center/brand-protection.mdx
+++ b/src/content/docs/security-center/brand-protection.mdx
@@ -4,6 +4,9 @@ title: Brand Protection
 description: Detect phishing domains and impersonation attempts targeting your brand.
 products:
   - security-center
+tags:
+  - Phishing
+  - AI
 sidebar:
   order: 7
 ---

--- a/src/content/docs/security-center/cloudforce-one/index.mdx
+++ b/src/content/docs/security-center/cloudforce-one/index.mdx
@@ -4,6 +4,9 @@ title: Cloudforce One
 description: Access Cloudflare threat intelligence, reports, and automated security rules.
 products:
   - security-center
+tags:
+  - AI
+  - AI Agents
 sidebar:
   order: 5
 

--- a/src/content/docs/security-center/indicator-feeds.mdx
+++ b/src/content/docs/security-center/indicator-feeds.mdx
@@ -4,6 +4,8 @@ title: Custom Indicator Feeds
 description: Receive curated threat intelligence feeds from Cyber Defense Collaboration groups.
 products:
   - security-center
+tags:
+  - REST API
 sidebar:
   order: 8
 ---

--- a/src/content/docs/security-center/intel-apis/index.mdx
+++ b/src/content/docs/security-center/intel-apis/index.mdx
@@ -4,6 +4,8 @@ title: Threat Intelligence APIs
 description: Query Cloudflare threat intelligence data for IPs, domains, ASNs, and more.
 products:
   - security-center
+tags:
+  - REST API
 sidebar:
   order: 3
 ---

--- a/src/content/docs/ssl/keyless-ssl/configuration/cloudflare-tunnel.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/cloudflare-tunnel.mdx
@@ -4,6 +4,8 @@ pcx_content_type: get-started
 description: Deploy Keyless SSL with Cloudflare Tunnel for private connectivity.
 products:
   - ssl
+tags:
+  - Integration
 sidebar:
   order: 1
 head:

--- a/src/content/docs/ssl/keyless-ssl/configuration/public-dns.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/public-dns.mdx
@@ -4,6 +4,8 @@ pcx_content_type: get-started
 description: Deploy Keyless SSL with public DNS resolution.
 products:
   - ssl
+tags:
+  - DNS
 sidebar:
   order: 2
 head:

--- a/src/content/docs/ssl/keyless-ssl/index.mdx
+++ b/src/content/docs/ssl/keyless-ssl/index.mdx
@@ -4,6 +4,8 @@ description: Keep private keys on your own infrastructure while using Cloudflare
 products:
   - ssl
 title: Keyless SSL
+tags:
+  - TLS
 sidebar:
   order: 8
 ---

--- a/src/content/docs/ssl/keyless-ssl/reference/keyless-delegation.mdx
+++ b/src/content/docs/ssl/keyless-ssl/reference/keyless-delegation.mdx
@@ -4,6 +4,8 @@ description: Delegate certificate signing to downstream key servers.
 products:
   - ssl
 title: Keyless delegation
+tags:
+  - TLS
 sidebar:
   order: 7
 

--- a/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
+++ b/src/content/docs/ssl/keyless-ssl/troubleshooting.mdx
@@ -3,6 +3,8 @@ title: Troubleshooting
 pcx_content_type: troubleshooting
 products:
   - ssl
+tags:
+  - Debugging
 sidebar:
   order: 6
 head:

--- a/src/content/docs/tunnel/advanced/local-management/as-a-service/linux.mdx
+++ b/src/content/docs/tunnel/advanced/local-management/as-a-service/linux.mdx
@@ -4,6 +4,8 @@ description: Install and run cloudflared as a systemd service on Linux.
 products:
   - tunnel
 title: Linux
+tags:
+  - Linux
 sidebar:
   order: 31
 head:

--- a/src/content/docs/tunnel/advanced/local-management/as-a-service/macos.mdx
+++ b/src/content/docs/tunnel/advanced/local-management/as-a-service/macos.mdx
@@ -4,6 +4,8 @@ description: Install and run cloudflared as a launch agent on macOS.
 products:
   - tunnel
 title: macOS
+tags:
+  - MacOS
 sidebar:
   order: 31
 head:

--- a/src/content/docs/tunnel/advanced/local-management/as-a-service/windows.mdx
+++ b/src/content/docs/tunnel/advanced/local-management/as-a-service/windows.mdx
@@ -4,6 +4,8 @@ description: Install and run cloudflared as a Windows service.
 products:
   - tunnel
 title: Windows
+tags:
+  - Windows
 sidebar:
   order: 31
 head:

--- a/src/content/docs/tunnel/advanced/local-management/configuration-file.mdx
+++ b/src/content/docs/tunnel/advanced/local-management/configuration-file.mdx
@@ -4,6 +4,8 @@ description: Configure locally-managed tunnels with a YAML configuration file.
 products:
   - tunnel
 title: Configuration file
+tags:
+  - YAML
 sidebar:
   order: 2
 ---

--- a/src/content/docs/tunnel/advanced/local-management/tunnel-useful-commands.mdx
+++ b/src/content/docs/tunnel/advanced/local-management/tunnel-useful-commands.mdx
@@ -4,6 +4,8 @@ description: Common cloudflared commands for managing tunnels.
 products:
   - tunnel
 title: Useful commands
+tags:
+  - CLI
 sidebar:
   order: 6
 ---

--- a/src/content/docs/tunnel/advanced/run-parameters.mdx
+++ b/src/content/docs/tunnel/advanced/run-parameters.mdx
@@ -4,6 +4,8 @@ description: Command-line flags for running cloudflared tunnel.
 products:
   - tunnel
 title: Run parameters
+tags:
+  - CLI
 sidebar:
   order: 2
 ---

--- a/src/content/docs/tunnel/advanced/tunnel-tokens.mdx
+++ b/src/content/docs/tunnel/advanced/tunnel-tokens.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Manage tunnel authentication tokens for remote and local tunnels.
 products:
   - tunnel
+tags:
+  - Authentication
 sidebar:
   order: 4
 ---

--- a/src/content/docs/tunnel/deployment-guides/ansible.mdx
+++ b/src/content/docs/tunnel/deployment-guides/ansible.mdx
@@ -4,6 +4,8 @@ description: Deploy Cloudflare Tunnel with Ansible automation.
 products:
   - tunnel
 title: Ansible
+tags:
+  - Integration
 sidebar:
   order: 1
 ---

--- a/src/content/docs/tunnel/deployment-guides/aws.mdx
+++ b/src/content/docs/tunnel/deployment-guides/aws.mdx
@@ -6,6 +6,7 @@ products:
 title: AWS
 tags:
   - AWS
+  - Integration
 sidebar:
   order: 2
 head:

--- a/src/content/docs/tunnel/deployment-guides/aws.mdx
+++ b/src/content/docs/tunnel/deployment-guides/aws.mdx
@@ -4,6 +4,8 @@ description: Deploy Cloudflare Tunnel on Amazon Web Services.
 products:
   - tunnel
 title: AWS
+tags:
+  - AWS
 sidebar:
   order: 2
 head:

--- a/src/content/docs/tunnel/deployment-guides/azure.mdx
+++ b/src/content/docs/tunnel/deployment-guides/azure.mdx
@@ -6,6 +6,7 @@ products:
 title: Azure
 tags:
   - Azure
+  - Integration
 sidebar:
   order: 3
 head:

--- a/src/content/docs/tunnel/deployment-guides/azure.mdx
+++ b/src/content/docs/tunnel/deployment-guides/azure.mdx
@@ -4,6 +4,8 @@ description: Deploy Cloudflare Tunnel on Microsoft Azure.
 products:
   - tunnel
 title: Azure
+tags:
+  - Azure
 sidebar:
   order: 3
 head:

--- a/src/content/docs/tunnel/deployment-guides/google-cloud-platform.mdx
+++ b/src/content/docs/tunnel/deployment-guides/google-cloud-platform.mdx
@@ -6,6 +6,7 @@ products:
 title: GCP
 tags:
   - GCP
+  - Integration
 sidebar:
   order: 5
 ---

--- a/src/content/docs/tunnel/deployment-guides/google-cloud-platform.mdx
+++ b/src/content/docs/tunnel/deployment-guides/google-cloud-platform.mdx
@@ -4,6 +4,8 @@ description: Deploy Cloudflare Tunnel on Google Cloud Platform.
 products:
   - tunnel
 title: GCP
+tags:
+  - GCP
 sidebar:
   order: 5
 ---

--- a/src/content/docs/tunnel/deployment-guides/kubernetes.mdx
+++ b/src/content/docs/tunnel/deployment-guides/kubernetes.mdx
@@ -6,6 +6,7 @@ products:
 title: Kubernetes
 tags:
   - Kubernetes
+  - Integration
 sidebar:
   order: 6
 ---

--- a/src/content/docs/tunnel/deployment-guides/kubernetes.mdx
+++ b/src/content/docs/tunnel/deployment-guides/kubernetes.mdx
@@ -4,6 +4,8 @@ description: Deploy Cloudflare Tunnel on Kubernetes clusters.
 products:
   - tunnel
 title: Kubernetes
+tags:
+  - Kubernetes
 sidebar:
   order: 6
 ---

--- a/src/content/docs/tunnel/deployment-guides/terraform.mdx
+++ b/src/content/docs/tunnel/deployment-guides/terraform.mdx
@@ -3,6 +3,8 @@ pcx_content_type: how-to
 products:
   - tunnel
 title: Terraform
+tags:
+  - Terraform
 sidebar:
   order: 7
 head:

--- a/src/content/docs/tunnel/deployment-guides/terraform.mdx
+++ b/src/content/docs/tunnel/deployment-guides/terraform.mdx
@@ -5,6 +5,7 @@ products:
 title: Terraform
 tags:
   - Terraform
+  - Integration
 sidebar:
   order: 7
 head:

--- a/src/content/docs/tunnel/index.mdx
+++ b/src/content/docs/tunnel/index.mdx
@@ -3,6 +3,8 @@ pcx_content_type: overview
 products:
   - tunnel
 title: Cloudflare Tunnel
+tags:
+  - Post-quantum
 sidebar:
   order: 1
 description: Securely connect your origin servers, APIs, and services to Cloudflare with post-quantum encrypted tunnels — no public IPs required.

--- a/src/content/docs/tunnel/integrations.mdx
+++ b/src/content/docs/tunnel/integrations.mdx
@@ -3,6 +3,9 @@ pcx_content_type: reference
 products:
   - tunnel
 title: Integrations
+tags:
+  - Integration
+  - Private networks
 sidebar:
   order: 6
 description: Use Cloudflare Tunnel with Cloudflare One, Workers VPC, Load Balancing, Access, Spectrum, and other Cloudflare services.

--- a/src/content/docs/tunnel/monitoring.mdx
+++ b/src/content/docs/tunnel/monitoring.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Monitor tunnel health, connectors, and connection status.
 products:
   - tunnel
+tags:
+  - Logging
 sidebar:
   order: 5
 ---

--- a/src/content/docs/tunnel/troubleshooting.mdx
+++ b/src/content/docs/tunnel/troubleshooting.mdx
@@ -4,6 +4,8 @@ pcx_content_type: troubleshooting
 description: Resolve common Cloudflare Tunnel connection and configuration issues.
 products:
   - tunnel
+tags:
+  - Debugging
 sidebar:
   order: 8
 ---

--- a/src/content/docs/tunnel/tutorials/grafana.mdx
+++ b/src/content/docs/tunnel/tutorials/grafana.mdx
@@ -5,6 +5,8 @@ difficulty: Intermediate
 pcx_content_type: tutorial
 products:
   - tunnel
+tags:
+  - Grafana
 title: Monitor Cloudflare Tunnel with Grafana
 description: >-
   This tutorial covers how to create the metrics endpoint and set up the Prometheus server.

--- a/src/content/docs/tunnel/tutorials/grafana.mdx
+++ b/src/content/docs/tunnel/tutorials/grafana.mdx
@@ -7,6 +7,7 @@ products:
   - tunnel
 tags:
   - Grafana
+  - Integration
 title: Monitor Cloudflare Tunnel with Grafana
 description: >-
   This tutorial covers how to create the metrics endpoint and set up the Prometheus server.

--- a/src/content/docs/turnstile/additional-configuration/ephemeral-id.mdx
+++ b/src/content/docs/turnstile/additional-configuration/ephemeral-id.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Generate single-use Ephemeral IDs for fraud detection and analytics.
 products:
   - turnstile
+tags:
+  - Account takeover
 sidebar:
   order: 4
 ---

--- a/src/content/docs/turnstile/additional-configuration/hostname-management/pre-clearance.mdx
+++ b/src/content/docs/turnstile/additional-configuration/hostname-management/pre-clearance.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Configure Pre-clearance to reduce repeated challenges for visitors.
 products:
   - turnstile
+tags:
+  - Cookies
 sidebar:
   order: 3
 

--- a/src/content/docs/turnstile/extensions/google-firebase.mdx
+++ b/src/content/docs/turnstile/extensions/google-firebase.mdx
@@ -4,6 +4,9 @@ description: Integrate Turnstile with Google Firebase for server-side validation
 products:
   - turnstile
 title: Implement Turnstile with Google Firebase
+tags:
+  - Google
+  - Integration
 sidebar:
   order: 2
   label: Google Firebase

--- a/src/content/docs/turnstile/get-started/client-side-rendering/index.mdx
+++ b/src/content/docs/turnstile/get-started/client-side-rendering/index.mdx
@@ -4,6 +4,9 @@ pcx_content_type: get-started
 description: Embed a Turnstile widget on your website with JavaScript or HTML.
 products:
   - turnstile
+tags:
+  - JavaScript
+  - SPA
 sidebar:
   order: 3
 ---

--- a/src/content/docs/turnstile/get-started/client-side-rendering/widget-configurations.mdx
+++ b/src/content/docs/turnstile/get-started/client-side-rendering/widget-configurations.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Configure widget appearance, language, and callback functions.
 products:
   - turnstile
+tags:
+  - JavaScript
 sidebar:
   order: 5
 ---

--- a/src/content/docs/turnstile/get-started/index.mdx
+++ b/src/content/docs/turnstile/get-started/index.mdx
@@ -4,6 +4,8 @@ pcx_content_type: get-started
 description: Set up Turnstile to verify visitors without a traditional CAPTCHA.
 products:
   - turnstile
+tags:
+  - Forms
 sidebar:
   order: 4
 ---

--- a/src/content/docs/turnstile/get-started/mobile-implementation.mdx
+++ b/src/content/docs/turnstile/get-started/mobile-implementation.mdx
@@ -4,6 +4,9 @@ pcx_content_type: concept
 description: Implement Turnstile in native mobile applications.
 products:
   - turnstile
+tags:
+  - iOS
+  - Android
 sidebar:
   order: 6
 ---

--- a/src/content/docs/turnstile/get-started/server-side-validation.mdx
+++ b/src/content/docs/turnstile/get-started/server-side-validation.mdx
@@ -4,6 +4,8 @@ pcx_content_type: get-started
 description: Validate Turnstile tokens on your server with the siteverify API.
 products:
   - turnstile
+tags:
+  - REST API
 sidebar:
   order: 4
 ---

--- a/src/content/docs/turnstile/get-started/widget-management/api.mdx
+++ b/src/content/docs/turnstile/get-started/widget-management/api.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Create and manage Turnstile widgets using the Cloudflare API.
 products:
   - turnstile
+tags:
+  - REST API
 sidebar:
     order: 2
     label: API

--- a/src/content/docs/turnstile/get-started/widget-management/terraform.mdx
+++ b/src/content/docs/turnstile/get-started/widget-management/terraform.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Create and manage Turnstile widgets using the Terraform provider.
 products:
   - turnstile
+tags:
+  - Terraform
 sidebar:
     order: 3
     label: Terraform

--- a/src/content/docs/turnstile/index.mdx
+++ b/src/content/docs/turnstile/index.mdx
@@ -4,6 +4,8 @@ pcx_content_type: overview
 description: Verify visitors are human with a CAPTCHA-free, privacy-preserving alternative.
 products:
   - turnstile
+tags:
+  - Privacy
 sidebar:
   order: 1
 head:

--- a/src/content/docs/turnstile/migration/hcaptcha.mdx
+++ b/src/content/docs/turnstile/migration/hcaptcha.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Migrate from hCaptcha to Cloudflare Turnstile.
 products:
   - turnstile
+tags:
+  - Migration
 sidebar:
   order: 2
 ---

--- a/src/content/docs/turnstile/migration/index.mdx
+++ b/src/content/docs/turnstile/migration/index.mdx
@@ -4,6 +4,8 @@ pcx_content_type: navigation
 description: Migrate to Turnstile from reCAPTCHA or hCaptcha.
 products:
   - turnstile
+tags:
+  - Migration
 sidebar:
   order: 6
 ---

--- a/src/content/docs/turnstile/migration/recaptcha.mdx
+++ b/src/content/docs/turnstile/migration/recaptcha.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Migrate from Google reCAPTCHA to Cloudflare Turnstile.
 products:
   - turnstile
+tags:
+  - Migration
 sidebar:
   order: 1
 ---

--- a/src/content/docs/turnstile/reference/content-security-policy.mdx
+++ b/src/content/docs/turnstile/reference/content-security-policy.mdx
@@ -4,6 +4,9 @@ pcx_content_type: reference
 description: Content Security Policy directives required for Turnstile widgets.
 products:
   - turnstile
+tags:
+  - CSP
+  - Headers
 sidebar:
   order: 1
 ---

--- a/src/content/docs/turnstile/reference/supported-languages.mdx
+++ b/src/content/docs/turnstile/reference/supported-languages.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Languages supported by Cloudflare Turnstile widgets.
 products:
   - turnstile
+tags:
+  - Localization
 sidebar:
   order: 3
 

--- a/src/content/docs/turnstile/troubleshooting/client-side-errors/error-codes.mdx
+++ b/src/content/docs/turnstile/troubleshooting/client-side-errors/error-codes.mdx
@@ -4,6 +4,8 @@ pcx_content_type: troubleshooting
 description: Error codes returned by Turnstile widgets and their meanings.
 products:
   - turnstile
+tags:
+  - Debugging
 sidebar:
   order: 2
 ---

--- a/src/content/docs/turnstile/troubleshooting/client-side-errors/index.mdx
+++ b/src/content/docs/turnstile/troubleshooting/client-side-errors/index.mdx
@@ -4,6 +4,9 @@ pcx_content_type: troubleshooting
 description: Resolve client-side errors in Turnstile widget rendering.
 products:
   - turnstile
+tags:
+  - Debugging
+  - JavaScript
 sidebar:
   order: 3
 

--- a/src/content/docs/turnstile/troubleshooting/testing.mdx
+++ b/src/content/docs/turnstile/troubleshooting/testing.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Test your Turnstile implementation with test site keys.
 products:
   - turnstile
+tags:
+  - Debugging
 sidebar:
   order: 1
   label: Testing

--- a/src/content/docs/turnstile/turnstile-analytics/challenge-outcomes.mdx
+++ b/src/content/docs/turnstile/turnstile-analytics/challenge-outcomes.mdx
@@ -4,6 +4,8 @@ pcx_content_type: concept
 description: View challenge outcome metrics for your Turnstile widgets.
 products:
   - turnstile
+tags:
+  - Analytics
 sidebar:
   order: 2
 ---

--- a/src/content/docs/turnstile/turnstile-analytics/index.mdx
+++ b/src/content/docs/turnstile/turnstile-analytics/index.mdx
@@ -3,6 +3,8 @@ title: Turnstile Analytics
 pcx_content_type: how-to
 products:
   - turnstile
+tags:
+  - Analytics
 sidebar:
   order: 5
 description: Use Turnstile Analytics to view the number of challenges issued,

--- a/src/content/docs/turnstile/turnstile-analytics/token-validation.mdx
+++ b/src/content/docs/turnstile/turnstile-analytics/token-validation.mdx
@@ -4,6 +4,8 @@ pcx_content_type: concept
 description: View token validation metrics for your Turnstile widgets.
 products:
   - turnstile
+tags:
+  - Analytics
 sidebar:
   order: 3
 ---

--- a/src/content/docs/turnstile/tutorials/fraud-detection-with-ephemeral-ids.mdx
+++ b/src/content/docs/turnstile/tutorials/fraud-detection-with-ephemeral-ids.mdx
@@ -8,6 +8,7 @@ tags:
   - JavaScript
   - Node.js
   - SQL
+  - Account takeover
 sidebar:
   order: 4
 description: >-

--- a/src/content/docs/turnstile/tutorials/integrating-turnstile-waf-and-bot-management.mdx
+++ b/src/content/docs/turnstile/tutorials/integrating-turnstile-waf-and-bot-management.mdx
@@ -6,6 +6,7 @@ difficulty: Beginner
 products: [waf, bots]
 tags:
   - JavaScript
+  - Authentication
 sidebar:
   order: 3
 description: >-

--- a/src/content/docs/turnstile/tutorials/login-pages.mdx
+++ b/src/content/docs/turnstile/tutorials/login-pages.mdx
@@ -8,6 +8,8 @@ difficulty: Beginner
 tags:
   - JavaScript
   - Node.js
+  - Forms
+  - Authentication
 sidebar:
   order: 2
 description: >-

--- a/src/content/docs/web3/ethereum-gateway/reference/rinkeby-deprecation.mdx
+++ b/src/content/docs/web3/ethereum-gateway/reference/rinkeby-deprecation.mdx
@@ -4,6 +4,8 @@ description: Deprecation notice for the Rinkeby test network.
 products:
   - web3
 title: Rinkeby deprecation
+tags:
+  - Migration
 sidebar:
   order: 5
 

--- a/src/content/docs/web3/ethereum-gateway/reference/supported-api-methods.mdx
+++ b/src/content/docs/web3/ethereum-gateway/reference/supported-api-methods.mdx
@@ -4,6 +4,8 @@ description: Ethereum JSON-RPC methods supported by the Cloudflare gateway.
 products:
   - web3
 title: Supported API methods
+tags:
+  - JSON
 sidebar:
   order: 1
 head:

--- a/src/content/docs/web3/how-to/use-ethereum-gateway.mdx
+++ b/src/content/docs/web3/how-to/use-ethereum-gateway.mdx
@@ -4,6 +4,8 @@ description: Send JSON-RPC requests through the Cloudflare Ethereum Gateway.
 products:
   - web3
 title: Use Ethereum gateway
+tags:
+  - JSON
 sidebar:
   order: 2
 ---

--- a/src/content/docs/web3/ipfs-gateway/concepts/dnslink.mdx
+++ b/src/content/docs/web3/ipfs-gateway/concepts/dnslink.mdx
@@ -4,6 +4,8 @@ description: Use DNSLink to map domain names to IPFS content.
 products:
   - web3
 title: DNSLink gateways
+tags:
+  - DNS
 sidebar:
   order: 4
 

--- a/src/content/docs/web3/ipfs-gateway/troubleshooting.mdx
+++ b/src/content/docs/web3/ipfs-gateway/troubleshooting.mdx
@@ -4,6 +4,8 @@ description: Resolve common IPFS Gateway issues including 523 and 524 errors.
 products:
   - web3
 title: Troubleshooting
+tags:
+  - Debugging
 sidebar:
   order: 11
 

--- a/src/content/docs/web3/reference/gateway-dns-records.mdx
+++ b/src/content/docs/web3/reference/gateway-dns-records.mdx
@@ -4,6 +4,8 @@ description: DNS records created for Web3 gateways.
 products:
   - web3
 title: Gateway DNS records
+tags:
+  - DNS
 sidebar:
   order: 1
 

--- a/src/content/docs/web3/reference/migration-guide.mdx
+++ b/src/content/docs/web3/reference/migration-guide.mdx
@@ -4,6 +4,8 @@ description: Migrate from legacy Web3 gateways to the current setup.
 products:
   - web3
 title: Legacy gateway migration
+tags:
+  - Migration
 sidebar:
   order: 4
 


### PR DESCRIPTION
### Summary
Adding relevant tags to front matter of AppSec docs pages, tagging 68 files across 7 sections (tiles).


### Documentation checklist
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
