### PR TITLE
CODEOWNERS: Add hannes-cf to DNS and 1.1.1.1 product paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,9 +89,9 @@ package.json @cloudflare/content-engineering
 
 # Consumer products
 
-/src/content/docs/1.1.1.1/ @RebeccaTamachiro @cf-rhett @cloudflare/product-owners
-/src/content/partials/1.1.1.1/ @RebeccaTamachiro @cf-rhett @cloudflare/product-owners
-/src/assets/images/1.1.1.1/ @RebeccaTamachiro @cf-rhett @cloudflare/product-owners
+/src/content/docs/1.1.1.1/ @RebeccaTamachiro @cf-rhett @hannes-cf @cloudflare/product-owners
+/src/content/partials/1.1.1.1/ @RebeccaTamachiro @cf-rhett @hannes-cf @cloudflare/product-owners
+/src/assets/images/1.1.1.1/ @RebeccaTamachiro @cf-rhett @hannes-cf @cloudflare/product-owners
 /src/content/docs/warp-client/ @ranbel @cf-rhett @cloudflare/product-owners
 /src/content/partials/warp-client/ @ranbel @cf-rhett @cloudflare/product-owners
 /src/content/warp-releases/ @ranbel @cf-rhett @cloudflare/product-owners
@@ -104,10 +104,10 @@ package.json @cloudflare/content-engineering
 /src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/ @baubuchon-cf @RebeccaTamachiro @cloudflare/product-owners
 /src/content/docs/china-network/ @pedrosousa @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/ @RebeccaTamachiro @cloudflare/product-owners
-/src/content/docs/dns/ @RebeccaTamachiro @cloudflare/product-owners
-/src/content/docs/dns/dns-firewall/ @RebeccaTamachiro @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/dns/internal-dns/ @RebeccaTamachiro @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/dns/private-origins/ @RebeccaTamachiro @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/dns/ @RebeccaTamachiro @hannes-cf @cloudflare/product-owners
+/src/content/docs/dns/dns-firewall/ @RebeccaTamachiro @hannes-cf @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/dns/internal-dns/ @RebeccaTamachiro @hannes-cf @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/dns/private-origins/ @RebeccaTamachiro @hannes-cf @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/fundamentals/ @dcpena @cloudflare/product-owners
 /src/content/docs/learning-paths/ @cloudflare/product-owners
 /src/content/docs/network-error-logging/ @dcpena @cloudflare/product-owners


### PR DESCRIPTION
[`#assistedByAI`](https://ai-label.org/)

## Summary

Adding myself as a co-owner in `CODEOWNERS` for DNS and 1.1.1.1 product documentation, following the PCX team dissolution. Product PMs are now responsible for docs ownership, reviews, and approvals.

## Paths added

| Path | Product |
|------|---------|
| `/src/content/docs/1.1.1.1/` | 1.1.1.1 |
| `/src/content/partials/1.1.1.1/` | 1.1.1.1 |
| `/src/assets/images/1.1.1.1/` | 1.1.1.1 |
| `/src/content/docs/dns/` | DNS |
| `/src/content/docs/dns/dns-firewall/` | DNS Firewall |
| `/src/content/docs/dns/internal-dns/` | Internal DNS |
| `/src/content/docs/dns/private-origins/` | DNS (private origins) |

## Notes

- All existing co-owners are preserved on each line (`@RebeccaTamachiro`, `@cf-rhett`, `@cloudflare/appsec-reviewers`, `@cloudflare/cf1-reviewers`, `@elithrar`, `@cloudflare/product-owners`)
- This is purely additive — no owners removed
- I'm already provisioned as a `cloudflare_docs_editors` outside collaborator (via `terraform-github-cloudflare`) with write access to this repo