### PR TITLE
docs(ai): fix 404 due to typo in href value for Sandbox SDK link

### DIFF
--- a/src/content/docs/ai/index.mdx
+++ b/src/content/docs/ai/index.mdx
@@ -91,6 +91,6 @@ Explore all AI models available through Cloudflare, including hosted models on W
 	Spin up isolated Workers on demand to execute code.
 </RelatedProduct>
 
-<RelatedProduct header="Sandbox SDK" href="/sandbox-sdk/" product="sandbox">
+<RelatedProduct header="Sandbox SDK" href="/sandbox/" product="sandbox">
 	Build secure, isolated code execution environments.
 </RelatedProduct>


### PR DESCRIPTION
### Summary

Fix 404 changing Sandbox SDK href value from "sandbox-sdk" to "sandbox"

