### PR TITLE
[Web Assets] Add cf-mcp endpoint label

### DIFF
--- a/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
+++ b/src/content/docs/api-shield/management-and-monitoring/endpoint-labels.mdx
@@ -56,6 +56,8 @@ Use managed labels to identify endpoints by use case. Cloudflare may automatical
 
 `cf-llm`: Services that are (partially) powered by Large Language Model (LLM).
 
+`cf-mcp`: Add this label to endpoints that implement the [Model Context Protocol (MCP)](/agents/model-context-protocol/) for AI tool and data access.
+
 `cf-rss-feed`: Add this label to endpoints that expect traffic from RSS clients.
 
 `cf-web-page`: Add this label to endpoints that serve HTML pages.


### PR DESCRIPTION
### Summary

Adds the `cf-mcp` managed endpoint label to the endpoint labeling service documentation.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).