### PR TITLE
Update docs for new sandbox R2 binding mount functionality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -185,7 +185,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/workers/static-assets @irvinebroque @GregBrimble @WalshyDev @cloudflare/deploy-config @cloudflare/product-owners @MattieTK
 /src/content/docs/workflows/ @elithrar @celso @mia303 @jonesphillip @cloudflare/product-owners
 /src/content/partials/workflows/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/product-owners
-/src/content/docs/sandbox/ @whoiskatrin @ghostwriternr @cloudflare/product-owners @cloudflare/ai-agents
+/src/content/docs/sandbox/ @whoiskatrin @ghostwriternr @scuffi @aron-cf @cloudflare/product-owners @cloudflare/ai-agents
 /src/content/docs/pipelines/ @Marcinthecloud @cmackenzie1 @oliy @garvit-gupta @sejoker @jonesphillip @elithrar @cloudflare/product-owners
 /src/content/docs/r2-sql/  @Marcinthecloud @netgusto @sesteves @sejoker @laplab @jonesphillip @elithrar @jonathanc-n @cloudflare/product-owners
 /src/content/docs/r2/data-catalog/ @Marcinthecloud @sejoker @jonesphillip @elithrar @laplab @vovacf201 @nagraham @cloudflare/product-owners
@@ -271,7 +271,7 @@ package.json @cloudflare/content-engineering
 # Support
 
 /src/content/docs/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie @krys-cf @stechedo @zeinjaber @shanecloudflare
-/src/assets/images/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie @krys-cf @stechedo @zeinjaber @shanecloudflare 
+/src/assets/images/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie @krys-cf @stechedo @zeinjaber @shanecloudflare
 
 # Turnstile
 

--- a/src/content/docs/sandbox/api/storage.mdx
+++ b/src/content/docs/sandbox/api/storage.mdx
@@ -177,7 +177,7 @@ type MountBucketOptions =
 
 - `prefix` (optional) - Subdirectory within the bucket to mount
   - When specified, only contents under this prefix are visible at the mount point
-	- Must start with `/` (for example, `/data/uploads` or `/data/uploads/`)
+  - Must start with `/` (for example, `/data/uploads` or `/data/uploads/`)
   - Default: Mount entire bucket
 
 - `s3fsOptions` (R2 binding and remote endpoint modes only) - Advanced s3fs mount flags

--- a/src/content/docs/sandbox/api/storage.mdx
+++ b/src/content/docs/sandbox/api/storage.mdx
@@ -10,7 +10,7 @@ products:
 
 import { TypeScriptExample } from "~/components";
 
-Mount S3-compatible storage buckets (R2, S3, GCS) into the sandbox filesystem for persistent data access.
+Mount S3-compatible storage buckets (R2, S3, GCS) into the sandbox filesystem for persistent data access. `mountBucket()` supports R2 binding mounts, local R2 binding sync during development, and remote S3-compatible endpoint mounts.
 
 ## Methods
 
@@ -22,29 +22,28 @@ Mount an S3-compatible bucket to a local path in the sandbox.
 await sandbox.mountBucket(
   bucket: string,
   mountPath: string,
-  options: MountBucketOptions
+  options?: MountBucketOptions
 ): Promise<void>
 ```
 
 **Parameters**:
 
-- `bucket` - Bucket name (e.g., `"my-r2-bucket"`)
+- `bucket` - Bucket identifier
+  - When `options.endpoint` is omitted, pass the Worker R2 binding name (for example, `"MY_BUCKET"`)
+  - When `options.endpoint` is provided, pass the remote bucket name (for example, `"my-r2-bucket"`)
 - `mountPath` - Local filesystem path to mount at (e.g., `"/data"`)
-- `options` - Mount configuration (see [`MountBucketOptions`](#mountbucketoptions))
+- `options` (optional) - Mount configuration (see [`MountBucketOptions`](#mountbucketoptions))
 
 <TypeScriptExample>
 ```
-// Mount R2 bucket to /data
-await sandbox.mountBucket('my-bucket', '/data', {
-  endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
-  provider: 'r2'
-});
+// Mount an R2 bucket by Worker binding name
+await sandbox.mountBucket('MY_BUCKET', '/data');
 
 // Read/write files directly
 const data = await sandbox.readFile('/data/config.json');
 await sandbox.writeFile('/data/results.json', JSON.stringify(data));
 
