### PR TITLE
feat: remove tooltips from Copy and View as Markdown page actions

### DIFF
--- a/src/components/PageActions.astro
+++ b/src/components/PageActions.astro
@@ -23,7 +23,6 @@ const iconScroll = phosphorIcon("scroll");
 	<button
 		class="not-content"
 		id="page-actions-copy"
-		data-tooltip="Copy Page as Markdown"
 		aria-label="Copy Page as Markdown"
 	>
 		<svg class="copy-icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 256 256" fill="currentColor" set:html={iconCopy} />
@@ -40,7 +39,6 @@ const iconScroll = phosphorIcon("scroll");
 	<a
 		class="not-content"
 		id="page-actions-view-md"
-		data-tooltip="View Page as Markdown"
 		aria-label="View Page as Markdown"
 		href="index.md"
 		target="_blank"


### PR DESCRIPTION
### Summary

Removes the Tippy.js tooltips from the first two items in the page actions bar ("Copy as Markdown" and "View as Markdown"). The label text is already visible inline, so the tooltips are redundant. The `aria-label` attributes are preserved for accessibility.
