### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-05-13)

### DIFF
--- a/src/content/changelog/logs/2026-05-13-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-05-13-log-fields-updated.mdx
@@ -1,0 +1,19 @@
+---
+title: New Logpush datasets and updated fields across multiple Logpush datasets in Cloudflare Logs
+description: New Logpush datasets are now available, and fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-05-13
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### New datasets
+
+- **Email Security Post-Delivery Events**: A new dataset with fields including `AlertID`, `CompletedAt`, `Destination`, `FinalDisposition`, `Folder`, `From`, `FromName`, `MessageID`, `MessageTimestamp`, `MicrosoftTenantID`, `Operation`, `PostfixID`, `Reasons`, `Recipient`, `RequestedAt`, `RequestedBy`, `RequestedDisposition`, `Status`, `Subject`, `Success`, and `To`.
+- **Magic Network Monitoring Flow Logs**: A new dataset with fields including `AWSVPCFlowJSON`, `Bits`, `DestinationAS`, `DestinationAddress`, `DestinationPort`, `DeviceID`, `EgressBits`, `EgressPackets`, `Ethertype`, `FlowProtocol`, `FlowTimestamp`, `NumFlows`, `PacketID`, `Packets`, `Protocol`, `RuleIDs`, `SampleRate`, `SampleRateType`, `SamplerAddress`, `SourceAS`, `SourceAddress`, `SourcePort`, `TcpFlags`, and `Timestamp`.
+
+### Updated fields in existing datasets
+
+- **Firewall events** (added): `AISecurityInjectionScore`, `AISecurityPIICategories`, `AISecurityTokenCount`, and `AISecurityUnsafeTopicCategories`.
+- **HTTP requests** (added): `AISecurityInjectionScore`, `AISecurityPIICategories`, `AISecurityTokenCount`, `AISecurityUnsafeTopicCategories`, and `Subrequests`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/email_security_post_delivery_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/email_security_post_delivery_events.md
@@ -1,0 +1,136 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: Email Security Post-Delivery Events
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `email_security_post_delivery_events`.
+
+## AlertID
+
+Type: `string`
+
+Email Security alert ID for the original message.
+
+## CompletedAt
+
+Type: `int or string`
+
+The timestamp when the post-delivery action completed. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+
+## Destination
+
+Type: `string`
+
+Target folder for MOVE operations (for example, 'RecoverableItemsPurges').
+
+## FinalDisposition
+
+Type: `string`
+
+Threat disposition of the original message. <br />Possible values are <em>unset</em> \| <em>none</em> \| <em>malicious</em> \| <em>suspicious</em> \| <em>spam</em> \| <em>spoof</em> \| <em>bulk</em>.
+
+## Folder
+
+Type: `string`
+
+Resolved folder name after a successful MOVE.
+
+## From
+
+Type: `string`
+
+From header address of the original message (for example, 'firstlast@cloudflare.com').
+
+## FromName
+
+Type: `string`
+
+From header display name of the original message (for example, 'First Last').
+
+## MessageID
+
+Type: `string`
+
+RFC Message-ID header of the original message.
+
+## MessageTimestamp
+
+Type: `int or string`
+
+The timestamp of the original message. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+
+## MicrosoftTenantID
+
+Type: `string`
+
+Microsoft 365 tenant identifier.
+
+## Operation
+
+Type: `string`
+
+Post-delivery action type. <br />Possible values are <em>move</em> \| <em>submission</em> \| <em>quarantineRelease</em>.
+
+## PostfixID
+
+Type: `string`
+
+Email Security postfix queue identifier for the original message.
+
+## Reasons
+
+Type: `array[string]`
+
+Detection findings that prompted the post-delivery action (for example, 'Malicious URL').
+
+## Recipient
+
+Type: `string`
+
+Email address of the targeted mailbox (for example, 'firstlast@cloudflare.com').
+
+## RequestedAt
+
+Type: `int or string`
+
+The timestamp when the post-delivery action was requested. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
+
+## RequestedBy
+
+Type: `string`
+
+Identity that requested the post-delivery action; expected format is an email address.
+
+## RequestedDisposition
+
+Type: `string`
+
+Requested disposition for SUBMISSION operations.
+
+## Status
+
+Type: `string`
+
+Status message returned by the post-delivery provider (for example, 'OK').
+
+## Subject
+
+Type: `string`
+
+Subject header of the original message.
+
+## Success
+
+Type: `bool`
+
+Whether the post-delivery action succeeded.
+
+## To
+
+Type: `array[string]`
+
+Recipient addresses of the original message (for example, 'firstlast@cloudflare.com').

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/mnm_flow_logs.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/mnm_flow_logs.md
@@ -1,0 +1,154 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: Magic Network Monitoring Flow Logs
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `mnm_flow_logs`.
+
+## AWSVPCFlowJSON
+
+Type: `string`
+
+AWS VPC Flow Logs JSON data. Only set if the flow protocol is AWS_VPC.
+
+## Bits
+
+Type: `int`
+
+The number of bits transmitted.
+
+## DestinationAS
+
+Type: `int`
+
+The autonomous system number of the destination.
+
+## DestinationAddress
+
+Type: `string`
+
+The destination IP address.
+
+## DestinationPort
+
+Type: `int`
+
+The destination port number.
+
+## DeviceID
+
+Type: `string`
+
+If the flow is routed through a WARP device, the device ID.
+
+## EgressBits
+
+Type: `int`
+
+The number of egress bits transmitted.
+
+## EgressPackets
+
+Type: `int`
+
+The number of egress packets transmitted.
+
+## Ethertype
+
+Type: `int`
+
+The ethertype of the packet (2048 for IPv4, 34525 for IPv6, etc.).
+
+## FlowProtocol
+
+Type: `string`
+
+The flow protocol (e.g., 'AWS_VPC', 'IPFIX', 'SFLOW_5', 'NETFLOW_V9', etc.).
+
+## FlowTimestamp
+
+Type: `int or string`
+
+The timestamp of the flow.
+
+## NumFlows
+
+Type: `int`
+
+The number of flows.
+
+## PacketID
+
+Type: `string`
+
+The packet ID.
+
+## Packets
+
+Type: `int`
+
+The number of packets transmitted.
+
+## Protocol
+
+Type: `int`
+
+The protocol number (e.g., 6 for TCP, 17 for UDP).
+
+## RuleIDs
+
+Type: `string`
+
+Comma-separated list of rule IDs associated with the flow if any.
+
+## SampleRate
+
+Type: `int`
+
+The sample rate of the flow set by the sampler (1, 100, 1000, 1024, 2000 are common).
+
+## SampleRateType
+
+Type: `string`
+
+The type of sample rate (e.g. 'flow', 'default', 'propagated').
+
+## SamplerAddress
+
+Type: `string`
+
+The sampler IP address.
+
+## SourceAS
+
+Type: `int`
+
+The autonomous system number of the source.
+
+## SourceAddress
+
+Type: `string`
+
+The source IP address.
+
+## SourcePort
+
+Type: `int`
+
+The source port number.
+
+## TcpFlags
+
+Type: `int`
+
+The TCP flags.
+
+## Timestamp
+
+Type: `int or string`
+
+The date and time of the event.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
@@ -7,8 +7,6 @@ sidebar:
   order: 21
 ---
 
