### PR TITLE
[Support] Add SaaS provider IP restriction use case to error 1034

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034.mdx
@@ -11,11 +11,20 @@ products:
 
 This error indicates that the IP address used for the domain is restricted by Cloudflare's edge validation.
 
-### Common cause
+### Common causes
 
-Customers who previously pointed their domains to `1.1.1.1` will now encounter `1034` error. This is due to a new edge validation check in Cloudflare's systems to prevent misconfiguration and/or potential abuse.
+#### Pointing to reserved IP addresses
 
-### Resolution
+Customers who previously pointed their domains to `1.1.1.1` will now encounter a `1034` error. This is due to edge validation checks in Cloudflare's systems to prevent misconfiguration and potential abuse.
 
-Ensure DNS records are pointed to IP addresses you control, and in the case a placeholder IP address is needed for “originless” setups, use the IPv6 reserved address `100::` or the IPv4 reserved address `192.0.2.0`.
+**Resolution**: Ensure DNS records are pointed to IP addresses you control. If a placeholder IP address is needed for "originless" setups, use the IPv6 reserved address `100::` or the IPv4 reserved address `192.0.2.0`.
 
+#### SaaS provider IP restrictions
+
+If you are using a SaaS provider that uses [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/), the provider may restrict access to their infrastructure to validated IP addresses only. In this case, requests to their IP addresses from domains that are not properly configured with the provider will be blocked with a `1034` error.
+
+**Resolution**: Verify that your domain is correctly configured with your SaaS provider. This typically involves:
+
+1. Ensuring your DNS records point to the correct IP addresses or hostnames provided by your SaaS provider.
+2. Confirming that your domain has been properly registered and validated with the SaaS provider's platform.
+3. Contacting your SaaS provider's support team if you continue to experience this error after verifying your configuration.


### PR DESCRIPTION
## Summary

Expands the error 1034 documentation to include the SaaS provider IP restriction use case.

## Problem

Customers using SaaS providers that leverage Cloudflare for SaaS may encounter 1034 errors when their domains are not properly configured with the provider. The current documentation only covers the reserved IP address scenario (pointing to `1.1.1.1`).

## Solution

Updated `/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034/` to:

- Restructure as "Common causes" with two distinct scenarios
- Keep the original cause: pointing to reserved IP addresses
- Add new cause: SaaS provider IP restrictions
- Provide resolution steps for SaaS provider configuration issues

The documentation intentionally does not mention internal feature names and instead guides end users to verify their configuration with their SaaS provider.

## Ticket

- SPM-1929
