### PR TITLE
[Cache] ELI5: Simplify cache-response-rules docs

### DIFF
--- a/src/content/docs/cache/how-to/cache-response-rules/create-dashboard.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/create-dashboard.mdx
@@ -13,23 +13,24 @@ head:
 
 import { Render, DashButton } from "~/components";
 
-1. In the Cloudflare dashboard, go to **Cache** > **Cache Rules**.
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account and domain.
+2. Go to **Cache** > **Cache Rules**.
 
    <DashButton url="/?to=/:account/:zone/caching/cache-rules" />
 
-2. Select the **Cache Response Rules** tab.
-3. Select **Create rule**.
+3. Select the **Cache Response Rules** tab.
+4. Select **Create rule**.
 
-4. Enter a descriptive name for the rule in **Rule name**.
-5. Under **When incoming requests match**, select **All incoming requests** if you want the rule to apply to all traffic or **Custom filter expression** if you want the rule to only apply to traffic matching the custom expression.
-6. If you selected **Custom filter expression**, define the [rule expression](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-builder). Use the **Field** drop-down list to choose an HTTP property and select an **Operator**. Both request fields (such as URI path or hostname) and response fields (such as response status code or response headers) are available for matching. Refer to [Available settings](/cache/how-to/cache-response-rules/settings/) for the full list of available fields and operators.
+5. Enter a descriptive name for the rule in **Rule name**.
+6. Under **When incoming requests match**, select **All incoming requests** to apply the rule to all traffic, or select **Custom filter expression** to apply the rule only to traffic matching the expression you define.
+7. If you selected **Custom filter expression**, define the [rule expression](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-builder). Use the **Field** drop-down list to choose an HTTP property and select an **Operator**. Both request fields (such as URI path or hostname) and response fields (such as response status code or response headers) are available for matching. Refer to [Available settings](/cache/how-to/cache-response-rules/settings/) for the full list of available fields and operators.
 
    :::note
    Rules can be further customized by using the **Edit expression** option. You can find more information in [Edit expressions in the dashboard](/ruleset-engine/rules-language/expressions/edit-expressions/).
    :::
 
-7. Following the selection of the field and operator, enter the corresponding value that will trigger the Cache Response Rule. For example, if the selected field is `Hostname` and the operator is `equals`, a value of `example.com` would mean the rule matches any request to that hostname.
-8. Under **Then**, select one of the following actions:
+8. Following the selection of the field and operator, enter the corresponding value that will trigger the Cache Response Rule. For example, if the selected field is `Hostname` and the operator is `equals`, a value of `example.com` would mean the rule matches any request to that hostname.
+9. Under **Then**, select one of the following actions:
 
    - **Modify cache-control directives**: Set or remove `Cache-Control` directives sent by your origin. For each directive, choose **Set directive** or **Remove directive**. For duration-based directives like `max-age` or `s-maxage`, enter a value in seconds. Turn on **Cloudflare only** to apply the directive only within Cloudflare's cache without changing what visitors receive. Refer to [Supported directives](/cache/how-to/cache-response-rules/settings/#supported-directives) for the full list.
 