-Network session logs are generated for all traffic proxied through Cloudflare Gateway across all supported [on-ramps](/cloudflare-one/networks/connectivity-options/), such as the Cloudflare One Client (WARP), proxy endpoints (PAC files), Browser Isolation, and Cloudflare Tunnel.
-
 The descriptions below detail the fields available for `zero_trust_network_sessions`.
 
 ## AccountID

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
@@ -9,6 +9,30 @@ sidebar:
 
 The descriptions below detail the fields available for `firewall_events`.
 
+## AISecurityInjectionScore
+
+Type: `int`
+
+The score indicating the likelihood of a prompt injection attack in the request, as determined by AI Security.
+
+## AISecurityPIICategories
+
+Type: `array[string]`
+
+List of PII categories detected in the request by AI Security.
+
+## AISecurityTokenCount
+
+Type: `int`
+
+The number of tokens in the request, as counted by AI Security.
+
+## AISecurityUnsafeTopicCategories
+
+Type: `array[string]`
+
+List of unsafe topic categories detected in the request by AI Security.
+
 ## Action
 
 Type: `string`
@@ -157,25 +181,25 @@ HTTP response status code returned to browser.
 
 Type: `int`
 
-The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI.
+The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI. Deprecated: Use AISecurityInjectionScore instead.
 
 ## FirewallForAIPIICategories
 
 Type: `array[string]`
 
-List of PII categories detected in the request by Firewall for AI.
+List of PII categories detected in the request by Firewall for AI. Deprecated: Use AISecurityPIICategories instead.
 
 ## FirewallForAITokenCount
 
 Type: `int`
 
-The number of tokens in the request, as counted by Firewall for AI.
+The number of tokens in the request, as counted by Firewall for AI. Deprecated: Use AISecurityTokenCount instead.
 
 ## FirewallForAIUnsafeTopicCategories
 
 Type: `array[string]`
 
-List of unsafe topic categories detected in the request by Firewall for AI.
+List of unsafe topic categories detected in the request by Firewall for AI. Deprecated: Use AISecurityUnsafeTopicCategories instead.
 
 ## FraudUserID
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -9,6 +9,30 @@ sidebar:
 
 The descriptions below detail the fields available for `http_requests`.
 
