### PR TITLE
[Workers Runtime] Document cache.put rejection of 301/302 redirects with query strings

### DIFF
--- a/src/content/docs/cache/how-to/cache-keys.mdx
+++ b/src/content/docs/cache/how-to/cache-keys.mdx
@@ -76,6 +76,14 @@ Understanding how `$scheme` interacts with your caching configuration is essenti
 
 A [Cache Level](/cache/how-to/set-caching-levels/) of Ignore Query String creates a Cache Key that includes all the elements in the default cache key, except for the query string in the URI that is no longer included. For instance, a request for `http://example.com/file.jpg?something=123` and a request for `http://example.com/file.jpg?something=789` will have the same cache key, in this case.
 
+:::caution
+
+When the cache key does not include the query string, Cloudflare will not cache `301` or `302` redirect responses if the `Location` header contains the request's query string. This is a security mitigation to prevent cache poisoning, where an attacker could use an unkeyed query string to poison cached redirects for all users.
+
+If you need to cache redirect responses that preserve query strings, either include the query string in your cache key or ensure your origin does not reflect the query string in the `Location` header.
+
+:::
+
 ## Cache Key Settings
 
 The following fields control the Cache Key Template.

--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -130,6 +130,12 @@ The `stale-while-revalidate` and `stale-if-error` directives are not supported w
 
 `cache.put` returns a `413` error if `Cache-Control` instructs not to cache or if the response is too large.
 
+:::note
+
+`cache.put` will silently reject a `301` or `302` redirect response when the cache key does not include the query string and the `Location` header contains the request's query string. Refer to [Cache keys](/cache/how-to/cache-keys/#cache-level-ignore-query-string) for details and workarounds. This restriction does not apply on `.workers.dev` domains, which include the query string in the cache key by default.
+
+:::
+
 ### `Match`
 
 ```js


### PR DESCRIPTION
### Summary

Adds a note to the Workers Cache API docs explaining that cache.put() silently rejects 301/302 redirect responses when the cache key excludes the query string and the Location header contains it. This is an existing anti-cache-poisoning mitigation that is not currently documented, causing confusion for customers using the Cache API with redirect responses on custom domain Worker routes.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
