### PR TITLE
[Fundamentals] Rename Direct Add to Skip email confirmation

### DIFF
--- a/src/content/partials/fundamentals/add-account-members.mdx
+++ b/src/content/partials/fundamentals/add-account-members.mdx
@@ -26,7 +26,7 @@ To add a member to your account:
 
 :::note
 
-If a user already has an account with Cloudflare and you have an Enterprise account, you can also select **Direct Add** to add them to your account without sending an email invitation.
+If a user already has an account with Cloudflare and you have an Enterprise account, you can also select **Skip email confirmation** to add them to your account without sending an email invitation.
 :::
 
 </TabItem> <TabItem label="API">


### PR DESCRIPTION
## Summary

- Updates the button label reference in the "Add account members" section from **Direct Add** to **Skip email confirmation** to match the current dashboard UI.

## Change

- `src/content/partials/fundamentals/add-account-members.mdx` — single note line updated