### PR TITLE
[SSL] Expand DCV troubleshooting with all CA error messages

### DIFF
--- a/src/content/docs/ssl/edge-certificates/changing-dcv-method/troubleshooting.mdx
+++ b/src/content/docs/ssl/edge-certificates/changing-dcv-method/troubleshooting.mdx
@@ -87,17 +87,41 @@ Resolve-DnsName -Name example.com -Type CAA
 
 <Render file="error-rate-limiting" product="ssl" />
 
-### Multiple perspective CAA check error
+When you see `The authority has rate limited these domains. Please wait for the rate limit to expire or try another authority`, the certificate authority has temporarily blocked certificate issuance for your domain due to too many recent requests.
 
-The error `Certificate authority encountered a multiple perspective CAA check error, please ensure your DNS is configured to allow CAA queries` means that the CA was not able to resolve the CAA records related to your domain from specific geographic locations.
+**Resolution**: Wait for the rate limit to expire (the error message includes the expiration time), or select a different [certificate authority](/ssl/reference/certificate-authorities/).
 
-You can investigate for resolution error using the [ping.pe tool](https://dig.ping.pe/).
-For example, for a [Google Trust Services](/ssl/reference/certificate-authorities/#google-trust-services) certificate encountering this issue, you can check for: `<hostname>:CAA:8.8.8.8`.
+### CAA records block issuance
 
-Read more from Certificate Authorities specific documentation: [SSL.com](https://www.ssl.com/blogs/multi-perspective-issuance-corroboration-mpic-arrives/), [Let's Encrypt](https://letsencrypt.org/2020/02/19/multi-perspective-validation), and [Google Trust Services](https://pki.goog/faq/#faq-mpic).
+The error `CAA records block issuance. Please remove all CAA records or add records for this authority` indicates that your domain's [CAA records](/ssl/edge-certificates/caa-records/) do not allow the selected certificate authority to issue certificates.
+
+**Resolution**: Either remove all CAA records from your domain, or add CAA records that explicitly allow [Cloudflare's partner certificate authorities](/ssl/reference/certificate-authorities/).
+
+### Multiple perspective validation errors
+
+Certificate authorities perform domain validation from multiple geographic locations to prevent certain attacks. You may encounter one of these errors:
+
+- `Certificate authority encountered a multiple perspective CAA check error, please ensure your DNS is configured to allow CAA queries from all geographic perspectives`
+- `Certificate authority was unable to verify domain ownership from multiple geographic locations (MPIC failure). Please ensure your DNS records are reachable from all geographic perspectives and try again.`
+
+**Resolution**: Ensure your DNS records (including CAA records) are consistently resolvable from all geographic locations. You can investigate resolution errors using the [ping.pe tool](https://dig.ping.pe/). For example, for a [Google Trust Services](/ssl/reference/certificate-authorities/#google-trust-services) certificate, check: `<hostname>:CAA:8.8.8.8`.
+
+Read more from certificate authority documentation: [SSL.com](https://www.ssl.com/blogs/multi-perspective-issuance-corroboration-mpic-arrives/), [Let's Encrypt](https://letsencrypt.org/2020/02/19/multi-perspective-validation), and [Google Trust Services](https://pki.goog/faq/#faq-mpic).
+
+### DNS lookup errors
+
+The error `the Certificate Authority had trouble performing a DNS lookup` indicates that the CA could not resolve your domain's DNS records. Common causes include SERVFAIL responses, NXDOMAIN, or DNSSEC validation failures.
+
+**Resolution**: Verify that your DNS records are correctly configured and resolvable. Use tools like [DNSViz](https://dnsviz.net/) to check for DNSSEC issues, and ensure your authoritative nameservers are responding correctly.
+
+### Rejected identifier
+
+The error `The certificate authority will not issue for this domain. Please check your input or try another authority` means the CA has policies that prevent issuing certificates for your specific domain.
+
+**Resolution**: Verify that your domain name is correctly spelled and does not violate the CA's issuance policies. If the domain is valid, try selecting a different [certificate authority](/ssl/reference/certificate-authorities/).
 
 ### Internal errors
 
-When the certificate authority finds an issue during the CA check portion of the [DCV flow](/ssl/edge-certificates/changing-dcv-method/dcv-flow/), you may see a `Internal error with Certificate Authority` message. In this case, either wait or try a different certificate authority.
+When you see `Internal error with Certificate Authority. Please check later`, the certificate authority encountered a temporary issue during validation.
 
-When the error states that the `certificate authority will not issue for this domain`, you can try a different certificate authority or contact the CA directly.
+**Resolution**: Wait a few minutes and retry. If the issue persists, try selecting a different [certificate authority](/ssl/reference/certificate-authorities/). Cloudflare will automatically retry validation according to the [validation backoff schedule](/ssl/edge-certificates/changing-dcv-method/validation-backoff-schedule/).

--- a/src/content/docs/ssl/edge-certificates/changing-dcv-method/troubleshooting.mdx
+++ b/src/content/docs/ssl/edge-certificates/changing-dcv-method/troubleshooting.mdx
@@ -100,7 +100,13 @@ Resolve-DnsName -Name example.com -Type CAA
 </TabItem>
 </Tabs>
 
-## CA errors
+## Certificate authority (CA) errors
+
+A [certificate authority (CA)](/ssl/reference/certificate-authorities/) is the organization that issues your SSL/TLS certificate. Cloudflare partners with multiple CAs to provide certificates for your domain.
+
+:::note
+Selecting a different CA is only available with [Advanced Certificate Manager](/ssl/edge-certificates/advanced-certificate-manager/) or [SSL for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/). [Universal SSL](/ssl/edge-certificates/universal-ssl/) customers cannot change the CA.
+:::
 
 ### Rate limiting
 
@@ -108,7 +114,11 @@ Resolve-DnsName -Name example.com -Type CAA
 
 When you see `The authority has rate limited these domains. Please wait for the rate limit to expire or try another authority`, the certificate authority has temporarily blocked certificate issuance for your domain due to too many recent requests.
 
-**Resolution**: Wait for the rate limit to expire (the error message includes the expiration time), or select a different [certificate authority](/ssl/reference/certificate-authorities/).
+Rate limit windows vary by CA:
+- **Let's Encrypt**: 7 days for most rate limits (refer to [Let's Encrypt rate limits](https://letsencrypt.org/docs/rate-limits/))
+- **Google Trust Services**: Varies by limit type (refer to [Google Trust Services documentation](https://pki.goog/faq/))
+
+**Resolution**: Wait for the rate limit window to expire, or select a different CA.
 
 ### CAA records block issuance
 
@@ -137,10 +147,10 @@ The error `the Certificate Authority had trouble performing a DNS lookup` indica
 
 The error `The certificate authority will not issue for this domain. Please check your input or try another authority` means the CA has policies that prevent issuing certificates for your specific domain.
 
-**Resolution**: Verify that your domain name is correctly spelled and does not violate the CA's issuance policies. If the domain is valid, try selecting a different [certificate authority](/ssl/reference/certificate-authorities/).
+**Resolution**: Verify that your domain name is correctly spelled and does not violate the CA's issuance policies. If the domain is valid, try selecting a different CA.
 
 ### Internal errors
 
 When you see `Internal error with Certificate Authority. Please check later`, the certificate authority encountered a temporary issue during validation.
 
-**Resolution**: Wait a few minutes and retry. If the issue persists, try selecting a different [certificate authority](/ssl/reference/certificate-authorities/). Cloudflare will automatically retry validation according to the [validation backoff schedule](/ssl/edge-certificates/changing-dcv-method/validation-backoff-schedule/).
+**Resolution**: Wait a few minutes and retry. If the issue persists, try selecting a different CA. Cloudflare will automatically retry validation according to the [validation backoff schedule](/ssl/edge-certificates/changing-dcv-method/validation-backoff-schedule/).

--- a/src/content/docs/ssl/edge-certificates/changing-dcv-method/troubleshooting.mdx
+++ b/src/content/docs/ssl/edge-certificates/changing-dcv-method/troubleshooting.mdx
@@ -13,14 +13,23 @@ head:
 
 import { GlossaryTooltip, Render, Tabs, TabItem } from "~/components";
 
-Taking into account the [steps involved in DCV](/ssl/edge-certificates/changing-dcv-method/dcv-flow/), some situations may interfere with certificate issuance and renewal.
-
-[Blocked validation URLs](#blocked-validation-url) or [misconfigured DNS settings](#dns-settings-and-records) might interfere with the <GlossaryTooltip term="Certificate Authority (CA)">certificate authority's</GlossaryTooltip> ability to finish the validation process. In these situations, you may need to update your configuration at Cloudflare or at your authoritative DNS provider. Additionally, there can also be [errors on the CA side](#ca-errors).
+If your certificate is stuck in **Pending Validation** or failing to issue, the <GlossaryTooltip term="Certificate Authority (CA)">certificate authority (CA)</GlossaryTooltip> may be unable to complete [domain control validation (DCV)](/ssl/edge-certificates/changing-dcv-method/dcv-flow/). This page helps you identify and resolve common DCV issues.
 
 :::note
-
 If you are using the Cloudflare API, error messages are presented under the `validation_errors` parameter.
 :::
+
+## Quick checklist
+
+Use this checklist to identify common DCV issues:
+
+- [ ] [No rules blocking the validation URL](#blocked-validation-url) - WAF rules, IP access rules, or Under Attack mode can block the CA
+- [ ] [No redirects on the validation path](#redirection) - The `/.well-known/*` path must not redirect (especially HTTP to HTTPS in partial setups)
+- [ ] [DNS records are resolvable](#dns-settings-and-records) - DNSSEC must be valid, and records must resolve from all locations
+- [ ] [CAA records allow the CA](#caa-records) - CAA records must permit Cloudflare's partner CAs to issue certificates
+- [ ] [No CA-side errors](#ca-errors) - Rate limits, policy blocks, or temporary CA issues
+
+---
 
 ## Blocked validation URL
 
@@ -42,7 +51,17 @@ Enabling [Always Use HTTPS](/ssl/edge-certificates/additional-options/always-use
 
 In a [Partial (CNAME) setup](/ssl/edge-certificates/changing-dcv-method/#partial-dns-setup---action-sometimes-required) where you are managing the token on the origin side, please ensure that no redirection from HTTP to HTTPS occurs on the `/.well-known/*` path.
 
-When using [Redirect Rules](/rules/url-forwarding/single-redirects/) the `/.well-known/*` path should be excluded from redirections.
+When using [Redirect Rules](/rules/url-forwarding/single-redirects/), exclude the `/.well-known/*` path from redirections by adding a condition to your rule:
+
+```txt
+not starts_with(http.request.uri.path, "/.well-known/")
+```
+
+For example, if you have a rule that redirects all HTTP traffic to HTTPS, modify the rule expression to:
+
+```txt
+(http.request.scheme eq "http") and not starts_with(http.request.uri.path, "/.well-known/")
+```
 
 ## DNS settings and records
 


### PR DESCRIPTION
## Summary

Expands the DCV troubleshooting documentation to include all error messages returned by certificate authorities, with clear resolution steps for each.

## Problem

Customers encountering DCV errors often do not know what action to take. The existing documentation only covered a few error types and lacked clear call-to-action guidance.

## Solution

Updated `/ssl/edge-certificates/changing-dcv-method/troubleshooting/` to document all DCV error messages from the COMS certificate validation system:

| Error | Resolution |
|-------|------------|
| `The authority has rate limited these domains...` | Wait for expiration or try different CA |
| `CAA records block issuance...` | Remove CAA records or add allowed CAs |
| `Certificate authority encountered a multiple perspective CAA check error...` | Ensure DNS is resolvable from all locations |
| `MPIC failure...` | Ensure DNS records are globally reachable |
| `the Certificate Authority had trouble performing a DNS lookup...` | Check DNS configuration and DNSSEC |
| `The certificate authority will not issue for this domain...` | Verify domain or try different CA |
| `Internal error with Certificate Authority...` | Wait and retry, or try different CA |

Each error now includes:
- The exact error message customers will see
- A clear **Resolution** section with actionable steps
- Links to relevant documentation

## Ticket

- SPM-3368
