### PR TITLE
CODEOWNERS: Add steve-cloudflare to Network Services product paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -111,7 +111,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/fundamentals/ @dcpena @cloudflare/product-owners
 /src/content/docs/learning-paths/ @cloudflare/product-owners
 /src/content/docs/network-error-logging/ @dcpena @cloudflare/product-owners
-/src/content/docs/network-interconnect/ @marciocloudflare @cloudflare/product-owners
+/src/content/docs/network-interconnect/ @marciocloudflare @steve-cloudflare @cloudflare/product-owners
 /src/content/docs/notifications/ @dcpena @cloudflare/product-owners
 /src/content/docs/registrar/ @dcpena @cloudflare/product-owners
 /src/content/docs/rules/ @pedrosousa @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
@@ -210,11 +210,11 @@ package.json @cloudflare/content-engineering
 
 # Magic products
 
-/src/content/docs/magic-transit/ @cloudflare/product-owners
-/src/content/docs/cloudflare-network-firewall/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/network-flow/ @cloudflare/product-owners
-/src/content/docs/cloudflare-wan/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/multi-cloud-networking/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/magic-transit/ @steve-cloudflare @cloudflare/product-owners
+/src/content/docs/cloudflare-network-firewall/ @steve-cloudflare @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/network-flow/ @steve-cloudflare @cloudflare/product-owners
+/src/content/docs/cloudflare-wan/ @steve-cloudflare @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/multi-cloud-networking/ @steve-cloudflare @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 
 # Migration guides
 


### PR DESCRIPTION
## Summary

Adding myself as a co-owner in `CODEOWNERS` for Network Services product documentation, following the PCX team dissolution. Product PMs are now responsible for docs ownership, reviews, and approvals.

## Paths added

| Path | Product |
|------|---------|
| `/src/content/docs/magic-transit/` | Magic Transit |
| `/src/content/docs/cloudflare-network-firewall/` | Magic Firewall |
| `/src/content/docs/network-flow/` | Network Flow |
| `/src/content/docs/cloudflare-wan/` | Cloudflare WAN |
| `/src/content/docs/multi-cloud-networking/` | Cloud Networking |
| `/src/content/docs/network-interconnect/` | Cloud Network Interconnect (CNI) |

## Notes

- All existing co-owners are preserved on each line (`@marciocloudflare`, `@cloudflare/cf1-reviewers`, `@elithrar`, `@cloudflare/product-owners`)
- This is purely additive — no owners removed
- I'm already provisioned as a `cloudflare_docs_editors` outside collaborator (via `terraform-github-cloudflare` !1436) with write access to this repo