### PR TITLE
fix: update broken MCP spec links to new URL structure

### DIFF
--- a/src/content/docs/agents/guides/test-remote-mcp-server.mdx
+++ b/src/content/docs/agents/guides/test-remote-mcp-server.mdx
@@ -12,7 +12,7 @@ products:
 
 import { Render } from "~/components";
 
-Remote, authorized connections are an evolving part of the [Model Context Protocol (MCP) specification](https://spec.modelcontextprotocol.io/specification/draft/basic/authorization/). Not all MCP clients support remote connections yet.
+Remote, authorized connections are an evolving part of the [Model Context Protocol (MCP) specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). Not all MCP clients support remote connections yet.
 
 This guide will show you options for how to start using your remote MCP server with MCP clients that support remote connections. If you haven't yet created and deployed a remote MCP server, you should follow the [Build a Remote MCP Server](/agents/guides/remote-mcp-server/) guide first.
 

--- a/src/content/docs/agents/model-context-protocol/authorization.mdx
+++ b/src/content/docs/agents/model-context-protocol/authorization.mdx
@@ -14,7 +14,7 @@ import { LinkCard } from "~/components";
 
 When building a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server, you need both a way to allow users to login (authentication) and allow them to grant the MCP client access to resources on their account (authorization).
 
-The Model Context Protocol uses [a subset of OAuth 2.1 for authorization](https://spec.modelcontextprotocol.io/specification/draft/basic/authorization/). OAuth allows your users to grant limited access to resources, without them having to share API keys or other credentials.
+The Model Context Protocol uses [a subset of OAuth 2.1 for authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). OAuth allows your users to grant limited access to resources, without them having to share API keys or other credentials.
 
 Cloudflare provides an [OAuth Provider Library](https://github.com/cloudflare/workers-oauth-provider) that implements the provider side of the OAuth 2.1 protocol, allowing you to easily add authorization to your MCP server.
 
@@ -56,7 +56,7 @@ export default new OAuthProvider({
 });
 ```
 
-Note that as [defined in the Model Context Protocol specification](https://spec.modelcontextprotocol.io/specification/draft/basic/authorization/#292-flow-description) when you use a third-party OAuth provider, the MCP Server (your Worker) generates and issues its own token to the MCP client:
+Note that as [defined in the Model Context Protocol specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-flow-steps) when you use a third-party OAuth provider, the MCP Server (your Worker) generates and issues its own token to the MCP client:
 
 ```mermaid
 sequenceDiagram

--- a/src/content/docs/agents/model-context-protocol/index.mdx
+++ b/src/content/docs/agents/model-context-protocol/index.mdx
@@ -27,7 +27,7 @@ You can build and deploy [Model Context Protocol (MCP)](https://modelcontextprot
 The MCP standard supports two modes of operation:
 
 - **Remote MCP connections**: MCP clients connect to MCP servers over the Internet, establishing a connection using [Streamable HTTP](/agents/model-context-protocol/transport/), and authorizing the MCP client access to resources on the user's account using [OAuth](/agents/model-context-protocol/authorization/).
-- **Local MCP connections**: MCP clients connect to MCP servers on the same machine, using [stdio](https://spec.modelcontextprotocol.io/specification/draft/basic/transports/#stdio) as a local transport method.
+- **Local MCP connections**: MCP clients connect to MCP servers on the same machine, using [stdio](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio) as a local transport method.
 
 ### Best Practices
 

--- a/src/content/docs/agents/model-context-protocol/transport.mdx
+++ b/src/content/docs/agents/model-context-protocol/transport.mdx
@@ -12,7 +12,7 @@ products:
 
 import { TypeScriptExample } from "~/components";
 
-The Model Context Protocol (MCP) specification defines two standard [transport mechanisms](https://spec.modelcontextprotocol.io/specification/draft/basic/transports/) for communication between clients and servers:
+The Model Context Protocol (MCP) specification defines two standard [transport mechanisms](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) for communication between clients and servers:
 
 1. **stdio** — Communication over standard in and standard out, designed for local MCP connections.
 2. **Streamable HTTP** — The standard transport method for remote MCP connections, [introduced](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) in March 2025. It uses a single HTTP endpoint for bidirectional messaging.


### PR DESCRIPTION
## Summary

- Updates 5 broken external links to the MCP specification across 4 files in the agents/MCP docs
- Anthropic moved their MCP spec from `spec.modelcontextprotocol.io/specification/draft/` to `modelcontextprotocol.io/specification/2025-06-18/`, breaking all links to the old domain
- The broken link on the [Authorization page](https://developers.cloudflare.com/agents/model-context-protocol/authorization/) was reported internally

## Files changed

| File | Links fixed |
|------|------------|
| `agents/model-context-protocol/authorization.mdx` | 2 (OAuth 2.1 authorization, flow description) |
| `agents/model-context-protocol/transport.mdx` | 1 (transport mechanisms) |
| `agents/model-context-protocol/index.mdx` | 1 (stdio transport) |
| `agents/guides/test-remote-mcp-server.mdx` | 1 (authorization spec) |
