### PR TITLE
[ACM] Document multi-level subdomain support and limits

### DIFF
--- a/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
@@ -78,7 +78,7 @@ These limits are defined by internet standards ([RFC 1035](https://www.rfc-edito
 
 - **Total domain length**: The entire domain name cannot exceed 253 characters.
 - **Label length**: Each individual level (the text between dots) cannot exceed 63 characters.
-- **Common Name (CN) length**: The Common Name field of a certificate cannot exceed 64 characters. If a hostname on your certificate exceeds 64 characters, you must order the certificate via the API and set the `cloudflare_branding` option to `true`. This places `sni.cloudflaressl.com` in the CN field and your long hostname in the SAN field. The dashboard does not support ordering certificates with hostnames longer than 64 characters.
+- **Common Name (CN) length**: The Common Name field of a certificate cannot exceed 64 characters. If a hostname on your certificate exceeds 64 characters, you must order the certificate via the [API](/api/resources/ssl/subresources/certificate_packs/methods/create/) and set the `cloudflare_branding` option to `true`. This places `sni.cloudflaressl.com` in the CN field and your long hostname in the SAN field. The dashboard does not support ordering certificates with hostnames longer than 64 characters.
 
 ### Wildcard coverage
 
@@ -93,7 +93,7 @@ A single advanced certificate can include up to **50 hosts** (SANs) total. The z
 
 ### Consistency across certificate authorities
 
-The character-length limits above (253-character total, 63-character label, 64-character CN) are defined by IETF standards ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035), [RFC 5280](https://www.rfc-editor.org/rfc/rfc5280)) and apply uniformly across all CAs. Other constraints, such as the per-certificate SAN count and supported validity periods, are Cloudflare ACM limits or vary by CA. Refer to [Certificate authorities](/ssl/reference/certificate-authorities/) for CA-specific details.
+The character-length limits above (253-character total, 63-character label, 64-character CN) are defined by IETF standards ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035), [RFC 5280](https://www.rfc-editor.org/rfc/rfc5280)) and apply uniformly across all CAs. Other constraints, such as the per-certificate SAN count and supported validity periods, are Cloudflare advanced certificates limits or vary by CA. Refer to [Certificate authorities](/ssl/reference/certificate-authorities/) for CA-specific details.
 
 ## Related resources
 

--- a/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
@@ -64,6 +64,33 @@ Advanced certificates cover hostnames within a single domain. If you need a cert
 
 :::
 
+## Multi-level subdomain support
+
+Advanced Certificate Manager supports deep, multi-level subdomains (for example, `level3.level2.level1.example.com`). There is no arbitrary limit on the number of subdomain levels, but you must consider the following constraints.
+
+### Domain name length limits
+
+These limits are defined by internet standards ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035) and [RFC 5280](https://www.rfc-editor.org/rfc/rfc5280)) and apply to all certificates, regardless of the certificate authority:
+
+- **Total domain length**: The entire domain name cannot exceed 253 characters.
+- **Label length**: Each individual level (the text between dots) cannot exceed 63 characters.
+- **Common Name (CN) length**: The Common Name field of a certificate cannot exceed 64 characters. If your multi-level subdomain exceeds this limit, Cloudflare uses `sni.cloudflaressl.com` as the Common Name and places your hostname in the Subject Alternative Name (SAN) field instead.
+
+### Wildcard coverage
+
+Wildcard certificates only cover **one subdomain level**:
+
+- A certificate for `*.example.com` covers `level1.example.com` but **not** `level2.level1.example.com`.
+- To cover multiple levels, you must explicitly add a wildcard for each level to your certificate (for example, `*.example.com`, `*.level1.example.com`, `*.level2.level1.example.com`).
+
+### Hostnames per certificate
+
+A single advanced certificate can include the zone apex and up to **50 hostnames** (SANs). This means you can cover a maximum of 50 distinct multi-level subdomains or wildcards within one certificate.
+
+### Certificate authority differences
+
+The limits described above are the same across all certificate authorities available in Advanced Certificate Manager (Google Trust Services, Let's Encrypt, and SSL.com). These constraints are defined by global standards from the IETF and the CA/Browser Forum, which all certificate authorities must follow.
+
 ## Related resources
 
 <DirectoryListing />

--- a/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/advanced-certificate-manager/index.mdx
@@ -25,7 +25,7 @@ To order advanced certificates, you must purchase the Advanced Certificate Manag
 Advanced Certificate Manager allows you to:
 
 - Order advanced certificates that can:
-  - Include the zone apex and up to 50 hosts as covered hostnames.
+  - Include up to 50 hosts as covered hostnames (the zone apex must be one of these 50).
   - Cover more than one level of subdomain.
   - Be issued by the certificate authority (CA) you choose.
   - Use your preferred validation method.
@@ -66,7 +66,11 @@ Advanced certificates cover hostnames within a single domain. If you need a cert
 
 ## Multi-level subdomain support
 
-Advanced Certificate Manager supports deep, multi-level subdomains (for example, `level3.level2.level1.example.com`). There is no arbitrary limit on the number of subdomain levels, but you must consider the following constraints.
+Advanced Certificate Manager supports deep, multi-level subdomains (for example, `api.staging.example.com`). There is no arbitrary limit on the number of subdomain levels, but you must consider the following constraints.
+
+:::note
+If you want to automatically issue certificates for all proxied hostnames without manually specifying each one, enable [Total TLS](/ssl/edge-certificates/additional-options/total-tls/).
+:::
 
 ### Domain name length limits
 
@@ -74,22 +78,22 @@ These limits are defined by internet standards ([RFC 1035](https://www.rfc-edito
 
 - **Total domain length**: The entire domain name cannot exceed 253 characters.
 - **Label length**: Each individual level (the text between dots) cannot exceed 63 characters.
-- **Common Name (CN) length**: The Common Name field of a certificate cannot exceed 64 characters. If your multi-level subdomain exceeds this limit, Cloudflare uses `sni.cloudflaressl.com` as the Common Name and places your hostname in the Subject Alternative Name (SAN) field instead.
+- **Common Name (CN) length**: The Common Name field of a certificate cannot exceed 64 characters. If a hostname on your certificate exceeds 64 characters, you must order the certificate via the API and set the `cloudflare_branding` option to `true`. This places `sni.cloudflaressl.com` in the CN field and your long hostname in the SAN field. The dashboard does not support ordering certificates with hostnames longer than 64 characters.
 
 ### Wildcard coverage
 
 Wildcard certificates only cover **one subdomain level**:
 
-- A certificate for `*.example.com` covers `level1.example.com` but **not** `level2.level1.example.com`.
-- To cover multiple levels, you must explicitly add a wildcard for each level to your certificate (for example, `*.example.com`, `*.level1.example.com`, `*.level2.level1.example.com`).
+- A certificate for `*.example.com` covers `www.example.com` and `api.example.com` but **not** `api.staging.example.com`.
+- To cover multiple levels, you must explicitly add a wildcard for each level to your certificate (for example, `*.example.com`, `*.staging.example.com`).
 
 ### Hostnames per certificate
 
-A single advanced certificate can include the zone apex and up to **50 hostnames** (SANs). This means you can cover a maximum of 50 distinct multi-level subdomains or wildcards within one certificate.
+A single advanced certificate can include up to **50 hosts** (SANs) total. The zone apex must be one of these 50, leaving room for up to 49 additional hostnames or wildcards.
 
-### Certificate authority differences
+### Consistency across certificate authorities
 
-The limits described above are the same across all certificate authorities available in Advanced Certificate Manager (Google Trust Services, Let's Encrypt, and SSL.com). These constraints are defined by global standards from the IETF and the CA/Browser Forum, which all certificate authorities must follow.
+The character-length limits above (253-character total, 63-character label, 64-character CN) are defined by IETF standards ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035), [RFC 5280](https://www.rfc-editor.org/rfc/rfc5280)) and apply uniformly across all CAs. Other constraints, such as the per-certificate SAN count and supported validity periods, are Cloudflare ACM limits or vary by CA. Refer to [Certificate authorities](/ssl/reference/certificate-authorities/) for CA-specific details.
 
 ## Related resources
 


### PR DESCRIPTION
## Summary

Documents the limits and capabilities for multi-level subdomains in Advanced Certificate Manager.

## Problem

Customers ask about subdomain depth limits when evaluating ACM for deep multi-level subdomains like `1.2.3.4.5.example.com`. The current documentation mentions "Cover more than one level of subdomain" but doesn't explain the actual constraints.

## Solution

Added a new "Multi-level subdomain support" section to the ACM page explaining:

- **No arbitrary depth limit** - subdomain depth is constrained by character limits, not level count
- **Domain name length limits** - 253 chars total, 63 chars per label (RFC 1035/5280)
- **Common Name workaround** - Cloudflare uses `sni.cloudflaressl.com` as CN when hostname exceeds 64 chars
- **Wildcard coverage** - wildcards only cover one level, with examples
- **50 hostnames per certificate** - practical limit for SANs
- **CA consistency** - same limits across Google Trust Services, Let's Encrypt, and SSL.com

## Ticket

- SPM-3540
