### PR TITLE
[Durable Objects] Document ctx.id.jurisdiction and improve ctx.id.name scanability

### DIFF
--- a/src/content/changelog/durable-objects/2026-03-26-durable-object-id-jurisdiction.mdx
+++ b/src/content/changelog/durable-objects/2026-03-26-durable-object-id-jurisdiction.mdx
@@ -9,11 +9,11 @@ date: 2026-03-26
 
 `ctx.id.jurisdiction` inside a Durable Object now reports the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) that the object was created in, matching the value seen client-side. If a Worker accesses a Durable Object through a jurisdiction-restricted namespace — for example `env.MY_DURABLE_OBJECT.jurisdiction("eu")` — the same jurisdiction is available on `ctx.id.jurisdiction` inside the object, so you can make region-aware decisions without passing the jurisdiction through method arguments or persisting it in storage.
 
-The `jurisdiction` property was previously gated behind an experimental flag because the value was not consistently available on the `DurableObjectId` exposed inside a Durable Object as `ctx.id`. With this change, `jurisdiction` is generally available and is preserved across every ID-construction path, including:
+`jurisdiction` is preserved across every ID-construction path, including:
 
 - IDs created from a jurisdiction-restricted subnamespace, for example `env.MY_DURABLE_OBJECT.jurisdiction("eu").idFromName("foo")` or `.newUniqueId()`.
 - IDs created via `env.MY_DURABLE_OBJECT.newUniqueId({ jurisdiction: "eu" })`.
