### PR TITLE
[SSL] Add zero-downtime ACM certificate pack rotation reference page

### DIFF
--- a/src/content/docs/ssl/reference/certificate-rotation.mdx
+++ b/src/content/docs/ssl/reference/certificate-rotation.mdx
@@ -1,0 +1,131 @@
+---
+pcx_content_type: how-to
+title: Rotate ACM certificate packs
+sidebar:
+  order: 7
+description: Replace an Advanced Certificate Manager certificate pack with zero downtime by creating the new pack, waiting for it to go Active, then deleting the old one.
+---
+
+import { DashButton, TabItem, Tabs } from "~/components";
+
+Advanced Certificate Manager (ACM) certificate packs cannot be updated in place. To replace an existing pack - for example, to change the certificate authority, add hostnames, or change validation method - you create a new pack, wait for it to reach **Active** status, and then delete the old one.
+
+The key principle is to ensure the new certificate pack reaches **Active** before removing the old one. This avoids any gap in coverage and means there is no downtime for your users.
+
+---
+
+## Recommended rotation process
+
+### 1. Create the new certificate pack
+
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+1. In the Cloudflare dashboard, go to the **Edge Certificates** page.
+
+   <DashButton url="/?to=/:account/:zone/ssl-tls/edge-certificates" />
+
+2. Select **Order Advanced Certificate**.
+3. Configure the new certificate pack with the desired hostnames, certificate authority, and validation method.
+4. Select **Save**.
+
+</TabItem> <TabItem label="API">
+
+Use the [Order Certificate Pack](/api/resources/ssl/subresources/certificate_packs/methods/create/) endpoint to create the new pack.
+
+</TabItem> <TabItem label="Terraform">
+
+Add a new `cloudflare_certificate_pack` resource to your Terraform configuration and apply it. Refer to the [Terraform-specific notes](#terraform) below before proceeding.
+
+</TabItem> </Tabs>
+
+### 2. Wait for Active status
+
+After ordering, the new certificate pack moves through several intermediate states before it is ready to serve traffic:
+
+1. **Initializing**
+2. **Pending Validation**
+3. **Pending Issuance**
+4. **Pending Deployment**
+5. **Active**
+
+Do not delete the old certificate pack until the new one reaches **Active**. Refer to [Certificate statuses](/ssl/reference/certificate-statuses/) for a description of each stage.
+
+Monitor progress on the [**Edge Certificates**](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates) page in the dashboard, or poll the [Get Certificate Pack](/api/resources/ssl/subresources/certificate_packs/methods/get/) API endpoint.
+
+For zones using Cloudflare as authoritative DNS (full setup), most validations complete within minutes. For [partial (CNAME) setups](/dns/zone-setups/partial-setup/), you will need to place DCV tokens manually - refer to [DCV methods](/ssl/edge-certificates/changing-dcv-method/) for details. DCV tokens expire if not satisfied within their validity window (7 days for Let's Encrypt, 14 days for Google Trust Services and SSL.com).
+
+### 3. Delete the old certificate pack
+
+Once the new pack is **Active**, it is safe to delete the old one.
+
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+1. In the Cloudflare dashboard, go to the **Edge Certificates** page.
+
+   <DashButton url="/?to=/:account/:zone/ssl-tls/edge-certificates" />
+
+2. Select the old certificate pack.
+3. Select **Delete Certificate**.
+
+</TabItem> <TabItem label="API">
+
+Use the [Delete Certificate Pack](/api/resources/ssl/subresources/certificate_packs/methods/delete/) endpoint.
+
+</TabItem> <TabItem label="Terraform">
+
+Remove the old `cloudflare_certificate_pack` resource from your Terraform configuration and apply. Refer to the [Terraform-specific notes](#terraform) below.
+
+</TabItem> </Tabs>
+
+### 4. Expect a brief Pending Deployment state
+
+After the old pack is deleted, the remaining certificate may briefly show **Pending Deployment** before returning to **Active**. This reflects a normal edge re-evaluation cycle as the global network reconciles the change, and typically resolves within a few minutes with no traffic impact.
+
+If the certificate remains in **Pending Deployment** for longer than expected, refer to [Certificate statuses](/ssl/reference/certificate-statuses/) and contact [Cloudflare Support](/support/contacting-cloudflare-support/).
+
+---
+
+## Terraform
+
+Certificate packs cannot be updated in place - every attribute of the `cloudflare_certificate_pack` resource forces a new resource on change. Plan your rotation around this constraint.
+
+:::caution
+
+Importing existing certificate packs into Terraform state is supported but not recommended. If Cloudflare reissues the certificate (for example, on renewal), the resource ID changes and your Terraform state goes out of sync. The recommended pattern is to manage the full lifecycle through Terraform - create, wait for active, then delete - rather than importing existing packs.
+
+:::
+
+### Wait for Active automatically
+
+Set `wait_for_active_status = true` on the new resource to have Terraform block the apply until the certificate pack reaches **Active**. This removes the need to manually poll the dashboard or API between steps 1 and 3.
+
+### Recommended pattern
+
+1. Add the new `cloudflare_certificate_pack` resource with `wait_for_active_status = true` and run `terraform apply`. The apply will not complete until the pack is Active.
+2. Remove the old resource from your configuration and run `terraform apply` to delete it.
+
+For zero-downtime rotation of a single resource (where you cannot have both old and new in state simultaneously), use Terraform's [`create_before_destroy`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#create_before_destroy) lifecycle meta-argument.
+
+Refer to the [`cloudflare_certificate_pack` provider documentation](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/certificate_pack) for the full resource schema.
+
+---
+
+## Common rotation issues
+
+### Let's Encrypt rate limit
+
+Let's Encrypt limits new certificates to five per seven-day window for the same exact set of hostnames. Repeated rotations (for example, during testing or automation loops) can exhaust this limit and block further issuance for up to a week.
+
+If you hit this limit, switch the certificate authority to [Google Trust Services or SSL.com](/ssl/reference/certificate-authorities/) or wait for the rate limit window to expire. Refer to [Let's Encrypt rate limits](https://letsencrypt.org/docs/rate-limits/) for details.
+
+### Pack stuck in Pending Validation
+
+If a new pack remains in **Pending Validation** for more than 15 minutes, check that your DCV method is set up correctly. Refer to [Domain Control Validation](/ssl/edge-certificates/changing-dcv-method/) and [Troubleshoot domain control validation](/ssl/edge-certificates/changing-dcv-method/troubleshooting/).
+
+---
+
+## Distinction from custom certificate replacement
+
+This page covers **ACM certificate packs** (Cloudflare-managed Domain Validated certificates ordered via Advanced Certificate Manager).
+
+If you are using a **custom certificate** (a certificate you supplied), Cloudflare provides an in-place **Replace SSL certificate and key** flow that handles the rotation without requiring you to manage two packs. Refer to [Manage custom certificates](/ssl/edge-certificates/custom-certificates/uploading/#update-an-existing-custom-certificate).


### PR DESCRIPTION
### Summary

Adds a new reference page documenting the recommended zero-downtime process for rotating an Advanced Certificate Manager (ACM) certificate pack.

**Type:** New page (reference / how-to)
**Path:** `/ssl/reference/certificate-rotation/`
**File:** `src/content/docs/ssl/reference/certificate-rotation.mdx`

**Why:**
This is a recurring question in customer support. Customers ask how to safely replace an ACM certificate pack (for example, changing CA, adding hostnames, or rotating before expiry) without serving stale or missing certificates. The existing docs cover certificate statuses and the custom-certificate replacement flow, but there is no single page describing the rotate-before-delete pattern for ACM packs. Customers and TSEs end up reconstructing the process from multiple pages.

Example ticket: `02122157`

**What the page covers:**

- The four-step rotation process: create new pack → wait for **Active** → delete old pack → expect a brief **Pending Deployment** on the remaining cert
- Validation duration expectations for full vs partial DNS setups, and DCV token expiry windows per CA
- Terraform-specific guidance: the `wait_for_active_status` attribute, the `create_before_destroy` lifecycle pattern, and a caution against importing existing packs into Terraform state
- Common rotation issues: Let's Encrypt rate limits (5 certs / 7 days for the same hostname set) and what to check if a pack is stuck in **Pending Validation**
- A clear distinction from the custom certificate replacement flow, with a link to that page

**Conventions followed:**

- `pcx_content_type: how-to` matching adjacent procedural pages
- `sidebar.order: 7` to slot between `certificate-authorities` (5) and the cluster of pages at order 8
- `<Tabs syncKey="dashPlusAPI">` pattern for Dashboard / API / Terraform variants
- `<DashButton />` for dashboard links, `:::caution` and `:::note` admonitions for guidance, matching the style of `manage-certificates.mdx` and `uploading.mdx`
- Auto-picked up by the existing `<DirectoryListing />` in `reference/index.mdx` — no nav changes needed

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? — Not added. This is a reference page documenting existing product behaviour rather than a new feature or change. Happy to add a changelog entry if reviewers feel it belongs there.
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes. — Not opened, going straight to PR per the Prevent It process (content owner is clear, content scope is well-defined). Happy to open an issue retroactively if preferred.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file). — N/A, new file.