### PR TITLE
[Cache] ELI5: Simplify how-to root-level docs

### DIFF
--- a/src/content/docs/cache/how-to/always-online.mdx
+++ b/src/content/docs/cache/how-to/always-online.mdx
@@ -9,45 +9,46 @@ products:
 
 import { FeatureTable, DashButton } from "~/components"
 
-Cloudflare’s Always Online feature is now integrated with the [Internet Archive](https://archive.org/) so that visitors can access a portion of your website even when your origin server is unreachable and a Cloudflare-cached version is unavailable. When your origin is unreachable, Always Online checks Cloudflare’s cache for a stale or expired version of your website. If a version does not exist, Cloudflare goes to the Internet Archive to fetch and serve static portions of your website.
+Always Online serves cached versions of your web pages when your origin server goes down, so visitors see content instead of an error page.
 
-When you enable Always Online with Internet Archive integration, Cloudflare shares your hostname and popular URL paths with the archive so that the Internet Archive’s crawler stores the pages you want archived. When submitting targets to the crawler, Cloudflare identifies the most popular URLs found among GET requests that returned a 200 HTTP status code in the previous five hours.
+Cloudflare's Always Online feature is integrated with the [Internet Archive](https://archive.org/) so that visitors can access a portion of your website even when your origin server is unreachable and a Cloudflare-cached version is unavailable. When your origin is unreachable, Always Online first checks Cloudflare's cache for a stale or expired version of your page. If no version exists in Cloudflare's cache, Cloudflare fetches and serves a static copy from the Internet Archive.
 
-Note that Cloudflare does not save a copy of every page of your website, and it cannot serve dynamic content while your origin is offline. If the requested page is not in the Internet Archive's Wayback Machine, the visitor sees the actual error page caused by the offline origin web server.
+When you turn on Always Online with Internet Archive integration, Cloudflare shares your hostname and popular URL paths with the archive so that the Internet Archive's crawler stores the pages you want archived. Cloudflare identifies the most popular URLs by looking at `GET` requests that returned a `200` HTTP status code in the previous five hours, then submits those URLs to the Internet Archive's crawler.
 
-When the Internet Archive integration is enabled, Cloudflare tells the Internet Archive what pages to crawl and how often. The pages to crawl, as previously mentioned, are the most popular URLs that were successfully visited in the last five hours. The crawling intervals, to ensure stability of service, are limited by Cloudflare. Limits vary according to your Cloudflare plan.
+Cloudflare does not save a copy of every page of your website, and it cannot serve dynamic content while your origin is offline. If the requested page is not in the Internet Archive's Wayback Machine, the visitor sees the actual error page caused by the offline origin web server.
+
+When the Internet Archive integration is turned on, Cloudflare tells the Internet Archive what pages to crawl and how often. The crawling intervals are limited by Cloudflare to ensure stability of service. Limits vary according to your Cloudflare plan.
 
 ## Availability
 
 <FeatureTable id="cache.always_online" />
 
-## Visitor Experience
+## Visitor experience
 
-When Always Online with Internet Archive integration is enabled, visitors see a banner at the top of the webpage explaining they are visiting an archived version of the website. Visitors can select the Refresh button to check whether the origin has recovered and fresh content is available.
+When Always Online with Internet Archive integration is turned on, visitors see a banner at the top of the webpage explaining they are visiting an archived version of the website. Visitors can select the **Refresh** button to check whether the origin has recovered and fresh content is available.
 
-When a visitor requests content for an offline website, Cloudflare returns an HTTP response status code in the range [520–527](/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520/), depending on the issue. These status codes indicate that the origin is unreachable.
+When a visitor requests content for an offline website, Cloudflare returns an HTTP response status code in the range [520-527](/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520/), depending on the issue. These status codes indicate that the origin is unreachable.
 
-When the Internet Archive integration is enabled, Cloudflare checks the archive and serves the most recently archived version of the page.
+When the Internet Archive integration is turned on, Cloudflare checks the archive and serves the most recently archived version of the page.
 
-Visitors who interact with dynamic parts of a website, such as a shopping cart or comment box, will see an error page caused by the offline origin web server.
+Visitors who interact with dynamic parts of a website, such as a shopping cart or comment box, will see an error page caused by the offline origin web server because those features require a live connection to your origin server.
 
-## Enable Always Online
+## Turn on Always Online
 
-Here is how to enable Always Online in the dashboard:
+To turn on Always Online in the dashboard:
 
-1. In the Cloudflare dashboard, go to the **Configuration** page.
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account and domain.
+
+2. Go to **Caching** > **Configuration**.
 
    <DashButton url="/?to=/:account/:zone/caching/configuration" />
 
-2. Choose the domain that will use Always Online with Internet Archive integration.
 3. Under **Always Online**, set the toggle to **On**.
 
-:::note[Note]
+:::note
 
-
-When turning on Always Online, you are also enabling the Internet Archive integration.
-
+When turning on Always Online, you also turn on the Internet Archive integration.
 
 :::
 
-Refer to [Always Online](/cache/troubleshooting/always-online/) for best practices, limitations, and FAQs.
+Refer to [Always Online troubleshooting](/cache/troubleshooting/always-online/) for best practices, limitations, and FAQs.

--- a/src/content/docs/cache/how-to/cache-keys.mdx
+++ b/src/content/docs/cache/how-to/cache-keys.mdx
@@ -16,21 +16,23 @@ head:
 
 import { FeatureTable, DashButton } from "~/components"
 
-A Cache Key is an identifier that Cloudflare uses for a file in our cache, and the Cache Key Template defines the identifier for a given HTTP request.
+A cache key is the identifier Cloudflare uses to store and look up a file in its cache. When a request arrives, Cloudflare builds a cache key from parts of the request and checks whether a matching entry already exists. The Cache Key Template defines which parts of an HTTP request are used to build that identifier.
 
 A default cache key includes:
 
 1. Full URL:
-   * scheme - could be HTTP or HTTPS.
-   * host - for example, `www.cloudflare.com`
-   * URI with query string - for example, `/logo.jpg?utm_source=newsletter`
-2. Origin header sent by client (for CORS support).
+   * Scheme — `HTTP` or `HTTPS`.
+   * Host — for example, `www.cloudflare.com`.
+   * URI with query string — for example, `/logo.jpg?utm_source=newsletter`.
+2. `Origin` header sent by the client (included by default to support [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS), which requires different cache entries for requests from different origins).
 3. `x-http-method-override`, `x-http-method`, and `x-method-override` headers.
 4. `x-forwarded-host`, `x-host`, `x-forwarded-scheme` (unless http or https), `x-original-url`, `x-rewrite-url`, and `forwarded` headers.
 
 ## Create custom cache keys
 
-Custom cache keys let you precisely set the cacheability setting for any resource. They provide the benefit of more control, though they may reduce your cache hit rate and result in cache sharding:
+Custom cache keys allow you to control exactly which parts of a request determine the cached version that Cloudflare serves. This gives you more control over caching behavior, but may reduce your cache hit rate if the key is too specific — a situation called cache sharding, where the same content is stored multiple times under different keys.
+
+To create a custom cache key:
 
 1. In the Cloudflare dashboard, go to the **Cache Rules** page.
 

--- a/src/content/docs/cache/how-to/configure-cache-status-code.mdx
+++ b/src/content/docs/cache/how-to/configure-cache-status-code.mdx
@@ -10,9 +10,11 @@ tags:
 
 import { Render } from "~/components"
 
-Customers can set cache time-to-live (TTL) based on the response status from the origin web server. Cache TTL refers to the duration of a resource in the Cloudflare network before being marked as `STALE` or discarded from cache. Status codes are returned by a resource's origin.
+When your origin server responds to a request, it includes an HTTP status code (such as `200` for success or `404` for not found). You can control how long Cloudflare caches a response based on that status code. This is useful when you want different caching durations for successful responses versus errors — for example, caching successful responses for a full day but not caching server errors at all.
 
-Setting cache TTL based on response status overrides the [default cache behavior (standard caching)](/cache/concepts/default-cache-behavior/) for static files and overrides cache instructions sent by the origin web server. To cache non-static assets, set a [Cache Level of Cache Everything using a Cache Rule](/cache/how-to/cache-rules/create-api/#example-requests). Setting `no-store` **Cache-Control** or a low TTL (using `max-age`/`s-maxage`) increases requests to origin web servers and decreases performance.
+Cache time-to-live (TTL) is the duration a resource stays in the Cloudflare network before being marked as stale or removed from cache.
+
+Setting cache TTL based on response status overrides the [default cache behavior (standard caching)](/cache/concepts/default-cache-behavior/) for static files and overrides cache instructions sent by the origin web server. To cache non-static assets, set a [Cache Level of Cache Everything using a Cache Rule](/cache/how-to/cache-rules/create-api/#example-requests). Setting `no-store` `Cache-Control` or a low TTL (using `max-age`/`s-maxage`) increases requests to origin web servers and decreases performance.
 
 ## Caching limits
 

--- a/src/content/docs/cache/how-to/index.mdx
+++ b/src/content/docs/cache/how-to/index.mdx
@@ -13,6 +13,6 @@ sidebar:
 
 import { DirectoryListing } from "~/components"
 
-Learn how to complete different configuration options to customize your cache behavior.
+Configure how Cloudflare caches your website's content. These options control what gets cached, how long it stays cached, and how to remove outdated content.
 
 <DirectoryListing />

--- a/src/content/docs/cache/how-to/set-caching-levels.mdx
+++ b/src/content/docs/cache/how-to/set-caching-levels.mdx
@@ -1,7 +1,7 @@
 ---
 title: Caching levels
 pcx_content_type: concept
-description: Set caching levels to control query string behavior.
+description: Control how query strings affect cached content.
 products:
   - cache
 head:
@@ -10,10 +10,10 @@ head:
 
 ---
 
-Caching levels determine how much of your website’s static content Cloudflare should cache. Cloudflare’s CDN caches static content according to the levels below.
+A query string is the part of a URL after the `?` character (for example, `?color=blue&size=large`). Caching levels determine whether Cloudflare treats URLs with different query strings as the same cached resource or as separate resources.
 
-* **No Query String**: Delivers resources from cache when there is no query string. Example URL: `example.com/pic.jpg`
-* **Ignore Query String**: Delivers the same resource to everyone independent of the query string. Example URL: `example.com/pic.jpg?ignore=this-query-string`
+* **No Query String**: Only delivers resources from cache when the URL has no query string. Example URL: `example.com/pic.jpg`
+* **Ignore Query String**: Delivers the same cached resource regardless of the query string. Example URL: `example.com/pic.jpg?ignore=this-query-string`
 * **Standard (Default)**: Delivers a different resource each time the query string changes. Example URL: `example.com/pic.jpg?with=query`
 
 You can adjust the caching level from the dashboard under **Caching** > **Configuration** > **Caching level**.
@@ -26,9 +26,9 @@ Ignore Query String only disregards the query string for static file extensions.
 
 :::
 
-## API Caching level values
+## API caching level values
 
-If you are using the API to change the cache level, the values will differ from those shown in the dashboard. Refer to the table below to see how the API values map to the values shown in the dashboard.
+If you are using the API to change the cache level, the values differ from those shown in the dashboard. Refer to the table below to see how the API values map to the values shown in the dashboard.
 
 | Dashboard           | API        |
 | ------------------- | ---------- |

--- a/src/content/docs/cache/how-to/tiered-cache.mdx
+++ b/src/content/docs/cache/how-to/tiered-cache.mdx
@@ -11,7 +11,7 @@ tags:
 
 import { Details, FeatureTable, APIRequest, Render, DashButton } from "~/components";
 
-Tiered Cache uses the size of the Cloudflare network to reduce requests to customer origins by dramatically increasing cache hit ratios. With data centers around the world, Cloudflare caches content very close to end users. However, if a piece of content is not in cache, the Cloudflare edge data centers must contact the origin server to receive the cacheable content.
+Tiered Cache reduces the number of requests that reach your origin server by adding intermediate cache layers within the Cloudflare network. Without Tiered Cache, every Cloudflare data center that does not have a piece of content in its cache contacts your origin directly. With Tiered Cache, those data centers first check a designated upper-tier data center, and only the upper-tier contacts your origin if it also does not have the content.
 
 Tiered Cache works by dividing Cloudflare’s data centers into a hierarchy of lower-tiers and upper-tiers. If content is not cached in lower-tier data centers (generally the ones closest to a visitor), the lower-tier must ask an upper-tier to see if it has the content. If the upper-tier does not have the content, only the upper-tier can ask the origin for content. This practice improves bandwidth efficiency by limiting the number of data centers that can ask the origin for content, which reduces origin load and makes websites more cost-effective to operate.
 


### PR DESCRIPTION
## Summary

Apply ELI5 analysis to 6 root-level files in docs/cache/how-to/. Add missing context, define jargon inline, fix style guide violations.

## Changes by file

- index.mdx: Replace vague intro with concrete description
- always-online.mdx: Add value statement, fix enable to turn on, add dashboard login convention
- cache-keys.mdx: Define cache key and cache sharding inline, explain CORS Origin header
- configure-cache-status-code.mdx: Add opening context, fix Cache-Control formatting
- set-caching-levels.mdx: Define query strings, fix heading case
- tiered-cache.mdx: Value-first opening explaining the problem it solves