### PR TITLE
Add csujedihy and lpraneis as warp docs codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,30 +78,30 @@ package.json @cloudflare/content-engineering
 /src/content/docs/cloudflare-one/applications/ @alexmoraru7 @kennyj42 @asamborski @ranbel @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/identity/ @kennyj42 @asamborski @ranbel @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/access-controls/ @kennyj42 @asamborski @ranbel @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/cloudflare-one/team-and-resources/devices/ @ranbel @cf-rhett @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/cloudflare-one/team-and-resources/devices/ @ranbel @cf-rhett @csujedihy @lpraneis @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/ @nikitacano @ranbel @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/ @nikitacano @ranbel @cf-rhett @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/ @nikitacano @ranbel @cf-rhett @csujedihy @lpraneis @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/ @nikitacano @ranbel @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/tunnel/ @nikitacano @ranbel @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
 /src/content/partials/cloudflare-one/tunnel/ @nikitacano @ranbel @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/content/partials/cloudflare-one/warp/ @ranbel @cf-rhett @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/partials/cloudflare-one/warp/ @ranbel @cf-rhett @csujedihy @lpraneis @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/cloud-and-saas-findings/ @Maddy-Cloudflare @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/traffic-policies/ @alexmoraru7 @Maddy-Cloudflare @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/remote-browser-isolation/ @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/data-loss-prevention/ @Maddy-Cloudflare @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/cloudflare-one/insights/dex/ @codyanthony850 @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/email-security/ @Maddy-Cloudflare @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
-/src/assets/images/cloudflare-one/ @ranbel @Maddy-Cloudflare @codyanthony850 @cf-rhett @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/assets/images/cloudflare-one/ @ranbel @Maddy-Cloudflare @codyanthony850 @cf-rhett @csujedihy @lpraneis @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 
 # Consumer products
 
-/src/content/docs/1.1.1.1/ @RebeccaTamachiro @cf-rhett @hannes-cf @cloudflare/product-owners @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
-/src/content/partials/1.1.1.1/ @RebeccaTamachiro @cf-rhett @hannes-cf @cloudflare/product-owners @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
-/src/assets/images/1.1.1.1/ @RebeccaTamachiro @cf-rhett @hannes-cf @cloudflare/product-owners @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
-/src/content/docs/warp-client/ @ranbel @cf-rhett @cloudflare/product-owners
-/src/content/partials/warp-client/ @ranbel @cf-rhett @cloudflare/product-owners
-/src/content/warp-releases/ @ranbel @cf-rhett @cloudflare/product-owners
-/src/content/changelog/cloudflare-one-client/ @ranbel @cf-rhett @cloudflare/pm-changelogs @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
+/src/content/docs/1.1.1.1/ @RebeccaTamachiro @cf-rhett @csujedihy @lpraneis @hannes-cf @cloudflare/product-owners @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
+/src/content/partials/1.1.1.1/ @RebeccaTamachiro @cf-rhett @csujedihy @lpraneis @hannes-cf @cloudflare/product-owners @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
+/src/assets/images/1.1.1.1/ @RebeccaTamachiro @cf-rhett @csujedihy @lpraneis @hannes-cf @cloudflare/product-owners @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
+/src/content/docs/warp-client/ @ranbel @cf-rhett @csujedihy @lpraneis @cloudflare/product-owners
+/src/content/partials/warp-client/ @ranbel @cf-rhett @csujedihy @lpraneis @cloudflare/product-owners
+/src/content/warp-releases/ @ranbel @cf-rhett @csujedihy @lpraneis @cloudflare/product-owners
+/src/content/changelog/cloudflare-one-client/ @ranbel @cf-rhett @csujedihy @lpraneis @cloudflare/pm-changelogs @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners
 
 # Core platform
 
@@ -273,7 +273,7 @@ package.json @cloudflare/content-engineering
 # Support
 
 /src/content/docs/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie @krys-cf @stechedo @zeinjaber @shanecloudflare
-/src/assets/images/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie @krys-cf @stechedo @zeinjaber @shanecloudflare 
+/src/assets/images/support/ @cloudflare/product-owners @cloudflare/customer-support @ngayerie @krys-cf @stechedo @zeinjaber @shanecloudflare
 
 # Turnstile
 


### PR DESCRIPTION
### Summary

Similar to https://github.com/cloudflare/cloudflare-docs/pull/30738, add @csujedihy and @lpraneis as cloudflare one docs codeowners

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
