### PR TITLE
[Access] Add Gateway Audit SSH rules to API deprecations

### DIFF
--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -3,6 +3,23 @@ link: "/fundamentals/api/reference/deprecations/"
 productName: API deprecations
 productLink: "/fundamentals/"
 entries:
+  - publish_date: "2026-05-13"
+    title: "Gateway Audit SSH rules"
+    description: |-
+      Deprecation date: November 3, 2025
+
+      End of life date: July 1, 2026
+
+      The Gateway Audit SSH action for [network policies](/cloudflare-one/traffic-policies/network-policies/) is deprecated and will be fully removed on July 1, 2026. [SSH with Access for Infrastructure](/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access/) is the replacement for managing and auditing SSH access.
+
+      Creating new Gateway rules with `action: "audit_ssh"` via the dashboard was disabled in December 2024. Creating new rules via the API and Terraform was disabled on November 3, 2025. Editing existing rules via the dashboard, API, and Terraform was disabled on January 15, 2026. On July 1, 2026, all remaining Audit SSH rules will stop working.
+
+      Deprecated APIs:
+      * `POST /accounts/{account_id}/gateway/rules` — creating rules with `action: "audit_ssh"` is no longer accepted
+      * `PUT /accounts/{account_id}/gateway/rules/{rule_id}` — editing rules with `action: "audit_ssh"` is no longer accepted
+
+      Replacement: [SSH with Access for Infrastructure](/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access/)
+
   - publish_date: "2026-03-19"
     title: "Service Key Authentication"
     description: |-


### PR DESCRIPTION
### Summary

Adds the Gateway Audit SSH rules deprecation to the API deprecations page. This deprecation has been in progress since December 2024 (dashboard creation disabled) with progressive milestones through November 2025 (API/Terraform creation disabled) and January 2026 (editing disabled). Full end of life is July 1, 2026.

This was missing from the deprecations page entirely, which contributed to affected customers not being aware of the change.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
