### PR TITLE
Adding topic tags to Docs 2026 05 , pt5

### DIFF
--- a/src/content/docs/data-localization/how-to/cache.mdx
+++ b/src/content/docs/data-localization/how-to/cache.mdx
@@ -5,6 +5,8 @@ description: Configure Cache with Regional Services and Customer Metadata Bounda
 products:
   - data-localization
   - cache
+tags:
+  - Caching
 sidebar:
   order: 3
 ---

--- a/src/content/docs/data-localization/how-to/r2.mdx
+++ b/src/content/docs/data-localization/how-to/r2.mdx
@@ -5,6 +5,9 @@ description: Configure R2 Object Storage with Regional Services and Customer Met
 products:
   - data-localization
   - r2
+tags:
+  - S3
+  - Logging
 sidebar:
   order: 6
 ---

--- a/src/content/docs/data-localization/how-to/zero-trust.mdx
+++ b/src/content/docs/data-localization/how-to/zero-trust.mdx
@@ -5,6 +5,9 @@ description: Use Zero Trust products with the Data Localization Suite, including
 products:
   - data-localization
   - cloudflare-one
+tags:
+  - Logging
+  - SSH
 sidebar:
   order: 1
 ---

--- a/src/content/docs/data-localization/metadata-boundary/get-started.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/get-started.mdx
@@ -4,6 +4,8 @@ pcx_content_type: get-started
 description: Configure Customer Metadata Boundary to select the region for your logs and analytics.
 products:
   - data-localization
+tags:
+  - Privacy
 sidebar:
   order: 2
 ---

--- a/src/content/docs/data-localization/metadata-boundary/out-of-region-access.mdx
+++ b/src/content/docs/data-localization/metadata-boundary/out-of-region-access.mdx
@@ -4,6 +4,8 @@ title: Out of region access
 description: Allow authorized users to access logs and analytics stored outside their physical region.
 products:
   - data-localization
+tags:
+  - Privacy
 sidebar:
   order: 5
 ---

--- a/src/content/docs/data-localization/regional-services/get-started.mdx
+++ b/src/content/docs/data-localization/regional-services/get-started.mdx
@@ -4,6 +4,8 @@ pcx_content_type: get-started
 description: Enable and configure Regional Services for your hostnames via dashboard or API.
 products:
   - data-localization
+tags:
+  - Terraform
 sidebar:
   order: 1
 head:

--- a/src/content/docs/ddos-protection/advanced-ddos-systems/api/tcp-protection/index.mdx
+++ b/src/content/docs/ddos-protection/advanced-ddos-systems/api/tcp-protection/index.mdx
@@ -10,6 +10,8 @@ sidebar:
 head:
   - tag: title
     content: Configure Advanced TCP Protection via API
+tags:
+  - TCP
 
 ---
 

--- a/src/content/docs/ddos-protection/advanced-ddos-systems/concepts.mdx
+++ b/src/content/docs/ddos-protection/advanced-ddos-systems/concepts.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Create an Advanced TCP Protection filter
+tags:
+  - TCP
 ---
 
 import { GlossaryTooltip, Render } from "~/components";

--- a/src/content/docs/ddos-protection/advanced-ddos-systems/overview/index.mdx
+++ b/src/content/docs/ddos-protection/advanced-ddos-systems/overview/index.mdx
@@ -10,6 +10,8 @@ sidebar:
 head:
   - tag: title
     content: Advanced DDoS Protection systems
+tags:
+  - TCP
 ---
 
 import { GlossaryTooltip, Render, Steps, DashButton } from "~/components";

--- a/src/content/docs/ddos-protection/best-practices/proactive-defense.mdx
+++ b/src/content/docs/ddos-protection/best-practices/proactive-defense.mdx
@@ -7,6 +7,8 @@ products:
   - ddos-protection
 sidebar:
   order: 3
