### PR TITLE
[Access] Document IdP federation for sharing identity providers across accounts

### DIFF
--- a/src/content/changelog/access/2026-05-19-idp-federation.mdx
+++ b/src/content/changelog/access/2026-05-19-idp-federation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Share identity providers across accounts with IdP federation
-description: Organizations with multiple Cloudflare accounts can now share a single identity provider configuration across accounts using IdP federation grants.
+description: Organizations with multiple Cloudflare accounts can now share a single identity provider configuration across accounts using IdP federation.
 date: 2026-05-19
 products:
   - access
@@ -8,13 +8,12 @@ products:
 
 Cloudflare Access now supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which allows organizations to share a single identity provider across multiple Cloudflare accounts.
 
-Instead of configuring the same IdP (for example, Okta or Entra ID) in every account, you configure it once in a source account and create a federation grant to share it. Recipient accounts automatically receive a read-only copy of the IdP connection. Users in those accounts authenticate through the shared IdP, and each account's Access policies evaluate the identity as normal.
+Instead of configuring the same IdP (for example, Okta or Entra ID) separately in every account, you configure it once in a source account and share it with the other accounts in your organization. Each recipient account gets a read-only IdP connection that routes authentication back to the source account through a bridge — a hidden application in the source account that brokers the cross-account login. End users sign in with their existing IdP credentials, and each account's Access policies evaluate the resulting identity just like any other IdP login.
 
 Key capabilities:
 
-- **One IdP, many accounts** — Configure your IdP once and distribute it to all accounts in your organization.
-- **Automatic lifecycle management** — Consumer IdPs are created and cleaned up automatically when grants are shared or revoked.
-- **Immutable consumer IdPs** — Federated IdP connections in recipient accounts cannot be accidentally modified or deleted.
-- **Audit logging** — Federation grant creation and deletion events are recorded in the Access audit log.
+- **One IdP, many accounts** — Configure your IdP once and share it with all accounts in your organization.
+- **Lifecycle management** — As accounts join or leave your Cloudflare organization, their IdP connections are provisioned and removed automatically — no manual cleanup required.
+- **Immutable recipient connections** — IdP connections in recipient accounts cannot be accidentally modified or deleted.
 
 To get started, refer to [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/).

