### PR TITLE
[AI Gateway] Deprecate Universal Endpoint and consolidate into a sing…

### DIFF
--- a/src/content/docs/ai-gateway/configuration/request-handling.mdx
+++ b/src/content/docs/ai-gateway/configuration/request-handling.mdx
@@ -1,14 +1,14 @@
 ---
 pcx_content_type: configuration
 title: Request handling
-description: Configure AI Gateway request timeouts, retries, and fallback strategies for reliable AI provider interactions.
+description: Configure AI Gateway request timeouts and retries for reliable AI provider interactions.
 sidebar:
   order: 4
 products:
   - ai-gateway
 ---
 
-import { Render, Aside } from "~/components";
+import { Render } from "~/components";
 
 :::note
 
@@ -20,7 +20,7 @@ Your AI gateway supports different strategies for handling requests to providers
 
 ## Request timeouts
 
-A request timeout allows you to return an error if a provider takes too long to respond.
+A request timeout allows you to return an error or trigger a retry if a provider takes too long to respond.
 
 These timeouts help:
 

--- a/src/content/docs/ai-gateway/configuration/request-handling.mdx
+++ b/src/content/docs/ai-gateway/configuration/request-handling.mdx
@@ -12,7 +12,7 @@ import { Render, Aside } from "~/components";
 
 :::note
 
