### PR TITLE
[Access] Document granular target permissions for Infrastructure Access

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/applications/non-http/infrastructure-apps.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/non-http/infrastructure-apps.mdx
@@ -110,6 +110,12 @@ To view all available filters, type `warp-cli target list --help`.
 
 To revoke a user's access to all infrastructure targets, you can either [revoke the user from Zero Trust](/cloudflare-one/access-controls/access-settings/session-management/#per-user) or revoke their device. Cloudflare does not currently support revoking a user's session for a specific target.
 
+## Granular target permissions
+
+Infrastructure Access supports granular read permissions through [Cloudflare's role-based access control](/fundamentals/setup/manage-members/roles/). Administrators can assign read-only roles scoped to specific targets instead of granting account-wide access. When a user with a scoped role calls the targets list API, the response is automatically filtered to only include the targets they have permission to view.
+
+This is useful for organizations that want to give teams visibility into their own infrastructure targets without exposing the full target inventory.
+
 ## Infrastructure policy selectors
 
 The following [Access policy selectors](/cloudflare-one/access-controls/policies/#selectors) are available for securing infrastructure applications:

--- a/src/content/docs/cloudflare-one/access-controls/applications/non-http/infrastructure-apps.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/non-http/infrastructure-apps.mdx
@@ -112,7 +112,7 @@ To revoke a user's access to all infrastructure targets, you can either [revoke 
 
 ## Granular target permissions
 
-Infrastructure Access supports granular read permissions through [Cloudflare's role-based access control](/fundamentals/setup/manage-members/roles/). Administrators can assign read-only roles scoped to specific targets instead of granting account-wide access. When a user with a scoped role calls the targets list API, the response is automatically filtered to only include the targets they have permission to view.
+Infrastructure Access supports granular read permissions through [Cloudflare's role-based access control](/fundamentals/manage-members/roles/). Administrators can assign read-only roles scoped to specific targets instead of granting account-wide access. When a user with a scoped role calls the targets list API, the response is automatically filtered to only include the targets they have permission to view.
 
 This is useful for organizations that want to give teams visibility into their own infrastructure targets without exposing the full target inventory.
 


### PR DESCRIPTION
## Summary

- Adds new **Granular target permissions** section to the Infrastructure Access docs
- Documents that scoped roles can filter the targets list API to only show authorized targets

## Source MR

- hephaestus !340 (ZTIA-1043) — AAuthz support for GET /targets list endpoint
