### PR TITLE
docs(logs): add Dynatrace as third-party Logpush integration

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/third-party/dynatrace.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/third-party/dynatrace.mdx
@@ -1,0 +1,10 @@
+---
+pcx_content_type: how-to
+title: Dynatrace
+external_link: https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-ingestion/lma-push-logs-with-cloudflare
+sidebar:
+  order: 5
+description: Learn about Dynatrace in Cloudflare Logs.
+products:
+  - logpush
+---


### PR DESCRIPTION
## What

Adds Dynatrace to the list of [third-party Logpush integrations](https://developers.cloudflare.com/logs/logpush/logpush-job/enable-destinations/third-party/).

Dynatrace published [step-by-step instructions](https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-ingestion/lma-push-logs-with-cloudflare) for pushing Cloudflare logs to Dynatrace via Logpush (dashboard and API). This page mirrors the existing pattern used for Axiom, Taegis, Exabeam, and Sekoia: a small page with frontmatter that links out to the partner's docs via `external_link`, picked up automatically by `<DirectoryListing />` in the index.

## Why

Customers asking how to ship Cloudflare logs to Dynatrace will now find the official Dynatrace guide directly from the Cloudflare third-party integrations page.

## Files

- `src/content/docs/logs/logpush/logpush-job/enable-destinations/third-party/dynatrace.mdx` (new)

Sidebar order set to `5` (after Sekoia=4).