### PR TITLE
Improve sandbox docs for mounting /workspace

### DIFF
--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -12,67 +12,73 @@ import { TypeScriptExample, WranglerConfig } from "~/components";
 
 Create point-in-time snapshots of sandbox directories and restore them using copy-on-write overlays. Backups are stored in an R2 bucket and use squashfs compression.
 
+Backup and restore is useful when you need workspace state to come back later, such as a project directory under `/workspace`. This is often the clearest approach when you want to preserve the working project across sandbox lifecycles.
+
+If you want `/workspace` to behave like a persistent working directory, backup and restore is often a better fit. If you want a separate persisted storage directory attached to the sandbox, use bucket mounts.
+
+If your image contains starter files, be aware that mounting a bucket over `/workspace` can overlay those files in production. One practical pattern is to keep starter files outside `/workspace` or copy them into `/workspace` during initialization, then create backups of `/workspace` if you want that project state to persist over time.
+
 ## Prerequisites
 
 1. Create an R2 bucket for storing backups:
 
-   ```sh
-   npx wrangler r2 bucket create my-backup-bucket
-   ```
+```sh
+npx wrangler r2 bucket create my-backup-bucket
+```
 
 2. Add the `BACKUP_BUCKET` R2 binding and presigned URL credentials to your Wrangler configuration:
 
-   <WranglerConfig>
+<WranglerConfig>
 
-   ```jsonc
-   {
-   	"name": "my-sandbox-worker",
-   	"main": "src/index.ts",
-   	"compatibility_date": "$today",
-   	"compatibility_flags": ["nodejs_compat"],
-   	"containers": [
-   		{
-   			"class_name": "Sandbox",
-   			"image": "./Dockerfile",
-   		},
-   	],
-   	"durable_objects": {
-   		"bindings": [
-   			{
-   				"class_name": "Sandbox",
-   				"name": "Sandbox",
-   			},
-   		],
-   	},
-   	"migrations": [
-   		{
-   			"new_sqlite_classes": ["Sandbox"],
-   			"tag": "v1",
-   		},
-   	],
-   	"vars": {
-   		"BACKUP_BUCKET_NAME": "my-backup-bucket",
-   		"CLOUDFLARE_ACCOUNT_ID": "<YOUR_ACCOUNT_ID>",
-   	},
-   	"r2_buckets": [
-   		{
-   			"binding": "BACKUP_BUCKET",
-   			"bucket_name": "my-backup-bucket",
-   		},
-   	],
-   }
-   ```
+```jsonc
+{
+  "name": "my-sandbox-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "$today",
+  "compatibility_flags": ["nodejs_compat"],
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+    },
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "Sandbox",
+        "name": "Sandbox",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "new_sqlite_classes": ["Sandbox"],
+      "tag": "v1",
+    },
+  ],
+  "vars": {
+    "BACKUP_BUCKET_NAME": "my-backup-bucket",
+    "CLOUDFLARE_ACCOUNT_ID": "<YOUR_ACCOUNT_ID>",
+  },
+  "r2_buckets": [
+    {
+      "binding": "BACKUP_BUCKET",
+      "bucket_name": "my-backup-bucket",
+    },
+  ],
+}
+```
 
-   </WranglerConfig>
+</WranglerConfig>
 
 3. Set your R2 API credentials as secrets:
 
-   ```sh
-   npx wrangler secret put R2_ACCESS_KEY_ID
-   npx wrangler secret put R2_SECRET_ACCESS_KEY
-   ```
+```sh
+npx wrangler secret put R2_ACCESS_KEY_ID
+npx wrangler secret put R2_SECRET_ACCESS_KEY
+```
 
-   You can create R2 API tokens in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **R2** > **Overview** > **Manage R2 API Tokens**. The token needs **Object Read & Write** permissions for your backup bucket.
+You can create R2 API tokens in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **R2** > **Overview** > **Manage R2 API Tokens**. The token needs **Object Read & Write** permissions for your backup bucket.
 
 :::note
 The `vars` and API secrets in steps 2 and 3 are only required for production. For local development with `wrangler dev`, only the `BACKUP_BUCKET` R2 binding is required. Refer to [Local development](#local-development) for details.
@@ -136,8 +142,8 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 // Back up only tracked and untracked non-ignored files
 const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	useGitignore: true,
+  dir: "/workspace",
+  useGitignore: true,
 });
 ```
 
@@ -164,12 +170,12 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 const checkpoint = await sandbox.createBackup({ dir: "/workspace" });
 
 try {
-	await sandbox.exec("npm install some-experimental-package");
-	await sandbox.exec("npm run build");
+  await sandbox.exec("npm install some-experimental-package");
+  await sandbox.exec("npm run build");
 } catch (error) {
-	// Restore to checkpoint if something goes wrong
-	await sandbox.restoreBackup(checkpoint);
-	console.log("Rolled back to checkpoint");
+  // Restore to checkpoint if something goes wrong
+  await sandbox.restoreBackup(checkpoint);
+  console.log("Rolled back to checkpoint");
 }
 ```
 
