### PR TITLE
[Cache] ELI5: Simplify edge-browser-cache-ttl docs

### DIFF
--- a/src/content/docs/cache/how-to/edge-browser-cache-ttl/index.mdx
+++ b/src/content/docs/cache/how-to/edge-browser-cache-ttl/index.mdx
@@ -11,11 +11,11 @@ import { FeatureTable } from "~/components"
 
 ## Edge Cache TTL
 
-Edge Cache TTL (Time to Live) specifies the maximum time to cache a resource in the Cloudflare global network. Edge Cache TTL is not visible in response headers and the minimum Edge Cache TTL depends on plan type.
+Edge Cache TTL (Time to Live) specifies the maximum time to cache a resource in the Cloudflare global network. A longer Edge Cache TTL means more requests are served from cache, reducing load on your origin server. Edge Cache TTL is not visible in response headers and the minimum Edge Cache TTL depends on plan type.
 
 <FeatureTable id="cache.edge_cache_ttl" />
 
-For more information on how to set up Edge Cache TTL, refer to [Cache rules](/cache/how-to/cache-rules/settings/#edge-ttl).
+For more information on how to configure Edge Cache TTL, refer to [Cache rules](/cache/how-to/cache-rules/settings/#edge-ttl).
 
 ## Browser Cache TTL
 
@@ -26,13 +26,13 @@ The Browser Cache TTL sets the expiration for resources cached in a visitor’s 
 
 Unless specifically set in a cache rule, Cloudflare does not override or insert `Cache-Control` headers if you set **Browser Cache TTL** to **Respect Existing Headers**.
 
-:::note[Note]
+:::note
 
-
-* Setting high Browser Cache TTL values means that the assets will be cached for a long time by users’ browsers.
+* Setting high Browser Cache TTL values means that the assets will be cached for a long time by users' browsers.
 * If you modify cached assets, the new assets may not be displayed to repeat visitors before the Browser Cache TTL expires.
-* Purging Cloudflare’s cache does not affect assets stored by a visitor’s browser. 
-  :::
+* Purging Cloudflare's cache does not affect assets stored by a visitor's browser.
+
+:::
 
 <FeatureTable id="cache.browser_cache_ttl" />
 

--- a/src/content/docs/cache/how-to/edge-browser-cache-ttl/set-browser-ttl.mdx
+++ b/src/content/docs/cache/how-to/edge-browser-cache-ttl/set-browser-ttl.mdx
@@ -15,27 +15,26 @@ Specify a time for a visitor’s Browser Cache TTL to accelerate the page load f
 
 By default, Cloudflare honors the cache expiration set in your `Expires` and `Cache-Control` headers. Cloudflare overrides any `Cache-Control` or `Expires` headers with values set via the **Browser Cache TTL** option under **Caching** on your dashboard if:
 
-* The value of the `Cache-Control` header from the origin web server is less than the **Browser Cache TTL** setting. This means that **Browser cache TTL** value needs to be higher than origin `max-age`.
+* The value of the `Cache-Control` or `Expires` header from the origin web server is less than the **Browser Cache TTL** setting.
 * The origin web server does not send a `Cache-Control` or an `Expires` header.
 
 Unless specifically set in a [Cache Rule](/cache/how-to/cache-rules/), Cloudflare does not override or insert `Cache-Control` headers if you set **Browser Cache TTL** to **Respect Existing Headers**.
 
-Nevertheless, the value you set via Cache Rule will be ignored if `Cache-Control: max-age` is higher. In other words, you can override to make browsers cache longer than Cloudflare's edge but not less.
+The zone-level **Browser Cache TTL** setting respects whichever value is higher — the setting you configure or the origin `max-age`. To override the origin `max-age` regardless of its value, use a [Cache Rule](/cache/how-to/cache-rules/settings/#browser-ttl) with **Override origin** mode instead.
 
 ## Set Browser Cache TTL
 
-:::note[Note]
+:::note
 
-
-If you modify cached assets, the new asset is not displayed to repeat visitors before the Browser Cache TTL duration. [Purging Cloudflare’s cache](/cache/how-to/purge-cache/) does not affect assets cached in a visitor’s browser.
-
+If you modify cached assets, the new asset is not displayed to repeat visitors before the Browser Cache TTL duration. [Purging Cloudflare's cache](/cache/how-to/purge-cache/) does not affect assets cached in a visitor's browser.
 
 :::
 
-1. In the Cloudflare dashboard, go to the **Caching** page.
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account and domain.
+2. Go to **Caching** > **Configuration**.
 
    <DashButton url="/?to=/:account/:zone/caching/configuration" />
 
-2. Under **Browser Cache TTL**, select the desired cache expiration time from the drop-down menu.
+3. Under **Browser Cache TTL**, select the desired cache expiration time from the dropdown menu.
 
 The **Respect Existing Headers** option tells Cloudflare to honor the settings in the `Cache-Control` headers from your origin web server.


### PR DESCRIPTION
## Summary

Apply ELI5 analysis to 2 files in docs/cache/how-to/edge-browser-cache-ttl/.

## Key fix

set-browser-ttl.mdx had a factual conflict: line 23 stated Cache Rule values are ignored when origin max-age is higher, but cache-control.mdx and cdn-cache-control.mdx both state that Browser Cache TTL Cache Rules override max-age. The whichever-is-higher behavior applies to the zone-level setting, not Cache Rules. Fixed to clarify the distinction and direct users to Cache Rules for override behavior.

## Other changes

- index.mdx: Add why context for Edge Cache TTL, fix broken admonition closing tag, remove redundant Note label, fix trailing whitespace
- set-browser-ttl.mdx: Add missing Expires header to override conditions, fix dashboard login convention, fix drop-down to dropdown, fix inconsistent Browser Cache TTL capitalization