-// Mount with explicit credentials
+// Mount a remote S3-compatible bucket, including explicit R2 endpoints
 await sandbox.mountBucket('my-bucket', '/storage', {
   endpoint: 'https://s3.amazonaws.com',
   credentials: {
@@ -53,16 +52,15 @@ await sandbox.mountBucket('my-bucket', '/storage', {
   }
 });
 
-// Read-only mount
-await sandbox.mountBucket('datasets', '/datasets', {
-  endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
-  readOnly: true
+// Mount an R2 bucket during local development with wrangler dev
+await sandbox.mountBucket('MY_BUCKET', '/local-data', {
+  localBucket: true
 });
 
-// Mount a subdirectory within the bucket
-await sandbox.mountBucket('shared-bucket', '/user-data', {
-  endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
-  prefix: '/users/user-123/'
+// Mount a prefix from an R2 binding
+await sandbox.mountBucket('MY_BUCKET', '/user-data', {
+  prefix: '/users/user-123',
+  readOnly: true
 });
 ```
 </TypeScriptExample>
@@ -72,10 +70,12 @@ await sandbox.mountBucket('shared-bucket', '/user-data', {
 - `BucketAccessError` - Bucket does not exist or insufficient permissions
 
 :::note[Authentication]
-Credentials can be provided via:
-1. Explicit `credentials` in options
-2. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
-3. Automatic detection from bound R2 buckets
+Authentication depends on the mount mode:
+1. Omit `endpoint` to mount an R2 bucket by Worker binding name in production
+2. Set `localBucket: true` to use the same R2 binding during local development
+3. Set `endpoint` to mount a remote S3-compatible bucket, then provide explicit `credentials` or rely on environment variables (`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`)
+
+Endpoint-based mounts remain supported for explicit R2 endpoint configuration and for other S3-compatible providers.
 
 See the [Mount Buckets guide](/sandbox/guides/mount-buckets/) for detailed authentication options.
 :::
@@ -95,7 +95,7 @@ await sandbox.unmountBucket(mountPath: string): Promise<void>
 <TypeScriptExample>
 ```
 // Mount, process, unmount
-await sandbox.mountBucket('data', '/data', { endpoint: '...' });
+await sandbox.mountBucket('MY_BUCKET', '/data');
 await sandbox.exec('python process.py');
 
 // Unmount
@@ -112,35 +112,63 @@ Mounted buckets are automatically unmounted when the container is destroyed.
 ### `MountBucketOptions`
 
 ```ts
-interface MountBucketOptions {
-	endpoint?: string;
-	localBucket?: boolean;
-	provider?: BucketProvider;
-	credentials?: BucketCredentials;
-	readOnly?: boolean;
-	prefix?: string;
-	s3fsOptions?: Record<string, string>;
+interface RemoteMountBucketOptions {
+  endpoint: string;
+  provider?: BucketProvider;
+  credentials?: BucketCredentials;
+  readOnly?: boolean;
+  s3fsOptions?: string[];
+  prefix?: string;
 }
+
+interface LocalMountBucketOptions {
+  localBucket: true;
+  prefix?: string;
+  readOnly?: boolean;
+}
+
+interface R2BindingMountBucketOptions {
+  endpoint?: never;
+  prefix?: string;
+  readOnly?: boolean;
+  s3fsOptions?: string[];
+}
+
+type MountBucketOptions =
+  | RemoteMountBucketOptions
+  | LocalMountBucketOptions
+  | R2BindingMountBucketOptions;
 ```
 
-**Fields**:
+`mountBucket()` supports these three modes:
 
-- `endpoint` (required when `localBucket` is `false` or unset) - S3-compatible endpoint URL
+- **R2 binding mount** - Omit `endpoint` to mount by Worker binding name in production
+  - Uses credential-less egress interception for R2
+  - Supports `prefix`, `readOnly`, and `s3fsOptions`
+
+- **Local R2 binding mount** - Set `localBucket: true` during `wrangler dev`
+  - Uses the Worker R2 binding directly through local synchronization
+  - Supports `prefix` and `readOnly`
+
+- **Remote endpoint mount** - Set `endpoint` to mount any S3-compatible provider
+  - Supports explicit `credentials` or environment variable auto-detection
+  - Supports `provider`, `prefix`, `readOnly`, and `s3fsOptions`
+
+**Field details**:
+
+- `endpoint` (remote endpoint mode only) - S3-compatible endpoint URL
   - R2: `'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'`
   - S3: `'https://s3.amazonaws.com'`
   - GCS: `'https://storage.googleapis.com'`
 
-- `localBucket` (optional) - Mount an R2 bucket using the Worker's R2 binding during local development with `wrangler dev`
+- `localBucket` (local development mode only) - Mount an R2 bucket using the Worker's R2 binding during local development with `wrangler dev`
   - When `true`, the SDK syncs the R2 binding directly instead of using an S3 endpoint
-  - `endpoint` and `credentials` are not required when this is `true`
-	- `provider` and `s3fsOptions` are not used when this is `true`
-  - Default: `false`
 
-- `provider` (optional) - Storage provider hint
+- `provider` (remote endpoint mode only) - Storage provider hint
   - Enables provider-specific optimizations
   - Values: `'r2'`, `'s3'`, `'gcs'`
 
-- `credentials` (optional) - API credentials
+- `credentials` (remote endpoint mode only) - API credentials
   - Contains `accessKeyId` and `secretAccessKey`
   - If not provided, uses environment variables
 
@@ -149,11 +177,12 @@ interface MountBucketOptions {
 
 - `prefix` (optional) - Subdirectory within the bucket to mount
   - When specified, only contents under this prefix are visible at the mount point
-  - Must start and end with `/` (e.g., `/data/uploads/`)
+	- Must start with `/` (for example, `/data/uploads` or `/data/uploads/`)
   - Default: Mount entire bucket
 
-- `s3fsOptions` (optional) - Advanced s3fs mount flags
-  - Example: `{ 'use_cache': '/tmp/cache' }`
+- `s3fsOptions` (R2 binding and remote endpoint modes only) - Advanced s3fs mount flags
+  - Type: `string[]`
+  - Example: `['use_cache=/tmp/cache', 'stat_cache_expire=1']`
 
 ### `BucketProvider`
 

--- a/src/content/docs/sandbox/bridge/http-api.mdx
+++ b/src/content/docs/sandbox/bridge/http-api.mdx
@@ -103,16 +103,35 @@ The `/hydrate` endpoint accepts a raw tar payload up to 32 MiB.
 | `POST` | `/v1/sandbox/:id/mount` | Mount an S3-compatible bucket as a local directory. |
 | `POST` | `/v1/sandbox/:id/unmount` | Unmount a previously mounted bucket. |
 
-The `/mount` endpoint accepts a JSON body:
+The `/mount` endpoint accepts a JSON body. Two flows are supported:
+
+### R2 binding mounts
+
+Omit `endpoint` and pass the Worker R2 binding name in `bucket`:
 
 ```json
 {
-  "bucket": "my-bucket",
+  "bucket": "MY_BUCKET",
+  "mountPath": "/mnt/data",
+  "options": {
+    "readOnly": false,
+    "prefix": "/subdir"
+  }
+}
+```
+
+When `options.endpoint` is omitted, `bucket` means the Worker R2 binding name.
+
+For an explicit S3-compatible endpoint mount, include `endpoint` and optionally `credentials`:
+
+```json
+{
+  "bucket": "my-r2-bucket",
   "mountPath": "/mnt/data",
   "options": {
     "endpoint": "https://ACCOUNT_ID.r2.cloudflarestorage.com",
     "readOnly": false,
-    "prefix": "subdir/",
+    "prefix": "/subdir",
     "credentials": {
       "accessKeyId": "...",
       "secretAccessKey": "..."
@@ -121,7 +140,7 @@ The `/mount` endpoint accepts a JSON body:
 }
 ```
 
-Credentials are optional — the bridge auto-detects from Worker secrets (`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) when omitted.
+When `endpoint` is provided, `bucket` means the remote bucket name. Credentials are optional in this mode only — the bridge auto-detects from Worker secrets (`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) when omitted.
 
 ## Sessions
 

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -10,7 +10,7 @@ products:
 
 import { TypeScriptExample, WranglerConfig } from "~/components";
 
-Mount S3-compatible object storage buckets as local filesystem paths. Access object storage using standard file operations.
+Mount S3-compatible object storage buckets as local filesystem paths. Access object storage using standard file operations. For Cloudflare R2 in production, you can also mount by Worker R2 binding name so credentials stay in the Worker runtime.
 
 :::caution[Mounting `/workspace`]
 Mounting a bucket at `/workspace` or a subpath under it can be confusing in app or project setups. In production, the mount overlays that path instead of merging with files already in the image or template. If you want `/workspace` itself to persist over time, [Backup and restore](/sandbox/guides/backup-restore/) is often a better fit.
@@ -19,6 +19,33 @@ Mounting a bucket at `/workspace` or a subpath under it can be confusing in app 
 :::note[S3-compatible providers]
 The SDK works with any S3-compatible object storage provider. Examples include Cloudflare R2, Amazon S3, Google Cloud Storage, Backblaze B2, MinIO, and [many others](https://github.com/s3fs-fuse/s3fs-fuse/wiki/Non-Amazon-S3). The SDK automatically detects and optimizes for R2, S3, and GCS.
 :::
+
+## Production prerequisites for R2 binding mounts
+
+To mount an R2 bucket in production without passing credentials into the container, add an R2 binding and export `ContainerProxy` from your Worker entrypoint.
+
+<WranglerConfig>
+```jsonc
+{
+	"r2_buckets": [
+		{
+			"binding": "MY_BUCKET",
+			"bucket_name": "my-r2-bucket"
+		}
+	]
+}
+```
+</WranglerConfig>
+
+<TypeScriptExample>
+```typescript
+import { ContainerProxy } from "@cloudflare/sandbox";
+
+export { ContainerProxy };
+```
+</TypeScriptExample>
+
+When you omit `endpoint`, the first argument to `mountBucket()` must be the Worker R2 binding name, such as `MY_BUCKET`.
 
 ## When to mount buckets
 
@@ -37,10 +64,8 @@ import { getSandbox } from '@cloudflare/sandbox';
 
 const sandbox = getSandbox(env.Sandbox, 'data-processor');
 
-// Mount R2 bucket
-await sandbox.mountBucket('my-r2-bucket', '/data', {
-endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'
-});
+// Mount R2 bucket by Worker binding name
+await sandbox.mountBucket('MY_BUCKET', '/data');
 
 // Access bucket with standard filesystem operations
 await sandbox.exec('ls', { args: ['/data'] });
@@ -55,15 +80,19 @@ df.describe().to_csv('/data/summary.csv')
 ```
 </TypeScriptExample>
 
+In this example, `MY_BUCKET` is the binding name from `wrangler.jsonc`. It does not have to match the bucket's dashboard name, although many projects use matching names.
+
 :::note[Mounting affects entire sandbox]
 Mounted buckets are visible across all sessions since they share the filesystem. Mount once per sandbox.
 :::
 
 ## Credentials
 
+R2 binding mounts do not require credentials. Remote endpoint mounts remain supported for Cloudflare R2 and other S3-compatible providers, and those flows can still use automatic credential detection or explicit credentials.
+
 ### Automatic detection
 
-Set credentials as Worker secrets and the SDK automatically detects them:
+When you include an `endpoint`, set credentials as Worker secrets and the SDK automatically detects them:
 
 ```sh
 npx wrangler secret put R2_ACCESS_KEY_ID
@@ -76,7 +105,7 @@ We also automatically detect `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for
 
 <TypeScriptExample>
 ```typescript
-// Credentials automatically detected from environment
+// Credentials automatically detected from environment for remote endpoint mounts
 await sandbox.mountBucket('my-r2-bucket', '/data', {
 	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'
 });
@@ -106,35 +135,32 @@ Mount a specific subdirectory within a bucket using the `prefix` option. Only co
 <TypeScriptExample>
 ```typescript
 // Mount only the /uploads/images/ subdirectory
-await sandbox.mountBucket('my-bucket', '/images', {
-	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
+await sandbox.mountBucket('MY_BUCKET', '/images', {
 	prefix: '/uploads/images/'
 });
 
 // Files appear at mount point without the prefix
-// Bucket: my-bucket/uploads/images/photo.jpg
+// Bound bucket: my-r2-bucket/uploads/images/photo.jpg
 // Mounted path: /images/photo.jpg
 await sandbox.exec('ls', { args: ['/images'] });
 
 // Write to subdirectory
 await sandbox.writeFile('/images/photo.jpg', imageData);
-// Creates my-bucket:/uploads/images/photo.jpg
+// Creates my-r2-bucket/uploads/images/photo.jpg
 
 // Mount different prefixes to different paths
-await sandbox.mountBucket('datasets', '/training-data', {
-endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
-prefix: '/ml/training/'
+await sandbox.mountBucket('MY_BUCKET', '/training-data', {
+	prefix: '/ml/training/'
 });
 
-await sandbox.mountBucket('datasets', '/test-data', {
-endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
-prefix: '/ml/testing/'
+await sandbox.mountBucket('MY_BUCKET', '/test-data', {
+	prefix: '/ml/testing/'
 });
 ```
 </TypeScriptExample>
 
 :::note[Prefix format]
-The `prefix` must start and end with `/` (e.g., `/data/`, `/logs/2024/`). This is required by the underlying s3fs tool.
+The `prefix` must start with `/` (for example, `/data` or `/logs/2024/`).
 :::
 
 ## Read-only mounts
@@ -143,8 +169,7 @@ Protect data by mounting buckets in read-only mode:
 
 <TypeScriptExample>
 ```typescript
-await sandbox.mountBucket('dataset-bucket', '/data', {
-	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
+await sandbox.mountBucket('MY_BUCKET', '/data', {
 	readOnly: true
 });
 
@@ -158,28 +183,7 @@ await sandbox.writeFile('/data/new-file.txt', 'data');  // Error: Read-only file
 
 ## Local development
 
-You can mount R2 buckets during local development with `wrangler dev` by passing the `localBucket` option. This uses the R2 binding from your Worker environment directly, so no S3-compatible endpoint or credentials are required.
-
-### Configure R2 bindings
-
-Add an R2 bucket binding to your Wrangler configuration:
-
-<WranglerConfig>
-```jsonc
-{
-	"r2_buckets": [
-		{
-			"binding": "MY_BUCKET",
-			"bucket_name": "my-test-bucket"
-		}
-	]
-}
-```
-</WranglerConfig>
-
-### Mount with `localBucket`
-
-Pass `localBucket: true` in the options to mount the bucket locally:
+You can also mount R2 buckets during local development with `wrangler dev` by passing the `localBucket` option. Production R2 binding mounts and local `localBucket` mounts both avoid explicit credentials, but they are different execution paths. Production uses credential-less egress interception and overlays the target path. Local development uses periodic synchronization with the R2 binding.
 
 <TypeScriptExample>
 ```typescript
@@ -197,13 +201,12 @@ await sandbox.writeFile('/data/results.json', JSON.stringify(results));
 You can use an environment variable to toggle `localBucket` between local development and production. Set an environment variable such as `LOCAL_DEV` in your Wrangler configuration using `vars` for local development, then reference it in your code:
 
 ```typescript
-await sandbox.mountBucket('MY_BUCKET', '/data', {
-	localBucket: Boolean(env.LOCAL_DEV),
-	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'
-});
+const mountOptions = env.LOCAL_DEV ? { localBucket: true } : {};
+
+await sandbox.mountBucket('MY_BUCKET', '/data', mountOptions);
 ```
 
-When `localBucket` is `true`, the `endpoint` is ignored and the SDK uses the R2 binding directly. For more information on setting environment variables, refer to [Environment variables in Wrangler configuration](/workers/configuration/environment-variables/).
+When `localBucket` is `true`, the SDK uses local R2 binding synchronization. When `localBucket` is `false` or omitted and `endpoint` is also omitted, the SDK uses the production R2 binding mount path. For more information on setting environment variables, refer to [Environment variables in Wrangler configuration](/workers/configuration/environment-variables/).
 :::
 
 The `readOnly` and `prefix` options work the same way in local mode:
@@ -218,8 +221,8 @@ await sandbox.mountBucket('MY_BUCKET', '/data', {
 
 // Mount a subdirectory
 await sandbox.mountBucket('MY_BUCKET', '/images', {
-localBucket: true,
-prefix: '/uploads/images/'
+	localBucket: true,
+	prefix: '/uploads/images/'
 });
 ```
 </TypeScriptExample>
@@ -241,7 +244,7 @@ These considerations apply to local development with `wrangler dev` only. In pro
 <TypeScriptExample>
 ```typescript
 // Mount for processing
-await sandbox.mountBucket('my-bucket', '/data', { endpoint: '...' });
+await sandbox.mountBucket('MY_BUCKET', '/data');
 
 // Do work
 await sandbox.exec('python process_data.py');
@@ -264,7 +267,7 @@ The SDK supports any S3-compatible object storage. Here are examples for common 
 <TypeScriptExample>
 ```typescript
 await sandbox.mountBucket('my-s3-bucket', '/data', {
-	endpoint: 'https://s3.us-west-2.amazonaws.com',  // Regional endpoint
+	endpoint: 'https://s3.us-west-2.amazonaws.com',
 	credentials: {
 		accessKeyId: env.AWS_ACCESS_KEY_ID,
 		secretAccessKey: env.AWS_SECRET_ACCESS_KEY
@@ -280,7 +283,7 @@ await sandbox.mountBucket('my-s3-bucket', '/data', {
 await sandbox.mountBucket('my-gcs-bucket', '/data', {
 	endpoint: 'https://storage.googleapis.com',
 	credentials: {
-		accessKeyId: env.GCS_ACCESS_KEY_ID,  // HMAC key
+		accessKeyId: env.GCS_ACCESS_KEY_ID,
 		secretAccessKey: env.GCS_SECRET_ACCESS_KEY
 	}
 });
@@ -288,7 +291,7 @@ await sandbox.mountBucket('my-gcs-bucket', '/data', {
 </TypeScriptExample>
 
 :::note[GCS requires HMAC keys]
-Generate HMAC keys in GCS console under Settings → Interoperability.
+Generate HMAC keys in GCS console under **Settings** > **Interoperability**.
 :::
 
 ### Other S3-compatible providers
@@ -298,7 +301,7 @@ For providers like Backblaze B2, MinIO, Wasabi, or others, use the standard moun
 <TypeScriptExample>
 ```typescript
 await sandbox.mountBucket('my-bucket', '/data', {
-	endpoint: 'https://s3.us-west-000.backblazeb2.com',  // Provider-specific endpoint
+	endpoint: 'https://s3.us-west-000.backblazeb2.com',
 	credentials: {
 		accessKeyId: env.ACCESS_KEY_ID,
 		secretAccessKey: env.SECRET_ACCESS_KEY
@@ -307,15 +310,38 @@ await sandbox.mountBucket('my-bucket', '/data', {
 ```
 </TypeScriptExample>
 
-For provider-specific configuration, see the [s3fs-fuse wiki](https://github.com/s3fs-fuse/s3fs-fuse/wiki/Non-Amazon-S3) which documents supported providers and their recommended flags.
+For provider-specific configuration, see the [s3fs-fuse wiki](https://github.com/s3fs-fuse/s3fs-fuse/wiki/Non-Amazon-S3) for supported providers and recommended flags.
 
 ## Troubleshooting
+
+### R2 binding not found error
+
+**Error**: `R2 binding "MY_BUCKET" not found in Worker env`
+
+**Solution**: Ensure your Worker has an `r2_buckets` binding and that `mountBucket()` uses the binding name, not the bucket's dashboard name:
+
+<WranglerConfig>
+```jsonc
+{
+	"r2_buckets": [
+		{
+			"binding": "MY_BUCKET",
+			"bucket_name": "my-r2-bucket"
+		}
+	]
+}
+```
+</WranglerConfig>
+
+### Credential-less R2 mount fails immediately
+
+**Solution**: Ensure your Worker entrypoint exports `ContainerProxy`. If you are using an older Wrangler version, you may also need the `enable_ctx_exports` compatibility flag.
 
 ### Missing credentials error
 
 **Error**: `MissingCredentialsError: No credentials found`
 
-**Solution**: Set credentials as Worker secrets:
+**Solution**: This error only applies when you mount a remote S3-compatible endpoint by setting `endpoint`. Set credentials as Worker secrets:
 
 ```sh
 npx wrangler secret put R2_ACCESS_KEY_ID
@@ -336,20 +362,19 @@ npx wrangler secret put AWS_SECRET_ACCESS_KEY
 **Common causes**:
 - Incorrect endpoint URL
 - Invalid credentials
+- Missing `ContainerProxy` export, or on older Wrangler versions missing `enable_ctx_exports`
 - Bucket doesn't exist
 - Network connectivity issues
 
-Verify your endpoint format and credentials:
+Verify your binding or endpoint configuration:
 
 <TypeScriptExample>
 ```typescript
 try {
-	await sandbox.mountBucket('my-bucket', '/data', {
-		endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com'
-	});
+	await sandbox.mountBucket('MY_BUCKET', '/data');
 } catch (error) {
 	console.error('Mount failed:', error.message);
-	// Check endpoint format, credentials, bucket existence
+	// Check binding name, ContainerProxy export, or remote endpoint configuration
 }
 ```
 </TypeScriptExample>
@@ -392,7 +417,7 @@ await sandbox.exec('cp', { args: ['/workspace/results.json', '/data/results/outp
 ## Best practices
 
 - **Mount early** - Mount buckets at sandbox initialization
-- **Use R2 for Cloudflare** - Zero egress fees and optimized configuration
+- **Choose the right mount mode** - Use R2 binding mounts when you want Worker-managed R2 access, or use `endpoint` for explicit R2, S3, GCS, and other S3-compatible providers
 - **Secure credentials** - Always use Worker secrets, never hardcode
 - **Read-only when possible** - Protect data with read-only mounts
 - **Use prefixes for isolation** - Mount subdirectories when working with specific datasets
@@ -404,6 +429,7 @@ await sandbox.exec('cp', { args: ['/workspace/results.json', '/data/results/outp
 
 - [Persistent storage tutorial](/sandbox/tutorials/persistent-storage/) - Complete R2 example
 - [Storage API reference](/sandbox/api/storage/) - Full method documentation
-- [Environment variables](/sandbox/configuration/environment-variables/) - Credential configuration
+- [Environment variables](/sandbox/configuration/environment-variables/) - Credential configuration for remote endpoint mounts
+- [Wrangler configuration](/sandbox/configuration/wrangler/) - Configure R2 bindings and compatibility flags
 - [R2 documentation](/r2/) - Learn about Cloudflare R2
-- [Proxy requests to external APIs](/sandbox/guides/proxy-requests/) - Keep R2 credentials out of the sandbox by proxying requests through a Worker
+- [Outbound traffic](/sandbox/guides/outbound-traffic/) - Learn how `ContainerProxy` and outbound interception work

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -25,15 +25,10 @@ The SDK works with any S3-compatible object storage provider. Examples include C
 To mount an R2 bucket in production without passing credentials into the container, add an R2 binding and export `ContainerProxy` from your Worker entrypoint.
 
 <WranglerConfig>
-```jsonc
-{
-	"r2_buckets": [
-		{
-			"binding": "MY_BUCKET",
-			"bucket_name": "my-r2-bucket"
-		}
-	]
-}
+```toml
+[[r2_buckets]]
+binding = "MY_BUCKET"
+bucket_name = "my-r2-bucket"
 ```
 </WranglerConfig>
 
@@ -80,7 +75,7 @@ df.describe().to_csv('/data/summary.csv')
 ```
 </TypeScriptExample>
 
-In this example, `MY_BUCKET` is the binding name from `wrangler.jsonc`. It does not have to match the bucket's dashboard name, although many projects use matching names.
+In this example, `MY_BUCKET` is the binding name from `wrangler.toml`. It does not have to match the bucket's dashboard name, although many projects use matching names.
 
 :::note[Mounting affects entire sandbox]
 Mounted buckets are visible across all sessions since they share the filesystem. Mount once per sandbox.
@@ -321,15 +316,10 @@ For provider-specific configuration, see the [s3fs-fuse wiki](https://github.com
 **Solution**: Ensure your Worker has an `r2_buckets` binding and that `mountBucket()` uses the binding name, not the bucket's dashboard name:
 
 <WranglerConfig>
-```jsonc
-{
-	"r2_buckets": [
-		{
-			"binding": "MY_BUCKET",
-			"bucket_name": "my-r2-bucket"
-		}
-	]
-}
+```toml
+[[r2_buckets]]
+binding = "MY_BUCKET"
+bucket_name = "my-r2-bucket"
 ```
 </WranglerConfig>
 


### PR DESCRIPTION
### Summary

Updating documentation for the new sandbox R2 binding mount support, implemented in https://github.com/cloudflare/sandbox-sdk/pull/691.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).