### PR TITLE
[Pages] Fix curl command and add troubleshooting reference

### DIFF
--- a/src/content/docs/pages/configuration/debugging-pages.mdx
+++ b/src/content/docs/pages/configuration/debugging-pages.mdx
@@ -107,7 +107,7 @@ Pages uses HTTP validation and needs to hit an HTTP endpoint during validation. 
 To check this, run a `curl` command against your domain hitting `/.well-known/acme-challenge/randomstring`. For example:
 
 ```sh
-curl -I https://example.com/.well-known/acme-challenge/randomstring
+curl -IX GET https://example.com/.well-known/acme-challenge/randomstring
 ```
 
 ```sh output
@@ -124,6 +124,8 @@ cf-ray: 7b1ffdaa8ad60693-MAN
 In the example above, you are redirecting to Cloudflare Access (as shown by the `Location` header). In this case, you need to disable Access over the domain until the domain is verified. After the domain is verified, Access can be re-enabled.
 
 You will need to do the same kind of thing for Redirect Rules or a Worker example too.
+
+Refer to the [Troubleshooting Domain control validation (DCV)](/ssl/edge-certificates/changing-dcv-method/troubleshooting/) article for more details.
 
 ### Missing CAA records
 

--- a/src/content/docs/pages/configuration/debugging-pages.mdx
+++ b/src/content/docs/pages/configuration/debugging-pages.mdx
@@ -107,7 +107,7 @@ Pages uses HTTP validation and needs to hit an HTTP endpoint during validation. 
 To check this, run a `curl` command against your domain hitting `/.well-known/acme-challenge/randomstring`. For example:
 
 ```sh
-curl -IX GET https://example.com/.well-known/acme-challenge/randomstring
+curl -s -o /dev/null -D - https://example.com/.well-known/acme-challenge/randomstring
 ```
 
 ```sh output


### PR DESCRIPTION
Updated curl command to use the correct HTTP method and added a reference to the Troubleshooting Domain control validation article.

