### PR TITLE
fix: remove duplicate word "containers" in getting started page

### DIFF
--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -59,7 +59,7 @@ During this time, requests are sent to the Worker, but calls to the Container wi
 
 ### Check deployment status
 
-After deploying, run the following command to show a list of containers containers in your Cloudflare account, and their deployment status:
+After deploying, run the following command to show a list of containers in your Cloudflare account, and their deployment status:
 
 <PackageManagers type="exec" pkg="wrangler" args="containers list" />
 


### PR DESCRIPTION
## Summary
Fixes a typo in the Containers getting started documentation where the  word "containers" appears twice consecutively.

## Change
- File: `src/content/docs/containers/get-started.mdx`
- Section: "Check deployment status"
- Before: "a list of containers containers in your Cloudflare account"
- After:  "a list of containers in your Cloudflare account"

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
