### PR TITLE
Update tunnel endpoint docs for single anycast IP allocation

### DIFF
--- a/src/content/changelog/cloudflare-wan/2026-05-12-single-anycast-ip-default.mdx
+++ b/src/content/changelog/cloudflare-wan/2026-05-12-single-anycast-ip-default.mdx
@@ -1,0 +1,17 @@
+---
+title: New accounts assigned a single IPv4 anycast address
+description: New Magic Transit and Cloudflare WAN accounts are now assigned a single IPv4 anycast address by default
+date: 2026-05-12
+products:
+  - cloudflare-wan
+  - magic-transit
+  - cloudflare-one
+---
+
+New Magic Transit and Cloudflare WAN accounts are now assigned a single IPv4 anycast address by default.
+
+Cloudflare handles failures on its network automatically by advertising your endpoint IP from multiple nodes across many globally distributed data centers. To handle failures on your network, configure two tunnels from separate routers.
+
+To request additional anycast IP addresses for your account, contact your account team.
+
+For tunnel configuration guidance, refer to [Configure tunnel endpoints](/cloudflare-wan/configuration/how-to/configure-tunnel-endpoints/) for Cloudflare WAN or [Configure tunnel endpoints](/magic-transit/how-to/configure-tunnel-endpoints/) for Magic Transit.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-wan/configuration/how-to/configure-tunnel-endpoints.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-wan/configuration/how-to/configure-tunnel-endpoints.mdx
@@ -5,9 +5,7 @@ products:
   - cloudflare-one
 sidebar:
   order: 1
-description: Cloudflare recommends two tunnels for each ISP and network location
-  router combination, one per Cloudflare endpoint. Learn how to configure IPsec
-  or GRE tunnels.
+description: Learn how to configure IPsec or GRE tunnels for Cloudflare WAN.
 tags:
   - IPsec
 ---

--- a/src/content/docs/cloudflare-wan/configuration/how-to/configure-tunnel-endpoints.mdx
+++ b/src/content/docs/cloudflare-wan/configuration/how-to/configure-tunnel-endpoints.mdx
@@ -6,9 +6,7 @@ products:
 sidebar:
   order: 1
 head: []
-description: Cloudflare recommends two tunnels for each ISP and network location
-  router combination, one per Cloudflare endpoint. Learn how to configure IPsec
-  or GRE tunnels.
+description: Learn how to configure IPsec or GRE tunnels for Cloudflare WAN.
 ---
 
 import { GlossaryTooltip, Render } from "~/components";

--- a/src/content/docs/magic-transit/how-to/configure-tunnel-endpoints.mdx
+++ b/src/content/docs/magic-transit/how-to/configure-tunnel-endpoints.mdx
@@ -6,7 +6,7 @@ title: Configure tunnel endpoints
 sidebar:
   order: 1
 head: []
-description: Cloudflare recommends two tunnels for each ISP and network location router combination, one per Cloudflare endpoint. Learn how to configure IPsec or GRE tunnels.
+description: Learn how to configure IPsec or GRE tunnels for Magic Transit.
 tags:
   - IPsec
   - ICMP

--- a/src/content/docs/reference-architecture/architectures/magic-transit.mdx
+++ b/src/content/docs/reference-architecture/architectures/magic-transit.mdx
@@ -65,7 +65,7 @@ The network diagram in Figure 2 illustrates such a Magic Transit setup, and the 
 
 ![Figure 2: Reference Configuration of Magic Transit anycast Tunnel (GRE) With Default DSR Option](~/assets/images/reference-architecture/magic-transit-ref-arch-diagrams/magic-transit-ref-arch-2.png "Figure 2: Reference Configuration of Magic Transit anycast Tunnel (GRE) With Default DSR Option")
 
-- Cloudflare provides the customer with a pair of anycast IP addresses for the Cloudflare end of the tunnel endpoints. These are publicly routable IP addresses from Cloudflare-owned address space. The pair of anycast IP addresses can be used to configure two tunnels for network redundancy, although only one is required for a basic configuration. The above configuration shows a single tunnel, with the Cloudflare end of the tunnel endpoint address being 192.0.2.1.
+- Cloudflare provides the customer with an IPv4 anycast address for the Cloudflare end of the tunnel endpoints. This is a publicly routable IP address from Cloudflare-owned address space. Cloudflare handles failures on its network automatically by advertising the endpoint IP from multiple nodes across many globally distributed data centers. To handle failures on the customer network, configure two tunnels from separate routers. Customers can contact their account team to request additional anycast IP addresses. The above configuration shows a single tunnel, with the Cloudflare end of the tunnel endpoint address being 192.0.2.1.
 
 - The customer end of the anycast GRE tunnel needs to be a publicly routable address. It is typically the IP address of the WAN interface on the customer edge router. In this example it is 192.0.2.153.
 

--- a/src/content/partials/networking-services/cloudflare-wan/third-party/fortinet.mdx
+++ b/src/content/partials/networking-services/cloudflare-wan/third-party/fortinet.mdx
@@ -24,11 +24,11 @@ The FortiGate configuration was tested on two different FortiGate firewalls:
 
 To set up Cloudflare WAN, add IPsec tunnels and static routes to your Cloudflare account using the dashboard or API.
 
