### PR TITLE
[PCX-21854] Note Enterprise unavailability on Usage Based Billing notification

### DIFF
--- a/src/content/notifications/index.yaml
+++ b/src/content/notifications/index.yaml
@@ -8,7 +8,10 @@ entries:
 
   - name: Usage Based Billing
     audience: Customers who want to receive a notification when the usage of a product goes above a set level.
-    availability: Professional plans or higher.
+    availability: |-
+      Professional plans or higher.
+
+      **Note:** Usage-based billing notifications are available to Pay-as-you-go accounts only. Most Enterprise contract accounts are not supported.
     associatedProducts: Billing
     nextSteps: Review your product usage and adjust the configuration and/or increase the alerting threshold.
     otherFilters: |-


### PR DESCRIPTION
**Tracking ticket:** [PCX-21854](https://jira.cfdata.org/browse/PCX-21854)

Updates the **Usage Based Billing** entry on [`/notifications/notification-available/`](https://developers.cloudflare.com/notifications/notification-available/#billing) to note that the product is not currently available to most Enterprise contract accounts.

This mirrors the existing note on the [Budget alerts](https://developers.cloudflare.com/billing/manage/budget-alerts/) page:

> Budget alerts are available to Pay-as-you-go accounts only. Enterprise contract accounts are not supported.

## Why `availability` and not a callout

The note is appended to the entry's `availability` field in `src/content/notifications/index.yaml`. The `<AvailableNotifications />` component renders YAML strings through `marked.parse()` directly, so Starlight `:::note` directives are not available inside this component. The Markdown `**Note:**` prefix is the closest equivalent without extending the component or the content schema.

## Preview

After merge, the note will appear inside the expanded **Usage Based Billing** details block, under **Included with**, on [Available Notifications → Billing](https://developers.cloudflare.com/notifications/notification-available/#billing).
