### PR TITLE
Increase maximum serialized size for WebSocket attachments

### DIFF
--- a/src/content/docs/durable-objects/best-practices/websockets.mdx
+++ b/src/content/docs/durable-objects/best-practices/websockets.mdx
@@ -335,7 +335,7 @@ Key behaviors:
 - If either side closes the connection, attachments are lost
 - Modifications to `value` after calling this method are not retained unless you call it again
 - The `value` can be any type supported by the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
-- Maximum serialized size is 2,048 bytes
+- Maximum serialized size is 16,384 bytes
 
 For larger values or data that must persist beyond WebSocket lifetime, use the [Storage API](/durable-objects/api/sqlite-storage-api/) and store the corresponding key as an attachment.
 


### PR DESCRIPTION

### Summary

The maximum size of the WebSocket attachments was bumped in this commit

https://github.com/cloudflare/workerd/commit/a7a6250582e32e3338149bc7645350a9e258772d

This updates the documentation to match

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
