### PR TITLE
Add split tunnel UI known issue to Cloudflare One Client 2026.4.1350.0 release notes

### DIFF
--- a/src/content/warp-releases/linux/ga/2026.4.1350.0.yaml
+++ b/src/content/warp-releases/linux/ga/2026.4.1350.0.yaml
@@ -10,6 +10,7 @@ releaseNotes: |-
 
   **Known issues**
   - Registration may hang at "Checking your organization configuration" due to IPC errors. A system reboot should resolve the error, allowing registration to proceed.
+  - Split tunnel list configuration is not available in the new UI. Management of split tunnel entries is currently only possible via `warp-cli tunnel ip` and `warp-cli tunnel host`. UI support will be added in a future release.
 version: 2026.4.1350.0
 releaseDate: 2026-05-11T15:17:54.055Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/fedora35-intel/version/2026.4.1350.0

--- a/src/content/warp-releases/macos/ga/2026.4.1350.0.yaml
+++ b/src/content/warp-releases/macos/ga/2026.4.1350.0.yaml
@@ -9,6 +9,7 @@ releaseNotes: |-
 
   **Known issues**
   - Registration may hang at "Checking your organization configuration" due to IPC errors. A system reboot should resolve the error, allowing registration to proceed.
+  - Split tunnel list configuration is not available in the new UI. Management of split tunnel entries is currently only possible via `warp-cli tunnel ip` and `warp-cli tunnel host`. UI support will be added in a future release.
 version: 2026.4.1350.0
 releaseDate: 2026-05-11T17:35:57.027Z
 packageURL: https://downloads.cloudflareclient.com/v1/download/macos/version/2026.4.1350.0

--- a/src/content/warp-releases/windows/ga/2026.4.1350.0.yaml
+++ b/src/content/warp-releases/windows/ga/2026.4.1350.0.yaml
@@ -11,6 +11,7 @@ releaseNotes: |-
   - Registration authentication for devices via the integrated WebView2 browser is unavailable in this version as a temporary measure. As a result, the client will utilize the default browser on the device to complete the authentication process.
   - An error indicating that Microsoft Edge can't read and write to its data directory may be displayed during captive portal login; this error is benign and can be dismissed.
   - Registration may hang at "Checking your organization configuration" due to IPC errors. A system reboot should resolve the error, allowing registration to proceed.
+  - Split tunnel list configuration is not available in the new UI. Management of Split Tunnel entries is currently only possible via `warp-cli tunnel ip` and `warp-cli tunnel host`. UI support will be added in a future release.
   - Windows ARM may prompt the user to close running applications while trying to install this version. Simply click “Ok” with the default highlighted option.
   - DNS resolution may be broken when the following conditions are all true:
     - The client is in Secure Web Gateway without DNS filtering (tunnel-only) mode.


### PR DESCRIPTION
Adds a known-issue note across the Linux, macOS, and Windows release-notes YAMLs for the `2026.4.1350.0` release: split tunnel list configuration is not yet available in the new UI and must be managed via `warp-cli tunnel ip` / `warp-cli tunnel host`.

Re-opens [#30740](https://github.com/cloudflare/cloudflare-docs/pull/30740) from an org-member fork so the required Actions can run (samin-cf is a first-time external contributor and his PR's workflow runs were paused with `action_required`).

Authored by @samin-cf. Original PR approved by @GregBrimble.