### PR TITLE
chore: check git status in pr skill to catch uncommitted files

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -35,7 +35,10 @@ Run `--stat` first to understand the scope without blowing up context:
 ```bash
 git log --oneline production..HEAD
 git diff production...HEAD --stat
+git status
 ```
+
+**If `git status` shows untracked or modified files**, stop and ask the user whether those files should be committed as part of this PR before proceeding. Do not silently ignore them — they may be integral to the work being submitted.
 
 If the stat output shows more than ~20 files changed, do **not** run the full diff. Instead, read specific files that are unclear from the stat output. For smaller changesets (under ~20 files), the full diff is fine:
 


### PR DESCRIPTION
### Summary

Fixes the `pr` agent skill to run `git status` as part of Step 1 context gathering, and instructs the agent to stop and ask the user about any untracked or modified files before proceeding. Previously the skill only diffed committed changes, causing untracked files to be silently omitted from PRs.