+## AISecurityInjectionScore
+
+Type: `int`
+
+The score indicating the likelihood of a prompt injection attack in the request, as determined by AI Security.
+
+## AISecurityPIICategories
+
+Type: `array[string]`
+
+List of PII categories detected in the request by AI Security.
+
+## AISecurityTokenCount
+
+Type: `int`
+
+The number of tokens in the request, as counted by AI Security.
+
+## AISecurityUnsafeTopicCategories
+
+Type: `array[string]`
+
+List of unsafe topic categories detected in the request by AI Security.
+
 ## BotDetectionIDs
 
 Type: `array[int]`
@@ -345,29 +369,29 @@ Type: `int`
 
 Total view of Time To First Byte as measured at Cloudflare's edge. Starts after a TCP connection is established and ends when Cloudflare begins returning the first byte of a response to eyeballs. Includes TLS handshake time (for new connections) and origin response time.
 
-## FirewallForAIInjectionScore
+## FirewallForAIInjectionScore (deprecated)
 
 Type: `int`
 
-The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI.
+The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI. Deprecated: Use AISecurityInjectionScore instead.
 
-## FirewallForAIPIICategories
+## FirewallForAIPIICategories (deprecated)
 
 Type: `array[string]`
 
-List of PII categories detected in the request by Firewall for AI.
+List of PII categories detected in the request by Firewall for AI. Deprecated: Use AISecurityPIICategories instead.
 
-## FirewallForAITokenCount
+## FirewallForAITokenCount (deprecated)
 
 Type: `int`
 
-The number of tokens in the request, as counted by Firewall for AI.
+The number of tokens in the request, as counted by Firewall for AI. Deprecated: Use AISecurityTokenCount instead.
 
-## FirewallForAIUnsafeTopicCategories
+## FirewallForAIUnsafeTopicCategories (deprecated)
 
 Type: `array[string]`
 
-List of unsafe topic categories detected in the request by Firewall for AI.
+List of unsafe topic categories detected in the request by Firewall for AI. Deprecated: Use AISecurityUnsafeTopicCategories instead.
 
 ## FraudAttack
 
@@ -451,7 +475,7 @@ Time taken to send request headers to origin after establishing a connection. No
 
 Type: `int`
 
-Number of bytes returned by the origin server. Consider using CacheResponseBytes and filtering out OriginResponseStatus with values 0 and 304, which indicate a revalidated response. Read more [here](/logs/faq/common-calculations/#how-can-i-calculate-bytes-served-by-the-origin-from-cloudflare-logs).
+Number of bytes returned by the origin server.
 
 ## OriginResponseDurationMs
 
@@ -578,6 +602,12 @@ Array of security products that matched the request. The same product can appear
 Type: `int`
 
 The Cloudflare data center used to connect to the origin server if Argo Smart Routing is used.
+
+## Subrequests
+
+Type: `array[object]`
+
+Flattened list of subrequests associated with this request. Each subrequest contains the same fields as the parent request (excluding Subrequests itself).
 
 ## UpperTierColoID
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### New datasets

- **Email Security Post-Delivery Events**: A new dataset with fields including `AlertID`, `CompletedAt`, `Destination`, `FinalDisposition`, `Folder`, `From`, `FromName`, `MessageID`, `MessageTimestamp`, `MicrosoftTenantID`, `Operation`, `PostfixID`, `Reasons`, `Recipient`, `RequestedAt`, `RequestedBy`, `RequestedDisposition`, `Status`, `Subject`, `Success`, and `To`.
- **Magic Network Monitoring Flow Logs**: A new dataset with fields including `AWSVPCFlowJSON`, `Bits`, `DestinationAS`, `DestinationAddress`, `DestinationPort`, `DeviceID`, `EgressBits`, `EgressPackets`, `Ethertype`, `FlowProtocol`, `FlowTimestamp`, `NumFlows`, `PacketID`, `Packets`, `Protocol`, `RuleIDs`, `SampleRate`, `SampleRateType`, `SamplerAddress`, `SourceAS`, `SourceAddress`, `SourcePort`, `TcpFlags`, and `Timestamp`.

### Updated fields in existing datasets

- **Firewall events** (added): `AISecurityInjectionScore`, `AISecurityPIICategories`, `AISecurityTokenCount`, and `AISecurityUnsafeTopicCategories`.
- **HTTP requests** (added): `AISecurityInjectionScore`, `AISecurityPIICategories`, `AISecurityTokenCount`, `AISecurityUnsafeTopicCategories`, and `Subrequests`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/{account,zone}/` — dataset pages
- `src/content/changelog/logs/2026-05-13-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
