### PR TITLE
style: kumo-ify tooltips

### DIFF
--- a/src/components/GlossaryTooltip.astro
+++ b/src/components/GlossaryTooltip.astro
@@ -41,7 +41,9 @@ definition = definition.split(/\r?\n/)[0];
 	}</span><script>
 	import { addTooltip } from "~/util/tippy";
 
-	const tooltips = document.querySelectorAll<HTMLSpanElement>("[data-tooltip]");
+	const tooltips = document.querySelectorAll<HTMLSpanElement>(
+		"[data-tooltip][data-content]",
+	);
 
 	for (const tooltip of tooltips) {
 		addTooltip(tooltip, tooltip.dataset.content as string);

--- a/src/components/PackageManagers.astro
+++ b/src/components/PackageManagers.astro
@@ -180,8 +180,6 @@ const uid = Math.random().toString(36).slice(2, 8);
 			.forEach((btn) => {
 				const tooltip: Instance = tippy(btn, {
 					content: "Copy to clipboard",
-					placement: "top",
-					arrow: true,
 					appendTo: () => document.body,
 				});
 

--- a/src/components/PackageManagers.astro
+++ b/src/components/PackageManagers.astro
@@ -181,7 +181,7 @@ const uid = Math.random().toString(36).slice(2, 8);
 				const tooltip: Instance = tippy(btn, {
 					content: "Copy to clipboard",
 					placement: "top",
-					arrow: false,
+					arrow: true,
 					appendTo: () => document.body,
 				});
 

--- a/src/components/PageActions.astro
+++ b/src/components/PageActions.astro
@@ -8,7 +8,10 @@ function phosphorIcon(name: string): string {
 	);
 	const svg = readFileSync(file, "utf-8");
 	// Extract inner content (strip outer <svg> wrapper — we render our own)
-	return svg.replace(/<svg[^>]*>/, "").replace(/<\/svg>/, "").trim();
+	return svg
+		.replace(/<svg[^>]*>/, "")
+		.replace(/<\/svg>/, "")
+		.trim();
 }
 
 const iconCopy = phosphorIcon("copy");
@@ -26,8 +29,22 @@ const iconScroll = phosphorIcon("scroll");
 		data-tooltip="Copy Page as Markdown"
 		aria-label="Copy Page as Markdown"
 	>
-		<svg class="copy-icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 256 256" fill="currentColor" set:html={iconCopy} />
-		<svg class="check-icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 256 256" fill="currentColor" set:html={iconCheckCircle} />
+		<svg
+			class="copy-icon"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			viewBox="0 0 256 256"
+			fill="currentColor"
+			set:html={iconCopy}
+		/>
+		<svg
+			class="check-icon"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			viewBox="0 0 256 256"
+			fill="currentColor"
+			set:html={iconCheckCircle}
+		/>
 		<span class="label-wrap">
 			<span class="label">Copy as Markdown</span>
 			<span class="copied-label" aria-hidden="true">Copied!</span>
@@ -46,7 +63,13 @@ const iconScroll = phosphorIcon("scroll");
 		target="_blank"
 		rel="noopener noreferrer"
 	>
-		<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 256 256" fill="currentColor" set:html={iconMarkdown} />
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			viewBox="0 0 256 256"
+			fill="currentColor"
+			set:html={iconMarkdown}
+		/>
 		<span>View as Markdown</span>
 	</a>
 
@@ -59,7 +82,13 @@ const iconScroll = phosphorIcon("scroll");
 		data-tooltip="Setup your agent to build on Cloudflare"
 		aria-label="Setup your agent to build on Cloudflare"
 	>
-		<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 256 256" fill="currentColor" set:html={iconRobot} />
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			viewBox="0 0 256 256"
+			fill="currentColor"
+			set:html={iconRobot}
+		/>
 		<span>Agent setup</span>
 	</button>
 
@@ -72,7 +101,13 @@ const iconScroll = phosphorIcon("scroll");
 		data-tooltip="Consume Cloudflare Docs with your agent"
 		aria-label="Consume Cloudflare Docs with your agent"
 	>
-		<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 256 256" fill="currentColor" set:html={iconScroll} />
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			viewBox="0 0 256 256"
+			fill="currentColor"
+			set:html={iconScroll}
+		/>
 		<span>Docs for agents</span>
 	</button>
 </nav>
@@ -181,46 +216,67 @@ const iconScroll = phosphorIcon("scroll");
 
 	function init() {
 		// Wire up tooltips
-		document.querySelectorAll<HTMLElement>(".page-actions [data-tooltip]").forEach((btn) => {
-			tippy(btn, {
-				content: btn.dataset.tooltip!,
-				arrow: false,
-				appendTo: () => document.body,
+		document
+			.querySelectorAll<HTMLElement>(".page-actions [data-tooltip]")
+			.forEach((btn) => {
+				tippy(btn, {
+					content: btn.dataset.tooltip!,
+					arrow: true,
+					appendTo: () => document.body,
+				});
 			});
-		});
 
 		// Copy as Markdown
-		document.getElementById("page-actions-copy")?.addEventListener("click", async () => {
-			const markdownUrl = new URL("index.md", window.location.href).toString();
-			const btn = document.getElementById("page-actions-copy") as HTMLButtonElement;
+		document
+			.getElementById("page-actions-copy")
+			?.addEventListener("click", async () => {
+				const markdownUrl = new URL(
+					"index.md",
+					window.location.href,
+				).toString();
+				const btn = document.getElementById(
+					"page-actions-copy",
+				) as HTMLButtonElement;
 
-			btn.classList.add("is-copied");
-			setTimeout(() => btn.classList.remove("is-copied"), 1500);
+				btn.classList.add("is-copied");
+				setTimeout(() => btn.classList.remove("is-copied"), 1500);
 
-			navigator.clipboard.write([new ClipboardItem({
-				"text/plain": fetch(markdownUrl)
-					.then((r) => r.text())
-					.then((t) => new Blob([t], { type: "text/plain" })),
-			})]).then(() => track("agents toolkit clicked", { value: "copy markdown" }))
-				.catch((e) => console.error("Failed to copy Markdown:", e));
-		});
+				navigator.clipboard
+					.write([
+						new ClipboardItem({
+							"text/plain": fetch(markdownUrl)
+								.then((r) => r.text())
+								.then((t) => new Blob([t], { type: "text/plain" })),
+						}),
+					])
+					.then(() =>
+						track("agents toolkit clicked", { value: "copy markdown" }),
+					)
+					.catch((e) => console.error("Failed to copy Markdown:", e));
+			});
 
 		// View as Markdown — href is a relative link; just track the click
-		document.getElementById("page-actions-view-md")?.addEventListener("click", () => {
-			track("agents toolkit clicked", { value: "view markdown" });
-		});
+		document
+			.getElementById("page-actions-view-md")
+			?.addEventListener("click", () => {
+				track("agents toolkit clicked", { value: "view markdown" });
+			});
 
 		// Agent setup
-		document.getElementById("page-actions-agent-setup")?.addEventListener("click", () => {
-			track("agents toolkit clicked", { value: "view ai options" });
-			window.open("/agent-setup/", "_blank");
-		});
+		document
+			.getElementById("page-actions-agent-setup")
+			?.addEventListener("click", () => {
+				track("agents toolkit clicked", { value: "view ai options" });
+				window.open("/agent-setup/", "_blank");
+			});
 
 		// Docs for agents
-		document.getElementById("page-actions-docs-for-agents")?.addEventListener("click", () => {
-			track("agents toolkit clicked", { value: "docs for agents" });
-			window.open("/docs-for-agents/", "_blank");
-		});
+		document
+			.getElementById("page-actions-docs-for-agents")
+			?.addEventListener("click", () => {
+				track("agents toolkit clicked", { value: "docs for agents" });
+				window.open("/docs-for-agents/", "_blank");
+			});
 	}
 
 	// Run on initial load and after Astro view transitions

--- a/src/components/PageActions.astro
+++ b/src/components/PageActions.astro
@@ -221,7 +221,6 @@ const iconScroll = phosphorIcon("scroll");
 			.forEach((btn) => {
 				tippy(btn, {
 					content: btn.dataset.tooltip!,
-					arrow: true,
 					appendTo: () => document.body,
 				});
 			});

--- a/src/scripts/explain-code.ts
+++ b/src/scripts/explain-code.ts
@@ -48,7 +48,7 @@ function init() {
 		const instance = tippy(button, {
 			content: "Explain Code",
 			placement: "top",
-			arrow: false,
+			arrow: true,
 			appendTo: () => document.body,
 		});
 		tippyInstances.push(instance);
@@ -61,7 +61,7 @@ function init() {
 		const instance = tippy(button, {
 			content: "Copy to clipboard",
 			placement: "top",
-			arrow: false,
+			arrow: true,
 			appendTo: () => document.body,
 		});
 		tippyInstances.push(instance);

--- a/src/scripts/explain-code.ts
+++ b/src/scripts/explain-code.ts
@@ -47,8 +47,6 @@ function init() {
 		button.addEventListener("click", handleExplainButtonClick);
 		const instance = tippy(button, {
 			content: "Explain Code",
-			placement: "top",
-			arrow: true,
 			appendTo: () => document.body,
 		});
 		tippyInstances.push(instance);
@@ -60,8 +58,6 @@ function init() {
 	copyButtons.forEach((button) => {
 		const instance = tippy(button, {
 			content: "Copy to clipboard",
-			placement: "top",
-			arrow: true,
 			appendTo: () => document.body,
 		});
 		tippyInstances.push(instance);

--- a/src/styles/tippy.css
+++ b/src/styles/tippy.css
@@ -1,26 +1,35 @@
-/*
- * Tooltip surface styled to match the kumo Tooltip component.
- * Theme-aware via Starlight color tokens (light + dark modes).
- *
- * Kumo reference: kumo/packages/kumo/src/components/tooltip/tooltip.tsx
- *   - bg-kumo-base       -> --sl-color-bg
- *   - text-kumo-default  -> --sl-color-text
- *   - outline-kumo-fill  -> --sl-color-hairline
- *   - rounded-md         -> 6px
- *   - px-2.5 py-1.5      -> 6px 10px
- *   - text-sm            -> 0.875rem
- */
-
 .tippy-box {
 	background-color: var(--sl-color-bg) !important;
 	color: var(--sl-color-text) !important;
 	border: 1px solid var(--sl-color-hairline) !important;
 	border-radius: 6px !important;
-	font-size: 0.875rem !important;
+	font-size: 0.8125rem !important;
 	line-height: 1.4 !important;
 	box-shadow:
 		0 4px 6px -1px rgb(0 0 0 / 0.1),
 		0 2px 4px -2px rgb(0 0 0 / 0.1) !important;
+}
+
+/* Dark mode — bump the border one step (`hairline-shade`) so the tooltip
+ * edge reads more clearly against the dark page surface. */
+[data-theme="dark"] .tippy-box {
+	border-color: var(--sl-color-hairline-shade) !important;
+}
+
+[data-theme="dark"] .tippy-box[data-placement^="top"] > .tippy-arrow::before {
+	filter: drop-shadow(0 1px 0 var(--sl-color-hairline-shade));
+}
+
+[data-theme="dark"] .tippy-box[data-placement^="bottom"] > .tippy-arrow::before {
+	filter: drop-shadow(0 -1px 0 var(--sl-color-hairline-shade));
+}
+
+[data-theme="dark"] .tippy-box[data-placement^="left"] > .tippy-arrow::before {
+	filter: drop-shadow(1px 0 0 var(--sl-color-hairline-shade));
+}
+
+[data-theme="dark"] .tippy-box[data-placement^="right"] > .tippy-arrow::before {
+	filter: drop-shadow(-1px 0 0 var(--sl-color-hairline-shade));
 }
 
 .tippy-box .tippy-content {

--- a/src/styles/tippy.css
+++ b/src/styles/tippy.css
@@ -20,7 +20,9 @@
 	filter: drop-shadow(0 1px 0 var(--sl-color-hairline-shade));
 }
 
-[data-theme="dark"] .tippy-box[data-placement^="bottom"] > .tippy-arrow::before {
+[data-theme="dark"]
+	.tippy-box[data-placement^="bottom"]
+	> .tippy-arrow::before {
 	filter: drop-shadow(0 -1px 0 var(--sl-color-hairline-shade));
 }
 

--- a/src/styles/tippy.css
+++ b/src/styles/tippy.css
@@ -1,14 +1,58 @@
+/*
+ * Tooltip surface styled to match the kumo Tooltip component.
+ * Theme-aware via Starlight color tokens (light + dark modes).
+ *
+ * Kumo reference: kumo/packages/kumo/src/components/tooltip/tooltip.tsx
+ *   - bg-kumo-base       -> --sl-color-bg
+ *   - text-kumo-default  -> --sl-color-text
+ *   - outline-kumo-fill  -> --sl-color-hairline
+ *   - rounded-md         -> 6px
+ *   - px-2.5 py-1.5      -> 6px 10px
+ *   - text-sm            -> 0.875rem
+ */
+
 .tippy-box {
-	background-color: #3d3d3d !important;
-	border: 1px solid #595959 !important;
-	color: #e6e6e6 !important;
-	font-size: 0.75rem !important;
+	background-color: var(--sl-color-bg) !important;
+	color: var(--sl-color-text) !important;
+	border: 1px solid var(--sl-color-hairline) !important;
+	border-radius: 6px !important;
+	font-size: 0.875rem !important;
+	line-height: 1.4 !important;
+	box-shadow:
+		0 4px 6px -1px rgb(0 0 0 / 0.1),
+		0 2px 4px -2px rgb(0 0 0 / 0.1) !important;
 }
 
 .tippy-box .tippy-content {
-	padding: 2px 7px !important;
+	padding: 6px 10px !important;
 }
 
+/* Keep inline links inside tooltips legible against the new surface */
+.tippy-box .tippy-content a {
+	color: var(--sl-color-text-accent);
+}
+
+/* Arrow — match the popup background and pick up the hairline as a faux border */
 .tippy-box .tippy-arrow {
-	display: none !important;
+	color: var(--sl-color-bg);
+}
+
+.tippy-box[data-placement^="top"] > .tippy-arrow::before {
+	border-top-color: var(--sl-color-bg);
+	filter: drop-shadow(0 1px 0 var(--sl-color-hairline));
+}
+
+.tippy-box[data-placement^="bottom"] > .tippy-arrow::before {
+	border-bottom-color: var(--sl-color-bg);
+	filter: drop-shadow(0 -1px 0 var(--sl-color-hairline));
+}
+
+.tippy-box[data-placement^="left"] > .tippy-arrow::before {
+	border-left-color: var(--sl-color-bg);
+	filter: drop-shadow(1px 0 0 var(--sl-color-hairline));
+}
+
+.tippy-box[data-placement^="right"] > .tippy-arrow::before {
+	border-right-color: var(--sl-color-bg);
+	filter: drop-shadow(-1px 0 0 var(--sl-color-hairline));
 }

--- a/src/util/tippy.ts
+++ b/src/util/tippy.ts
@@ -22,7 +22,7 @@ export function addTooltip(
 		allowHTML: true,
 		interactive: true,
 		placement: "top",
-		arrow: false,
+		arrow: true,
 		// This is imperfect as it stops you from tabbing into
 		// links inside the tooltip, but stops tooltips being
 		// cutoff by the sidebar

--- a/src/util/tippy.ts
+++ b/src/util/tippy.ts
@@ -21,8 +21,6 @@ export function addTooltip(
 		content,
 		allowHTML: true,
 		interactive: true,
-		placement: "top",
-		arrow: true,
 		// This is imperfect as it stops you from tabbing into
 		// links inside the tooltip, but stops tooltips being
 		// cutoff by the sidebar


### PR DESCRIPTION
### Summary

Kumo-ify the tooltips

### Screenshots (optional)

Before
<img width="691" height="156" alt="Screenshot 2026-05-07 at 12 41 24" src="https://github.com/user-attachments/assets/3546827f-dd62-4ba8-a0b1-fcafdb8d3d57" />

<img width="724" height="149" alt="Screenshot 2026-05-07 at 12 41 38" src="https://github.com/user-attachments/assets/2dabd7aa-43c5-4327-b87f-b0bf8b6f0954" />


After
<img width="725" height="136" alt="Screenshot 2026-05-07 at 12 41 12" src="https://github.com/user-attachments/assets/ed229fcc-3355-41a9-beec-7397be52e513" />

<img width="746" height="153" alt="Screenshot 2026-05-07 at 12 43 08" src="https://github.com/user-attachments/assets/9e04bb69-1e9d-45e9-8eb1-5a63ac91241c" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
