### PR TITLE
[Cache] ELI5: Simplify cache-rules examples and fix cookie name bug

### DIFF
--- a/src/content/docs/cache/how-to/cache-rules/examples/browser-cache-ttl.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/browser-cache-ttl.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: example
 summary: Browser Cache TTL
 title: Browser Cache TTL
-description: Browser Cache TTL
+description: Set a custom browser cache TTL using a cache rule.
 products: [cache-rules]
 ---
 

--- a/src/content/docs/cache/how-to/cache-rules/examples/bypass-cache-on-cookie.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/bypass-cache-on-cookie.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: example
 summary: Bypass Cache on Cookie
 title: Bypass Cache on Cookie
-description: Bypass Cache on Cookie
+description: Bypass cache when a specific cookie is present.
 products: [cache-rules]
 tags:
   - Cookies
@@ -12,7 +12,7 @@ import { Example, Render } from "~/components";
 
 <Render file="page-rules-migration" product="cache" />
 
-[Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to bypass cache for requests containing cookie `test_cookie` for any hostname containing `example.com`:
+[Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to bypass cache for requests containing cookie `test-cookie` for any hostname containing `example.com`:
 
 <Example>
 

--- a/src/content/docs/cache/how-to/cache-rules/examples/cache-deception-armor.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/cache-deception-armor.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: example
 summary: Cache Deception Armor
 title: Cache Deception Armor
-description: Cache Deception Armor
+description: Turn on Cache Deception Armor using a cache rule.
 products: [cache-rules]
 tags:
   - Security
@@ -12,7 +12,7 @@ import { Example, Render } from "~/components";
 
 <Render file="page-rules-migration" product="cache" />
 
-[Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to protect against cache deception attacks for any hostname containing `example.com`:
+[Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to protect against [cache deception attacks](/cache/cache-security/cache-deception-armor/) for any hostname containing `example.com`:
 
 <Example>
 

--- a/src/content/docs/cache/how-to/cache-rules/examples/cache-device-type.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/cache-device-type.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: example
 summary: Cache by Device Type
 title: Cache by Device Type
-description: Cache by Device Type
+description: Cache different content based on device type.
 products: [cache-rules]
 ---
 

--- a/src/content/docs/cache/how-to/cache-rules/examples/cache-everything.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/cache-everything.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: example
 summary: Cache Level (Cache Everything)
 title: Cache Level (Cache Everything)
-description: Cache Level (Cache Everything)
+description: Cache all content for a hostname using a cache rule.
 products: [cache-rules]
 ---
 
@@ -32,4 +32,5 @@ This option caches all HTML regardless of the presence of dynamic content. If yo
 - Checking for the presence of a cookie.
 - Negative matching against known dynamic content file paths.
 - Negative matching against dynamic content extensions (or lack of an extension).
-  :::
+
+:::

--- a/src/content/docs/cache/how-to/cache-rules/examples/edge-ttl.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/edge-ttl.mdx
@@ -8,7 +8,7 @@ products: [cache-rules]
 
 import { Example } from "~/components";
 
-[Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to adjust edge cache TTL for caching resources on Cloudflare edge to one day, for any hostname containing `example.com`:
+[Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to set the edge cache TTL to one day for any hostname containing `example.com`:
 
 <Example>
 

--- a/src/content/docs/cache/how-to/cache-rules/examples/origin-cache-control.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/origin-cache-control.mdx
@@ -2,25 +2,25 @@
 pcx_content_type: example
 summary: Origin Cache Control
 title: Origin Cache Control
-description: Origin Cache Control
+description: Configure Origin Cache Control using a cache rule.
 products: [cache-rules]
 ---
 
-import { Example } from "~/components"
+import { Example } from "~/components";
 
 [Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to determine edge cache behavior for any hostname containing `example.com`:
 
 <Example>
 
-* **When incoming requests match**: Custom filter expression
-  * Using the Expression Builder:<br/>
+- **When incoming requests match**: Custom filter expression
+  - Using the Expression Builder:<br/>
     `Hostname contains "example.com"`
-  * Using the Expression Editor:<br/>
+  - Using the Expression Editor:<br/>
     `(http.host contains "example.com")`
 
-* **Then**:
-  * **Cache eligibility**: Eligible for cache
-  * **Setting**: Origin Cache Control
-    * **Enable Origin Cache Control**: Off
+- **Then**:
+  - **Cache eligibility**: Eligible for cache
+  - **Setting**: Origin Cache Control
+    - **Enable Origin Cache Control**: Off
 
 </Example>

--- a/src/content/docs/cache/how-to/cache-rules/examples/query-string-sort.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/query-string-sort.mdx
@@ -2,25 +2,25 @@
 pcx_content_type: example
 summary: Query String Sort
 title: Query String Sort
-description: Query String Sort
+description: Sort query string parameters for caching using a cache rule.
 products: [cache-rules]
 ---
 
-import { Example } from "~/components"
+import { Example } from "~/components";
 
 [Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to sort query string parameters for caching purposes, for any hostname containing `example.com`:
 
 <Example>
 
-* **When incoming requests match**: Custom filter expression
-  * Using the Expression Builder:<br/>
+- **When incoming requests match**: Custom filter expression
+  - Using the Expression Builder:<br/>
     `Hostname contains "example.com"`
-  * Using the Expression Editor:<br/>
+  - Using the Expression Editor:<br/>
     `(http.host contains "example.com")`
 
-* **Then**:
-  * **Cache eligibility**: Eligible for cache
-  * **Setting**: Cache key
-    * **Sort query string**: On
+- **Then**:
+  - **Cache eligibility**: Eligible for cache
+  - **Setting**: Cache key
+    - **Sort query string**: On
 
 </Example>

--- a/src/content/docs/cache/how-to/cache-rules/examples/respect-strong-etags.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/examples/respect-strong-etags.mdx
@@ -2,25 +2,25 @@
 pcx_content_type: example
 summary: Respect Strong ETags
 title: Respect Strong ETags
-description: Respect Strong ETags
+description: Preserve strong ETag headers using a cache rule.
 products: [cache-rules]
 ---
 
-import { Example } from "~/components"
+import { Example } from "~/components";
 
 [Create a cache rule](/cache/how-to/cache-rules/create-dashboard/) to respect strong ETags for any hostname containing `example.com`:
 
 <Example>
 
-* **When incoming requests match**: Custom filter expression
-  * Using the Expression Builder:<br/>
+- **When incoming requests match**: Custom filter expression
+  - Using the Expression Builder:<br/>
     `Hostname contains "example.com"`
-  * Using the Expression Editor:<br/>
+  - Using the Expression Editor:<br/>
     `(http.host contains "example.com")`
 
-* **Then**:
-  * **Cache eligibility**: Eligible for cache
-  * **Setting**: Respect strong ETags
-    * **Use strong ETag headers**: On
+- **Then**:
+  - **Cache eligibility**: Eligible for cache
+  - **Setting**: Respect strong ETags
+    - **Use strong ETag headers**: On
 
 </Example>


### PR DESCRIPTION
## Summary

Apply ELI5 analysis to 12 example files in docs/cache/how-to/cache-rules/examples/. 9 files changed, 3 needed no changes.

## Key fixes

- **bypass-cache-on-cookie.mdx**: Cookie name mismatch — prose said test_cookie (underscore) but Expression Builder/Editor both use test-cookie (hyphen). Fixed to test-cookie.
- **cache-deception-armor.mdx**: Added cross-link to the cache deception attacks concept page — the term was used without definition or link.
- **cache-everything.mdx**: Fixed misindented admonition closing tag that could cause rendering issues.
- **edge-ttl.mdx**: Removed tautological phrasing (edge cache TTL for caching resources on Cloudflare edge).

## Consistency fixes across 5 files

- Fixed description fields that duplicated the title verbatim
- Normalized list markers (asterisk to dash) for consistency with sibling files
- Added missing semicolons to import statements