--- a/src/content/changelog/access/2026-05-19-idp-federation.mdx
+++ b/src/content/changelog/access/2026-05-19-idp-federation.mdx
@@ -1,0 +1,20 @@
+---
+title: Share identity providers across accounts with IdP federation
+description: Organizations with multiple Cloudflare accounts can now share a single identity provider configuration across accounts using IdP federation grants.
+date: 2026-05-19
+products:
+  - access
+---
+
+Cloudflare Access now supports [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/), which allows organizations to share a single identity provider across multiple Cloudflare accounts.
+
+Instead of configuring the same IdP (for example, Okta or Entra ID) in every account, you configure it once in a source account and create a federation grant to share it. Recipient accounts automatically receive a read-only copy of the IdP connection. Users in those accounts authenticate through the shared IdP, and each account's Access policies evaluate the identity as normal.
+
+Key capabilities:
+
+- **One IdP, many accounts** — Configure your IdP once and distribute it to all accounts in your organization.
+- **Automatic lifecycle management** — Consumer IdPs are created and cleaned up automatically when grants are shared or revoked.
+- **Immutable consumer IdPs** — Federated IdP connections in recipient accounts cannot be accidentally modified or deleted.
+- **Audit logging** — Federation grant creation and deletion events are recorded in the Access audit log.
+
+To get started, refer to [IdP federation](/cloudflare-one/integrations/identity-providers/idp-federation/).

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
@@ -1,0 +1,108 @@
+---
+pcx_content_type: how-to
+description: Share an identity provider across multiple Cloudflare accounts in your organization using IdP federation.
+products:
+  - cloudflare-one
+title: IdP federation
+sidebar:
+  order: 100
+tags:
+  - REST API
+---
+
+import { Tabs, TabItem, APIRequest, Details } from "~/components";
+
+IdP federation allows organizations with multiple Cloudflare accounts to share a single identity provider (IdP) configuration across accounts. Instead of configuring the same IdP (for example, Okta or Entra ID) separately in every account, you configure it once in a source account and share it with the other accounts in your organization.
+
+When you share an IdP, each recipient account receives a read-only copy of the IdP connection. Users in those accounts authenticate through the source account's IdP, and each account's Access policies evaluate the resulting identity as normal.
+
+## How it works
+
+IdP federation uses two resources:
+
+1. **Federation grant** — Created in the source account, a grant permits a specific IdP to be shared. Creating a grant also provisions a hidden proxy application that handles the cross-account authentication flow.
+2. **Consumer IdP** — A read-only IdP connection automatically created in each recipient account when the grant is distributed. Consumer IdPs cannot be edited or deleted directly — they are managed by the federation lifecycle.
+
+When a user in a recipient account authenticates, the request is routed through the source account's proxy application to the original IdP. The source IdP handles authentication, and the resulting identity claims are passed back to the recipient account's Access policies.
+
+## Prerequisites
+
+- All accounts must belong to the same Cloudflare organization.
+- The source IdP must already be configured and working in the source account.
+- You must have **Administrator** or equivalent permissions in the source account.
+
+## Create a federation grant
+
+A federation grant permits a specific IdP in your account to be shared with other accounts in your organization.
+
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Integrations** > **Identity providers**.
+2. Find the IdP you want to share and select the three dots menu.
+3. Select **Share**.
+4. Confirm the sharing configuration and select **Create grant**.
+
+The IdP will be distributed to other accounts in your organization automatically.
+
+</TabItem> <TabItem label="API">
+
+Make a `POST` request to create a federation grant:
+
+<APIRequest
+	path="/accounts/{account_id}/access/idp_federation_grants"
+	method="POST"
+	json={{
+		idp_id: "<IDP_UUID>",
+	}}
+/>
+
+The response includes the grant `id`, which you can use to manage or delete the grant later.
+
+To list all federation grants in your account:
+
+<APIRequest
+	path="/accounts/{account_id}/access/idp_federation_grants"
+	method="GET"
+/>
+
+To get a specific grant:
+
+<APIRequest
+	path="/accounts/{account_id}/access/idp_federation_grants/{grant_id}"
+	method="GET"
+/>
+
+</TabItem></Tabs>
+
+## Delete a federation grant
+
+Deleting a federation grant removes the shared IdP from all recipient accounts. Consumer IdP connections in those accounts will be automatically cleaned up.
+
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Integrations** > **Identity providers**.
+2. Find the shared IdP and select the three dots menu.
+3. Select **Remove sharing**.
+4. Confirm the deletion.
+
+</TabItem> <TabItem label="API">
+
+<APIRequest
+	path="/accounts/{account_id}/access/idp_federation_grants/{grant_id}"
+	method="DELETE"
+/>
+
+</TabItem></Tabs>
+
+:::caution
+
+Deleting a federation grant immediately removes the consumer IdP from all recipient accounts. Any Access policies in those accounts that reference the federated IdP will no longer match, which may lock users out. Verify that recipient accounts have alternative authentication methods before deleting a grant.
+
+:::
+
+## Limitations
+
+- Consumer IdPs are **read-only**. You cannot modify or delete a consumer IdP directly — manage it through the federation grant in the source account.
+- The source IdP cannot be deleted while an active federation grant references it. Delete the grant first.
+- Federation grants are currently immutable after creation. To change which IdP is shared, delete the existing grant and create a new one.
+- All participating accounts must be in the same Cloudflare organization.

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
@@ -12,41 +12,44 @@ tags:
 
 import { Tabs, TabItem, CURL, Details } from "~/components";
 
-IdP federation allows organizations with multiple Cloudflare accounts to share a single identity provider (IdP) configuration across accounts. Instead of configuring the same IdP (for example, Okta or Entra ID) separately in every account, you configure it once in a source account and share it with the other accounts in your organization.
+IdP federation allows organizations with multiple Cloudflare accounts to use a single identity provider (IdP) configuration across accounts. Instead of configuring the same IdP (for example, Okta or Entra ID) separately in every account, you configure it once in a source account and share it with the other accounts in your organization.
 
-When you share an IdP, each recipient account receives a read-only copy of the IdP connection. Users in those accounts authenticate through the source account's IdP, and each account's Access policies evaluate the resulting identity as normal.
+Each recipient account gets a read-only IdP connection that routes authentication back to the source account through a bridge — a hidden application in the source account that brokers the cross-account login. End users sign in with their existing IdP credentials, and each account's Access policies evaluate the resulting identity just like any other IdP login.
 
 ## How it works
 
