### PR TITLE
Fix Gateway Audit SSH EOL date to July 15, 2026

### DIFF
--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -8,11 +8,11 @@ entries:
     description: |-
       Deprecation date: November 3, 2025
 
-      End of life date: July 1, 2026
+      End of life date: July 15, 2026
 
-      The Gateway Audit SSH action for [network policies](/cloudflare-one/traffic-policies/network-policies/) is deprecated and will be fully removed on July 1, 2026. [SSH with Access for Infrastructure](/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access/) is the replacement for managing and auditing SSH access.
+      The Gateway Audit SSH action for [network policies](/cloudflare-one/traffic-policies/network-policies/) is deprecated and will be fully removed on July 15, 2026. [SSH with Access for Infrastructure](/cloudflare-one/connections/connect-networks/use-cases/ssh/ssh-infrastructure-access/) is the replacement for managing and auditing SSH access.
 
-      Creating new Gateway rules with `action: "audit_ssh"` via the dashboard was disabled in December 2024. Creating new rules via the API and Terraform was disabled on November 3, 2025. Editing existing rules via the dashboard, API, and Terraform was disabled on January 15, 2026. On July 1, 2026, all remaining Audit SSH rules will stop working.
+      Creating new Gateway rules with `action: "audit_ssh"` via the dashboard was disabled in December 2024. Creating new rules via the API and Terraform was disabled on November 3, 2025. Editing existing rules via the dashboard, API, and Terraform was disabled on January 15, 2026. On July 15, 2026, all remaining Audit SSH rules will stop working.
 
       Deprecated APIs:
       * `POST /accounts/{account_id}/gateway/rules` — creating rules with `action: "audit_ssh"` is no longer accepted


### PR DESCRIPTION
## Summary

- Corrects the Gateway Audit SSH rules end-of-life date from July 1 to **July 15, 2026** in the API deprecations page
- The original PR (#30810) had the wrong date; July 15 is the confirmed EOL date per the customer notification email

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).