### PR TITLE
[Sandbox SDK] Document new streaming support for readFile()

### DIFF
--- a/src/content/docs/sandbox/api/files.mdx
+++ b/src/content/docs/sandbox/api/files.mdx
@@ -53,29 +53,47 @@ await sandbox.writeFile('/workspace/archive.tar.gz', req.body);
 
 ### `readFile()`
 
-Read a file from the sandbox.
+Read a file from the sandbox. By default returns the content as a string. This is useful for small text files. For larger files and binary data use `encoding: "none"` to get back a `ReadableStream` with the file data.
 
 ```ts
-const file = await sandbox.readFile(path: string, options?: ReadFileOptions): Promise<FileInfo>
+const file = await sandbox.readFile(path: string, options?: ReadFileOptions): Promise<ReadFileResult | ReadFileStreamResult>
 ```
 
 **Parameters**:
 - `path` - Absolute path to the file
 - `options` (optional):
-  - `encoding` - File encoding (`"utf-8"` or `"base64"`, default: auto-detected from MIME type)
+  - `encoding` - File encoding (`"utf-8"`, `"base64"` or `"none"`, default: auto-detected from MIME type)
 
-**Returns**: `Promise<FileInfo>` with `content` and `encoding`
+**Returns**: `Promise<ReadFileResult | ReadFileStreamResult>`.
+
+:::note[Encoding]
+The `"none"` encoding property was added in 0.10.1 and aims to improve support for streaming binary data. When `encoding: "none"` is provided the `content` field will be a `ReadableStream<Uint8Array>`. It is only supported with the [RPC transport](/sandbox/configuration/transport/).
+:::
 
 <TypeScriptExample>
 ```
 const file = await sandbox.readFile('/workspace/package.json');
 const pkg = JSON.parse(file.content);
 
-// Binary data (auto-detected or forced)
-const image = await sandbox.readFile('/tmp/image.png', { encoding: 'base64' });
+// Binary data (since 0.10.1 using `rpc` transport)
+const { content, size, mimeType } = await sandbox.readFile("/workspace/archive.tar.gz", {
+  encoding: "none"
+});
 
-// Force encoding (override MIME detection)
-const textAsBase64 = await sandbox.readFile('/workspace/data.txt', { encoding: 'base64' });
+// Example 1: Store on R2:
+const stream = request.body.pipeThrough(new FixedLengthStream(size));
+await env.MY_BUCKET.put('/bucket/archive.tar.gz', stream, {
+  httpMetadata: { contentType: mimeType }
+});
+
+// Example 2: Stream an HTTP response:
+return new Response(content, { headers: { "Content-Type": mimeType } });
+
+// Older versions/transports used the base64 encoding for binary data:
+const archive = await sandbox.readFile("/workspace/archive.tar.gz", {
+  encoding: "base64"
+});
+console.log(archive.content); // => "<base64 encoded string>";
 ```
 </TypeScriptExample>
 

--- a/src/content/docs/sandbox/guides/manage-files.mdx
+++ b/src/content/docs/sandbox/guides/manage-files.mdx
@@ -67,17 +67,17 @@ console.log(file.content);
 const configFile = await sandbox.readFile('/workspace/config.json');
 const config = JSON.parse(configFile.content);
 
-// Read binary file
-const imageFile = await sandbox.readFile('/workspace/image.png', { encoding: 'base64' });
-return new Response(atob(imageFile.content), {
-  headers: { 'Content-Type': 'image/png' }
+// Read binary file (v0.10.1 with `rpc` transport)
+const imageFile = await sandbox.readFile('/workspace/image.png', { encoding: 'none' });
+return new Response(imageFile.content, {
+  headers: { 'Content-Type': imageFile.mimeType }
 });
-
-// Force encoding for transmission (text → base64)
-const textAsBase64 = await sandbox.readFile('/workspace/data.txt', { encoding: 'base64' });
-// Useful for transmitting text files without encoding issues
 ```
 </TypeScriptExample>
+
+:::note
+For more details on the `rpc` transport please see the [Transport](/sandbox/configuration/transport/) docs.
+:::
 
 ## Organize files
 
@@ -163,14 +163,26 @@ await sandbox.writeFile('/workspace/data/file.txt', content);
 
 ### Binary file encoding
 
-Use base64 for binary files:
+Use `encoding: "none"` (with `rpc` transport) for binary files:
 
 <TypeScriptExample>
 ```
 // Write binary
-await sandbox.writeFile('/workspace/image.png', base64Data, {
-  encoding: 'base64'
+await sandbox.writeFile('/workspace/image.png', readableStream);
+
+// Read binary
+const file = await sandbox.readFile('/workspace/image.png', {
+  encoding: 'none'
 });
+```
+</TypeScriptExample>
+
+For older SDK versions or `http` transport:
+
+<TypeScriptExample>
+```
+// Write binary
+await sandbox.writeFile('/workspace/image.png', base64data, { encoding: "base64" });
 
 // Read binary
 const file = await sandbox.readFile('/workspace/image.png', {

--- a/src/content/docs/sandbox/tutorials/analyze-data-with-ai.mdx
+++ b/src/content/docs/sandbox/tutorials/analyze-data-with-ai.mdx
@@ -118,12 +118,26 @@ export default {
 				);
 			}
 
+			async function streamToBase64(stream) {
+			  const blob = await new Response(stream).blob();
+			  const buffer = await blob.arrayBuffer();
+			  const bytes = new Uint8Array(buffer);
+
+			  // Convert to base64
+			  let binary = '';
+			  for (let i = 0; i < bytes.length; i++) {
+			    binary += String.fromCharCode(bytes[i]);
+			  }
+			  return btoa(binary);
+			}
+
 			// Check for generated chart
 			let chart = null;
 			try {
-				const chartFile = await sandbox.readFile("/workspace/chart.png");
-				const buffer = new Uint8Array(chartFile.content);
-				chart = `data:image/png;base64,${btoa(String.fromCharCode(...buffer))}`;
+				const { content, mimeType } = await sandbox.readFile("/workspace/chart.png", {
+					encoding: "none"
+				});
+				chart = `data:${mimeType};base64,${await streamToBase64(content)}`;
 			} catch {
 				// No chart generated
 			}
@@ -200,10 +214,12 @@ Use pandas, numpy, matplotlib.`,
 Create a `.dev.vars` file in your project root for local development:
 
 ```sh
-echo "ANTHROPIC_API_KEY=your_api_key_here" > .dev.vars
+echo "ANTHROPIC_API_KEY=your_api_key_here\nSANDBOX_TRANSPORT=rpc" > .dev.vars
 ```
 
 Replace `your_api_key_here` with your actual API key from the [Anthropic Console](https://console.anthropic.com/).
+
+The `SANDBOX_TRANSPORT` is required to use the new file streaming APIs.
 
 :::note
 The `.dev.vars` file is automatically gitignored and only used during local development with `npm run dev`.


### PR DESCRIPTION
### Summary

@cloudflare/sandbox-sdk v0.10.1 added support for passing `encoding: "none"` as an option to the `readFile()` method. This PR documents that change.


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->