### PR TITLE
[Workers VPC] Document Cloudflare WAN reachability via VPC Networks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -188,6 +188,10 @@ package.json @cloudflare/content-engineering
 /src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/ @baubuchon-cf @irvinebroque @dinasaur404 @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/workers/observability/ @irvinebroque @mikenomitch @nevikashah @cloudflare/product-owners
 /src/content/docs/workers/static-assets @irvinebroque @GregBrimble @WalshyDev @cloudflare/deploy-config @cloudflare/product-owners @MattieTK
+/src/content/docs/workers-vpc/ @nikitacano @elithrar @thomasgauvin @cloudflare/product-owners
+/src/content/partials/workers-vpc/ @nikitacano @elithrar @thomasgauvin @cloudflare/product-owners
+/src/content/changelog/workers-vpc/ @nikitacano @elithrar @thomasgauvin @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/assets/images/changelog/workers-vpc/ @nikitacano @elithrar @thomasgauvin @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/content/docs/workflows/ @elithrar @celso @mia303 @jonesphillip @cloudflare/product-owners
 /src/content/partials/workflows/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/product-owners
 /src/content/docs/sandbox/ @whoiskatrin @ghostwriternr @cloudflare/product-owners @cloudflare/ai-agents

--- a/src/content/changelog/workers-vpc/2026-05-21-vpc-networks-cloudflare-wan.mdx
+++ b/src/content/changelog/workers-vpc/2026-05-21-vpc-networks-cloudflare-wan.mdx
@@ -1,0 +1,38 @@
+---
+title: Reach Cloudflare WAN destinations from Workers VPC
+description: VPC Network bindings using cf1:network now reach destinations connected through Cloudflare WAN on-ramps (GRE, IPsec, CNI), in addition to Cloudflare Mesh nodes and subnet or hostname routes announced through Cloudflare Tunnel or Mesh.
+date: 2026-05-21
+---
+
+import { WranglerConfig } from "~/components";
+
+You can now use [VPC Network](/workers-vpc/configuration/vpc-networks/) bindings with `network_id: "cf1:network"` to reach your full private network from Workers, including:
+
+- [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) nodes and client devices
+- Subnet routes and hostname routes announced through [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) or Cloudflare Mesh
+- Destinations connected through [Cloudflare WAN](/cloudflare-wan/) on-ramps — GRE, IPsec, and CNI
+
+This means a single VPC Network binding can route Worker requests to private services regardless of how those services are connected to Cloudflare: through a Cloudflare Tunnel from a cloud VPC, a Mesh node on a private subnet, or a Cloudflare WAN on-ramp from your data center or branch site.
+
+<WranglerConfig>
+```jsonc
+{
+	"vpc_networks": [
+		{
+			"binding": "PRIVATE_NETWORK",
+			"network_id": "cf1:network",
+			"remote": true,
+		},
+	],
+}
+```
+</WranglerConfig>
+
+At runtime, the URL you pass to `fetch()` determines the destination:
+
+```js
+// Reach a service behind a Cloudflare WAN IPsec on-ramp
+const response = await env.PRIVATE_NETWORK.fetch("http://10.50.0.100:8080/api");
+```
+
+For configuration options, refer to [VPC Networks](/workers-vpc/configuration/vpc-networks/).

--- a/src/content/docs/workers-vpc/api/index.mdx
+++ b/src/content/docs/workers-vpc/api/index.mdx
@@ -29,11 +29,11 @@ A VPC Service binding routes requests to a specific pre-registered host and port
 
 ### VPC Network
 
-A VPC Network binding grants access to any service reachable through the bound tunnel or Cloudflare Mesh. The URL passed to `fetch()` determines the actual destination — hostname or IP address and port.
+A VPC Network binding grants access to any service reachable through the bound Cloudflare Tunnel or through Cloudflare Mesh — including subnet and hostname routes announced through Cloudflare Tunnel or Mesh, and destinations connected through Cloudflare WAN on-ramps (GRE, IPsec, or CNI). The URL passed to `fetch()` determines the actual destination — hostname or IP address and port.
 
 ## fetch()
 
