### PR TITLE
[Cloudflare WAN, Magic Transit] Document Network Analytics support for Unified Routing

### DIFF
--- a/src/content/changelog/cloudflare-wan/2026-05-18-unified-routing-network-analytics.mdx
+++ b/src/content/changelog/cloudflare-wan/2026-05-18-unified-routing-network-analytics.mdx
@@ -1,0 +1,14 @@
+---
+title: Network Analytics support for Unified Routing
+description: Network Analytics is now fully supported for accounts using Unified Routing mode on Cloudflare WAN and Magic Transit.
+date: 2026-05-18
+products:
+  - cloudflare-wan
+  - magic-transit
+---
+
+[Network Analytics](/analytics/network-analytics/) is now fully supported for accounts using [Unified Routing](/cloudflare-wan/reference/traffic-steering/#unified-routing-mode-beta) mode. Traffic that traverses Unified Routing onramps and offramps is now visible in Network Analytics with the same dimensions and filters as traffic on the standard data plane.
+
+This closes a parity gap for customers who had moved tunnels onto Unified Routing and lost visibility into their dataplane traffic in the Network Analytics dashboard. No configuration change is required — analytics data is collected automatically for all accounts with Unified Routing enabled.
+
+For the remaining beta limitations, refer to [Traffic steering beta limitations](/cloudflare-wan/reference/traffic-steering/#beta-limitations).

--- a/src/content/partials/networking-services/reference/traffic-steering.mdx
+++ b/src/content/partials/networking-services/reference/traffic-steering.mdx
@@ -273,7 +273,6 @@ The following limitations apply to accounts using Unified Routing mode. This lis
 | Current beta limitations | Details |
 | --- | --- |
 | Performance | Typically around 150 Mbps for each onramp |
-| Network analytics | Not yet fully supported |
 | Basic packet captures | Captures exclude Automatic Return Routing or BGP-over-tunnels traffic |
 | Full packet captures | Not yet supported |
 | Cloudflare Advanced Network Firewall features: IP Lists, ASN Lists, Threat Intel Lists, IDS, Rate Limiting, SIP, Managed Rulesets | Not yet supported |


### PR DESCRIPTION
### Summary

Network Analytics is now fully supported for accounts using Unified Routing mode on Cloudflare WAN and Magic Transit. This PR:

- Removes the `Network analytics — Not yet fully supported` row from the Unified Routing beta limitations table in `src/content/partials/networking-services/reference/traffic-steering.mdx`. The table is a shared partial, so the entry is removed from both `/cloudflare-wan/reference/traffic-steering/#beta-limitations` and `/magic-transit/reference/traffic-steering/#beta-limitations`.
- Adds a changelog entry under `src/content/changelog/cloudflare-wan/` announcing the parity.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
