### PR TITLE
[AI Gateway] Document "default" gateway ID in Workers binding docs

### DIFF
--- a/src/content/docs/ai-gateway/integrations/aig-workers-ai-binding.mdx
+++ b/src/content/docs/ai-gateway/integrations/aig-workers-ai-binding.mdx
@@ -69,11 +69,11 @@ To bind Workers AI to your Worker, add the following to the end of your [Wrangle
 
 Your binding is [available in your Worker code](/workers/reference/migrate-to-module-workers/#bindings-in-es-modules-format) on [`env.AI`](/workers/runtime-apis/handlers/fetch/).
 
-You will need to have your `gateway id` for the next step. You can learn [how to create an AI Gateway in this tutorial](/ai-gateway/get-started/).
+You can use `"default"` as the gateway ID in the next step. AI Gateway automatically creates a default gateway on the first authenticated request. Alternatively, you can [create a gateway manually](/ai-gateway/get-started/) and use its ID.
 
 ## 3. Run an inference task containing AI Gateway in your Worker
 
-You are now ready to run an inference task in your Worker. In this case, you will use an LLM, [`llama-3.1-8b-instruct-fast`](/workers-ai/models/llama-3.1-8b-instruct-fast/), to answer a question. Your gateway ID is found on the dashboard.
+You are now ready to run an inference task in your Worker. In this case, you will use an LLM, [`llama-3.1-8b-instruct-fast`](/workers-ai/models/llama-3.1-8b-instruct-fast/), to answer a question.
 
 Update the `index.ts` file in your `hello-ai` application directory with the following code:
 
@@ -94,7 +94,7 @@ export default {
 			},
 			{
 				gateway: {
-					id: "GATEWAYID", // Use your gateway label here
+					id: "default", // Uses the default gateway, or replace with your gateway ID
 					skipCache: true, // Optional: Skip cache if needed
 				},
 			},

--- a/src/content/docs/ai-gateway/integrations/worker-binding-methods.mdx
+++ b/src/content/docs/ai-gateway/integrations/worker-binding-methods.mdx
@@ -56,7 +56,7 @@ const resp = await env.AI.run(
 	},
 	{
 		gateway: {
-			id: "my-gateway",
+			id: "default", // or use a specific gateway name
 		},
 	},
 );
@@ -76,7 +76,7 @@ const resp = await env.AI.run(
 	},
 	{
 		gateway: {
-			id: "my-gateway",
+			id: "default", // or use a specific gateway name
 		},
 	},
 );
@@ -98,7 +98,7 @@ The third argument to `env.AI.run()` accepts a `gateway` object with the followi
 
 | Parameter    | Type      | Default    | Description                                                                                      |
 | ------------ | --------- | ---------- | ------------------------------------------------------------------------------------------------ |
-| `id`         | `string`  | _required_ | Name of your [AI Gateway](/ai-gateway/get-started/). Must be in the same account as your Worker. |
+| `id`         | `string`  | _required_ | Name of your [AI Gateway](/ai-gateway/get-started/). Must be in the same account as your Worker. Use `"default"` to automatically create a gateway on the first authenticated request. Refer to [Default gateway](/ai-gateway/configuration/manage-gateway/#default-gateway) for details. |
 | `skipCache`  | `boolean` | `false`    | Skip the [cache](/ai-gateway/features/caching/) for this request.                                |
 | `cacheTtl`   | `number`  | —          | [Cache TTL](/ai-gateway/features/caching/) in seconds.                                           |
 | `cacheKey`   | `string`  | —          | Custom [cache key](/ai-gateway/features/caching/) for this request.                              |


### PR DESCRIPTION
### Summary

Updates the Workers AI binding docs to make it clear that users can pass `"default"` as the gateway ID, which auto-creates a gateway on the first authenticated request. Previously, the tutorial required users to create a gateway manually before getting started, and the reference page didn't mention the `"default"` shortcut.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
