### PR TITLE
[Browser Run] Add engineering team as code owners for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,10 @@ package.json @cloudflare/content-engineering
 # Browser Run
 
 /src/content/docs/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
+/src/content/partials/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
+/src/content/changelog/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
+/src/content/release-notes/browser-run.yaml @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
+/src/assets/images/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
 
 # Changelogs
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@ package.json @cloudflare/content-engineering
 
 # Browser Run
 
-/src/content/docs/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena
+/src/content/docs/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
 
 # Changelogs
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,11 +56,11 @@ package.json @cloudflare/content-engineering
 
 # Browser Run
 
-/src/content/docs/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
-/src/content/partials/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
-/src/content/changelog/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
-/src/content/release-notes/browser-run.yaml @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
-/src/assets/images/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira
+/src/content/docs/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira @Refaerds @omarmosid
+/src/content/partials/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira @Refaerds @omarmosid
+/src/content/changelog/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira @Refaerds @omarmosid
+/src/content/release-notes/browser-run.yaml @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira @Refaerds @omarmosid
+/src/assets/images/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena @meddulla @simonabadoiu @jonnyparris @ruifigueira @Refaerds @omarmosid
 
 # Changelogs
 


### PR DESCRIPTION
## Summary

Adds Browser Run engineering team members as code owners for `/src/content/docs/browser-run/` so they can review and approve docs changes directly.

**New code owners added:**
- `@meddulla` (Sofia Cardita)
- `@simonabadoiu` (Simona Badoiu)
- `@jonnyparris` (Ruskin Constant)
- `@ruifigueira` (Rui Figueira)

These team members already have GitHub seats in the Cloudflare org.