### PR TITLE
[Containers] Document SSH enabled by default

### DIFF
--- a/src/content/changelog/containers/2026-05-12-ssh-enabled-by-default.mdx
+++ b/src/content/changelog/containers/2026-05-12-ssh-enabled-by-default.mdx
@@ -1,0 +1,54 @@
+---
+title: SSH through Wrangler is now enabled by default for Containers
+description: SSH through Wrangler is now enabled by default. Add a public key to connect, or opt out in your Container configuration.
+products:
+  - containers
+date: 2026-05-12
+---
+
+import { WranglerConfig } from "~/components";
+
+SSH through Wrangler is now enabled by default for [Containers](/containers/). Previously, you had to set `ssh.enabled` to `true` in your Container configuration before you could connect.
+
+This change does not expose any publicly accessible ports on your Container. The SSH service is reachable only through [`wrangler containers ssh`](/workers/wrangler/commands/containers/#containers-ssh), which authenticates against your Cloudflare account. You also need to add an `ssh-ed25519` public key to `authorized_keys` before anyone can connect, so enabling SSH alone does not grant access.
+
+To connect, add a public key to your Container configuration and run `wrangler containers ssh <INSTANCE_ID>`:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"containers": [
+		{
+			"authorized_keys": [
+				{
+					"name": "<NAME>",
+					"public_key": "<YOUR_PUBLIC_KEY_HERE>",
+				},
+			],
+		},
+	],
+}
+```
+
+</WranglerConfig>
+
+To disable SSH, set `ssh.enabled` to `false` in your Container configuration:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"containers": [
+		{
+			"ssh": {
+				"enabled": false,
+			},
+		},
+	],
+}
+```
+
+</WranglerConfig>
+
+For more information, refer to the [SSH documentation](/containers/ssh/).

--- a/src/content/docs/containers/ssh.mdx
+++ b/src/content/docs/containers/ssh.mdx
@@ -10,19 +10,19 @@ products:
 
 import { WranglerConfig } from "~/components";
 
-Anyone with write access to a Container can SSH into it with Wrangler as long as SSH is enabled.
+Anyone with write access to a Container can SSH into it with Wrangler as long as a matching public key is listed in `authorized_keys`.
+
+SSH does not expose a publicly accessible port on the Container. The only way to connect is through Wrangler with [`wrangler containers ssh`](/workers/wrangler/commands/containers/#containers-ssh), which authenticates against your Cloudflare account.
 
 ## Configure SSH
 
 SSH can be configured in your [Container's configuration](/workers/wrangler/configuration/#containers) with the `ssh` and `authorized_keys` properties. Only the `ssh-ed25519` key type is supported.
 
-The `ssh.enabled` property only controls whether you can SSH into a Container through Wrangler.
-If `ssh.enabled` is false but keys are still present in `authorized_keys`, the SSH service will still be started on the Container.
+The `ssh.enabled` property only controls whether you can SSH into a Container through Wrangler. It defaults to `true`. Set it to `false` to disable SSH access completely.
 
 ## Connect with Wrangler
 
-To SSH into a Container with Wrangler, you must first enable SSH in your Container configuration.
-The following example shows a basic configuration:
+To SSH into a Container with Wrangler, add an `ssh-ed25519` public key to `authorized_keys` in your Container configuration. The following example shows a basic configuration:
 
 <WranglerConfig>
 
@@ -31,9 +31,6 @@ The following example shows a basic configuration:
 	"containers": [
 		{
 			// other options here...
-			"ssh": {
-				"enabled": true
-			},
 			"authorized_keys": [
 				{
 					"name": "<NAME>",

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1426,7 +1426,7 @@ Configuration for SSH access to a Container instance through Wrangler. For a gui
 The following options are available:
 
 - `enabled` <Type text="boolean" /> <MetaInfo text="optional" />
-  - Whether SSH through Wrangler is enabled. Defaults to `false`.
+  - Whether SSH through Wrangler is enabled. Defaults to `true`. Set to `false` to disable SSH access.
 
 - `port` <Type text="number" /> <MetaInfo text="optional" />
   - The port for the SSH service to run on. Defaults to `22`.


### PR DESCRIPTION
### Summary

Update docs (and add a changelog) to indicate new default value for containers SSH.


### Documentation checklist


- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).