### PR TITLE
Add @ncrouch-cflare to reference-architecture CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -249,8 +249,8 @@ package.json @cloudflare/content-engineering
 
 # Reference architecture
 
-/src/content/docs/reference-architecture/ @securitypedant @cloudflare/product-owners
-/src/assets/images/reference-architecture/ @securitypedant @cloudflare/product-owners
+/src/content/docs/reference-architecture/ @securitypedant @cloudflare/product-owners @ncrouch-cflare
+/src/assets/images/reference-architecture/ @securitypedant @cloudflare/product-owners @ncrouch-cflare
 
 # Security products
 


### PR DESCRIPTION
### Summary

Adds `@ncrouch-cflare` as a code owner for the reference-architecture paths:

- `/src/content/docs/reference-architecture/`
- `/src/assets/images/reference-architecture/`

Per the recent PCX transition (product teams / ENG now own their docs), I need approval authority on reference-architecture content so I can review and approve Load Balancing reference architecture changes — for example, [#30938](https://github.com/cloudflare/cloudflare-docs/pull/30938) which I'm already a code owner on for the `/load-balancing/` paths but cannot fully approve because it also touches `reference-architecture/architectures/load-balancing.mdx`.

I'm already a listed code owner for `/src/content/docs/load-balancing/` and other Performance product paths, so this is a natural extension.

### Documentation checklist

- [x] No changelog entry needed (CODEOWNERS-only change, no customer-facing docs).
- [x] No style-guide impact.
- [x] No redirects needed.
