### PR TITLE
[Cloudflare WAN, Magic Transit] Country rules now supported in Unified Routing

### DIFF
--- a/src/content/changelog/cloudflare-wan/2026-04-21-unified-routing-geoip-country-rules.mdx
+++ b/src/content/changelog/cloudflare-wan/2026-04-21-unified-routing-geoip-country-rules.mdx
@@ -1,0 +1,16 @@
+---
+title: Country rules supported in Unified Routing
+description: Cloudflare Advanced Network Firewall Country rules now work with Unified Routing mode.
+date: 2026-04-21T12:00:00
+products:
+  - cloudflare-network-firewall
+  - magic-transit
+---
+
+[Cloudflare Advanced Network Firewall](/cloudflare-network-firewall/) Country rules are now supported for accounts using [Unified Routing](/cloudflare-wan/reference/traffic-steering/#unified-routing-mode-beta) mode. This feature requires a Cloudflare Advanced Network Firewall subscription.
+
+You can create firewall rules that match traffic based on source or destination country to enforce geographic access policies across your network.
+
+This is the first of the Cloudflare Advanced Network Firewall features to become available in Unified Routing. Support for additional features - IP Lists, ASN Lists, Threat Intel Lists, IDS, Rate Limiting, SIP, and Managed Rulesets - is planned.
+
+For the full list of current beta limitations, refer to [Traffic steering beta limitations](/cloudflare-wan/reference/traffic-steering/#beta-limitations).

--- a/src/content/partials/networking-services/reference/traffic-steering.mdx
+++ b/src/content/partials/networking-services/reference/traffic-steering.mdx
@@ -276,7 +276,7 @@ The following limitations apply to accounts using Unified Routing mode. This lis
 | Network analytics | Not yet fully supported |
 | Basic packet captures | Captures exclude Automatic Return Routing or BGP-over-tunnels traffic |
 | Full packet captures | Not yet supported |
-| Advanced Cloudflare Network Firewall features: GeoIP/Country rules, IP Lists, ASN Lists, Threat Intel Lists, IDS, Rate Limiting, SIP, Managed Rulesets | Not yet supported |
+| Advanced Cloudflare Network Firewall features: IP Lists, ASN Lists, Threat Intel Lists, IDS, Rate Limiting, SIP, Managed Rulesets | Not yet supported |
 | Gateway filtering rules | Not supported on traffic where both the onramp and offramp is IPsec/GRE/CNI |
 | Load Balancer | Public-to-private use case is supported to IPsec/GRE/CNI destinations. Private-to-private use case does not yet support Cloudflare Source IPs |
 

--- a/src/content/partials/networking-services/reference/traffic-steering.mdx
+++ b/src/content/partials/networking-services/reference/traffic-steering.mdx
@@ -276,7 +276,7 @@ The following limitations apply to accounts using Unified Routing mode. This lis
 | Network analytics | Not yet fully supported |
 | Basic packet captures | Captures exclude Automatic Return Routing or BGP-over-tunnels traffic |
 | Full packet captures | Not yet supported |
-| Advanced Cloudflare Network Firewall features: IP Lists, ASN Lists, Threat Intel Lists, IDS, Rate Limiting, SIP, Managed Rulesets | Not yet supported |
+| Cloudflare Advanced Network Firewall features: IP Lists, ASN Lists, Threat Intel Lists, IDS, Rate Limiting, SIP, Managed Rulesets | Not yet supported |
 | Gateway filtering rules | Not supported on traffic where both the onramp and offramp is IPsec/GRE/CNI |
 | Load Balancer | Public-to-private use case is supported to IPsec/GRE/CNI destinations. Private-to-private use case does not yet support Cloudflare Source IPs |
 


### PR DESCRIPTION
### Summary

Removes Country rules (previously listed as GeoIP/Country rules) from the Unified Routing beta limitations table and adds a changelog entry. This is the first Cloudflare Advanced Network Firewall feature to become available in Unified Routing mode.

- Updated the beta limitations table in the shared traffic steering partial to remove Country rules and rename "Advanced Cloudflare Network Firewall" to "Cloudflare Advanced Network Firewall"
- Added changelog entry under `cloudflare-wan` dated April 21, noting the subscription requirement

Affects both [Cloudflare WAN](/cloudflare-wan/reference/traffic-steering/#beta-limitations) and [Magic Transit](/magic-transit/reference/traffic-steering/#beta-limitations) pages.

