### PR TITLE
docs: clarify WorkflowStepConfig retry limit semantics

### DIFF
--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -83,7 +83,7 @@ let someState = await step.do(
 	"call an API",
 	{
 		retries: {
-			limit: 10, // The total number of attempts
+			limit: 10, // The total number of retries (11 attempts total)
 			delay: "10 seconds", // Delay between each retry
 			backoff: "exponential", // Any of "constant" | "linear" | "exponential";
 		},


### PR DESCRIPTION
## Summary
- clarify that `retries.limit` is the number of retries, not total attempts
- update the retry steps code comment to note that `limit: 10` means 11 total attempts

## Why
Issue #30627 points out that the prose says the sample limits a step to 10 retries, while the inline code comment says `limit` is the total number of attempts. This update makes the example internally consistent with the documented behavior.

Closes #30627