### PR TITLE
[CODEOWNERS] Added Ryan Townsend (PM) as code owner of Web Analytics / RUM

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -281,8 +281,8 @@ package.json @cloudflare/content-engineering
 # Web Analytics
 
 /src/content/docs/web-analytics/ @angelampcosta @dcpena @ryantownsend @cloudflare/product-owners
-/src/content/changelog/web-analytics/ @ryantownsend @cloudflare/pm-changelogs @cloudflare/product-owners
-/src/content/release-notes/beacon-min-js.yaml @ryantownsend @cloudflare/product-owners
+/src/content/changelog/web-analytics/ @angelampcosta @dcpena @ryantownsend @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/release-notes/beacon-min-js.yaml @angelampcosta @dcpena @ryantownsend @cloudflare/product-owners
 
 # AI Prompts for Cloudflare Workers development
 /public/workers/prompts/ @jahands @Maximo-Guk @cloudflare/product-owners @MattieTK

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -280,7 +280,9 @@ package.json @cloudflare/content-engineering
 
 # Web Analytics
 
-/src/content/docs/web-analytics/ @angelampcosta @dcpena @cloudflare/product-owners
+/src/content/docs/web-analytics/ @angelampcosta @dcpena @ryantownsend @cloudflare/product-owners
+/src/content/changelog/web-analytics/ @ryantownsend @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/content/release-notes/beacon-min-js.yaml @ryantownsend @cloudflare/product-owners
 
 # AI Prompts for Cloudflare Workers development
 /public/workers/prompts/ @jahands @Maximo-Guk @cloudflare/product-owners @MattieTK


### PR DESCRIPTION
## Summary

Adding myself as a co-owner in `CODEOWNERS` for Web Analytics product documentation, following the PCX team dissolution. Product PMs are now responsible for docs ownership, reviews, and approvals.

## Changes

* `/src/content/docs/web-analytics/`
  Added `@ryantownsend` to existing codeowners
* `/src/content/changelog/web-analytics/`
  New entry with same codeowners as above, _with_ the addition of `@cloudflare/pm-changelogs`
* `/src/content/release-notes/beacon-min-js.yaml`
  New entry with same codeowners as above, _without_ the addition of `@cloudflare/pm-changelogs`

## Notes

- All existing co-owners are preserved on each line
- This is purely additive — no owners removed
- I'm already provisioned as a `cloudflare_docs_editors` outside collaborator (via `terraform-github-cloudflare` !1436) with write access to this repo