### PR TITLE
Update Cloudflare One links in Ubiquiti documentation

### DIFF
--- a/src/content/partials/networking-services/cloudflare-wan/third-party/ubiquiti.mdx
+++ b/src/content/partials/networking-services/cloudflare-wan/third-party/ubiquiti.mdx
@@ -31,7 +31,7 @@ Connect a Ubiquiti UniFi Gateway to Cloudflare's network using Cloudflare WAN (f
 	</>
 ) : (
 	<Markdown
-		text={`1. Log in to <a href="https://one.dash.cloudflare.com/">Cloudflare One</a>, and go to **Networks**.
+		text={`1. Log in to <a href="https://dash.cloudflare.com/">Cloudflare One</a>, and go to **Networks**.
 2. Go to **Connectors** > **Cloudflare WAN**, and select **Create**.`}
 		inline={false}
 	/>
@@ -99,7 +99,7 @@ Connect a Ubiquiti UniFi Gateway to Cloudflare's network using Cloudflare WAN (f
 	</>
 ) : (
 	<Markdown
-		text={`1. Log in to <a href="https://one.dash.cloudflare.com/">Cloudflare One</a>, and go to **Networks**.
+		text={`1. Log in to <a href="https://dash.cloudflare.com/">Cloudflare One</a>, and go to **Networks**.
 2. In **Cloudflare WAN**, find the IPsec tunnel you have just created.`}
 		inline={false}
 	/>
@@ -129,7 +129,7 @@ Connect a Ubiquiti UniFi Gateway to Cloudflare's network using Cloudflare WAN (f
 	</>
 ) : (
 	<Markdown
-		text={`1. Log in to <a href="https://one.dash.cloudflare.com/">Cloudflare One</a>, and go to **Networks**.
+		text={`1. Log in to <a href="https://dash.cloudflare.com/">Cloudflare One</a>, and go to **Networks**.
 2. Go to **Routes** > **WAN routes** > **Create**.`}
 		inline={false}
 	/>
@@ -161,7 +161,7 @@ Wait a few minutes, then access both Cloudflare and UniFi to verify the tunnel's
 	</>
 ) : (
 	<Markdown
-		text={`1. Log in to <a href="https://one.dash.cloudflare.com/">Cloudflare One</a>, and go to **Insights**.
+		text={`1. Log in to <a href="https://dash.cloudflare.com/">Cloudflare One</a>, and go to **Insights**.
 2. Go to **Network visibility** > **WAN connector health**.
 3. Find the tunnel you have just created and make sure its status shows **Up**. Refer to [Check tunnel health in the dashboard](/cloudflare-one/networks/connectors/cloudflare-wan/configuration/common-settings/check-tunnel-health-dashboard/) for more information.`}
 		inline={false}


### PR DESCRIPTION

### Summary

Changed https://one.dash.cloudflare.com/ to https://dash.cloudflare.com/
### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->