+tags:
+  - Caching
 ---
 
 import { GlossaryTooltip, Steps } from "~/components"

--- a/src/content/docs/ddos-protection/botnet-threat-feed.mdx
+++ b/src/content/docs/ddos-protection/botnet-threat-feed.mdx
@@ -12,6 +12,8 @@ head:
 learning_center:
   title: What is a DDoS botnet?
   link: https://www.cloudflare.com/learning/ddos/what-is-a-ddos-botnet/
+tags:
+  - REST API
 
 ---
 import { Steps, APIRequest, DashButton } from "~/components"

--- a/src/content/docs/ddos-protection/managed-rulesets/http/http-overrides/override-expressions.mdx
+++ b/src/content/docs/ddos-protection/managed-rulesets/http/http-overrides/override-expressions.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Override expressions for HTTP DDoS Attack Protection
+tags:
+  - Headers
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/ddos-protection/managed-rulesets/network/network-overrides/override-expressions.mdx
+++ b/src/content/docs/ddos-protection/managed-rulesets/network/network-overrides/override-expressions.mdx
@@ -9,6 +9,9 @@ sidebar:
 head:
   - tag: title
     content: Override expressions for Network-layer DDoS Attack Protection
+tags:
+  - TCP
+  - UDP
 ---
 
 import { GlossaryTooltip } from "~/components";

--- a/src/content/docs/magic-transit/analytics/index.mdx
+++ b/src/content/docs/magic-transit/analytics/index.mdx
@@ -7,6 +7,8 @@ sidebar:
   order: 9
 head: []
 description: Use Magic Transit analytics to monitor network performance and troubleshoot potential issues.
+tags:
+  - Analytics
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/magic-transit/analytics/query-bandwidth.mdx
+++ b/src/content/docs/magic-transit/analytics/query-bandwidth.mdx
@@ -6,7 +6,9 @@ products:
 title: Query Magic Transit tunnel bandwidth analytics with GraphQL
 sidebar:
   order: 5
-
+tags:
+  - GraphQL
+  - Shell
 ---
 
 import { Render } from "~/components"

--- a/src/content/docs/magic-transit/analytics/query-tunnel-health.mdx
+++ b/src/content/docs/magic-transit/analytics/query-tunnel-health.mdx
@@ -6,7 +6,9 @@ products:
 title: Query Magic Transit tunnel health check results with GraphQL
 sidebar:
   order: 6
-
+tags:
+  - GraphQL
+  - Shell
 ---
 
 import { Render } from "~/components"

--- a/src/content/docs/magic-transit/get-started.mdx
+++ b/src/content/docs/magic-transit/get-started.mdx
@@ -6,6 +6,8 @@ products:
 title: Get started
 sidebar:
   order: 4
+tags:
+  - IPsec
 ---
 
 import { Render } from "~/components"

--- a/src/content/docs/magic-transit/how-to/configure-routes.mdx
+++ b/src/content/docs/magic-transit/how-to/configure-routes.mdx
@@ -7,7 +7,8 @@ sidebar:
   order: 2
 head: []
 description: Magic Transit uses a static configuration to route your traffic through anycast tunnels from Cloudflare's global network to your locations. If you are connected through CNI with Dataplane v2, you also have access to BGP peering (beta).
-
+tags:
+  - IPsec
 ---
 
 import { Render } from "~/components"

--- a/src/content/docs/magic-transit/how-to/configure-tunnel-endpoints.mdx
+++ b/src/content/docs/magic-transit/how-to/configure-tunnel-endpoints.mdx
@@ -7,6 +7,9 @@ sidebar:
   order: 1
 head: []
 description: Cloudflare recommends two tunnels for each ISP and network location router combination, one per Cloudflare endpoint. Learn how to configure IPsec or GRE tunnels.