-Before proceeding, ensure that you have the anycast IPs assigned to your account. You can find them in the Cloudflare dashboard under **Address Space** > [**Leased IPs**](https://dash.cloudflare.com/?to=/:account/ip-addresses/address-space).
+Before proceeding, ensure that you have the IPv4 anycast address assigned to your account. You can find it in the Cloudflare dashboard under **Address Space** > [**Leased IPs**](https://dash.cloudflare.com/?to=/:account/ip-addresses/address-space).
 
-### IPsec Tunnels
+### IPsec tunnels
 
-Cloudflare recommends customers configure two IPsec tunnels per firewall/router - one to each of the two anycast IP addresses.
+Cloudflare handles failures on its network automatically by advertising your endpoint IP from multiple nodes across many globally distributed data centers. To handle failures on your network, configure two IPsec tunnels from separate routers.
 
 1. Follow the <a href={props.addTunnelsUrl}>Add tunnels</a> instructions to create the required IPsec tunnels with the following options:
    - **Health check type**: Change to _Request_.

--- a/src/content/partials/networking-services/routing/configure-tunnels.mdx
+++ b/src/content/partials/networking-services/routing/configure-tunnels.mdx
@@ -22,13 +22,15 @@ params:
 
 import { AnchorHeading, APIRequest, CURL, DashButton, Details, GlossaryTooltip, Markdown, Render, TabItem, Tabs } from "~/components";
 
-Cloudflare recommends two tunnels for each ISP and network location router combination, one per Cloudflare endpoint. Cloudflare assigns two endpoint addresses to your account that you can use as the tunnel destinations on your network location's routers/endpoints. You can find these addresses in the Cloudflare dashboard under **Address Space** > [**Leased IPs**](https://dash.cloudflare.com/?to=/:account/ip-addresses/address-space).
+Cloudflare assigns an IPv4 anycast address to your account for use as the tunnel destination for your network's routers. You can find this address in the Cloudflare dashboard under **Address Space** > [**Leased IPs**](https://dash.cloudflare.com/?to=/:account/ip-addresses/address-space). To request additional endpoint addresses, contact your account team.
+
+Cloudflare handles failures on its network automatically by advertising your endpoint IP from multiple nodes across many globally distributed data centers. To handle failures on your network, configure two tunnels from separate routers.
 
 ## Before you begin
 
 Before creating a tunnel, make sure you have the following information:
 
-- **Cloudflare endpoint addresses**: The anycast IP addresses assigned to your account. You can find them in the Cloudflare dashboard under **Address Space** > [**Leased IPs**](https://dash.cloudflare.com/?to=/:account/ip-addresses/address-space).
+- **Cloudflare endpoint address**: The anycast IP address assigned to your account. You can find it in the Cloudflare dashboard under **Address Space** > [**Leased IPs**](https://dash.cloudflare.com/?to=/:account/ip-addresses/address-space).
 - **Customer endpoint IP**: A public Internet routable IP address outside of the prefixes Cloudflare will advertise on your behalf (typically provided by your ISP). Not required if using [Cloudflare Network Interconnect](/network-interconnect/) or for <GlossaryTooltip term="IPsec tunnel">IPsec</GlossaryTooltip> tunnels (unless your router uses an <GlossaryTooltip term="Internet key exchange (IKE)">IKE</GlossaryTooltip> ID of type `ID_IPV4_ADDR`).
 - **Interface address**: A `/31` (recommended) or `/30` subnet from RFC 1918 private IP space (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) or `169.254.240.0/20`{props.ipRange}.
 


### PR DESCRIPTION
## Summary

New Cloudflare WAN and Magic Transit accounts are now assigned a single IPv4 anycast address by default. This PR updates documentation to reflect the new behavior and adjust the redundancy guidance.

## Changes

### Documentation
- `src/content/partials/networking-services/routing/configure-tunnels.mdx` — Shared partial powering the **Configure tunnel endpoints** page for Cloudflare WAN, Magic Transit, the Cloudflare One mirror, and the data center protection learning path. Updated to describe single anycast address assignment and reframed redundancy guidance.
- `src/content/partials/networking-services/cloudflare-wan/third-party/fortinet.mdx` — Updated intro language and IPsec tunnels heading guidance to align with the new principle.
- `src/content/docs/reference-architecture/architectures/magic-transit.mdx` — Updated topology bullet to describe a single anycast address and aligned redundancy explanation.
- Updated page-level `description` frontmatter in three configure-tunnel-endpoints `.mdx` files to remove the outdated framing.

### Changelog
- `src/content/changelog/cloudflare-wan/2026-05-12-single-anycast-ip-default.mdx` — Tagged for `cloudflare-wan`, `magic-transit`, and `cloudflare-one`.

## Redundancy framing

The previous guidance recommended two tunnels, one per Cloudflare endpoint, implying redundancy came from having two Cloudflare endpoints. The Cloudflare endpoint is anycast — it is advertised from many nodes across many globally distributed data centers, so failures on the Cloudflare side recover automatically. Redundancy on the customer side comes from configuring multiple tunnels from separate routers.

The new standard paragraph is:

> Cloudflare handles failures on its network automatically by advertising your endpoint IP from multiple nodes across many globally distributed data centers. To handle failures on your network, configure two tunnels from separate routers.

## Scope

Out of scope: Cloudflare Network Interconnect (CNI). CNI uses separate point-to-point address allocation that is unchanged.

## Validation

`pnpm run check:astro` passes with 0 errors and 0 warnings.