### PR TITLE
[ZT] Add managed OAuth step to self-hosted MCP server guide

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/secure-mcp-servers.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/secure-mcp-servers.mdx
@@ -113,12 +113,13 @@ The Worker will be deployed to your `*.workers.dev` subdomain at `mcp-access-sel
    	params={{ appType: "self-hosted" }}
    />
 7. Select **Create**.
-8. On the application details page, go to **Additional settings** > **AUD tag** and copy the value. You will need this value to configure your MCP server.
+8. On the application details page, go to **Additional settings** and turn on **Managed OAuth**. This allows non-browser MCP clients to authenticate using a standard OAuth 2.0 flow instead of receiving a browser redirect. For more information, refer to [Managed OAuth](/cloudflare-one/access-controls/applications/http-apps/managed-oauth/).
+9. Copy the **AUD tag** value shown in **Additional settings**. You will need this value to configure your MCP server.
 
 </TabItem>
 <TabItem label="API">
 
-1. Make a `POST` request to the [Access applications](/api/resources/zero_trust/subresources/access/subresources/applications/methods/create/) endpoint:
+1. Make a `POST` request to the [Access applications](/api/resources/zero_trust/subresources/access/subresources/applications/methods/create/) endpoint with `oauth_configuration.enabled` set to `true`:
 
    <APIRequest
    	path="/accounts/{account_id}/access/apps"
@@ -129,6 +130,9 @@ The Worker will be deployed to your `*.workers.dev` subdomain at `mcp-access-sel
    		domain: "mcp-access-self-hosted.<YOUR_SUBDOMAIN>.workers.dev",
    		policies: ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
    		allowed_idps: [],
+   		oauth_configuration: {
+   			enabled: true,
+   		},
    	}}
    />
 

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/secure-mcp-servers.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/secure-mcp-servers.mdx
@@ -113,7 +113,7 @@ The Worker will be deployed to your `*.workers.dev` subdomain at `mcp-access-sel
    	params={{ appType: "self-hosted" }}
    />
 7. Select **Create**.
-8. On the application details page, go to **Additional settings** and turn on **Managed OAuth**. This allows non-browser MCP clients to authenticate using a standard OAuth 2.0 flow instead of receiving a browser redirect. For more information, refer to [Managed OAuth](/cloudflare-one/access-controls/applications/http-apps/managed-oauth/).
+8. On the application details page, go to **Advanced settings** and turn on **Managed OAuth**. This allows non-browser MCP clients to authenticate using a standard OAuth 2.0 flow instead of receiving a browser redirect. For more information, refer to [Managed OAuth](/cloudflare-one/access-controls/applications/http-apps/managed-oauth/).
 9. Copy the **AUD tag** value shown in **Additional settings**. You will need this value to configure your MCP server.
 
 </TabItem>


### PR DESCRIPTION
### Summary

The self-hosted MCP server guide (Secure MCP servers > Self-hosted application) was missing the step to enable **Managed OAuth** on the Access application. Without this, non-browser MCP clients (CLIs, AI agents, SDKs) receive a `302` browser redirect instead of a proper OAuth `401` with `WWW-Authenticate` headers, effectively blocking them from authenticating.

This PR adds:
- A Dashboard step instructing users to turn on **Managed OAuth** in **Additional settings**, with a link to the [Managed OAuth](/cloudflare-one/access-controls/applications/http-apps/managed-oauth/) reference page.
- The `oauth_configuration: { enabled: true }` field to the API tab's example request body.

### Screenshots (optional)

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