+tags:
+  - IPsec
+  - ICMP
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/magic-transit/network-health/run-endpoint-health-checks.mdx
+++ b/src/content/docs/magic-transit/network-health/run-endpoint-health-checks.mdx
@@ -9,7 +9,9 @@ sidebar:
     text: Beta
   order: 1
   label: Run endpoint health checks
-
+tags:
+  - GraphQL
+  - ICMP
 ---
 
 import { CURL, Render, DashButton } from '~/components';

--- a/src/content/docs/magic-transit/partners/kentik.mdx
+++ b/src/content/docs/magic-transit/partners/kentik.mdx
@@ -8,6 +8,8 @@ sidebar:
   order: 1
 description: >-
   Kentik is a network observability company that helps detect attacks on your network and triggers Cloudflare's Magic Transit to begin advertisement. The example scenario includes two mitigations, one which pulls the advertisement from the router and a second mitigation that makes an API call to Cloudflare.
+tags:
+  - Integration
 ---
 
 import { DashButton } from "~/components";

--- a/src/content/docs/magic-transit/reference/anti-replay-protection.mdx
+++ b/src/content/docs/magic-transit/reference/anti-replay-protection.mdx
@@ -7,6 +7,8 @@ head: []
 description: If you use Magic Transit and anycast IPsec tunnels, disable anti-replay protection. Review the information to learn more.
 sidebar:
   order: 1
+tags:
+  - IPsec
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/magic-transit/reference/gre-ipsec-tunnels.mdx
+++ b/src/content/docs/magic-transit/reference/gre-ipsec-tunnels.mdx
@@ -7,6 +7,9 @@ head: []
 description: Magic Transit uses Generic Routing Encapsulation (GRE) and IPsec tunnels to transmit packets from Cloudflare's global network to your origin network.
 sidebar:
   order: 4
+tags:
+  - IPsec
+  - Post-quantum
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/magic-transit/reference/mtu-mss.mdx
+++ b/src/content/docs/magic-transit/reference/mtu-mss.mdx
@@ -7,6 +7,10 @@ title: Maximum transmission unit and maximum segment size
 sidebar:
   label: MTU and MSS
   order: 5
+tags:
+  - TCP
+  - IPsec
+  - UDP
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/magic-transit/reference/traffic-steering.mdx
+++ b/src/content/docs/magic-transit/reference/traffic-steering.mdx
@@ -7,6 +7,8 @@ head: []
 description: Magic Transit uses a static configuration to route traffic through anycast tunnels using the Generic Routing Encapsulation (GRE) and Internet Protocol Security (IPsec) protocols from Cloudflare's global network to your network.
 sidebar:
   order: 7
+tags:
+  - IPsec
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/magic-transit/reference/tunnel-health-checks.mdx
+++ b/src/content/docs/magic-transit/reference/tunnel-health-checks.mdx
@@ -7,6 +7,9 @@ head: []
 description: Magic Transit uses probes to check for tunnel health. Review information on this page to learn more.
 sidebar:
   order: 8
+tags:
+  - ICMP
+  - IPsec
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/magic-transit/troubleshooting/index.mdx
+++ b/src/content/docs/magic-transit/troubleshooting/index.mdx
@@ -8,7 +8,8 @@ sidebar:
   order: 15
   group:
     hideIndex: true
-
+tags:
+  - Debugging
 ---
 
 import { DirectoryListing } from "~/components"

--- a/src/content/docs/magic-transit/troubleshooting/ipsec-troubleshoot.mdx
+++ b/src/content/docs/magic-transit/troubleshooting/ipsec-troubleshoot.mdx
@@ -6,6 +6,10 @@ products:
   - magic-transit
 sidebar:
   order: 1
+tags:
+  - IPsec
+  - ICMP
+  - Logging
 ---
 
 import { Render } from "~/components"

--- a/src/content/docs/magic-transit/troubleshooting/tunnel-health.mdx
+++ b/src/content/docs/magic-transit/troubleshooting/tunnel-health.mdx
@@ -6,6 +6,9 @@ products:
   - magic-transit
 sidebar:
   order: 2
