### PR TITLE
[Workflows] Document saga rollbacks

### DIFF
--- a/src/content/changelog/workflows/2026-05-22-saga-rollbacks.mdx
+++ b/src/content/changelog/workflows/2026-05-22-saga-rollbacks.mdx
@@ -8,7 +8,7 @@ date: 2026-05-22
 
 import { TypeScriptExample } from "~/components";
 
-[Workflows](/workflows/) now supports saga-style rollbacks for `step.do()`. You can register a compensating action for a step, and if the instance later fails, the rollback handlers will execute in reverse completion order.
+[Workflows](/workflows/) now supports saga-style rollbacks for `step.do()`. You can register a compensating action for a step, and if the instance later fails, the rollback handlers will execute in reverse `step-start` order.
 
 This is useful for multi-step operations that touch external systems, such as inventory reservations, payment authorization, ticket creation, or infrastructure provisioning. Instead of writing all cleanup logic in a top-level `catch`, you can keep each compensating action next to the step it undoes.
 

--- a/src/content/changelog/workflows/2026-05-22-saga-rollbacks.mdx
+++ b/src/content/changelog/workflows/2026-05-22-saga-rollbacks.mdx
@@ -1,0 +1,41 @@
+---
+title: Saga rollbacks are now available in Workflows
+description: Workflows now lets you attach rollback handlers to step.do(), inspect rollback outcomes, and query rollback events in analytics.
+products:
+  - workflows
+date: 2026-05-22
+---
+
+import { TypeScriptExample } from "~/components";
+
+[Workflows](/workflows/) now supports saga-style rollbacks for `step.do()`. You can register a compensating action for a step, and if the instance later fails, the rollback handlers will execute in reverse completion order.
+
+This is useful for multi-step operations that touch external systems, such as inventory reservations, payment authorization, ticket creation, or infrastructure provisioning. Instead of writing all cleanup logic in a top-level `catch`, you can keep each compensating action next to the step it undoes.
+
+Rollback handlers support their own retry and timeout configuration, and Workflows now exposes rollback outcomes in instance status responses. Workflows analytics also emits rollback lifecycle events, making it easier to distinguish a forward execution failure from a rollback failure when debugging production workflows.
+
+<TypeScriptExample>
+
+```ts
+await step.do(
+	"provision resource",
+	async () => {
+		const resource = await provisionResource();
+		return { resourceId: resource.id };
+	},
+	{
+		rollback: async ({ output }) => {
+			const { resourceId } = output as { resourceId: string };
+			await deleteResource(resourceId);
+		},
+		rollbackConfig: {
+			retries: { limit: 3, delay: "15 seconds", backoff: "linear" },
+			timeout: "2 minutes",
+		},
+	},
+);
+```
+
+</TypeScriptExample>
+
+Refer to the [Workers API reference for `step.do()`](/workflows/build/workers-api/#rollback-options), [sleeping and retrying](/workflows/build/sleeping-and-retrying/#register-rollback-handlers), and [metrics and analytics](/workflows/observability/metrics-analytics/#event-types) to learn more.

--- a/src/content/changelog/workflows/2026-05-22-saga-rollbacks.mdx
+++ b/src/content/changelog/workflows/2026-05-22-saga-rollbacks.mdx
@@ -1,14 +1,14 @@
 ---
-title: Saga rollbacks are now available in Workflows
+title: "Rollback support now available in Workflows"
 description: Workflows now lets you attach rollback handlers to step.do(), inspect rollback outcomes, and query rollback events in analytics.
 products:
   - workflows
-date: 2026-05-22
+date: 2026-05-27 12:00:00 UTC
 ---
 
 import { TypeScriptExample } from "~/components";
 
-[Workflows](/workflows/) now supports saga-style rollbacks for `step.do()`. You can register a compensating action for a step, and if the instance later fails, the rollback handlers will execute in reverse `step-start` order.
+[Workflows](/workflows/) now supports saga-style rollbacks,  allowing you to add compensating logic to each `step.do()` in case of downstream failures. If the instance fails, the rollback handlers will execute in reverse `step-start` order.
 
 This is useful for multi-step operations that touch external systems, such as inventory reservations, payment authorization, ticket creation, or infrastructure provisioning. Instead of writing all cleanup logic in a top-level `catch`, you can keep each compensating action next to the step it undoes.
 
@@ -38,4 +38,4 @@ await step.do(
 
 </TypeScriptExample>
 
-Refer to the [Workers API reference for `step.do()`](/workflows/build/workers-api/#rollback-options), [sleeping and retrying](/workflows/build/sleeping-and-retrying/#register-rollback-handlers), and [metrics and analytics](/workflows/observability/metrics-analytics/#event-types) to learn more.
+Refer to [rollback options](/workflows/build/workers-api/#rollback-options) to learn more.

--- a/src/content/changelog/workflows/2026-05-22-saga-rollbacks.mdx
+++ b/src/content/changelog/workflows/2026-05-22-saga-rollbacks.mdx
@@ -3,7 +3,7 @@ title: "Rollback support now available in Workflows"
 description: Workflows now lets you attach rollback handlers to step.do(), inspect rollback outcomes, and query rollback events in analytics.
 products:
   - workflows
-date: 2026-05-27 12:00:00 UTC
+date: 2026-06-02 2:30:00 UTC
 ---
 
 import { TypeScriptExample } from "~/components";

--- a/src/content/changelog/workflows/2026-06-05-saga-rollbacks.mdx
+++ b/src/content/changelog/workflows/2026-06-05-saga-rollbacks.mdx
@@ -3,7 +3,7 @@ title: "Rollback support now available in Workflows"
 description: Workflows now lets you attach rollback handlers to step.do(), inspect rollback outcomes, and query rollback events in analytics.
 products:
   - workflows
-date: 2026-06-02 2:30:00 UTC
+date: 2026-06-05 15:00:00 UTC
 ---
 
 import { TypeScriptExample } from "~/components";

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -8,6 +8,8 @@ products:
   - workflows
 ---
 
+import { TypeScriptExample } from "~/components";
+
 This guide details how to sleep a Workflow and/or configure retries for a Workflow step.
 
 ## Sleep a Workflow
@@ -125,6 +127,61 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 ```
 
 The Workflow instance itself will fail immediately, no further steps will be invoked, and the Workflow will not be retried.
+
+If earlier steps registered rollback handlers, those handlers will still run before the instance settles into its terminal state.
+
+## Register rollback handlers
+
+You can attach a rollback handler to `step.do()` to implement saga-style compensation. When the Workflow later fails, Workflows runs registered rollback handlers in reverse completion order.
+
+Only steps that completed and registered a rollback handler participate in rollback. If a rollback handler fails after exhausting its own retries, the rollback outcome is marked as failed and later rollback handlers are not run.
+
+<TypeScriptExample>
+
+```ts
+import {
+	WorkflowEntrypoint,
+	type WorkflowEvent,
+	type WorkflowStep,
+} from "cloudflare:workers";
+import { NonRetryableError } from "cloudflare:workflows";
+
+export class OrderWorkflow extends WorkflowEntrypoint<Env> {
+	async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+		await step.do(
+			"reserve inventory",
+			async () => {
+				const reservation = await reserveInventory();
+				return { reservationId: reservation.id };
+			},
+			{
+				rollback: async ({ output }) => {
+					const { reservationId } = output as { reservationId: string };
+					await releaseInventory(reservationId);
+				},
+				rollbackConfig: {
+					retries: { limit: 3, delay: "10 seconds", backoff: "linear" },
+					timeout: "2 minutes",
+				},
+			},
+		);
+
+		await step.do("charge card", async () => {
+			throw new NonRetryableError("payment processor rejected the charge");
+		});
+	}
+}
+```
+
+</TypeScriptExample>
+
+Rollback handlers receive:
+
+- `error` - the error that caused the Workflow to fail.
+- `output` - the value returned by the forward step.
+- `stepName` - the fully-qualified step name, including its count suffix.
+
+You can use `rollbackConfig` to control retry behavior for the rollback handler. Throw a `NonRetryableError` from the rollback handler to stop retrying it immediately.
 
 ## Catch Workflow errors
 

--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -132,9 +132,9 @@ If earlier steps registered rollback handlers, those handlers will still run bef
 
 ## Register rollback handlers
 
-You can attach a rollback handler to `step.do()` to implement saga-style compensation. When the Workflow later fails, Workflows runs registered rollback handlers in reverse completion order.
+You can attach a rollback handler to `step.do()` to implement saga-style compensation. When the Workflow later fails, Workflows runs registered rollback handlers in reverse `step-start` order.
 
-Only steps that completed and registered a rollback handler participate in rollback. If a rollback handler fails after exhausting its own retries, the rollback outcome is marked as failed and later rollback handlers are not run.
+A failed step with rollback options can also participate in rollback alongside any completed steps which have a rollback handler registered. For example, if a steps throws a `NonRetryableError` after registering rollback, its rollback handler runs with `output` set to `undefined`.
 
 <TypeScriptExample>
 
@@ -178,7 +178,7 @@ export class OrderWorkflow extends WorkflowEntrypoint<Env> {
 Rollback handlers receive:
 
 - `error` - the error that caused the Workflow to fail.
-- `output` - the value returned by the forward step.
+- `output` - the value returned by the forward step, or `undefined` if the step failed before returning
 - `stepName` - the fully-qualified step name, including its count suffix.
 
 You can use `rollbackConfig` to control retry behavior for the rollback handler. Throw a `NonRetryableError` from the rollback handler to stop retrying it immediately.

--- a/src/content/docs/workflows/build/trigger-workflows.mdx
+++ b/src/content/docs/workflows/build/trigger-workflows.mdx
@@ -128,7 +128,18 @@ The possible values of status are as follows:
     message: string
   };
 	output?: unknown;
+	rollback:
+		| {
+				outcome: "complete" | "failed";
+				error: {
+					name: string,
+					message: string,
+				} | null,
+		  }
+		| null;
 ```
+
+If your Workflow registers rollback handlers on `step.do()`, inspect `rollback` after the instance finishes to see whether the compensating steps completed successfully. While rollback is actively running, the Workers API continues to return `status: "running"`.
 
 ### Explicitly pause a Workflow
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -205,7 +205,7 @@ Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-
 ```ts
 type RollbackContext = {
 	error: Error;
-	output: unknown;
+	output: unknown | undefined ;
 	stepName: string;
 };
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -79,11 +79,18 @@ Refer to the [events and parameters](/workflows/build/events-and-parameters/) do
 
 {/* prettier-ignore */}
 - <code>step.do(name: string, callback: (ctx: WorkflowStepContext): RpcSerializable): Promise&lt;T&gt;</code>
+- <code>step.do(name: string, callback: (ctx: WorkflowStepContext): RpcSerializable, options?: RollbackOptions): Promise&lt;T&gt;</code>
 - <code>step.do(name: string, config?: WorkflowStepConfig, callback: (ctx: WorkflowStepContext):
 	RpcSerializable): Promise&lt;T&gt;</code>
-  - `name` - the name of the step, up to 256 characters.
-  - `config` (optional) - an optional `WorkflowStepConfig` for configuring [step specific retry behaviour](/workflows/build/sleeping-and-retrying/).
-  - `callback` - an asynchronous function that receives a [`WorkflowStepContext`](/workflows/build/step-context/) and optionally returns serializable state for the Workflow to persist. In JavaScript Workflows, this includes a fresh, unlocked `ReadableStream<Uint8Array>` for large binary output.
+	- `name` - the name of the step, up to 256 characters.
+	- `config` (optional) - an optional `WorkflowStepConfig` for configuring [step specific retry behaviour](/workflows/build/sleeping-and-retrying/).
+	- `callback` - an asynchronous function that receives a [`WorkflowStepContext`](/workflows/build/step-context/) and optionally returns serializable state for the Workflow to persist. In JavaScript Workflows, this includes a fresh, unlocked `ReadableStream<Uint8Array>` for large binary output.
+- <code>step.do(name: string, config?: WorkflowStepConfig, callback: (ctx: WorkflowStepContext):
+	RpcSerializable, options?: RollbackOptions): Promise&lt;T&gt;</code>
+	- `name` - the name of the step, up to 256 characters.
+	- `config` (optional) - an optional `WorkflowStepConfig` for configuring [step specific retry behaviour](/workflows/build/sleeping-and-retrying/).
+	- `callback` - an asynchronous function that receives a [`WorkflowStepContext`](/workflows/build/step-context/) and optionally returns serializable state for the Workflow to persist. In JavaScript Workflows, this includes a fresh, unlocked `ReadableStream<Uint8Array>` for large binary output.
+	- `options` (optional) - register rollback logic for the step. If the Workflow later fails, registered rollbacks run in reverse completion order.
 
 :::note[Returning state]
 
@@ -192,6 +199,59 @@ export type WorkflowStepConfig = {
 - A `WorkflowStepConfig` is an optional argument to the `do` method of a `WorkflowStep` and defines properties that allow you to configure the retry behaviour of that step.
 
 Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-and-retrying/) to learn more about how Workflows are retried.
+
+## Rollback options
+
+```ts
+type RollbackContext = {
+	error: Error;
+	output: unknown;
+	stepName: string;
+};
+
+type RollbackFn = (ctx: RollbackContext) => Promise<void>;
+
+type RollbackOptions = {
+	rollback: RollbackFn;
+	rollbackConfig?: WorkflowStepConfig;
+};
+```
+
+- Pass this `RollbackOptions` object as the final argument to `step.do()` to register a compensating action for a successful step.
+- `rollback` receives the error that caused the Workflow to fail, the step output returned by the forward step, and the fully-qualified step name.
+- `rollbackConfig` applies retry and timeout settings to the rollback handler itself.
+
+<TypeScriptExample>
+
+```ts
+export class BillingWorkflow extends WorkflowEntrypoint<Env> {
+	async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+		await step.do(
+			"create charge",
+			async () => {
+				const charge = await createCharge();
+				return { chargeId: charge.id };
+			},
+			{
+				rollback: async ({ output, error }) => {
+					const { chargeId } = output as { chargeId: string };
+					await refundCharge(chargeId, { reason: error.message });
+				},
+				rollbackConfig: {
+					retries: {
+						limit: 3,
+						delay: "30 seconds",
+						backoff: "linear",
+					},
+					timeout: "5 minutes",
+				},
+			},
+		);
+	}
+}
+```
+
+</TypeScriptExample>
 
 ## WorkflowStepContext
 
@@ -667,7 +727,16 @@ type InstanceStatus = {
 		message: string;
 	};
 	output?: unknown;
+	rollback: {
+		outcome: "complete" | "failed";
+		error: {
+			name: string;
+			message: string;
+		} | null;
+	} | null;
 };
 ```
+
+If a Workflow enters rollback, the Workers API continues to report `status: "running"` for compatibility while the rollback is executing. After the instance reaches a terminal state, inspect `rollback` to determine whether compensating steps completed successfully or failed.
 
 [^1]: Match pattern: `^[a-zA-Z0-9_][a-zA-Z0-9-_]*$`

--- a/src/content/docs/workflows/observability/metrics-analytics.mdx
+++ b/src/content/docs/workflows/observability/metrics-analytics.mdx
@@ -52,6 +52,9 @@ The possible values for `eventType` are documented below:
 - `WORKFLOW_SUCCESS` - the Workflow finished without errors.
 - `WORKFLOW_FAILURE` - the Workflow failed due to errors (exhausting retries, errors thrown, etc).
 - `WORKFLOW_TERMINATED` - the Workflow was explicitly terminated.
+- `ROLLBACK_START` - the Workflow began executing registered rollback handlers.
+- `ROLLBACK_COMPLETE` - all rollback handlers that were run completed successfully.
+- `ROLLBACK_FAILED` - a rollback handler failed and rollback did not finish cleanly.
 
 #### Step-level status labels
 
@@ -63,6 +66,14 @@ The possible values for `eventType` are documented below:
 - `ATTEMPT_START` - a step is retrying.
 - `ATTEMPT_SUCCESS` - the retry succeeded.
 - `ATTEMPT_FAILURE` - the retry attempt failed.
+- `ROLLBACK_STEP_START` - a rollback handler started running.
+- `ROLLBACK_STEP_SUCCESS` - a rollback handler finished successfully.
+- `ROLLBACK_STEP_FAILURE` - a rollback handler failed.
+- `ROLLBACK_ATTEMPT_START` - a rollback retry attempt started.
+- `ROLLBACK_ATTEMPT_SUCCESS` - a rollback retry attempt succeeded.
+- `ROLLBACK_ATTEMPT_FAILURE` - a rollback retry attempt failed.
+
+Rollback events let you distinguish forward execution failures from compensation failures when you are querying Workflow health or debugging instance timelines.
 
 ## View metrics in the dashboard
 


### PR DESCRIPTION
### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).