### PR TITLE
[Cloudflare One] Update Cloudflare Network Firewall link and reference

### DIFF
--- a/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
+++ b/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
@@ -86,7 +86,7 @@ Connections to Zero Trust will always appear in your [Zero Trust network session
 
 ### Filter TCP SYN packets with Cloudflare Network Firewall
 
-Because Gateway sends a TCP SYN to the destination server before evaluating policies, Gateway Network or HTTP Block policies do not prevent the initial TCP SYN from reaching the destination server. If you need to prevent TCP SYN packets from being sent to specific destination IP addresses, you can create a [Cloudflare Network Firewall](/cloudflare-one/traffic-policies/packet-filtering/) rule to block traffic at the packet level. As shown in the [enforcement flowchart](#order-of-enforcement), Cloudflare Network Firewall evaluates traffic before Gateway checks for origin availability.
+Because Gateway sends a TCP SYN to the destination server before evaluating policies, Gateway Network or HTTP Block policies do not prevent the initial TCP SYN from reaching the destination server. If you need to prevent TCP SYN packets from being sent to specific destination IP addresses, you can create a [Cloudflare Network Firewall](/cloudflare-network-firewall/) rule to block traffic at the packet level. As shown in the [enforcement flowchart](#_top), Cloudflare Network Firewall evaluates traffic before Gateway checks for origin availability.
 
 :::note
 Cloudflare Network Firewall is available to Enterprise users only.

--- a/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
+++ b/src/content/partials/cloudflare-one/gateway/order-of-enforcement.mdx
@@ -86,7 +86,7 @@ Connections to Zero Trust will always appear in your [Zero Trust network session
 
 ### Filter TCP SYN packets with Cloudflare Network Firewall
 
-Because Gateway sends a TCP SYN to the destination server before evaluating policies, Gateway Network or HTTP Block policies do not prevent the initial TCP SYN from reaching the destination server. If you need to prevent TCP SYN packets from being sent to specific destination IP addresses, you can create a [Cloudflare Network Firewall](/cloudflare-network-firewall/) rule to block traffic at the packet level. As shown in the [enforcement flowchart](#_top), Cloudflare Network Firewall evaluates traffic before Gateway checks for origin availability.
+Because Gateway sends a TCP SYN to the destination server before evaluating policies, Gateway Network or HTTP Block policies do not prevent the initial TCP SYN from reaching the destination server. If you need to prevent TCP SYN packets from being sent to specific destination IP addresses, you can create a [Cloudflare Network Firewall](cloudflare-network-firewall/how-to/add-policies/) rule to block traffic at the packet level. As shown in the [enforcement flowchart](#_top), Cloudflare Network Firewall evaluates traffic before Gateway checks for origin availability.
 
 :::note
 Cloudflare Network Firewall is available to Enterprise users only.


### PR DESCRIPTION
### Summary

The link to https://developers.cloudflare.com/cloudflare-one/traffic-policies/packet-filtering/ does not explain "create a Cloudflare Network Firewall rule to block traffic" changed it to https://developers.cloudflare.com/cloudflare-network-firewall/how-to/add-policies/ instead. 

Updated the anchor for enforcement flowchart which now goes to the flowchart on the top instead of not working.

### Screenshots (optional)
<img width="856" height="316" alt="image" src="https://github.com/user-attachments/assets/75d3e624-08bb-4821-b159-bc29d9096f1f" />



### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