-- IDs restored from a string via `idFromString()`, including when restored through the unrestricted namespace binding.
+- IDs restored from a string via `idFromString()` — the jurisdiction is encoded in the string itself, so it works on any namespace binding.
 - IDs observed inside [alarm handlers](/durable-objects/api/alarms/) for alarms scheduled on 2026-03-15 or later.
 
 ```js

--- a/src/content/changelog/durable-objects/2026-03-26-durable-object-id-jurisdiction.mdx
+++ b/src/content/changelog/durable-objects/2026-03-26-durable-object-id-jurisdiction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Access Durable Object jurisdiction via `ctx.id.jurisdiction`
-description: Read the jurisdiction of a jurisdiction-restricted Durable Object from within the object itself.
+description: Read the jurisdiction of a Durable Object from within the object itself.
 products:
   - durable-objects
   - workers

--- a/src/content/changelog/durable-objects/2026-03-26-durable-object-id-jurisdiction.mdx
+++ b/src/content/changelog/durable-objects/2026-03-26-durable-object-id-jurisdiction.mdx
@@ -4,7 +4,7 @@ description: Read the jurisdiction of a jurisdiction-restricted Durable Object f
 products:
   - durable-objects
   - workers
-date: 2026-05-18
+date: 2026-03-26
 ---
 
 `ctx.id.jurisdiction` inside a Durable Object now reports the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) that the object was created in, matching the value seen client-side. If a Worker accesses a Durable Object through a jurisdiction-restricted namespace — for example `env.MY_DURABLE_OBJECT.jurisdiction("eu")` — the same jurisdiction is available on `ctx.id.jurisdiction` inside the object, so you can make region-aware decisions without passing the jurisdiction through method arguments or persisting it in storage.

--- a/src/content/changelog/durable-objects/2026-03-26-durable-object-id-jurisdiction.mdx
+++ b/src/content/changelog/durable-objects/2026-03-26-durable-object-id-jurisdiction.mdx
@@ -7,14 +7,7 @@ products:
 date: 2026-03-26
 ---
 
-`ctx.id.jurisdiction` inside a Durable Object now reports the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) that the object was created in, matching the value seen client-side. If a Worker accesses a Durable Object through a jurisdiction-restricted namespace — for example `env.MY_DURABLE_OBJECT.jurisdiction("eu")` — the same jurisdiction is available on `ctx.id.jurisdiction` inside the object, so you can make region-aware decisions without passing the jurisdiction through method arguments or persisting it in storage.
-
-`jurisdiction` is preserved across every ID-construction path, including:
-
-- IDs created from a jurisdiction-restricted subnamespace, for example `env.MY_DURABLE_OBJECT.jurisdiction("eu").idFromName("foo")` or `.newUniqueId()`.
-- IDs created via `env.MY_DURABLE_OBJECT.newUniqueId({ jurisdiction: "eu" })`.
-- IDs restored from a string via `idFromString()` — the jurisdiction is encoded in the string itself, so it works on any namespace binding.
-- IDs observed inside [alarm handlers](/durable-objects/api/alarms/) for alarms scheduled on 2026-03-15 or later.
+`ctx.id.jurisdiction` inside a Durable Object now reports the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) the object was created in — for example `"eu"` when accessed through `env.MY_DURABLE_OBJECT.jurisdiction("eu")` — so you can make region-aware decisions without passing the jurisdiction through method arguments or persisting it in storage. For the full list of ID-construction paths that preserve `jurisdiction`, refer to the [Durable Object ID documentation](/durable-objects/api/id/#jurisdiction).
 
 ```js
 export class RegionalRoom extends DurableObject {
@@ -35,5 +28,3 @@ export default {
 ```
 
 `ctx.id.jurisdiction` is `undefined` for Durable Objects that were not created in a jurisdiction-restricted namespace. Alarms scheduled before 2026-03-15 also do not have `jurisdiction` stored; to backfill the value, reschedule the alarm from a `fetch()` or RPC handler.
-
-For more information, refer to the [Durable Object ID documentation](/durable-objects/api/id/#jurisdiction).

--- a/src/content/changelog/durable-objects/2026-05-18-durable-object-id-jurisdiction.mdx
+++ b/src/content/changelog/durable-objects/2026-05-18-durable-object-id-jurisdiction.mdx
@@ -1,0 +1,39 @@
+---
+title: Access Durable Object jurisdiction via `ctx.id.jurisdiction`
+description: Read the jurisdiction of a jurisdiction-restricted Durable Object from within the object itself.
+products:
+  - durable-objects
+  - workers
+date: 2026-05-18
+---
+
+`ctx.id.jurisdiction` inside a Durable Object now reports the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) that the object was created in, matching the value seen client-side. If a Worker accesses a Durable Object through a jurisdiction-restricted namespace — for example `env.MY_DURABLE_OBJECT.jurisdiction("eu")` — the same jurisdiction is available on `ctx.id.jurisdiction` inside the object, so you can make region-aware decisions without passing the jurisdiction through method arguments or persisting it in storage.
+
+The `jurisdiction` property was previously gated behind an experimental flag because the value was not consistently available on the `DurableObjectId` exposed inside a Durable Object as `ctx.id`. With this change, `jurisdiction` is generally available and is preserved across every ID-construction path, including:
+
+- IDs created from a jurisdiction-restricted subnamespace, for example `env.MY_DURABLE_OBJECT.jurisdiction("eu").idFromName("foo")` or `.newUniqueId()`.
+- IDs created via `env.MY_DURABLE_OBJECT.newUniqueId({ jurisdiction: "eu" })`.
+- IDs restored from a string via `idFromString()`, including when restored through the unrestricted namespace binding.
+- IDs observed inside [alarm handlers](/durable-objects/api/alarms/) for alarms scheduled on 2026-03-15 or later.
+
+```js
+export class RegionalRoom extends DurableObject {
+	async fetch(request) {
+		// "eu" when accessed through env.MY_DURABLE_OBJECT.jurisdiction("eu")
+		const region = this.ctx.id.jurisdiction;
+		return new Response(`Hello from ${region ?? "the default region"}!`);
+	}
+}
+
+// Worker
+export default {
+	async fetch(request, env) {
+		const stub = env.MY_DURABLE_OBJECT.jurisdiction("eu").getByName("general");
+		return stub.fetch(request);
+	},
+};
+```
+
+`ctx.id.jurisdiction` is `undefined` for Durable Objects that were not created in a jurisdiction-restricted namespace. Alarms scheduled before 2026-03-15 also do not have `jurisdiction` stored; to backfill the value, reschedule the alarm from a `fetch()` or RPC handler.
+
+For more information, refer to the [Durable Object ID documentation](/durable-objects/api/id/#jurisdiction).

--- a/src/content/docs/durable-objects/api/id.mdx
+++ b/src/content/docs/durable-objects/api/id.mdx
@@ -157,23 +157,12 @@ class ChatRoom(DurableObject):
 
 ### `jurisdiction`
 
-`jurisdiction` is an optional property of a `DurableObjectId`, which returns the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) the ID is restricted to, such as `"eu"` or `"fedramp"`. This value is `undefined` if the `DurableObjectId` was created from a namespace that is not restricted to a jurisdiction.
+`jurisdiction` is an optional property of a `DurableObjectId`, which returns the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) the ID is restricted to, such as `"eu"` or `"fedramp"`. The same value is available inside the Durable Object via `ctx.id.jurisdiction`, including in [alarm handlers](/durable-objects/api/alarms/) and after restoring an ID via `idFromString()`, so you can make region-aware decisions without passing the jurisdiction as an argument or persisting it in storage.
 
-The `jurisdiction` property is also available on `ctx.id` inside the Durable Object. Unlike `name`, the jurisdiction is preserved across every ID-construction path:
+`ctx.id.jurisdiction` is `undefined` in two cases:
 
-- **Populated** when the ID is created from a jurisdiction-restricted subnamespace returned by `env.MY_DURABLE_OBJECT.jurisdiction("eu")` — for example via `.idFromName("foo")` or `.newUniqueId()`.
-- **Populated** when the ID is created with `env.MY_DURABLE_OBJECT.newUniqueId({ jurisdiction: "eu" })`.
-- **Populated** after a round-trip through `toString()` and `idFromString()`, including when the ID is restored through the non-restricted namespace binding.
-- **Populated** inside [alarm handlers](/durable-objects/api/alarms/) for alarms scheduled on 2026-03-15 or later.
-- **`undefined`** for Durable Objects created in a namespace that is not restricted to a jurisdiction.
-
-:::tip[Useful for region-aware logic]
-Because `ctx.id.jurisdiction` is available inside the Durable Object — including in `alarm()` handlers and after restoring an ID from a string — you can use it to make region-aware decisions without passing the jurisdiction as an argument or persisting it in storage.
-:::
-
-:::note
-Alarms created before 2026-03-15 do not have `jurisdiction` stored. When such an alarm fires, `ctx.id.jurisdiction` will be `undefined`, and any new alarm scheduled from that handler will also lack a `jurisdiction`. To fix this, reschedule the alarm from a `fetch()` or RPC handler where `jurisdiction` is available.
-:::
+- The Durable Object was not created in a jurisdiction-restricted namespace.
+- The Durable Object's alarm was scheduled before 2026-03-15. To backfill the value, reschedule the alarm from a `fetch()` or RPC handler.
 
 <Tabs>
 
@@ -195,38 +184,6 @@ plain_id = env.MY_DURABLE_OBJECT.idFromName("foo")
 eu_id = env.MY_DURABLE_OBJECT.jurisdiction("eu").idFromName("foo")
 assert plain_id.jurisdiction is None, "no jurisdiction set"
 assert eu_id.jurisdiction == "eu", "jurisdiction matches namespace"
-```
-
-</TabItem>
-
-</Tabs>
-
-The same `jurisdiction` is available inside the Durable Object via `ctx.id.jurisdiction`:
-
-<Tabs>
-
-<TabItem label="JavaScript" icon="seti:javascript">
-
-```js
-import { DurableObject } from "cloudflare:workers";
-
-export class RegionalRoom extends DurableObject {
-	async getRegion() {
-		return this.ctx.id.jurisdiction; // "eu" when created via .jurisdiction("eu")
-	}
-}
-```
-
-</TabItem>
-
-<TabItem label="Python" icon="seti:python">
-
-```python
-from workers import DurableObject
-
-class RegionalRoom(DurableObject):
-    async def get_region(self):
-        return self.ctx.id.jurisdiction  # "eu" when created via .jurisdiction("eu")
 ```
 
 </TabItem>

--- a/src/content/docs/durable-objects/api/id.mdx
+++ b/src/content/docs/durable-objects/api/id.mdx
@@ -157,7 +157,7 @@ class ChatRoom(DurableObject):
 
 ### `jurisdiction`
 
-`jurisdiction` is an optional property of a `DurableObjectId`, which returns the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) the ID is restricted to, such as `"eu"` or `"fedramp"`. The same value is available inside the Durable Object via `ctx.id.jurisdiction`, including in [alarm handlers](/durable-objects/api/alarms/) and after restoring an ID via `idFromString()`, so you can make region-aware decisions without passing the jurisdiction as an argument or persisting it in storage.
+`jurisdiction` is an optional property of a `DurableObjectId`, which returns the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) the ID is restricted to, such as `"eu"` or `"fedramp"`. The same value is available inside the Durable Object via `ctx.id.jurisdiction`, including in [alarm handlers](/durable-objects/api/alarms/) and objects accessed via `idFromString()`, so you can make region-aware decisions without passing the jurisdiction as an argument or persisting it in storage.
 
 `ctx.id.jurisdiction` is `undefined` in two cases:
 

