### PR TITLE
[DNS/SSL] Clarify HTTPS record behavior with Universal SSL and proxied hostnames

### DIFF
--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -340,7 +340,7 @@ For [proxied (orange cloud)](/dns/proxy-status/) names, Cloudflare synthesizes H
 
 If you have disabled Universal SSL (for example, because you use [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) exclusively), Cloudflare will not generate HTTPS records for proxied names.
 
-For [DNS-only (grey cloud)](/dns/proxy-status/) hostnames, you can manually add HTTPS records and Cloudflare will serve them. However, **all records on the same label must be DNS-only** for the manual HTTPS record to be served.
+For [DNS-only (grey cloud)](/dns/proxy-status/) names, you can manually add HTTPS records and Cloudflare will serve them. However, **all records on the same label must be DNS-only** for the manual HTTPS record to be served.
 
 <Details header="Example: Manual HTTPS records and proxy status">
 

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -335,13 +335,12 @@ Service Binding (SVCB) and HTTPS Service (HTTPS) records allow you to provide a 
 
 If your domain has [HTTP/2 or HTTP/3 enabled](/speed/optimization/protocol/), [proxied DNS records](/dns/proxy-status/), and is also using [Universal SSL](/ssl/edge-certificates/universal-ssl/), Cloudflare automatically generates HTTPS records on the fly, to advertise to clients how they should connect to your server.
 
-:::note[Proxied vs DNS-only hostnames]
+#### Proxied vs DNS-only names
 For [proxied (orange cloud)](/dns/proxy-status/) hostnames, Cloudflare synthesizes HTTPS records automatically when Universal SSL is enabled. Manually-added HTTPS records on proxied hostnames are not served — Cloudflare uses the auto-generated records instead.
 
 If you have disabled Universal SSL (for example, because you use [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) exclusively), Cloudflare will not generate HTTPS records for proxied hostnames.
 
 For [DNS-only (grey cloud)](/dns/proxy-status/) hostnames, you can manually add HTTPS records and Cloudflare will serve them. However, **all records on the same label must be DNS-only** for the manual HTTPS record to be served.
-:::
 
 <Details header="Example: Manual HTTPS records and proxy status">
 

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -340,15 +340,15 @@ For [proxied (orange cloud)](/dns/proxy-status/) names, Cloudflare synthesizes H
 
 If you have disabled Universal SSL (for example, because you use [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) exclusively), Cloudflare will not generate HTTPS records for proxied names.
 
-For [DNS-only (grey cloud)](/dns/proxy-status/) names, you can manually add HTTPS records and Cloudflare will serve them. However, **all records on the same label must be DNS-only** for the manual HTTPS record to be served.
+For [DNS-only (grey cloud)](/dns/proxy-status/) names, you can manually add HTTPS records and Cloudflare will serve them. However, **all records with the same name must be DNS-only** for the manual HTTPS record to be served.
 
 <Details header="Example: Manual HTTPS records and proxy status">
 
-A label refers to all DNS records in a zone that share the same name. For Cloudflare to serve a manually-added HTTPS record, every record on that label must be DNS-only (grey cloud).
+For Cloudflare to serve a manually-added HTTPS record, every record with the same name must be DNS-only (grey cloud).
 
 <Example>
 
-**Will work** — All records on the label are DNS-only:
+**Will work** — All records with the same name are DNS-only:
 
 | Type  | Name        | Content         | Proxy status |
 | ----- | ----------- | --------------- | ------------ |
@@ -361,14 +361,14 @@ The HTTPS record will be served because the A record is DNS-only.
 
 <Example>
 
-**Will not work** — Mixed proxy status on the same label:
+**Will not work** — Mixed proxy status for the same name:
 
 | Type  | Name        | Content         | Proxy status |
 | ----- | ----------- | --------------- | ------------ |
 | AAAA  | example.com | `2001:db8::1`   | Proxied      |
 | HTTPS | example.com | `1 . alpn="h3"` | -            |
 
-The HTTPS record will **not** be served because the AAAA record on the same label is proxied.
+The HTTPS record will **not** be served because the AAAA record with the same name is proxied.
 
 </Example>
 

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -336,12 +336,44 @@ Service Binding (SVCB) and HTTPS Service (HTTPS) records allow you to provide a 
 If your domain has [HTTP/2 or HTTP/3 enabled](/speed/optimization/protocol/), [proxied DNS records](/dns/proxy-status/), and is also using [Universal SSL](/ssl/edge-certificates/universal-ssl/), Cloudflare automatically generates HTTPS records on the fly, to advertise to clients how they should connect to your server.
 
 :::note[Proxied vs DNS-only hostnames]
