### PR TITLE
[Logpush] Add the missing requirement to the Sentinel documentation

### DIFF
--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -25,6 +25,8 @@ This guide provides clear, step-by-step instructions for integrating Cloudflare 
 - Microsoft Sentinel Workspace already set up in your Azure environment.
 - Azure Storage Account with a Blob container for storing Cloudflare logs.
 - Cloudflare Account with access to the domain whose logs you wish to export, and permission to configure Logpush jobs.
+- The storage account needs to be set to public network access.
+- The storage account needs to be in the same subscription as the Sentinel workspace.
 
 ## Step 2: Set up a logpush job
 


### PR DESCRIPTION
On the documentation page: https://developers.cloudflare.com/analytics/analytics-integrations/sentinel/

Prerequisites:
- The storage account needs to be set to public network access
- The storage account needs to be in the same subscription as the sentinel workspace

Without these, the connector will never be onboarded and it would help if the documentation states that per case 01981282.