### PR TITLE
[Access] Changelog: SPA redirect fragment encoding fix

### DIFF
--- a/src/content/changelog/access/2026-05-14-spa-redirect-fragment-fix.mdx
+++ b/src/content/changelog/access/2026-05-14-spa-redirect-fragment-fix.mdx
@@ -1,0 +1,13 @@
+---
+title: Fix redirect URL fragment encoding for single-page applications
+description: Access no longer over-encodes URL fragment characters, fixing post-login redirects for single-page applications with fragment-based routing.
+date: 2026-05-14
+products:
+  - access
+---
+
+Access now correctly preserves URL fragment characters (`/`, `?`, `=`, `&`, `;`) when redirecting users back to an application after login. Previously, these characters were encoded with `encodeURIComponent`, which mangled fragment-based routes used by single-page applications (SPAs).
+
+For example, an SPA URL like `https://app.example.com/#/dashboard?tab=settings&view=advanced` would previously redirect to a broken URL after login. This is now handled correctly.
+
+If your SPA users were experiencing broken navigation after authenticating through Access, this fix resolves the issue without any configuration changes.

--- a/src/content/changelog/access/2026-07-01-spa-redirect-fragment-fix.mdx
+++ b/src/content/changelog/access/2026-07-01-spa-redirect-fragment-fix.mdx
@@ -1,7 +1,7 @@
 ---
 title: Fix redirect URL fragment encoding for single-page applications
 description: Access no longer over-encodes URL fragment characters, fixing post-login redirects for single-page applications with fragment-based routing.
-date: 2026-05-14
+date: 2026-07-01
 products:
   - access
 ---


### PR DESCRIPTION
## Summary

- Adds changelog entry for the SPA redirect fragment encoding fix shipped in heimtor !2380 (AUTH-8638)

## What changed

Access was over-encoding URL fragment characters (`/`, `?`, `=`, `&`) using `encodeURIComponent` instead of `encodeURI`. This broke post-login redirects for SPAs with fragment-based routing (e.g., `/#/dashboard?tab=settings`).

## Source MR

- heimtor !2380 — AUTH-8638: relax redirect URL fragment encoding
