### PR TITLE
Add @kennyj42 as code owner for /src/content/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,9 @@
 
 * @cloudflare/product-owners
 
+# Content ownership
+/src/content/ @kennyj42 @cloudflare/product-owners
+
 # More dev-specific files
 
 /.github/ @cloudflare/content-engineering @kodster28 @mvvmm @colbywhite @ahaywood @MohamedH1998


### PR DESCRIPTION
## Summary

Adds `@kennyj42` (Access PM) as a code owner for `/src/content/` to enable `/bonk` usage and review requests across all docs content.

Note: I am already listed on several specific Cloudflare One paths. This broadens coverage to all content files. More specific CODEOWNERS rules below this line will still take precedence per GitHub's last-match-wins behavior.