@@ -43,7 +44,7 @@ import { Render, DashButton } from "~/components";
    - **Strip headers**: Remove `Set-Cookie`, `ETag`, or `Last-Modified` headers from the origin response before Cloudflare evaluates the response for caching. Select which headers to strip.
 
    For more details on each action, refer to [Available settings](/cache/how-to/cache-response-rules/settings/#available-actions).
-9. Under **Place at**, from the dropdown, you can select the order of your rule. From the main page, you can also change the order of the rules you have created.
-10. To save and deploy your rule, select **Deploy**. If you are not ready to deploy your rule, select **Save as Draft**.
+10. Under **Place at**, from the dropdown, you can select the order of your rule. From the main page, you can also change the order of the rules you have created.
+11. To save and deploy your rule, select **Deploy**. If you are not ready to deploy your rule, select **Save as Draft**.
 
    <Render file="rules-creation-dash-dns-popup" product="rules" />

--- a/src/content/docs/cache/how-to/cache-response-rules/index.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/index.mdx
@@ -10,7 +10,7 @@ sidebar:
 
 import { FeatureTable, InlineBadge, Render } from "~/components";
 
-Cache Response Rules allow you to configure cache settings based on request and response attributes. These rules execute prior to caching in the `http_response_cache_settings` phase, which runs after Cloudflare receives the origin response.
+Cache Response Rules allow you to adjust cache settings based on request and response attributes. These rules run in the `http_response_cache_settings` [phase](/ruleset-engine/reference/phases-list/), which executes after Cloudflare receives the response from your origin server but before the response is cached.
 
 With Cache Response Rules you can:
 
@@ -45,22 +45,22 @@ Cache Response Rules operate on the origin response, while [Cache Rules](/cache/
 Key differences:
 
 - **Cache eligibility**: Cache Rules remain the only mechanism to decide whether content is eligible for caching. However, Cache Response Rules can make a cacheable asset non-cacheable by setting the `no-store` directive using the `set_cache_control` action.
-- **Origin Cache Control (OCC)**: If any rule in the `http_response_cache_settings` phase matches, Cloudflare defaults to Origin Cache Control behavior (`origin_cache_control = true`).
+- **Origin Cache Control**: If any rule in the `http_response_cache_settings` phase matches, Cloudflare defaults to Origin Cache Control behavior (`origin_cache_control = true`).
 - **CDN-Cache-Control precedence**: `Cache-Control` directives set by Cache Response Rules take precedence over origin-set `Cloudflare-CDN-Cache-Control` and `CDN-Cache-Control` headers. For more information, refer to [CDN-Cache-Control header precedence](/cache/concepts/cdn-cache-control/#header-precedence).
 - **Stacking**: Cache Response Rules stack the same way as Cache Rules. When multiple rules specify the same setting, the last matching rule wins.
 
-### Example: OCC precedence over Edge TTL
+### Example: Origin Cache Control precedence over Edge TTL
 
 Consider the following scenario:
 
 1. A Cache Rule sets **Edge TTL** to `override_origin` with a value of `7200` seconds (2 hours).
-2. A Cache Response Rule uses `set_cache_control` to set `s-maxage` to `3600` seconds (1 hour) with `cloudflare_only` enabled.
+2. A Cache Response Rule uses `set_cache_control` to set `s-maxage` to `3600` seconds (1 hour) with `cloudflare_only` turned on.
 3. The origin responds with `Cache-Control: s-maxage=600`.
 
-In this case, the Cache Response Rule takes precedence. Cloudflare caches the asset for `3600` seconds (1 hour) based on the `s-maxage` directive set by the Cache Response Rule, while visitors still receive the original `s-maxage=600` from the origin because `cloudflare_only` is enabled.
+In this case, the Cache Response Rule takes precedence. Cloudflare caches the asset for `3600` seconds (1 hour) based on the `s-maxage` directive set by the Cache Response Rule, while visitors still receive the original `s-maxage=600` from the origin because `cloudflare_only` is turned on.
 
 ## Notes
 
-- If you strip last modified then Smart Edge Revalidation will be turned off.
-- Cache Response Rules ignore [`1xx` HTTP response status codes](/support/troubleshooting/http-status-codes/1xx-informational/) as they are treated as informational responses.
-- Cache Response Rules can be versioned. Refer to the [Version Management](/version-management/) documentation for more information.
+- If you strip `ETag` or `Last-Modified` headers, [Smart Edge Revalidation](/cache/concepts/revalidation/#smart-revalidation-towards-users) is turned off for the affected responses.
+- Cache Response Rules ignore [`1xx` HTTP response status codes](/support/troubleshooting/http-status-codes/1xx-informational/) because they are treated as informational responses.
+- Cache Response Rules can be versioned. For more information, refer to [Version Management](/version-management/).

--- a/src/content/docs/cache/how-to/cache-response-rules/settings.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/settings.mdx
@@ -50,7 +50,7 @@ These are the settings that you can configure when creating a Cache Response Rul
 | `http.response.headers.names` | Array | Response header names |
 | `http.response.headers.values` | Array | Response header values |
 
-If you select the [Edit expression](/ruleset-engine/rules-language/expressions/edit-expressions/#expression-editor) option, you can enter any of the above response fields.
+If you select the **Edit expression** option, you can enter any of the above response fields.
 
 ## Functions
 
@@ -106,7 +106,7 @@ Configures settings related to caching on the origin response. The following par
 
 :::note
 
-If `strip_etags` or `strip_last_modified` is `true` after all matching rules are applied, [Smart Edge Revalidation](https://blog.cloudflare.com/introducing-smart-edge-revalidation/) is disabled for the origin response.
+If `strip_etags` or `strip_last_modified` is `true` after all matching rules are applied, [Smart Edge Revalidation](/cache/concepts/revalidation/#smart-revalidation-towards-users) is turned off for the origin response.
 
 :::
 
@@ -130,7 +130,7 @@ Refer to [Create a rule via API](/cache/how-to/cache-response-rules/create-api/)
 
 ### Action: set_cache_tags
 
-Modifies the cache tags associated with the response. Cache tags can be used for targeted [cache purging](/cache/how-to/purge-cache/purge-by-tags/).
+Modifies the cache tags associated with the response. Cache tags are labels you attach to cached responses so you can later [purge specific groups of cached content](/cache/how-to/purge-cache/purge-by-tags/) without clearing your entire cache.
 
 | Parameter | Type | Description |
 | --- | --- | --- |
@@ -164,7 +164,7 @@ Refer to [Create a rule via API](/cache/how-to/cache-response-rules/create-api/)
 
 ### Action: set_cache_control
 
-Modifies Cache-Control header directives in the origin response.
+Modifies `Cache-Control` header directives in the origin response. This allows you to override how long Cloudflare and downstream clients cache content, without changing your origin server configuration.
 
 #### Supported directives
 
@@ -201,7 +201,7 @@ Applies to `max-age`, `s-maxage`, `stale-if-error`, and `stale-while-revalidate`
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `operation` | String | **Required.** `set` or `remove`. |
-| `cloudflare_only` | Boolean | When enabled, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive. |
+| `cloudflare_only` | Boolean | When turned on, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive from the origin. |
 | `value` | Integer | Duration in seconds. **Required when operation is `set`.** |
 
 ##### Directives with optional qualifiers
@@ -211,7 +211,7 @@ Applies to `private` and `no-cache`.
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `operation` | String | **Required.** `set` or `remove`. |
-| `cloudflare_only` | Boolean | When enabled, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive. |
+| `cloudflare_only` | Boolean | When turned on, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive from the origin. |
 | `qualifiers` | Array | Optional list of header names to qualify the directive. |
 
 ##### Boolean directives
@@ -221,7 +221,7 @@ Applies to `no-store`, `no-transform`, `must-revalidate`, `proxy-revalidate`, `m
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `operation` | String | **Required.** `set` or `remove`. |
-| `cloudflare_only` | Boolean | When enabled, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive. |
+| `cloudflare_only` | Boolean | When turned on, this setting only affects how Cloudflare caches your content. Your visitors still receive the original directive from the origin. |
 
 <Details header="API information">
 


### PR DESCRIPTION
## Summary

Apply ELI5 analysis to 3 files in docs/cache/how-to/cache-response-rules/. Two files (create-api.mdx, terraform-example.mdx) were skipped as developer-focused API references with no clarity issues.

## Changes by file

- index.mdx: Fix factual error (stripping ETag also disables Smart Edge Revalidation, not just Last-Modified), replace external blog link with internal docs link, clarify phase timing, remove unused OCC abbreviation, fix style (enabled to turned on)
- create-dashboard.mdx: Add standard login step per style guide convention, simplify conditional phrasing
- settings.mdx: Bold Edit expression as UI element, replace blog link with internal docs, define cache tags inline, add why context for set_cache_control action, fix enabled to turned on (3 occurrences)

## Review notes

Key fix: index.mdx had a factual error — original said only stripping Last-Modified disables Smart Edge Revalidation, but settings.mdx confirms stripping ETag OR Last-Modified disables it.