### PR TITLE
[Workers] Split version overrides into dedicated page, add service bindings guidance

### DIFF
--- a/src/content/docs/workers/configuration/previews.mdx
+++ b/src/content/docs/workers/configuration/previews.mdx
@@ -26,7 +26,7 @@ Preview URLs can be:
 - Used for collaboration between teams to test code changes in a live environment and verify updates.
 - Used to test new API endpoints, validate data formats, and ensure backward compatibility with existing services.
 
-When testing zone level performance or security features for a version, we recommend using [version overrides](/workers/configuration/versions-and-deployments/gradual-deployments/#version-overrides) so that your zone's performance and security settings apply.
+When testing zone level performance or security features for a version, we recommend using [version overrides](/workers/configuration/versions-and-deployments/version-overrides/) so that your zone's performance and security settings apply.
 
 :::note
 Preview URLs are only available for Worker versions uploaded after 2024-09-25.

--- a/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
@@ -5,6 +5,8 @@ head: []
 description: Incrementally deploy code changes to your Workers with gradual deployments.
 products:
   - workers
+sidebar:
+  order: 2
 ---
 
 import { Example, DashButton, PackageManagers } from "~/components";
@@ -72,7 +74,7 @@ done
 
 You should see 10 responses. Responses will reflect the content returned by the versions in your deployment. Responses will vary depending on the percentages configured in [step #3](/workers/configuration/versions-and-deployments/gradual-deployments/#3-create-a-new-deployment).
 
-You can test also target a specific version using [version overrides](#version-overrides).
+You can also target a specific version using [version overrides](/workers/configuration/versions-and-deployments/version-overrides/).
 
 #### 5. Set your new version to 100% deployment
 
@@ -147,55 +149,9 @@ Selected operation under **Modify request header**: _Set dynamic_
 
 ## Version overrides
 
-You can use version overrides to send a request to a specific version of your Worker in your gradual deployment.
+You can use [version overrides](/workers/configuration/versions-and-deployments/version-overrides/) to send a specific request to a specific version of your Worker, bypassing the percentage-based routing. Version overrides also work on subrequests made through [service bindings](/workers/runtime-apis/bindings/service-bindings/).
 
-To specify a version override in your request, you can set the `Cloudflare-Workers-Version-Overrides` header on the request to your Worker. For example:
-
-```sh
-curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
-```
-
-`Cloudflare-Workers-Version-Overrides` is a [Dictionary Structured Header](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
-
-The dictionary can contain multiple key-value pairs. Each key indicates the name of the Worker the override should be applied to. The value indicates the version ID that should be used and must be a [String](https://www.rfc-editor.org/rfc/rfc8941#name-strings).
-
-A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list`](/workers/wrangler/commands/general/#deployments-list) command or on the **Workers & Pages** page of the Cloudflare dashboard > Select your Workers > Deployments > Active Deployment.
-
-:::note[Verifying that the version override was applied]
-
-There are a number of reasons why a request's version override may not be applied. For example:
-
-- The deployment containing the specified version may not have propagated yet.
-- The header value may not be a valid [Dictionary](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
-
-In the case that a request's version override is not applied, the request will be routed according to the percentages set in the gradual deployment configuration.
-
-To make sure that the request's version override was applied correctly, you can [observe](#observability) the version of your Worker that was invoked. You could even automate this check by using the [runtime binding](#runtime-binding) to return the version in the Worker's response.
-
-:::
-
-### Example
-
-You may want to test a new version in production before gradually deploying it to an increasing proportion of external traffic.
-
-In this example, your deployment is initially configured to route all traffic to a single version:
-
-|              Version ID              | Percentage |
-| :----------------------------------: | :--------: |
-| db7cd8d3-4425-4fe7-8c81-01bf963b6067 |    100%    |
-
-Create a new deployment using [`wrangler versions deploy`](/workers/wrangler/commands/general/#versions-deploy) and specify 0% for the new version whilst keeping the previous version at 100%.
-
-|              Version ID              | Percentage |
-| :----------------------------------: | :--------: |
-| dc8dcd28-271b-4367-9840-6c244f84cb40 |     0%     |
-| db7cd8d3-4425-4fe7-8c81-01bf963b6067 |    100%    |
-
-Now test the new version with a version override before gradually progressing the new version to 100%:
-
-```sh
-curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
-```
+Refer to [Version overrides](/workers/configuration/versions-and-deployments/version-overrides/) for full details, including usage with service bindings.
 
 ## Gradual deployments for Durable Objects
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/gradual-deployments.mdx
@@ -149,7 +149,7 @@ Selected operation under **Modify request header**: _Set dynamic_
 
 ## Version overrides
 
-You can use [version overrides](/workers/configuration/versions-and-deployments/version-overrides/) to send a specific request to a specific version of your Worker, bypassing the percentage-based routing. Version overrides also work on subrequests made through [service bindings](/workers/runtime-apis/bindings/service-bindings/).
+You can use [version overrides](/workers/configuration/versions-and-deployments/version-overrides/) to send a request to a specific version of your Worker, bypassing the percentage-based routing (even when at 0%). Version overrides also work on subrequests made through [service bindings](/workers/runtime-apis/bindings/service-bindings/).
 
 Refer to [Version overrides](/workers/configuration/versions-and-deployments/version-overrides/) for full details, including usage with service bindings.
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -18,7 +18,7 @@ curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-
 
 The dictionary can contain multiple key-value pairs. Each key indicates the name of the Worker the override should be applied to. The value indicates the version ID that should be used and must be a [String](https://www.rfc-editor.org/rfc/rfc8941#name-strings).
 
-A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list`](/workers/wrangler/commands/general/#deployments-list) command or on the **Workers & Pages** page of the Cloudflare dashboard > select your Worker > **Deployments** > **Active Deployment**.
+A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list`](/workers/wrangler/commands/general/#deployments-list) command or on the [**Workers & Pages** page of the Cloudflare dashboard > select your Worker > **Deployments** > **Active Deployment**](https://dash.cloudflare.com/?to=/:account/workers/services/view/:worker/production/deployments).
 
 :::note[Verifying that the version override was applied]
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -35,7 +35,7 @@ You can observe the version of your Worker that was invoked using [Observability
 
 ## Example
 
-You may want to test a new version in production before gradually deploying it to an increasing proportion of external traffic.
+You may want to test a new version in production before gradually deploying it to an increasing proportion of external traffic. This is commonly referred to as a "smoke test".
 
 In this example, your deployment is initially configured to route all traffic to a single version:
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -29,7 +29,7 @@ There are a number of reasons why a request's version override may not be applie
 
 In the case that a request's version override is not applied, the request will be routed according to the percentages set in the gradual deployment configuration.
 
-To make sure that the request's version override was applied correctly, you can observe the version of your Worker that was invoked using [Logpush](/workers/observability/logs/logpush/) or the [version metadata binding](/workers/runtime-apis/bindings/version-metadata/). You could even automate this check by using the version metadata binding to return the version in the Worker's response.
+You can observe the version of your Worker that was invoked using [Observability](https://developers.cloudflare.com/workers/observability/), including in features such as [Logpush](/workers/observability/logs/logpush/). Alternatively, if you want to inform clients about the version they ran (e.g. for faster and more transparent debugging), you could use the [version metadata binding](/workers/runtime-apis/bindings/version-metadata/) and return the version ID in the Worker's response.
 
 :::
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -24,7 +24,7 @@ A version override will only be applied if the specified version is in the curre
 
 There are a number of reasons why a request's version override may not be applied. For example:
 
-- The deployment containing the specified version may not have propagated yet.
+- The deployment may not contain the specified version. It can take up to a couple of seconds to be available globally after a recent change.
 - The header value may not be a valid [Dictionary](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
 
 In the case that a request's version override is not applied, the request will be routed according to the percentages set in the gradual deployment configuration.

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -60,10 +60,20 @@ curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-
 
 You can set the `Cloudflare-Workers-Version-Overrides` header when making a subrequest from one Worker to another using a [service binding](/workers/runtime-apis/bindings/service-bindings/). This lets you test a specific version of a downstream Worker from an upstream Worker.
 
-The header from the original inbound request is **not** automatically forwarded to service-binding subrequests. The calling Worker must explicitly set it:
+If you forward the original request object, the override header carries through automatically:
 
 ```js
-// Caller Worker — explicitly set the override on the service-binding subrequest.
+// The override header from the inbound request is forwarded to the downstream Worker.
+export default {
+  async fetch(request, env) {
+    return env.MY_SERVICE.fetch(request);
+  },
+};
+```
+
+If you are constructing a new request, you must set the header explicitly:
+
+```js
 // Replace the version ID with the target version from `wrangler versions list`.
 export default {
   async fetch(request, env) {
@@ -74,22 +84,6 @@ export default {
       },
     });
     return response;
-  },
-};
-```
-
-If you want to forward a version override from the inbound request to a service binding, you must read the header and set it on the subrequest yourself:
-
-```js
-export default {
-  async fetch(request, env) {
-    const headers = {};
-    const override = request.headers.get("Cloudflare-Workers-Version-Overrides");
-    if (override) {
-      headers["Cloudflare-Workers-Version-Overrides"] = override;
-    }
-
-    return env.MY_SERVICE.fetch("https://example.com/", { headers });
   },
 };
 ```

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -71,7 +71,7 @@ export default {
 };
 ```
 
-If you are constructing a new request, you must set the header explicitly:
+Alternatively, you can set an override header explicitly:
 
 ```js
 // Replace the version ID with the target version from `wrangler versions list`.

--- a/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/version-overrides.mdx
@@ -1,0 +1,105 @@
+---
+pcx_content_type: configuration
+title: Version overrides
+description: Send requests to a specific version of your Worker in a gradual deployment using version overrides.
+sidebar:
+  order: 3
+---
+
+You can use version overrides to send a request to a specific version of your Worker in your [gradual deployment](/workers/configuration/versions-and-deployments/gradual-deployments/).
+
+To specify a version override in your request, set the `Cloudflare-Workers-Version-Overrides` header on the request to your Worker. For example:
+
+```sh
+curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
+```
+
+`Cloudflare-Workers-Version-Overrides` is a [Dictionary Structured Header](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
+
+The dictionary can contain multiple key-value pairs. Each key indicates the name of the Worker the override should be applied to. The value indicates the version ID that should be used and must be a [String](https://www.rfc-editor.org/rfc/rfc8941#name-strings).
+
+A version override will only be applied if the specified version is in the current deployment. The versions in the current deployment can be found using the [`wrangler deployments list`](/workers/wrangler/commands/general/#deployments-list) command or on the **Workers & Pages** page of the Cloudflare dashboard > select your Worker > **Deployments** > **Active Deployment**.
+
+:::note[Verifying that the version override was applied]
+
+There are a number of reasons why a request's version override may not be applied. For example:
+
+- The deployment containing the specified version may not have propagated yet.
+- The header value may not be a valid [Dictionary](https://www.rfc-editor.org/rfc/rfc8941#name-dictionaries).
+
+In the case that a request's version override is not applied, the request will be routed according to the percentages set in the gradual deployment configuration.
+
+To make sure that the request's version override was applied correctly, you can observe the version of your Worker that was invoked using [Logpush](/workers/observability/logs/logpush/) or the [version metadata binding](/workers/runtime-apis/bindings/version-metadata/). You could even automate this check by using the version metadata binding to return the version in the Worker's response.
+
+:::
+
+## Example
+
+You may want to test a new version in production before gradually deploying it to an increasing proportion of external traffic.
+
+In this example, your deployment is initially configured to route all traffic to a single version:
+
+|              Version ID              | Percentage |
+| :----------------------------------: | :--------: |
+| db7cd8d3-4425-4fe7-8c81-01bf963b6067 |    100%    |
+
+Create a new deployment using [`wrangler versions deploy`](/workers/wrangler/commands/general/#versions-deploy) and specify 0% for the new version whilst keeping the previous version at 100%.
+
+|              Version ID              | Percentage |
+| :----------------------------------: | :--------: |
+| dc8dcd28-271b-4367-9840-6c244f84cb40 |     0%     |
+| db7cd8d3-4425-4fe7-8c81-01bf963b6067 |    100%    |
+
+Now test the new version with a version override before gradually progressing the new version to 100%:
+
+```sh
+curl -s https://example.com -H 'Cloudflare-Workers-Version-Overrides: my-worker-name="dc8dcd28-271b-4367-9840-6c244f84cb40"'
+```
+
+## Service bindings
+
+You can set the `Cloudflare-Workers-Version-Overrides` header when making a subrequest from one Worker to another using a [service binding](/workers/runtime-apis/bindings/service-bindings/). This lets you test a specific version of a downstream Worker from an upstream Worker.
+
+The header from the original inbound request is **not** automatically forwarded to service-binding subrequests. The calling Worker must explicitly set it:
+
+```js
+// Caller Worker — explicitly set the override on the service-binding subrequest.
+// Replace the version ID with the target version from `wrangler versions list`.
+export default {
+  async fetch(request, env) {
+    const response = await env.MY_SERVICE.fetch("https://example.com/", {
+      headers: {
+        "Cloudflare-Workers-Version-Overrides":
+          'my-downstream-worker="dc8dcd28-271b-4367-9840-6c244f84cb40"',
+      },
+    });
+    return response;
+  },
+};
+```
+
+If you want to forward a version override from the inbound request to a service binding, you must read the header and set it on the subrequest yourself:
+
+```js
+export default {
+  async fetch(request, env) {
+    const headers = {};
+    const override = request.headers.get("Cloudflare-Workers-Version-Overrides");
+    if (override) {
+      headers["Cloudflare-Workers-Version-Overrides"] = override;
+    }
+
+    return env.MY_SERVICE.fetch("https://example.com/", { headers });
+  },
+};
+```
+
+:::note
+Version overrides only apply to `fetch()`-based service binding calls. There is currently no way to specify version overrides when calling a service binding via RPC (`env.MY_SERVICE.someMethod()`), because RPC calls do not support attaching headers.
+:::
+
+## Related resources
+
+- [Gradual deployments](/workers/configuration/versions-and-deployments/gradual-deployments/) — Learn how percentage-based traffic splitting works, including version affinity and observability.
+- [Service bindings](/workers/runtime-apis/bindings/service-bindings/) — How Workers communicate with each other.
+- [Version metadata binding](/workers/runtime-apis/bindings/version-metadata/) — Access version ID and tag from within your Worker.


### PR DESCRIPTION
## Summary

- Extracts the **Version overrides** section from `gradual-deployments.mdx` into its own dedicated page (`version-overrides.mdx`)
- Adds a new **Service bindings** section documenting that `Cloudflare-Workers-Version-Overrides` works on service-binding `fetch()` subrequests
- Clarifies that the header is **not** automatically propagated — the calling Worker must explicitly set it
- Adds a note that version overrides do **not** work with RPC calls (`env.MY_SERVICE.someMethod()`), since RPC has no mechanism for attaching headers
- Fixes a broken link in `previews.mdx` to point to the new page

## Context

This builds on the work in #30733 by @thomsoncf — same customer feedback

## Verified

Deployed two Workers (caller + callee) with a service binding and gradual deployment (v1=100%, v2=0%). Confirmed:

| Scenario | Result |
|---|---|
| No override header | callee returns v1 |
| Caller explicitly sets override → v2 on `env.CALLEE.fetch()` | callee returns **v2** |

## Files changed

- **New:** `version-overrides.mdx` — dedicated version overrides page with service bindings section
- **Modified:** `gradual-deployments.mdx` — replaced version overrides section with link to new page
- **Modified:** `previews.mdx` — updated link to point to new page