+tags:
+  - IPsec
+  - ICMP
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/network-error-logging/get-started.mdx
+++ b/src/content/docs/network-error-logging/get-started.mdx
@@ -4,6 +4,8 @@ pcx_content_type: get-started
 description: Enable Network Error Logging for your zone.
 products:
   - network-error-logging
+tags:
+  - Logging
 
 ---
 

--- a/src/content/docs/network-error-logging/how-to.mdx
+++ b/src/content/docs/network-error-logging/how-to.mdx
@@ -3,6 +3,8 @@ title: How to
 pcx_content_type: how-to
 products:
   - network-error-logging
+tags:
+  - Logging
 head:
   - tag: title
     content: View Reports

--- a/src/content/docs/network-error-logging/index.mdx
+++ b/src/content/docs/network-error-logging/index.mdx
@@ -4,6 +4,9 @@ pcx_content_type: overview
 description: Collect reports about network errors affecting your visitors.
 products:
   - network-error-logging
+tags:
+  - Privacy
+  - Logging
 sidebar:
   order: 1
 head:

--- a/src/content/docs/network-error-logging/reference.mdx
+++ b/src/content/docs/network-error-logging/reference.mdx
@@ -4,6 +4,10 @@ pcx_content_type: reference
 description: Reference information for Network Error Logging.
 products:
   - network-error-logging
+tags:
+  - TLS
+  - Debugging
+  - TCP
 head:
   - tag: title
     content: Failures

--- a/src/content/docs/network-flow/cloud-flow-logs.mdx
+++ b/src/content/docs/network-flow/cloud-flow-logs.mdx
@@ -4,6 +4,9 @@ pcx_content_type: reference
 description: Collect flow logs from cloud provider environments.
 products:
   - network-flow
+tags:
+  - AWS
+  - Logging
 sidebar:
   order: 5
   label: Cloud flow logs

--- a/src/content/docs/network-flow/faq.mdx
+++ b/src/content/docs/network-flow/faq.mdx
@@ -3,6 +3,8 @@ pcx_content_type: faq
 description: Answers to common questions about Network Flow.
 products:
   - network-flow
+tags:
+  - IPsec
 title: FAQ
 structured_data: true
 sidebar:

--- a/src/content/docs/network-flow/get-started.mdx
+++ b/src/content/docs/network-flow/get-started.mdx
@@ -4,6 +4,9 @@ pcx_content_type: get-started
 description: Set up Network Flow to monitor network traffic patterns.
 products:
   - network-flow
+tags:
+  - NetFlow
+  - AWS
 sidebar:
   order: 2
 ---

--- a/src/content/docs/network-flow/magic-transit-integration.mdx
+++ b/src/content/docs/network-flow/magic-transit-integration.mdx
@@ -4,6 +4,8 @@ pcx_content_type: reference
 description: Integrate Network Flow with Magic Transit.
 products:
   - network-flow
+tags:
+  - Integration
 sidebar:
   order: 7
 

--- a/src/content/docs/network-flow/routers/netflow-ipfix-config.mdx
+++ b/src/content/docs/network-flow/routers/netflow-ipfix-config.mdx
@@ -3,6 +3,9 @@ title: Netflow/IPFIX configuration
 pcx_content_type: how-to
 products:
   - network-flow
+tags:
+  - NetFlow
+  - UDP
 sidebar:
   order: 3
 head: []

--- a/src/content/docs/network-flow/routers/recommended-sampling-rate.mdx
+++ b/src/content/docs/network-flow/routers/recommended-sampling-rate.mdx
@@ -3,6 +3,8 @@ title: Recommended sampling rate
 pcx_content_type: reference
 products:
   - network-flow
+tags:
+  - NetFlow
 sidebar:
   order: 2
 head: []

