### PR TITLE
[Changelog] Origin Analytics

### DIFF
--- a/src/content/changelog/speed/2026-05-18-origin-analytics.mdx
+++ b/src/content/changelog/speed/2026-05-18-origin-analytics.mdx
@@ -10,8 +10,8 @@ You can now see how your origin server responds to Cloudflare using **Origin Ana
 
 Origin Analytics helps you:
 
-- **Monitor origin response times** at the 50th, 95th, and 99th percentiles, with a reference line showing your zone's configured timeout.
-- **Compare origin and edge status codes.** See both `originResponseStatus` (what your origin returned) and `edgeResponseStatus` (what Cloudflare served the end user), making it possible to diagnose cases where your origin returns a `200` but Cloudflare serves a `520`.
-- **Find slow or failing endpoints.** A sortable table ranks request paths by P95 response time, error rate, request volume, or TCP failure rate.
+- **Spot slowdowns before they cause timeouts.** Track origin response times at P50, P95, and P99 against your zone's configured timeout threshold.
+- **Understand what your origin actually returned.** When your users see a `520`, Origin Analytics shows whether your origin returned a `200` with malformed headers, a `503`, or no response at all.
+- **Narrow down which endpoint is the problem.** Sort request paths by response time, error rate, or TCP failure rate to isolate the source.
 
 To get started, go to **Speed** > **Origin Analytics** in the [Cloudflare dashboard](https://dash.cloudflare.com/). For more information, refer to [Origin Analytics](/speed/origin-analytics/).

--- a/src/content/changelog/speed/2026-05-18-origin-analytics.mdx
+++ b/src/content/changelog/speed/2026-05-18-origin-analytics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Diagnose origin server issues with Origin Analytics
-description: Origin Analytics shows how your origin responds to Cloudflare, helping you identify slow endpoints and diagnose errors without filing a support ticket.
+description: Origin Analytics shows how your origin responds to Cloudflare, helping you identify slow endpoints and diagnose errors.
 products:
   - speed
 date: 2026-05-18

--- a/src/content/changelog/speed/2026-05-18-origin-analytics.mdx
+++ b/src/content/changelog/speed/2026-05-18-origin-analytics.mdx
@@ -1,0 +1,19 @@
+---
+title: Diagnose origin server issues with Origin Analytics
+description: Origin Analytics shows how your origin responds to Cloudflare, helping you identify slow endpoints and diagnose errors without filing a support ticket.
+products:
+  - speed
+date: 2026-05-18
+---
+
+You can now see how your origin server is performing directly from the Cloudflare dashboard using **Origin Analytics**, a new tab under **Speed**. Origin Analytics uses data collected at the edge without an agent on your origin.
+
+When something goes wrong between Cloudflare and your origin, Origin Analytics shows what your origin returned to Cloudflare alongside what Cloudflare served to the end user. You can tell whether the source of an issue is your origin, the network path, or Cloudflare.
+
+Origin Analytics helps you:
+
+- **Monitor origin response times** at the 50th, 95th, and 99th percentiles, with a reference line showing your zone's configured timeout.
+- **Compare origin and edge status codes.** See both `originResponseStatus` (what your origin returned) and `edgeResponseStatus` (what Cloudflare served the end user), making it possible to diagnose cases where your origin returns a `200` but Cloudflare serves a `520`.
+- **Find slow or failing endpoints.** A sortable table ranks request paths by P95 response time, error rate, request volume, or TCP failure rate.
+
+To get started, go to **Speed** > **Origin Analytics** in the [Cloudflare dashboard](https://dash.cloudflare.com/). For more information, refer to [Origin Analytics](/speed/origin-analytics/).

--- a/src/content/changelog/speed/2026-05-18-origin-analytics.mdx
+++ b/src/content/changelog/speed/2026-05-18-origin-analytics.mdx
@@ -6,9 +6,7 @@ products:
 date: 2026-05-18
 ---
 
-You can now see how your origin server is performing directly from the Cloudflare dashboard using **Origin Analytics**, a new tab under **Speed**. Origin Analytics uses data collected at the edge without an agent on your origin.
-
-When something goes wrong between Cloudflare and your origin, Origin Analytics shows what your origin returned to Cloudflare alongside what Cloudflare served to the end user. You can tell whether the source of an issue is your origin, the network path, or Cloudflare.
+You can now see how your origin server responds to Cloudflare using **Origin Analytics**, a new tab under **Speed**. Origin Analytics shows what your origin returned alongside what Cloudflare served to the end user, so you can tell whether an issue is your origin, the network path, or Cloudflare. No agent or origin-side setup is required.
 
 Origin Analytics helps you:
 


### PR DESCRIPTION
### Summary

Changelog entry for Origin Analytics, a new tab under Speed that shows origin server performance from Cloudflare's edge. GA launch date is May 18, 2026 (with blog post).

Related: PCX-20808, SHIP-8038. Docs PR: #30523.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
