### PR TITLE
chore: bump pnpm to v11

### DIFF
--- a/.github/workflows/anchor-link-audit.yml
+++ b/.github/workflows/anchor-link-audit.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         id: setup-node

--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -112,7 +112,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - name: Set up node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -122,7 +122,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - name: Set up node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -189,7 +189,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - name: Set up node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -245,7 +245,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - name: Set up node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -302,7 +302,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - name: Set up node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         id: setup-node

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-save-dev=true
-save-exact=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,18 @@ blockExoticSubdeps: true
 
 # Explicit allowlist of packages permitted to run install scripts.
 # These are well-known packages that require build scripts to download platform-specific binaries.
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
-  - tldjs
-  - workerd
+allowBuilds:
+  esbuild: true
+  sharp: true
+  tldjs: true
+  workerd: true
+  # Transitive deps of @flue/runtime and agents — native binaries not needed by this repo
+  "@google/genai": false
+  "@mongodb-js/zstd": false
+  core-js-pure: false
+  node-liblzma: false
+  protobufjs: false
+
+# Always save dependencies as exact versions and to devDependencies by default.
+saveExact: true
+saveDev: true


### PR DESCRIPTION
### Summary

Upgrades pnpm from v10 to v11 across CI workflows and repo config.

Changes:
- All 5 GitHub Actions workflows updated to `version: 11`
- `pnpm-workspace.yaml`: replaced removed `onlyBuiltDependencies` setting with the new `allowBuilds` map; added `saveExact` and `saveDev` settings (moved from `.npmrc`)
- `.npmrc` deleted — pnpm 11 restricts `.npmrc` to auth/registry settings only; non-auth config now lives in `pnpm-workspace.yaml`
- Explicitly denied build scripts for transitive deps (`@google/genai`, `@mongodb-js/zstd`, `core-js-pure`, `node-liblzma`, `protobufjs`) that don't need native binaries in this repo