--- a/src/content/docs/network-flow/routers/sflow-config.mdx
+++ b/src/content/docs/network-flow/routers/sflow-config.mdx
@@ -3,6 +3,8 @@ title: sFlow configuration
 pcx_content_type: how-to
 products:
   - network-flow
+tags:
+  - UDP
 sidebar:
   order: 4
 head: []

--- a/src/content/docs/network-flow/routers/supported-routers.mdx
+++ b/src/content/docs/network-flow/routers/supported-routers.mdx
@@ -3,6 +3,8 @@ title: Supported routers
 pcx_content_type: reference
 products:
   - network-flow
+tags:
+  - NetFlow
 sidebar:
   order: 1
 head: []

--- a/src/content/docs/network-flow/rules/index.mdx
+++ b/src/content/docs/network-flow/rules/index.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Create rules to alert on network flow anomalies.
 products:
   - network-flow
+tags:
+  - JSON
 sidebar:
   label: Overview
   order: 4

--- a/src/content/docs/network-flow/tutorials/encrypt-network-flow-data.mdx
+++ b/src/content/docs/network-flow/tutorials/encrypt-network-flow-data.mdx
@@ -5,6 +5,9 @@ difficulty: Advanced
 products:
   - network-flow
 reviewed: 2024-10-03
+tags:
+  - Shell
+  - CLI
 sidebar:
   order: 1
 head:

--- a/src/content/docs/network-interconnect/get-started.mdx
+++ b/src/content/docs/network-interconnect/get-started.mdx
@@ -6,6 +6,9 @@ title: Get started
 description: Connect your network privately to Cloudflare
 sidebar:
   order: 2
+tags:
+  - AWS
+  - GCP
 ---
 
 import { Render, DashButton } from "~/components"

--- a/src/content/docs/smart-shield/concepts/connection-reuse.mdx
+++ b/src/content/docs/smart-shield/concepts/connection-reuse.mdx
@@ -6,6 +6,9 @@ products:
   - smart-shield
 sidebar:
   order: 4
+tags:
+  - TCP
+  - TLS
 ---
 
 Smart Shield reduces the number of connections between Cloudflare and your origin server by batching multiple requests through shared connections. When requests from an [upper-tier data center](/smart-shield/configuration/smart-tiered-cache/) — the layer of Cloudflare's cache that sits closest to your origin — need to reach your server, Smart Shield sends them over a single connection instead of opening a new connection for each request. This reduces overall connections to your origin by 30% on average, which lowers resource consumption on your origin and reduces the risk of connection exhaustion under high traffic.

--- a/src/content/docs/smart-shield/configuration/dedicated-egress-ips/other-products.mdx
+++ b/src/content/docs/smart-shield/configuration/dedicated-egress-ips/other-products.mdx
@@ -7,6 +7,10 @@ products:
 sidebar:
   order: 9
   label: Other products
+tags:
+  - Integration
+  - TCP
+  - UDP
 ---
 
 Use Dedicated CDN Egress IPs in combination with different Cloudflare products.

--- a/src/content/docs/smart-shield/configuration/dedicated-egress-ips/setup.mdx
+++ b/src/content/docs/smart-shield/configuration/dedicated-egress-ips/setup.mdx
@@ -9,6 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Set up Dedicated CDN Egress IPs
+tags:
+  - REST API
 ---
 
 import { APIRequest, Render } from "~/components";

--- a/src/content/docs/smart-shield/configuration/health-checks/zone-lockdown.mdx
+++ b/src/content/docs/smart-shield/configuration/health-checks/zone-lockdown.mdx
@@ -9,7 +9,8 @@ sidebar:
 head:
   - tag: title
     content: Zone lockdown migration guide
-
+tags:
+  - Migration
 ---
 
 import { Render } from "~/components";