-[Dynamic Routing](/ai-gateway/features/dynamic-routing/) also offers timeouts and retries per model, along with conditional routing, rate limiting, and budget limiting through a visual interface. This page documents request-handling configuration available through Universal Endpoint provider `config` settings as well as per-request `cf-aig-*` headers that work with any provider endpoint. You can also configure retries at the [gateway level](/ai-gateway/configuration/manage-gateway/#retry-requests).
+[Dynamic Routing](/ai-gateway/features/dynamic-routing/) also offers timeouts and retries per model, along with conditional routing, rate limiting, and budget limiting through a visual interface. This page documents request-handling configuration available through per-request `cf-aig-*` headers that work with any provider endpoint. You can also configure retries at the [gateway level](/ai-gateway/configuration/manage-gateway/#retry-requests).
 
 :::
 
@@ -20,83 +20,16 @@ Your AI gateway supports different strategies for handling requests to providers
 
 ## Request timeouts
 
-A request timeout allows you to trigger fallbacks or a retry if a provider takes too long to respond.
+A request timeout allows you to return an error if a provider takes too long to respond.
 
 These timeouts help:
 
 - Improve user experience, by preventing users from waiting too long for a response
-- Proactively handle errors, by detecting unresponsive providers and triggering a fallback option
+- Proactively handle errors, by detecting unresponsive providers
 
-Request timeouts can be set on a Universal Endpoint or directly on a request to any provider.
-
-### Definitions
-
-A timeout is set in milliseconds. Additionally, the timeout is based on when the first part of the response comes back. As long as the first part of the response returns within the specified timeframe - such as when streaming a response - your gateway will wait for the response.
+A timeout is set in milliseconds. The timeout is based on when the first part of the response comes back. As long as the first part of the response returns within the specified timeframe — such as when streaming a response — your gateway will wait for the response.
 
 ### Configuration
-
-#### Universal Endpoint
-
-If set on a [Universal Endpoint](/ai-gateway/usage/universal/), a request timeout specifies the timeout duration for requests and triggers a fallback.
-
-For a Universal Endpoint, configure the timeout value by setting a `requestTimeout` property within the provider-specific `config` object. Each provider can have a different `requestTimeout` value for granular customization.
-
-```bash title="Provider-level config" {11-13} collapse={15-48}
-curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}' \
-	--header 'Content-Type: application/json' \
-	--data '[
-    {
-        "provider": "workers-ai",
-        "endpoint": "@cf/meta/llama-3.1-8b-instruct",
-        "headers": {
-            "Authorization": "Bearer {cloudflare_token}",
-            "Content-Type": "application/json"
-        },
-        "config": {
-            "requestTimeout": 1000
-        },
-        "query": {
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "You are a friendly assistant"
-                },
-                {
-                    "role": "user",
-                    "content": "What is Cloudflare?"
-                }
-            ]
-        }
-    },
-    {
-        "provider": "workers-ai",
-        "endpoint": "@cf/meta/llama-3.1-8b-instruct-fast",
-        "headers": {
-            "Authorization": "Bearer {cloudflare_token}",
-            "Content-Type": "application/json"
-        },
-        "query": {
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "You are a friendly assistant"
-                },
-                {
-                    "role": "user",
-                    "content": "What is Cloudflare?"
-                }
-            ]
-        },
-				"config": {
-            "requestTimeout": 3000
-        },
-    }
-]'
-```
-
-#### Direct provider
-
-If set on a [provider](/ai-gateway/usage/providers/) request, request timeout specifies the timeout duration for a request and - if exceeded - returns an error.
 
 For a provider-specific endpoint, configure the timeout value by adding a `cf-aig-request-timeout` header.
 
@@ -112,13 +45,9 @@ curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/workers-ai/@
 
 ## Request retries
 
-AI Gateway also supports automatic retries for failed requests, with a maximum of five retry attempts.
+AI Gateway supports automatic retries for failed requests, with a maximum of five retry attempts.
 
 This feature improves your application's resiliency, ensuring you can recover from temporary issues without manual intervention.
-
-Request timeouts can be set on a Universal Endpoint or directly on a request to any provider.
-
-### Definitions
 
 With request retries, you can adjust a combination of three properties:
 
@@ -129,83 +58,6 @@ With request retries, you can adjust a combination of three properties:
 On the final retry attempt, your gateway will wait until the request completes, regardless of how long it takes.
 
 ### Configuration
-
-#### Universal endpoint
-
-If set on a [Universal Endpoint](/ai-gateway/usage/universal/), a request retry will automatically retry failed requests up to five times before triggering any configured fallbacks.
-
-For a Universal Endpoint, configure the retry settings with the following properties in the provider-specific `config`:
-
-```json
-config:{
-	maxAttempts?: number;
-	retryDelay?: number;
-	backoff?: "constant" | "linear" | "exponential";
-}
-```
-
-As with the [request timeout](/ai-gateway/configuration/request-handling/#universal-endpoint), each provider can have a different retry settings for granular customization.
-
-```bash title="Provider-level config" {11-15} collapse={16-55}
-curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}' \
-	--header 'Content-Type: application/json' \
-	--data '[
-    {
-        "provider": "workers-ai",
-        "endpoint": "@cf/meta/llama-3.1-8b-instruct",
-        "headers": {
-            "Authorization": "Bearer {cloudflare_token}",
-            "Content-Type": "application/json"
-        },
-        "config": {
-            "maxAttempts": 2,
-						"retryDelay": 1000,
-						"backoff": "constant"
-        },
-        "query": {
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "You are a friendly assistant"
-                },
-                {
-                    "role": "user",
-                    "content": "What is Cloudflare?"
-                }
-            ]
-        }
-    },
-    {
-        "provider": "workers-ai",
-        "endpoint": "@cf/meta/llama-3.1-8b-instruct-fast",
-        "headers": {
-            "Authorization": "Bearer {cloudflare_token}",
-            "Content-Type": "application/json"
-        },
-        "query": {
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "You are a friendly assistant"
-                },
-                {
-                    "role": "user",
-                    "content": "What is Cloudflare?"
-                }
-            ]
-        },
-				"config": {
-            "maxAttempts": 4,
-						"retryDelay": 1000,
-						"backoff": "exponential"
-        },
-    }
-]'
-```
-
-#### Direct provider
-
-If set on a [provider](/ai-gateway/usage/universal/) request, a request retry will automatically retry failed requests up to five times. On the final retry attempt, your gateway will wait until the request completes, regardless of how long it takes.
 
 For a provider-specific endpoint, configure the retry settings by adding different header values:
 

--- a/src/content/docs/ai-gateway/evaluations/set-up-evaluations.mdx
+++ b/src/content/docs/ai-gateway/evaluations/set-up-evaluations.mdx
@@ -37,7 +37,7 @@ Please keep in mind that datasets currently use `AND` joins, so there can only b
 | Provider        | specific providers                                           | the selected AI provider.                 |
 | AI Models       | specific models                                              | the selected AI model.                    |
 | Cost            | less than, greater than                                      | cost, specifying a threshold.             |
-| Request type    | Universal, Workers AI Binding, WebSockets                    | the type of request.                      |
+| Request type    | Workers AI Binding, WebSockets                               | the type of request.                      |
 | Tokens          | Total tokens, Tokens In, Tokens Out                          | token count (less than or greater than).  |
 | Duration        | less than, greater than                                      | request duration.                         |
 | Feedback        | equals, does not equal (thumbs up, thumbs down, no feedback) | feedback type.                            |

--- a/src/content/docs/ai-gateway/glossary.mdx
+++ b/src/content/docs/ai-gateway/glossary.mdx
@@ -16,13 +16,11 @@ AI Gateway supports a variety of headers to help you configure, customize, and m
 
 ## Configuration hierarchy
 
-Settings in AI Gateway can be configured at three levels: **Provider**, **Request**, and **Gateway**. Since the same settings can be configured in multiple locations, the following hierarchy determines which value is applied:
+Settings in AI Gateway can be configured at two levels: **Request** and **Gateway**. Since the same settings can be configured in multiple locations, the following hierarchy determines which value is applied:
 
-1. **Provider-level headers**:
-   Relevant only when using the [Universal Endpoint](/ai-gateway/usage/universal/), these headers take precedence over all other configurations.
-2. **Request-level headers**:
-   Apply if no provider-level headers are set.
-3. **Gateway-level settings**:
-   Act as the default if no headers are set at the provider or request levels.
+1. **Request-level headers**:
+   Headers included in individual requests take precedence over gateway-level settings.
+2. **Gateway-level settings**:
+   Act as the default if no headers are set at the request level.
 
-This hierarchy ensures consistent behavior, prioritizing the most specific configurations. Use provider-level and request-level headers for more fine-tuned control, and gateway settings for general defaults.
+This hierarchy ensures consistent behavior, prioritizing the most specific configurations. Use request-level headers for fine-tuned control, and gateway settings for general defaults.

--- a/src/content/docs/ai-gateway/integrations/worker-binding-methods.mdx
+++ b/src/content/docs/ai-gateway/integrations/worker-binding-methods.mdx
@@ -9,7 +9,7 @@ tags:
 description: >-
   Reference for the AI binding with AI Gateway. Call Workers AI and
   third-party models with env.AI.run(), access log IDs, and use gateway methods
-  for feedback, logging, URLs, and universal requests.
+  for feedback, logging, and URLs.
 products:
   - ai-gateway
 ---
@@ -198,21 +198,4 @@ const anthropic = createAnthropic({
 });
 ```
 
-### `run()`
 
-Executes a [universal request](/ai-gateway/usage/universal/) to any supported provider. Accepts a single request object or an array.
-
-```typescript
-const resp = await gateway.run({
-	provider: "workers-ai",
-	endpoint: "@cf/meta/llama-3.1-8b-instruct",
-	headers: {
-		authorization: "Bearer my-api-token",
-	},
-	query: {
-		prompt: "tell me a joke",
-	},
-});
-```
-
-**Returns:** `Promise<Response>`

--- a/src/content/docs/ai-gateway/observability/logging/index.mdx
+++ b/src/content/docs/ai-gateway/observability/logging/index.mdx
@@ -120,7 +120,7 @@ See full list of available filters and their descriptions below:
 | Provider        | specific providers                                           | the selected AI provider.                 |
 | AI Models       | specific models                                              | the selected AI model.                    |
 | Cost            | less than, greater than                                      | cost, specifying a threshold.             |
-| Request type    | Universal, Workers AI Binding, WebSockets                    | the type of request.                      |
+| Request type    | Workers AI Binding, WebSockets                               | the type of request.                      |
 | Tokens          | Total tokens, Tokens In, Tokens Out                          | token count (less than or greater than).  |
 | Duration        | less than, greater than                                      | request duration.                         |
 | Feedback        | equals, does not equal (thumbs up, thumbs down, no feedback) | feedback type.                            |

--- a/src/content/docs/ai-gateway/tutorials/deploy-aig-worker.mdx
+++ b/src/content/docs/ai-gateway/tutorials/deploy-aig-worker.mdx
@@ -23,7 +23,7 @@ All of the tutorials assume you have already completed the [Get started guide](/
 
 ## 1. Create an AI Gateway and OpenAI API key
 
-On the AI Gateway page in the Cloudflare dashboard, create a new AI Gateway by clicking the plus button on the top right. You should be able to name the gateway as well as the endpoint. Click on the API Endpoints button to copy the endpoint. You can choose from provider-specific endpoints such as OpenAI, HuggingFace, and Replicate. Or you can use the universal endpoint that accepts a specific schema and supports model fallback and retries.
+On the AI Gateway page in the Cloudflare dashboard, create a new AI Gateway by clicking the plus button on the top right. You should be able to name the gateway as well as the endpoint. Click on the API Endpoints button to copy the endpoint. You can choose from provider-specific endpoints such as OpenAI, HuggingFace, and Replicate.
 
 For this tutorial, we will be using the OpenAI provider-specific endpoint, so select OpenAI in the dropdown and copy the new endpoint.
 

--- a/src/content/docs/ai-gateway/usage/universal.mdx
+++ b/src/content/docs/ai-gateway/usage/universal.mdx
@@ -1,7 +1,7 @@
 ---
-title: Universal Endpoint
+title: Universal Endpoint (Deprecated)
 description: Route requests to any AI provider through a single AI Gateway endpoint with support for fallbacks and retries.
-pcx_content_type: get-started
+pcx_content_type: reference
 sidebar:
   order: 2
   hidden: true
@@ -11,38 +11,189 @@ products:
 
 import { Render, Badge, WranglerConfig } from "~/components";
 
-:::note
+:::caution[Deprecated]
 
-It is recommended to use the Dynamic Routes to implement model fallback feature
+The Universal Endpoint is deprecated. Use the [OpenAI-compatible endpoint](/ai-gateway/usage/chat-completion/) for new integrations, and [Dynamic Routing](/ai-gateway/features/dynamic-routing/) for fallbacks, retries, and conditional routing. The Universal Endpoint will continue to work for existing integrations.
 
 :::
 
-You can use the Universal Endpoint to contact every provider.
+The Universal Endpoint allows you to contact every provider through a single endpoint.
 
 ```txt
 https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}
 ```
 
-AI Gateway offers multiple endpoints for each Gateway you create - one endpoint per provider, and one Universal Endpoint. The Universal Endpoint requires some adjusting to your schema, but supports additional features. Some of these features are, for example, retrying a request if it fails the first time, or configuring a [fallback model/provider](/ai-gateway/configuration/fallbacks/).
+The payload expects an array of messages. Each message is an object with the following parameters:
 
-You can use the Universal endpoint to contact every provider. The payload is expecting an array of message, and each message is an object with the following parameters:
-
-- `provider` : the name of the provider you would like to direct this message to. Can be OpenAI, workers-ai, or any of our supported providers.
-- `endpoint`: the pathname of the provider API you’re trying to reach. For example, on OpenAI it can be `chat/completions`, and for Workers AI this might be [`@cf/meta/llama-3.1-8b-instruct`](/workers-ai/models/llama-3.1-8b-instruct/). See more in the sections that are specific to [each provider](/ai-gateway/usage/providers/).
-- `authorization`: the content of the Authorization HTTP Header that should be used when contacting this provider. This usually starts with 'Token' or 'Bearer'.
+- `provider`: the name of the provider you would like to direct this message to. Can be OpenAI, workers-ai, or any of our supported providers.
+- `endpoint`: the pathname of the provider API you are trying to reach. For example, on OpenAI it can be `chat/completions`, and for Workers AI this might be [`@cf/meta/llama-3.1-8b-instruct`](/workers-ai/models/llama-3.1-8b-instruct/). Refer to the sections that are specific to [each provider](/ai-gateway/usage/providers/).
+- `authorization`: the content of the Authorization HTTP Header that should be used when contacting this provider. This usually starts with `Token` or `Bearer`.
 - `query`: the payload as the provider expects it in their official API.
 
 ## cURL example
 
 <Render file="universal-gateway-example" product="ai-gateway" />
 
-The above will send a request to Workers AI Inference API, if it fails it will proceed to OpenAI. You can add as many fallbacks as you need, just by adding another JSON in the array.
+The above will send a request to Workers AI Inference API. If it fails, it will proceed to OpenAI. You can add as many fallbacks as you need by adding another object in the array.
+
+## Fallbacks
+
+You can specify model or provider fallbacks to handle request failures and ensure reliability. The payload array defines the fallback sequence — if the first provider fails, the request falls to the next entry in the array. For more details, refer to [Fallbacks](/ai-gateway/configuration/fallbacks/).
+
+By default, Cloudflare triggers your fallback if a model request returns an error. You can also configure [request timeouts](#request-timeouts) to trigger fallbacks when a provider takes too long to respond.
+
+### Response header (`cf-aig-step`)
+
+When using fallbacks, the response header `cf-aig-step` indicates which model successfully processed the request by returning the step number:
+
+- `cf-aig-step:0` — The first (primary) model was used successfully.
+- `cf-aig-step:1` — The request fell back to the second model.
+- `cf-aig-step:2` — The request fell back to the third model.
+- Subsequent steps — Each fallback increments the step number by 1.
+
+## Request timeouts
+
+A request timeout triggers a fallback if a provider takes too long to respond.
+
+Configure the timeout by setting a `requestTimeout` property (in milliseconds) within the provider-specific `config` object. Each provider can have a different `requestTimeout` value.
+
+The timeout is based on when the first part of the response comes back. As long as the first part of the response returns within the specified timeframe — such as when streaming a response — your gateway will wait for the response.
+
+```bash title="Request timeout example" {11-13} collapse={15-48}
+curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}' \
+	--header 'Content-Type: application/json' \
+	--data '[
+    {
+        "provider": "workers-ai",
+        "endpoint": "@cf/meta/llama-3.1-8b-instruct",
+        "headers": {
+            "Authorization": "Bearer {cloudflare_token}",
+            "Content-Type": "application/json"
+        },
+        "config": {
+            "requestTimeout": 1000
+        },
+        "query": {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a friendly assistant"
+                },
+                {
+                    "role": "user",
+                    "content": "What is Cloudflare?"
+                }
+            ]
+        }
+    },
+    {
+        "provider": "workers-ai",
+        "endpoint": "@cf/meta/llama-3.1-8b-instruct-fast",
+        "headers": {
+            "Authorization": "Bearer {cloudflare_token}",
+            "Content-Type": "application/json"
+        },
+        "query": {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a friendly assistant"
+                },
+                {
+                    "role": "user",
+                    "content": "What is Cloudflare?"
+                }
+            ]
+        },
+				"config": {
+            "requestTimeout": 3000
+        },
+    }
+]'
+```
+
+## Request retries
+
+The Universal Endpoint supports automatic retries for failed requests, with a maximum of five retry attempts. Retries are attempted before triggering any configured fallbacks.
+
+Configure the retry settings with the following properties in the provider-specific `config`:
+
+```json
+config:{
+	maxAttempts?: number;
+	retryDelay?: number;
+	backoff?: "constant" | "linear" | "exponential";
+}
+```
+
+- `maxAttempts`: Maximum number of retry attempts (up to 5).
+- `retryDelay`: Delay before retrying, in milliseconds (maximum of 5 seconds).
+- `backoff`: Backoff method — `constant`, `linear`, or `exponential`.
+
+On the final retry attempt, your gateway will wait until the request completes, regardless of how long it takes. Each provider can have different retry settings.
+
+```bash title="Request retry example" {11-15} collapse={16-55}
+curl 'https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}' \
+	--header 'Content-Type: application/json' \
+	--data '[
+    {
+        "provider": "workers-ai",
+        "endpoint": "@cf/meta/llama-3.1-8b-instruct",
+        "headers": {
+            "Authorization": "Bearer {cloudflare_token}",
+            "Content-Type": "application/json"
+        },
+        "config": {
+            "maxAttempts": 2,
+						"retryDelay": 1000,
+						"backoff": "constant"
+        },
+        "query": {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a friendly assistant"
+                },
+                {
+                    "role": "user",
+                    "content": "What is Cloudflare?"
+                }
+            ]
+        }
+    },
+    {
+        "provider": "workers-ai",
+        "endpoint": "@cf/meta/llama-3.1-8b-instruct-fast",
+        "headers": {
+            "Authorization": "Bearer {cloudflare_token}",
+            "Content-Type": "application/json"
+        },
+        "query": {
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a friendly assistant"
+                },
+                {
+                    "role": "user",
+                    "content": "What is Cloudflare?"
+                }
+            ]
+        },
+				"config": {
+            "maxAttempts": 4,
+						"retryDelay": 1000,
+						"backoff": "exponential"
+        },
+    }
+]'
+```
 
 ## WebSockets API <Badge text="beta" variant="tip" size="small" />
 
 The Universal Endpoint can also be accessed via a [WebSockets API](/ai-gateway/usage/websockets-api/) which provides a single persistent connection, enabling continuous communication. This API supports all AI providers connected to AI Gateway, including those that do not natively support WebSockets.
 
-## WebSockets example
+### WebSockets example
 
 ```javascript
 import WebSocket from "ws";
