### PR TITLE
[Workers AI] Announce planned model deprecations for May 30, 2026

### DIFF
--- a/bin/fetch-ai-models.js
+++ b/bin/fetch-ai-models.js
@@ -2,15 +2,33 @@ import fs from "node:fs";
 import path from "node:path";
 
 const OUTPUT_DIR = path.join(process.cwd(), "src/content/workers-ai-models");
+const API_URL = "https://ai-cloudflare-com.pages.dev/api/models";
 
-const response = await fetch("https://ai-cloudflare-com.pages.dev/api/models");
+const response = await fetch(API_URL);
+if (!response.ok) {
+	throw new Error(
+		`fetch-ai-models: API returned HTTP ${response.status} ${response.statusText}.`,
+	);
+}
+
 const data = await response.json();
+
 const existingFiles = new Set(
 	fs.readdirSync(OUTPUT_DIR).filter((file) => file.endsWith(".json")),
 );
 
+const now = Date.now();
+
 for (const model of data.models) {
 	const fileName = `${model.name.split("/")[2]}.json`;
+
+	const deprecation = (model.properties ?? []).find(
+		(p) => p.property_id === "planned_deprecation_date",
+	);
+	if (deprecation && new Date(deprecation.value).getTime() < now) {
+		continue;
+	}
+
 	existingFiles.delete(fileName);
 	fs.writeFileSync(
 		path.join(OUTPUT_DIR, fileName),
@@ -20,5 +38,13 @@ for (const model of data.models) {
 }
 
 for (const fileName of existingFiles) {
-	fs.unlinkSync(path.join(OUTPUT_DIR, fileName));
+	const filePath = path.join(OUTPUT_DIR, fileName);
+	const file = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	const deprecation = (file.properties ?? []).find(
+		(p) => p.property_id === "planned_deprecation_date",
+	);
+	if (deprecation && new Date(deprecation.value).getTime() >= now) {
+		continue;
+	}
+	fs.unlinkSync(filePath);
 }

--- a/src/content/changelog/workers-ai/2026-05-08-planned-model-deprecations.mdx
+++ b/src/content/changelog/workers-ai/2026-05-08-planned-model-deprecations.mdx
@@ -1,0 +1,57 @@
+---
+title: "Planned model deprecations on Workers AI"
+description: We are refreshing the Workers AI model catalog. Eighteen older models will be deprecated on May 30, 2026.
+products:
+  - workers-ai
+date: 2026-05-08
+---
+
+We are refreshing the Workers AI model catalog to make room for newer releases. Please update your apps to remove references to the models listed below before the deprecation date.
+
+## Recommended replacements
+
+- [`@cf/zai-org/glm-4.7-flash`](/workers-ai/models/glm-4.7-flash/) — fast multilingual model with multi-turn tool calling and coding capabilities.
+- [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) — efficient open model with vision and tool calling.
+- [`@cf/moonshotai/kimi-k2.6`](/workers-ai/models/kimi-k2.6/) — capable tool-calling and vision model for agentic workloads and coding.
+
+For pricing, refer to the [Workers AI pricing page](/workers-ai/platform/pricing/).
+
+## Kimi K2.5
+
+We originally stated Kimi K2.5 would be deprecated on May 10, 2026, however we have extended the deprecation date to May 30, 2026. Requests will be automatically aliased to Kimi K2.6 on May 30, 2026, which has a higher price. Please review the [`@cf/moonshotai/kimi-k2.6`](/workers-ai/models/kimi-k2.6/) pricing and model capabilities prior to May 30, 2026 to ensure that the model suits your needs.
+
+## Models deprecated on May 30, 2026
+
+- `@cf/moonshotai/kimi-k2.5` --> `@cf/moonshotai/kimi-k2.6`
+- `@hf/meta-llama/meta-llama-3-8b-instruct`
+- `@cf/meta/llama-3-8b-instruct`
+- `@cf/meta/llama-3-8b-instruct-awq`
+- `@cf/meta/llama-3.1-8b-instruct`
+- `@cf/meta/llama-3.1-8b-instruct-awq`
+- `@cf/meta/llama-3.1-70b-instruct`
+- `@cf/meta/llama-2-7b-chat-int8`
+- `@cf/meta/llama-2-7b-chat-fp16`
+- `@cf/mistral/mistral-7b-instruct-v0.1`
+- `@hf/mistral/mistral-7b-instruct-v0.2`
+- `@hf/google/gemma-7b-it`
+- `@cf/google/gemma-3-12b-it`
+- `@hf/nousresearch/hermes-2-pro-mistral-7b`
+- `@cf/microsoft/phi-2`
+- `@cf/defog/sqlcoder-7b-2`
+- `@cf/unum/uform-gen2-qwen-500m`
+- `@cf/facebook/bart-large-cnn`
+
+## Variants that remain active
+
+The `-fast` and `-lora` variants of models will remain active, including:
+
+- `@cf/meta/llama-3.3-70b-instruct-fp8-fast`
+- `@cf/meta/llama-3.1-8b-instruct-fast`
+- `@cf/google/gemma-7b-it-lora`
+- `@cf/google/gemma-2b-it-lora`
+- `@cf/mistral/mistral-7b-instruct-v0.2-lora`
+- `@cf/meta-llama/llama-2-7b-chat-hf-lora`
+
+LoRA models may be deprecated in the future. We will be adding more LoRA capabilities to the catalog, and will communicate when new LoRA models come online to give users time to train new LoRAs before we deprecate old ones.
+
+For the full list of available models, refer to the [Workers AI model catalog](/workers-ai/models/).

--- a/src/content/release-notes/workers-ai.yaml
+++ b/src/content/release-notes/workers-ai.yaml
@@ -3,6 +3,32 @@ link: "/workers-ai/changelog/"
 productName: Workers AI
 productLink: "/workers-ai/"
 entries:
+  - publish_date: "2026-05-08"
+    title: Planned model deprecations
+    description: |-
+      - We are refreshing the Workers AI model catalog to make room for newer releases. Please update your apps to remove references to the models listed below before the deprecation date. Refer to the [changelog](/changelog/post/2026-05-08-planned-model-deprecations/) for full details.
+      - We recommend migrating to newer models such as [`@cf/zai-org/glm-4.7-flash`](/workers-ai/models/glm-4.7-flash/) for fast tool-calling, [`@cf/google/gemma-4-26b-a4b-it`](/workers-ai/models/gemma-4-26b-a4b-it/) for an efficient open model, or [`@cf/moonshotai/kimi-k2.6`](/workers-ai/models/kimi-k2.6/) for a capable tool-calling and vision model.
+      - On May 30, 2026, requests to [`@cf/moonshotai/kimi-k2.5`](/workers-ai/models/kimi-k2.5/) will be automatically aliased to [`@cf/moonshotai/kimi-k2.6`](/workers-ai/models/kimi-k2.6/), which has a higher price. The deprecation date was extended from May 10, 2026. Please review the [K2.6 pricing and model capabilities](/workers-ai/models/kimi-k2.6/) prior to May 30, 2026.
+      - On May 30, 2026, the following models will be deprecated:
+          - `@cf/moonshotai/kimi-k2.5` --> `@cf/moonshotai/kimi-k2.6`
+          - `@hf/meta-llama/meta-llama-3-8b-instruct`
+          - `@cf/meta/llama-3-8b-instruct`
+          - `@cf/meta/llama-3-8b-instruct-awq`
+          - `@cf/meta/llama-3.1-8b-instruct`
+          - `@cf/meta/llama-3.1-8b-instruct-awq`
+          - `@cf/meta/llama-3.1-70b-instruct`
+          - `@cf/meta/llama-2-7b-chat-int8`
+          - `@cf/meta/llama-2-7b-chat-fp16`
+          - `@cf/mistral/mistral-7b-instruct-v0.1`
+          - `@hf/mistral/mistral-7b-instruct-v0.2`
+          - `@hf/google/gemma-7b-it`
+          - `@cf/google/gemma-3-12b-it`
+          - `@hf/nousresearch/hermes-2-pro-mistral-7b`
+          - `@cf/microsoft/phi-2`
+          - `@cf/defog/sqlcoder-7b-2`
+          - `@cf/unum/uform-gen2-qwen-500m`
+          - `@cf/facebook/bart-large-cnn`
+      - The `-fast` and `-lora` variants of models will remain active. LoRA models may be deprecated in the future, and we will communicate when new LoRA models come online to give users time to train new LoRAs before we deprecate old ones.
   - publish_date: "2026-04-20"
     title: Moonshot AI Kimi K2.6 now available on Workers AI
     description: |-

--- a/src/content/workers-ai-models/bart-large-cnn.json
+++ b/src/content/workers-ai-models/bart-large-cnn.json
@@ -24,6 +24,10 @@
                     "currency": "USD"
                 }
             ]
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/gemma-3-12b-it.json
+++ b/src/content/workers-ai-models/gemma-3-12b-it.json
@@ -33,6 +33,10 @@
         {
             "property_id": "lora",
             "value": "true"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/gemma-7b-it.json
+++ b/src/content/workers-ai-models/gemma-7b-it.json
@@ -28,6 +28,10 @@
             "value": "true"
         },
         {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
+        },
+        {
             "property_id": "terms",
             "value": "https://ai.google.dev/gemma/terms"
         }

