### PR TITLE
Add SPMs as codeowners for /support section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,10 @@ package.json @cloudflare/content-engineering
 /src/content/docs/terraform/ @dcpena @cloudflare/product-owners
 /src/content/docs/version-management/ @dcpena @cloudflare/product-owners
 
+# Billing
+
+/src/content/docs/billing/ @cloudflare/customer-support @cloudflare/product-owners @shanecloudflare
+
 # Browser Run
 
 /src/content/docs/browser-run/ @mchenco @cloudflare/product-owners @celso @kathayl @dcpena
@@ -266,9 +270,8 @@ package.json @cloudflare/content-engineering
 
 # Support
 
-/src/content/docs/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie
-/src/assets/images/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie
-/src/content/docs/billing/ @cloudflare/customer-support @cloudflare/product-owners @ngayerie 
+/src/content/docs/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie @krys-cf @stechedo @zeinjaber @shanecloudflare
+/src/assets/images/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie @krys-cf @stechedo @zeinjaber @shanecloudflare 
 
 # Turnstile
 


### PR DESCRIPTION
## Summary
Updates CODEOWNERS for the /support and /billing documentation sections.

## Changes

### /support section
Added the following SPMs as codeowners:
- @krys-cf
- @stechedo
- @zeinjaber
- @shanecloudflare

### /billing section
- Moved to its own section (previously grouped under Support)
- Added @shanecloudflare as codeowner

### Housekeeping
- Reordered CODEOWNERS sections alphabetically

## Related
Addresses DEE-3531