--- a/src/content/docs/tunnel/advanced/local-management/create-local-tunnel.mdx
+++ b/src/content/docs/tunnel/advanced/local-management/create-local-tunnel.mdx
@@ -4,6 +4,12 @@ pcx_content_type: how-to
 description: Create and configure a locally-managed Cloudflare Tunnel.
 products:
   - tunnel
+tags:
+  - CLI
+  - YAML
+  - Linux
+  - MacOS
+  - Windows
 sidebar:
   order: 1
 ---

--- a/src/content/docs/tunnel/advanced/origin-parameters.mdx
+++ b/src/content/docs/tunnel/advanced/origin-parameters.mdx
@@ -4,6 +4,8 @@ description: Parameters for configuring the connection between cloudflared and y
 products:
   - tunnel
 title: Origin parameters
+tags:
+  - TLS
 sidebar:
   order: 3
 ---

--- a/src/content/docs/tunnel/configuration.mdx
+++ b/src/content/docs/tunnel/configuration.mdx
@@ -4,6 +4,9 @@ pcx_content_type: reference
 description: Configure tunnel ingress rules, origins, and protocol settings.
 products:
   - tunnel
+tags:
+  - Post-quantum
+  - QUIC
 sidebar:
   order: 4
 ---

--- a/src/content/docs/tunnel/downloads/update-cloudflared.mdx
+++ b/src/content/docs/tunnel/downloads/update-cloudflared.mdx
@@ -4,6 +4,8 @@ description: Update cloudflared to the latest version.
 products:
   - tunnel
 title: Update cloudflared
+tags:
+  - Docker
 sidebar:
   order: 2
 ---

--- a/src/content/docs/tunnel/routing.mdx
+++ b/src/content/docs/tunnel/routing.mdx
@@ -4,6 +4,9 @@ description: Route traffic to private networks and services through Cloudflare T
 products:
   - tunnel
 title: Routing
+tags:
+  - DNS
+  - WebSockets
 sidebar:
   order: 3
 ---

--- a/src/content/docs/warp-client/get-started/android.mdx
+++ b/src/content/docs/warp-client/get-started/android.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Install and configure WARP on Android devices.
 products:
   - warp-client
+tags:
+  - Android
 weight: 0
 head:
   - tag: title

--- a/src/content/docs/warp-client/get-started/iOS.mdx
+++ b/src/content/docs/warp-client/get-started/iOS.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Install and configure WARP on iOS devices.
 products:
   - warp-client
+tags:
+  - iOS
 weight: 0
 head:
   - tag: title

--- a/src/content/docs/warp-client/get-started/linux.mdx
+++ b/src/content/docs/warp-client/get-started/linux.mdx
@@ -4,6 +4,9 @@ pcx_content_type: how-to
 description: Install and configure WARP on Linux.
 products:
   - warp-client
+tags:
+  - Linux
+  - CLI
 weight: 0
 head:
   - tag: title

--- a/src/content/docs/warp-client/get-started/macOS.mdx
+++ b/src/content/docs/warp-client/get-started/macOS.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Install and configure WARP on macOS.
 products:
   - warp-client
+tags:
+  - MacOS
 weight: 0
 head:
   - tag: title

--- a/src/content/docs/warp-client/get-started/windows.mdx
+++ b/src/content/docs/warp-client/get-started/windows.mdx
@@ -4,6 +4,8 @@ pcx_content_type: how-to
 description: Install and configure WARP on Windows.
 products:
   - warp-client
+tags:
+  - Windows
 weight: 0
 head:
   - tag: title

--- a/src/content/docs/warp-client/warp-modes.mdx
+++ b/src/content/docs/warp-client/warp-modes.mdx
@@ -4,6 +4,8 @@ description: Available WARP connection modes and their behavior.
 products:
   - warp-client
 title: WARP modes
+tags:
+  - Post-quantum
 sidebar:
   order: 2
 ---


### PR DESCRIPTION
### Summary
Adding topic tags to frontmatter for network product tiles.

### Documentation checklist
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.