### PR TITLE
[Cache] ELI5: Simplify interaction-cloudflare-products docs

### DIFF
--- a/src/content/docs/cache/interaction-cloudflare-products/index.mdx
+++ b/src/content/docs/cache/interaction-cloudflare-products/index.mdx
@@ -13,6 +13,6 @@ sidebar:
 
 import { DirectoryListing } from "~/components"
 
-Review the following topics to learn more about how Cache interacts with other Cloudflare products.
+Cloudflare caches content at data centers close to your visitors so your origin server handles fewer requests. The pages below explain how caching works when you also use Workers, R2 storage, or WAF security rules, and what to watch out for when combining them.
 
 <DirectoryListing />

--- a/src/content/docs/cache/interaction-cloudflare-products/r2.mdx
+++ b/src/content/docs/cache/interaction-cloudflare-products/r2.mdx
@@ -12,23 +12,32 @@ head:
 
 ---
 
-To enable caching for a [Cloudflare R2](/r2/) bucket, make sure your bucket is public and accessible by the Cache. This can be done by creating a [Custom Domain](/r2/buckets/public-buckets/#custom-domains). Follow these steps to set up a Custom Domain for your bucket:
+By default, R2 buckets are private. To serve R2 objects through Cloudflare's cache, you need to attach a domain name you control — called a [Custom Domain](/r2/buckets/public-buckets/#custom-domains) — to the bucket. This creates a public URL backed by Cloudflare's network, so requests for your stored files go through Cloudflare's cache instead of hitting R2 directly every time.
+
+Follow these steps to set up a Custom Domain for your bucket:
 
 1. Go to **R2** and select your bucket.
 2. On the bucket page, select **Settings**.
 3. Under **Public access** > **Custom Domains**, select **Connect Domain**.
 4. Enter the domain name you want to connect to and select **Continue**.
-5. Review the new record that will be added to the DNS table and select **Connect Domain**.
+5. Review the new DNS record that will be added and select **Connect Domain**.
 
-This will generate a publicly available CNAME in the format `[name].domain.com`.
+Cloudflare automatically adds a CNAME record that maps your domain to the bucket, generating a publicly available URL in the format `[name].domain.com`.
+
+:::note
+The development URL (`r2.dev`) does not support caching, WAF, or bot management. You must use a Custom Domain for these features.
+:::
 
 ## Tiered Cache
 
-By default Cloudflare will cache R2 content based on [cache rules](/cache/how-to/cache-rules/) at the Edge only.
+By default, Cloudflare caches R2 content at edge data centers (the data centers closest to visitors) based on [cache rules](/cache/how-to/cache-rules/). Each edge data center that gets a cache miss fetches content directly from R2.
 
-Tiered cache can be enabled by configuring [Smart Tiered Cache](/cache/how-to/tiered-cache/#smart-tiered-cache) which will select an Upper Tier data center next to your R2 bucket for optimal performance.
+[Tiered Cache](/cache/how-to/tiered-cache/) changes this by organizing data centers into a hierarchy. When a nearby data center has a cache miss, it first checks a designated upper-tier data center before going to R2. This reduces the number of requests that reach R2.
+
+To enable Tiered Cache for R2, configure [Smart Tiered Cache](/cache/how-to/tiered-cache/#smart-tiered-cache), which automatically selects the upper-tier data center with the lowest latency to your R2 bucket.
 
 ## Additional considerations
 
-- Apply access controls to your newly public bucket. Refer to [Control cache access with WAF and Snippets](/cache/interaction-cloudflare-products/waf-snippets/) for more information.
-- Be aware of the [cacheable size limits](/cache/concepts/default-cache-behavior/#cacheable-size-limits) for files.
+- **Access controls**: When you connect a Custom Domain, your R2 bucket becomes publicly accessible. Apply access controls to restrict who can request your files. Refer to [Control cache access with WAF and Snippets](/cache/interaction-cloudflare-products/waf-snippets/) for more information.
+- **Cacheable size limits**: Files that exceed the [cacheable size limits](/cache/concepts/default-cache-behavior/#cacheable-size-limits) are not cached. Free, Pro, and Business plans have a limit of 512 MB per file. Enterprise plans default to 5 GB per file.
+- **Default cached file types**: Cloudflare does not cache all file types by default. For example, HTML and JSON are not cached unless you create a [Cache Rule](/cache/how-to/cache-rules/) with the appropriate settings.

--- a/src/content/docs/cache/interaction-cloudflare-products/waf-snippets.mdx
+++ b/src/content/docs/cache/interaction-cloudflare-products/waf-snippets.mdx
@@ -13,9 +13,9 @@ head:
     content: Control cache access with WAF and Snippets
 ---
 
-To limit access to the public bucket created for caching content, you can use Cloudflare's [WAF](/waf/custom-rules/use-cases/configure-token-authentication/). The WAF provides an additional security layer to filter requests and ensure that only authorized traffic reaches your bucket. 
+When you make an R2 bucket publicly accessible for caching (via a [Custom Domain](/r2/buckets/public-buckets/#custom-domains)), anyone who knows the URL can access the content. To restrict access, you can use Cloudflare's [WAF](/waf/custom-rules/use-cases/configure-token-authentication/) to validate requests before they reach the cache or your bucket.
 
-The following diagram illustrates the flow of a user's request through WAF, Cache, and R2.
+The following diagram illustrates the flow of a request through WAF, Cache, and R2. WAF custom rules run before cache rules in the [request pipeline](/ruleset-engine/reference/phases-list/), so invalid requests are blocked before consuming cache resources.
 
 ```mermaid
 flowchart LR
@@ -25,15 +25,15 @@ A[User's request] --> B[WAF] --> C[Cache] --> D[R2]
 
 <br/>
 
-The WAF product uses token authentication to either sign or authenticate a request. You can then use this in either Workers or Snippets to control access.
-
 ## Presigned URLs
 
-You can presign URLs similar to [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html), enabling you to share direct access to your content with a with an associated timeout. This approach can be implemented using a combination of Snippets, Rules, or Cloudflare Workers.
+A presigned URL is a regular URL with a cryptographic token appended to it. The token contains a hash-based message authentication code (HMAC) computed from the URL path, a timestamp, and a secret key shared between the signing service and the validator. Anyone with the URL can access the content until the token expires, but the token cannot be reused for a different URL path.
 
-For optimal performance, we recommend separating the creation and validation processes as follows:
+You can presign URLs similar to [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html), enabling you to share direct access to your content with an associated timeout. This approach can be implemented using a combination of Snippets, Rules, or Cloudflare Workers.
 
-- [Snippets](/rules/snippets/examples/signing-requests/) for HMAC creation
-- [Rules](/ruleset-engine/rules-language/functions/#hmac-validation) for HMAC validation
+For optimal performance, we recommend separating the creation and validation processes:
 
-In the Workers documentation, in the section [Signing requests](/workers/examples/signing-requests/), you can also find an example of how to verify a signed request using the HMAC.
+- [Snippets](/rules/snippets/examples/signing-requests/) for HMAC creation (signing the URL)
+- [WAF custom rules](/ruleset-engine/rules-language/functions/#hmac-validation) for HMAC validation (verifying the token on each request)
+
+In the Workers documentation, the [Signing requests](/workers/examples/signing-requests/) example shows how to both generate and verify signed requests using HMAC. The Workers implementation is compatible with the WAF's [`is_timed_hmac_valid_v0()` validation function](/waf/custom-rules/use-cases/configure-token-authentication/), so you can sign with Workers and validate with WAF custom rules, or handle both in Workers.

--- a/src/content/docs/cache/interaction-cloudflare-products/workers-cache-rules.mdx
+++ b/src/content/docs/cache/interaction-cloudflare-products/workers-cache-rules.mdx
@@ -12,9 +12,9 @@ head:
 
 ---
 
-Your Workers script can override [Cache Rules](/cache/how-to/cache-rules/) behavior, whether it is applied to a zone using Cloudflare or a zone that is not proxied through Cloudflare.
+When you use both [Cache Rules](/cache/how-to/cache-rules/) and [Workers](/workers/) on the same request, the Worker's cache settings take priority — but only when the required [compatibility flags](#compatibility-flags) are enabled.
 
-For example, if there is a cache rule configured to bypass cache for `example.com/foo`, but your Workers script sets `cacheEverything: true`, the script's setting will take precedence, and the request will be cached. The same applies if the request is made to a non-Cloudflare zone — the Worker's `cacheEverything` setting will still override.
+Your Workers script can override Cache Rules behavior, whether the request is for a domain proxied through Cloudflare or a domain that is not. For example, if a Cache Rule is configured to bypass cache for `example.com/foo`, but your Workers script sets `cacheEverything: true` in the [`cf` object](/workers/runtime-apis/request/#the-cf-property-requestinitcfproperties) of a `fetch()` request, the Worker's setting takes precedence and the response is cached.
 
 ## Precedence order
 
@@ -24,33 +24,33 @@ Cache behavior is determined by the following order of precedence:
 2. [Cache rules](/cache/how-to/cache-rules/)
 3. [Page rules](/rules/page-rules/)
 
-Cache rules override page rule settings, and Workers scripts override cache rules. Among rules at the same level, the one with the highest specificity takes priority.
+Workers override Cache Rules, and Cache Rules override Page Rules. When multiple rules at the same level match the same request, the [last matching rule wins](/cache/how-to/cache-rules/order/) for any conflicting settings.
 
 ## Compatibility flags
 
-This override behavior is controlled by [compatibility flags](/workers/configuration/compatibility-flags/):
+The override behavior is controlled by [compatibility flags](/workers/configuration/compatibility-flags/) — configuration settings that opt your Worker into specific runtime behaviors. There are two flags because Workers have two ways to interact with the cache:
 
-- For the [Fetch API](/workers/runtime-apis/fetch/): `request_cf_overrides_cache_rules`
-- For the [Cache API](/workers/runtime-apis/cache/): `cache_api_request_cf_overrides_cache_rules`
+- For the [Fetch API](/workers/runtime-apis/fetch/) (`fetch()` with `cf` properties): `request_cf_overrides_cache_rules`
+- For the [Cache API](/workers/runtime-apis/cache/) (`caches.default.put()` / `caches.default.match()`): `cache_api_request_cf_overrides_cache_rules`
 
-These flags must be enabled to allow Workers scripts to override cache rules.
+These flags must be enabled to allow Workers scripts to override Cache Rules. If the correct flag is not enabled for the API you are using, your Worker's cache settings are silently ignored and Cache Rules apply instead.
 
 ### Compatibility date behavior
 
-Whether these flags are enabled by default depends on your Worker's compatibility date:
+A Worker's [compatibility date](/workers/configuration/compatibility-dates/) determines which flags are active by default. When you set a compatibility date, all flags with an enable date on or before that date are automatically turned on.
 
-- **Fetch API (`request_cf_overrides_cache_rules`)**
-  - Enabled by default for compatibility dates **on or after 2025-04-02**.
-- **Cache API (`cache_api_request_cf_overrides_cache_rules`)**
-  - Enabled by default for compatibility dates **on or after 2025-05-19**.
-  - **Important:** For `cache_api_request_cf_overrides_cache_rules` to be recognized, you must also enable `cache_api_compat_flags`.
-    - `cache_api_compat_flags` enables the compatibility flag functionality for Workers. If `cache_api_compat_flags` is not set, then no compatibility flags — even if configured — will be recognized by the Cache API.
-    - `cache_api_compat_flags` is enabled by default for compatibility dates **on or after 2025-04-19**.
+| Flag | Enabled by default | Prerequisite |
+| --- | --- | --- |
+| `request_cf_overrides_cache_rules` (Fetch API) | Compatibility dates on or after `2025-04-02` | None |
+| `cache_api_compat_flags` | Compatibility dates on or after `2025-04-19` | None |
+| `cache_api_request_cf_overrides_cache_rules` (Cache API) | Compatibility dates on or after `2025-05-19` | Requires `cache_api_compat_flags` |
 
-If your Worker has an earlier compatibility date than the ones listed above, the corresponding flags must be manually enabled; otherwise, cache behavior will follow the original cache rules instead of the Worker's settings.
+The Cache API has an extra requirement: `cache_api_compat_flags` must be enabled for any compatibility flags to take effect on the Cache API. Without it, the Cache API ignores all compatibility flags, even ones you explicitly list in your configuration.
+
+If your Worker uses a compatibility date before the dates listed above, you must manually add the flags to your configuration. Otherwise, cache behavior follows Cache Rules instead of the Worker's settings.
 
 ### Example (Older compatibility date)
 
-If a cache rule is configured to bypass cache for `example.com/foo`, and a Worker with a compatibility date of `2025-04-02` or earlier tries to set `cacheEverything: true`, the cache rule will take effect, and the response will not be cached.
+A Cache Rule bypasses cache for `example.com/foo`. A Worker with a compatibility date before `2025-04-02` sets `cacheEverything: true` via `fetch()`. Because the compatibility date is too old for `request_cf_overrides_cache_rules` to be active by default, the Cache Rule wins and the response is not cached.
 
-Likewise, if using the Cache API without `cache_api_compat_flags` enabled, even if you enable `cache_api_request_cf_overrides_cache_rules`, the Cache API will not take effect.
+Similarly, if you use the Cache API and your compatibility date is before `2025-04-19`, `cache_api_compat_flags` is not active. Even if you manually add `cache_api_request_cf_overrides_cache_rules` to your configuration, it has no effect because the Cache API does not recognize compatibility flags without `cache_api_compat_flags`.

--- a/src/content/docs/cache/interaction-cloudflare-products/workers.mdx
+++ b/src/content/docs/cache/interaction-cloudflare-products/workers.mdx
@@ -12,36 +12,38 @@ head:
 
 ---
 
-You can use [Workers](/workers/) to customize cache behavior on Cloudflare's CDN. Cloudflare Workers provide flexibility in handling assets and responses by running both before and after the cache. A Worker can be configured to run before a request reaches the cache, allowing for modifications to the request, and it can also be used to modify assets once they are returned from the cache.
+You can use [Workers](/workers/) to customize cache behavior on Cloudflare's network. Workers run as middleware in the request lifecycle — a single Worker handles both the request and response phases. When a request arrives, it hits the Worker before the cache is checked. The Worker can modify the incoming request (for example, rewrite the URL or add headers), then call `fetch()` to continue the request through the cache. When the response comes back — whether from cache or from the origin server — the Worker can also modify the response before it is sent to the visitor.
 
 The diagram below illustrates a common interaction flow between Workers and Cache.
 
 ![Workers and cache flow example flow diagram.](~/assets/images/cache/workers-cache-flow.png)
 
-1. A User (a) Requests a URI, and this request is directed to a Worker. The Worker can then interact with the request, either requesting the content further upstream using (b) fetch() or sending a (f) Response back to the User.
-2. If the content is cached, the Cache will send a (e) Response back to the Worker which can now interact with the response before sending a (f) Response back to the user.
-3. When using cache rules with Workers, the cache rule should not be set based on the user URL/host (a). Instead, the rule must match the properties of the URL in the fetch() (b) request — such as headers, hostname, or URL path — otherwise, the rule will not be applied.
+1. A visitor (a) requests a URL, and this request is directed to a Worker. The Worker can then interact with the request, either requesting the content from the origin server using (b) `fetch()` or sending a (f) response back to the visitor.
+2. If the content is cached, the cache sends a (e) response back to the Worker, which can modify the response before sending a (f) response back to the visitor.
+3. When using [cache rules](/cache/how-to/cache-rules/) with Workers, the cache rule must match the properties of the URL in the `fetch()` (b) request — such as headers, hostname, or URL path — not the original visitor URL/host (a). Otherwise, the rule will not be applied.
 
 Here are a few examples of how Workers can be used to customize cache behavior:
 
 - **Modify Response**: Adjust or enhance content after it is retrieved from the cache, ensuring that responses are up-to-date or tailored to specific needs.
 
-- **Signed URLs**: Generate URLs that are valid for a specific duration (for example, minutes, hours, days) to control access and enhance security.
+- **Signed URLs**: Generate time-limited signed URLs to control access and enhance security.
 
-- **Personalized Response**: Deliver personalized content based on user data while leveraging cached resources to reduce the load on the origin.
+- **Personalized Response**: Deliver personalized content based on user data while using cached resources to reduce the load on the origin server.
 
-- **Reduce Latency**: Serve content from a location close to the user, decreasing load times and improving the user experience.
+- **Reduce Latency**: Serve content from a data center close to the visitor, decreasing load times and improving the user experience.
 
-You can also use [Snippets](/rules/snippets/) as a free alternative for simple modifications and logic, bypassing the need for full Worker scripts. These lightweight scripts enable quick adjustments and optimizations, offering an efficient way to enhance your Cloudflare setup without the complexity and overhead of more extensive code deployments.
+You can also use [Snippets](/rules/snippets/) for lightweight modifications like header changes, redirects, and JWT validation without deploying a full Worker script. Snippets are included at no additional cost on all paid plans but have stricter resource limits (5 ms execution time, 32 KB package size).
 
 :::note
-When using Workers and [O2O](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/), some caveats and limitations may apply.
+When using Workers and [O2O](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) (a traffic routing configuration where requests pass through two Cloudflare zones), some caveats and limitations may apply.
 :::
 
 ## Cache features in Workers
 
-- **fetch()**: Allows interaction with Cloudflare's Cache and Tiered Cache, providing control over how requests are handled. To optimize caching behavior, you can set TTLs, define custom cache keys, and configure cache headers directly within a fetch request. For more details on these configurations, refer to [Cache using fetch](/workers/examples/cache-using-fetch/).
+Workers offer two ways to interact with the cache. Use `fetch()` when your Worker makes subrequests to an origin. Use the Cache API when your Worker generates responses without a backend origin.
 
-- **Cache API**: Enables storing and retrieving responses from Cloudflare's cache, limited to the cache in the local data center and excluding content stored in the Tiered Cache. To use the Cache API to store responses in Cloudflare's cache, refer to [Using the Cache API](/workers/examples/cache-api/).
+- **fetch()**: When a Worker calls `fetch()`, the request passes through Cloudflare's cache and [Tiered Cache](/cache/how-to/tiered-cache/) (if enabled). You can control caching behavior by setting properties on the request's [`cf` object](/workers/runtime-apis/request/#the-cf-property-requestinitcfproperties) — including time-to-live (TTL) values, custom cache keys, and cache headers. For more details, refer to [Cache using fetch](/workers/examples/cache-using-fetch/).
 
-To understand more about how Cache and Workers interact refer to [Cache in Workers](/workers/reference/how-the-cache-works/).
+- **Cache API**: Allows you to programmatically store, retrieve, and delete responses in Cloudflare's cache using `caches.default` or `caches.open()`. Unlike `fetch()`, the Cache API only operates on the cache in the data center handling the current request — it does not interact with Tiered Cache. Use the Cache API when you need to cache responses that did not come from an origin. For more details, refer to [Using the Cache API](/workers/examples/cache-api/).
+
+To understand more about how Cache and Workers interact, refer to [Cache in Workers](/workers/reference/how-the-cache-works/).


### PR DESCRIPTION
## Summary

- Apply ELI5 (technical simplification) analysis to 5 pages in `docs/cache/interaction-cloudflare-products/`
- Improve readability by defining jargon inline, adding "why" context before procedural steps, and replacing marketing language with concrete descriptions
- Fix a date boundary error in the `workers-cache-rules.mdx` example (original said "2025-04-02 or earlier" but that date itself has the flag enabled)

## Changes by file

| File | Key changes |
|------|-------------|
| `index.mdx` | Add context sentence explaining what caching does and why product interactions matter |
| `workers.mdx` | Clarify request lifecycle, define O2O inline, replace vague Snippets paragraph with concrete capabilities, add guidance on when to use `fetch()` vs Cache API |
| `workers-cache-rules.mdx` | Add compatibility flag summary table, fix date boundary error in example, define compatibility dates/flags inline, clarify `cache_api_compat_flags` description |
| `waf-snippets.mdx` | Explain presigned URLs and HMAC before implementation details, clarify WAF/cache pipeline ordering, note Workers HMAC compatibility |
| `r2.mdx` | Explain why Custom Domains are required, expand Tiered Cache with hierarchy explanation, add notes on `r2.dev` limitations and default cached file types |

## Review notes

All changes were validated through an adversarial review step that verified claims against source documentation in the repo. No unsourced critical claims. Three low-to-medium misleading flags were addressed before applying changes.