### PR TITLE
Remove old 1015 Workers rate limit references

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1015.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1015.mdx
@@ -28,8 +28,5 @@ The website owner has configured rate limiting rules that restrict how many requ
 - If a rate limiting rule is blocking requests in a short time period (for example, one second), try increasing the time period to 10 seconds.
 
 :::note
-If you expect a new Cloudflare Worker to exceed rate limits, refer to the [Workers documentation](/workers/platform/limits/) for guidance.
-:::
-:::note
 _Unable to purge_ is another `1015` error code relating to [Cloudflare cache purge](/cache/how-to/purge-cache). Retry the cache purge and contact [Cloudflare support](/support/contacting-cloudflare-support/) if errors persist.
 :::

--- a/src/content/docs/workers/observability/errors.mdx
+++ b/src/content/docs/workers/observability/errors.mdx
@@ -20,7 +20,6 @@ When a Worker running in production has an error that prevents it from returning
 | `1101`     | Worker threw a JavaScript exception.                                                                                                            |
 | `1102`     | Worker exceeded [CPU time limit](/workers/platform/limits/#cpu-time).                                                                           |
 | `1103`     | The owner of this worker needs to contact [Cloudflare Support](/support/contacting-cloudflare-support/)                                         |
-| `1015`     | Worker hit the [burst rate limit](/workers/platform/limits/#daily-requests).                                                                        |
 | `1019`     | Worker hit [loop limit](#loop-limit).                                                                                                           |
 | `1021`     | Worker has requested a host it cannot access.                                                                                                   |
 | `1022`     | Cloudflare has failed to route the request to the Worker.                                                                                       |


### PR DESCRIPTION
### Summary

This was removed a long time ago but these docs were missed. The burst rate limit is no more.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
