### PR TITLE
docs(workers): clarify Version-Overrides header works on service-binding subrequests

### DIFF
--- a/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
@@ -159,6 +159,18 @@ curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-
 
 The dictionary can contain multiple key-value pairs. Each key indicates the name of the Worker the override should be applied to. The value indicates the version ID that should be used and must be a [String](https://www.rfc-editor.org/rfc/rfc8941#name-strings).
 
+You can set the `Cloudflare-Workers-Version-Overrides` header both when making an external request from the Internet to your Worker, as well as when making a subrequest from one Worker to another Worker using a [service binding](/workers/runtime-apis/bindings/service-bindings/). The header is not automatically propagated through service bindings — the calling Worker must explicitly set it on the subrequest:
+
+```js
+// Caller Worker — explicitly forward an override on the service-binding subrequest
+await env.MY_SERVICE.fetch("https://example.com/", {
+	headers: {
+		"Cloudflare-Workers-Version-Overrides":
+			'my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"',
+	},
+});
+```
+
 A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list`](/workers/wrangler/commands/general/#deployments-list) command or on the **Workers & Pages** page of the Cloudflare dashboard > Select your Workers > Deployments > Active Deployment.
 
 :::note[Verifying that the version override was applied]


### PR DESCRIPTION
## Summary

Adds a single paragraph + small JS snippet to the **Version overrides** section of the Gradual Deployments docs, clarifying that `Cloudflare-Workers-Version-Overrides` is honoured on subrequests made through a Worker-to-Worker [service binding](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/) — but only when the calling Worker explicitly sets the header on the subrequest.

## Why

The neighbouring **Version affinity** section already documents that `Cloudflare-Workers-Version-Key` works on service-binding subrequests:

> You can set the `Cloudflare-Workers-Version-Key` header both when making an external request from the Internet to your Worker, as well as when making a subrequest from one Worker to another Worker using a service binding.

The same is true of `Cloudflare-Workers-Version-Overrides`, but the docs don't currently say so, which leads to repeat questions about whether the override header is honoured on service bindings.

There is also a subtle difference worth surfacing: the override header is **not** automatically propagated through a service binding — the calling Worker must explicitly include it on the subrequest. This PR makes that explicit with a short JS example using `env.MY_SERVICE.fetch()`.

## Verified empirically

Set up two Workers in one account:
- Callee with v1 (100%) and v2 (0%) in its gradual deployment.
- Caller with a service binding to the callee, conditionally setting the override header on `env.CALLEE.fetch()`.

| Scenario | Result |
|---|---|
| No override header | callee returns v1 (default) |
| Caller explicitly sets override → v2 on the subrequest | callee returns **v2** ✅ |
| Invalid version ID in override | falls back to v1 (matches existing docs) |
| Header set only on inbound request, caller does not forward it | callee returns v1 (no auto-propagation) |

## Out of scope

- RPC method calls (`env.MY_SERVICE.someMethod()`) — there is no API to attach headers per-call, so this PR doesn't address that case.
- Automatic propagation through service-binding chains — separate runtime work, not a docs change.