### PR TITLE
[Agents] Sync SDK reference docs

### DIFF
--- a/src/content/docs/agents/api-reference/agent-tools.mdx
+++ b/src/content/docs/agents/api-reference/agent-tools.mdx
@@ -14,6 +14,12 @@ Agent tools let one chat agent dispatch another chat-capable sub-agent as part o
 
 Agent tools support `@cloudflare/think` agents and `AIChatAgent` subclasses. `AIChatAgent` children run headlessly through `saveMessages()`, so they should use server-side tools. Browser-provided client tools are not available during an agent-tool turn unless you model that interaction as server-side state or a separate parent-mediated workflow.
 
+## Agent tools vs sub-agent RPC
+
+Use `subAgent(...).chat()` when parent code needs direct streaming RPC to a specific child and your code owns forwarding, cancellation, and replay policy.
+
+Use `agentTool()` or `runAgentTool()` when a parent model or workflow delegates work to a child agent and you want retained child runs, event replay, abort bridging, and UI drill-in. For Think-specific turn choices, refer to [Choose a turn API](/agents/api-reference/think/#choose-a-turn-api).
+
 ## Use an agent as an AI SDK tool
 
 Use `agentTool()` when the parent model should decide when to call the helper.
@@ -98,6 +104,29 @@ export class Assistant extends AIChatAgent<Env> {
 </TypeScriptExample>
 
 The generated tool calls `this.runAgentTool(ChildAgent, ...)`, streams `agent-tool-event` frames on the parent WebSocket, and returns the child summary to the parent model. If the run fails, aborts, or is interrupted, the tool returns a structured failure instead of an empty success value.
+
+For Think children that do workflow-style work without user-facing assistant text, override `getAgentToolOutput()` and, if needed, `getAgentToolSummary()`. Assistant text remains the default summary when present, but a Think agent-tool run can complete successfully without emitting text chunks.
+
+Persist any structured output before the child turn finishes, because `getAgentToolOutput()` is read as soon as `saveMessages()` resolves. Keep `getAgentToolSummary()` concise for display; the full structured value is stored separately as the tool output.
+
+<TypeScriptExample>
+
+```ts
+export class Extractor extends Think<Env> {
+	protected override getAgentToolOutput(runId: string) {
+		const rows = this.sql<{ result_json: string }>`
+			SELECT result_json FROM extraction_runs WHERE id = ${runId}
+		`;
+		return rows[0] ? JSON.parse(rows[0].result_json) : undefined;
+	}
+
+	protected override getAgentToolSummary(_runId: string, output: unknown) {
+		return output ? "Extraction complete" : "";
+	}
+}
+```
+
+</TypeScriptExample>
 
 ## Run an agent tool imperatively
 

--- a/src/content/docs/agents/api-reference/chat-agents.mdx
+++ b/src/content/docs/agents/api-reference/chat-agents.mdx
@@ -759,6 +759,7 @@ function Chat() {
 | `tools`                       | `Record<string, AITool>`                      | —        | Advanced: dynamically register client-executed tools from the browser                                                    |
 | `autoContinueAfterToolResult` | `boolean`                                     | `true`   | Auto-continue conversation after client tool results and approvals                                                       |
 | `resume`                      | `boolean`                                     | `true`   | Enable automatic stream resumption on reconnect                                                                          |
+| `cancelOnClientAbort`         | `boolean`                                     | `false`  | Cancel the server turn when generic client stream abort or cleanup occurs                                                |
 | `body`                        | `object \| () => object`                      | —        | Custom data sent with every request                                                                                      |
 | `prepareSendMessagesRequest`  | `(options) => { body?, headers? }`            | —        | Advanced per-request customization                                                                                       |
 | `getInitialMessages`          | `(options) => Promise<UIMessage[]>` or `null` | —        | Custom initial message loader. Set to `null` to skip the HTTP fetch entirely (useful when providing `messages` directly) |
@@ -1180,6 +1181,20 @@ When streaming is active:
 1. All chunks are buffered in SQLite as they are generated
 2. If the client disconnects, the server continues streaming and buffering
 3. When the client reconnects, it receives all buffered chunks and resumes live streaming
+
+Generic client stream abort or cleanup stays local to the browser by default, so the server turn keeps running and can be resumed later. Calling `stop()` explicitly still cancels the server turn:
+
+<TypeScriptExample>
+
+```tsx
+const { messages, stop } = useAgentChat({ agent });
+
+return <button onClick={stop}>Stop</button>;
+```
+
+</TypeScriptExample>
+
+Set `cancelOnClientAbort: true` when your app intentionally wants the browser lifecycle to own the server lifecycle, such as request-lifetime or token-saving flows. Explicit `stop()` always cancels server work regardless of this option.
 
 Disable with `resume: false`:
 

--- a/src/content/docs/agents/api-reference/client-sdk.mdx
+++ b/src/content/docs/agents/api-reference/client-sdk.mdx
@@ -614,6 +614,23 @@ client.addEventListener("message", () => {});
 
 </TypeScriptExample>
 
+## Agent-tool events
+
+If your chat UI renders retained child runs from [Agent tools](/agents/api-reference/agent-tools/), use `useAgentToolEvents()` alongside `useAgent()` and `useAgentChat()`. The hook subscribes to the parent connection, replays retained child timelines, and groups runs by parent tool call ID.
+
+<TypeScriptExample>
+
+```tsx
+import { useAgent, useAgentToolEvents } from "agents/react";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
+
+const agent = useAgent({ agent: "Assistant", name: userId });
+const { messages } = useAgentChat({ agent });
+const agentTools = useAgentToolEvents({ agent });
+```
+
+</TypeScriptExample>
+
 ## Next steps
 
 <LinkCard

--- a/src/content/docs/agents/api-reference/codemode.mdx
+++ b/src/content/docs/agents/api-reference/codemode.mdx
@@ -238,6 +238,75 @@ const codemode = createCodeTool({
 
 Tool names with hyphens or dots (common in MCP) are automatically sanitized to valid JavaScript identifiers (for example, `my-server.list-items` becomes `my_server_list_items`).
 
+### Browser executor with dynamic client tools
+
+If your tools live in the browser instead of the Agent, build codemode from those browser-side functions and register it with your client tool layer. This keeps the server generic while running generated code in an iframe sandbox on the page.
+
+**Server:**
+
+<TypeScriptExample>
+
+```ts
+import { AIChatAgent, createToolsFromClientSchemas } from "@cloudflare/ai-chat";
+import { convertToModelMessages, stepCountIs, streamText } from "ai";
+
+export class BrowserCodemodeAgent extends AIChatAgent<Env> {
+	async onChatMessage(_onFinish, options) {
+		const result = streamText({
+			model: this.env.MODEL,
+			messages: await convertToModelMessages(this.messages),
+			tools: createToolsFromClientSchemas(options?.clientTools),
+			stopWhen: stepCountIs(10),
+		});
+
+		return result.toUIMessageStreamResponse();
+	}
+}
+```
+
+</TypeScriptExample>
+
+**Client:**
+
+<TypeScriptExample>
+
+```tsx
+import { useAgent } from "agents/react";
+import { useAgentChat, type AITool } from "@cloudflare/ai-chat/react";
+import {
+	IframeSandboxExecutor,
+	createBrowserCodeTool,
+} from "@cloudflare/codemode/browser";
+
+const codemode = createBrowserCodeTool({
+	tools: {
+		getPageTitle: {
+			description: "Get the current page title",
+			inputSchema: { type: "object", properties: {}, required: [] },
+			execute: async () => ({ title: document.title }),
+		},
+	},
+	executor: new IframeSandboxExecutor(),
+});
+
+const agent = useAgent({ agent: "BrowserCodemodeAgent" });
+const tools: Record<string, AITool> = {
+	codemode: {
+		description: codemode.description,
+		parameters: codemode.inputSchema,
+		execute: codemode.execute,
+	},
+};
+
+const { messages, sendMessage } = useAgentChat({ agent, tools });
+```
+
+</TypeScriptExample>
+
+This pattern is useful when the browser owns the tool surface at runtime, the page exposes client-side capabilities that only the browser can run, or you want codemode's typed code-generation prompt without routing tool execution through the server.
+
+If you need approval-gated tools, use the standard `needsApproval` and `useAgentChat` approval flow described in [Human in the Loop](/agents/concepts/human-in-the-loop/). Codemode excludes tools with `needsApproval` instead of pausing execution for approval.
+
 ## MCP server wrappers
 
 The `@cloudflare/codemode/mcp` export provides two functions that wrap MCP servers with Code Mode.
@@ -323,14 +392,23 @@ Returns an AI SDK compatible `Tool`.
 
 Executes code in an isolated Cloudflare Worker via `WorkerLoader`.
 
-| Option           | Type                       | Default  | Description                                                                        |
-| ---------------- | -------------------------- | -------- | ---------------------------------------------------------------------------------- |
-| `loader`         | `WorkerLoader`             | required | Worker Loader binding from `env.LOADER`                                            |
-| `timeout`        | `number`                   | `30000`  | Execution timeout in ms                                                            |
-| `globalOutbound` | `Fetcher \| null`          | `null`   | Network access control. `null` = blocked, `Fetcher` = routed                       |
-| `modules`        | `Record<string, string>`   | —        | Custom ES modules available in the sandbox. Keys are specifiers, values are source. |
+| Option           | Type                     | Default  | Description                                                                         |
+| ---------------- | ------------------------ | -------- | ----------------------------------------------------------------------------------- |
+| `loader`         | `WorkerLoader`           | required | Worker Loader binding from `env.LOADER`                                             |
+| `timeout`        | `number`                 | `30000`  | Execution timeout in ms                                                             |
+| `globalOutbound` | `Fetcher \| null`        | `null`   | Network access control. `null` = blocked, `Fetcher` = routed                        |
+| `modules`        | `Record<string, string>` | —        | Custom ES modules available in the sandbox. Keys are specifiers, values are source. |
 
 Code and tool names are normalized and sanitized internally — you do not need to call `normalizeCode()` or `sanitizeToolName()` before passing them to `execute()`.
+
+### `IframeSandboxExecutor`
+
+Executes code in a sandboxed browser iframe. Import it from `@cloudflare/codemode/browser`.
+
+| Option    | Type     | Default                                                         | Description                                                              |
+| --------- | -------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `timeout` | `number` | `30000`                                                         | Execution timeout in ms. Cannot preempt tight synchronous browser loops. |
+| `csp`     | `string` | `default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval';` | Content Security Policy applied to the sandbox iframe document.          |
 
 ### `generateTypes(tools)`
 
@@ -386,10 +464,11 @@ sanitizeToolName("delete"); // "delete_"
 - Tool calls are dispatched via Workers RPC, not network requests.
 - Execution has a configurable **timeout** (default 30 seconds).
 - Console output is captured separately and does not leak to the host.
+- Browser iframe execution runs in a sandboxed iframe with a restrictive CSP by default. It uses nonce-scoped internal messages, but its timeout cannot preempt tight synchronous loops like `while (true) {}` because those block the browser event loop.
 
 ## Current limitations
 
-- **Tool approval (`needsApproval`) is not supported yet.** Tools with `needsApproval: true` execute immediately inside the sandbox without pausing for approval. Support for approval flows within codemode is planned. For now, do not pass approval-required tools to `createCodeTool` — use them through standard AI SDK tool calling instead.
+- **Tool approval (`needsApproval`) is not supported yet.** Codemode excludes approval-required tools instead of pausing execution for approval. Use those tools through standard AI SDK tool calling instead.
 - Requires Cloudflare Workers environment for `DynamicWorkerExecutor`.
 - Limited to JavaScript execution.
 - LLM code quality depends on prompt engineering and model capability.

--- a/src/content/docs/agents/api-reference/observability.mdx
+++ b/src/content/docs/agents/api-reference/observability.mdx
@@ -32,16 +32,16 @@ Every event has these fields:
 
 Events are routed to eight named channels based on their type:
 
-| Channel            | Event types                                                                                                                                                      | Description                         |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `agents:state`     | `state:update`                                                                                                                                                   | State sync events                   |
-| `agents:rpc`       | `rpc`, `rpc:error`                                                                                                                                               | RPC method calls and failures       |
-| `agents:message`   | `message:request`, `message:response`, `message:clear`, `message:cancel`, `message:error`, `tool:result`, `tool:approval`                                        | Chat message and tool lifecycle     |
-| `agents:schedule`  | `schedule:create`, `schedule:execute`, `schedule:cancel`, `schedule:retry`, `schedule:error`, `queue:create`, `queue:retry`, `queue:error`                       | Scheduled and queued task lifecycle |
-| `agents:lifecycle` | `connect`, `disconnect`, `destroy`                                                                                                                               | Agent connection and teardown       |
-| `agents:workflow`  | `workflow:start`, `workflow:event`, `workflow:approved`, `workflow:rejected`, `workflow:terminated`, `workflow:paused`, `workflow:resumed`, `workflow:restarted` | Workflow state transitions          |
-| `agents:mcp`       | `mcp:client:preconnect`, `mcp:client:connect`, `mcp:client:authorize`, `mcp:client:discover`                                                                     | MCP client operations               |
-| `agents:email`     | `email:receive`, `email:reply`                                                                                                                                   | Email processing                    |
+| Channel            | Event types                                                                                                                                                                             | Description                                        |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `agents:state`     | `state:update`                                                                                                                                                                          | State sync events                                  |
+| `agents:rpc`       | `rpc`, `rpc:error`                                                                                                                                                                      | RPC method calls and failures                      |
+| `agents:message`   | `message:request`, `message:response`, `message:clear`, `message:cancel`, `message:error`, `tool:result`, `tool:approval`, `submission:create`, `submission:status`, `submission:error` | Chat message, tool, and Think submission lifecycle |
+| `agents:schedule`  | `schedule:create`, `schedule:execute`, `schedule:cancel`, `schedule:retry`, `schedule:error`, `schedule:duplicate_warning`, `queue:create`, `queue:retry`, `queue:error`                | Scheduled and queued task lifecycle                |
+| `agents:lifecycle` | `connect`, `disconnect`, `destroy`                                                                                                                                                      | Agent connection and teardown                      |
+| `agents:workflow`  | `workflow:start`, `workflow:event`, `workflow:approved`, `workflow:rejected`, `workflow:terminated`, `workflow:paused`, `workflow:resumed`, `workflow:restarted`                        | Workflow state transitions                         |
+| `agents:mcp`       | `mcp:client:preconnect`, `mcp:client:connect`, `mcp:client:authorize`, `mcp:client:discover`                                                                                            | MCP client operations                              |
+| `agents:email`     | `email:receive`, `email:reply`, `email:send`                                                                                                                                            | Email processing                                   |
 
 ## Subscribing to events
 
@@ -168,32 +168,36 @@ class MyAgent extends Agent {
 | -------------- | ------- | ---------------------- |
 | `state:update` | `{}`    | `setState()` is called |
 
-### Message and tool events (AIChatAgent)
+### Message, tool, and submission events
 
-These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track the chat message lifecycle, including client-side tool interactions.
+These events track chat message lifecycle, client-side tool interactions, and Think durable submissions.
 
-| Type               | Payload                    | When                                |
-| ------------------ | -------------------------- | ----------------------------------- |
-| `message:request`  | `{}`                       | A chat message is received          |
-| `message:response` | `{}`                       | A chat response stream completes    |
-| `message:clear`    | `{}`                       | Chat history is cleared             |
-| `message:cancel`   | `{ requestId }`            | A streaming request is cancelled    |
-| `message:error`    | `{ error }`                | A chat stream fails                 |
-| `tool:result`      | `{ toolCallId, toolName }` | A client tool result is received    |
-| `tool:approval`    | `{ toolCallId, approved }` | A tool call is approved or rejected |
+| Type                | Payload                    | When                                |
+| ------------------- | -------------------------- | ----------------------------------- |
+| `message:request`   | `{}`                       | A chat message is received          |
+| `message:response`  | `{}`                       | A chat response stream completes    |
+| `message:clear`     | `{}`                       | Chat history is cleared             |
+| `message:cancel`    | `{ requestId }`            | A streaming request is cancelled    |
+| `message:error`     | `{ error }`                | A chat stream fails                 |
+| `tool:result`       | `{ toolCallId, toolName }` | A client tool result is received    |
+| `tool:approval`     | `{ toolCallId, approved }` | A tool call is approved or rejected |
+| `submission:create` | `{ submissionId }`         | A Think submission is accepted      |
+| `submission:status` | `{ submissionId, status }` | A Think submission status changes   |
+| `submission:error`  | `{ submissionId, error }`  | A Think submission fails            |
 
 ### Schedule and queue events
 
-| Type               | Payload                                  | When                                         |
-| ------------------ | ---------------------------------------- | -------------------------------------------- |
-| `schedule:create`  | `{ callback, id }`                       | A schedule is created                        |
-| `schedule:execute` | `{ callback, id }`                       | A scheduled callback starts                  |
-| `schedule:cancel`  | `{ callback, id }`                       | A schedule is cancelled                      |
-| `schedule:retry`   | `{ callback, id, attempt, maxAttempts }` | A scheduled callback is retried              |
-| `schedule:error`   | `{ callback, id, error, attempts }`      | A scheduled callback fails after all retries |
-| `queue:create`     | `{ callback, id }`                       | A task is enqueued                           |
-| `queue:retry`      | `{ callback, id, attempt, maxAttempts }` | A queued callback is retried                 |
-| `queue:error`      | `{ callback, id, error, attempts }`      | A queued callback fails after all retries    |
+| Type                         | Payload                                  | When                                         |
+| ---------------------------- | ---------------------------------------- | -------------------------------------------- |
+| `schedule:create`            | `{ callback, id }`                       | A schedule is created                        |
+| `schedule:execute`           | `{ callback, id }`                       | A scheduled callback starts                  |
+| `schedule:cancel`            | `{ callback, id }`                       | A schedule is cancelled                      |
+| `schedule:retry`             | `{ callback, id, attempt, maxAttempts }` | A scheduled callback is retried              |
+| `schedule:error`             | `{ callback, id, error, attempts }`      | A scheduled callback fails after all retries |
+| `schedule:duplicate_warning` | `{ callback }`                           | A non-idempotent schedule may duplicate work |
+| `queue:create`               | `{ callback, id }`                       | A task is enqueued                           |
+| `queue:retry`                | `{ callback, id, attempt, maxAttempts }` | A queued callback is retried                 |
+| `queue:error`                | `{ callback, id, error, attempts }`      | A queued callback fails after all retries    |
 
 ### Lifecycle events
 
@@ -231,6 +235,7 @@ These events are emitted by `AIChatAgent` from `@cloudflare/ai-chat`. They track
 | --------------- | ------------------------ | --------------------- |
 | `email:receive` | `{ from, to, subject? }` | An email is received  |
 | `email:reply`   | `{ from, to, subject? }` | A reply email is sent |
+| `email:send`    | `{ from, to, subject? }` | An email is sent      |
 
 ## Next steps
 

--- a/src/content/docs/agents/api-reference/routing.mdx
+++ b/src/content/docs/agents/api-reference/routing.mdx
@@ -475,6 +475,24 @@ For agent-specific initialization, use `getAgentByName` instead where you contro
 For `McpAgent`, props are automatically stored and accessible via `this.props`. Refer to [MCP servers](/agents/api-reference/mcp-agent-api/) for details.
 :::
 
+### Routing retry
+
+Use `routingRetry` with `getAgentByName()` when server-side code should retry transient Durable Object routing failures:
+
+<TypeScriptExample>
+
+```ts
+const agent = await getAgentByName(env.MyAgent, "instance-name", {
+	routingRetry: {
+		maxAttempts: 3,
+	},
+});
+```
+
+</TypeScriptExample>
+
+This option is useful for request forwarding and RPC paths where a short-lived routing failure should be retried before returning an error to the caller.
+
 ### Hooks
 
 `routeAgentRequest` supports hooks for intercepting requests before they reach agents:
@@ -803,13 +821,14 @@ Routes a request to the appropriate agent.
 
 Get an agent instance by name for server-side RPC or request forwarding.
 
-| Parameter              | Type                        | Description                           |
-| ---------------------- | --------------------------- | ------------------------------------- |
-| `namespace`            | `DurableObjectNamespace<T>` | Agent binding from env                |
-| `name`                 | `string`                    | Instance name                         |
-| `options.locationHint` | `string`                    | Preferred location                    |
-| `options.jurisdiction` | `string`                    | Data jurisdiction                     |
-| `options.props`        | `Record<string, unknown>`   | Initialization properties for onStart |
+| Parameter              | Type                        | Description                                                       |
+| ---------------------- | --------------------------- | ----------------------------------------------------------------- |
+| `namespace`            | `DurableObjectNamespace<T>` | Agent binding from env                                            |
+| `name`                 | `string`                    | Instance name                                                     |
+| `options.locationHint` | `string`                    | Preferred location                                                |
+| `options.jurisdiction` | `string`                    | Data jurisdiction                                                 |
+| `options.props`        | `Record<string, unknown>`   | Initialization properties for onStart                             |
+| `options.routingRetry` | `object`                    | Retry configuration for transient Durable Object routing failures |
 
 **Returns:** `Promise<DurableObjectStub<T>>` - Typed stub for calling agent methods or forwarding requests.
 

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -140,7 +140,7 @@ Both Think and [`AIChatAgent`](/agents/api-reference/chat-agents/) extend `Agent
 | **Regeneration**       | Destructive (old response deleted)                               | Non-destructive branching (old responses preserved)                 |
 | **Context management** | Manual                                                           | Context blocks with LLM-writable persistent memory                  |
 | **Sub-agent RPC**      | Not built in                                                     | `chat()` with `StreamCallback`                                      |
-| **Programmatic turns** | `saveMessages()`                                                 | `saveMessages()` + `continueLastTurn()`                             |
+| **Programmatic turns** | `saveMessages()`                                                 | `saveMessages()`, `submitMessages()`, `continueLastTurn()`          |
 | **Compaction**         | `maxPersistedMessages` (deletes oldest)                          | Non-destructive summaries via overlays                              |
 | **Search**             | Not available                                                    | FTS5 full-text search per-session and cross-session                 |
 
@@ -158,6 +158,25 @@ Both Think and [`AIChatAgent`](/agents/api-reference/chat-agents/) extend `Agent
 - You need conversation search (FTS5)
 - You are building a sub-agent system (parent-child RPC with streaming)
 - You need proactive agents (programmatic turns from scheduled tasks or webhooks)
+- You need durable async submission for webhook or RPC callers
+
+## Choose a turn API
+
+Think has several ways to start or continue a turn. Choose based on who starts the work and what the caller needs back.
+
+| Use case                                                   | API                                             |
+| ---------------------------------------------------------- | ----------------------------------------------- |
+| A browser user sends chat messages                         | `useAgentChat` over the WebSocket chat protocol |
+| Server code can wait for the model response                | `saveMessages()`                                |
+| Server code needs fast durable acceptance and later status | `submitMessages()`                              |
+| Parent code needs direct streaming RPC to a child          | `subAgent(...).chat()`                          |
+| A parent delegates work to a retained child agent          | `agentTool()` or `runAgentTool()`               |
+| Add context without starting a model turn                  | `persistMessages()`                             |
+| Continue after the latest assistant message                | `continueLastTurn()`                            |
+
+Use `saveMessages()` when the caller owns the trigger and can wait for the turn to finish. Use [`submitMessages()`](#submitmessages) when timeout ambiguity would make retries unsafe.
+
+Use `chat()` for low-level parent-to-child streaming when your code owns forwarding, cancellation, and replay policy. Use [Agent tools](/agents/api-reference/agent-tools/) when a parent model or workflow delegates to a child agent and you want retained child runs, event replay, abort bridging, and UI drill-in.
 
 ## Configuration overrides
 
@@ -266,11 +285,12 @@ On every turn, Think merges tools from multiple sources. Later sources override 
 
 1. **Workspace tools** — `read`, `write`, `edit`, `list`, `find`, `grep`, `delete` (built-in)
 2. **`getTools()`** — your custom server-side tools
-3. **Extension tools** — tools from loaded extensions (prefixed by extension name)
-4. **Session tools** — `set_context`, `load_context`, `search_context` (from `configureSession`)
+3. **Session tools** — `set_context`, `load_context`, `search_context` (from `configureSession`)
+4. **Extension tools** — tools from loaded extensions (prefixed by extension name)
 5. **MCP tools** — from connected MCP servers
 6. **Client tools** — from the browser (refer to [Client tools](#client-tools))
-7. **Caller tools** — from `chat()` options when used as a sub-agent
+
+Tools belong to the agent running the turn. For parent-child orchestration, use [Agent tools](/agents/api-reference/agent-tools/) instead of passing one-off tools through `chat()`.
 
 ### Built-in workspace tools
 
@@ -278,7 +298,7 @@ Every Think agent gets `this.workspace` — a virtual filesystem backed by Durab
 
 | Tool     | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
-| `read`   | Read a file's content                                                       |
+| `read`   | Read text with line numbers; pass images and PDFs to multimodal models      |
 | `write`  | Write content to a file (creates parent directories)                        |
 | `edit`   | Apply a find-and-replace edit to an existing file (supports fuzzy matching) |
 | `list`   | List files and directories in a path                                        |
@@ -724,7 +744,7 @@ const readTool = createReadTool({ ops: myReadOps });
 
 ## Lifecycle hooks
 
-Think owns the `streamText` call and provides hooks at each stage of the chat turn. Hooks fire on every turn regardless of entry path — WebSocket chat, sub-agent `chat()`, `saveMessages`, and auto-continuation after tool results.
+Think owns the `streamText` call and provides hooks at each stage of the chat turn. Hooks fire on every turn regardless of entry path — WebSocket chat, sub-agent `chat()`, `saveMessages()`, durable `submitMessages()` execution, `continueLastTurn()`, and auto-continuation after tool results.
 
 ### Hook summary
 
@@ -782,14 +802,14 @@ beforeTurn(ctx: TurnContext): TurnConfig | void | Promise<TurnConfig | void>
 
 #### TurnContext
 
-| Field          | Type                      | Description                                                                           |
-| -------------- | ------------------------- | ------------------------------------------------------------------------------------- |
-| `system`       | `string`                  | Assembled system prompt (from context blocks or `getSystemPrompt()`)                  |
-| `messages`     | `ModelMessage[]`          | Assembled model messages (truncated, pruned)                                          |
-| `tools`        | `ToolSet`                 | Merged tool set (workspace + getTools + extensions + session + MCP + client + caller) |
-| `model`        | `LanguageModel`           | The model from `getModel()`                                                           |
-| `continuation` | `boolean`                 | Whether this is a continuation turn (auto-continue after tool result)                 |
-| `body`         | `Record<string, unknown>` | Custom body fields from the client request                                            |
+| Field          | Type                      | Description                                                                  |
+| -------------- | ------------------------- | ---------------------------------------------------------------------------- |
+| `system`       | `string`                  | Assembled system prompt (from context blocks or `getSystemPrompt()`)         |
+| `messages`     | `ModelMessage[]`          | Assembled model messages (truncated, pruned)                                 |
+| `tools`        | `ToolSet`                 | Merged tool set (workspace + getTools + session + extensions + MCP + client) |
+| `model`        | `LanguageModel`           | The model from `getModel()`                                                  |
+| `continuation` | `boolean`                 | Whether this is a continuation turn (auto-continue after tool result)        |
+| `body`         | `Record<string, unknown>` | Custom body fields from the client request                                   |
 
 #### TurnConfig
 
@@ -1135,10 +1155,9 @@ async chat(
 
 #### ChatOptions
 
-| Field    | Description                                                 |
-| -------- | ----------------------------------------------------------- |
-| `signal` | `AbortSignal` to cancel the turn mid-stream                 |
-| `tools`  | Extra tools to merge for this turn (highest merge priority) |
+| Field    | Description                                 |
+| -------- | ------------------------------------------- |
+| `signal` | `AbortSignal` to cancel the turn mid-stream |
 
 #### Example: parent calling a child
 
@@ -1181,29 +1200,6 @@ export class ChildAgent extends Think<Env> {
 		return "You are a research assistant. Analyze data and report findings.";
 	}
 }
-```
-
-</TypeScriptExample>
-
-#### Passing extra tools
-
-The `tools` option adds tools for this turn only, with the highest merge priority:
-
-<TypeScriptExample>
-
-```ts
-import { tool } from "ai";
-import { z } from "zod";
-
-await child.chat("Summarize the report", callback, {
-	tools: {
-		fetchReport: tool({
-			description: "Fetch the report data",
-			inputSchema: z.object({}),
-			execute: async () => this.getReportData(),
-		}),
-	},
-});
 ```
 
 </TypeScriptExample>
@@ -1319,6 +1315,111 @@ async onChatResponse(result: ChatResponseResult) {
 }
 ```
 
+### submitMessages
+
+Durably accept a Think turn and return before inference runs. Use `submitMessages()` for webhook handlers, RPC callers, and parent Workers that need a fast acknowledgement, safe retry, and later status inspection.
+
+```ts
+async submitMessages(
+	messages: UIMessage[],
+	options?: {
+		submissionId?: string;
+		idempotencyKey?: string;
+		metadata?: Record<string, unknown>;
+	},
+): Promise<SubmitMessagesResult>
+```
+
+`submitMessages()` accepts serializable `UIMessage[]` values. It does not accept the function form supported by `saveMessages((messages) => ...)`, because durable submissions persist work before execution and cannot store closures. The array must contain at least one message.
+
+<TypeScriptExample>
+
+```ts
+const submission = await this.submitMessages(
+	[
+		{
+			id: crypto.randomUUID(),
+			role: "user",
+			parts: [{ type: "text", text: "Process webhook event 123" }],
+		},
+	],
+	{ idempotencyKey: "webhook-event-123" },
+);
+
+return Response.json({
+	submissionId: submission.submissionId,
+	status: submission.status,
+	accepted: submission.accepted,
+});
+```
+
+</TypeScriptExample>
+
+#### Submission statuses
+
+| Status      | Meaning                                        |
+| ----------- | ---------------------------------------------- |
+| `pending`   | Accepted and waiting for its turn              |
+| `running`   | Claimed by the agent and executing             |
+| `completed` | The Think turn completed successfully          |
+| `aborted`   | The submission was cancelled                   |
+| `skipped`   | Turn state was reset before the submission ran |
+| `error`     | Execution failed or recovery was unsafe        |
+
+#### Idempotent retries
+
+Pass an `idempotencyKey` from your external system. Retrying with the same key returns the existing submission with `accepted: false` instead of inserting duplicate messages:
+
+<TypeScriptExample>
+
+```ts
+const first = await this.submitMessages(messages, {
+	idempotencyKey: payload.id,
+});
+
+const retry = await this.submitMessages(messages, {
+	idempotencyKey: payload.id,
+});
+
+console.log(first.submissionId === retry.submissionId); // true
+console.log(retry.accepted); // false
+```
+
+</TypeScriptExample>
+
+If you pass both `submissionId` and `idempotencyKey`, they must identify the same submission. If they point at different existing submissions, `submitMessages()` throws.
+
+#### Inspect, list, cancel, and delete
+
+Use the submission APIs to inspect active work, cancel a durable submission, and clean up terminal records:
+
+<TypeScriptExample>
+
+```ts
+const current = await this.inspectSubmission(submission.submissionId);
+
+const active = await this.listSubmissions({
+	status: ["pending", "running"],
+});
+
+await this.cancelSubmission(submission.submissionId, "No longer needed");
+
+await this.deleteSubmissions({
+	status: ["completed", "error", "aborted"],
+	completedBefore: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+});
+```
+
+</TypeScriptExample>
+
+Use `cancelSubmission(submissionId)` for durable cancellation across Worker and Durable Object RPC boundaries. Use `AbortSignal` with `saveMessages()` or `continueLastTurn()` only when the caller creates the signal inside the Durable Object that runs the turn.
+
+Think stores accepted submissions in a submission ledger first. It appends submitted messages to the conversation Session only when the submission starts executing. Later accepted submissions are not visible to the model until their own turn starts, which preserves first-in, first-out turn semantics.
+
+If the chat is cleared or turn state is reset before a pending submission runs, the submission is marked `skipped`.
+
+Use Workflows for multi-step orchestration, retries per step, long waits, external events, human approvals, or pipelines that may trigger Think as one part of a larger process.
+
 ### continueLastTurn
 
 Run another model call after the latest assistant message without injecting a new user message. Think persists the result as a new assistant message with `continuation: true`; it does not append chunks to the existing assistant message.
@@ -1361,7 +1462,7 @@ export class MyAgent extends Think<Env> {
 
 </TypeScriptExample>
 
-When `chatRecovery` is `true`, all four turn paths (WebSocket, auto-continuation, `saveMessages`, `continueLastTurn`) are wrapped in `runFiber`.
+When `chatRecovery` is `true`, WebSocket turns, sub-agent `chat()` turns, durable `submitMessages()` executions, auto-continuations, `saveMessages()`, and `continueLastTurn()` are wrapped in `runFiber`.
 
 #### onChatRecovery
 

--- a/src/content/docs/agents/api-reference/voice.mdx
+++ b/src/content/docs/agents/api-reference/voice.mdx
@@ -421,17 +421,23 @@ const {
 	agent: "MyAgent",
 	name: "default",
 	host: window.location.host,
+	enabled: true,
 });
 ```
 
+Use `enabled: false` when the app must wait for async connection prerequisites, such as a user-scoped capability token. While disabled, the hook does not create or connect a `VoiceClient`, returns the idle disconnected state, and action callbacks such as `startCall()`, `sendText()`, and `sendJSON()` are safe no-ops.
+
+When `enabled` changes to `true`, the hook connects with the current options. The first enable is treated as an initial connection, so `onReconnect` only fires for later connection identity changes while the hook remains enabled.
+
 #### Tuning options
 
-| Option               | Type     | Default | Description                                      |
-| -------------------- | -------- | ------- | ------------------------------------------------ |
-| `silenceThreshold`   | `number` | `0.04`  | RMS below this is silence                        |
-| `silenceDurationMs`  | `number` | `500`   | Silence duration before `end_of_speech` (ms)     |
-| `interruptThreshold` | `number` | `0.05`  | RMS to detect speech during playback             |
-| `interruptChunks`    | `number` | `2`     | Consecutive high-RMS chunks to trigger interrupt |
+| Option               | Type      | Default | Description                                      |
+| -------------------- | --------- | ------- | ------------------------------------------------ |
+| `enabled`            | `boolean` | `true`  | Delay client creation and connection when false  |
+| `silenceThreshold`   | `number`  | `0.04`  | RMS below this is silence                        |
+| `silenceDurationMs`  | `number`  | `500`   | Silence duration before `end_of_speech` (ms)     |
+| `interruptThreshold` | `number`  | `0.05`  | RMS to detect speech during playback             |
+| `interruptChunks`    | `number`  | `2`     | Consecutive high-RMS chunks to trigger interrupt |
 
 Changing tuning options triggers a client reconnect (the connection key includes them).
 

--- a/src/content/docs/agents/concepts/memory.mdx
+++ b/src/content/docs/agents/concepts/memory.mdx
@@ -270,6 +270,19 @@ const session = Session.create(this)
 
 The `prefix` option scopes the provider to a subdirectory in the bucket. Skill keys in the metadata listing are shown without the prefix, so `skills/api-ref` becomes `api-ref` in the system prompt.
 
+Use `keys` to allowlist specific prefix-relative skills for `get()` and `load()`:
+
+<TypeScriptExample>
+
+```ts
+new R2SkillProvider(env.SKILLS_BUCKET, {
+	prefix: "skills/",
+	keys: ["deploy-checklist", "api-ref"],
+});
+```
+
+</TypeScriptExample>
+
 Add an R2 bucket binding to your Wrangler configuration:
 
 <WranglerConfig>

--- a/src/content/docs/agents/concepts/workflows.mdx
+++ b/src/content/docs/agents/concepts/workflows.mdx
@@ -37,6 +37,7 @@ Agents can loop, branch, and interact directly with users. Workflows execute ste
 - Quick API calls and responses
 - Real-time collaborative features
 - Tasks under 30 seconds
+- One durable Think chat turn with [`submitMessages()`](/agents/api-reference/think/#submitmessages)
 
 **Use Agents with Workflows for:**
 

--- a/src/content/docs/agents/guides/autonomous-responses.mdx
+++ b/src/content/docs/agents/guides/autonomous-responses.mdx
@@ -21,6 +21,7 @@ The key primitives:
 | Primitive           | Role                                                                               |
 | ------------------- | ---------------------------------------------------------------------------------- |
 | `saveMessages`      | Inject a message and trigger the LLM — the server-side equivalent of `sendMessage` |
+| `submitMessages`    | Durably accept a Think turn for async execution and inspect it later               |
 | `persistMessages`   | Store messages without triggering a response — for injecting context silently      |
 | `onChatResponse`    | React when any response completes, including ones you did not initiate             |
 | `isServerStreaming` | Client-side flag: `true` when a server-initiated stream is active                  |
@@ -30,6 +31,41 @@ The key primitives:
 `saveMessages` persists messages to SQLite **and** triggers `onChatMessage` for a new LLM response. It is awaitable — after it returns, the LLM has responded and the message is persisted.
 
 `persistMessages` stores messages and broadcasts them to connected clients, but does **not** trigger a model turn. Use it when you want to inject context (for example, a system message or background data) into the conversation without starting a response.
+
+### `saveMessages` vs `submitMessages`
+
+Use `saveMessages()` when the caller can wait for the model turn to finish.
+
+Use `submitMessages()` with Think when the caller needs a fast durable receipt, idempotent retry, and later status inspection. This is useful for webhook handlers, RPC callers, and parent Workers with strict timeout limits:
+
+<TypeScriptExample>
+
+```ts
+const submission = await this.submitMessages(
+	[
+		{
+			id: crypto.randomUUID(),
+			role: "user",
+			parts: [
+				{ type: "text", text: `Webhook event: ${JSON.stringify(payload)}` },
+			],
+		},
+	],
+	{ idempotencyKey: payload.id },
+);
+
+return Response.json({
+	submissionId: submission.submissionId,
+	status: submission.status,
+	accepted: submission.accepted,
+});
+```
+
+</TypeScriptExample>
+
+`submitMessages()` stores pending work first and appends the messages to the conversation Session only when the submission starts executing. It accepts serializable `UIMessage[]` values, not the function form supported by `saveMessages((messages) => ...)`.
+
+For the full Think API, refer to [`submitMessages()`](/agents/api-reference/think/#submitmessages).
 
 ### When to use `saveMessages` vs `onChatResponse`
 
@@ -214,6 +250,38 @@ async onRequest(request: Request): Promise<Response> {
 	return super.onRequest(request);
 }
 ```
+
+If the webhook provider expects a quick response, use `submitMessages()` instead. This gives the provider a durable acknowledgement and lets it safely retry with the same idempotency key:
+
+<TypeScriptExample>
+
+```ts
+async onRequest(request: Request): Promise<Response> {
+	if (request.method !== "POST") return super.onRequest(request);
+
+	const payload = await request.json<{ id: string }>();
+	const submission = await this.submitMessages(
+		[
+			{
+				id: crypto.randomUUID(),
+				role: "user",
+				parts: [
+					{ type: "text", text: `Webhook event: ${JSON.stringify(payload)}` },
+				],
+			},
+		],
+		{ idempotencyKey: payload.id },
+	);
+
+	return Response.json({
+		submissionId: submission.submissionId,
+		accepted: submission.accepted,
+		status: submission.status,
+	});
+}
+```
+
+</TypeScriptExample>
 
 ### Injecting context without triggering a response
 
@@ -402,14 +470,44 @@ The `messageConcurrency` setting on `AIChatAgent` controls how overlapping user 
 
 ## Combining with other Agent primitives
 
-| Primitive          | How to combine                                                                                |
-| ------------------ | --------------------------------------------------------------------------------------------- |
-| `schedule()`       | Schedule a callback that calls `saveMessages` — see the cron example above                    |
-| `queue()`          | Queue a method that calls `saveMessages` for deferred processing                              |
-| `runWorkflow()`    | Start a Workflow; use `AgentWorkflow.agent` RPC to call a method that triggers `saveMessages` |
-| `onEmail()`        | Convert email content to a chat message and call `saveMessages`                               |
-| `onRequest()`      | Handle webhooks and call `saveMessages`                                                       |
-| `this.broadcast()` | Broadcast custom state from `onChatResponse`                                                  |
+| Primitive          | How to combine                                                                                                    |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `schedule()`       | Schedule a callback that calls `saveMessages` — see the cron example above                                        |
+| `queue()`          | Queue a method that calls `saveMessages` for deferred processing                                                  |
+| `runWorkflow()`    | Start a Workflow; use `AgentWorkflow.agent` RPC to call a method that triggers `saveMessages` or `submitMessages` |
+| `onEmail()`        | Convert email content to a chat message and call `saveMessages`                                                   |
+| `onRequest()`      | Handle webhooks and call `saveMessages` or `submitMessages`                                                       |
+| `this.broadcast()` | Broadcast custom state from `onChatResponse`                                                                      |
+
+## Cancelling a server-driven turn
+
+Pass an `AbortSignal` when the same Durable Object starts and controls the turn:
+
+<TypeScriptExample>
+
+```ts
+const controller = new AbortController();
+const result = await this.saveMessages(
+	[
+		{
+			id: crypto.randomUUID(),
+			role: "user",
+			parts: [{ type: "text", text: "Run the long analysis." }],
+		},
+	],
+	{ signal: controller.signal },
+);
+
+if (result.status === "aborted") {
+	// Partial chunks already streamed are persisted.
+}
+```
+
+</TypeScriptExample>
+
+`continueLastTurn()` accepts the same `options.signal` argument. `AbortSignal` objects cannot cross Durable Object RPC boundaries, and the signal is in memory only. If the Durable Object hibernates mid-turn and chat recovery is enabled, the recovered turn runs without the original signal.
+
+Use `cancelSubmission(submissionId)` for durable cancellation when work was accepted with `submitMessages()` or when cancellation must cross Worker and Durable Object RPC boundaries.
 
 ## Important notes
 

--- a/src/content/docs/agents/guides/autonomous-responses.mdx
+++ b/src/content/docs/agents/guides/autonomous-responses.mdx
@@ -253,8 +253,6 @@ async onRequest(request: Request): Promise<Response> {
 
 If the webhook provider expects a quick response, use `submitMessages()` instead. This gives the provider a durable acknowledgement and lets it safely retry with the same idempotency key:
 
-<TypeScriptExample>
-
 ```ts
 async onRequest(request: Request): Promise<Response> {
 	if (request.method !== "POST") return super.onRequest(request);
@@ -280,8 +278,6 @@ async onRequest(request: Request): Promise<Response> {
 	});
 }
 ```
-
-</TypeScriptExample>
 
 ### Injecting context without triggering a response
 


### PR DESCRIPTION
### Summary

Updates the Agents documentation to match user-facing SDK changes landed in `cloudflare/agents` over the recent release window. This is a broad reference sync focused on API drift and missing guidance for developers using Think, AIChatAgent, Agent tools, Codemode, Voice, routing, observability, and memory.

The main changes are:

- Adds Think `submitMessages()` documentation, including durable submission statuses, idempotency, inspection, cancellation, cleanup, FIFO session behavior, and when to choose it over `saveMessages()` or Workflows.
- Adds a Think turn API selector so readers can choose between `useAgentChat`, `saveMessages()`, `submitMessages()`, `subAgent(...).chat()`, `agentTool()` / `runAgentTool()`, `persistMessages()`, and `continueLastTurn()`.
- Corrects Think sub-agent/tool guidance by removing stale per-call `chat(..., { tools })` semantics and directing tool ownership to the child agent or retained Agent tools.
- Documents `useAgentChat({ cancelOnClientAbort })` and clarifies the difference between generic client cleanup, resumable server turns, and explicit `stop()` cancellation.
- Expands Agent tools docs with guidance on when to use retained Agent tools vs raw sub-agent RPC, plus Think structured output hooks for child runs without assistant text.
- Adds Codemode browser iframe executor guidance, `IframeSandboxExecutor` API reference, approval-gated tool caveats, and browser sandbox security notes.
- Adds `useVoiceAgent({ enabled })`, `getAgentByName({ routingRetry })`, Think submission observability events, `useAgentToolEvents()` client SDK guidance, and `R2SkillProvider` `keys` allowlist documentation.

Validation run locally:

- `pnpm exec prettier --check` on all edited files: passed.
- `git diff --check` on all edited files: passed.
- IDE lints on all edited files: no errors.
- `pnpm run check`: blocked before content validation by an existing Starlight sidebar config validation error unrelated to this PR (`autogenerate` sidebar entries rejected by the installed Starlight schema).

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