--- a/src/content/workers-ai-models/hermes-2-pro-mistral-7b.json
+++ b/src/content/workers-ai-models/hermes-2-pro-mistral-7b.json
@@ -26,6 +26,10 @@
         {
             "property_id": "info",
             "value": "https://huggingface.co/NousResearch/Hermes-2-Pro-Mistral-7B"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/kimi-k2.5.json
+++ b/src/content/workers-ai-models/kimi-k2.5.json
@@ -44,6 +44,10 @@
             "value": "true"
         },
         {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
+        },
+        {
             "property_id": "reasoning",
             "value": "true"
         },

--- a/src/content/workers-ai-models/llama-2-7b-chat-fp16.json
+++ b/src/content/workers-ai-models/llama-2-7b-chat-fp16.json
@@ -35,6 +35,10 @@
             "value": "https://ai.meta.com/llama/"
         },
         {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
+        },
+        {
             "property_id": "terms",
             "value": "https://ai.meta.com/resources/models-and-libraries/llama-downloads/"
         }

--- a/src/content/workers-ai-models/llama-2-7b-chat-int8.json
+++ b/src/content/workers-ai-models/llama-2-7b-chat-int8.json
@@ -14,6 +14,10 @@
         {
             "property_id": "context_window",
             "value": "8192"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/llama-3-8b-instruct-awq.json
+++ b/src/content/workers-ai-models/llama-3-8b-instruct-awq.json
@@ -35,6 +35,10 @@
             "value": "https://llama.meta.com"
         },
         {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
+        },
+        {
             "property_id": "terms",
             "value": "https://llama.meta.com/llama3/license/#"
         }

