### PR TITLE
[Durable Objects] Add changelog for ctx.id.name support

### DIFF
--- a/src/content/changelog/durable-objects/2026-03-26-durable-object-id-name.mdx
+++ b/src/content/changelog/durable-objects/2026-03-26-durable-object-id-name.mdx
@@ -1,0 +1,39 @@
+---
+title: Access Durable Object name via `ctx.id.name`
+description: Retrieve the name of a named Durable Object from within the object itself.
+products:
+  - durable-objects
+  - workers
+date: 2026-03-26
+---
+
+`ctx.id.name` inside a Durable Object now matches what you see client-side. If a Worker accesses a Durable Object via `idFromName()` or `getByName()`, the same name is now available on `ctx.id.name` inside the object — no need to pass it through method arguments or persist it in storage.
+
+Previously, the TypeScript type for `ctx.id` declared `name` as `string | undefined`, which led developers and LLM-based coding assistants to assume the name would be available inside the Durable Object. In reality, it was always `undefined` from inside, forcing manual workarounds.
+
+```js
+export class ChatRoom extends DurableObject {
+  async fetch(request) {
+    // ctx.id.name now matches the name passed to getByName() or idFromName() on the client side
+    const roomName = this.ctx.id.name;
+    return new Response(`Welcome to ${roomName}!`);
+  }
+}
+
+// Worker
+export default {
+  async fetch(request, env) {
+    const stub = env.CHAT_ROOM.getByName("general");
+    return stub.fetch(request);
+  },
+};
+```
+
+A few things to note about when `ctx.id.name` is set:
+
+- **Populated** when the Durable Object is accessed via `idFromName()` or `getByName()`.
+- **`undefined`** for Durable Objects created with `newUniqueId()`.
+- **`undefined`** when accessed via `idFromString()`, even if the ID was originally created from a name.
+- **`undefined`** for names longer than 1,024 bytes.
+
+For more information, refer to the [Durable Object ID documentation](/durable-objects/api/id/#name).


### PR DESCRIPTION
## Summary

Adds a changelog entry dated 2026-03-26 documenting that `ctx.id.name` is now populated inside a Durable Object when accessed via `idFromName()` or `getByName()`.

The entry:
- Highlights that the in-Durable-Object `ctx.id.name` value now matches what the client sees on the stub's ID.
- Explains the prior pain point (TypeScript types implied `name` would be populated, but it was always `undefined` inside the Durable Object).
- Documents the four cases where `name` is `undefined` (unique IDs, `idFromString()`, names > 1024 bytes).

## References

- workerd PR: https://github.com/cloudflare/workerd/pull/6421
- Original issue: https://github.com/cloudflare/workerd/issues/2240