@@ -186,9 +192,9 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 // Create a backup and store the handle in KV
 const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	name: "deploy-v2",
-	ttl: 604800, // 7 days
+  dir: "/workspace",
+  name: "deploy-v2",
+  ttl: 604800, // 7 days
 });
 
 await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
@@ -196,8 +202,8 @@ await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
 // Later, retrieve and restore
 const stored = await env.KV.get(`backup:${userId}`);
 if (stored) {
-	const backupHandle = JSON.parse(stored);
-	await sandbox.restoreBackup(backupHandle);
+  const backupHandle = JSON.parse(stored);
+  await sandbox.restoreBackup(backupHandle);
 }
 ```
 
@@ -213,8 +219,8 @@ Add a `name` option to identify backups. Names can be up to 256 characters:
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	name: "before-migration",
+  dir: "/workspace",
+  name: "before-migration",
 });
 
 console.log(`Backup ID: ${backup.id}`);
@@ -233,15 +239,15 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 // Short-lived backup for a quick operation
 const shortBackup = await sandbox.createBackup({
-	dir: "/workspace",
-	ttl: 600, // 10 minutes
+  dir: "/workspace",
+  ttl: 600, // 10 minutes
 });
 
 // Long-lived backup for extended workflows
 const longBackup = await sandbox.createBackup({
-	dir: "/workspace",
-	name: "daily-snapshot",
-	ttl: 604800, // 7 days
+  dir: "/workspace",
+  name: "daily-snapshot",
+  ttl: 604800, // 7 days
 });
 ```
 
@@ -271,12 +277,12 @@ Add a `BACKUP_BUCKET` R2 binding to your Wrangler configuration:
 
 ```jsonc
 {
-	"r2_buckets": [
-		{
-			"binding": "BACKUP_BUCKET",
-			"bucket_name": "my-backup-bucket"
-		}
-	]
+  "r2_buckets": [
+    {
+      "binding": "BACKUP_BUCKET",
+      "bucket_name": "my-backup-bucket"
+    }
+  ]
 }
 ```
 
@@ -293,8 +299,8 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 // Create a local backup
 const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	localBucket: true,
+  dir: "/workspace",
+  localBucket: true,
 });
 
 // Restore the backup
@@ -309,8 +315,8 @@ You can use an environment variable to toggle `localBucket` between local develo
 
 ```ts
 const backup = await sandbox.createBackup({
-	dir: "/workspace",
-	localBucket: Boolean(env.LOCAL_DEV),
+  dir: "/workspace",
+  localBucket: Boolean(env.LOCAL_DEV),
 });
 ```
 
@@ -324,7 +330,7 @@ When `localBucket` is `true`, presigned URL credentials are not required and the
 - **Same archive format** - Local backups use the same squashfs archive format as production backups.
 
 :::note
-These considerations apply to local development with `wrangler dev` only. In production, backup and restore use presigned URLs and FUSE overlayfs.
+These considerations apply to local development with `wrangler dev` only. In production, backup and restore use presigned URLs and FUSE overlayfs. Local backup and restore behavior can also differ from local bucket mounting behavior, which uses sync-style updates rather than a production FUSE mount.
 :::
 
 ## Clean up backup objects in R2

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -18,63 +18,63 @@ Use backup and restore when you want workspace state, such as `/workspace`, to c
 
 1. Create an R2 bucket for storing backups:
 
-```sh
-npx wrangler r2 bucket create my-backup-bucket
-```
+   ```sh
+   npx wrangler r2 bucket create my-backup-bucket
+   ```
 
 2. Add the `BACKUP_BUCKET` R2 binding and presigned URL credentials to your Wrangler configuration:
 
-<WranglerConfig>
+   <WranglerConfig>
 
