### PR TITLE
[Log Explorer] Rename custom dashboards to dashboards

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -201,7 +201,8 @@
 /analytics/graphql-api/tutorials/build-your-own-analytics/ /analytics/graphql-api/tutorials/ 301
 /analytics/graphql-api/tutorials/export-graphql-to-csv/ /analytics/graphql-api/tutorials/ 301
 /analytics/analytics-integrations/google-cloud/ /analytics/analytics-integrations/ 301
-/analytics/dashboards/ /log-explorer/custom-dashboards/ 301
+/analytics/dashboards/ /log-explorer/dashboards/ 301
+/log-explorer/custom-dashboards/ /log-explorer/dashboards/ 301
 
 # email-security
 /email-security/reporting/search/detection-search/ /email-security/reporting/search/ 301

--- a/src/content/docs/fundamentals/reference/cloudflare-ray-id.mdx
+++ b/src/content/docs/fundamentals/reference/cloudflare-ray-id.mdx
@@ -32,7 +32,7 @@ Please note that Security Events may use sampled data to improve performance. If
 ### Log Explorer
 
 [Log Explorer](/log-explorer/) provides access to Cloudflare logs with all the context available within the Cloudflare platform. 
-You can monitor security and performance issues with custom dashboards or investigate and troubleshoot issues with log search.
+You can monitor security and performance issues with dashboards or investigate and troubleshoot issues with log search.
 Log explorer allows you to [build queries](/log-explorer/log-search/) for filtering specific Ray IDs.
 
 ### Logs

--- a/src/content/docs/log-explorer/dashboards.mdx
+++ b/src/content/docs/log-explorer/dashboards.mdx
@@ -1,11 +1,11 @@
 ---
 pcx_content_type: reference
-title: Custom dashboards
+title: Dashboards
 sidebar:
   order: 4
 ---
 
-Custom dashboards allow you to create tailored dashboards to monitor application security, performance, and usage. You can create monitors for ongoing monitoring of a previous incident, use them to identify indicators of suspicious activity, and access templates to help you get started.
+Dashboards allow you to create tailored views to monitor application security, performance, and usage. You can create monitors for ongoing monitoring of a previous incident, use them to identify indicators of suspicious activity, and access templates to help you get started.
 
 :::note
 Enterprise customers can create up to 100 dashboards.

--- a/src/content/docs/log-explorer/index.mdx
+++ b/src/content/docs/log-explorer/index.mdx
@@ -13,7 +13,7 @@ Store and explore your Cloudflare logs directly within the Cloudflare dashboard 
 
 Log Explorer is Cloudflare's native observability and forensics product that enables security teams and developers to analyze, investigate, and monitor issues directly from the Cloudflare dashboard, without the expense and complexity of forwarding logs to third-party tools.
 
-Log Explorer provides access to Cloudflare logs with all the context available within the Cloudflare platform. You can monitor security and performance issues with custom dashboards or investigate and troubleshoot issues with log search. Benefits include: 
+Log Explorer provides access to Cloudflare logs with all the context available within the Cloudflare platform. You can monitor security and performance issues with dashboards or investigate and troubleshoot issues with log search. Benefits include: 
 
 - **Reduced cost and complexity**: Drastically reduce the expense and operational overhead associated with forwarding, storing, and analyzing terabytes of log data in external tools.
 - **Faster detection and triage**: Access Cloudflare-native logs directly, eliminating cumbersome data pipelines and the ingest lags that delay critical security insights.
@@ -26,7 +26,7 @@ Log Explorer provides access to Cloudflare logs with all the context available w
 Explore your Cloudflare logs directly within the Cloudflare dashboard or [API](/log-explorer/api/).
 </Feature>
 
-<Feature header="Custom dashboards" href="/log-explorer/custom-dashboards/">
+<Feature header="Dashboards" href="/log-explorer/dashboards/">
 Design customized views for tracking application security, performance, and usage metrics.
 </Feature>
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/index.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/index.mdx
@@ -13,7 +13,7 @@ source: null
 ## Log Explorer
 
 [Log Explorer](/log-explorer/) provides access to Cloudflare logs with all the context available within the Cloudflare platform. 
-You can monitor security and performance issues with custom dashboards or investigate and troubleshoot issues with log search.
+You can monitor security and performance issues with dashboards or investigate and troubleshoot issues with log search.
 Log explorer [allows to build queries](/log-explorer/log-search/) filtering for specific Ray ID, which can be useful to investigate HTTP Errors.
 
 ## 400 Bad Request

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/index.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/index.mdx
@@ -43,7 +43,7 @@ To view Error Analytics:
 ### Log Explorer
 
 [Log Explorer](/log-explorer/) provides access to Cloudflare logs with all the context available within the Cloudflare platform. 
-You can monitor security and performance issues with custom dashboards or investigate and troubleshoot issues with log search.
+You can monitor security and performance issues with dashboards or investigate and troubleshoot issues with log search.
 Log explorer [allows to build queries](/log-explorer/log-search/) filtering for specific Ray ID, which can be useful to investigate HTTP Errors.
 
 ---


### PR DESCRIPTION
### Summary

Renames the "Custom dashboards" page to just "Dashboards" — users can still create custom dashboards, but the product surface now calls them dashboards, so the docs should match.

- Renamed `custom-dashboards.mdx` to `dashboards.mdx` and updated the page title and intro copy
- Added a 301 redirect from `/log-explorer/custom-dashboards/` to `/log-explorer/dashboards/`
- Updated the existing `/analytics/dashboards/` redirect to point directly at the new path (avoids a double-hop)
- Updated the Log Explorer landing page Feature card + intro copy
- Updated references to "custom dashboards" in support and fundamentals pages that mirror the Log Explorer landing copy

Pages with unrelated uses of the phrase "custom dashboards" (e.g. GraphQL-built dashboards in Cloudflare for SaaS, reference architecture) were intentionally left alone. The June 2025 GA changelog entry was also left as-is for historical accuracy.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).