### PR TITLE
Adds documentation for Claude Managed Agents and Sandboxes

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -4,6 +4,9 @@
 # ============================================================================
 
 
+# Sandbox (claude-managed-agents moved to tutorials)
+/sandbox/claude-managed-agents/ /sandbox/tutorials/claude-managed-agents/ 301
+
 # Blocked Content (Security center restructuring)
 /security-center/blocked-content/ /fundamentals/reference/report-abuse/blocked-content/ 301
 

--- a/src/content/docs/sandbox/tutorials/claude-managed-agents.mdx
+++ b/src/content/docs/sandbox/tutorials/claude-managed-agents.mdx
@@ -1,0 +1,83 @@
+---
+title: Set up Claude Managed Agents
+pcx_content_type: tutorial
+difficulty: Beginner
+description: Run Claude Managed Agents on self-managed Cloudflare environments.
+sidebar:
+  order: 3
+products:
+  - sandbox
+  - containers
+  - agents
+tags:
+  - AI
+---
+
+import { LinkButton } from "~/components";
+
+Cloudflare provides a self-managed environment for [Claude Managed Agents](https://docs.anthropic.com/en/docs/agents-and-tools/claude-managed-agents). The agent loop runs on the Anthropic platform, while Cloudflare provides the runtime — sandboxes, egress control, browser access, email, and custom tools — that the agent's actions execute in.
+
+This integration ships as an open-source deployment template. Fork the repo, deploy it to your Cloudflare account, and customize it as needed.
+
+<LinkButton variant="primary" href="https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/claude-managed-agents">
+	Deploy to Cloudflare
+</LinkButton>
+<LinkButton variant="secondary" href="https://github.com/cloudflare/claude-managed-agents">
+	View on GitHub
+</LinkButton>
+
+## What you get
+
+Deploy a Workers-based control plane that gives you:
+
+- **Two sandbox backends** — Each agent can run on a full MicroVM ([Containers](/containers/)) or a lightweight isolate ([Dynamic Workers](/dynamic-workers/)). MicroVMs give the agent a full Linux environment with bash and arbitrary processes. Isolates cold-start in milliseconds and costs a fraction of a container session.
+- **Private service connectivity** — Connect agents to private internal services over [Workers VPC](/workers-vpc/) and [Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) without exposing them to the public internet.
+- **Egress control** — Run all agent traffic through customizable proxies. Inject credentials into outbound requests without the agent ever seeing them, restrict access to specific domains, or write arbitrary proxy middleware.
+- **Agent Email** — Give each agent session its own email address for sending and receiving messages with [Cloudflare Email Service](/email-service).
+- **Browser Run tools** — Give agents headless browsers powered by [Browser Run](/browser-run/) for web fetches, screenshots, and CDP control. Session recordings provide an audit trail of every browser action.
+- **Image generation** — Generate images with [Workers AI](/workers-ai/).
+- **Custom tools** — Extend agents with your own tools by adding a function definition to a single file. Tools run in the Workers runtime with access to all your bindings. No additional infrastructure required.
+- **Dashboard** — A built-in UI for managing agents, viewing sessions, inspecting logs, and SSH-ing into running MicroVM sandboxes.
+
+## How it works
+
+When a Claude agent starts a session, Anthropic sends a webhook to the Workers-based control plane running in your Cloudflare account. The control plane gives each session its own sandbox, routes outbound traffic through a per-session egress policy, and persists state across session sleeps.
+
+Anthropic describes this as decoupling the brain from the hands — the agent loop runs on Anthropic (the brain), but the infrastructure for running and executing code (the hands) runs on Cloudflare.
+
+## When to use this
+
+Use a self-managed Cloudflare environment when you need:
+
+- Control over the sandbox infrastructure your agents run in
+- Secure connections to private internal services
+- Custom egress policies for credential injection and domain restrictions
+- Custom tools that use Cloudflare bindings (R2, D1, KV, Vectorize, and others)
+- The ability to choose between MicroVM and isolate backends per agent
+
+## Get started
+
+Follow the [onboarding guide](https://github.com/cloudflare/claude-managed-agents#onboarding-guide) in the repository to deploy the control plane to your account. The guide walks through creating an Anthropic environment, setting secrets, provisioning storage, deploying the Worker, and configuring webhooks.
+
+:::note
+
+You need a Workers Paid plan or Enterprise account. [Containers](/containers/) (used by MicroVM sandboxes) and Worker Loader bindings (used by isolate code execution and egress proxies) require the paid plan.
+
+:::
+
+## Key documentation
+
+The repository includes detailed documentation on each capability:
+
+| Topic | What it covers |
+| --- | --- |
+| [Connecting to private services](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/connecting-to-private-services.md) | Reach services in other clouds, on-prem, or on your laptop with Workers VPC bindings |
+| [Applying egress policies](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/applying-egress-policies.md) | Inject credentials and lock down agent sessions. Set up allow/deny lists, header injection, custom Worker proxies, and VPC routing |
+| [Isolate vs VM-based sandboxes](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/isolate-vs-vm-sandboxes.md) | Pick the best agent execution environment |
+| [Agent email](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/agent-email.md) | Give agents their own email addresses and sending abilities |
+| [Browser rendering tools](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/browser-rendering-tools.md) | Observable agent browser interactions with Browser Run |
+| [Adding custom tools](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/adding-custom-tools.md) | New tools are declared in a single file — [`src/tools/custom-tools.ts`](https://github.com/cloudflare/claude-managed-agents/blob/main/src/tools/custom-tools.ts) |
+| [Customizing sandboxes](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/customizing-sandboxes.md) | Change `Dockerfile` and `instance_type` knobs for the MicroVM backend |
+| [Snapshots and state persistence](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/snapshots-and-state-persistence.md) | State persistence across both sandbox types |
+| [Architecture](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/architecture.md) | Request lifecycle from webhook ingress through dispatch to either sandbox backend, and every Worker binding the control plane uses |
+| [Securing access](https://github.com/cloudflare/claude-managed-agents/blob/main/docs/securing-access.md) | Secure access to the CMA control plane |


### PR DESCRIPTION
### Summary

Adds documentation on hooking up Claude Managed Agents to Cloudflare Sandboxes using self-managed environments.

Going to add a changelog later today, but want to get this part out ASAP as Anthropic is linking to it in their blog post. Their link is going to /claude-managed-agents so I added that redirect.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
