### PR TITLE
[WARP] Document EPEL requirement for Linux client UI on RHEL 9+

### DIFF
--- a/src/content/partials/cloudflare-one/mesh/install-node.mdx
+++ b/src/content/partials/cloudflare-one/mesh/install-node.mdx
@@ -22,6 +22,14 @@ sudo warp-cli connector new <TOKEN> && sudo warp-cli connect
 </TabItem>
 <TabItem label="RedHat / CentOS">
 
+On RHEL 9 and later, enable the Extra Packages for Enterprise Linux (EPEL) repository before installing `cloudflare-warp`. EPEL provides dependencies required by the Cloudflare One Client UI:
+
+```sh
+sudo dnf install -y epel-release
+```
+
+Then install the package:
+
 ```sh
 curl -fsSl https://pkg.cloudflareclient.com/cloudflare-warp-ascii.repo | sudo tee /etc/yum.repos.d/cloudflare-warp.repo &&
 sudo yum install -y cloudflare-warp &&

--- a/src/content/partials/cloudflare-one/warp/system-requirements/linux.mdx
+++ b/src/content/partials/cloudflare-one/warp/system-requirements/linux.mdx
@@ -5,11 +5,13 @@
 
 |                       |                                                                               |
 | --------------------- | ----------------------------------------------------------------------------- |
-| **OS version**        | CentOS 8, RHEL 8, Debian 12, Debian 13, Fedora 34, Fedora 35, Ubuntu 22.04 LTS, Ubuntu 24.04 LTS |
+| **OS version**        | CentOS 8, RHEL 8, RHEL 9 [^1], Debian 12, Debian 13, Fedora 34, Fedora 35, Ubuntu 22.04 LTS, Ubuntu 24.04 LTS |
 | **Processor**         | AMD64 / x86-64 or ARM64 / AArch64                                   |
 | **HD space**          | 75 MB                                                                         |
 | **Memory**            | 35 MB                                                                         |
 | **Network interface type**  | Wi-Fi or LAN |
-| **MTU** | 1381 bytes recommended [^1] |
+| **MTU** | 1381 bytes recommended [^2] |
 
-[^1]: Minimum 1281 bytes with [Path MTU Discovery](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/path-mtu-discovery/)
+[^1]: On RHEL 9 and later, enable the [Extra Packages for Enterprise Linux (EPEL)](https://docs.fedoraproject.org/en-US/epel/) repository (`sudo dnf install epel-release`) before installing `cloudflare-warp`. EPEL provides dependencies required by the client UI.
+
+[^2]: Minimum 1281 bytes with [Path MTU Discovery](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/path-mtu-discovery/)


### PR DESCRIPTION
The new Cloudflare One Client UI on RHEL 9 and later depends on packages from EPEL for the tray icon and captive portal webview. `dnf` cannot resolve these dependencies without EPEL enabled, so the repository must be added before installing `cloudflare-warp`.

- Add RHEL 9 to the supported OS list in the system requirements partial with a footnote pointing at the EPEL prerequisite.
- Add an EPEL prerequisite step to the RHEL tab of the Mesh node install snippet.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
