### PR TITLE
[Cloudflare One] Add Mesh short path redirect

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -65,6 +65,7 @@
 /workers/runtime-apis/bindings/worker-loader/ /dynamic-workers/ 301
 /dynamic-workers/examples/dynamic-workflows/ /dynamic-workers/usage/dynamic-workflows/ 301
 /docs/ /directory/ 301
+/mesh/ /cloudflare-one/networks/connectors/cloudflare-mesh/ 302
 /support/ai/ / 301
 /products/ /directory/ 301
 /zero-trust/ /products/?product-group=Cloudflare+One 301


### PR DESCRIPTION
Adds a temporary 302 redirect from `/mesh/` to the Cloudflare Mesh docs so the short path can be used while the docs continue to live under Cloudflare One.

cc @nikitacano