-IdP federation uses two resources:
+Setting up IdP federation is a two-step process:
 
-1. **Federation grant** — Created in the source account, a grant permits a specific IdP to be shared. Creating a grant also provisions a hidden proxy application that handles the cross-account authentication flow.
-2. **Consumer IdP** — A read-only IdP connection automatically created in each recipient account when the grant is distributed. Consumer IdPs cannot be edited or deleted directly — they are managed by the federation lifecycle.
+1. **Create a federation grant.** A grant permits an IdP to be shared across accounts. Creating a grant also provisions a hidden bridge application in the source account.
+2. **Share the grant.** Distribute the grant to other accounts in your organization. Each recipient account is automatically provisioned with a read-only IdP connection that points to the bridge.
 
-When a user in a recipient account authenticates, the request is routed through the source account's proxy application to the original IdP. The source IdP handles authentication, and the resulting identity claims are passed back to the recipient account's Access policies.
+When a user in a recipient account authenticates, the request is routed through the bridge to the source IdP. The source IdP handles authentication, and the resulting identity claims are passed back to the recipient account's Access policies.
 
 ## Prerequisites
 
-- All accounts must belong to the same Cloudflare organization.
-- The source IdP must already be configured and working in the source account.
-- You must have **Administrator** or equivalent permissions in the source account.
+- You must have permission to edit the source IdP in the source account.
+- You must be a member of a Cloudflare organization.
+- The source account must belong to a Cloudflare organization.
 
-## Create a federation grant
-
-A federation grant permits a specific IdP in your account to be shared with other accounts in your organization.
+## Share an IdP
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+The dashboard combines grant creation and sharing into a single flow. If a federation grant already exists for the IdP, it will be reused; otherwise, one is created automatically.
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Integrations** > **Identity providers**.
 2. Find the IdP you want to share and select the three dots menu.
 3. Select **Share**.
-4. Confirm the sharing configuration and select **Create grant**.
+4. Select the recipient accounts you want to share the IdP with.
+5. Review the sharing configuration and select **Confirm**.
 
-The IdP will be distributed to other accounts in your organization automatically.
+The IdP is shared to the selected accounts automatically. Each recipient account receives a read-only IdP connection that points to the bridge in the source account.
 
 </TabItem> <TabItem label="API">
 
-Make a `POST` request to create a federation grant:
+Sharing an IdP via the API is a two-step process: create a federation grant, then share it with recipient accounts.
+
+#### 1. Create a federation grant
 
 <CURL
 	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/idp_federation_grants"
@@ -57,9 +60,7 @@ Make a `POST` request to create a federation grant:
 	}}
 />
 
-The response includes the grant `id`, which you can use to manage or delete the grant later.
-
-To list all federation grants in your account:
+The response includes the grant `id`, which you will use in the next step. To list all federation grants in your account:
 
 <CURL
 	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/idp_federation_grants"
@@ -67,28 +68,54 @@ To list all federation grants in your account:
 	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
-To get a specific grant:
+#### 2. Share the grant with recipient accounts
+
+Share the grant with one or more recipient accounts.
 
 <CURL
-	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/idp_federation_grants/{grant_id}"
-	method="GET"
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/shares"
+	method="POST"
 	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
+	json={{
+		name: "Identity provider: OpenID Connect",
+		recipients: [{ account_id: "<RECIPIENT_ACCOUNT_ID>" }],
+		resources: [
+			{
+				resource_account_id: "<SOURCE_ACCOUNT_ID>",
+				resource_id: "<GRANT_ID>",
+				resource_type: "idp-federation-grant",
+				meta: {},
+			},
+		],
+	}}
 />
+
+Each recipient account will be automatically provisioned with a read-only IdP connection that points to the bridge.
 
 </TabItem></Tabs>
 
-## Delete a federation grant
+## Stop Sharing an IdP
 
-Deleting a federation grant removes the shared IdP from all recipient accounts. Consumer IdP connections in those accounts will be automatically cleaned up.
+To stop sharing an IdP, delete the federation grant, as well as the share.
+
+:::caution
+Deleting the federation grant immediately removes the IdP connection from all recipient accounts. Any Access policies in those accounts that reference the federated IdP will no longer match, which may lock users out. Verify that recipient accounts have alternative authentication methods before you stop sharing.
+:::
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
+The dashboard handles both grant and share deletion in a single flow.
+
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Integrations** > **Identity providers**.
 2. Find the shared IdP and select the three dots menu.
