### PR TITLE
[R2] Add Data Catalog GraphQL analytics docs

### DIFF
--- a/src/content/changelog/r2/2025-09-25-data-catalog-compaction.mdx
+++ b/src/content/changelog/r2/2025-09-25-data-catalog-compaction.mdx
@@ -6,9 +6,8 @@ products:
 date: 2025-09-25
 hidden: false
 ---
-import {
-	LinkCard,
-} from "~/components";
+
+import { LinkCard } from "~/components";
 
 You can now enable automatic compaction for [Apache Iceberg](https://iceberg.apache.org/) tables in [R2 Data Catalog](/r2/data-catalog/) to improve query performance.
 

--- a/src/content/changelog/r2/2025-12-18-r2-data-catalog-snapshot-expiration.mdx
+++ b/src/content/changelog/r2/2025-12-18-r2-data-catalog-snapshot-expiration.mdx
@@ -11,9 +11,10 @@ date: 2025-12-18
 In Apache Iceberg, a snapshot is metadata that represents the state of a table at a given point in time. Every mutation creates a new snapshot which enable powerful features like time travel queries and rollback capabilities but will accumulate over time.
 
 Without regular cleanup, these accumulated snapshots can lead to:
- - Metadata overhead
- - Slower table operations
- - Increased storage costs.
+
+- Metadata overhead
+- Slower table operations
+- Increased storage costs.
 
 Snapshot expiration in R2 Data Catalog automatically removes old table snapshots based on your configured retention policy, improving performance and storage costs.
 
@@ -26,8 +27,9 @@ npx wrangler r2 bucket catalog snapshot-expiration enable my-bucket \
 ```
 
 Snapshot expiration uses two parameters to determine which snapshots to remove:
+
 - `--older-than-days`: age threshold in days
--  `--retain-last`: minimum snapshot count to retain
+- `--retain-last`: minimum snapshot count to retain
 
 Both conditions must be met before a snapshot is expired, ensuring you always retain recent snapshots even if they exceed the age threshold.
 

--- a/src/content/changelog/r2/2026-05-12-r2-data-catalog-graphql-analytics.mdx
+++ b/src/content/changelog/r2/2026-05-12-r2-data-catalog-graphql-analytics.mdx
@@ -1,0 +1,18 @@
+---
+title: R2 Data Catalog now exposes metrics via the GraphQL Analytics API
+description: Monitor Iceberg REST API operations and table maintenance jobs for your R2 Data Catalog warehouses using the GraphQL Analytics API.
+products:
+  - r2
+date: 2026-05-12
+---
+
+[R2 Data Catalog](/r2/data-catalog/) is a managed Apache Iceberg data catalog built directly into your R2 bucket that allows you to connect query engines like [R2 SQL](/r2-sql/), Spark, Snowflake, and DuckDB to your data in R2.
+
+You can now query analytics for your R2 Data Catalog warehouses via Cloudflare's [GraphQL Analytics API](/analytics/graphql-api/). Two new datasets are available:
+
+- **`r2CatalogDataOperationsAdaptiveGroups`** tracks Iceberg REST API requests made to your catalog, including operation type, request duration, HTTP status, and request body bytes. Use this to monitor request volume and latency across warehouses, namespaces, and tables.
+- **`r2CatalogTableMaintenanceAdaptiveGroups`** tracks table maintenance jobs such as compaction and snapshot expiration. Use this to monitor job success rates, files processed, bytes read and written, and job duration.
+
+Both datasets support filtering by warehouse name, namespace, table name, and time range. They also include percentile aggregations for duration metrics.
+
+For detailed schema information and example queries, refer to the [R2 Data Catalog metrics and analytics documentation](/r2/data-catalog/observability/metrics/).

--- a/src/content/docs/r2/data-catalog/config-examples/spark-scala.mdx
+++ b/src/content/docs/r2/data-catalog/config-examples/spark-scala.mdx
@@ -7,8 +7,7 @@ products:
   - r2
 ---
 
-import { FileTree } from "~/components"
-
+import { FileTree } from "~/components";
 
 Below is an example of how you can build an [Apache Spark](https://spark.apache.org/) application (with Scala) which connects to R2 Data Catalog. This application is built to run locally, but it can be adapted to run on a cluster.
 

--- a/src/content/docs/r2/data-catalog/config-examples/trino.mdx
+++ b/src/content/docs/r2/data-catalog/config-examples/trino.mdx
@@ -19,7 +19,9 @@ Below is an example of using [Apache Trino](https://trino.io/) to connect to R2 
 - Install [Docker](https://docs.docker.com/get-docker/) to run the Trino container.
 
 ## Setup
+
 Create a local directory for the catalog configuration and change directories to it
+
 ```bash
 mkdir -p trino-catalog && cd trino-catalog/
 ```

--- a/src/content/docs/r2/data-catalog/deleting-data.mdx
+++ b/src/content/docs/r2/data-catalog/deleting-data.mdx
@@ -8,22 +8,25 @@ sidebar:
   order: 5
 ---
 
-import { FileTree } from "~/components"
-import { Tabs, TabItem } from "~/components"
+import { FileTree } from "~/components";
+import { Tabs, TabItem } from "~/components";
 import { InlineBadge } from "~/components";
 
 Deleting data from R2 Data Catalog or any Apache Iceberg catalog requires that operations are done in a transaction through the catalog itself. Manually deleting metadata or data files directly can lead to data catalog corruption.
 
 ## Automatic table maintenance
+
 R2 Data Catalog can automatically manage table maintenance operations such as snapshot expiration and compaction. These continuous operations help keep latency and storage costs down.
- - **Snapshot expiration**: Automatically removes old snapshots and the respective unreferenced data files. This reduces both metadata overhead and storage costs.
- - **Compaction**: Merges small data files into larger ones. This optimizes read performance and reduces the number of files read during queries.
 
- Without enabling automatic maintenance, you need to manually handle these operations.
+- **Snapshot expiration**: Automatically removes old snapshots and the respective unreferenced data files. This reduces both metadata overhead and storage costs.
+- **Compaction**: Merges small data files into larger ones. This optimizes read performance and reduces the number of files read during queries.
 
- Learn more in the [table maintenance](/r2/data-catalog/table-maintenance/) documentation.
+Without enabling automatic maintenance, you need to manually handle these operations.
+
+Learn more in the [table maintenance](/r2/data-catalog/table-maintenance/) documentation.
 
 ## Examples of enabling automatic table maintenance in R2 Data Catalog
+
 ```bash
 # Enable automatic snapshot expiration for entire catalog
 npx wrangler r2 bucket catalog snapshot-expiration enable my-bucket \
@@ -34,13 +37,16 @@ npx wrangler r2 bucket catalog snapshot-expiration enable my-bucket \
 npx wrangler r2 bucket catalog compaction enable my-bucket \
 	--target-size 256
 ```
+
 Refer to additional examples in the [manage catalogs](/r2/data-catalog/manage-catalogs/) documentation.
 
 ## Manually deleting and removing data
+
 You need to manually delete data for:
- - Complying with data retention policies such as GDPR or CCPA.
- - Selective based deletes using conditional logic.
- - Removing stale or unreferenced files that R2 Data Catalog does not manage.
+
+- Complying with data retention policies such as GDPR or CCPA.
+- Selective based deletes using conditional logic.
+- Removing stale or unreferenced files that R2 Data Catalog does not manage.
 
 The following are basic examples using PySpark but similar operations can be performed using other Iceberg-compatible engines. To configure PySpark, refer to our [example](/r2/data-catalog/config-examples/spark-python/) or the official [PySpark documentation](https://spark.apache.org/docs/latest/api/python/getting_started/index.html).
 
@@ -62,7 +68,9 @@ spark.sql("""
     WHERE date_partition < '2024-01-01'
 """)
 ```
+
 ### Dropping tables and namespaces
+
 ```py
 # Removes table from catalog but keeps data files in R2 storage
 spark.sql("DROP TABLE r2dc.namespace.table_name")
@@ -88,6 +96,7 @@ spark.sql("DROP NAMESPACE r2dc.namespace_name CASCADE")
 :::
 
 ### Manual maintenance operations
+
 ```py
 # Remove old metadata and data files marked for deletion
 # The following retains the last 5 snapshots and deletes files older than Nov 28, 2024
@@ -119,12 +128,12 @@ spark.sql("""
 
 Apache Iceberg uses a layered metadata structure to manage table data efficiently. Here are the key components and file structure:
 
-  - **metadata.json**: Top-level JSON file pointing to the current snapshot
-  - **snapshot-***: Immutable table state for a given point in time
-  - **manifest-list-*.avro**: An Avro file listing all manifest files for a given snapshot
-  - **manifest-file-*.avro**: An Avro file tracking data files and their statistics
-  - **data-*.parquet**: Parquet files containing actual table data
-  - **Note**: Unchanged manifest files are reused across snapshots
+- **metadata.json**: Top-level JSON file pointing to the current snapshot
+- **snapshot-\***: Immutable table state for a given point in time
+- **manifest-list-\*.avro**: An Avro file listing all manifest files for a given snapshot
+- **manifest-file-\*.avro**: An Avro file tracking data files and their statistics
+- **data-\*.parquet**: Parquet files containing actual table data
+- **Note**: Unchanged manifest files are reused across snapshots
 
 :::caution
 Manually modifying or deleting any of these files directly can lead to data catalog corruption.
@@ -161,39 +170,40 @@ Manually modifying or deleting any of these files directly can lead to data cata
 
 Apache Iceberg supports two deletion modes: **Copy-on-Write (COW)** and **Merge-on-Read (MOR)**. Both create a new snapshot and mark old files for cleanup, but handle the deletion differently:
 
-| Aspect | Copy-on-Write (COW) | Merge-on-Read (MOR) |
-|--------|---------------------|---------------------|
-| **How deletes work** | Rewrites data files without deleted rows | Creates delete files marking rows to skip |
-| **Query performance** | Fast (no merge needed) | Slower (requires read-time merge) |
-| **Write performance** | Slower (rewrites data files) | Fast (only writes delete markers) |
-| **Storage impact** | Creates new data files immediately | Accumulates delete files over time |
-| **Maintenance needs** | Snapshot expiration | Snapshot expiration + compaction (`rewrite_data_files`) |
-| **Best for** | Read-heavy workloads | Write-heavy workloads with frequent small mutations |
+| Aspect                | Copy-on-Write (COW)                      | Merge-on-Read (MOR)                                     |
+| --------------------- | ---------------------------------------- | ------------------------------------------------------- |
+| **How deletes work**  | Rewrites data files without deleted rows | Creates delete files marking rows to skip               |
+| **Query performance** | Fast (no merge needed)                   | Slower (requires read-time merge)                       |
+| **Write performance** | Slower (rewrites data files)             | Fast (only writes delete markers)                       |
+| **Storage impact**    | Creates new data files immediately       | Accumulates delete files over time                      |
+| **Maintenance needs** | Snapshot expiration                      | Snapshot expiration + compaction (`rewrite_data_files`) |
+| **Best for**          | Read-heavy workloads                     | Write-heavy workloads with frequent small mutations     |
 
 :::note[Important for all deletion modes]
+
 - Deleted data is **not immediately removed** from R2 - files are marked for cleanup
 - Enable [snapshot expiration](/r2/data-catalog/table-maintenance) in R2 Data Catalog to automatically clean up old snapshots and files
-:::
+  :::
 
 ### Common deletion operations
 
 These operations work the same way for both COW and MOR tables:
 
-| Operation | What it does | Data deleted? | Reversible? |
-|-----------|-------------|---------------|-------------|
-| `DELETE FROM` | Removes rows matching condition | No (marked for cleanup) | Via time travel[^1] |
-| `DROP TABLE` | Removes table from catalog | No | Yes (if data files exist) |
-| `DROP TABLE ... PURGE` | Removes table and deletes data | **Yes** | **No** |
-| `expire_snapshots` | Cleans up old snapshots/files | **Yes** | **No** |
-| `remove_orphan_files` | Removes unreferenced files | **Yes** | **No** |
+| Operation              | What it does                    | Data deleted?           | Reversible?               |
+| ---------------------- | ------------------------------- | ----------------------- | ------------------------- |
+| `DELETE FROM`          | Removes rows matching condition | No (marked for cleanup) | Via time travel[^1]       |
+| `DROP TABLE`           | Removes table from catalog      | No                      | Yes (if data files exist) |
+| `DROP TABLE ... PURGE` | Removes table and deletes data  | **Yes**                 | **No**                    |
+| `expire_snapshots`     | Cleans up old snapshots/files   | **Yes**                 | **No**                    |
+| `remove_orphan_files`  | Removes unreferenced files      | **Yes**                 | **No**                    |
 
 ### MOR-specific operations
 
 For Merge-on-Read tables, you may need to manually apply deletes for performance:
 
-| Operation | What it does | When to use |
-|-----------|-------------|-------------|
-| `rewrite_data_files` (compaction)| Applies deletes and consolidates files | When query performance degrades due to many delete files |
+| Operation                         | What it does                           | When to use                                              |
+| --------------------------------- | -------------------------------------- | -------------------------------------------------------- |
+| `rewrite_data_files` (compaction) | Applies deletes and consolidates files | When query performance degrades due to many delete files |
 
 :::note
 R2 Data Catalog can automate [rewriting data files](/r2/data-catalog/table-maintenance/) for you.
@@ -207,4 +217,3 @@ R2 Data Catalog can automate [rewriting data files](/r2/data-catalog/table-maint
 - [Apache Iceberg Maintenance](https://iceberg.apache.org/docs/latest/maintenance/) - Official Iceberg documentation on table maintenance
 
 [^1]: Time travel available until `expire_snapshots` is called
-

--- a/src/content/docs/r2/data-catalog/get-started.mdx
+++ b/src/content/docs/r2/data-catalog/get-started.mdx
@@ -277,6 +277,7 @@ We will use [marimo](https://github.com/marimo-team/marimo) as a Python notebook
 			Once your notebook connects to the catalog, you'll see the catalog along with its namespaces and tables appear in marimo's Datasources panel.
 
 </Steps>
+
 In the Python notebook above, you:
 
 1. Connect to your catalog.

--- a/src/content/docs/r2/data-catalog/manage-catalogs.mdx
+++ b/src/content/docs/r2/data-catalog/manage-catalogs.mdx
@@ -202,10 +202,10 @@ To connect your Iceberg engine to R2 Data Catalog, you must provide a Cloudflare
 
 ### Create API token in the dashboard
 
-Create an [R2 API token](/r2/api/tokens/#permissions) with **Admin Read & Write** or **Admin Read only** permissions. These permissions include both:
+Create an [R2 API token](/r2/api/tokens/#permissions) with **Admin Read & Write** permissions. These permissions include both:
 
-- Access to R2 Data Catalog (read-only or read/write, depending on chosen permission)
-- Access to R2 storage (read-only or read/write, depending on chosen permission)
+- Access to R2 Data Catalog (read/write)
+- Access to R2 storage (read/write)
 
 Providing the resulting token value to your Iceberg engine gives it the ability to manage catalog metadata and handle data operations (reads or writes to R2).
 

--- a/src/content/docs/r2/data-catalog/manage-catalogs.mdx
+++ b/src/content/docs/r2/data-catalog/manage-catalogs.mdx
@@ -89,6 +89,7 @@ Table maintenance operations such as compaction and snapshot expiration requires
 
 Refer to [Authenticate your Iceberg engine](#authenticate-your-iceberg-engine) for details on creating a token with the required permissions.
 :::
+
 <Tabs syncKey='CLIvDash'>
 <TabItem label='Dashboard'>
 
@@ -241,6 +242,7 @@ To create an API token programmatically for use with R2 Data Catalog, you'll nee
 To learn more about how to create API tokens for R2 Data Catalog using the API, including required permission groups and usage examples, refer to the [Create API tokens via API documentation](/r2/api/tokens/#create-api-tokens-via-api).
 
 ## R2 Local Uploads
+
 [Local Uploads](/r2/buckets/local-uploads) writes object data to a nearby location, then asynchronously copies it to your bucket. Data is queryable immediately and remains strongly consistent. This can significantly improve latency of writes from Apache Iceberg clients outside of the region of the respective R2 Data Catalog bucket.
 
 To enable R2 Local Uploads, you can use the following Wrangler command:
@@ -250,8 +252,8 @@ npx wrangler r2 bucket catalog local-uploads enable <R2_Data_Catalog_BUCKET_NAME
 ```
 
 ## Limitations
-- R2 Data Catalog does not currently support R2 buckets in a non-default jurisdiction.
 
+- R2 Data Catalog does not currently support R2 buckets in a non-default jurisdiction.
 
 ## Learn more
 

--- a/src/content/docs/r2/data-catalog/observability/index.mdx
+++ b/src/content/docs/r2/data-catalog/observability/index.mdx
@@ -1,0 +1,14 @@
+---
+title: Observability
+pcx_content_type: navigation
+sidebar:
+  order: 6
+  group:
+    hideIndex: true
+products:
+  - r2
+---
+
+import { DirectoryListing } from "~/components";
+
+<DirectoryListing />

--- a/src/content/docs/r2/data-catalog/observability/metrics.mdx
+++ b/src/content/docs/r2/data-catalog/observability/metrics.mdx
@@ -10,7 +10,7 @@ products:
 
 R2 Data Catalog exposes metrics that allow you to monitor Iceberg REST API requests and table maintenance jobs (compaction and snapshot expiration) across your warehouses.
 
-The metrics displayed in the [Cloudflare dashboard](https://dash.cloudflare.com/) are queried from Cloudflare's [GraphQL Analytics API](/analytics/graphql-api/). You can access the metrics [programmatically](#query-via-the-graphql-api) via GraphQL or any HTTP client.
+The metrics displayed in the Cloudflare dashboard are queried from Cloudflare's [GraphQL Analytics API](/analytics/graphql-api/). You can access the metrics [programmatically](#query-via-the-graphql-api) via GraphQL or any HTTP client.
 
 ## Metrics
 
@@ -18,11 +18,11 @@ The metrics displayed in the [Cloudflare dashboard](https://dash.cloudflare.com/
 
 R2 Data Catalog exports the below metrics within the `r2CatalogDataOperationsAdaptiveGroups` dataset. These metrics track Iceberg REST API requests made to your catalog, such as loading tables, listing namespaces, and committing updates.
 
-| Metric | GraphQL Field Name | Aggregation | Description |
-| --- | --- | --- | --- |
-| Request count | `count` | count | Total number of Iceberg REST API requests |
-| Request body bytes | `requestBodyBytes` | sum | Total bytes sent in request bodies |
-| Request duration | `requestDurationMs` | sum, avg, quantiles | Request duration in milliseconds |
+| Metric             | GraphQL Field Name  | Aggregation         | Description                               |
+| ------------------ | ------------------- | ------------------- | ----------------------------------------- |
+| Request count      | `count`             | count               | Total number of Iceberg REST API requests |
+| Request body bytes | `requestBodyBytes`  | sum                 | Total bytes sent in request bodies        |
+| Request duration   | `requestDurationMs` | sum, avg, quantiles | Request duration in milliseconds          |
 
 The `r2CatalogDataOperationsAdaptiveGroups` dataset provides the following dimensions for filtering and grouping queries:
 
@@ -42,14 +42,14 @@ The `r2CatalogDataOperationsAdaptiveGroups` dataset provides the following dimen
 
 R2 Data Catalog exports the below metrics within the `r2CatalogTableMaintenanceAdaptiveGroups` dataset. These metrics track table maintenance jobs including [compaction and snapshot expiration](/r2/data-catalog/table-maintenance/).
 
-| Metric | GraphQL Field Name | Aggregation | Description |
-| --- | --- | --- | --- |
-| Job count | `count` | count | Total number of maintenance jobs executed |
-| Files processed | `filesProcessed` | sum | Total input files processed by maintenance jobs |
-| Files output | `filesOutput` | sum | Total output files created by maintenance jobs |
-| Input bytes | `inputBytes` | sum | Total bytes read or scanned by maintenance jobs |
-| Output bytes | `outputBytes` | sum | Total bytes written by maintenance jobs |
-| Job duration | `jobDurationMs` | sum, avg, quantiles | Job duration in milliseconds |
+| Metric          | GraphQL Field Name | Aggregation         | Description                                     |
+| --------------- | ------------------ | ------------------- | ----------------------------------------------- |
+| Job count       | `count`            | count               | Total number of maintenance jobs executed       |
+| Files processed | `filesProcessed`   | sum                 | Total input files processed by maintenance jobs |
+| Files output    | `filesOutput`      | sum                 | Total output files created by maintenance jobs  |
+| Input bytes     | `inputBytes`       | sum                 | Total bytes read or scanned by maintenance jobs |
+| Output bytes    | `outputBytes`      | sum                 | Total bytes written by maintenance jobs         |
+| Job duration    | `jobDurationMs`    | sum, avg, quantiles | Job duration in milliseconds                    |
 
 The `r2CatalogTableMaintenanceAdaptiveGroups` dataset provides the following dimensions for filtering and grouping queries:
 
@@ -77,35 +77,35 @@ This query returns the total number of Iceberg REST API requests and total reque
 
 ```graphql
 query CatalogDataOperations(
-  $accountTag: String!
-  $warehouseName: String!
-  $datetimeStart: Time!
-  $datetimeEnd: Time!
+	$accountTag: String!
+	$warehouseName: String!
+	$datetimeStart: Time!
+	$datetimeEnd: Time!
 ) {
-  viewer {
-    accounts(filter: { accountTag: $accountTag }) {
-      r2CatalogDataOperationsAdaptiveGroups(
-        limit: 10000
-        filter: {
-          warehouseName: $warehouseName
-          datetime_geq: $datetimeStart
-          datetime_leq: $datetimeEnd
-        }
-      ) {
-        count
-        dimensions {
-          operation
-        }
-        sum {
-          requestBodyBytes
-          requestDurationMs
-        }
-        avg {
-          requestDurationMs
-        }
-      }
-    }
-  }
+	viewer {
+		accounts(filter: { accountTag: $accountTag }) {
+			r2CatalogDataOperationsAdaptiveGroups(
+				limit: 10000
+				filter: {
+					warehouseName: $warehouseName
+					datetime_geq: $datetimeStart
+					datetime_leq: $datetimeEnd
+				}
+			) {
+				count
+				dimensions {
+					operation
+				}
+				sum {
+					requestBodyBytes
+					requestDurationMs
+				}
+				avg {
+					requestDurationMs
+				}
+			}
+		}
+	}
 }
 ```
 
@@ -115,33 +115,33 @@ This query returns request duration percentiles for a specific warehouse, which 
 
 ```graphql
 query CatalogLatencyPercentiles(
-  $accountTag: String!
-  $warehouseName: String!
-  $datetimeStart: Time!
-  $datetimeEnd: Time!
+	$accountTag: String!
+	$warehouseName: String!
+	$datetimeStart: Time!
+	$datetimeEnd: Time!
 ) {
-  viewer {
-    accounts(filter: { accountTag: $accountTag }) {
-      r2CatalogDataOperationsAdaptiveGroups(
-        limit: 10000
-        filter: {
-          warehouseName: $warehouseName
-          datetime_geq: $datetimeStart
-          datetime_leq: $datetimeEnd
-        }
-      ) {
-        count
-        dimensions {
-          operation
-        }
-        quantiles {
-          requestDurationMsP50
-          requestDurationMsP90
-          requestDurationMsP99
-        }
-      }
-    }
-  }
+	viewer {
+		accounts(filter: { accountTag: $accountTag }) {
+			r2CatalogDataOperationsAdaptiveGroups(
+				limit: 10000
+				filter: {
+					warehouseName: $warehouseName
+					datetime_geq: $datetimeStart
+					datetime_leq: $datetimeEnd
+				}
+			) {
+				count
+				dimensions {
+					operation
+				}
+				quantiles {
+					requestDurationMsP50
+					requestDurationMsP90
+					requestDurationMsP99
+				}
+			}
+		}
+	}
 }
 ```
 
@@ -151,37 +151,37 @@ This query returns a summary of compaction and snapshot expiration jobs for a sp
 
 ```graphql
 query CatalogMaintenanceMetrics(
-  $accountTag: String!
-  $warehouseName: String!
-  $datetimeStart: Time!
-  $datetimeEnd: Time!
+	$accountTag: String!
+	$warehouseName: String!
+	$datetimeStart: Time!
+	$datetimeEnd: Time!
 ) {
-  viewer {
-    accounts(filter: { accountTag: $accountTag }) {
-      r2CatalogTableMaintenanceAdaptiveGroups(
-        limit: 10000
-        filter: {
-          warehouseName: $warehouseName
-          datetime_geq: $datetimeStart
-          datetime_leq: $datetimeEnd
-        }
-      ) {
-        count
-        dimensions {
-          jobType
-          tableName
-          success
-        }
-        sum {
-          filesProcessed
-          filesOutput
-          inputBytes
-          outputBytes
-          jobDurationMs
-        }
-      }
-    }
-  }
+	viewer {
+		accounts(filter: { accountTag: $accountTag }) {
+			r2CatalogTableMaintenanceAdaptiveGroups(
+				limit: 10000
+				filter: {
+					warehouseName: $warehouseName
+					datetime_geq: $datetimeStart
+					datetime_leq: $datetimeEnd
+				}
+			) {
+				count
+				dimensions {
+					jobType
+					tableName
+					success
+				}
+				sum {
+					filesProcessed
+					filesOutput
+					inputBytes
+					outputBytes
+					jobDurationMs
+				}
+			}
+		}
+	}
 }
 ```
 
@@ -190,40 +190,60 @@ query CatalogMaintenanceMetrics(
 You can narrow results to a specific Iceberg operation or table. For example, to query only `load-table` operations for a specific table:
 
 ```graphql
-r2CatalogDataOperationsAdaptiveGroups(
-  limit: 10000
-  filter: {
-    warehouseName: "my-warehouse"
-    operation: "load-table"
-    tableName: "my_table"
-    datetime_geq: $datetimeStart
-    datetime_leq: $datetimeEnd
-  }
+query CatalogFilterByOperation(
+	$accountTag: String!
+	$datetimeStart: Time!
+	$datetimeEnd: Time!
 ) {
-  count
-  sum {
-    requestDurationMs
-  }
+	viewer {
+		accounts(filter: { accountTag: $accountTag }) {
+			r2CatalogDataOperationsAdaptiveGroups(
+				limit: 10000
+				filter: {
+					warehouseName: "my-warehouse"
+					operation: "load-table"
+					tableName: "my_table"
+					datetime_geq: $datetimeStart
+					datetime_leq: $datetimeEnd
+				}
+			) {
+				count
+				sum {
+					requestDurationMs
+				}
+			}
+		}
+	}
 }
 ```
 
 To query only failed maintenance jobs:
 
 ```graphql
-r2CatalogTableMaintenanceAdaptiveGroups(
-  limit: 10000
-  filter: {
-    warehouseName: "my-warehouse"
-    success: 0
-    datetime_geq: $datetimeStart
-    datetime_leq: $datetimeEnd
-  }
+query CatalogFailedMaintenanceJobs(
+	$accountTag: String!
+	$datetimeStart: Time!
+	$datetimeEnd: Time!
 ) {
-  count
-  dimensions {
-    jobType
-    tableName
-  }
+	viewer {
+		accounts(filter: { accountTag: $accountTag }) {
+			r2CatalogTableMaintenanceAdaptiveGroups(
+				limit: 10000
+				filter: {
+					warehouseName: "my-warehouse"
+					success: 0
+					datetime_geq: $datetimeStart
+					datetime_leq: $datetimeEnd
+				}
+			) {
+				count
+				dimensions {
+					jobType
+					tableName
+				}
+			}
+		}
+	}
 }
 ```
 
@@ -232,20 +252,27 @@ r2CatalogTableMaintenanceAdaptiveGroups(
 To query metrics across all warehouses on an account, omit the `warehouseName` filter and include `warehouseName` in the dimensions:
 
 ```graphql
-r2CatalogDataOperationsAdaptiveGroups(
-  limit: 10000
-  filter: {
-    datetime_geq: $datetimeStart
-    datetime_leq: $datetimeEnd
-  }
+query CatalogAllWarehouses(
+	$accountTag: String!
+	$datetimeStart: Time!
+	$datetimeEnd: Time!
 ) {
-  count
-  dimensions {
-    warehouseName
-    operation
-  }
-  sum {
-    requestDurationMs
-  }
+	viewer {
+		accounts(filter: { accountTag: $accountTag }) {
+			r2CatalogDataOperationsAdaptiveGroups(
+				limit: 10000
+				filter: { datetime_geq: $datetimeStart, datetime_leq: $datetimeEnd }
+			) {
+				count
+				dimensions {
+					warehouseName
+					operation
+				}
+				sum {
+					requestDurationMs
+				}
+			}
+		}
+	}
 }
 ```

--- a/src/content/docs/r2/data-catalog/observability/metrics.mdx
+++ b/src/content/docs/r2/data-catalog/observability/metrics.mdx
@@ -1,0 +1,251 @@
+---
+pcx_content_type: concept
+title: Metrics and analytics
+description: Query R2 Data Catalog metrics for Iceberg REST API operations and table maintenance jobs via the GraphQL Analytics API.
+sidebar:
+  order: 1
+products:
+  - r2
+---
+
+R2 Data Catalog exposes metrics that allow you to monitor Iceberg REST API requests and table maintenance jobs (compaction and snapshot expiration) across your warehouses.
+
+The metrics displayed in the [Cloudflare dashboard](https://dash.cloudflare.com/) are queried from Cloudflare's [GraphQL Analytics API](/analytics/graphql-api/). You can access the metrics [programmatically](#query-via-the-graphql-api) via GraphQL or any HTTP client.
+
+## Metrics
+
+### Data operations metrics
+
+R2 Data Catalog exports the below metrics within the `r2CatalogDataOperationsAdaptiveGroups` dataset. These metrics track Iceberg REST API requests made to your catalog, such as loading tables, listing namespaces, and committing updates.
+
+| Metric | GraphQL Field Name | Aggregation | Description |
+| --- | --- | --- | --- |
+| Request count | `count` | count | Total number of Iceberg REST API requests |
+| Request body bytes | `requestBodyBytes` | sum | Total bytes sent in request bodies |
+| Request duration | `requestDurationMs` | sum, avg, quantiles | Request duration in milliseconds |
+
+The `r2CatalogDataOperationsAdaptiveGroups` dataset provides the following dimensions for filtering and grouping queries:
+
+- `warehouseName` - The name of the R2 Data Catalog warehouse
+- `operation` - The Iceberg REST API operation name (for example, `load-table`, `list-namespaces`, `commit-table`)
+- `namespaceName` - The Iceberg namespace targeted by the request, if applicable
+- `tableName` - The Iceberg table targeted by the request, if applicable
+- `httpStatus` - HTTP response status code
+- `datetime` - Request timestamp
+- `date` - Request timestamp, truncated to the start of a day
+- `datetimeHour` - Request timestamp, truncated to the start of an hour
+- `datetimeMinute` - Request timestamp, truncated to the start of a minute
+- `datetimeFiveMinutes` - Request timestamp, truncated to the start of five minutes
+- `datetimeFifteenMinutes` - Request timestamp, truncated to the start of fifteen minutes
+
+### Table maintenance metrics
+
+R2 Data Catalog exports the below metrics within the `r2CatalogTableMaintenanceAdaptiveGroups` dataset. These metrics track table maintenance jobs including [compaction and snapshot expiration](/r2/data-catalog/table-maintenance/).
+
+| Metric | GraphQL Field Name | Aggregation | Description |
+| --- | --- | --- | --- |
+| Job count | `count` | count | Total number of maintenance jobs executed |
+| Files processed | `filesProcessed` | sum | Total input files processed by maintenance jobs |
+| Files output | `filesOutput` | sum | Total output files created by maintenance jobs |
+| Input bytes | `inputBytes` | sum | Total bytes read or scanned by maintenance jobs |
+| Output bytes | `outputBytes` | sum | Total bytes written by maintenance jobs |
+| Job duration | `jobDurationMs` | sum, avg, quantiles | Job duration in milliseconds |
+
+The `r2CatalogTableMaintenanceAdaptiveGroups` dataset provides the following dimensions for filtering and grouping queries:
+
+- `warehouseName` - The name of the R2 Data Catalog warehouse
+- `jobType` - The type of maintenance job (`compaction`, `snapshot-expiration`)
+- `namespaceName` - The Iceberg namespace containing the table
+- `tableName` - The Iceberg table that was maintained
+- `success` - Whether the job succeeded (`1`) or failed (`0`)
+- `datetime` - Job timestamp
+- `date` - Job timestamp, truncated to the start of a day
+- `datetimeHour` - Job timestamp, truncated to the start of an hour
+- `datetimeMinute` - Job timestamp, truncated to the start of a minute
+- `datetimeFiveMinutes` - Job timestamp, truncated to the start of five minutes
+- `datetimeFifteenMinutes` - Job timestamp, truncated to the start of fifteen minutes
+
+## Query via the GraphQL API
+
+You can programmatically query analytics for your R2 Data Catalog warehouses via the [GraphQL Analytics API](/analytics/graphql-api/). This API queries the same datasets as the Cloudflare dashboard and supports GraphQL [introspection](/analytics/graphql-api/features/discovery/introspection/).
+
+R2 Data Catalog GraphQL datasets require an `accountTag` filter with your Cloudflare account ID.
+
+### Measure data operations over a time period
+
+This query returns the total number of Iceberg REST API requests and total request duration, grouped by operation, for a specific warehouse.
+
+```graphql
+query CatalogDataOperations(
+  $accountTag: String!
+  $warehouseName: String!
+  $datetimeStart: Time!
+  $datetimeEnd: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      r2CatalogDataOperationsAdaptiveGroups(
+        limit: 10000
+        filter: {
+          warehouseName: $warehouseName
+          datetime_geq: $datetimeStart
+          datetime_leq: $datetimeEnd
+        }
+      ) {
+        count
+        dimensions {
+          operation
+        }
+        sum {
+          requestBodyBytes
+          requestDurationMs
+        }
+        avg {
+          requestDurationMs
+        }
+      }
+    }
+  }
+}
+```
+
+### Measure request latency percentiles
+
+This query returns request duration percentiles for a specific warehouse, which is useful for understanding latency distribution.
+
+```graphql
+query CatalogLatencyPercentiles(
+  $accountTag: String!
+  $warehouseName: String!
+  $datetimeStart: Time!
+  $datetimeEnd: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      r2CatalogDataOperationsAdaptiveGroups(
+        limit: 10000
+        filter: {
+          warehouseName: $warehouseName
+          datetime_geq: $datetimeStart
+          datetime_leq: $datetimeEnd
+        }
+      ) {
+        count
+        dimensions {
+          operation
+        }
+        quantiles {
+          requestDurationMsP50
+          requestDurationMsP90
+          requestDurationMsP99
+        }
+      }
+    }
+  }
+}
+```
+
+### Query table maintenance job metrics
+
+This query returns a summary of compaction and snapshot expiration jobs for a specific warehouse, including files processed, bytes read and written, and success or failure status.
+
+```graphql
+query CatalogMaintenanceMetrics(
+  $accountTag: String!
+  $warehouseName: String!
+  $datetimeStart: Time!
+  $datetimeEnd: Time!
+) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      r2CatalogTableMaintenanceAdaptiveGroups(
+        limit: 10000
+        filter: {
+          warehouseName: $warehouseName
+          datetime_geq: $datetimeStart
+          datetime_leq: $datetimeEnd
+        }
+      ) {
+        count
+        dimensions {
+          jobType
+          tableName
+          success
+        }
+        sum {
+          filesProcessed
+          filesOutput
+          inputBytes
+          outputBytes
+          jobDurationMs
+        }
+      }
+    }
+  }
+}
+```
+
+### Filter by operation or table
+
+You can narrow results to a specific Iceberg operation or table. For example, to query only `load-table` operations for a specific table:
+
+```graphql
+r2CatalogDataOperationsAdaptiveGroups(
+  limit: 10000
+  filter: {
+    warehouseName: "my-warehouse"
+    operation: "load-table"
+    tableName: "my_table"
+    datetime_geq: $datetimeStart
+    datetime_leq: $datetimeEnd
+  }
+) {
+  count
+  sum {
+    requestDurationMs
+  }
+}
+```
+
+To query only failed maintenance jobs:
+
+```graphql
+r2CatalogTableMaintenanceAdaptiveGroups(
+  limit: 10000
+  filter: {
+    warehouseName: "my-warehouse"
+    success: 0
+    datetime_geq: $datetimeStart
+    datetime_leq: $datetimeEnd
+  }
+) {
+  count
+  dimensions {
+    jobType
+    tableName
+  }
+}
+```
+
+### Query across all warehouses
+
+To query metrics across all warehouses on an account, omit the `warehouseName` filter and include `warehouseName` in the dimensions:
+
+```graphql
+r2CatalogDataOperationsAdaptiveGroups(
+  limit: 10000
+  filter: {
+    datetime_geq: $datetimeStart
+    datetime_leq: $datetimeEnd
+  }
+) {
+  count
+  dimensions {
+    warehouseName
+    operation
+  }
+  sum {
+    requestDurationMs
+  }
+}
+```


### PR DESCRIPTION
### Summary

Documents the new GraphQL Analytics API datasets for R2 Data Catalog, which allow users to monitor Iceberg REST API operations and table maintenance jobs (compaction, snapshot expiration) across their warehouses.

- Add observability section with metrics reference and example GraphQL queries
- Add changelog entry for the new GraphQL analytics datasets
- Fix API token permissions in manage-catalogs to require Admin Read & Write only

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