-For [DNS-only (grey cloud)](/dns/proxy-status/) hostnames, you can manually add HTTPS records and Cloudflare will serve them.
-
 For [proxied (orange cloud)](/dns/proxy-status/) hostnames, Cloudflare synthesizes HTTPS records automatically when Universal SSL is enabled. Manually-added HTTPS records on proxied hostnames are not served — Cloudflare uses the auto-generated records instead.
 
 If you have disabled Universal SSL (for example, because you use [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) exclusively), Cloudflare will not generate HTTPS records for proxied hostnames.
+
+For [DNS-only (grey cloud)](/dns/proxy-status/) hostnames, you can manually add HTTPS records and Cloudflare will serve them. However, **all records on the same label must be DNS-only** for the manual HTTPS record to be served.
 :::
+
+<Details header="Example: Manual HTTPS records and proxy status">
+
+A label refers to all DNS records in a zone that share the same name. For Cloudflare to serve a manually-added HTTPS record, every record on that label must be DNS-only (grey cloud).
+
+<Example>
+
+**Will work** — All records on the label are DNS-only:
+
+| Type  | Name        | Content         | Proxy status |
+| ----- | ----------- | --------------- | ------------ |
+| A     | example.com | `192.0.2.1`     | DNS only     |
+| HTTPS | example.com | `1 . alpn="h3"` | -            |
+
+The HTTPS record will be served because the A record is DNS-only.
+
+</Example>
+
+<Example>
+
+**Will not work** — Mixed proxy status on the same label:
+
+| Type  | Name        | Content         | Proxy status |
+| ----- | ----------- | --------------- | ------------ |
+| AAAA  | example.com | `2001:db8::1`   | Proxied      |
+| HTTPS | example.com | `1 . alpn="h3"` | -            |
+
+The HTTPS record will **not** be served because the AAAA record on the same label is proxied.
+
+</Example>
+
+</Details>
 
 For more details and context, refer to the [announcement blog post](https://blog.cloudflare.com/speeding-up-https-and-http-3-negotiation-with-dns/) and [RFC 9460](https://www.rfc-editor.org/rfc/rfc9460.html).
 

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -336,9 +336,9 @@ Service Binding (SVCB) and HTTPS Service (HTTPS) records allow you to provide a 
 If your domain has [HTTP/2 or HTTP/3 enabled](/speed/optimization/protocol/), [proxied DNS records](/dns/proxy-status/), and is also using [Universal SSL](/ssl/edge-certificates/universal-ssl/), Cloudflare automatically generates HTTPS records on the fly, to advertise to clients how they should connect to your server.
 
 #### Proxied vs DNS-only names
-For [proxied (orange cloud)](/dns/proxy-status/) hostnames, Cloudflare synthesizes HTTPS records automatically when Universal SSL is enabled. Manually-added HTTPS records on proxied hostnames are not served — Cloudflare uses the auto-generated records instead.
+For [proxied (orange cloud)](/dns/proxy-status/) names, Cloudflare synthesizes HTTPS records automatically when Universal SSL is enabled. Manually-added HTTPS records on proxied names are not served — Cloudflare uses the auto-generated records instead.
 
-If you have disabled Universal SSL (for example, because you use [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) exclusively), Cloudflare will not generate HTTPS records for proxied hostnames.
+If you have disabled Universal SSL (for example, because you use [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) exclusively), Cloudflare will not generate HTTPS records for proxied names.
 
 For [DNS-only (grey cloud)](/dns/proxy-status/) hostnames, you can manually add HTTPS records and Cloudflare will serve them. However, **all records on the same label must be DNS-only** for the manual HTTPS record to be served.
 

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -335,6 +335,14 @@ Service Binding (SVCB) and HTTPS Service (HTTPS) records allow you to provide a 
 
 If your domain has [HTTP/2 or HTTP/3 enabled](/speed/optimization/protocol/), [proxied DNS records](/dns/proxy-status/), and is also using [Universal SSL](/ssl/edge-certificates/universal-ssl/), Cloudflare automatically generates HTTPS records on the fly, to advertise to clients how they should connect to your server.
 
+:::note[Proxied vs DNS-only hostnames]
+For [DNS-only (grey cloud)](/dns/proxy-status/) hostnames, you can manually add HTTPS records and Cloudflare will serve them.
+
+For [proxied (orange cloud)](/dns/proxy-status/) hostnames, Cloudflare synthesizes HTTPS records automatically when Universal SSL is enabled. Manually-added HTTPS records on proxied hostnames are not served — Cloudflare uses the auto-generated records instead.
+
+If you have disabled Universal SSL (for example, because you use [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) exclusively), Cloudflare will not generate HTTPS records for proxied hostnames.
+:::
+
 For more details and context, refer to the [announcement blog post](https://blog.cloudflare.com/speeding-up-https-and-http-3-negotiation-with-dns/) and [RFC 9460](https://www.rfc-editor.org/rfc/rfc9460.html).
 
 <Render file="api-field-definitions" product="dns" />

--- a/src/content/docs/ssl/reference/browser-compatibility.mdx
+++ b/src/content/docs/ssl/reference/browser-compatibility.mdx
@@ -48,7 +48,7 @@ If your domain has [HTTP/2 or HTTP/3 enabled](/speed/optimization/protocol/), [p
 :::caution[Universal SSL required for automatic HTTPS records]
 Disabling Universal SSL will prevent automatic HTTPS record generation for proxied hostnames, even if you have [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) or [custom certificates](/ssl/edge-certificates/custom-certificates/) configured. This is because automatic HTTPS record generation is tied specifically to the Universal SSL feature.
 
-If you need HTTPS records without Universal SSL, you can manually add them for [DNS-only (grey cloud)](/dns/proxy-status/) hostnames only.
+If you need HTTPS records without Universal SSL, you can manually add them, but only if **all records on the same label are DNS-only (grey cloud)**. Refer to [SVCB and HTTPS records](/dns/manage-dns-records/reference/dns-record-types/#svcb-and-https) for details and examples.
 :::
 
 ## OCSP and HTTP versions

--- a/src/content/docs/ssl/reference/browser-compatibility.mdx
+++ b/src/content/docs/ssl/reference/browser-compatibility.mdx
@@ -48,7 +48,7 @@ If your domain has [HTTP/2 or HTTP/3 enabled](/speed/optimization/protocol/), [p
 :::caution[Universal SSL required for automatic HTTPS records]
 Disabling Universal SSL will prevent automatic HTTPS record generation for proxied hostnames, even if you have [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) or [custom certificates](/ssl/edge-certificates/custom-certificates/) configured. This is because automatic HTTPS record generation is tied specifically to the Universal SSL feature.
 
-If you need HTTPS records without Universal SSL, you can manually add them, but only if **all records on the same label are DNS-only (grey cloud)**. Refer to [SVCB and HTTPS records](/dns/manage-dns-records/reference/dns-record-types/#svcb-and-https) for details and examples.
+If you need HTTPS records without Universal SSL, you can manually add them, but only if **all records with the same name are DNS-only (grey cloud)**. Refer to [SVCB and HTTPS records](/dns/manage-dns-records/reference/dns-record-types/#svcb-and-https) for details and examples.
 :::
 
 ## OCSP and HTTP versions

--- a/src/content/docs/ssl/reference/browser-compatibility.mdx
+++ b/src/content/docs/ssl/reference/browser-compatibility.mdx
@@ -45,8 +45,10 @@ To support non-SNI requests, you can:
 
 If your domain has [HTTP/2 or HTTP/3 enabled](/speed/optimization/protocol/), [proxied DNS records](/dns/proxy-status/), and is also using [Universal SSL](/ssl/edge-certificates/universal-ssl/), Cloudflare automatically generates HTTPS records on the fly, to advertise to clients how they should connect to your server.
 
-:::caution
-Both HTTP/2 and HTTP/3 configurations also require that you have an SSL/TLS certificate served by Cloudflare. This means that disabling Universal SSL, for example, could impact this behavior.
+:::caution[Universal SSL required for automatic HTTPS records]
+Disabling Universal SSL will prevent automatic HTTPS record generation for proxied hostnames, even if you have [Advanced Certificates](/ssl/edge-certificates/advanced-certificate-manager/) or [custom certificates](/ssl/edge-certificates/custom-certificates/) configured. This is because automatic HTTPS record generation is tied specifically to the Universal SSL feature.
+
+If you need HTTPS records without Universal SSL, you can manually add them for [DNS-only (grey cloud)](/dns/proxy-status/) hostnames only.
 :::
 
 ## OCSP and HTTP versions


### PR DESCRIPTION
Updates documentation to explain:
- Manual HTTPS records on proxied hostnames are not served (Cloudflare uses auto-generated records)
- Disabling Universal SSL prevents automatic HTTPS record generation for proxied hostnames
- Manual HTTPS records only work for DNS-only (grey cloud) hostnames

Files updated:
- dns-record-types.mdx: Added note explaining proxied vs DNS-only behavior
- browser-compatibility.mdx: Strengthened language about Universal SSL requirement

Addresses ESCALATION-2549

## Summary

Clarifies documentation about when HTTPS records are served and when they are not.

## Problem

Customers disable Universal SSL (for policy reasons) while using Advanced Certificates, then expect HTTPS records to be served. The current documentation was ambiguous ("could impact this behavior").

## Solution

Updated two pages:
- `/dns/manage-dns-records/reference/dns-record-types/` - Added note explaining:
  - Manual HTTPS records work for DNS-only hostnames
  - Manual HTTPS records on proxied hostnames are ignored (auto-generated used instead)
  - Disabling Universal SSL stops auto-generation for proxied hostnames

- `/ssl/reference/browser-compatibility/` - Strengthened caution to clearly state Universal SSL is required for automatic HTTPS record generation

## Ticket

- ESCALATION-2549