-Makes an HTTP request to the private service through the configured tunnel.
+Makes an HTTP request to the private service through the bound Cloudflare Tunnel or Cloudflare Mesh.
 
 ```js
 const response = await env.MY_BINDING.fetch(resource, options);
@@ -127,7 +127,7 @@ export default {
 
 ## Required roles
 
-To bind a VPC Service or VPC Network in a Worker, your user needs `Connectivity Directory Bind` (or `Connectivity Directory Admin`). Binding directly to a tunnel through a VPC Network binding requires `Connectivity Directory Admin`. For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
+To bind a VPC Service or VPC Network in a Worker, your user needs `Connectivity Directory Bind` (or `Connectivity Directory Admin`). Binding directly to a Cloudflare Tunnel through a VPC Network binding requires `Connectivity Directory Admin`. For role definitions, refer to [Roles](/fundamentals/manage-members/roles/#account-scoped-roles).
 
 ## Next steps
 

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: VPC Networks
-description: Bind Workers to an entire tunnel or Cloudflare Mesh without pre-registering hosts.
+description: Bind Workers to an entire Cloudflare Tunnel or Cloudflare Mesh without pre-registering hosts.
 pcx_content_type: concept
 sidebar:
   order: 2
@@ -10,9 +10,9 @@ products:
 
 import { WranglerConfig } from "~/components";
 
-VPC Networks allow your Workers to access any service in your private network without pre-registering individual hosts or ports. You can bind to a specific [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/) to reach any service behind that tunnel, or bind to [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) to reach any Mesh node, client device, or IP route in your account.
+VPC Networks allow your Workers to access any service in your private network without pre-registering individual hosts or ports. You can bind to a specific [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/) to reach any service behind that tunnel, or bind to [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) to reach any Mesh node, client device, subnet route or hostname route announced through Cloudflare Tunnel or Mesh, or destination reachable through a [Cloudflare WAN](/cloudflare-wan/) on-ramp (GRE, IPsec, or CNI).
 
-At runtime, the URL you pass to `fetch()` determines the destination — any hostname or IP address reachable through the bound tunnel or Mesh network. This differs from [VPC Services](/workers-vpc/configuration/vpc-services/), which require you to create a separate binding for each target host and port combination.
+At runtime, the URL you pass to `fetch()` determines the destination — any hostname or IP address reachable through the bound Cloudflare Tunnel or through Cloudflare Mesh. This differs from [VPC Services](/workers-vpc/configuration/vpc-services/), which require you to create a separate binding for each target host and port combination.
 
 :::note
 
@@ -20,11 +20,11 @@ Workers VPC is currently in beta. Features and APIs may change before general av
 
 :::
 
-## Bind to a tunnel
+## Bind to a Cloudflare Tunnel
 
 :::note
 
-Binding directly to a tunnel through a VPC Network binding requires the **Connectivity Directory Admin** role.
+Binding directly to a Cloudflare Tunnel through a VPC Network binding requires the **Connectivity Directory Admin** role.
 
 :::
 
@@ -48,17 +48,23 @@ The `remote` flag must be set to `true` to enable remote bindings during local d
 
 ## Bind to Cloudflare Mesh
 
-[Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) (formerly WARP Connector) connects your services, devices, and Workers through Cloudflare's global network. When you bind a Worker to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach any Mesh node, client device, or IP route in your account — without specifying a particular tunnel UUID.
+[Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) (formerly WARP Connector) connects your services, devices, and Workers through Cloudflare's global network. When you bind a Worker to Cloudflare Mesh using `network_id: "cf1:network"`, your Worker can reach:
 
-Use Cloudflare Mesh when:
+- Any Mesh node or client device in your account
+- Subnet routes and hostname routes announced through Cloudflare Tunnel or Cloudflare Mesh
+- Destinations reachable through [Cloudflare WAN](/cloudflare-wan/) on-ramps (GRE, IPsec, and CNI)
 
-- Your Workers need to reach private services across multiple tunnels or Mesh nodes
-- You want to access your entire private network from a Worker without managing individual tunnel bindings
-- Your private network topology may change (new tunnels, new nodes) and you do not want to update Worker configuration each time
+All of this without specifying a particular Cloudflare Tunnel UUID.
+
+Use `cf1:network` when:
+
+- Your Workers need to reach private services across multiple Cloudflare Tunnels, Mesh nodes, or Cloudflare WAN on-ramps
+- You want to access your entire private network from a Worker without managing individual Cloudflare Tunnel bindings
+- Your private network topology may change (new connections, new nodes, new routes) and you do not want to update Worker configuration each time
 
 :::note
 
-Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) or [Mesh node](/cloudflare-one/networks/connectors/cloudflare-mesh/) that can reach the target services.
+Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/), [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) node, or [Cloudflare WAN](/cloudflare-wan/) on-ramp that can reach the target services.
 
 :::
 
@@ -103,14 +109,14 @@ When a VPC Network cannot establish a connection to your target service, `fetch(
 VPC Networks and [VPC Services](/workers-vpc/configuration/vpc-services/) both connect Workers to private infrastructure, but they make different trade-offs.
 
 - **Use VPC Services** when you have a known set of targets and want each binding scoped to a specific host and port.
-- **Use VPC Networks** when you need broader access — an entire tunnel or your full Mesh network — and want the URL in your `fetch()` call to control routing at runtime.
+- **Use VPC Networks** when you need broader access — an entire Cloudflare Tunnel or all of Cloudflare Mesh — and want the URL in your `fetch()` call to control routing at runtime.
 
 The following table summarizes the differences:
 
 | Feature              | VPC Networks                                                                  | VPC Services              |
 | -------------------- | ----------------------------------------------------------------------------- | ------------------------- |
-| Scope                | Entire tunnel or full Mesh network                                            | Specific host + port      |
-| Configuration        | `tunnel_id` (single tunnel) or `cf1:network` (all tunnels and Mesh nodes)     | `service_id`              |
+| Scope                | A single Cloudflare Tunnel, or Cloudflare Mesh and Cloudflare WAN routes      | Specific host + port      |
+| Configuration        | `tunnel_id` (single Cloudflare Tunnel) or `cf1:network` (account-wide)        | `service_id`              |
 | Service registration | Not required                                                                  | Required for each target  |
 | Use when             | Dynamic discovery, network-wide access, reaching services across your account | Fixed, cataloged services |
 
@@ -118,5 +124,6 @@ The following table summarizes the differences:
 
 - Set up [Cloudflare Tunnel](/workers-vpc/configuration/tunnel/)
 - [Set up Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/get-started/)
+- [Set up Cloudflare WAN](/cloudflare-wan/get-started/)
 - Try the [Connect Workers to Cloudflare Mesh](/workers-vpc/examples/connect-to-cloudflare-mesh/) example
 - Learn about the [Workers Binding API](/workers-vpc/api/)

--- a/src/content/docs/workers-vpc/examples/connect-to-cloudflare-mesh.mdx
+++ b/src/content/docs/workers-vpc/examples/connect-to-cloudflare-mesh.mdx
@@ -8,9 +8,9 @@ products:
 
 import { WranglerConfig } from "~/components";
 
-This example demonstrates how to use a VPC Network binding with [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) (formerly WARP Connector) to connect to any private service in your account from a Worker — without pre-registering individual hosts or specifying a tunnel UUID.
+This example demonstrates how to use a VPC Network binding with [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) (formerly WARP Connector) to connect to any private service in your account from a Worker — without pre-registering individual hosts or specifying a Cloudflare Tunnel UUID.
 
-When you bind to [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) using `network_id: "cf1:network"`, your Worker can reach any Mesh node, client device, or subnet route in your account.
+When you bind to [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) using `network_id: "cf1:network"`, your Worker can reach any Mesh node, client device, subnet or hostname route announced through Cloudflare Tunnel or Cloudflare Mesh, or destination connected through a [Cloudflare WAN](/cloudflare-wan/) on-ramp (GRE, IPsec, or CNI).
 
 ## Prerequisites
 
@@ -39,7 +39,7 @@ Bind your Worker to Cloudflare Mesh using `network_id: "cf1:network"` in your Wr
 ```
 </WranglerConfig>
 
-With this single binding, your Worker can reach any service across all tunnels and Mesh nodes in your account.
+With this single binding, your Worker can reach any service across all Cloudflare Tunnels, Mesh nodes, and Cloudflare WAN on-ramps in your account.
 
 ## 2. Implement the Worker
 

--- a/src/content/docs/workers-vpc/index.mdx
+++ b/src/content/docs/workers-vpc/index.mdx
@@ -33,6 +33,8 @@ Workers VPC allows you to connect your Workers to your private APIs, services, a
 
 With Workers VPC, you can configure a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) to establish secure, private connections from your private networks to Cloudflare. Then, you can configure a [VPC Service](/workers-vpc/configuration/vpc-services/) for each service in the external private network you need to connect to, and use [VPC Service bindings](/workers-vpc/api/) to connect from Workers. VPC Services support both HTTP and TCP service types, allowing you to connect to web APIs and databases (through [Hyperdrive](/hyperdrive/)).
 
+You can also use [VPC Network bindings](/workers-vpc/configuration/vpc-networks/) to give Workers broader access to your private infrastructure — services behind [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/), subnet and hostname routes announced through Cloudflare Tunnel or Mesh, and destinations connected through [Cloudflare WAN](/cloudflare-wan/) on-ramps (GRE, IPsec, and CNI).
+
 :::note
 
 Workers VPC is currently in beta. Features and APIs may change before general availability. While in beta, Workers VPC is available for free to all Workers plans.


### PR DESCRIPTION
### Summary

Documents that VPC Network bindings using `cf1:network` reach destinations connected through Cloudflare WAN on-ramps (GRE, IPsec, CNI) in addition to Cloudflare Tunnels and Mesh nodes. This capability works today but was not reflected anywhere in the developer docs.

Updates:

- `workers-vpc/configuration/vpc-networks/index.mdx` — concept doc: page intro, `cf1:network` section, comparison table, next steps
- `workers-vpc/api/index.mdx` — VPC Network binding description
- `workers-vpc/index.mdx` — overview page
- `workers-vpc/examples/connect-to-cloudflare-mesh.mdx` — Mesh example
- `changelog/workers-vpc/2026-05-21-vpc-networks-cloudflare-wan.mdx` — new changelog entry to surface the capability to customers

Also adds CODEOWNERS entries for the workers-vpc docs, partials, and changelog paths, which were previously missing. `@nikitacano` is the new PM owner of Workers VPC (taking over from `@thomasgauvin`).

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry?
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
