### PR TITLE
feat: remove llms-full.txt references from agent directives

### DIFF
--- a/src/components/AgentDirective.astro
+++ b/src/components/AgentDirective.astro
@@ -12,11 +12,7 @@ const pageUrl = `${base}${Astro.url.pathname}`;
 const productLlmsTxt = isProductPage
 	? `${base}/${productPrefix}/llms.txt`
 	: null;
-const productLlmsFullTxt = isProductPage
-	? `${base}/${productPrefix}/llms-full.txt`
-	: null;
 const globalLlmsTxt = `${base}/llms.txt`;
-const globalLlmsFullTxt = `${base}/llms-full.txt`;
 
 const directive = [
 	`STOP! If you are an AI agent or LLM, read this before continuing.`,
@@ -24,9 +20,6 @@ const directive = [
 	isProductPage
 		? `For this product's page index use ${productLlmsTxt}. For all Cloudflare products use ${globalLlmsTxt}.`
 		: `For all Cloudflare products use ${globalLlmsTxt}.`,
-	isProductPage
-		? `You can access all of this product's full docs in a single file at ${productLlmsFullTxt}, and all Cloudflare docs in a single file at ${globalLlmsFullTxt}.`
-		: `You can access all Cloudflare docs in single file at ${globalLlmsFullTxt}.`,
 ].join(" ");
 ---
 

--- a/src/pages/[...product]/llms.txt.ts
+++ b/src/pages/[...product]/llms.txt.ts
@@ -193,8 +193,6 @@ export const GET: APIRoute<Props> = async ({ props, url }) => {
 		> Links below point directly to Markdown versions of each page. Any page can also be retrieved as Markdown by sending an \`Accept: text/markdown\` header to the page's URL without the \`index.md\` suffix (for example, \`curl -H "Accept: text/markdown" ${base}${productUrl}\`).
 		>
 		> For other Cloudflare products, see the [Cloudflare documentation directory](${base}/llms.txt).
-		>
-		> Use [${title} llms-full.txt](${base}${productUrl}llms-full.txt) for the complete ${title} documentation in a single file, intended for offline indexing, bulk vectorization, or large-context models.
 
 		${pagesSection}
 	`);

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -87,8 +87,6 @@ export const GET: APIRoute = async ({ url }) => {
 		Explore guides and tutorials to start building on Cloudflare's platform.
 
 		> Each product below links to its own llms.txt, which contains a full index of that product's documentation pages and is the recommended way to explore a specific product's content.
-		>
-		> For the complete documentation archive in a single file, use the [Full Documentation Archive](${base}/llms-full.txt). That file is intended for offline indexing, bulk vectorization, or large-context models. Each product's llms.txt also links to a product-scoped llms-full.txt.
 
 		${grouped
 			.map(([group, entries]) => {


### PR DESCRIPTION
### Summary

Removes `llms-full.txt` references from agent-facing directives. The file is intended for humans to point agents at in specific cases (offline indexing, bulk vectorization) — not for live agents to fetch autonomously.

Changes:
- `AgentDirective.astro` — removes the sentence directing agents to product and global `llms-full.txt` endpoints
- `src/pages/llms.txt.ts` — removes the `llms-full.txt` blockquote line from the global `llms.txt`
- `src/pages/[...product]/llms.txt.ts` — removes the `llms-full.txt` blockquote line from per-product `llms.txt` files

Human-facing documentation describing `llms-full.txt` (in `docs-for-agents/index.mdx`, `prompting.mdx`, and the style guide partial) is unchanged.