-```jsonc
-{
-  "name": "my-sandbox-worker",
-  "main": "src/index.ts",
-  "compatibility_date": "$today",
-  "compatibility_flags": ["nodejs_compat"],
-  "containers": [
-    {
-      "class_name": "Sandbox",
-      "image": "./Dockerfile",
-    },
-  ],
-  "durable_objects": {
-    "bindings": [
-      {
-        "class_name": "Sandbox",
-        "name": "Sandbox",
-      },
-    ],
-  },
-  "migrations": [
-    {
-      "new_sqlite_classes": ["Sandbox"],
-      "tag": "v1",
-    },
-  ],
-  "vars": {
-    "BACKUP_BUCKET_NAME": "my-backup-bucket",
-    "CLOUDFLARE_ACCOUNT_ID": "<YOUR_ACCOUNT_ID>",
-  },
-  "r2_buckets": [
-    {
-      "binding": "BACKUP_BUCKET",
-      "bucket_name": "my-backup-bucket",
-    },
-  ],
-}
-```
+   ```jsonc
+   {
+   	"name": "my-sandbox-worker",
+   	"main": "src/index.ts",
+   	"compatibility_date": "$today",
+   	"compatibility_flags": ["nodejs_compat"],
+   	"containers": [
+   		{
+   			"class_name": "Sandbox",
+   			"image": "./Dockerfile",
+   		},
+   	],
+   	"durable_objects": {
+   		"bindings": [
+   			{
+   				"class_name": "Sandbox",
+   				"name": "Sandbox",
+   			},
+   		],
+   	},
+   	"migrations": [
+   		{
+   			"new_sqlite_classes": ["Sandbox"],
+   			"tag": "v1",
+   		},
+   	],
+   	"vars": {
+   		"BACKUP_BUCKET_NAME": "my-backup-bucket",
+   		"CLOUDFLARE_ACCOUNT_ID": "<YOUR_ACCOUNT_ID>",
+   	},
+   	"r2_buckets": [
+   		{
+   			"binding": "BACKUP_BUCKET",
+   			"bucket_name": "my-backup-bucket",
+   		},
+   	],
+   }
+   ```
 
-</WranglerConfig>
+   </WranglerConfig>
 
 3. Set your R2 API credentials as secrets:
 
-```sh
-npx wrangler secret put R2_ACCESS_KEY_ID
-npx wrangler secret put R2_SECRET_ACCESS_KEY
-```
+   ```sh
+   npx wrangler secret put R2_ACCESS_KEY_ID
+   npx wrangler secret put R2_SECRET_ACCESS_KEY
+   ```
 
