### PR TITLE
[Workers] Fix wrangler command links and clarify Save button location

### DIFF
--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -48,7 +48,7 @@ Review the different ways you can create versions of your Worker and deploy them
 
 A new version that is automatically deployed to 100% of traffic when:
 
-- Changes are uploaded with [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) via the Cloudflare Dashboard
+- Changes are uploaded with [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) via the Cloudflare dashboard
 - Changes are deployed with the command [`npx wrangler deploy`](/workers/wrangler/commands/workers/#deploy) via [Workers Builds](/workers/ci-cd/builds)
 - Changes are uploaded with the [Workers Script Upload API](/api/resources/workers/subresources/scripts/methods/update/)
 

--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -48,8 +48,8 @@ Review the different ways you can create versions of your Worker and deploy them
 
 A new version that is automatically deployed to 100% of traffic when:
 
-- Changes are uploaded with [`wrangler deploy`](/workers/wrangler/commands/general/#deploy) via the Cloudflare Dashboard
-- Changes are deployed with the command [`npx wrangler deploy`](/workers/wrangler/commands/general/#deploy) via [Workers Builds](/workers/ci-cd/builds)
+- Changes are uploaded with [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) via the Cloudflare Dashboard
+- Changes are deployed with the command [`npx wrangler deploy`](/workers/wrangler/commands/workers/#deploy) via [Workers Builds](/workers/ci-cd/builds)
 - Changes are uploaded with the [Workers Script Upload API](/api/resources/workers/subresources/scripts/methods/update/)
 
 #### Upload a new version to be gradually deployed or deployed at a later time
@@ -60,12 +60,12 @@ Wrangler versions before 3.73.0 require you to specify a `--x-versions` flag.
 
 :::
 
-To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) command or create a new version via the Cloudflare dashboard using the **Save** button. You can find the **Save** option under the down arrow beside the "Deploy" button.
+To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/workers/#versions-upload) command or create a new version in the Cloudflare dashboard code editor by selecting **Edit code**, then the **Save** option from the dropdown beside the **Deploy** button.
 
-Versions created in this way can then be deployed all at once or gradually deployed using the [`wrangler versions deploy`](/workers/wrangler/commands/general/#versions-deploy) command or via the Cloudflare dashboard under the **Deployments** tab.
+Versions created in this way can then be deployed all at once or gradually deployed using the [`wrangler versions deploy`](/workers/wrangler/commands/workers/#versions-deploy) command or via the Cloudflare dashboard under the **Deployments** tab.
 
 :::note
-When using [Wrangler](/workers/wrangler/), changes made to a Worker's triggers [routes, domains](/workers/configuration/routing/) or [cron triggers](/workers/configuration/cron-triggers/) need to be applied with the command [`wrangler triggers deploy`](/workers/wrangler/commands/general/#triggers).
+When using [Wrangler](/workers/wrangler/), changes made to a Worker's triggers [routes, domains](/workers/configuration/routing/) or [cron triggers](/workers/configuration/cron-triggers/) need to be applied with the command [`wrangler triggers deploy`](/workers/wrangler/commands/workers/#triggers-deploy).
 :::
 
 :::note
@@ -80,7 +80,7 @@ See examples of creating a Worker, Versions, and Deployments directly with the A
 
 #### Via Wrangler
 
-Wrangler allows you to view the 100 most recent versions and deployments. Refer to the [`versions list`](/workers/wrangler/commands/general/#list-4) and [`deployments`](/workers/wrangler/commands/general/#list-5) documentation to view the commands.
+Wrangler allows you to view the 100 most recent versions and deployments. Refer to the [`versions list`](/workers/wrangler/commands/workers/#versions-list) and [`deployments list`](/workers/wrangler/commands/workers/#deployments-list) documentation to view the commands.
 
 #### Via the Cloudflare dashboard
 
@@ -96,16 +96,16 @@ To view your deployments in the Cloudflare dashboard:
 
 ### First upload
 
-You must use [C3](/workers/get-started/guide/#1-create-a-new-worker-project) or [`wrangler deploy`](/workers/wrangler/commands/general/#deploy) the first time you create a new Workers project. Using [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload) the first time you upload a Worker will fail.
+You must use [C3](/workers/get-started/guide/#1-create-a-new-worker-project) or [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) the first time you create a new Workers project. Using [`wrangler versions upload`](/workers/wrangler/commands/workers/#versions-upload) the first time you upload a Worker will fail.
 
 ### Service worker syntax
 
-Service worker syntax is not supported for versions that are uploaded through [`wrangler versions upload`](/workers/wrangler/commands/general/#versions-upload). You must use ES modules format.
+Service worker syntax is not supported for versions that are uploaded through [`wrangler versions upload`](/workers/wrangler/commands/workers/#versions-upload). You must use ES modules format.
 
 Refer to [Migrate from Service Workers to ES modules](/workers/reference/migrate-to-module-workers/#advantages-of-migrating) to learn how to migrate your Workers from the service worker format to the ES modules format.
 
 ### Durable Object migrations
 
-Uploading a version with [Durable Object migrations](/durable-objects/reference/durable-objects-migrations/) is not supported. Use [`wrangler deploy`](/workers/wrangler/commands/general/#deploy) if you are applying a [Durable Object migration](/durable-objects/reference/durable-objects-migrations/).
+Uploading a version with [Durable Object migrations](/durable-objects/reference/durable-objects-migrations/) is not supported. Use [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) if you are applying a [Durable Object migration](/durable-objects/reference/durable-objects-migrations/).
 
-This will be supported in the near future.
+This is not currently supported.

--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -108,4 +108,3 @@ Refer to [Migrate from Service Workers to ES modules](/workers/reference/migrate
 
 Uploading a version with [Durable Object migrations](/durable-objects/reference/durable-objects-migrations/) is not supported. Use [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) if you are applying a [Durable Object migration](/durable-objects/reference/durable-objects-migrations/).
 
-This will be supported in the near future.

--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -108,4 +108,4 @@ Refer to [Migrate from Service Workers to ES modules](/workers/reference/migrate
 
 Uploading a version with [Durable Object migrations](/durable-objects/reference/durable-objects-migrations/) is not supported. Use [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) if you are applying a [Durable Object migration](/durable-objects/reference/durable-objects-migrations/).
 
-This is not currently supported.
+This will be supported in the near future.

--- a/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
+++ b/src/content/docs/workers/configuration/versions-and-deployments/index.mdx
@@ -60,7 +60,7 @@ Wrangler versions before 3.73.0 require you to specify a `--x-versions` flag.
 
 :::
 
-To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/workers/#versions-upload) command or create a new version in the Cloudflare dashboard code editor by selecting **Edit code**, then the **Save** option from the dropdown beside the **Deploy** button.
+To create a new version of your Worker that is not deployed immediately, use the [`wrangler versions upload`](/workers/wrangler/commands/workers/#versions-upload) command or create a new version in the Cloudflare dashboard code editor by selecting **Edit code**, then the **Save** option from the **Deploy** button dropdown.
 
 Versions created in this way can then be deployed all at once or gradually deployed using the [`wrangler versions deploy`](/workers/wrangler/commands/workers/#versions-deploy) command or via the Cloudflare dashboard under the **Deployments** tab.
 


### PR DESCRIPTION
Updates the versions-and-deployments documentation to fix outdated wrangler command links and clarify how to save a new version via the dashboard.

- Updates all wrangler command links from `/workers/wrangler/commands/general/` to `/workers/wrangler/commands/workers/` to fix broken paths
- Replaces numbered anchors (`#list-4`, `#list-5`, `#triggers`) with descriptive anchors (`#versions-list`, `#deployments-list`, `#triggers-deploy`)
- Clarifies the dashboard Save workflow by specifying the **Edit code** step and changing "down arrow" to "dropdown" for accuracy
- Removes time-sensitive language ("in the near future") per style guide