### PR TITLE
fix: correct typo 'balanace' to 'balance' in containers get-started

### DIFF
--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -74,7 +74,7 @@ Now, open the URL for your Worker. It should look something like `https://hello-
 If you make requests to the paths `/container/1` or `/container/2`, your Worker routes requests to specific containers.
 Each different path after "/container/" routes to a unique container.
 
-If you make requests to `/lb`, you will load balanace requests to one of 3 containers chosen at random.
+If you make requests to `/lb`, you will load balance requests to one of 3 containers chosen at random.
 
 You can confirm this behavior by reading the output of each request.
 


### PR DESCRIPTION
## Summary
Fixes a spelling typo in the Containers getting started documentation.

## Change
File: `src/content/docs/containers/get-started.mdx` Section: "Make requests to Containers"

- Before: "you will load balanace requests to one of 3 containers"
- After:  "you will load balance requests to one of 3 containers"

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
