### PR TITLE
[Cache] ELI5 on advanced configuration pages

### DIFF
--- a/src/content/docs/cache/advanced-configuration/cache-reserve.mdx
+++ b/src/content/docs/cache/advanced-configuration/cache-reserve.mdx
@@ -14,9 +14,9 @@ import { Render, TabItem, Tabs, APIRequest, DashButton } from "~/components";
 
 ![Content served from origin and getting cached in Cache Reserve, and Edge Cache Data Centers (T1=upper-tier, T2=lower-tier) on its way back to the client](~/assets/images/cache/content-being-served.png)
 
-How long content in Cache Reserve will be considered “fresh” is determined by Edge Cache TTL setting or Cache-Control headers at your origin, if [Edge Cache TTL](/cache/how-to/edge-browser-cache-ttl/#edge-cache-ttl) is not set. After freshness expires, Cloudflare will attempt to revalidate the asset when a subsequent request arrives in Cache Reserve for the asset. This is the same behavior as in Cloudflare's regular CDN.
+Content in Cache Reserve is considered fresh based on the [Edge Cache TTL](/cache/how-to/edge-browser-cache-ttl/#edge-cache-ttl) setting, or your origin's `Cache-Control` headers if Edge Cache TTL is not set. After the freshness period expires, Cloudflare revalidates the asset with your origin the next time it is requested. This is the same behavior as in Cloudflare's regular CDN.
 
-The retention period of an asset is how long we will keep the asset in Cache Reserve before marking it for eviction. Cache Reserve starts with a retention period of 30 days. If an asset is not requested within the retention period, it will be evicted from Cache Reserve. Accessing the asset will refresh the retention period.
+The retention period controls how long an asset stays in Cache Reserve before it is removed. Cache Reserve starts with a retention period of 30 days. If an asset is not requested within the retention period, it is removed from Cache Reserve. Requesting the asset resets the retention period.
 
 Assets must [meet certain criteria](#cache-reserve-asset-eligibility) to use Cache Reserve.
 
@@ -24,7 +24,7 @@ Cache Reserve is a usage-based product and [pricing](#pricing) is detailed below
 
 ## Enable Cache Reserve
 
-A paid Cache Reserve Plan is required for the enablement.
+A paid Cache Reserve plan is required.
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
@@ -147,7 +147,7 @@ the estimated cost for the month would be:
 
 ## Tips and best practices
 
-Cache Reserve should be used with [Tiered Cache](/cache/how-to/tiered-cache/) enabled. Cache Reserve is designed for use with Tiered Cache enabled for maximum origin shielding. Using Cache Reserve without Tiered Cache may result in higher storage operation costs. Enabling Cache Reserve via the Cloudflare dashboard will check and provide a warning if you try to use Cache Reserve without Tiered Cache enabled.
+Cache Reserve is designed for use with [Tiered Cache](/cache/how-to/tiered-cache/) enabled for maximum origin shielding. Using Cache Reserve without Tiered Cache may result in higher storage operation costs. The Cloudflare dashboard will warn you if you try to enable Cache Reserve without Tiered Cache.
 
 ## Cache Reserve Analytics
 

--- a/src/content/docs/cache/advanced-configuration/crawler-hints.mdx
+++ b/src/content/docs/cache/advanced-configuration/crawler-hints.mdx
@@ -19,7 +19,7 @@ With Crawler Hints, Cloudflare can proactively tell a crawler about the best tim
 
 ## Benefits
 
-Crawler Hints helps search engines and other bot-powered services serve the freshest version of your content, which can improve search rankings.
+Crawler Hints help search engines and other bot-powered services serve the freshest version of your content, which can improve search rankings.
 
 Crawler Hints also reduces unnecessary crawl traffic to your origin, lowering resource consumption and improving site performance.
 

--- a/src/content/docs/cache/advanced-configuration/crawler-hints.mdx
+++ b/src/content/docs/cache/advanced-configuration/crawler-hints.mdx
@@ -9,7 +9,7 @@ title: Crawler Hints
 
 import { FeatureTable, DashButton } from "~/components"
 
-Crawler Hints aims to increase the proportion of relevant crawls and limit crawls that do not find fresh content to reduce the need for repeated crawls.
+Crawler Hints uses Cloudflare cache signals to tell search engines when your content has likely changed, so they crawl your site at the right time instead of guessing.
 
 ## Background
 
@@ -19,9 +19,9 @@ With Crawler Hints, Cloudflare can proactively tell a crawler about the best tim
 
 ## Benefits
 
-For a website owner, Crawler Hints ensures that search engines and other bot-powered experiences have the freshest version of your content, translating into happier users and ultimately influencing search rankings.
+Crawler Hints helps search engines and other bot-powered services serve the freshest version of your content, which can improve search rankings.
 
-Crawler Hints also means less traffic hitting your origin, improving resource consumption, site performance, and environmental impact.
+Crawler Hints also reduces unnecessary crawl traffic to your origin, lowering resource consumption and improving site performance.
 
 ## Availability
 

--- a/src/content/docs/cache/advanced-configuration/early-hints.mdx
+++ b/src/content/docs/cache/advanced-configuration/early-hints.mdx
@@ -9,9 +9,9 @@ products:
 
 import { FeatureTable, DashButton } from "~/components"
 
-Early Hints takes advantage of “server think time” to asynchronously send instructions to the browser to begin loading resources while the origin server is compiling the full response. By sending these hints to a browser before the full response is prepared, the browser can figure out how to load the webpage faster for the end user.
+When a browser requests a page, the origin server takes time to prepare the full response. Early Hints uses this wait time to send the browser a preliminary `103` response containing `Link` headers that tell the browser which assets it will need. The browser can start loading those assets before the full response arrives, which speeds up page loads.
 
-Formally, Early Hints is a [web standard](https://httpwg.org/specs/rfc8297.html) that defines a new HTTP status code (103 Early Hints) that defines new interactions between a client and server. 103s are served to clients while a 200 OK (or error) response is prepared, which is the “server think time.” You can enable Cloudflare's edge to cache and send 103 Early Hints responses with Link headers from your HTML pages. The response contains hints about which assets will likely be needed to fully render the webpage. This "hinting" speeds up page loads and generally reduces user-perceived latency.
+Early Hints is defined in [RFC 8297](https://httpwg.org/specs/rfc8297.html) as a new HTTP status code (`103 Early Hints`). Cloudflare's edge caches and serves these `103` responses with `Link` headers from your HTML pages, reducing user-perceived latency.
 
 :::note[Note]
 

--- a/src/content/docs/cache/advanced-configuration/early-hints.mdx
+++ b/src/content/docs/cache/advanced-configuration/early-hints.mdx
@@ -11,7 +11,7 @@ import { FeatureTable, DashButton } from "~/components"
 
 When a browser requests a page, the origin server takes time to prepare the full response. Early Hints uses this wait time to send the browser a preliminary `103` response containing `Link` headers that tell the browser which assets it will need. The browser can start loading those assets before the full response arrives, which speeds up page loads.
 
-Early Hints is defined in [RFC 8297](https://httpwg.org/specs/rfc8297.html) as a new HTTP status code (`103 Early Hints`). Cloudflare's edge caches and serves these `103` responses with `Link` headers from your HTML pages, reducing user-perceived latency.
+Early Hints is defined in [RFC 8297](https://httpwg.org/specs/rfc8297.html) as a new HTTP status code (`103 Early Hints`). Cloudflare caches and serves these `103` responses with `Link` headers from your HTML pages, reducing user-perceived latency.
 
 :::note[Note]
 

--- a/src/content/docs/cache/advanced-configuration/vary-for-images.mdx
+++ b/src/content/docs/cache/advanced-configuration/vary-for-images.mdx
@@ -9,11 +9,11 @@ products:
 
 import { Details, FeatureTable, APIRequest } from "~/components"
 
-`Vary` is an HTTP response header that allows origins to serve variants of the same content that can be used depending on the browser sending the request.
+The `Vary` HTTP response header tells Cloudflare that an origin can serve different versions of the same resource depending on the request headers. For images, this allows your origin to serve modern formats like WebP or AVIF to browsers that support them, while continuing to serve JPEG or PNG to others.
 
-Cloudflare sits in between the browser and the origin. When Cloudflare receives the origin’s response, the specific image variant is cached so that subsequent requests from browsers with the same image preferences can be served from cache. This also means that serving multiple image variants for the same asset will create distinct cache entries.
+When Cloudflare receives a response with image variants, it caches each variant separately. Subsequent requests from browsers with the same image format preferences are served directly from cache without contacting your origin.
 
-`Vary` for Images reduces the content-negotiation process by parsing a request’s `Accept` header, which is sent to the origin to deliver the correct content to the browser.
+Vary for Images works by parsing the `Accept` header in each request to determine which image format the browser supports, then serving the matching cached variant.
 
 Vary for images is available for Pro, Business, and Enterprise customers.
 
@@ -43,7 +43,7 @@ You can use vary for images on the file extensions below if the origin server se
 
 ## Enable vary for images
 
-Vary for Images is enabled through Cloudflare’s API by creating a variants rule. In the examples below, learn how to serve JPEG, WebP, and AVIF variants for `.jpeg` and `.jpg` extensions.
+Vary for Images is enabled through Cloudflare's API by creating a variants rule. In the examples below, learn how to serve JPEG, WebP, and AVIF variants for `.jpeg` and `.jpg` extensions.
 
 ### Create a variants rule
 


### PR DESCRIPTION
### Summary

ELI5 pass on the 7 files in `/cache/advanced-configuration/`. Three files had no changes needed: `index.mdx` (navigation page), `query-string-sort.mdx` (well-written with good examples), and `serve-tailored-content.mdx` (developer-focused code examples, clear for audience). Four files were improved.

**Key changes:**

- **`cache-reserve.mdx`:** Removed scare-quoted "fresh" and restructured the sentence for clarity. Replaced first-person "we will keep" with direct phrasing. Simplified "A paid Cache Reserve Plan is required for the enablement" → "A paid Cache Reserve plan is required." Removed redundant sentence in the Tiered Cache tips section (said the same thing twice).
- **`crawler-hints.mdx`:** Replaced the dense opening (uses "crawls" three times in one sentence) with a clearer explanation. Removed marketing language ("happier users," "environmental impact"). Ensured the mechanism description accurately reflects that Crawler Hints uses cache MISS signals as a heuristic, not direct content change detection.
- **`early-hints.mdx`:** Rewrote the two dense opening paragraphs. Replaced scare-quoted "server think time" with a plain-language explanation of what happens when a browser requests a page. Made the 103 status code and Link headers concrete instead of abstract.
- **`vary-for-images.mdx`:** Rewrote the opening paragraphs to clearly explain what `Vary` does, how Cloudflare caches variants separately, and what the `Accept` header parsing achieves. Correctly attributed format fallback to the origin (not Cloudflare).

All changes verified through adversarial fact-check review. The review caught and corrected: Crawler Hints intro overstating the mechanism, Vary for Images misattributing format fallback to Cloudflare, and an overly narrow example list for Early Hints assets.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