-You can create R2 API tokens in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **R2** > **Overview** > **Manage R2 API Tokens**. The token needs **Object Read & Write** permissions for your backup bucket.
+   You can create R2 API tokens in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **R2** > **Overview** > **Manage R2 API Tokens**. The token needs **Object Read & Write** permissions for your backup bucket.
 
 :::note
 The `vars` and API secrets in steps 2 and 3 are only required for production. For local development with `wrangler dev`, only the `BACKUP_BUCKET` R2 binding is required. Refer to [Local development](#local-development) for details.
@@ -138,8 +138,8 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 // Back up only tracked and untracked non-ignored files
 const backup = await sandbox.createBackup({
-  dir: "/workspace",
-  useGitignore: true,
+	dir: "/workspace",
+	useGitignore: true,
 });
 ```
 
@@ -166,12 +166,12 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 const checkpoint = await sandbox.createBackup({ dir: "/workspace" });
 
 try {
-  await sandbox.exec("npm install some-experimental-package");
-  await sandbox.exec("npm run build");
+	await sandbox.exec("npm install some-experimental-package");
+	await sandbox.exec("npm run build");
 } catch (error) {
-  // Restore to checkpoint if something goes wrong
-  await sandbox.restoreBackup(checkpoint);
-  console.log("Rolled back to checkpoint");
+	// Restore to checkpoint if something goes wrong
+	await sandbox.restoreBackup(checkpoint);
+	console.log("Rolled back to checkpoint");
 }
 ```
 
@@ -188,9 +188,9 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 // Create a backup and store the handle in KV
 const backup = await sandbox.createBackup({
-  dir: "/workspace",
-  name: "deploy-v2",
-  ttl: 604800, // 7 days
+	dir: "/workspace",
+	name: "deploy-v2",
+	ttl: 604800, // 7 days
 });
 
 await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
@@ -198,8 +198,8 @@ await env.KV.put(`backup:${userId}`, JSON.stringify(backup));
 // Later, retrieve and restore
 const stored = await env.KV.get(`backup:${userId}`);
 if (stored) {
-  const backupHandle = JSON.parse(stored);
-  await sandbox.restoreBackup(backupHandle);
+	const backupHandle = JSON.parse(stored);
+	await sandbox.restoreBackup(backupHandle);
 }
 ```
 
@@ -215,8 +215,8 @@ Add a `name` option to identify backups. Names can be up to 256 characters:
 const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 const backup = await sandbox.createBackup({
-  dir: "/workspace",
-  name: "before-migration",
+	dir: "/workspace",
+	name: "before-migration",
 });
 
 console.log(`Backup ID: ${backup.id}`);
@@ -235,15 +235,15 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 // Short-lived backup for a quick operation
 const shortBackup = await sandbox.createBackup({
-  dir: "/workspace",
-  ttl: 600, // 10 minutes
+	dir: "/workspace",
+	ttl: 600, // 10 minutes
 });
 
 // Long-lived backup for extended workflows
 const longBackup = await sandbox.createBackup({
-  dir: "/workspace",
-  name: "daily-snapshot",
-  ttl: 604800, // 7 days
+	dir: "/workspace",
+	name: "daily-snapshot",
+	ttl: 604800, // 7 days
 });
 ```
 
@@ -273,12 +273,12 @@ Add a `BACKUP_BUCKET` R2 binding to your Wrangler configuration:
 
 ```jsonc
 {
-  "r2_buckets": [
-    {
-      "binding": "BACKUP_BUCKET",
-      "bucket_name": "my-backup-bucket"
-    }
-  ]
+	"r2_buckets": [
+		{
+			"binding": "BACKUP_BUCKET",
+			"bucket_name": "my-backup-bucket"
+		}
+	]
 }
 ```
 
@@ -295,8 +295,8 @@ const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 // Create a local backup
 const backup = await sandbox.createBackup({
-  dir: "/workspace",
-  localBucket: true,
+	dir: "/workspace",
+	localBucket: true,
 });
 
 // Restore the backup
@@ -311,8 +311,8 @@ You can use an environment variable to toggle `localBucket` between local develo
 
 ```ts
 const backup = await sandbox.createBackup({
-  dir: "/workspace",
-  localBucket: Boolean(env.LOCAL_DEV),
+	dir: "/workspace",
+	localBucket: Boolean(env.LOCAL_DEV),
 });
 ```
 

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -12,11 +12,7 @@ import { TypeScriptExample, WranglerConfig } from "~/components";
 
 Create point-in-time snapshots of sandbox directories and restore them using copy-on-write overlays. Backups are stored in an R2 bucket and use squashfs compression.
 
-Backup and restore is useful when you need workspace state to come back later, such as a project directory under `/workspace`. This is often the clearest approach when you want to preserve the working project across sandbox lifecycles.
-
-If you want `/workspace` to behave like a persistent working directory, backup and restore is often a better fit. If you want a separate persisted storage directory attached to the sandbox, use bucket mounts.
-
-If your image contains starter files, be aware that mounting a bucket over `/workspace` can overlay those files in production. One practical pattern is to keep starter files outside `/workspace` or copy them into `/workspace` during initialization, then create backups of `/workspace` if you want that project state to persist over time.
+Use backup and restore when you want workspace state, such as `/workspace`, to come back later. This is often a better fit for persistent project directories, while bucket mounts are better suited to separate persisted storage paths. If you mount a bucket over `/workspace`, be aware that it can overlay files seeded by your image in production.
 
 ## Prerequisites
 

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -13,9 +13,7 @@ import { TypeScriptExample, WranglerConfig } from "~/components";
 Mount S3-compatible object storage buckets as local filesystem paths. Access object storage using standard file operations.
 
 :::caution[Mounting `/workspace`]
-Mounting a bucket at `/workspace` or a subpath under `/workspace` can be confusing for normal app or project setups. In production, a bucket mount replaces the visible contents at that path. It does not merge bucket contents with files already present in your image or template.
-
-If you use `/workspace` as a mount point, plan for the mounted bucket to overlay that directory. For many applications, it is simpler to mount buckets at paths such as `/data`, `/storage`, or `/mnt/uploads`, and use [Backup and restore](/sandbox/guides/backup-restore/) when you want the working project in `/workspace` to persist across sandbox lifecycles.
+Mounting a bucket at `/workspace` or a subpath under it can be confusing in app or project setups. In production, the mount overlays that path instead of merging with files already in the image or template. If you want `/workspace` itself to persist over time, [Backup and restore](/sandbox/guides/backup-restore/) is often a better fit.
 :::
 
 :::note[S3-compatible providers]
@@ -30,23 +28,6 @@ Mount S3-compatible buckets when you need:
 - **Large datasets** - Process data without downloading
 - **Shared storage** - Multiple sandboxes access the same data
 - **Cost-effective persistence** - Cheaper than keeping sandboxes alive
-
-## Choose the right persistence pattern
-
-Use `mountBucket()` when you want persisted external storage for:
-
-- datasets
-- user uploads
-- generated artifacts
-- shared storage across sandboxes
-
-Consider backup and restore when you want to persist:
-
-- the project root
-- source files under `/workspace`
-- a working directory that should come back as a whole later
-
-If your image seeds project files, mounting a bucket over `/workspace` can hide those seeded files in production. To avoid surprises, keep template files outside `/workspace`, for example under `/opt/template`, and copy them into `/workspace` when you initialize the project. If your goal is to preserve that initialized workspace over time, backup and restore is usually the better fit.
 
 ## Mount an R2 bucket
 

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -12,6 +12,12 @@ import { TypeScriptExample, WranglerConfig } from "~/components";
 
 Mount S3-compatible object storage buckets as local filesystem paths. Access object storage using standard file operations.
 
+:::caution[Mounting `/workspace`]
+Mounting a bucket at `/workspace` or a subpath under `/workspace` can be confusing for normal app or project setups. In production, a bucket mount replaces the visible contents at that path. It does not merge bucket contents with files already present in your image or template.
+
+If you use `/workspace` as a mount point, plan for the mounted bucket to overlay that directory. For many applications, it is simpler to mount buckets at paths such as `/data`, `/storage`, or `/mnt/uploads`, and use [Backup and restore](/sandbox/guides/backup-restore/) when you want the working project in `/workspace` to persist across sandbox lifecycles.
+:::
+
 :::note[S3-compatible providers]
 The SDK works with any S3-compatible object storage provider. Examples include Cloudflare R2, Amazon S3, Google Cloud Storage, Backblaze B2, MinIO, and [many others](https://github.com/s3fs-fuse/s3fs-fuse/wiki/Non-Amazon-S3). The SDK automatically detects and optimizes for R2, S3, and GCS.
 :::
@@ -24,6 +30,23 @@ Mount S3-compatible buckets when you need:
 - **Large datasets** - Process data without downloading
 - **Shared storage** - Multiple sandboxes access the same data
 - **Cost-effective persistence** - Cheaper than keeping sandboxes alive
+
+## Choose the right persistence pattern
+
+Use `mountBucket()` when you want persisted external storage for:
+
+- datasets
+- user uploads
+- generated artifacts
+- shared storage across sandboxes
+
+Consider backup and restore when you want to persist:
+
+- the project root
+- source files under `/workspace`
+- a working directory that should come back as a whole later
+
+If your image seeds project files, mounting a bucket over `/workspace` can hide those seeded files in production. To avoid surprises, keep template files outside `/workspace`, for example under `/opt/template`, and copy them into `/workspace` when you initialize the project. If your goal is to preserve that initialized workspace over time, backup and restore is usually the better fit.
 
 ## Mount an R2 bucket
 
@@ -229,7 +252,7 @@ During local development, files are synchronized between R2 and the container us
 - **Bidirectional sync** - Changes made in the container are synced to R2, and changes made in R2 are synced to the container. Both directions follow the same periodic sync model.
 
 :::note
-These considerations apply to local development with `wrangler dev` only. In production, bucket mounts use a direct filesystem mount with no synchronization delay.
+These considerations apply to local development with `wrangler dev` only. In production, bucket mounts use a direct filesystem mount with no synchronization delay. Local sync-style behavior may not fully reflect how a production mount overlays the target path.
 :::
 
 ## Unmount buckets
@@ -392,7 +415,7 @@ await sandbox.exec('cp', { args: ['/workspace/results.json', '/data/results/outp
 - **Secure credentials** - Always use Worker secrets, never hardcode
 - **Read-only when possible** - Protect data with read-only mounts
 - **Use prefixes for isolation** - Mount subdirectories when working with specific datasets
-- **Mount paths** - Use `/data`, `/storage`, or `/mnt/*` (avoid `/workspace`, `/tmp`)
+- **Mount paths** - Prefer `/data`, `/storage`, or `/mnt/*`; if you mount under `/workspace`, account for the mount overlaying that path in production
 - **Handle errors** - Wrap mount operations in `try...catch` blocks
 - **Optimize access** - Copy frequently accessed files locally
 

--- a/src/content/docs/sandbox/tutorials/persistent-storage.mdx
+++ b/src/content/docs/sandbox/tutorials/persistent-storage.mdx
@@ -15,6 +15,8 @@ import { Render, PackageManagers, TypeScriptExample } from "~/components";
 
 Mount object storage buckets as local filesystem paths to persist data across sandbox lifecycles. This tutorial uses Cloudflare R2, but the same approach works with any S3-compatible provider.
 
+This tutorial shows how to persist an external data directory mounted at `/data`. It is a good fit for persisted storage such as datasets, uploads, and artifacts. If you are trying to preserve the working project in `/workspace`, review [Backup and restore](/sandbox/guides/backup-restore/) as well.
+
 **Time to complete:** 20 minutes
 
 ## What you'll build
@@ -176,6 +178,10 @@ Try this flow:
 ```
 </TypeScriptExample>
 
+:::note[Mounting `/workspace`]
+Some applications may choose to mount a bucket at `/workspace`, but it is important to understand the tradeoff: in production, the mount overlays that path and can hide files that were seeded there by your image or template. If you want the visible workspace contents to persist over time, backup and restore is usually the clearer approach.
+:::
+
 :::note[Replace YOUR_ACCOUNT_ID]
 Replace `YOUR_ACCOUNT_ID` in the endpoint URL with your Cloudflare account ID. Find it in the [dashboard](https://dash.cloudflare.com/) under **R2** > **Overview**.
 :::
@@ -239,6 +245,7 @@ In this tutorial, you built a data pipeline that demonstrates filesystem persist
 - **Mounting buckets**: Use `mountBucket()` to make R2 accessible as a local directory
 - **Standard file operations**: Access mounted buckets using familiar filesystem commands (`cat`, Python `open()`, etc.)
 - **Automatic persistence**: Data written to mounted directories survives sandbox destruction
+- **Choose the right persistence model**: Use bucket mounts for external storage directories such as `/data`, and consider backup and restore when you need a persistent workspace under `/workspace`
 - **Credential management**: Configure R2 access using environment variables or explicit credentials
 
 ## Next steps

--- a/src/content/docs/sandbox/tutorials/persistent-storage.mdx
+++ b/src/content/docs/sandbox/tutorials/persistent-storage.mdx
@@ -15,7 +15,7 @@ import { Render, PackageManagers, TypeScriptExample } from "~/components";
 
 Mount object storage buckets as local filesystem paths to persist data across sandbox lifecycles. This tutorial uses Cloudflare R2, but the same approach works with any S3-compatible provider.
 
-This tutorial shows how to persist an external data directory mounted at `/data`. It is a good fit for persisted storage such as datasets, uploads, and artifacts. If you are trying to preserve the working project in `/workspace`, review [Backup and restore](/sandbox/guides/backup-restore/) as well.
+This tutorial shows how to persist an external data directory mounted at `/data`. If you want the working project in `/workspace` to persist, refer to [Backup and restore](/sandbox/guides/backup-restore/).
 
 **Time to complete:** 20 minutes
 
@@ -177,10 +177,6 @@ Try this flow:
 };
 ```
 </TypeScriptExample>
-
-:::note[Mounting `/workspace`]
-Some applications may choose to mount a bucket at `/workspace`, but it is important to understand the tradeoff: in production, the mount overlays that path and can hide files that were seeded there by your image or template. If you want the visible workspace contents to persist over time, backup and restore is usually the clearer approach.
-:::
 
 :::note[Replace YOUR_ACCOUNT_ID]
 Replace `YOUR_ACCOUNT_ID` in the endpoint URL with your Cloudflare account ID. Find it in the [dashboard](https://dash.cloudflare.com/) under **R2** > **Overview**.


### PR DESCRIPTION
### Summary

Improve sandbox docs to clarify when to use bucket mounts versus backup and restore. The updates explain the risks of mounting buckets at `/workspace`, recommend bucket mounts for external persisted storage, and point users to backup and restore for persistent workspaces, with notes about local versus production behaviour.

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
