### PR TITLE
feat: move page actions above component usage in page header

### DIFF
--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -120,7 +120,7 @@ if (!hideBreadcrumbs) {
 
 {
 	component && (
-			<div class="sl-markdown-content md-ignore">
+			<div class="sl-markdown-content md-ignore component-usage-wrapper">
 				<ComponentUsage component={component} />
 			</div>
 	)
@@ -133,6 +133,10 @@ if (!hideBreadcrumbs) {
 
 	.page-actions-wrapper {
 		margin-top: 1rem;
+	}
+
+	.component-usage-wrapper {
+		margin-top: 3rem;
 	}
 
 	:global(.c-breadcrumbs) {

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -111,18 +111,18 @@ if (!hideBreadcrumbs) {
 {summary && <Description set:html={marked.parse(summary)} />}
 
 {
-	component && (
-			<div class="sl-markdown-content md-ignore">
-				<ComponentUsage component={component} />
-			</div>
-	)
-}
-
-{
 	showPageActions && (
 		<div class="page-actions-wrapper">
 			<PageActions />
 		</div>
+	)
+}
+
+{
+	component && (
+			<div class="sl-markdown-content md-ignore">
+				<ComponentUsage component={component} />
+			</div>
 	)
 }
 


### PR DESCRIPTION
### Summary

Reorders the page header elements so the agent toolkit bar (Copy as Markdown / View as Markdown / Agent setup / Docs for agents) appears above the component usage section on style-guide component pages, rather than below it.

### Images
#### Before
<img width="938" height="544" alt="Screenshot 2026-05-11 at 5 15 31 PM" src="https://github.com/user-attachments/assets/ddee2603-fe2b-4818-bc53-93556044915d" />

#### After
<img width="943" height="581" alt="Screenshot 2026-05-11 at 5 18 02 PM" src="https://github.com/user-attachments/assets/81acb9fd-6613-402f-bd7d-8e4a5909df1a" />

