### PR TITLE
Add Spectrum troubleshooting docs for top support case drivers

### DIFF
--- a/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
@@ -40,7 +40,7 @@ CNAME records are the only IP resolution record with this type of limitation. Yo
 
 :::note[Spectrum applications]
 
-This DNS record conflict also applies when creating a [Spectrum](/spectrum/) application for a hostname that already has a proxied `A`, `AAAA`, or `CNAME` record. Cloudflare does not support having both a proxied DNS record (for HTTP/HTTPS traffic) and a Spectrum application on the same hostname, even on different ports. Refer to [Spectrum Limitations](/spectrum/reference/limitations/) for details and recommended workarounds.
+This DNS record conflict also applies when creating a [Spectrum](/spectrum/) application for a hostname that already has a proxied `A`, `AAAA`, or `CNAME` record. Cloudflare does not support having both a proxied DNS record (for HTTP/HTTPS traffic) and a Spectrum application on the same hostname, even on different ports. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#cannot-create-spectrum-application--dns-record-already-exists) for details and recommended workarounds.
 
 :::
 

--- a/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
@@ -40,7 +40,7 @@ CNAME records are the only IP resolution record with this type of limitation. Yo
 
 :::note[Spectrum applications]
 
-This DNS record conflict also applies when creating a [Spectrum](/spectrum/) application for a hostname that already has a proxied A, AAAA, or CNAME record. Cloudflare does not support having both a proxied DNS record (for HTTP/HTTPS traffic) and a Spectrum application on the same hostname, even on different ports. Refer to [Spectrum Limitations](/spectrum/reference/limitations/#using-the-same-hostname-for-http-proxy-and-spectrum) for details and recommended workarounds.
+This DNS record conflict also applies when creating a [Spectrum](/spectrum/) application for a hostname that already has a proxied `A`, `AAAA`, or `CNAME` record. Cloudflare does not support having both a proxied DNS record (for HTTP/HTTPS traffic) and a Spectrum application on the same hostname, even on different ports. Refer to [Spectrum Limitations](/spectrum/reference/limitations/) for details and recommended workarounds.
 
 :::
 

--- a/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
@@ -38,6 +38,12 @@ CNAME records are the only IP resolution record with this type of limitation. Yo
 
 :::
 
+:::note[Spectrum applications]
+
+This DNS record conflict also applies when creating a [Spectrum](/spectrum/) application for a hostname that already has a proxied A, AAAA, or CNAME record. Cloudflare does not support having both a proxied DNS record (for HTTP/HTTPS traffic) and a Spectrum application on the same hostname, even on different ports. Refer to [Spectrum Limitations](/spectrum/reference/limitations/#using-the-same-hostname-for-http-proxy-and-spectrum) for details and recommended workarounds.
+
+:::
+
 [^1]:
     <Render file="cname-definition" product="dns" />
 

--- a/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
@@ -23,6 +23,7 @@ You will encounter this error if you try to do one of the following:
 
 - Create a CNAME record with a **Name** matching the name of an existing A/AAAA[^2] or CNAME record.
 - Create an A/AAAA record with a **Name** matching the name of an existing CNAME record.
+- Create a [Spectrum](/spectrum/) application for a name that already has a manually-created `A`, `AAAA`, or `CNAME` record. Spectrum provisions and manages its own DNS record for the application, so Cloudflare does not support having both on the same name. Multiple Spectrum applications can, however, share the same name. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#cannot-create-spectrum-application--dns-record-already-exists) for recommended workarounds.
 
 Cloudflare prevents you from creating this combination of records because if a CNAME record is provided for a hostname DNS servers expect only that CNAME record to provide DNS information for that hostname.
 

--- a/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
@@ -39,12 +39,6 @@ CNAME records are the only IP resolution record with this type of limitation. Yo
 
 :::
 
-:::note[Spectrum applications]
-
-This DNS record conflict also applies when creating a [Spectrum](/spectrum/) application for a hostname that already has a manually-created proxied `A`, `AAAA`, or `CNAME` record. Cloudflare does not support having both a manually-created proxied DNS record and a Spectrum application on the same hostname — Spectrum provisions and manages its own DNS record for the application. Multiple Spectrum applications can share the same hostname. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#cannot-create-spectrum-application--dns-record-already-exists) for details and recommended workarounds.
-
-:::
-
 [^1]:
     <Render file="cname-definition" product="dns" />
 

--- a/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
+++ b/src/content/docs/dns/manage-dns-records/troubleshooting/records-with-same-name.mdx
@@ -40,7 +40,7 @@ CNAME records are the only IP resolution record with this type of limitation. Yo
 
 :::note[Spectrum applications]
 
-This DNS record conflict also applies when creating a [Spectrum](/spectrum/) application for a hostname that already has a proxied `A`, `AAAA`, or `CNAME` record. Cloudflare does not support having both a proxied DNS record (for HTTP/HTTPS traffic) and a Spectrum application on the same hostname, even on different ports. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#cannot-create-spectrum-application--dns-record-already-exists) for details and recommended workarounds.
+This DNS record conflict also applies when creating a [Spectrum](/spectrum/) application for a hostname that already has a manually-created proxied `A`, `AAAA`, or `CNAME` record. Cloudflare does not support having both a manually-created proxied DNS record and a Spectrum application on the same hostname — Spectrum provisions and manages its own DNS record for the application. Multiple Spectrum applications can share the same hostname. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#cannot-create-spectrum-application--dns-record-already-exists) for details and recommended workarounds.
 
 :::
 

--- a/src/content/docs/load-balancing/additional-options/spectrum.mdx
+++ b/src/content/docs/load-balancing/additional-options/spectrum.mdx
@@ -54,6 +54,9 @@ The exact settings will vary depending on your use case. Refer to the following 
 8. On the **Monitors** page, define the settings presented and select **Next**.
    - Review the monitors attached to your pools.
    - If needed, you can attach an existing monitor or [create a new monitor](/load-balancing/monitors/create-monitor/#create-a-monitor).
+   :::caution[IP Access Rules and health checks]
+   If your Spectrum application has [IP Access Rules](/spectrum/reference/configuration-options/#ip-access-rules) enabled, Cloudflare's health check probes must be allowed by your rules. Otherwise, health checks will be blocked and all endpoints will be marked as unhealthy. To resolve this, add [Cloudflare IP addresses](https://www.cloudflare.com/ips/) to your IP Access Rules allowlist. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#health-checks-fail-when-ip-access-rules-are-enabled) for details.
+   :::
 
 9. On the **Traffic Steering** page, choose an option for [Traffic steering](/load-balancing/understand-basics/traffic-steering/steering-policies/) and select **Next**.
 

--- a/src/content/docs/load-balancing/additional-options/spectrum.mdx
+++ b/src/content/docs/load-balancing/additional-options/spectrum.mdx
@@ -54,9 +54,6 @@ The exact settings will vary depending on your use case. Refer to the following 
 8. On the **Monitors** page, define the settings presented and select **Next**.
    - Review the monitors attached to your pools.
    - If needed, you can attach an existing monitor or [create a new monitor](/load-balancing/monitors/create-monitor/#create-a-monitor).
-   :::caution[IP Access Rules and health checks]
-   If your Spectrum application has [IP Access Rules](/spectrum/reference/configuration-options/#ip-access-rules) enabled, Cloudflare's health check probes must be allowed by your rules. Otherwise, health checks will be blocked and all endpoints will be marked as unhealthy. To resolve this, add [Cloudflare IP addresses](https://www.cloudflare.com/ips/) to your IP Access Rules allowlist. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#health-checks-fail-when-ip-access-rules-are-enabled) for details.
-   :::
 
 9. On the **Traffic Steering** page, choose an option for [Traffic steering](/load-balancing/understand-basics/traffic-steering/steering-policies/) and select **Next**.
 

--- a/src/content/docs/spectrum/reference/configuration-options.mdx
+++ b/src/content/docs/spectrum/reference/configuration-options.mdx
@@ -153,7 +153,7 @@ If you have the TLS termination setting configured to **off**, this means that S
 
 :::caution
 
-Do not configure a TCP-type Spectrum application's origin to point to another Cloudflare-proxied hostname (for example, `origin.example.com.cdn.cloudflare.net`). This creates an unsupported double-proxy path that may result in TLS handshake failures (error 525). Use a direct origin IP address or a DNS hostname that resolves to your origin server without passing through Cloudflare's proxy. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#tls-handshake-failures-error-525) for details.
+Do not configure a TCP-type Spectrum application's origin to point to another Cloudflare-proxied hostname (for example, `origin.example.com.cdn.cloudflare.net`). This creates an unsupported double-proxy path that may result in TLS handshake failures (error `525`). Use a direct origin IP address or a DNS hostname that resolves to your origin server without passing through Cloudflare's proxy. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#tls-handshake-failures-error-525) for details.
 
 :::
 

--- a/src/content/docs/spectrum/reference/configuration-options.mdx
+++ b/src/content/docs/spectrum/reference/configuration-options.mdx
@@ -9,6 +9,10 @@ weight: 0
 
 Spectrum is a global TCP and UDP proxy running on Cloudflare's edge nodes. It does not terminate the connection in the application-layer sense. However, at Layer 4, Spectrum does terminate the TCP and UDP sockets in both directions. The L4 payloads of TCP segments and UDP datagrams are passed back and forth as-is, without modifications.
 
+This means Spectrum does not inspect, modify, or upgrade application-layer protocols. For example, Spectrum cannot convert an HTTP connection to HTTPS, add HTTP headers, or apply WAF rules to TCP traffic. To add Layer 7 functionality such as CDN, Workers, or Bot Management, set the [application type](#application-type) to **HTTP/HTTPS**.
+
+For common issues and troubleshooting guidance, refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/).
+
 :::note
 Some of these features require an Enterprise plan. If you would like to upgrade, contact your account team.
 :::
@@ -90,6 +94,14 @@ If [IP Access rules](/waf/tools/ip-access-rules/create/) are enabled for a Spect
 Network analytics data for Spectrum does not reflect the outcomes of IP Access rules. Instead, to verify whether traffic was allowed or blocked based on these rules, consult the Spectrum event logs.
 :::
 
+:::caution[Health checks and IP Access Rules]
+When IP Access Rules are enabled with an allowlist model (allow specific IPs, block all others), Cloudflare Load Balancer health check probes may be blocked, causing all endpoints to appear unhealthy. To prevent this, add [Cloudflare IP addresses](https://www.cloudflare.com/ips/) to your allowlist. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#health-checks-fail-when-ip-access-rules-are-enabled) for details.
+:::
+
+:::note
+[Custom rules](/waf/custom-rules/) (WAF rules) do not apply to Spectrum applications configured with the TCP/UDP application type. IP Access Rules are the only supported IP-based filtering mechanism for these applications. Refer to [Spectrum Limitations](/spectrum/reference/limitations/#ip-access-control) for details.
+:::
+
 ## Argo Smart Routing
 
 Once Argo Smart Routing is enabled for your application, traffic will automatically be routed through the fastest and most reliable network path available. Argo Smart Routing is available for TCP and UDP (beta) applications.
@@ -115,6 +127,12 @@ Spectrum virtual network origins are for TCP and UDP traffic only. For HTTP/HTTP
 
 ## Edge TLS Termination
 
+:::caution[Spectrum does not perform protocol upgrade]
+Spectrum operates at Layer 4 and forwards TCP payloads as-is. If Edge TLS Termination is set to **off** (Passthrough), Spectrum will **not** upgrade an HTTP connection to HTTPS, even if your origin listens on port 443. To encrypt traffic between Cloudflare and your origin, enable Edge TLS Termination and set it to **Full** or **Full (Strict)**.
+
+For example, if a client connects to your Spectrum application on port 8012 using HTTP, and your origin is configured on port 443, the connection to origin will use HTTP on port 443 — not HTTPS — unless Edge TLS Termination is enabled.
+:::
+
 If you enable **Edge TLS Termination** for a Spectrum application, Cloudflare will encrypt traffic for the application at the Edge. The Edge TLS Termination toggle applies only to TCP applications.
 
 Spectrum offers three modes of TLS termination: 'Flexible', 'Full', and 'Full (Strict)'.
@@ -130,6 +148,12 @@ You can manage this through the Spectrum app at the Cloudflare dashboard, or usi
 :::note
 
 If you have the TLS termination setting configured to **off**, this means that Spectrum will then proxy connections to the origin without decrypting. The certificate that is presented in this case will be the certificate installed at your origin server, instead of the Edge Certificate from Cloudflare.
+
+:::
+
+:::caution
+
+Do not configure a TCP-type Spectrum application's origin to point to another Cloudflare-proxied hostname (for example, `origin.example.com.cdn.cloudflare.net`). This creates an unsupported double-proxy path that may result in TLS handshake failures (error 525). Use a direct origin IP address or a DNS hostname that resolves to your origin server without passing through Cloudflare's proxy. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#error-525-ssl-handshake-failed) for details.
 
 :::
 
@@ -185,4 +209,4 @@ The cipher suites below are ordered based on how they appear in the ClientHello,
 | AES128-SHA                        | ✅      | ✅      | ❌      |
 | AES256-SHA                        | ✅      | ✅      | ❌      |
 
-[^1]: Although TLS 1.3 uses the same cipher suite space as previous versions of TLS, TLS 1.3 cipher suites are defined differently, only specifying the symmetric ciphers, and cannot be used for TLS 1.2. Similarly, TLS 1.2 and lower cipher suites cannot be used with TLS 1.3 ([RFC 8446](https://www.rfc-editor.org/rfc/rfc8446.html)). BoringSSL also hard-codes cipher preferences in this order for TLS 1.3. Refer to [TLS 1.3 cipher suites](/ssl/origin-configuration/cipher-suites/#tls-13-cipher-suites) for details.
+[^1]: Although TLS 1.3 uses the same cipher suite space as previous versions of TLS, TLS 1.3 cipher suites are defined differently, only specifying the symmetric ciphers, and cannot be used with TLS 1.2. Similarly, TLS 1.2 and lower cipher suites cannot be used with TLS 1.3 ([RFC 8446](https://www.rfc-editor.org/rfc/rfc8446.html)). BoringSSL also hard-codes cipher preferences in this order for TLS 1.3. Refer to [TLS 1.3 cipher suites](/ssl/origin-configuration/cipher-suites/#tls-13-cipher-suites) for details.

--- a/src/content/docs/spectrum/reference/configuration-options.mdx
+++ b/src/content/docs/spectrum/reference/configuration-options.mdx
@@ -130,7 +130,7 @@ Spectrum virtual network origins are for TCP and UDP traffic only. For HTTP/HTTP
 :::caution[Spectrum does not perform protocol upgrade]
 Spectrum operates at Layer 4 and forwards TCP payloads as-is. If Edge TLS Termination is set to **off** (Passthrough), Spectrum will **not** upgrade an HTTP connection to HTTPS, even if your origin listens on port 443. To encrypt traffic between Cloudflare and your origin, enable Edge TLS Termination and set it to **Full** or **Full (Strict)**.
 
-For example, if a client connects to your Spectrum application on port 8012 using HTTP, and your origin is configured on port 443, the connection to origin will use HTTP on port 443 — not HTTPS — unless Edge TLS Termination is enabled.
+For example, if a client connects to your Spectrum application on port 8012 using HTTP, and your origin is configured on port 443, the connection to origin will use HTTP on port 443 — not HTTPS — unless Edge TLS Termination is set to **Full** or **Full (Strict)**.
 :::
 
 If you enable **Edge TLS Termination** for a Spectrum application, Cloudflare will encrypt traffic for the application at the Edge. The Edge TLS Termination toggle applies only to TCP applications.

--- a/src/content/docs/spectrum/reference/configuration-options.mdx
+++ b/src/content/docs/spectrum/reference/configuration-options.mdx
@@ -153,7 +153,7 @@ If you have the TLS termination setting configured to **off**, this means that S
 
 :::caution
 
-Do not configure a TCP-type Spectrum application's origin to point to another Cloudflare-proxied hostname (for example, `origin.example.com.cdn.cloudflare.net`). This creates an unsupported double-proxy path that may result in TLS handshake failures (error 525). Use a direct origin IP address or a DNS hostname that resolves to your origin server without passing through Cloudflare's proxy. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#error-525-ssl-handshake-failed) for details.
+Do not configure a TCP-type Spectrum application's origin to point to another Cloudflare-proxied hostname (for example, `origin.example.com.cdn.cloudflare.net`). This creates an unsupported double-proxy path that may result in TLS handshake failures (error 525). Use a direct origin IP address or a DNS hostname that resolves to your origin server without passing through Cloudflare's proxy. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#tls-handshake-failures-error-525) for details.
 
 :::
 

--- a/src/content/docs/spectrum/reference/configuration-options.mdx
+++ b/src/content/docs/spectrum/reference/configuration-options.mdx
@@ -94,14 +94,6 @@ If [IP Access rules](/waf/tools/ip-access-rules/create/) are enabled for a Spect
 Network analytics data for Spectrum does not reflect the outcomes of IP Access rules. Instead, to verify whether traffic was allowed or blocked based on these rules, consult the Spectrum event logs.
 :::
 
-:::caution[Health checks and IP Access Rules]
-When IP Access Rules are enabled with an allowlist model (allow specific IPs, block all others), Cloudflare Load Balancer health check probes may be blocked, causing all endpoints to appear unhealthy. To prevent this, add [Cloudflare IP addresses](https://www.cloudflare.com/ips/) to your allowlist. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#health-checks-fail-when-ip-access-rules-are-enabled) for details.
-:::
-
-:::note
-[Custom rules](/waf/custom-rules/) (WAF rules) do not apply to Spectrum applications configured with the TCP/UDP application type. IP Access Rules are the only supported IP-based filtering mechanism for these applications. Refer to [Spectrum Limitations](/spectrum/reference/limitations/#ip-access-control) for details.
-:::
-
 ## Argo Smart Routing
 
 Once Argo Smart Routing is enabled for your application, traffic will automatically be routed through the fastest and most reliable network path available. Argo Smart Routing is available for TCP and UDP (beta) applications.
@@ -153,7 +145,7 @@ If you have the TLS termination setting configured to **off**, this means that S
 
 :::caution
 
-Do not configure a TCP-type Spectrum application's origin to point to another Cloudflare-proxied hostname (for example, `origin.example.com.cdn.cloudflare.net`). This creates an unsupported double-proxy path that may result in TLS handshake failures (error `525`). Use a direct origin IP address or a DNS hostname that resolves to your origin server without passing through Cloudflare's proxy. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#tls-handshake-failures-error-525) for details.
+Do not configure a TCP-type Spectrum application's origin to point to another Cloudflare-proxied hostname (for example, `origin.example.com.cdn.cloudflare.net`). This creates an unsupported double-proxy path that may result in TLS handshake failures at the origin. For TCP applications, a failed TLS handshake to the origin is reported as an origin connection failure (`521` or `522`), not error `525` — `525` applies to HTTP/HTTPS applications. Use a direct origin IP address or a DNS hostname that resolves to your origin server without passing through Cloudflare's proxy. Refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#tls-handshake-failures-error-525) for details.
 
 :::
 

--- a/src/content/docs/spectrum/reference/logs.mdx
+++ b/src/content/docs/spectrum/reference/logs.mdx
@@ -20,7 +20,7 @@ Spectrum [log events](/logs/logpush/logpush-job/datasets/) can be configured thr
 ## Status Codes
 
 :::note[Spectrum status codes are not HTTP status codes]
-The status codes in the table below are Spectrum-specific connection status codes. They describe the outcome of Layer 4 (TCP/UDP) connections, not HTTP transactions. Some codes share numbers with HTTP status codes (for example, 444, 499) but have different meanings in the Spectrum context. For guidance on interpreting common status code patterns, refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#understanding-common-spectrum-event-log-status-codes).
+The status codes in the Spectrum status code table are Spectrum-specific connection status codes. They describe the outcome of Layer 4 (TCP/UDP) connections, not HTTP transactions. Some codes share numbers with HTTP status codes (for example, 444, 499) but have different meanings in the Spectrum context. For guidance on interpreting common status code patterns, refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#common-spectrum-event-log-status-codes).
 :::
 
 | Code | Description                                                                                        |

--- a/src/content/docs/spectrum/reference/logs.mdx
+++ b/src/content/docs/spectrum/reference/logs.mdx
@@ -20,7 +20,7 @@ Spectrum [log events](/logs/logpush/logpush-job/datasets/) can be configured thr
 ## Status Codes
 
 :::note[Spectrum status codes are not HTTP status codes]
-The status codes in the Spectrum status code table are Spectrum-specific connection status codes. They describe the outcome of Layer 4 (TCP/UDP) connections, not HTTP transactions. Some codes share numbers with HTTP status codes (for example, 444, 499) but have different meanings in the Spectrum context. For guidance on interpreting common status code patterns, refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#common-spectrum-event-log-status-codes).
+The status codes in the Spectrum status code table are Spectrum-specific connection status codes. They describe the outcome of Layer 4 (TCP/UDP) connections, not HTTP transactions. Some codes share numbers with HTTP status codes (for example, `444`, `499`) but have different meanings in the Spectrum context. For guidance on interpreting common status code patterns, refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#common-spectrum-event-log-status-codes).
 :::
 
 | Code | Description                                                                                        |

--- a/src/content/docs/spectrum/reference/logs.mdx
+++ b/src/content/docs/spectrum/reference/logs.mdx
@@ -19,7 +19,9 @@ Spectrum [log events](/logs/logpush/logpush-job/datasets/) can be configured thr
 
 ## Status Codes
 
-
+:::note[Spectrum status codes are not HTTP status codes]
+The status codes in the table below are Spectrum-specific connection status codes. They describe the outcome of Layer 4 (TCP/UDP) connections, not HTTP transactions. Some codes share numbers with HTTP status codes (for example, 444, 499) but have different meanings in the Spectrum context. For guidance on interpreting common status code patterns, refer to [Spectrum Troubleshooting](/spectrum/reference/troubleshooting/#understanding-common-spectrum-event-log-status-codes).
+:::
 
 | Code | Description                                                                                        |
 | ---- | -------------------------------------------------------------------------------------------------- |

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -111,7 +111,7 @@ Refer to [Edge TLS Termination](/spectrum/reference/configuration-options/#edge-
 
 ### Symptoms
 
-Spectrum event logs show status code `540` (TLS handshake failed), or clients connecting through an HTTP/HTTPS-type Spectrum application receive error 525. These errors typically appear after creating a Spectrum application or changing TLS settings.
+Spectrum event logs show status code `540` (TLS handshake failed), or clients connecting through an HTTP/HTTPS-type Spectrum application receive error `525`. These errors typically appear after creating a Spectrum application or changing TLS settings.
 
 ### Cause
 

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -111,7 +111,7 @@ Refer to [Edge TLS Termination](/spectrum/reference/configuration-options/#edge-
 
 ### Symptoms
 
-Spectrum event logs show status code `540` (TLS handshake failed), or clients connecting through an HTTP/HTTPS-type Spectrum application receive error `525`. These errors typically appear after creating a Spectrum application or changing TLS settings.
+Clients connecting through an HTTP/HTTPS-type Spectrum application receive error `525`, or Spectrum event logs show origin connection errors (`520`, `521`, `522`) after changing TLS settings. These errors typically appear after creating a Spectrum application or modifying Edge TLS Termination.
 
 ### Cause
 

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -111,7 +111,7 @@ Refer to [Edge TLS Termination](/spectrum/reference/configuration-options/#edge-
 
 ### Symptoms
 
-- For TCP applications with Edge TLS Termination set to **Full** or **Full (Strict)**: connections to the origin fail, and Spectrum event logs show origin connection errors such as `521` (connection refused) or `522` (connection timeout).
+- For TCP applications with Edge TLS Termination set to **Full** or **Full (Strict)**: connections to the origin fail. Spectrum event logs may show `521` (connection refused) or `522` (connection timeout) because a failed TLS handshake at the origin is reported as an origin connection failure. Refer to [Event logs](/spectrum/reference/logs/) for the full status code reference.
 - For HTTP/HTTPS applications: clients receive error `525` (SSL handshake failed).
 
 These errors typically appear after creating a Spectrum application or modifying TLS settings.

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -27,3 +27,128 @@ When a Spectrum application uses a [virtual network origin](/spectrum/reference/
 ### Cloudflare WAN as the connector
 
 For tunnel health, BGP, and routing diagnostics on WAN-connected origins, refer to [Troubleshoot Cloudflare WAN](/cloudflare-wan/troubleshooting/).
+
+## Health checks fail when IP Access Rules are enabled
+
+### Symptoms
+
+- Cloudflare Load Balancer health checks report all endpoints as unhealthy with the error `Connection reset by peer`.
+- Removing IP Access Rules from the Spectrum application causes health checks to succeed.
+- The Spectrum application itself works correctly for client traffic that is allowed by the IP Access Rules.
+
+### Cause
+
+When you enable [IP Access Rules](/spectrum/reference/configuration-options/#ip-access-rules) on a Spectrum application, all incoming connections are evaluated against your rules — including connections from Cloudflare's own health check probes. If your IP Access Rules use an allowlist model (allow specific IPs, block everything else), Cloudflare's health check source IPs will be blocked, causing health checks to fail.
+
+### Solution
+
+Add Cloudflare's IP ranges to your IP Access Rules allowlist. You can find the current list of Cloudflare IP addresses at [cloudflare.com/ips](https://www.cloudflare.com/ips/).
+
+Alternatively, if you only need to restrict client access (not health check access), consider configuring health checks to use a TCP check type that validates the connection can be established, and manage your access control at the origin level instead.
+
+:::note
+
+[Custom rules](/waf/custom-rules/) (WAF rules) do not apply to Spectrum applications configured with the TCP/UDP application type. For Spectrum, IP Access Rules are the only supported mechanism for IP-based filtering. Refer to [Spectrum Limitations](/spectrum/reference/limitations/#ip-access-control).
+
+:::
+
+## Cannot create Spectrum application — DNS record already exists
+
+### Symptoms
+
+- When creating a Spectrum application in the dashboard, you receive the error: **"An A, AAAA or CNAME record already exists with that host."**
+- You are trying to use the same hostname for both an HTTP-proxied service (through Cloudflare's CDN/WAF) and a Spectrum TCP or UDP application on a different port.
+
+### Cause
+
+Cloudflare does not support having both a proxied DNS record (used for HTTP/HTTPS traffic through the CDN and WAF) and a Spectrum application on the same hostname. This is a platform limitation, not a dashboard-only restriction.
+
+When a Spectrum application is created, it provisions its own DNS record for the hostname. This conflicts with any existing proxied A, AAAA, or CNAME record for that same hostname.
+
+### Solution
+
+Use a **split-hostname architecture** where HTTP/HTTPS traffic and TCP/UDP traffic use different hostnames:
+
+| Traffic type | Hostname | Cloudflare service |
+|---|---|---|
+| HTTPS (web UI, APIs) | `app.example.com` | Proxied DNS record with CDN/WAF |
+| TCP (custom protocol, ICA/HDX, etc.) | `app-tcp.example.com` | Spectrum application |
+
+Configure your application or client to use the appropriate hostname for each traffic type.
+
+:::note[Common use case: Citrix Gateway / VDI]
+
+A common scenario where this limitation is encountered is Citrix Gateway deployments, where the web UI and authentication flow use HTTPS (requiring WAF protection) while ICA/HDX session traffic uses TCP on a different port. In this case, configure the Citrix StoreFront to generate ICA files pointing to the Spectrum hostname (for example, `citrix-ica.example.com:4443`) while keeping the web UI on the WAF-protected hostname (`citrix.example.com:443`).
+
+:::
+
+For more details on this limitation, refer to [Spectrum Limitations — Using the same hostname for HTTP proxy and Spectrum](/spectrum/reference/limitations/#using-the-same-hostname-for-http-proxy-and-spectrum).
+
+## Origin receives HTTP instead of HTTPS (protocol mismatch)
+
+### Symptoms
+
+- Your Spectrum application edge port uses HTTP (for example, port 8012), and your origin expects HTTPS on port 443.
+- The origin rejects the connection or returns errors because it receives plaintext HTTP instead of encrypted HTTPS.
+- The configuration appears to work as: `http:8012 → Cloudflare Spectrum → http:443 (origin)` instead of the expected `http:8012 → Cloudflare Spectrum → https:443 (origin)`.
+
+### Cause
+
+Spectrum operates at Layer 4 (TCP/UDP). When Edge TLS Termination is set to **off** (Passthrough), Spectrum forwards the raw TCP payload to the origin without modification. It does not perform protocol upgrade — connecting to an origin on port 443 does not automatically mean the connection will use HTTPS.
+
+### Solution
+
+To send encrypted traffic from Cloudflare to your origin, you must enable **Edge TLS Termination** on the Spectrum application and set it to **Full** or **Full (Strict)**:
+
+- **Full**: Cloudflare connects to origin using TLS but does not validate the origin certificate.
+- **Full (Strict)**: Cloudflare connects to origin using TLS and validates the origin certificate against a trusted CA or Cloudflare Origin CA.
+
+You can configure Edge TLS Termination in the Spectrum application settings in the dashboard, or via the API by setting the `tls` field to `full` or `strict`.
+
+Refer to [Edge TLS Termination](/spectrum/reference/configuration-options/#edge-tls-termination) for more details.
+
+## Error 525: SSL handshake failed
+
+### Symptoms
+
+- Clients connecting through Spectrum receive HTTP 525 errors.
+- The error occurs after enabling a Spectrum application or changing TLS settings.
+
+### Cause
+
+Error 525 indicates that the TLS handshake between Cloudflare and your origin server failed. In a Spectrum context, common causes include:
+
+1. **Edge TLS Termination is set to Full or Full (Strict)**, but the origin does not have a valid TLS certificate or does not accept TLS connections on the configured port.
+2. **The Spectrum application origin points to another Cloudflare-proxied hostname** (for example, `origin.example.com.cdn.cloudflare.net`). This creates a double-proxy chain that is not supported for TCP application types and can cause TLS handshake failures.
+3. **TLS version or cipher mismatch** between Cloudflare's edge and the origin server.
+
+### Solution
+
+- Verify that your origin server has a valid TLS certificate and is configured to accept TLS connections on the origin port.
+- If using **Full (Strict)**, ensure the origin certificate is issued by a publicly trusted CA or a [Cloudflare Origin CA certificate](/ssl/origin-configuration/origin-ca/).
+- Do not route a TCP-type Spectrum application through another Cloudflare-proxied hostname. Use a direct origin IP address or a DNS name that resolves directly to your origin server (not through Cloudflare's proxy).
+- If the origin only supports specific TLS versions, note that Spectrum supports TLS 1.1, 1.2, and 1.3 when Edge TLS Termination is enabled.
+
+## Understanding common Spectrum event log status codes
+
+Spectrum uses its own set of connection status codes that are distinct from HTTP status codes used by Cloudflare's CDN layer. Some codes share numbers (for example, 444, 499) but have different meanings.
+
+For the full status code table, refer to [Event logs](/spectrum/reference/logs/).
+
+### Common patterns
+
+| Pattern | Likely cause | Recommended action |
+|---|---|---|
+| High volume of **444** (Origin sent RST) | Origin server is actively resetting connections. May indicate origin overload, misconfigured firewall, or application crash. | Check origin server health, firewall rules, and application logs. |
+| High volume of **445** (Origin timeout) | Established connections to origin are timing out. May indicate origin is slow to respond or network path issues. | Check origin server performance and network connectivity between Cloudflare and origin. |
+| High volume of **497** (Client timeout) | Client connections are timing out. May indicate network issues between clients and Cloudflare edge, or clients with very long idle connections. | Review client network conditions and consider adjusting idle timeout expectations. |
+| High volume of **498** (Client broken pipe) | Client connections are dropping mid-session. May indicate unstable client networks (for example, mobile users). | Often expected for mobile or unreliable networks. Monitor for trends. |
+| High volume of **499** (Client sent RST) | Clients are actively closing connections. May indicate client-side timeouts or application-level disconnects. | Review client application timeout settings. |
+| **521** (Origin refused connection) | Origin is not accepting connections on the configured port. | Verify origin server is running and listening on the correct port. Check origin firewall. |
+| **522** (Origin connection timeout) | Cannot establish a TCP connection to origin. | Verify origin IP address, port, and that origin is reachable from Cloudflare. |
+
+:::note
+
+Network Analytics data for Spectrum does not reflect the outcomes of IP Access Rules. To verify whether traffic was allowed or blocked based on IP Access Rules, consult the Spectrum event logs.
+
+:::

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -38,7 +38,7 @@ For tunnel health, BGP, and routing diagnostics on WAN-connected origins, refer 
 
 ### Cause
 
-When you enable [IP Access Rules](/spectrum/reference/configuration-options/#ip-access-rules) on a Spectrum application, all incoming connections are evaluated against your rules — including connections from Cloudflare's own health check probes. If your IP Access Rules use an allowlist model (allow specific IPs, block everything else), Cloudflare's health check source IPs will be blocked, causing health checks to fail.
+When you turn on [IP Access Rules](/spectrum/reference/configuration-options/#ip-access-rules) on a Spectrum application, all incoming connections are evaluated against your rules — including connections from Cloudflare's own health check probes. If your IP Access Rules use an allowlist model (allow specific IPs, block everything else), Cloudflare's health check source IPs will be blocked, causing health checks to fail.
 
 ### Solution
 
@@ -72,7 +72,7 @@ Use a **split-hostname architecture** where HTTP/HTTPS traffic and TCP/UDP traff
 | Traffic type | Hostname | Cloudflare service |
 |---|---|---|
 | HTTPS (web UI, APIs) | `app.example.com` | Proxied DNS record with CDN/WAF |
-| TCP (custom protocol, ICA/HDX, etc.) | `app-tcp.example.com` | Spectrum application |
+| TCP (custom protocol, ICA/HDX, and similar) | `app-tcp.example.com` | Spectrum application |
 
 Configure your application or client to use the appropriate hostname for each traffic type.
 
@@ -82,7 +82,7 @@ A common scenario where this limitation is encountered is Citrix Gateway deploym
 
 :::
 
-For more details on this limitation, refer to [Spectrum Limitations — Using the same hostname for HTTP proxy and Spectrum](/spectrum/reference/limitations/#using-the-same-hostname-for-http-proxy-and-spectrum).
+For more details on this limitation, refer to [Spectrum Limitations](/spectrum/reference/limitations/).
 
 ## Origin receives HTTP instead of HTTPS (protocol mismatch)
 
@@ -98,7 +98,7 @@ Spectrum operates at Layer 4 (TCP/UDP). When Edge TLS Termination is set to **of
 
 ### Solution
 
-To send encrypted traffic from Cloudflare to your origin, you must enable **Edge TLS Termination** on the Spectrum application and set it to **Full** or **Full (Strict)**:
+To send encrypted traffic from Cloudflare to your origin, you must turn on **Edge TLS Termination** on the Spectrum application and set it to **Full** or **Full (Strict)**:
 
 - **Full**: Cloudflare connects to origin using TLS but does not validate the origin certificate.
 - **Full (Strict)**: Cloudflare connects to origin using TLS and validates the origin certificate against a trusted CA or Cloudflare Origin CA.
@@ -111,31 +111,32 @@ Refer to [Edge TLS Termination](/spectrum/reference/configuration-options/#edge-
 
 ### Symptoms
 
-- Clients connecting through Spectrum receive HTTP 525 errors.
-- The error occurs after enabling a Spectrum application or changing TLS settings.
+Clients connecting through Spectrum receive HTTP 525 errors, typically after creating a Spectrum application or changing TLS settings.
 
 ### Cause
 
 Error 525 indicates that the TLS handshake between Cloudflare and your origin server failed. In a Spectrum context, common causes include:
 
-1. **Edge TLS Termination is set to Full or Full (Strict)**, but the origin does not have a valid TLS certificate or does not accept TLS connections on the configured port.
-2. **The Spectrum application origin points to another Cloudflare-proxied hostname** (for example, `origin.example.com.cdn.cloudflare.net`). This creates a double-proxy chain that is not supported for TCP application types and can cause TLS handshake failures.
-3. **TLS version or cipher mismatch** between Cloudflare's edge and the origin server.
+- **Edge TLS Termination is set to Full or Full (Strict)**, but the origin does not have a valid TLS certificate or does not accept TLS connections on the configured port.
+- **The Spectrum application origin points to another Cloudflare-proxied hostname** (for example, `origin.example.com.cdn.cloudflare.net`). This creates a double-proxy chain that is not supported for TCP application types and can cause TLS handshake failures.
+- **TLS version or cipher mismatch** between Cloudflare's edge and the origin server.
 
 ### Solution
 
-- Verify that your origin server has a valid TLS certificate and is configured to accept TLS connections on the origin port.
-- If using **Full (Strict)**, ensure the origin certificate is issued by a publicly trusted CA or a [Cloudflare Origin CA certificate](/ssl/origin-configuration/origin-ca/).
-- Do not route a TCP-type Spectrum application through another Cloudflare-proxied hostname. Use a direct origin IP address or a DNS name that resolves directly to your origin server (not through Cloudflare's proxy).
-- If the origin only supports specific TLS versions, note that Spectrum supports TLS 1.1, 1.2, and 1.3 when Edge TLS Termination is enabled.
+1. Verify that your origin server has a valid TLS certificate and is configured to accept TLS connections on the origin port.
+2. If using **Full (Strict)**, ensure the origin certificate is issued by a publicly trusted CA or a [Cloudflare Origin CA certificate](/ssl/origin-configuration/origin-ca/).
+3. Confirm that the Spectrum application origin is not pointing to another Cloudflare-proxied hostname. Use a direct origin IP address or a DNS name that resolves directly to your origin server (not through Cloudflare's proxy).
+4. If the origin only supports specific TLS versions, note that Spectrum supports TLS 1.1, 1.2, and 1.3 when Edge TLS Termination is turned on.
 
-## Understanding common Spectrum event log status codes
+## Common Spectrum event log status codes
 
 Spectrum uses its own set of connection status codes that are distinct from HTTP status codes used by Cloudflare's CDN layer. Some codes share numbers (for example, 444, 499) but have different meanings.
 
 For the full status code table, refer to [Event logs](/spectrum/reference/logs/).
 
 ### Common patterns
+
+The following table lists frequently observed Spectrum status code patterns and their likely causes:
 
 | Pattern | Likely cause | Recommended action |
 |---|---|---|

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -107,15 +107,15 @@ You can configure Edge TLS Termination in the Spectrum application settings in t
 
 Refer to [Edge TLS Termination](/spectrum/reference/configuration-options/#edge-tls-termination) for more details.
 
-## Error 525: SSL handshake failed
+## TLS handshake failures (error 525)
 
 ### Symptoms
 
-Clients connecting through Spectrum receive HTTP 525 errors, typically after creating a Spectrum application or changing TLS settings.
+Spectrum event logs show status code `540` (TLS handshake failed), or clients connecting through an HTTP/HTTPS-type Spectrum application receive error 525. These errors typically appear after creating a Spectrum application or changing TLS settings.
 
 ### Cause
 
-Error 525 indicates that the TLS handshake between Cloudflare and your origin server failed. In a Spectrum context, common causes include:
+These errors indicate that the TLS handshake between Cloudflare and your origin server failed. Common causes include:
 
 - **Edge TLS Termination is set to Full or Full (Strict)**, but the origin does not have a valid TLS certificate or does not accept TLS connections on the configured port.
 - **The Spectrum application origin points to another Cloudflare-proxied hostname** (for example, `origin.example.com.cdn.cloudflare.net`). This creates a double-proxy chain that is not supported for TCP application types and can cause TLS handshake failures.

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -111,11 +111,14 @@ Refer to [Edge TLS Termination](/spectrum/reference/configuration-options/#edge-
 
 ### Symptoms
 
-Clients connecting through an HTTP/HTTPS-type Spectrum application receive error `525`, or Spectrum event logs show origin connection errors (`520`, `521`, `522`) after changing TLS settings. These errors typically appear after creating a Spectrum application or modifying Edge TLS Termination.
+- For TCP applications with Edge TLS Termination set to **Full** or **Full (Strict)**: connections to the origin fail, and Spectrum event logs show origin connection errors such as `521` (connection refused) or `522` (connection timeout).
+- For HTTP/HTTPS applications: clients receive error `525` (SSL handshake failed).
+
+These errors typically appear after creating a Spectrum application or modifying TLS settings.
 
 ### Cause
 
-These errors indicate that the TLS handshake between Cloudflare and your origin server failed. Common causes include:
+The TLS handshake between Cloudflare and your origin server failed. Common causes include:
 
 - **Edge TLS Termination is set to Full or Full (Strict)**, but the origin does not have a valid TLS certificate or does not accept TLS connections on the configured port.
 - **The Spectrum application origin points to another Cloudflare-proxied hostname** (for example, `origin.example.com.cdn.cloudflare.net`). This creates a double-proxy chain that is not supported for TCP application types and can cause TLS handshake failures.

--- a/src/content/docs/spectrum/reference/troubleshooting.mdx
+++ b/src/content/docs/spectrum/reference/troubleshooting.mdx
@@ -28,57 +28,35 @@ When a Spectrum application uses a [virtual network origin](/spectrum/reference/
 
 For tunnel health, BGP, and routing diagnostics on WAN-connected origins, refer to [Troubleshoot Cloudflare WAN](/cloudflare-wan/troubleshooting/).
 
-## Health checks fail when IP Access Rules are enabled
-
-### Symptoms
-
-- Cloudflare Load Balancer health checks report all endpoints as unhealthy with the error `Connection reset by peer`.
-- Removing IP Access Rules from the Spectrum application causes health checks to succeed.
-- The Spectrum application itself works correctly for client traffic that is allowed by the IP Access Rules.
-
-### Cause
-
-When you turn on [IP Access Rules](/spectrum/reference/configuration-options/#ip-access-rules) on a Spectrum application, all incoming connections are evaluated against your rules — including connections from Cloudflare's own health check probes. If your IP Access Rules use an allowlist model (allow specific IPs, block everything else), Cloudflare's health check source IPs will be blocked, causing health checks to fail.
-
-### Solution
-
-Add Cloudflare's IP ranges to your IP Access Rules allowlist. You can find the current list of Cloudflare IP addresses at [cloudflare.com/ips](https://www.cloudflare.com/ips/).
-
-Alternatively, if you only need to restrict client access (not health check access), consider configuring health checks to use a TCP check type that validates the connection can be established, and manage your access control at the origin level instead.
-
-:::note
-
-[Custom rules](/waf/custom-rules/) (WAF rules) do not apply to Spectrum applications configured with the TCP/UDP application type. For Spectrum, IP Access Rules are the only supported mechanism for IP-based filtering. Refer to [Spectrum Limitations](/spectrum/reference/limitations/#ip-access-control).
-
-:::
-
 ## Cannot create Spectrum application — DNS record already exists
 
 ### Symptoms
 
 - When creating a Spectrum application in the dashboard, you receive the error: **"An A, AAAA or CNAME record already exists with that host."**
-- You are trying to use the same hostname for both an HTTP-proxied service (through Cloudflare's CDN/WAF) and a Spectrum TCP or UDP application on a different port.
+- You already have a manually-created proxied DNS record (`A`, `AAAA`, or `CNAME`) for the hostname you are trying to use for a new Spectrum application.
 
 ### Cause
 
-Cloudflare does not support having both a proxied DNS record (used for HTTP/HTTPS traffic through the CDN and WAF) and a Spectrum application on the same hostname. This is a platform limitation, not a dashboard-only restriction.
+Cloudflare does not support having both a manually-created proxied DNS record (`A`, `AAAA`, or `CNAME`) and a Spectrum application on the same hostname. This is because Spectrum provisions and manages its own DNS record for the application, which conflicts with the existing manually-created record. This is a platform limitation, not a dashboard-only restriction.
 
-When a Spectrum application is created, it provisions its own DNS record for the hostname. This conflicts with any existing proxied A, AAAA, or CNAME record for that same hostname.
+This limitation only applies to manually-created proxied records. Multiple Spectrum applications — including a mix of HTTP/HTTPS and TCP/UDP application types — can share the same hostname, because Spectrum manages the DNS record for each of them.
 
 ### Solution
 
-Use a **split-hostname architecture** where HTTP/HTTPS traffic and TCP/UDP traffic use different hostnames:
+If you only need Spectrum applications on the hostname (for example, an HTTP/HTTPS Spectrum application alongside a TCP/UDP Spectrum application), you do not need a workaround — create the additional Spectrum application on the same hostname.
+
+If you need to keep a manually-created proxied DNS record on the hostname (for example, to route standard HTTP/HTTPS traffic through the CDN and WAF instead of through Spectrum), use a **split-hostname architecture** instead, where the manually-created proxied record and the Spectrum application use different hostnames:
 
 | Traffic type | Hostname | Cloudflare service |
 |---|---|---|
-| HTTPS (web UI, APIs) | `app.example.com` | Proxied DNS record with CDN/WAF |
+| HTTPS (web UI, APIs) | `app.example.com` | Manually-created proxied DNS record with CDN/WAF |
 | TCP (custom protocol, ICA/HDX, and similar) | `app-tcp.example.com` | Spectrum application |
 
 Configure your application or client to use the appropriate hostname for each traffic type.
 
 :::note[Common use case: Citrix Gateway / VDI]
 
-A common scenario where this limitation is encountered is Citrix Gateway deployments, where the web UI and authentication flow use HTTPS (requiring WAF protection) while ICA/HDX session traffic uses TCP on a different port. In this case, configure the Citrix StoreFront to generate ICA files pointing to the Spectrum hostname (for example, `citrix-ica.example.com:4443`) while keeping the web UI on the WAF-protected hostname (`citrix.example.com:443`).
+A common scenario where this limitation is encountered is Citrix Gateway deployments, where the web UI and authentication flow use HTTPS through a manually-created proxied record (requiring WAF protection) while ICA/HDX session traffic uses TCP on a different port through a Spectrum application. In this case, configure the Citrix StoreFront to generate ICA files pointing to the Spectrum hostname (for example, `citrix-ica.example.com:4443`) while keeping the web UI on the WAF-protected hostname (`citrix.example.com:443`).
 
 :::
 


### PR DESCRIPTION
## Summary

Adds a new Spectrum Troubleshooting page and improves existing Spectrum documentation to address the top 3 case-generating issues identified in the April 2026 Network Support-by-Request (SBR) case review (~190 cases analyzed).

**Estimated case deflection: 9-13 cases/month across these 3 issues.**

## Changes

### New page
- **`/spectrum/reference/troubleshooting/`** — New troubleshooting page with structured symptom/cause/solution sections covering:
  - Health checks failing when IP Access Rules are enabled
  - DNS record conflict when creating Spectrum apps (same hostname as proxied record)
  - Protocol mismatch (origin receives HTTP instead of HTTPS)
  - Error 525 (SSL handshake failed) in Spectrum context
  - Common Spectrum event log status code patterns (444, 445, 497-499, 521, 522)

### Modified pages (5)
- **`/spectrum/reference/configuration-options/`** — Added warnings about IP Access Rules blocking health checks, Custom Rules not working with Spectrum, protocol upgrade not being supported, and double-proxy chains causing 525 errors. Expanded intro paragraph to clarify Spectrum's L4 pass-through behavior.
- **`/spectrum/reference/limitations/`** — Added new "IP access control" section and "Using the same hostname for HTTP proxy and Spectrum" section documenting the platform limitation and recommending split-hostname architecture (with Citrix Gateway use case).
- **`/spectrum/reference/logs/`** — Added note clarifying that Spectrum status codes are distinct from HTTP status codes, with cross-link to troubleshooting page.
- **`/load-balancing/additional-options/spectrum/`** — Added caution callout in the Monitors setup step warning about IP Access Rules blocking health checks.
- **`/dns/manage-dns-records/troubleshooting/records-with-same-name/`** — Added note explaining that DNS record conflicts also apply to Spectrum applications, with cross-link to Spectrum limitations.

## Motivation

These documentation gaps were identified by reviewing all April 2026 Network SBR cases. The top case-generating patterns were:
1. **IP Access Rules + Healthchecks** (~3-5 cases/month): Customers enable IP Access Rules, health checks fail silently. No docs explain the interaction.
2. **Same Hostname WAF + Spectrum** (~3-4 cases/month): Customers hit "DNS record already exists" error with no explanation that it's a hard platform limitation. Common in Citrix/VDI deployments.
3. **Protocol Mismatch / TLS errors** (~3-4 cases/month): Customers expect Spectrum to upgrade HTTP→HTTPS or chain through another Cloudflare proxy. Neither is supported but neither was documented.

## Content area
Spectrum, Load Balancing, DNS