### PR TITLE
docs(browser-run): add multiple CDP connections and secure credential…

### DIFF
--- a/src/content/docs/browser-run/cdp/index.mdx
+++ b/src/content/docs/browser-run/cdp/index.mdx
@@ -51,4 +51,64 @@ HTTP endpoints are also available to manage the browser lifecycle without using 
 
 Check the [API reference](/api/resources/browser_rendering/) for the full list of endpoints.
 
+## Multiple connections to the same session
+
+A Browser Run session supports multiple simultaneous CDP connections. Two or more clients can connect to the same browser session, or to the same tab, at the same time.
+
+This is useful when you need to separate concerns between different services interacting with the same browser. For example:
+
+- A primary automation script controls navigation and page interactions, while a separate service connects to the same tab to inject credentials or perform privileged operations.
+- An AI agent drives the browser through one connection, while an MCP server connects independently to the same tab to handle sensitive actions the agent should not have direct access to.
+- A monitoring or debugging tool observes a session in real time while another client drives automation.
+
+To connect multiple clients to the same session, [create the session via HTTP](/browser-run/cdp/session-management/#step-1-acquire-a-browser-session) first to obtain a session-specific `webSocketDebuggerUrl`. Both clients then connect to that URL and can discover pages using `browser.targets()`.
+
+:::note
+You must use the session-specific WebSocket URL (which includes the session ID) returned by `POST /devtools/browser`. Connecting to the generic `/devtools/browser?keep_alive=...` endpoint without a session ID creates a new session each time.
+:::
+
+```js
+import puppeteer from "puppeteer-core";
+
+const ACCOUNT_ID = "<ACCOUNT_ID>";
+const API_TOKEN = "<API_TOKEN>";
+const BASE = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/browser-rendering`;
+const HEADERS = { Authorization: `Bearer ${API_TOKEN}` };
+
+// Step 1: Create a session via HTTP to get a session-specific WebSocket URL
+const res = await fetch(`${BASE}/devtools/browser?keep_alive=600000`, {
+  method: "POST",
+  headers: HEADERS,
+});
+const { sessionId, webSocketDebuggerUrl } = await res.json();
+
+// Step 2: First client connects and navigates to a page
+const browser1 = await puppeteer.connect({
+  browserWSEndpoint: webSocketDebuggerUrl,
+  headers: HEADERS,
+});
+const page = await browser1.newPage();
+await page.goto("https://example.com/login");
+
+// Step 3: Second client connects to the same session
+const browser2 = await puppeteer.connect({
+  browserWSEndpoint: webSocketDebuggerUrl,
+  headers: HEADERS,
+});
+
+// Step 4: Second client finds the page via targets
+const target = browser2
+  .targets()
+  .find((t) => t.url().includes("example.com/login"));
+const samePage = await target.page();
+
+// Both clients can now interact with the same page independently
+await samePage.type("#username", "user@example.com");
+
+// Changes are visible to both clients
+console.log(await page.title()); // reflects any changes made by browser2
+```
+
+How you share the `webSocketDebuggerUrl` between services depends on your architecture. See [Secure credential injection for AI agents](/browser-run/how-to/secure-credential-injection/) for a full example of this pattern.
+
 <Render file="faq" product="browser-run" />

--- a/src/content/docs/browser-run/how-to/secure-credential-injection.mdx
+++ b/src/content/docs/browser-run/how-to/secure-credential-injection.mdx
@@ -1,0 +1,118 @@
+---
+pcx_content_type: tutorial
+title: Secure credential injection for AI agents
+products: [browser-run]
+difficulty: Advanced
+tags:
+  - AI
+  - Security
+  - CDP
+sidebar:
+  order: 3
+description: >-
+  Keep credentials out of the LLM context by using a separate service that connects directly to a Browser Run session via CDP to inject credentials.
+---
+
+When building AI agents that automate browser tasks, the agent often needs to log in to websites on behalf of a user. Passing credentials through the LLM context is a security risk: prompt injection attacks could extract them, and they may appear in logs or conversation history.
+
+This guide describes an architecture pattern where a separate, trusted service connects directly to the same browser session via [CDP](/browser-run/cdp/) and injects credentials without the AI agent ever seeing them. The agent calls a tool (for example, an [MCP](https://modelcontextprotocol.io/) tool) that returns only a success or failure result.
+
+## How it works
+
+Browser Run supports [multiple simultaneous CDP connections](/browser-run/cdp/#multiple-connections-to-the-same-session) to the same browser session. This makes it possible to split responsibilities between two services:
+
+1. **The AI agent** controls navigation and page interactions through one CDP connection.
+2. **A credential service** connects to the same browser tab through a second CDP connection, types the credentials into form fields, and reports back whether login succeeded.
+
+The agent never sees the credentials, the WebSocket URL to the browser, or the form selectors used for login.
+
+```
+Agent                          Credential Service                Browser Run
+  │                                    │                              │
+  │  tool call: login(sessionId, ...)  │                              │
+  │ ─────────────────────────────────► │                              │
+  │                                    │  CDP connect (2nd client)    │
+  │                                    │ ────────────────────────────►│
+  │                                    │  find page, type credentials │
+  │                                    │ ────────────────────────────►│
+  │                                    │  wait for success selector   │
+  │                                    │ ◄────────────────────────────│
+  │         { ok: true }               │                              │
+  │ ◄───────────────────────────────── │                              │
+  │                                    │                              │
+  │  (agent continues, never saw       │                              │
+  │   credentials or browser wsUrl)    │                              │
+```
+
+## Credential service implementation
+
+The credential service can be a Worker, a Durable Object, an MCP server, or any backend that can make WebSocket connections. It needs:
+
+- Access to the user's stored credentials (from your own database or secret store).
+- The Browser Run session ID, so it can connect to the same browser.
+- A configuration of form selectors (username field, password field, submit button, success indicator) for each site the agent may need to log in to.
+
+### Connecting to the same browser tab
+
+Use the [HTTP API](/browser-run/cdp/session-management/) to list targets in the session and find the login page, then connect via Puppeteer:
+
+```js
+import puppeteer from "puppeteer-core";
+
+const ACCOUNT_ID = "<ACCOUNT_ID>";
+const API_TOKEN = "<API_TOKEN>";
+const BASE = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/browser-rendering`;
+const HEADERS = { Authorization: `Bearer ${API_TOKEN}` };
+
+async function injectCredentials(sessionId, username, password, selectors) {
+  // Connect to the existing session
+  const wsUrl = `wss://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/browser-rendering/devtools/browser/${sessionId}`;
+  const browser = await puppeteer.connect({
+    browserWSEndpoint: wsUrl,
+    headers: HEADERS,
+  });
+
+  // Find the login page among the session's open tabs
+  const target = browser
+    .targets()
+    .find((t) => t.url().includes(selectors.loginUrlPattern));
+  if (!target) {
+    browser.disconnect();
+    return { ok: false, reason: "Login page not found" };
+  }
+  const page = await target.page();
+
+  // Type credentials and submit
+  await page.type(selectors.usernameField, username);
+  await page.type(selectors.passwordField, password);
+  await page.click(selectors.submitButton);
+
+  // Wait for success indicator
+  try {
+    await page.waitForSelector(selectors.successSelector, { timeout: 10000 });
+    browser.disconnect();
+    return { ok: true };
+  } catch {
+    browser.disconnect();
+    return { ok: false, reason: "Login did not succeed within timeout" };
+  }
+}
+```
+
+The agent only needs to pass the `sessionId` to the credential service. It never sees the credentials, the WebSocket URL, or the selectors.
+
+## Security considerations
+
+When building this pattern, keep these points in mind:
+
+- **Selectors should come from a configuration store, not the LLM.** If the agent could pass arbitrary selectors, a prompt injection attack could redirect credentials to an attacker-controlled field. Define selectors per site in your service's configuration.
+- **The browser WebSocket URL should not pass through the agent.** The credential service resolves it from the session ID using its own API token. This keeps the CDP endpoint out of the LLM context.
+- **Always verify login success.** Every login configuration should include a success selector (for example, a dashboard element or a URL change). Without verification, the agent may continue assuming login worked when it did not.
+- **Decrypt credentials in memory only.** Retrieve encrypted credentials from your data store and decrypt them within the credential service. Never write decrypted credentials to logs, responses, or intermediate storage.
+
+## Related resources
+
+- [Multiple connections to the same session](/browser-run/cdp/#multiple-connections-to-the-same-session)
+- [Session management (HTTP)](/browser-run/cdp/session-management/)
+- [Using with Puppeteer (CDP)](/browser-run/cdp/puppeteer/)
+- [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)


### PR DESCRIPTION
… injection guide

- Document that Browser Run supports multiple simultaneous CDP connections to the same session, with a verified code sample
- Add tutorial for secure credential injection pattern where a separate service injects credentials via CDP without the AI agent seeing them
- Both code samples tested against live Browser Run

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
