### PR TITLE
[Pipelines] Rename pipeline field to stream in binding configuration

### DIFF
--- a/src/content/changelog/pipelines/2026-05-08-pipeline-binding-stream-field.mdx
+++ b/src/content/changelog/pipelines/2026-05-08-pipeline-binding-stream-field.mdx
@@ -1,0 +1,52 @@
+---
+title: Pipeline binding configuration field renamed to stream
+description: The pipeline field in Wrangler pipeline binding configuration has been renamed to stream. The old field is deprecated but still accepted.
+products:
+  - pipelines
+  - workers
+date: 2026-05-08
+---
+
+import { WranglerConfig } from "~/components";
+
+The `pipeline` field inside the `pipelines` binding configuration in your [Wrangler configuration file](/workers/wrangler/configuration/) has been renamed to `stream`. The old field is deprecated but still accepted.
+
+Update your configuration to use `stream` to avoid the deprecation warning.
+
+**Before (deprecated):**
+
+<WranglerConfig>
+
+```jsonc
+{
+	"pipelines": [
+		{
+			"binding": "MY_PIPELINE",
+			"pipeline": "<STREAM_ID>"
+		}
+	]
+}
+```
+
+</WranglerConfig>
+
+**After:**
+
+<WranglerConfig>
+
+```jsonc
+{
+	"pipelines": [
+		{
+			"binding": "MY_PIPELINE",
+			"stream": "<STREAM_ID>"
+		}
+	]
+}
+```
+
+</WranglerConfig>
+
+No other changes are required. The binding name, TypeScript types, and runtime API (`env.MY_PIPELINE.send(...)`) remain the same.
+
+For more information on configuring pipeline bindings, refer to [Writing to streams](/pipelines/streams/writing-to-streams/#configure-pipeline-binding).

--- a/src/content/changelog/pipelines/2026-05-27-pipeline-binding-stream-field.mdx
+++ b/src/content/changelog/pipelines/2026-05-27-pipeline-binding-stream-field.mdx
@@ -4,7 +4,7 @@ description: The pipeline field in Wrangler pipeline binding configuration has b
 products:
   - pipelines
   - workers
-date: 2026-05-27
+date: 2026-06-04
 ---
 
 import { WranglerConfig } from "~/components";

--- a/src/content/changelog/pipelines/2026-05-27-pipeline-binding-stream-field.mdx
+++ b/src/content/changelog/pipelines/2026-05-27-pipeline-binding-stream-field.mdx
@@ -4,7 +4,7 @@ description: The pipeline field in Wrangler pipeline binding configuration has b
 products:
   - pipelines
   - workers
-date: 2026-05-08
+date: 2026-05-27
 ---
 
 import { WranglerConfig } from "~/components";

--- a/src/content/changelog/pipelines/2026-05-27-pipeline-binding-stream-field.mdx
+++ b/src/content/changelog/pipelines/2026-05-27-pipeline-binding-stream-field.mdx
@@ -17,15 +17,10 @@ Update your configuration to use `stream` to avoid the deprecation warning.
 
 <WranglerConfig>
 
-```jsonc
-{
-	"pipelines": [
-		{
-			"binding": "MY_PIPELINE",
-			"pipeline": "<STREAM_ID>"
-		}
-	]
-}
+```toml
+[[pipelines]]
+binding = "MY_PIPELINE"
+pipeline = "<STREAM_ID>"
 ```
 
 </WranglerConfig>
@@ -34,15 +29,10 @@ Update your configuration to use `stream` to avoid the deprecation warning.
 
 <WranglerConfig>
 
-```jsonc
-{
-	"pipelines": [
-		{
-			"binding": "MY_PIPELINE",
-			"stream": "<STREAM_ID>"
-		}
-	]
-}
+```toml
+[[pipelines]]
+binding = "MY_PIPELINE"
+stream = "<STREAM_ID>"
 ```
 
 </WranglerConfig>

--- a/src/content/docs/pipelines/streams/writing-to-streams.mdx
+++ b/src/content/docs/pipelines/streams/writing-to-streams.mdx
@@ -25,13 +25,17 @@ Add a pipeline binding to your Wrangler file that points to your stream:
 {
 	"pipelines": [
 		{
-			"pipeline": "<STREAM_ID>",
-			"binding": "STREAM"
+			"binding": "STREAM",
+			"stream": "<STREAM_ID>"
 		}
 	]
 }
 ```
 </WranglerConfig>
+
+:::note
+The `pipeline` field in the `pipelines` binding configuration has been renamed to `stream`. Existing configurations that use `pipeline` will continue to work, but Wrangler will display a deprecation warning. Update your configuration to use `stream` instead.
+:::
 
 ### Workers API
 


### PR DESCRIPTION
### Summary

Updates the Pipelines documentation to reflect the `pipeline` → `stream` field rename in Wrangler pipeline binding configuration, matching the workers-sdk change in https://github.com/cloudflare/workers-sdk/pull/13860.

- Updates the Wrangler config example in the "Writing to streams" page to use the new `stream` field
- Adds a deprecation note explaining the old `pipeline` field is still accepted but will emit a warning
- Adds a changelog entry with before/after config examples and migration guidance

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