-3. Select **Remove sharing**.
-4. Confirm the deletion.
+3. Select **Unshare**.
+4. Confirm the action.
 
 </TabItem> <TabItem label="API">
+
+Unfederating an IdP via the API is a two-step process. Deleting the grant stops the sharing and removes the read-only IdP from recipient accounts. You can optionally clean up the share record afterward.
+
+#### 1. Delete the federation grant
 
 <CURL
 	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/idp_federation_grants/{grant_id}"
@@ -96,17 +123,16 @@ Deleting a federation grant removes the shared IdP from all recipient accounts. 
 	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
+#### 2. (Optional) Delete the share
+
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/shares/{share_id}"
+	method="DELETE"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
+/>
 </TabItem></Tabs>
-
-:::caution
-
-Deleting a federation grant immediately removes the consumer IdP from all recipient accounts. Any Access policies in those accounts that reference the federated IdP will no longer match, which may lock users out. Verify that recipient accounts have alternative authentication methods before deleting a grant.
-
-:::
 
 ## Limitations
 
-- Consumer IdPs are **read-only**. You cannot modify or delete a consumer IdP directly — manage it through the federation grant in the source account.
-- The source IdP cannot be deleted while an active federation grant references it. Delete the grant first.
-- Federation grants are currently immutable after creation. To change which IdP is shared, delete the existing grant and create a new one.
-- All participating accounts must be in the same Cloudflare organization.
+- An account can federate at most one IdP as a source.
+- A source IdP cannot be deleted while it has a federation grant associated with it. Delete the grant first.

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/idp-federation.mdx
@@ -10,7 +10,7 @@ tags:
   - REST API
 ---
 
-import { Tabs, TabItem, APIRequest, Details } from "~/components";
+import { Tabs, TabItem, CURL, Details } from "~/components";
 
 IdP federation allows organizations with multiple Cloudflare accounts to share a single identity provider (IdP) configuration across accounts. Instead of configuring the same IdP (for example, Okta or Entra ID) separately in every account, you configure it once in a source account and share it with the other accounts in your organization.
 
@@ -48,9 +48,10 @@ The IdP will be distributed to other accounts in your organization automatically
 
 Make a `POST` request to create a federation grant:
 
-<APIRequest
-	path="/accounts/{account_id}/access/idp_federation_grants"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/idp_federation_grants"
 	method="POST"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 	json={{
 		idp_id: "<IDP_UUID>",
 	}}
@@ -60,16 +61,18 @@ The response includes the grant `id`, which you can use to manage or delete the 
 
 To list all federation grants in your account:
 
-<APIRequest
-	path="/accounts/{account_id}/access/idp_federation_grants"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/idp_federation_grants"
 	method="GET"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
 To get a specific grant:
 
-<APIRequest
-	path="/accounts/{account_id}/access/idp_federation_grants/{grant_id}"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/idp_federation_grants/{grant_id}"
 	method="GET"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
 </TabItem></Tabs>
@@ -87,9 +90,10 @@ Deleting a federation grant removes the shared IdP from all recipient accounts. 
 
 </TabItem> <TabItem label="API">
 
-<APIRequest
-	path="/accounts/{account_id}/access/idp_federation_grants/{grant_id}"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/idp_federation_grants/{grant_id}"
 	method="DELETE"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
 </TabItem></Tabs>


### PR DESCRIPTION
## Summary

- New doc page for **IdP federation** (`integrations/identity-providers/idp-federation.mdx`) — explains how to share identity providers across Cloudflare accounts in the same organization
- Covers: how it works, creating/deleting federation grants (Dashboard + API tabs), prerequisites, limitations
- Changelog entry for the feature launch

## What is IdP federation?

Organizations with multiple Cloudflare accounts can share a single IdP configuration. A source account creates a "federation grant" for an IdP, and the Share API distributes read-only consumer IdP connections to recipient accounts. Users authenticate through the source IdP, and each account's Access policies evaluate the resulting identity normally.


## Context

Feature shipping soon. Docs should be ready for launch.
