### PR TITLE
Fix Ubuntu release lifecycle link

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/support-lifecycle.mdx
@@ -101,7 +101,7 @@ As of December 2025, the following versions of Debian are supported:
 
 ### Ubuntu
 
-The Cloudflare One Client supports all Ubuntu releases within their [Standard Security Maintenance window](https://www.debian.org/releases/). Devices must be updated to the latest point release (for example, `22.04.5`) to receive support.
+The Cloudflare One Client supports all Ubuntu releases within their [Standard Security Maintenance window](https://ubuntu.com/about/release-cycle). Devices must be updated to the latest point release (for example, `22.04.5`) to receive support.
 
 As of December 2025, the following versions of Ubuntu are supported:
 


### PR DESCRIPTION
### Summary

Fixes the link to the Ubuntu lifecycle page

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).