### PR TITLE
Update MCP configuration instructions in documentation

### DIFF
--- a/src/content/docs/agent-setup/github-copilot.mdx
+++ b/src/content/docs/agent-setup/github-copilot.mdx
@@ -37,7 +37,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 	3. **Configure Cloudflare MCP servers**
 
-		For VS Code, add to `.vscode/mcp.json`. For Copilot CLI, add to `~/.copilot/mcp-config.json` for user-level configuration or `.mcp.json` for project-level configuration. For domain-specific MCP servers, refer to [mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare). For the full Cloudflare API MCP server (Code Mode), refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
+		For VS Code, add to `.vscode/mcp.json`. For Copilot CLI, add to `~/.copilot/mcp-config.json` for user-level configuration or `.mcp.json` or `.github/mcp.json` for project-level configuration. For domain-specific MCP servers, refer to [mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare). For the full Cloudflare API MCP server (Code Mode), refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
 
 		```json
 		{

--- a/src/content/docs/agent-setup/github-copilot.mdx
+++ b/src/content/docs/agent-setup/github-copilot.mdx
@@ -37,7 +37,7 @@ import OtherAgents from "~/components/agent-setup/OtherAgents.astro";
 
 	3. **Configure Cloudflare MCP servers**
 
-		For VS Code, add to `.vscode/mcp.json`. For Copilot CLI, add to `~/.copilot/mcp-config.json`. For domain-specific MCP servers, refer to [mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare). For the full Cloudflare API MCP server (Code Mode), refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
+		For VS Code, add to `.vscode/mcp.json`. For Copilot CLI, add to `~/.copilot/mcp-config.json` for user-level configuration or `.mcp.json` for project-level configuration. For domain-specific MCP servers, refer to [mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare). For the full Cloudflare API MCP server (Code Mode), refer to [cloudflare/mcp](https://github.com/cloudflare/mcp).
 
 		```json
 		{


### PR DESCRIPTION
Clarified MCP server configuration instructions for Copilot CLI.

### Summary
I was a little confused to see the MCP server configurations listed here, as I typically look for configurations at project/repo level, which isn't addressed in the docs at all.

The GitHub Copilot CLI v1.0.43 (even when used within VS Code) advises users to migrate from `.vscode/mcp.json` to `.mcp.json`:
<img width="822" height="52" alt="image" src="https://github.com/user-attachments/assets/d47c6285-6373-43b2-b715-25dabc3b388c" />

[GitHub Copilot CLI reference - Migrating from .vscode/mcp.json](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#migrating-from-vscodemcpjson)

`.vscode/mcp.json` is still valid for VS Code however and both configs can exist at the same time.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
