### PR TITLE
[API] Deprecate legacy Workers KV /workers/namespaces/* routes

### DIFF
--- a/src/content/changelog/kv/2026-07-15-kv-legacy-namespace-routes-deprecation.mdx
+++ b/src/content/changelog/kv/2026-07-15-kv-legacy-namespace-routes-deprecation.mdx
@@ -1,0 +1,23 @@
+---
+title: Deprecate legacy Workers KV namespace API routes
+description: The legacy Workers KV API routes under /accounts/{account_id}/workers/namespaces/* are deprecated. Migrate to /accounts/{account_id}/storage/kv/namespaces/* before October 15, 2026.
+products:
+  - kv
+date: 2026-07-15
+---
+
+The legacy Workers KV API routes under `/accounts/{account_id}/workers/namespaces/*` are deprecated as of July 15, 2026, and will stop working on October 15, 2026. Migrate to the documented [Workers KV API](/api/resources/kv/) routes under `/accounts/{account_id}/storage/kv/namespaces/*` before that date.
+
+The legacy and replacement routes are interchangeable. They accept the same request parameters and return the same response payloads. To migrate, update the URL path from `/workers/namespaces/` to `/storage/kv/namespaces/`.
+
+## What you need to do
+
+Update any integration that calls a route under `/accounts/{account_id}/workers/namespaces/` to use the equivalent route under `/accounts/{account_id}/storage/kv/namespaces/`. The migration is a direct URL path substitution — request parameters and response payloads are identical:
+
+- `GET` and `POST /accounts/{account_id}/workers/namespaces` → `GET` and `POST /accounts/{account_id}/storage/kv/namespaces`
+- `GET`, `PUT`, and `DELETE /accounts/{account_id}/workers/namespaces/{namespace_id}` → `GET`, `PUT`, and `DELETE /accounts/{account_id}/storage/kv/namespaces/{namespace_id}`
+- `GET /accounts/{account_id}/workers/namespaces/{namespace_id}/keys` → `GET /accounts/{account_id}/storage/kv/namespaces/{namespace_id}/keys`
+- `GET /accounts/{account_id}/workers/namespaces/{namespace_id}/metadata/{key_name}` → `GET /accounts/{account_id}/storage/kv/namespaces/{namespace_id}/metadata/{key_name}`
+- `GET`, `PUT`, and `DELETE /accounts/{account_id}/workers/namespaces/{namespace_id}/values/{key_name}` → `GET`, `PUT`, and `DELETE /accounts/{account_id}/storage/kv/namespaces/{namespace_id}/values/{key_name}`
+
+For more information about the deprecation timeline, refer to [API deprecations](/fundamentals/api/reference/deprecations/).

--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -3,6 +3,37 @@ link: "/fundamentals/api/reference/deprecations/"
 productName: API deprecations
 productLink: "/fundamentals/"
 entries:
+  - publish_date: "2026-07-15"
+    title: "Workers KV: Legacy Namespace Routes"
+    description: |-
+      Deprecation date: July 15, 2026
+
+      End of life date: October 15, 2026
+
+      The legacy Workers KV API routes under `/accounts/{account_id}/workers/namespaces/*` are deprecated in favor of the [Workers KV API](/api/resources/kv/) routes under `/accounts/{account_id}/storage/kv/namespaces/*`.
+
+      The legacy and replacement routes are interchangeable. They accept the same request parameters and return the same response payloads. To migrate, update the URL path from `/workers/namespaces/` to `/storage/kv/namespaces/`.
+
+      Deprecated APIs:
+
+      - `GET` and `POST /accounts/{account_id}/workers/namespaces` (list and create namespaces)
+      - `GET`, `PUT`, and `DELETE /accounts/{account_id}/workers/namespaces/{namespace_id}` (get, rename, and remove a namespace)
+      - `GET /accounts/{account_id}/workers/namespaces/{namespace_id}/keys` (list keys)
+      - `GET /accounts/{account_id}/workers/namespaces/{namespace_id}/metadata/{key_name}` (read key metadata)
+      - `GET`, `PUT`, and `DELETE /accounts/{account_id}/workers/namespaces/{namespace_id}/values/{key_name}` (read, write, and delete key-value pairs)
+
+      Replacements:
+
+      Update the URL path from `/workers/namespaces/` to `/storage/kv/namespaces/` in each endpoint.
+
+      - `GET` and `POST /accounts/{account_id}/storage/kv/namespaces` (list and create namespaces)
+      - `GET`, `PUT`, and `DELETE /accounts/{account_id}/storage/kv/namespaces/{namespace_id}` (get, rename, and remove a namespace)
+      - `GET /accounts/{account_id}/storage/kv/namespaces/{namespace_id}/keys` (list keys)
+      - `GET /accounts/{account_id}/storage/kv/namespaces/{namespace_id}/metadata/{key_name}` (read key metadata)
+      - `GET`, `PUT`, and `DELETE /accounts/{account_id}/storage/kv/namespaces/{namespace_id}/values/{key_name}` (read, write, and delete key-value pairs)
+
+      After October 15, 2026, requests to the legacy `/accounts/{account_id}/workers/namespaces/*` routes will no longer be supported. Update integrations to use the documented Workers KV API endpoints before that date to ensure uninterrupted service.
+
   - publish_date: "2026-06-29"
     title: "Legacy Registrar Domain Management API"
     description: |-


### PR DESCRIPTION
### Summary

Deprecate the legacy `/accounts/{account_id}/workers/namespaces/*` routes in favor of the documented /accounts/{account_id}/storage/kv/namespaces/* routes. The two route sets are interchangeable; migration only requires updating the URL path.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
