### PR TITLE
Fix typo in custom header name for Google Workspace tenant control

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/tenant-control.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/tenant-control.mdx
@@ -78,7 +78,7 @@ For more information, refer to the [Microsoft Entra ID documentation](https://le
 
 | Custom header name           | Custom header value        |
 | ---------------------------- | -------------------------- |
-| `X-GooGApps-Allowed-Domains` | Your organization's domain |
+| `X-GoogApps-Allowed-Domains` | Your organization's domain |
 
 For more information, refer to the [Google Workspace documentation](https://support.google.com/a/answer/1668854).
 


### PR DESCRIPTION
### Summary

Google's own documentation shows the headers as `X-GoogApps-Allowed-Domains`. Source: https://knowledge.workspace.google.com/admin/security/block-access-to-consumer-accounts?visit_id=639136542423448155-1550308544&rd=1#use_a_web_proxy_server_to_block_accounts:~:text=the%20HTTP%20header-,X%2DGoogApps%2DAllowed%2DDomains,-%3A%20followed%20by

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
