### PR TITLE
Update pathing-status.mdx

### DIFF
--- a/src/content/docs/logs/reference/pathing-status.mdx
+++ b/src/content/docs/logs/reference/pathing-status.mdx
@@ -44,7 +44,7 @@ jq -r .EdgePathingSrc logs.json | sort -n | uniq -c | sort -n | tail
 
 ### EdgePathingOp
 
-**EdgePathingOp** indicates how the request was handled. `wl` is a request that passed all checks and went to your origin server. Other possible values are:
+**EdgePathingOp** indicates how the request was handled. `wl` is a request that passed all security checks in the cn. Other possible values are:
 
 - `errHost` (host header mismatch, DNS errors, etc.)
 - `ban` (blocked by IP address, range, etc.)


### PR DESCRIPTION
removed the indication a "wl" edgePathingOp guarantees the request going to the origin server. it just tell us the request passed security check

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
