### PR TITLE
smart-shield: clarify Regional Tiered Cache availability (SHIP-15052)

### DIFF
--- a/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
+++ b/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
@@ -13,7 +13,7 @@ tags:
 import { Render } from "~/components";
 
 :::note[Availability]
-Available with Smart Shield Advanced.
+Included with Enterprise plans. Available to Free, Pro, and Business plans through Smart Shield Advanced.
 :::
 
 <Render file="regional-tiered-cache" product="cache" />

--- a/src/content/docs/smart-shield/get-started.mdx
+++ b/src/content/docs/smart-shield/get-started.mdx
@@ -48,6 +48,10 @@ The full package with additional caching customization through regional and pers
 
 - Includes [Smart Tiered Cache](/smart-shield/configuration/smart-tiered-cache/), [Connection Reuse](/smart-shield/concepts/connection-reuse/), [Argo Smart Routing](/smart-shield/configuration/argo/), [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/), and [Cache Reserve](/smart-shield/configuration/cache-reserve/).
 
+:::note[Regional Tiered Cache for Enterprise]
+Enterprise customers have access to [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) as part of their plan, regardless of which Smart Shield package they use. Free, Pro, and Business plans receive Regional Tiered Cache through Smart Shield Advanced.
+:::
+
 :::note[Dedicated CDN Egress IPs]
 Enterprise customers also have the option to configure [Dedicated CDN Egress IPs](/smart-shield/configuration/dedicated-egress-ips/), allowing you to increase origin security by only allowing traffic from a small list of IP addresses. If you are interested, reach out to your account team.
 :::

--- a/src/content/docs/smart-shield/index.mdx
+++ b/src/content/docs/smart-shield/index.mdx
@@ -23,7 +23,7 @@ Smart Shield includes [Smart Tiered Cache](/smart-shield/configuration/smart-tie
 Depending on your [package tier](/smart-shield/get-started/#packages-and-availability), Smart Shield can also include:
 
 - [Argo Smart Routing](/smart-shield/configuration/argo/) — routes traffic through the fastest network paths to reduce latency.
-- [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) — adds a regional cache layer between lower-tier and upper-tier data centers for geographic data locality.
+- [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) — adds a regional cache layer between lower-tier and upper-tier data centers for geographic data locality (included with Enterprise plans, or available to Free, Pro, and Business plans through Smart Shield Advanced).
 - [Cache Reserve](/smart-shield/configuration/cache-reserve/) — persistent cache storage that reduces cache misses for infrequently accessed content.
 - [Health Checks](/smart-shield/configuration/health-checks/) — monitors your origin server availability (Pro plans and above).
 - [Dedicated CDN Egress IPs](/smart-shield/configuration/dedicated-egress-ips/) — reserved IP addresses for origin allowlisting (Enterprise).

--- a/src/content/docs/smart-shield/index.mdx
+++ b/src/content/docs/smart-shield/index.mdx
@@ -23,7 +23,7 @@ Smart Shield includes [Smart Tiered Cache](/smart-shield/configuration/smart-tie
 Depending on your [package tier](/smart-shield/get-started/#packages-and-availability), Smart Shield can also include:
 
 - [Argo Smart Routing](/smart-shield/configuration/argo/) — routes traffic through the fastest network paths to reduce latency.
-- [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) — adds a regional cache layer between lower-tier and upper-tier data centers for geographic data locality (included with Enterprise plans, or available to Free, Pro, and Business plans through Smart Shield Advanced).
+- [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) — adds a regional cache layer between lower-tier and upper-tier data centers for geographic data locality (Enterprise plans, or Smart Shield Advanced).
 - [Cache Reserve](/smart-shield/configuration/cache-reserve/) — persistent cache storage that reduces cache misses for infrequently accessed content.
 - [Health Checks](/smart-shield/configuration/health-checks/) — monitors your origin server availability (Pro plans and above).
 - [Dedicated CDN Egress IPs](/smart-shield/configuration/dedicated-egress-ips/) — reserved IP addresses for origin allowlisting (Enterprise).


### PR DESCRIPTION
## Summary

Clarify that Regional Tiered Cache is included with Enterprise plans, and that Smart Shield Advanced is the path for non-ENT (Free/Pro/Business) plans. Current docs state only "Available with Smart Shield Advanced," which implies all plan tiers must purchase Smart Shield Advanced — incorrect.

This was the source of in-product confusion where an Enterprise zone sees the RTC toggle on the free Smart Shield package while the docs and the dashboard Explore Packages modal both imply Smart Shield Advanced is required. Confirmed with the Smart Shield PM that the correct positioning is: ENT plans include RTC as they always have; Smart Shield Advanced adds RTC for non-ENT plans.

## Changes

- `src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx` — rewrite the availability note from `Available with Smart Shield Advanced.` to `Included with Enterprise plans. Available to Free, Pro, and Business plans through Smart Shield Advanced.`
- `src/content/docs/smart-shield/get-started.mdx` — add a callout under the **Smart Shield Advanced** subsection (parallel in style and placement to the existing **Dedicated CDN Egress IPs** callout) explaining ENT entitlement.
- `src/content/docs/smart-shield/index.mdx` — extend the Regional Tiered Cache bullet on the overview page to reflect the dual availability path.

## Why this matters

The Regional Tiered Cache PRD explicitly states: _"Regional Tiered Cache is ENT-only and is included in that plan level."_ Smart Shield Advanced was introduced later as a way to extend RTC (and Cache Reserve, Aegis) to PAYGO/non-ENT customers — it does not replace the existing ENT plan entitlement.

Field-side this caused a multi-surface contradiction across the dashboard splash, Explore packages modal, and developer docs in the same customer session. The dashboard-side fixes are tracked under SHIP-15053; this PR fixes the docs side.

## Verification

- After merge, confirm https://developers.cloudflare.com/smart-shield/configuration/regional-tiered-cache/ displays the updated availability note.
- Confirm https://developers.cloudflare.com/smart-shield/get-started/ shows two side-by-side callouts (Regional Tiered Cache for Enterprise; Dedicated CDN Egress IPs).
- Confirm https://developers.cloudflare.com/smart-shield/ overview page reflects the updated bullet.

## Reviewer

Requested review: Cody Anthony (canthony@cloudflare.com — please add yourself as a reviewer when you see this; I could not resolve your GitHub handle confidently).

## References

- Internal: SHIP-15052 (this work)
- Internal: SHIP-15053 (sibling: dashboard fix)
- Internal: SHIP-14978 (parent: Smart Shield Master Task)