### PR TITLE
docs: use @cloudflare/radar team for Radar CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -240,8 +240,8 @@ package.json @cloudflare/content-engineering
 
 # Radar
 
-/src/content/docs/radar/ @andre-j3sus @cloudflare/product-owners
-/src/content/release-notes/radar.yaml @andre-j3sus @cloudflare/product-owners
+/src/content/docs/radar/ @andre-j3sus @devandrepascoa @rubenalex @cloudflare/product-owners
+/src/content/release-notes/radar.yaml @andre-j3sus @devandrepascoa @rubenalex @cloudflare/product-owners
 
 # Reference architecture
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -240,8 +240,8 @@ package.json @cloudflare/content-engineering
 
 # Radar
 
-/src/content/docs/radar/ @andre-j3sus @devandrepascoa @rubenalex @cloudflare/product-owners
-/src/content/release-notes/radar.yaml @andre-j3sus @devandrepascoa @rubenalex @cloudflare/product-owners
+/src/content/docs/radar/ @cloudflare/radar @cloudflare/product-owners
+/src/content/release-notes/radar.yaml @cloudflare/radar @cloudflare/product-owners
 
 # Reference architecture
 


### PR DESCRIPTION
Replace individual user @andre-j3sus with @cloudflare/radar team as code owners for the Radar docs section.