### PR TITLE
[Realtimekit]: Add docs around end of meeting transcriptions private beta removal

### DIFF
--- a/src/content/docs/realtime/realtimekit/ai/index.mdx
+++ b/src/content/docs/realtime/realtimekit/ai/index.mdx
@@ -16,34 +16,31 @@ RealtimeKit provides AI-powered features using Cloudflare's AI infrastructure to
 
 ## Available features
 
-| Feature | Description |
-|---------|-------------|
-| [Transcription](/realtime/realtimekit/ai/transcription/) | Real-time and post-meeting speech-to-text |
-| [Summary](/realtime/realtimekit/ai/summary/) | AI-generated meeting summaries |
+| Feature                                                  | Description                                 |
+| -------------------------------------------------------- | -----------------------------------------   |
+| [Transcription](/realtime/realtimekit/ai/transcription/) | Real-time and end-of-meeting speech-to-text |
+| [Summary](/realtime/realtimekit/ai/summary/)             | AI-generated meeting summaries              |
 
 ## Quick start
 
-Enable AI features when creating a meeting:
+Enable end of meeting transcription when creating a meeting:
 
 ```json
 {
-  "title": "Team Standup",
-  "ai_config": {
-    "transcription": {
-      "language": "en-US"
-    },
-    "summarization": {
-      "summary_type": "team_meeting"
-    }
-  },
-  "summarize_on_end": true
+	"title": "Team Standup",
+	"transcribe_on_end": true,
+	"ai_config": {
+		"transcription": {
+			"language": "en"
+		}
+	}
 }
 ```
 
-Ensure participants have `transcription_enabled: true` in their [preset](/realtime/realtimekit/concepts/preset/).
+Use `transcribe_on_end` for end of meeting transcripts. Use `summarize_on_end` for AI-generated summaries. For real-time transcription, ensure participants have `transcription_enabled: true` in their [preset](/realtime/realtimekit/concepts/preset/).
 
 ## Storage and retention
 
-- Transcripts and summaries are stored for **7 days** from meeting start
+- Transcripts and summaries are stored for **7 days** after the meeting ends
 - Files are stored in R2 with presigned URLs for secure access
 - Delivered via [webhooks](/api/resources/realtime_kit/subresources/webhooks/) or REST API

--- a/src/content/docs/realtime/realtimekit/ai/transcription.mdx
+++ b/src/content/docs/realtime/realtimekit/ai/transcription.mdx
@@ -122,7 +122,7 @@ Set `transcribe_on_end: true` when [creating a meeting](/api/resources/realtime_
 }
 ```
 
-Use `ai_config.transcription.language` to set the transcript language. If `transcribe_on_end` is not set, end-of-meeting transcription is disabled and real time transcripts are used.
+Use `ai_config.transcription.language` to set the transcript language. If `transcribe_on_end` is not set, end-of-meeting transcription is disabled and real time transcripts are generated.
 
 ### Supported languages
 

--- a/src/content/docs/realtime/realtimekit/ai/transcription.mdx
+++ b/src/content/docs/realtime/realtimekit/ai/transcription.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: how-to
 title: Transcription
-description: Enable real-time and post-meeting speech-to-text transcription in RealtimeKit.
+description: Enable real-time and end-of-meeting speech-to-text transcription in RealtimeKit.
 sidebar:
   order: 1
 products:
@@ -12,10 +12,10 @@ import { Render } from "~/components";
 
 RealtimeKit provides two transcription modes powered by Cloudflare Workers AI:
 
-| Mode             | Model                                                                | Use Case                       |
-| ---------------- | -------------------------------------------------------------------- | ------------------------------ |
-| **Real-time**    | [Deepgram Nova-3](/workers-ai/models/nova-3/)                        | Live captions during meeting   |
-| **Post-meeting** | [Whisper Large v3 Turbo](/workers-ai/models/whisper-large-v3-turbo/) | Accurate offline transcription |
+| Mode               | Model                                                                | Use Case                       |
+| ----------------   | -------------------------------------------------------------------- | ------------------------------ |
+| **Real-time**      | [Deepgram Nova-3](/workers-ai/models/nova-3/)                        | Live captions during meeting   |
+| **End-of-meeting** | [Whisper Large v3 Turbo](/workers-ai/models/whisper-large-v3-turbo/) | Accurate offline transcription |
 
 ## Real-time transcription
 
@@ -107,17 +107,26 @@ meeting.ai.on("transcript", (data) => {
 
 ---
 
-## Post-meeting transcription
+## End of meeting transcription
 
 Generates transcripts after the meeting ends using [Whisper Large v3 Turbo](/workers-ai/models/whisper-large-v3-turbo/). Transcripts from all participants are consolidated into a unified timeline and delivered via webhook or REST API.
 
-:::note
-Post-meeting transcription is currently in closed beta. If you are interested in this feature, contact your account team.
-:::
+### Enable end of meeting transcription
+
+Set `transcribe_on_end: true` when [creating a meeting](/api/resources/realtime_kit/subresources/meetings/methods/create/):
+
+```json
+{
+	"title": "Team Standup",
+	"transcribe_on_end": true
+}
+```
+
+Use `ai_config.transcription.language` to set the transcript language. If `transcribe_on_end` is not set, end-of-meeting transcription is disabled and real time transcripts are used.
 
 ### Supported languages
 
-Supports all languages in [Whisper Large v3 Turbo](/workers-ai/models/whisper-large-v3-turbo/). Uses ISO 639-1 language codes.
+Supports all languages in [Whisper Large v3 Turbo](/workers-ai/models/whisper-large-v3-turbo/). Use ISO 639-1 language codes, such as `en`, `es`, or `fr`.
 
 ### Output formats
 


### PR DESCRIPTION
### Summary
* Remove end of meeting transcription private beta.
* New option of `transcribe_on_end` in create meeting.

### Screenshots (optional)
<img width="831" height="487" alt="Screenshot 2026-05-20 at 12 39 49 PM" src="https://github.com/user-attachments/assets/ecee0c29-9672-4ca8-8911-a5a982b795bd" />

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
