### PR TITLE
docs(billing): add backup payment method auto-retry documentation

### DIFF
--- a/src/content/docs/billing/payment-methods/backup-payment-method-auto-retry.mdx
+++ b/src/content/docs/billing/payment-methods/backup-payment-method-auto-retry.mdx
@@ -1,0 +1,70 @@
+---
+title: Backup payment method auto-retry
+pcx_content_type: concept
+sidebar:
+  order: 2
+description: Automatic payment retry using backup payment methods for Cloudflare subscription renewals.
+products:
+  - billing
+---
+
+import { DashButton } from "~/components";
+
+If your subscription renewal payment fails on your primary payment method, Cloudflare automatically retries the payment using your other payment methods on file. This keeps your services active without requiring you to take action.
+
+## How backup payment auto-retry works
+
+1. **Primary attempt**: Your subscription renewal payment is attempted using your primary (default) payment method.
+2. **Automatic retry**: If the payment fails, Cloudflare attempts each of your other payment methods in sequence.
+3. **Success notification**: If a backup payment succeeds, your services remain active and you receive an email confirming which payment method was charged.
+4. **All methods fail**: If all payment methods fail, standard payment retry processes continue. You may receive an email asking you to update your payment information.
+
+:::note
+Auto-retry applies to subscription renewal payments only. One-time purchases and initial subscription payments are not affected.
+:::
+
+## Eligibility
+
+Backup payment auto-retry is available to pay-as-you-go accounts with at least two payment methods on file — one primary and one or more backups. The feature is enabled automatically. No action is needed to turn it on.
+
+## Supported payment methods
+
+Auto-retry works with all payment methods supported by Cloudflare, including credit cards, debit cards, and PayPal. Any combination of primary and backup payment method types is supported.
+
+## Email notification
+
+When a backup payment method is charged, you receive an email with:
+
+- The invoice amount and number
+- Which primary payment method failed
+- Which backup payment method was charged
+- A link to manage your payment methods
+
+## Manage your payment methods
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/).
+2. Go to **Manage Account** > **Billing**.
+
+   <DashButton url="/?to=/:account/billing" />
+
+3. In the **Payment Methods** section, review your primary and backup payment methods.
+
+Add a second payment method to ensure auto-retry can keep your services active if your primary method fails.
+
+## FAQ
+
+### Multiple charges
+
+You are never charged on more than one payment method for the same invoice. A backup payment method is only charged if your primary payment method fails.
+
+### All payment methods fail
+
+If your primary and all backup payment methods fail, the standard payment retry process continues. You may receive an email asking you to update your payment information.
+
+### Multiple backup payment methods
+
+All backup payment methods are tried in sequence if your primary payment method fails. The more payment methods you have on file, the more chances for your payment to succeed automatically.
+
+### Next renewal behavior
+
+Your next renewal always attempts your primary (default) payment method first. Backup payment methods are only used if the primary fails.

--- a/src/content/docs/billing/payment-methods/backup-payment-method-auto-retry.mdx
+++ b/src/content/docs/billing/payment-methods/backup-payment-method-auto-retry.mdx
@@ -3,7 +3,7 @@ title: Backup payment method auto-retry
 pcx_content_type: concept
 sidebar:
   order: 2
-description: Automatic payment retry using backup payment methods for Cloudflare subscription renewals.
+description: How Cloudflare retries failed payments using backup methods.
 products:
   - billing
 ---
@@ -14,13 +14,13 @@ If your subscription renewal payment fails on your primary payment method, Cloud
 
 ## How backup payment auto-retry works
 
-1. **Primary attempt**: Your subscription renewal payment is attempted using your primary (default) payment method.
+1. **Primary attempt**: Cloudflare attempts your subscription renewal payment using your primary (default) payment method.
 2. **Automatic retry**: If the payment fails, Cloudflare attempts each of your other payment methods in sequence.
 3. **Success notification**: If a backup payment succeeds, your services remain active and you receive an email confirming which payment method was charged.
 4. **All methods fail**: If all payment methods fail, standard payment retry processes continue. You may receive an email asking you to update your payment information.
 
 :::note
-Auto-retry applies to subscription renewal payments only. One-time purchases and initial subscription payments are not affected.
+Auto-retry applies to subscription renewal payments only. Auto-retry does not apply to one-time purchases or initial subscription payments.
 :::
 
 ## Eligibility
@@ -29,7 +29,7 @@ Backup payment auto-retry is available to pay-as-you-go accounts with at least t
 
 ## Supported payment methods
 
-Auto-retry works with all payment methods supported by Cloudflare, including credit cards, debit cards, and PayPal. Any combination of primary and backup payment method types is supported.
+Auto-retry works with all payment methods supported by Cloudflare, including credit cards, debit cards, and PayPal. Auto-retry supports any combination of primary and backup payment method types.
 
 ## Email notification
 
@@ -42,11 +42,11 @@ When a backup payment method is charged, you receive an email with:
 
 ## Manage your payment methods
 
-1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/).
-2. Go to **Manage Account** > **Billing**.
+1. In the Cloudflare dashboard, go to the Billing page.
 
    <DashButton url="/?to=/:account/billing" />
 
+2. Select **Payment**.
 3. In the **Payment Methods** section, review your primary and backup payment methods.
 
 Add a second payment method to ensure auto-retry can keep your services active if your primary method fails.


### PR DESCRIPTION
## Summary

- Adds customer-facing documentation for the backup payment method auto-retry feature
- When a subscription renewal fails on the primary payment method, Cloudflare automatically retries using all backup payment methods in sequence
- Feature is live at 100% production traffic as of 2026-05-06

## Content

New page at `/billing/payment-methods/backup-payment-method-auto-retry` covering:
- How auto-retry works (sequential retry of all backup PMs)
- Eligibility (pay-as-you-go accounts with 2+ payment methods)
- Supported payment methods
- Email notification behavior
- FAQ (multiple charges, failure behavior, next renewal)

## Related

- SHIP-14763
- Internal wiki: [Backup PM Auto-Retry - Customer Documentation](https://wiki.cfdata.org/spaces/BILL/pages/1387682147)
- Implementation: [subscriptions-api !9997](https://gitlab.cfdata.org/cloudflare/bill/subscriptions-api/-/merge_requests/9997) (FINPE-149)
