### PR TITLE
[Cache] ELI5: Simplify performance-review docs

### DIFF
--- a/src/content/docs/cache/performance-review/cache-analytics.mdx
+++ b/src/content/docs/cache/performance-review/cache-analytics.mdx
@@ -9,7 +9,7 @@ products:
 
 import { FeatureTable, DashButton } from "~/components"
 
-Use Cache Analytics to improve site performance or reduce origin web server traffic. Cache Analytics helps determine if resources are [missing from cache](/cache/concepts/cache-responses/#miss), [expired](/cache/concepts/cache-responses/#expired), or [ineligible for caching](/cache/concepts/cache-responses/#noneunknown). Cache Analytics includes filter by hostname, list of top URLs that miss cache, and a query of up to three days of data.
+Cache Analytics shows how much of your site's traffic is served from Cloudflare's cache versus your origin server. When content is served from cache, visitors get faster page loads and your origin web server handles less traffic. Use Cache Analytics to identify resources that are [missing from cache](/cache/concepts/cache-responses/#miss), [expired](/cache/concepts/cache-responses/#expired) (cached copy is outdated), or [ineligible for caching](/cache/concepts/cache-responses/#noneunknown) (not eligible for caching). You can filter by hostname, review the top URLs that miss cache, and query up to three days of data.
 
 ## Availability
 
@@ -25,8 +25,8 @@ In the Cloudflare dashboard, go to the **Caching** page.
 
 You can decide whether to focus on **Requests** or **Data Transfer**:
 
-- **Requests** (default view) help assess performance, as each cache [MISS](/cache/concepts/cache-responses/#miss) slows down content delivery.
-- **Data Transfer** is useful for cost analysis, since most hosting providers charge for every byte that leaves their network.
+- **Requests** (default view) helps assess performance. Each cache [MISS](/cache/concepts/cache-responses/#miss) means the request must go to your origin server instead of being served from Cloudflare's cache, which adds latency.
+- **Data Transfer** is useful for cost analysis, since most hosting providers charge for data sent from their servers (egress bandwidth).
 
 You can switch between these views while keeping other analytics filters applied.
 
@@ -34,26 +34,26 @@ For best practices related to Cache Analytics, refer to [Cache performance](/cac
 
 ## Add filters
 
-Cache Analytics also allows for flexible filtering of data. Create filters to focus on the traffic to optimize. Example filters include **Cache status**, **Host**, **Path**, or **Content type**.
+Create filters to narrow the data to specific traffic segments. Example filters include **Cache status**, **Host**, **Path**, or **Content type**.
 
 To add filters, under **Cache Performance**, select **Add filter**. Select **Apply** when you are done.
 
 ## Review cache status
 
-The **Requests summary** graph depicts how your traffic changes over time, such as in response to a high-traffic event or a recent configuration change. Note that the Requests summary content is based on a 10% sample of requests. For more information on how sampling works, refer to [Understanding sampling in Cloudflare Analytics](/analytics/sampling/).
+The **Requests summary** graph shows how your traffic changes over time, such as in response to a high-traffic event or a recent configuration change. The Requests summary is based on a sample of requests, not the full dataset. Totals are extrapolated from the sample to represent overall traffic. For more information on how sampling works, refer to [Understanding sampling in Cloudflare Analytics](/analytics/sampling/).
 
 **Served by Cloudflare** indicates content served by Cloudflare that did not require contacting your origin web server. **Served by Origin** indicates traffic served from the origin web server.
 
-For **Data Transfer**, **Revalidated** requests are considered **Served by Cloudflare**. However, revalidated requests count as **Served by Origin** within the **Requests** view. This analytics behavior reflects that Cloudflare must check the origin web server for revalidated cache requests before returning a result from cache.
+Revalidated requests — where Cloudflare checks with your origin to confirm cached content is still current — are counted differently depending on the view. In the **Data Transfer** view, revalidated requests count as **Served by Cloudflare** because the response body is served from cache, not re-downloaded from the origin. In the **Requests** view, revalidated requests count as **Served by Origin** because Cloudflare still contacts the origin server to verify the content.
 
-**Cache status** graphs help explain why traffic is served from Cloudflare versus the origin web server. The graph shows analytics by content-type to portray how different components of your website perform:
+**Cache status** graphs break down why traffic is served from Cloudflare versus the origin web server, organized by content type.
 
 For a breakdown of cache statuses and their descriptions, refer to [Cloudflare cache responses](/cache/concepts/cache-responses/).
 
 ## Review requests by source
 
-Cache Analytics shows top metrics (Top-N) for several request components. Apply filters before reviewing Top-N metrics. For example, filtering to only view traffic with an Expired or Revalidated Cache status lets you review which URLs were primarily responsible for those statuses.
+Cache Analytics shows the most frequent values (top N) for several request attributes. Apply filters before reviewing these metrics to focus on specific traffic. For example, filtering to only view traffic with an Expired or Revalidated cache status shows which URLs were primarily responsible for those statuses.
 
 ### Empty content types
 
-Finding an **empty** content type when reviewing your analytics is common. This content type occurs when 301/302 redirects do not contain an HTTP response body. Additionally, most HTTP error codes, such as 403, do not return text/html and are therefore also reported as empty.
+Finding an **empty** content type in your analytics is common. Responses to redirect status codes (`301`/`302`) typically do not include content, so they have no content type. Similarly, many HTTP error responses, such as `403`, do not return `text/html` and are also reported as empty.

--- a/src/content/docs/cache/performance-review/cache-performance.mdx
+++ b/src/content/docs/cache/performance-review/cache-performance.mdx
@@ -8,18 +8,20 @@ products:
 
 ## Optimize cache ratios
 
-Depending on the cache status you receive, you can make modifications to improve your cache ratio. To review the list of cache statuses, refer to [Cloudflare cache responses](/cache/concepts/cache-responses/).
+Your cache ratio measures how often Cloudflare serves content from cache instead of contacting your origin server. A higher ratio means faster responses for visitors and less traffic to your origin.
 
-- **Dynamic**: Default response for many file types including HTML. To cache additional content, refer to [Cache Rules](/cache/how-to/cache-rules/).
-- **Revalidated**: To address an atypical quantity of revalidated content, consider [increasing your Edge Cache TTLs](/cache/how-to/cache-rules/settings/#edge-ttl).
-- **Expired**: Consider [extending Edge Cache TTLs](/cache/how-to/cache-rules/settings/#edge-ttl)) for these resources via a Cache Rule or enable revalidation at your origin.
-- **Miss**: Although tricky to optimize, there are a few potential remedies:
-  - [Enable Argo Tiered Caching](/cache/how-to/tiered-cache/#enable-tiered-cache) to check cache in another Cloudflare data center before checking the origin web server.
-  - [Create a custom cache key](/cache/how-to/cache-rules/examples/custom-cache-key/) for multiple URLs to match the same cached resource, for example by ignoring query string.
+Depending on the [cache status](/cache/concepts/cache-responses/) you receive, you can make modifications to improve your cache ratio.
 
-## Example reports for troubleshooting cache performance
+- **Dynamic**: The resource was not eligible for caching. This is the default response for many file types including HTML. To cache additional content, refer to [Cache Rules](/cache/how-to/cache-rules/).
+- **Revalidated**: The resource was in cache but Cloudflare confirmed with your origin that it was still current before serving it. To address an atypical quantity of revalidated content, consider [increasing your Edge Cache TTLs](/cache/how-to/cache-rules/settings/#edge-ttl) (how long Cloudflare considers cached content fresh before checking your origin).
+- **Expired**: The cached resource's TTL elapsed before it was requested again. Consider [extending Edge Cache TTLs](/cache/how-to/cache-rules/settings/#edge-ttl) for these resources via a Cache Rule, or configure your origin to return [revalidation headers](/cache/concepts/cache-control/) (`Last-Modified` or `ETag`) so Cloudflare can confirm content is still current without downloading it again.
+- **Miss**: The resource was not found in cache and was served from your origin. Although tricky to optimize, there are a few potential remedies:
+  - [Enable Tiered Cache](/cache/how-to/tiered-cache/#enable-tiered-cache) to check an upper-tier Cloudflare data center before contacting your origin server.
+  - [Create a custom cache key](/cache/how-to/cache-rules/examples/custom-cache-key/) so that multiple URLs match the same cached resource, for example by ignoring the query string.
 
-Several examples of helpful insights into your site performance via Cache Analytics include:
+## Troubleshoot cache performance with example reports
+
+Use [Cache Analytics](/cache/performance-review/cache-analytics/) to identify cache performance issues. The following examples show how to filter for common problems and resolve them.
 
 - Not caching HTML.
 
@@ -28,19 +30,19 @@ Several examples of helpful insights into your site performance via Cache Analyt
 
 :::caution
 
-This option caches all HTML regardless of the presence of dynamic content. If you use this approach to cache pages containing dynamic content, visitors may receive information not intended for them. To avoid caching dynamic content, you can add a condition to the rule's matching criteria to prevent it from matching that content. Some examples include:
+This option caches all HTML regardless of the presence of dynamic content (content that changes per visitor, such as time of visit, location, or device). If you use this approach to cache pages containing dynamic content, visitors may receive information not intended for them. To avoid caching dynamic content, add a condition to the rule's matching criteria to exclude it. Some examples include:
 
 - Checking for the presence of a cookie.
-- Negative matching against known dynamic content file paths.
-- Negative matching against dynamic content extensions (or lack of an extension).
-  :::
+- Excluding requests that match known dynamic content file paths.
+- Excluding requests with dynamic content extensions (or no extension).
+:::
 
-* Short cache expiration TTL.
+- Short cache expiration TTL.
 
   - Identify the issue: Select **Add filter** and select **Cache status equals Revalidated**.
   - Resolution: [Increase Cloudflare's Edge Cache TTL via a Cache Rule](/cache/how-to/cache-rules/examples/edge-ttl/).
 
-* Need to enable Tiered Cache or Custom Cache Key
+- Need to enable Tiered Cache or custom cache key.
 
   - Identify the issue: Select **Add filter** and select **Cache status equals Miss**.
-  - Resolution: [Enable Argo Tiered Caching](/cache/how-to/tiered-cache/#enable-tiered-cache) or [create a custom cache key](/cache/how-to/cache-rules/examples/custom-cache-key/).
+  - Resolution: [Enable Tiered Cache](/cache/how-to/tiered-cache/#enable-tiered-cache) or [create a custom cache key](/cache/how-to/cache-rules/examples/custom-cache-key/).

--- a/src/content/docs/cache/performance-review/index.mdx
+++ b/src/content/docs/cache/performance-review/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Performance review
 pcx_content_type: navigation
-description: Review cache performance metrics and analytics.
+description: Understand cache hit rates and optimize caching for your site.
 products:
   - cache
 sidebar:
@@ -13,6 +13,6 @@ sidebar:
 
 import { DirectoryListing } from "~/components"
 
-Review the following content to learn more about cache performance.
+Use Cache Analytics to understand how effectively Cloudflare caches your content, and apply optimization techniques to improve your cache hit ratio and reduce origin server load.
 
 <DirectoryListing />


### PR DESCRIPTION
## Summary

- Apply ELI5 (technical simplification) analysis to 3 pages in `docs/cache/performance-review/`
- Define key terms inline (cache ratio, cache statuses, Edge Cache TTL, revalidation)
- Fix factual and syntax issues found during analysis

## Changes by file

| File | Key changes |
|------|-------------|
| `index.mdx` | Replace generic intro with value-oriented context about cache hit ratios and origin load |
| `cache-analytics.mdx` | Clarify revalidation counting per view, fix inaccurate "10% sample" claim to match adaptive sampling docs, add inline cache status context, format HTTP status codes per style guide |
| `cache-performance.mdx` | Define "cache ratio" in opening, add one-sentence inline definitions for all cache statuses, fix double-parenthesis syntax error, replace vague "enable revalidation at your origin" with specific headers and link, rename "Argo Tiered Caching" to "Tiered Cache", replace "negative matching" jargon with plain language |

## Review notes

All changes validated through adversarial review. No unsourced critical claims. Key fix: the original `cache-analytics.mdx` claimed data was "based on a 10% sample" but the sampling docs describe adaptive sampling at multiple resolutions (100%/10%/1%), not a fixed 10%.