### PR TITLE
Add explicit CODEOWNERS rule for /src/content/partials/load-balancing/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -237,6 +237,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/cache/ @cloudflare/product-owners
 /src/content/docs/health-checks/ @cloudflare/product-owners @ncrouch-cflare
 /src/content/docs/load-balancing/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
+/src/content/partials/load-balancing/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
 /src/content/docs/smart-shield/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
 /src/content/docs/spectrum/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @cansu
 /src/content/docs/speed/ @cloudflare/product-owners


### PR DESCRIPTION
### Summary

Adds an explicit CODEOWNERS rule for `/src/content/partials/load-balancing/` mirroring the owners of `/src/content/docs/load-balancing/`:

```
/src/content/partials/load-balancing/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
```

### Why

Today, load-balancing partials fall through to the top-level default rule (`* @cloudflare/product-owners`), which means PRs that touch both `docs/load-balancing/` and `partials/load-balancing/` require approvals from two different sets of reviewers — even though the same Load Balancing team owns both. For example, [#30938](https://github.com/cloudflare/cloudflare-docs/pull/30938) touches both, and my approval as a named code owner on `/docs/load-balancing/` does not satisfy the default rule that covers the partials file.

This is consistent with how other products handle their partials — `/src/content/partials/r2/`, `/src/content/partials/d1/`, `/src/content/partials/workers/`, `/src/content/partials/hyperdrive/`, etc. all have explicit rules that match (or extend) their corresponding `docs/` rule.

### Documentation checklist

- [x] No changelog entry needed (CODEOWNERS-only change, no customer-facing docs).
- [x] No style-guide impact.
- [x] No redirects needed.