### PR TITLE
add feature set for moq draft version 7 and 14

### DIFF
--- a/src/content/docs/moq/feature-matrix.mdx
+++ b/src/content/docs/moq/feature-matrix.mdx
@@ -1,0 +1,83 @@
+---
+pcx_content_type: get-started
+title: MoQ Feature Matrix
+sidebar:
+  order: 18
+
+---
+
+## Draft-14 Messages
+
+### Supported
+
+| Message | Support | Relevant specification |
+| ------- | ------- | ---------------------- |
+| SUBSCRIBE | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| UNSUBSCRIBE | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| TRACK_STATUS | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| PUBLISH_NAMESPACE_CANCEL | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| PUBLISH_NAMESPACE_OK | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| PUBLISH_NAMESPACE_ERROR | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| PUBLISH_OK | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| PUBLISH_NAMESPACE | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| PUBLISH_NAMESPACE_DONE | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| PUBLISH_DONE | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| SUBSCRIBE_OK | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| SUBSCRIBE_ERROR | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| TRACK_STATUS_OK | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| SETUP_MESSAGES (client and server) | ✅ | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+
+### Unsupported
+
+| Message | Support | Relevant specification |
+| ------- | ------- | ---------------------- |
+| GOAWAY | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| MAX_REQUEST_ID | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| REQUESTS_BLOCKED | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| SUBSCRIBE_UPDATE | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| PUBLISH_ERROR | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| FETCH | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| FETCH_OK | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| FETCH_ERROR | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| FETCH_CANCEL | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| TRACK_STATUS_ERROR | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| SUBSCRIBE_NAMESPACE | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| SUBSCRIBE_NAMESPACE_OK | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| SUBSCRIBE_NAMESPACE_ERROR | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+| UNSUBSCRIBE_NAMESPACE | No | [draft-ietf-moq-transport-14](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-14) |
+
+## Draft-07 Messages
+
+### Supported
+
+| Message | Support | Relevant specification |
+| ------- | ------- | ---------------------- |
+| ANNOUNCE_OK | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| ANNOUNCE_ERROR | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| ANNOUNCE_CANCEL | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| SUBSCRIBE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| UNSUBSCRIBE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| TRACK_STATUS_REQUEST | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| ANNOUNCE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| UNANNOUNCE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| SUBSCRIBE_OK | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| SUBSCRIBE_ERROR | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| SUBSCRIBE_DONE | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| MAX_SUBSCRIBE_ID | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| TRACK_STATUS | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| SETUP_MESSAGES (client and server) | ✅ | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+
+### Unsupported
+
+| Message | Support | Relevant specification |
+| ------- | ------- | ---------------------- |
+| SUBSCRIBE_UPDATE | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| GOAWAY | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| SUBSCRIBE_ANNOUNCES | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| SUBSCRIBE_ANNOUNCES_OK | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| SUBSCRIBE_ANNOUNCES_ERROR | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| UNSUBSCRIBE_ANNOUNCES | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| FETCH | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| FETCH_OK | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| FETCH_ERROR | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |
+| FETCH_CANCEL | No | [draft-ietf-moq-transport-07](https://datatracker.ietf.org/doc/html/draft-ietf-moq-transport-07) |


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Adds comparison on available feature/message sets for draft-07 and draft-14

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