--- a/src/content/workers-ai-models/llama-3-8b-instruct.json
+++ b/src/content/workers-ai-models/llama-3-8b-instruct.json
@@ -35,6 +35,10 @@
             "value": "https://llama.meta.com"
         },
         {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
+        },
+        {
             "property_id": "terms",
             "value": "https://llama.meta.com/llama3/license/#"
         }

--- a/src/content/workers-ai-models/llama-3.1-70b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.1-70b-instruct.json
@@ -10,6 +10,10 @@
       {
          "property_id" : "context_window",
          "value" : "24000"
+      },
+      {
+         "property_id" : "planned_deprecation_date",
+         "value" : "2026-05-30"
       }
    ],
    "schema" : {

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct-awq.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct-awq.json
@@ -31,6 +31,10 @@
             "value": "8192"
         },
         {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
+        },
+        {
             "property_id": "terms",
             "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
         }

--- a/src/content/workers-ai-models/llama-3.1-8b-instruct.json
+++ b/src/content/workers-ai-models/llama-3.1-8b-instruct.json
@@ -33,6 +33,10 @@
         {
             "property_id": "terms",
             "value": "https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/meta-llama-3-8b-instruct.json
+++ b/src/content/workers-ai-models/meta-llama-3-8b-instruct.json
@@ -14,6 +14,10 @@
         {
             "property_id": "context_window",
             "value": "8192"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.1.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.1.json
@@ -37,6 +37,10 @@
         {
             "property_id": "lora",
             "value": "true"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/mistral-7b-instruct-v0.2.json
+++ b/src/content/workers-ai-models/mistral-7b-instruct-v0.2.json
@@ -38,6 +38,10 @@
         {
             "property_id": "max_total_tokens",
             "value": "4096"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/phi-2.json
+++ b/src/content/workers-ai-models/phi-2.json
@@ -22,6 +22,10 @@
         {
             "property_id": "info",
             "value": "https://huggingface.co/microsoft/phi-2"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {

--- a/src/content/workers-ai-models/sqlcoder-7b-2.json
+++ b/src/content/workers-ai-models/sqlcoder-7b-2.json
@@ -24,6 +24,10 @@
             "value": "https://huggingface.co/defog/sqlcoder-7b-2"
         },
         {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
+        },
+        {
             "property_id": "terms",
             "value": "https://creativecommons.org/licenses/by-sa/4.0/deed.en"
         }

--- a/src/content/workers-ai-models/uform-gen2-qwen-500m.json
+++ b/src/content/workers-ai-models/uform-gen2-qwen-500m.json
@@ -18,6 +18,10 @@
         {
             "property_id": "info",
             "value": "https://www.unum.cloud/"
+        },
+        {
+            "property_id": "planned_deprecation_date",
+            "value": "2026-05-30"
         }
     ],
     "schema": {


### PR DESCRIPTION
Adds release-notes entry and changelog post announcing planned deprecation of 17 legacy Workers AI models on May 30, 2026. Kimi K2.5 will be aliased to K2.6 on the same date.

Adds planned_deprecation_date to 18 model JSONs so model pages render a 'Planned deprecation' pill before the date and disappear after.

Updates bin/fetch-ai-models.js to:
- Throw on non-2xx API responses
- Skip writing models whose deprecation date has passed
- Preserve hand-maintained files marked for future deprecation that the API does not return (e.g., alias-only docs pages)

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