--- a/src/content/docs/durable-objects/api/id.mdx
+++ b/src/content/docs/durable-objects/api/id.mdx
@@ -155,6 +155,84 @@ class ChatRoom(DurableObject):
 
 </Tabs>
 
+### `jurisdiction`
+
+`jurisdiction` is an optional property of a `DurableObjectId`, which returns the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) the ID is restricted to, such as `"eu"` or `"fedramp"`. This value is `undefined` if the `DurableObjectId` was created from a namespace that is not restricted to a jurisdiction.
+
+The `jurisdiction` property is also available on `ctx.id` inside the Durable Object. Unlike `name`, the jurisdiction is preserved across every ID-construction path:
+
+- **Populated** when the ID is created from a jurisdiction-restricted subnamespace returned by `env.MY_DURABLE_OBJECT.jurisdiction("eu")` — for example via `.idFromName("foo")` or `.newUniqueId()`.
+- **Populated** when the ID is created with `env.MY_DURABLE_OBJECT.newUniqueId({ jurisdiction: "eu" })`.
+- **Populated** after a round-trip through `toString()` and `idFromString()`, including when the ID is restored through the non-restricted namespace binding.
+- **Populated** inside [alarm handlers](/durable-objects/api/alarms/) for alarms scheduled on 2026-03-15 or later.
+- **`undefined`** for Durable Objects created in a namespace that is not restricted to a jurisdiction.
+
+:::tip[Useful for region-aware logic]
+Because `ctx.id.jurisdiction` is available inside the Durable Object — including in `alarm()` handlers and after restoring an ID from a string — you can use it to make region-aware decisions without passing the jurisdiction as an argument or persisting it in storage.
+:::
+
+:::note
+Alarms created before 2026-03-15 do not have `jurisdiction` stored. When such an alarm fires, `ctx.id.jurisdiction` will be `undefined`, and any new alarm scheduled from that handler will also lack a `jurisdiction`. To fix this, reschedule the alarm from a `fetch()` or RPC handler where `jurisdiction` is available.
+:::
+
+<Tabs>
+
+<TabItem label="JavaScript" icon="seti:javascript">
+
+```js
+const plainId = env.MY_DURABLE_OBJECT.idFromName("foo");
+const euId = env.MY_DURABLE_OBJECT.jurisdiction("eu").idFromName("foo");
+console.assert(plainId.jurisdiction === undefined, "no jurisdiction set");
+console.assert(euId.jurisdiction === "eu", "jurisdiction matches namespace");
+```
+
+</TabItem>
+
+<TabItem label="Python" icon="seti:python">
+
+```python
+plain_id = env.MY_DURABLE_OBJECT.idFromName("foo")
+eu_id = env.MY_DURABLE_OBJECT.jurisdiction("eu").idFromName("foo")
+assert plain_id.jurisdiction is None, "no jurisdiction set"
+assert eu_id.jurisdiction == "eu", "jurisdiction matches namespace"
+```
+
+</TabItem>
+
+</Tabs>
+
+The same `jurisdiction` is available inside the Durable Object via `ctx.id.jurisdiction`:
+
+<Tabs>
+
+<TabItem label="JavaScript" icon="seti:javascript">
+
+```js
+import { DurableObject } from "cloudflare:workers";
+
+export class RegionalRoom extends DurableObject {
+	async getRegion() {
+		return this.ctx.id.jurisdiction; // "eu" when created via .jurisdiction("eu")
+	}
+}
+```
+
+</TabItem>
+
+<TabItem label="Python" icon="seti:python">
+
+```python
+from workers import DurableObject
+
+class RegionalRoom(DurableObject):
+    async def get_region(self):
+        return self.ctx.id.jurisdiction  # "eu" when created via .jurisdiction("eu")
+```
+
+</TabItem>
+
+</Tabs>
+
 ## Related resources
 
 - [Durable Objects: Easy, Fast, Correct – Choose Three](https://blog.cloudflare.com/durable-objects-easy-fast-correct-choose-three/).

--- a/src/content/docs/durable-objects/api/id.mdx
+++ b/src/content/docs/durable-objects/api/id.mdx
@@ -80,7 +80,15 @@ assert not id1.equals(id2), "Different unique ids should never be equal."
 
 `name` is an optional property of a `DurableObjectId`, which returns the name that was used to create the `DurableObjectId` via [`DurableObjectNamespace::idFromName`](/durable-objects/api/namespace/#idfromname). This value is undefined if the `DurableObjectId` was constructed using [`DurableObjectNamespace::newUniqueId`](/durable-objects/api/namespace/#newuniqueid).
 
-The `name` property is available on `ctx.id` inside the Durable Object when the caller uses `idFromName()` or `getByName()`. If the caller accesses the Durable Object using `idFromString()`, `ctx.id.name` will be `undefined`, even if the ID was originally created with `idFromName()`. Names longer than 1,024 bytes are not passed through and will be `undefined` on `ctx.id`.
+The `name` property is also available on `ctx.id` inside the Durable Object when the caller uses `idFromName()` or `getByName()`. `ctx.id.name` will be `undefined` in the following cases:
+
+- The caller accesses the Durable Object using `idFromString()`, even if the ID was originally created with `idFromName()`.
+- Names longer than 1,024 bytes are not passed through to `ctx.id`.
+- The Durable Object was created with `newUniqueId()`.
+
+:::tip[Useful for alarms]
+`ctx.id.name` is especially useful inside [alarm handlers](/durable-objects/api/alarms/), where there is no calling client to pass the name as an argument. When the alarm fires, `ctx.id.name` holds the same name the object was originally accessed with.
+:::
 
 :::note
 Alarms created before 2026-03-15 do not have `name` stored. When such an alarm fires, `ctx.id.name` will be `undefined`, and any new alarm scheduled from that handler will also lack a `name`. To fix this, reschedule the alarm from a `fetch()` or RPC handler where `name` is available.
@@ -109,6 +117,38 @@ unique_id = env.MY_DURABLE_OBJECT.newUniqueId()
 from_name_id = env.MY_DURABLE_OBJECT.idFromName("foo")
 assert unique_id.name is None, "unique ids have no name"
 assert from_name_id.name == "foo", "name matches parameter to idFromName"
+```
+
+</TabItem>
+
+</Tabs>
+
+The same `name` is available inside the Durable Object via `ctx.id.name`:
+
+<Tabs>
+
+<TabItem label="JavaScript" icon="seti:javascript">
+
+```js
+import { DurableObject } from "cloudflare:workers";
+
+export class ChatRoom extends DurableObject {
+	async getRoomName() {
+		return this.ctx.id.name; // "foo" when accessed via getByName("foo")
+	}
+}
+```
+
+</TabItem>
+
+<TabItem label="Python" icon="seti:python">
+
+```python
+from workers import DurableObject
+
+class ChatRoom(DurableObject):
+    async def get_room_name(self):
+        return self.ctx.id.name  # "foo" when accessed via get_by_name("foo")
 ```
 
 </TabItem>

--- a/src/content/docs/durable-objects/api/id.mdx
+++ b/src/content/docs/durable-objects/api/id.mdx
@@ -86,11 +86,9 @@ The `name` property is also available on `ctx.id` inside the Durable Object when
 - Names longer than 1,024 bytes are not passed through to `ctx.id`.
 - The Durable Object was created with `newUniqueId()`.
 
-:::tip[Useful for alarms]
+:::note[Alarms]
 `ctx.id.name` is especially useful inside [alarm handlers](/durable-objects/api/alarms/), where there is no calling client to pass the name as an argument. When the alarm fires, `ctx.id.name` holds the same name the object was originally accessed with.
-:::
 
-:::note
 Alarms created before 2026-03-15 do not have `name` stored. When such an alarm fires, `ctx.id.name` will be `undefined`, and any new alarm scheduled from that handler will also lack a `name`. To fix this, reschedule the alarm from a `fetch()` or RPC handler where `name` is available.
 :::
 
@@ -101,6 +99,20 @@ Alarms created before 2026-03-15 do not have `name` stored. When such an alarm f
 ```js
 const uniqueId = env.MY_DURABLE_OBJECT.newUniqueId();
 const fromNameId = env.MY_DURABLE_OBJECT.idFromName("foo");
+console.assert(uniqueId.name === undefined, "unique ids have no name");
+console.assert(
+	fromNameId.name === "foo",
+	"name matches parameter to idFromName",
+);
+```
+
+</TabItem>
+
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```ts
+const uniqueId: DurableObjectId = env.MY_DURABLE_OBJECT.newUniqueId();
+const fromNameId: DurableObjectId = env.MY_DURABLE_OBJECT.idFromName("foo");
 console.assert(uniqueId.name === undefined, "unique ids have no name");
 console.assert(
 	fromNameId.name === "foo",
@@ -141,6 +153,20 @@ export class ChatRoom extends DurableObject {
 
 </TabItem>
 
+<TabItem label="TypeScript" icon="seti:typescript">
+
+```ts
+import { DurableObject } from "cloudflare:workers";
+
+export class ChatRoom extends DurableObject<Env> {
+	async getRoomName(): Promise<string | undefined> {
+		return this.ctx.id.name; // "foo" when accessed via getByName("foo")
+	}
+}
+```
+
+</TabItem>
+
 <TabItem label="Python" icon="seti:python">
 
 ```python
@@ -158,6 +184,12 @@ class ChatRoom(DurableObject):
 ### `jurisdiction`
 
 `jurisdiction` is an optional property of a `DurableObjectId`, which returns the [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) the ID is restricted to, such as `"eu"` or `"fedramp"`. The same value is available inside the Durable Object via `ctx.id.jurisdiction`, including in [alarm handlers](/durable-objects/api/alarms/) and objects accessed via `idFromString()`, so you can make region-aware decisions without passing the jurisdiction as an argument or persisting it in storage.
+
+`jurisdiction` is preserved across every ID-construction path, including:
+
+- IDs created from a jurisdiction-restricted subnamespace, for example `env.MY_DURABLE_OBJECT.jurisdiction("eu").idFromName("foo")` or `.newUniqueId()`.
+- IDs created via `env.MY_DURABLE_OBJECT.newUniqueId({ jurisdiction: "eu" })`.
+- IDs restored from a string via `idFromString()` — the jurisdiction is encoded in the string itself, so it works on any namespace binding.
 
 `ctx.id.jurisdiction` is `undefined` in two cases:
 

--- a/src/content/docs/durable-objects/reference/data-location.mdx
+++ b/src/content/docs/durable-objects/reference/data-location.mdx
@@ -58,10 +58,14 @@ Note that it is also possible to specify a jurisdiction by creating an individua
 
 ### Supported locations
 
-| Parameter | Location                     |
-| --------- | ---------------------------- |
-| eu        | The European Union           |
+| Parameter | Location                       |
+| --------- | ------------------------------ |
+| eu        | The European Union             |
 | fedramp   | FedRAMP-compliant data centers |
+
+### Read the jurisdiction from inside a Durable Object
+
+The jurisdiction of a Durable Object is available inside the object via [`ctx.id.jurisdiction`](/durable-objects/api/id/#jurisdiction). The value is preserved across `toString()` and `idFromString()` round-trips and is also available inside [alarm handlers](/durable-objects/api/alarms/) for alarms scheduled on 2026-03-15 or later, which makes it suitable for region-aware logic inside the Durable Object.
 
 ## Provide a location hint
 
@@ -102,9 +106,13 @@ Hints are a best effort and not a guarantee. Unlike with jurisdictions, Durable 
 | afr       | Africa <sup>2</sup>        |
 | me        | Middle East <sup>2</sup>   |
 
-<sup>1</sup> Dynamic relocation of existing Durable Objects is planned for the future.
+<sup>1</sup> Dynamic relocation of existing Durable Objects is planned for the
+future.
 
-<sup>2</sup> Durable Objects currently do not spawn in this location. Instead, the Durable Object will spawn in a nearby location which does support Durable Objects. For example, Durable Objects hinted to South America spawn in Eastern North America instead.
+<sup>2</sup> Durable Objects currently do not spawn in this location. Instead,
+the Durable Object will spawn in a nearby location which does support Durable
+Objects. For example, Durable Objects hinted to South America spawn in Eastern
+North America instead.
 
 ## Additional resources
 


### PR DESCRIPTION
## Summary

This PR covers two related bodies of work on the Durable Objects `ctx.id` API documentation:

1. **Improve scanability of the `name` section** in `src/content/docs/durable-objects/api/id.mdx` (companion to #30897 which addressed Vy's review feedback on the `ctx.id.name` changelog).
2. **Document the `jurisdiction` property** of `DurableObjectId`, which is now generally available (no longer experimental). The property reports the [jurisdiction](https://developers.cloudflare.com/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction) a Durable Object is restricted to (`"eu"` or `"fedramp"`), and is now consistently available on `ctx.id.jurisdiction` inside the Durable Object — including across `toString()`/`idFromString()` round-trips and inside alarm handlers for alarms scheduled on 2026-03-15 or later.

## Changes

### `name` section scanability (existing commit)

- **Bulleted list for `undefined` cases.** The dense run-on sentence covering `idFromString()`, names > 1,024 bytes, and `newUniqueId()` is now a scannable three-bullet list. The `newUniqueId()` case is consolidated here for completeness (it was previously only in the first paragraph).
- **Alarms tip callout.** Added a `:::tip[Useful for alarms]:::` callout between the bulleted list and the existing historical-caveat note. Alarms are the strongest use case for `ctx.id.name` — when an alarm fires, no client called the DO, so `ctx.id.name` is the only way to know which named object woke up. The existing historical-caveat note (pre-2026-03-15 alarms) is preserved unchanged.
- **In-DO code example.** Added a new `<Tabs>` group (JavaScript + Python) showing `ctx.id.name` usage inside a Durable Object class, placed after the existing client-side code examples.

### `jurisdiction` documentation (new commit)

| File | Change |
| ---- | ------ |
| `src/content/changelog/durable-objects/2026-05-18-durable-object-id-jurisdiction.mdx` | New changelog entry announcing GA |
| `src/content/docs/durable-objects/api/id.mdx` | New `### jurisdiction` section under Properties, modeled after the existing `### name` section |
| `src/content/docs/durable-objects/reference/data-location.mdx` | New discoverability hook linking from the jurisdiction conceptual page to the new API reference |

Upstream sources:

- workerd PR: https://github.com/cloudflare/workerd/pull/6324 (the one-line flag flip)
- Supporting infrastructure (STOR-4870): adds `globalActorId` to actor invocation + alarm persistence so `ctx.id.jurisdiction` is populated at runtime

## Related

- Changelog draft PR: #30897
- Original changelog PR: #30843

## Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
