### PR TITLE
[Cache] Document 301/302 redirect caching restriction when query string is excluded from cache key

### DIFF
--- a/src/content/docs/workers/runtime-apis/cache.mdx
+++ b/src/content/docs/workers/runtime-apis/cache.mdx
@@ -130,6 +130,17 @@ The `stale-while-revalidate` and `stale-if-error` directives are not supported w
 
 `cache.put` returns a `413` error if `Cache-Control` instructs not to cache or if the response is too large.
 
+:::note
+
+`cache.put` will silently reject a `301` or `302` redirect response if both of the following are true:
+
+1. The cache key does not include the query string (for example, a custom cache key set via Workers or Page Rules that strips the query string).
+2. The `Location` header in the redirect response contains the request's query string.
+
+This is a cache-poisoning mitigation. To cache redirect responses with query strings, either include the query string in your cache key, or remove the query string from the `Location` header before calling `cache.put()`. This restriction does not apply on `.workers.dev` domains, which include the query string in the cache key by default.
+
+:::
+
 ### `Match`
 
 ```js


### PR DESCRIPTION
### Summary

Adds a caution callout to the Cache Keys docs explaining that Cloudflare
will not cache 301/302 redirect responses when the cache key excludes
the query string and the Location header contains it. This is an existing
anti-cache-poisoning mitigation that was not previously documented.
Also adds a cross-reference from the Workers Cache API cache.put() docs
to the cache-keys page.


<!-- Add context such as the type of documentation being updated or added -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).