### PR TITLE
fix: use permissions: write in bonk instead of CODEOWNERS

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -141,7 +141,6 @@ jobs:
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           agent: docs
-          permissions: write
           token_permissions: NO_PUSH
           prompt: |
             Review this pull request. Review the title, description, and diff.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -87,7 +87,7 @@ jobs:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           agent: docs
           mentions: "/bonk"
-          permissions: CODEOWNERS
+          permissions: write
 
   bonk-auto-review:
     needs: check-codeowner

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -141,6 +141,7 @@ jobs:
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           agent: docs
+          permissions: write
           token_permissions: NO_PUSH
           prompt: |
             Review this pull request. Review the title, description, and diff.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -141,7 +141,6 @@ jobs:
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           agent: docs
-          permissions: CODEOWNERS
           token_permissions: NO_PUSH
           prompt: |
             Review this pull request. Review the title, description, and diff.


### PR DESCRIPTION
### Summary

The `bonk-auto-review` job was failing with exit code 1 for contributors who are codeowners via team membership (e.g. `jhutchings1`). The ask-bonk action's internal `permissions: CODEOWNERS` check does a flat string match against the CODEOWNERS file and does not resolve GitHub team membership, so it rejects valid codeowners listed via team references like `@cloudflare/product-owners`. https://github.com/Cloudflare-Studio/ask-bonk/issues/173

Replaces `permissions: CODEOWNERS` with `permissions: write` in the bonk steps. The `write` check uses GitHub's actual permissions API, which correctly resolves team membership. Generally speaking, all CODEOWNERS should have write access. This also serves as defense-in-depth alongside the job-level `if:` condition which gates on `needs.check-codeowner.outputs.is-codeowner == 'true'`.
