### PR TITLE
Add @ncrouch-cflare to CODEOWNERS for Argo, Health Checks, Load Balancing, Smart Shield

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -223,12 +223,12 @@ package.json @cloudflare/content-engineering
 
 # Performance products
 
-/src/content/docs/argo-smart-routing/ @cloudflare/product-owners
+/src/content/docs/argo-smart-routing/ @cloudflare/product-owners @ncrouch-cflare
 /src/content/docs/automatic-platform-optimization/ @cloudflare/product-owners
 /src/content/docs/cache/ @cloudflare/product-owners
-/src/content/docs/health-checks/ @cloudflare/product-owners
-/src/content/docs/load-balancing/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/smart-shield/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/health-checks/ @cloudflare/product-owners @ncrouch-cflare
+/src/content/docs/load-balancing/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
+/src/content/docs/smart-shield/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
 /src/content/docs/spectrum/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @cansu
 /src/content/docs/speed/ @cloudflare/product-owners
 /src/content/docs/web3/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners


### PR DESCRIPTION
### Summary

Adds `@ncrouch-cflare` to the existing CODEOWNERS entries for four products I own as Senior PM:

- `/src/content/docs/argo-smart-routing/`
- `/src/content/docs/health-checks/`
- `/src/content/docs/load-balancing/`
- `/src/content/docs/smart-shield/`

### Context

Following the PCX team wind-down, product teams (PM / ENG) now own their docs including approvals and reviews. This PR ensures incoming docs PRs for these products land in my review queue.

### Prerequisite

This PR depends on the companion GitLab MR that adds me as an outside collaborator on `cloudflare-docs` so that GitHub recognises `@ncrouch-cflare` as a valid code owner:

- https://gitlab.cfdata.org/cloudflare/iac/terraform-github-cloudflare/-/merge_requests/1457

If the CODEOWNERS validity check fails on this PR, it's because that MR hasn't merged yet. Please merge the GitLab MR first, then re-run checks here.

### Documentation checklist

- [x] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
- [x] No content files are touched — only `.github/CODEOWNERS`.
- [x] No redirects needed.