@@ -129,7 +280,7 @@ Since the same settings can be configured in multiple locations, AI Gateway appl
 
 This hierarchy ensures consistent behavior, prioritizing the most specific configurations. Use provider-level and request-level headers for fine-tuned control, and gateway settings for general defaults.
 
-## Hierarchy example
+### Hierarchy example
 
 This example demonstrates how headers set at different levels impact caching behavior:
 

--- a/src/content/docs/ai-gateway/usage/universal.mdx
+++ b/src/content/docs/ai-gateway/usage/universal.mdx
@@ -118,7 +118,7 @@ The Universal Endpoint supports automatic retries for failed requests, with a ma
 
 Configure the retry settings with the following properties in the provider-specific `config`:
 
-```json
+```ts
 config:{
 	maxAttempts?: number;
 	retryDelay?: number;

--- a/src/content/docs/ai-gateway/usage/websockets-api/non-realtime-api.mdx
+++ b/src/content/docs/ai-gateway/usage/websockets-api/non-realtime-api.mdx
@@ -13,7 +13,7 @@ The Non-realtime WebSockets API allows you to establish persistent connections f
 ## Set up WebSockets API
 
 1. Generate an AI Gateway token with appropriate AI Gateway Run and opt in to using an authenticated gateway.
-2. Modify your Universal Endpoint URL by replacing `https://` with `wss://` to initiate a WebSocket connection:
+2. Use the `wss://` protocol to initiate a WebSocket connection:
    ```
    wss://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}
    ```

--- a/src/content/glossary/ai-gateway.yaml
+++ b/src/content/glossary/ai-gateway.yaml
@@ -7,7 +7,7 @@ entries:
 
   - term: cf-aig-step
     general_definition: |-
-      [cf-aig-step](/ai-gateway/configuration/fallbacks/#response-headercf-aig-step) identifies the processing step in the AI Gateway flow for better tracking and debugging.
+      The cf-aig-step response header identifies which step in a request flow successfully processed the request, useful for tracking and debugging.
 
   - term: cf-aig-log-id
     general_definition: |-
@@ -43,7 +43,7 @@ entries:
 
   - term: cf-aig-request-timeout
     general_definition: |-
-      Header to trigger a fallback provider based on a [predetermined response time](/ai-gateway/configuration/fallbacks/#request-timeouts) (measured in milliseconds).
+      Header to set a [request timeout](/ai-gateway/configuration/request-handling/#request-timeouts) (measured in milliseconds). If the provider does not respond within this time, the request returns an error.
 
   - term: cf-aig-max-attempts
     general_definition: |-


### PR DESCRIPTION
…le unlinked reference page

Remove Universal API mentions from all AI Gateway docs while keeping a single hidden reference page (usage/universal.mdx) with a deprecation banner pointing users to the OpenAI-compatible endpoint and Dynamic Routing.

- Consolidate timeout/retry config examples into universal.mdx
- Add fallbacks section with cf-aig-step docs to universal.mdx
- Remove Universal sections from request-handling.mdx
- Remove run() binding method from worker-binding-methods.mdx
- Remove Universal from filter tables in logging and evaluations
- Update glossary entries to remove fallbacks.mdx references
- Update glossary header hierarchy to remove provider-level (Universal-only)
- Remove Universal mention from tutorial and WebSocket prose

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
