### PR TITLE
[WAF] Clarify managed rules must be turned on for AI Security Log Mode

### DIFF
--- a/src/content/docs/waf/detections/ai-security-for-apps/log-mode-vs-production-mode.mdx
+++ b/src/content/docs/waf/detections/ai-security-for-apps/log-mode-vs-production-mode.mdx
@@ -76,8 +76,8 @@ In log mode:
    <DashButton url="/?to=/:account/:zone/security/settings" />
 
 2. Under **AI Security for Apps**, find the **Managed Ruleset** section.
-3. Enable the **AI Security Log Mode Ruleset**.
-4. Set the action to _Log_.
+3. Turn on the **AI Security Log Mode Ruleset**.
+4. Expand the ruleset and confirm that each rule — **PII detected**, **Unsafe topic detected**, and **Prompt injection detected** — is turned on with its action set to _Log_. Turning on the ruleset alone does not turn on the rules inside it. The ruleset produces no events or payload logs for rules that are off or set to a different action.
 5. (Recommended) Configure [payload logging](/waf/managed-rules/payload-logging/) so you can decrypt and view the full prompt content alongside detection results.
 
 </Steps>
@@ -108,12 +108,16 @@ Deploy the managed ruleset using a `PUT` request:
 
 The ID of the AI Security Log Mode Ruleset is <RuleID id="b7cd52df92f74c848cec0c2ed385e336" />.
 
-To set individual rule actions to `log`, override the rules within the managed ruleset using `action_parameters.overrides`. For more information, refer to [Override a managed ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset/).
+For events and payload logs to appear, each rule inside the AI Security Log Mode Ruleset must be turned on and have its action set to `log`. Use `action_parameters.overrides` to set the per-rule action when deploying the ruleset. For more information, refer to [Override a managed ruleset](/ruleset-engine/managed-rulesets/override-managed-ruleset/).
 
 </TabItem> </Tabs>
 
 :::caution
 Since the managed ruleset uses broad, binary detection logic (detected/not detected), it can be too aggressive for production traffic. Without score-based thresholds, you should expect a higher rate of false positives if the action is set to _Block_.
+:::
+
+:::note[Troubleshooting: detections appear in analytics but no managed-rule events]
+If [Security Analytics](/waf/analytics/security-analytics/) shows AI detection fields populated (for example, `cf.llm.prompt.pii_detected` equals `true`) but no matching entries appear under the AI Security Log Mode Ruleset in [Security Events](/waf/analytics/security-events/), the most common cause is that the rules inside the managed ruleset are off or not set to _Log_. Turning on the managed ruleset is not sufficient. Each rule (PII, unsafe topics, prompt injection) must be turned on and have its action set to _Log_ for events and payload logs to appear.
 :::
 
 ## Recommended workflow


### PR DESCRIPTION
## Summary

Clarifies that the three rules inside the **AI Security Log Mode Ruleset** (PII detected, Unsafe topic detected, Prompt injection detected) must each be turned on with their action set to _Log_ for the ruleset to produce events and trigger payload logging.

## Context / motivation

Several customers configuring AI Security for Apps payload logging have reported the following symptom:

- Security Analytics shows AI detection fields populated (for example, `cf.llm.prompt.pii_detected` equals `true`).
- However, no matching entries appear under the AI Security Log Mode Ruleset in Security Events.
- Consequently, no decrypted prompt content appears in payload logs.

Root cause is that turning on the managed ruleset alone does not turn on the rules inside it. Each of the three rules must be turned on individually and have its action set to _Log_ before any events or payload logs are produced. The current page describes step 4 as "Set the action to _Log_," which suggests a single ruleset-level toggle. The API tab mentions per-rule overrides in passing, but it is easy to miss.

The internal AI Security PM has previously acknowledged this is unintuitive and that the public docs should call it out explicitly.

## Changes

All in `src/content/docs/waf/detections/ai-security-for-apps/log-mode-vs-production-mode.mdx`:

1. **Dashboard tab Steps** — replaced "Set the action to _Log_" with an explicit instruction to expand the ruleset and confirm that each of the three rules is turned on with its action set to _Log_, plus a sentence explaining why this matters.
2. **API tab** — rewrote the override sentence so the per-rule action requirement is prescriptive rather than incidental.
3. **New troubleshooting admonition** — added a `:::note` placed after the `:::caution` and before "Recommended workflow," mapping the exact symptom (detection fields populated in analytics but no managed-rule events) to the fix.

## Style compliance

- "Turn on / turn off" used in new sentences (per [Terminology and UI interactions](https://developers.cloudflare.com/style-guide/grammar/)).
- "Refer to" used for cross-references.
- Em dashes with surrounding spaces.
- Sentence-case headings preserved.
- Root-relative internal links.
- No contractions.
- `:::note[Header]` admonition format.

## Validation

- `pnpm run check` — 0 errors, 0 warnings related to this change.
- `pnpm run format:core:check` — passes.
- `prettier --check` on the edited file — passes.
