### PR TITLE
docs(durable-objects): Remove references to wrangler dev --remote

### DIFF
--- a/src/content/changelog/durable-objects/2026-05-18-wrangler-dev-remote-removed.mdx
+++ b/src/content/changelog/durable-objects/2026-05-18-wrangler-dev-remote-removed.mdx
@@ -1,5 +1,5 @@
 ---
-title: "`wrangler dev --remote` support removed for KV-backed Durable Objects"
+title: "Legacy `wrangler dev --remote` support removed for KV-backed Durable Objects"
 description: Support for the legacy `wrangler dev --remote` flag has been removed for KV-backed Durable Objects.
 products:
   - durable-objects
@@ -7,8 +7,8 @@ products:
 date: 2026-05-18
 ---
 
-Starting 2026-05-18, support for the deprecated, legacy [`wrangler dev --remote`](/workers/development-testing/#wrangler-dev---remote-legacy) flag has been removed for KV-backed Durable Objects. Running `wrangler dev --remote` against a KV-backed Durable Object will return an error.
+Starting 2026-05-18, support for the deprecated, legacy [`wrangler dev --remote`](/workers/development-testing/#wrangler-dev---remote-legacy) flag has been removed for KV-backed Durable Objects and will return an error. The `--remote` flag was never supported with the recommended [SQLite storage backend](/durable-objects/best-practices/rules-of-durable-objects/#use-sqlite-backed-durable-objects) for Durable Objects.
 
-`wrangler dev --remote` was never supported with SQLite-backed Durable Objects.
+For all Durable Objects, continue to use [`wrangler dev`](/workers/development-testing/#local-development) for local development and testing.
 
-For local development with Durable Objects, refer to [Using remote resources with Durable Objects and Workflows](/workers/development-testing/#using-remote-resources-with-durable-objects-and-workflows).
+During local development if you need to access remote resources running on Cloudflare's network, refer to [Using remote resources with Durable Objects and Workflows](/workers/development-testing/#using-remote-resources-with-durable-objects-and-workflows).

--- a/src/content/changelog/durable-objects/2026-05-18-wrangler-dev-remote-removed.mdx
+++ b/src/content/changelog/durable-objects/2026-05-18-wrangler-dev-remote-removed.mdx
@@ -1,0 +1,14 @@
+---
+title: "`wrangler dev --remote` support removed for KV-backed Durable Objects"
+description: Support for the legacy `wrangler dev --remote` flag has been removed for KV-backed Durable Objects.
+products:
+  - durable-objects
+  - workers
+date: 2026-05-18
+---
+
+Starting 2026-05-18, support for the deprecated, legacy [`wrangler dev --remote`](/workers/development-testing/#wrangler-dev---remote-legacy) flag has been removed for KV-backed Durable Objects. Running `wrangler dev --remote` against a KV-backed Durable Object will return an error.
+
+`wrangler dev --remote` was never supported with SQLite-backed Durable Objects.
+
+For local development with Durable Objects, refer to [Using remote resources with Durable Objects and Workflows](/workers/development-testing/#using-remote-resources-with-durable-objects-and-workflows).

--- a/src/content/docs/durable-objects/observability/troubleshooting.mdx
+++ b/src/content/docs/durable-objects/observability/troubleshooting.mdx
@@ -12,8 +12,6 @@ products:
 
 [`wrangler dev`](/workers/wrangler/commands/general/#dev) and [`wrangler tail`](/workers/wrangler/commands/general/#tail) are both available to help you debug your Durable Objects.
 
-The `wrangler dev --remote` command opens a tunnel from your local development environment to Cloudflare's global network, letting you test your Durable Objects code in the Workers environment as you write it.
-
 `wrangler tail` displays a live feed of console and exception logs for each request served by your Worker code, including both normal Worker requests and Durable Object requests. After running `npx wrangler deploy`, you can use `wrangler tail` in the root directory of your Worker project and visit your Worker URL to see console and error logs in your terminal.
 
 ## Common errors


### PR DESCRIPTION
### Summary

Remove the sentence describing wrangler dev --remote from the Durable Objects troubleshooting docs, as this flag is being deprecated.
