### PR TITLE
[Cache] ELI5 on concepts pages

### DIFF
--- a/src/content/docs/cache/concepts/cache-behavior.mdx
+++ b/src/content/docs/cache/concepts/cache-behavior.mdx
@@ -9,7 +9,7 @@ tags:
   - Cookies
 ---
 
-In this page, we document how Cloudflare's cache system behaves in interaction with:
+This page describes how Cloudflare's cache system behaves in interaction with:
 
 * `HEAD` requests
 * `Set-Cookie` response headers
@@ -18,7 +18,7 @@ In this page, we document how Cloudflare's cache system behaves in interaction w
 
 Cloudflare converts `HEAD` requests to `GET` requests for [cacheable requests](/cache/concepts/default-cache-behavior/#default-cached-file-extensions).
 
-When you make a `HEAD` request for a cacheable resource and Cloudflare does not have that resource in the edge cache, a cache miss happens. Cloudflare will send a `GET` request to your origin, cache the full response and return the response headers only. Make sure the origin server is setup to handle `GET` requests, even if only `HEAD` requests are expected, so that compatibility with this behavior is ensured.
+When you make a `HEAD` request for a cacheable resource and Cloudflare does not have that resource in the edge cache, a cache miss happens. Cloudflare will send a `GET` request to your origin, cache the full response and return the response headers only. Make sure the origin server is set up to handle `GET` requests, even if only `HEAD` requests are expected, so that compatibility with this behavior is ensured.
 
 ## Interaction of `Set-Cookie` response header with Cache
 

--- a/src/content/docs/cache/concepts/cache-control.mdx
+++ b/src/content/docs/cache/concepts/cache-control.mdx
@@ -21,7 +21,7 @@ With the Origin Cache Control feature enabled, `Cache-Control` directives presen
 
 Cloudflare's [Cache Rules](/cache/how-to/cache-rules/) allows users to either augment or override an origin server's `Cache-Control` headers or [default policies](/cache/concepts/default-cache-behavior/) set by Cloudflare.
 
-In the following sections, we will provide more details regarding:
+The following sections cover:
 
 * The most common `Cache-Control` directives.
 * How to enable Origin Cache Control.
@@ -303,7 +303,7 @@ This configuration indicates the asset is fresh for 600 seconds. The asset can b
 
 ## Interaction with other Cloudflare features
 
-In this section, we provide details regarding how other Cloudflare features interact with `Cache-Control` directives.
+This section covers how other Cloudflare features interact with `Cache-Control` directives.
 
 ### Edge Cache TTL
 

--- a/src/content/docs/cache/concepts/default-cache-behavior.mdx
+++ b/src/content/docs/cache/concepts/default-cache-behavior.mdx
@@ -90,7 +90,7 @@ Cloudflare’s CDN provides several cache customization options:
 
 Customers can reduce the **Maximum Upload Size** from the zone's **Network** page.
 
-If you require a larger upload, you can group requests into smaller chunks, upload the full resource through an [unproxied (grey-clouded) DNS record](/dns/proxy-status/) or [upgrade your plan](/billing/manage/change-plan/).
+If you require a larger upload, you can group requests into smaller chunks, upload the full resource through a [DNS-only (unproxied) DNS record](/dns/proxy-status/) or [upgrade your plan](/billing/manage/change-plan/).
 
 ### Cacheable size limits
 

--- a/src/content/docs/cache/concepts/retention-vs-freshness.mdx
+++ b/src/content/docs/cache/concepts/retention-vs-freshness.mdx
@@ -11,11 +11,13 @@ In the context of Cloudflare CDN (Content Delivery Network), retention and fresh
 
 ## Retention
 
-When a file or resource is requested from a website, Cloudflare caches it to avoid having to ask the origin server for it again the next time it is requested, reducing latency and improving delivery speed. But if an object in cache does not get requested again, eventually it will be removed to make room for newer, more popular objects. This process is called eviction and is a standard part of cache management. When the cache wants to store a new object but does not have room, it uses an algorithm called Least Recently Used, or LRU, to nominate an object to evict and replace it with the new one. An object’s cache retention period refers to the duration the object is stored in Cloudflare’s cache before being evicted. It is worth noting that an object’s retention period is a function of its relative popularity and the size of Cloudflare’s caches, and therefore is not configurable.
+When a resource is requested, Cloudflare caches it so that subsequent requests can be served without contacting the origin server. If a cached object is not requested again, it is eventually removed to make room for newer, more popular content. This removal process is called eviction.
+
+Cloudflare uses a Least Recently Used (LRU) algorithm to decide which objects to evict when the cache is full. An object's retention period is how long it stays in cache before being evicted. Retention is determined by the object's relative popularity and the size of the cache, and is not configurable.
 
 ## Freshness (TTL)
 
-The time window that an object should be considered safe for a cache to use is dictated by its freshness, also known as Time to Live (TTL). If an object has a TTL of five minutes that means that, starting from the moment the cache first receives the object, for the next five minutes the cache can use that object without checking with the origin again. After five minutes have passed, if Cloudflare gets another request for that object, we cannot use what is stored in the cache without first checking the origin to see if the object is still valid. Those first five minutes in this object’s case are its freshness period. There are a few ways to configure TTLs for resources served through Cloudflare’s Content Delivery Network:
+Freshness, also known as Time to Live (TTL), determines how long a cache can use an object without checking with the origin again. For example, if an object has a TTL of five minutes, the cache serves it directly for five minutes after first receiving it. After five minutes, Cloudflare must check with the origin to confirm the object is still valid before serving it again. There are a few ways to configure TTLs for resources served through Cloudflare's CDN:
 
 * Include [Origin Cache Control](/cache/concepts/cache-control/) or [CDN Cache Control](/cache/concepts/cache-control/) directives, like `max-age` or `s-maxage`, in the origin cache-control response header.
 


### PR DESCRIPTION
### Summary

ELI5 pass on the 9 files in `/cache/concepts/`. Five files had no changes needed (`index.mdx`, `cache-responses.mdx`, `cdn-cache-control.mdx`, `customize-cache.mdx`, `revalidation.mdx`). Four files were improved with surgical edits.

**Key changes:**

- **`cache-behavior.mdx`:** Replaced first-person "we document" with "This page describes." Fixed "setup" → "set up" (grammar).
- **`cache-control.mdx`:** Replaced two instances of first-person voice ("we will provide," "we provide") with direct phrasing.
- **`default-cache-behavior.mdx`:** Updated "unproxied (grey-clouded)" to "DNS-only (unproxied)" to match canonical terminology in `/dns/proxy-status/`.
- **`retention-vs-freshness.mdx`:** Broke the retention section from a single dense paragraph into two focused paragraphs. Rewrote the freshness section to lead with a definition instead of a convoluted clause ("The time window that an object should be considered safe for a cache to use is dictated by its freshness"). Removed first-person "we cannot use what is stored in the cache."

All changes verified through adversarial fact-check review — no factual inaccuracies found.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
