### PR TITLE
[Agents] Sync recent SDK documentation updates

### DIFF
--- a/src/content/docs/agents/api-reference/agents-api.mdx
+++ b/src/content/docs/agents/api-reference/agents-api.mdx
@@ -85,27 +85,27 @@ flowchart TD
 
 ## Server-side API reference
 
-| Feature               | Methods                                                                      | Documentation                                                       |
-| --------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| **State**             | `setState()`, `onStateChanged()`, `initialState`                             | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
-| **Callable methods**  | `@callable()` decorator                                                      | [Callable methods](/agents/api-reference/callable-methods/)         |
-| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getScheduleById()`, `listSchedules()`      | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
-| **Durable execution** | `runFiber()`, `startFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()` | [Durable execution](/agents/api-reference/durable-execution/)       |
-| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                         | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
-| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                     | [WebSockets](/agents/api-reference/websockets/)                     |
-| **HTTP/SSE**          | `onRequest()`                                                                | [HTTP and SSE](/agents/api-reference/http-sse/)                     |
-| **Email**             | `onEmail()`, `replyToEmail()`                                                | [Email routing](/agents/api-reference/email/)                       |
-| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                         | [Run Workflows](/agents/api-reference/run-workflows/)               |
-| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                     | [MCP Client API](/agents/api-reference/mcp-client-api/)             |
-| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                       | [Using AI models](/agents/api-reference/using-ai-models/)           |
-| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`              | [Protocol messages](/agents/api-reference/protocol-messages/)       |
-| **Context**           | `getCurrentAgent()`                                                          | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
-| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                            | [Observability](/agents/api-reference/observability/)               |
-| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                          | [Sub-agents](/agents/api-reference/sub-agents/)                     |
-| **Agent tools**       | `runAgentTool()`, `clearAgentToolRuns()`, `hasAgentToolRun()`                | [Agent tools](/agents/api-reference/agent-tools/)                   |
-| **Sessions**          | `Session.create()`, context blocks, compaction, search                       | [Sessions](/agents/api-reference/sessions/)                         |
-| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions             | [Think](/agents/api-reference/think/)                               |
-| **Chat SDK**          | `createChatSdkState()`, `ChatSdkStateAgent`                                  | [Chat SDK](/agents/api-reference/chat-sdk/)                         |
+| Feature               | Methods                                                                                          | Documentation                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| **State**             | `setState()`, `onStateChanged()`, `initialState`                                                 | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
+| **Callable methods**  | `@callable()` decorator                                                                          | [Callable methods](/agents/api-reference/callable-methods/)         |
+| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getScheduleById()`, `listSchedules()`                          | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
+| **Durable execution** | `runFiber()`, `startFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()`, `keepAliveWhile()` | [Durable execution](/agents/api-reference/durable-execution/)       |
+| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                                             | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
+| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                                         | [WebSockets](/agents/api-reference/websockets/)                     |
+| **HTTP/SSE**          | `onRequest()`                                                                                    | [HTTP and SSE](/agents/api-reference/http-sse/)                     |
+| **Email**             | `onEmail()`, `replyToEmail()`                                                                    | [Email routing](/agents/api-reference/email/)                       |
+| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                                             | [Run Workflows](/agents/api-reference/run-workflows/)               |
+| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                                         | [MCP Client API](/agents/api-reference/mcp-client-api/)             |
+| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                                           | [Using AI models](/agents/api-reference/using-ai-models/)           |
+| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`                                  | [Protocol messages](/agents/api-reference/protocol-messages/)       |
+| **Context**           | `getCurrentAgent()`                                                                              | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
+| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                                | [Observability](/agents/api-reference/observability/)               |
+| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                                              | [Sub-agents](/agents/api-reference/sub-agents/)                     |
+| **Agent tools**       | `runAgentTool()`, `clearAgentToolRuns()`, `hasAgentToolRun()`                                    | [Agent tools](/agents/api-reference/agent-tools/)                   |
+| **Sessions**          | `Session.create()`, context blocks, compaction, search                                           | [Sessions](/agents/api-reference/sessions/)                         |
+| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions                                 | [Think](/agents/api-reference/think/)                               |
+| **Chat SDK**          | `createChatSdkState()`, `ChatSdkStateAgent`                                                      | [Chat SDK](/agents/api-reference/chat-sdk/)                         |
 
 ## SQL API
 

--- a/src/content/docs/agents/api-reference/agents-api.mdx
+++ b/src/content/docs/agents/api-reference/agents-api.mdx
@@ -85,26 +85,27 @@ flowchart TD
 
 ## Server-side API reference
 
-| Feature               | Methods                                                                          | Documentation                                                       |
-| --------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| **State**             | `setState()`, `onStateChanged()`, `initialState`                                 | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
-| **Callable methods**  | `@callable()` decorator                                                          | [Callable methods](/agents/api-reference/callable-methods/)         |
-| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getScheduleById()`, `listSchedules()`          | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
-| **Durable execution** | `runFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()`, `keepAliveWhile()` | [Durable execution](/agents/api-reference/durable-execution/)       |
-| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                             | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
-| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                         | [WebSockets](/agents/api-reference/websockets/)                     |
-| **HTTP/SSE**          | `onRequest()`                                                                    | [HTTP and SSE](/agents/api-reference/http-sse/)                     |
-| **Email**             | `onEmail()`, `replyToEmail()`                                                    | [Email routing](/agents/api-reference/email/)                       |
-| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                             | [Run Workflows](/agents/api-reference/run-workflows/)               |
-| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                         | [MCP Client API](/agents/api-reference/mcp-client-api/)             |
-| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                           | [Using AI models](/agents/api-reference/using-ai-models/)           |
-| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`                  | [Protocol messages](/agents/api-reference/protocol-messages/)       |
-| **Context**           | `getCurrentAgent()`                                                              | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
-| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                | [Observability](/agents/api-reference/observability/)               |
-| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                              | [Sub-agents](/agents/api-reference/sub-agents/)                     |
-| **Agent tools**       | `runAgentTool()`, `clearAgentToolRuns()`, `hasAgentToolRun()`                    | [Agent tools](/agents/api-reference/agent-tools/)                   |
-| **Sessions**          | `Session.create()`, context blocks, compaction, search                           | [Sessions](/agents/api-reference/sessions/)                         |
-| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions                 | [Think](/agents/api-reference/think/)                               |
+| Feature               | Methods                                                                      | Documentation                                                       |
+| --------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **State**             | `setState()`, `onStateChanged()`, `initialState`                             | [Store and sync state](/agents/api-reference/store-and-sync-state/) |
+| **Callable methods**  | `@callable()` decorator                                                      | [Callable methods](/agents/api-reference/callable-methods/)         |
+| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getScheduleById()`, `listSchedules()`      | [Schedule tasks](/agents/api-reference/schedule-tasks/)             |
+| **Durable execution** | `runFiber()`, `startFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()` | [Durable execution](/agents/api-reference/durable-execution/)       |
+| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                         | [Queue tasks](/agents/api-reference/queue-tasks/)                   |
+| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                     | [WebSockets](/agents/api-reference/websockets/)                     |
+| **HTTP/SSE**          | `onRequest()`                                                                | [HTTP and SSE](/agents/api-reference/http-sse/)                     |
+| **Email**             | `onEmail()`, `replyToEmail()`                                                | [Email routing](/agents/api-reference/email/)                       |
+| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                         | [Run Workflows](/agents/api-reference/run-workflows/)               |
+| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                     | [MCP Client API](/agents/api-reference/mcp-client-api/)             |
+| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                       | [Using AI models](/agents/api-reference/using-ai-models/)           |
+| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`              | [Protocol messages](/agents/api-reference/protocol-messages/)       |
+| **Context**           | `getCurrentAgent()`                                                          | [getCurrentAgent()](/agents/api-reference/get-current-agent/)       |
+| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                            | [Observability](/agents/api-reference/observability/)               |
+| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                          | [Sub-agents](/agents/api-reference/sub-agents/)                     |
+| **Agent tools**       | `runAgentTool()`, `clearAgentToolRuns()`, `hasAgentToolRun()`                | [Agent tools](/agents/api-reference/agent-tools/)                   |
+| **Sessions**          | `Session.create()`, context blocks, compaction, search                       | [Sessions](/agents/api-reference/sessions/)                         |
+| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions             | [Think](/agents/api-reference/think/)                               |
+| **Chat SDK**          | `createChatSdkState()`, `ChatSdkStateAgent`                                  | [Chat SDK](/agents/api-reference/chat-sdk/)                         |
 
 ## SQL API
 

--- a/src/content/docs/agents/api-reference/chat-sdk.mdx
+++ b/src/content/docs/agents/api-reference/chat-sdk.mdx
@@ -8,7 +8,12 @@ products:
   - agents
 ---
 
-import { LinkCard, TypeScriptExample, WranglerConfig } from "~/components";
+import {
+	LinkCard,
+	PackageManagers,
+	TypeScriptExample,
+	WranglerConfig,
+} from "~/components";
 
 Use `agents/chat-sdk` when you run the [Chat SDK](https://chat-sdk.dev/) inside an Agent. The first integration helper is a Chat SDK `StateAdapter` that stores state in Agents sub-agents.
 
@@ -18,9 +23,7 @@ The adapter stores Chat SDK subscriptions, locks, queues, dedupe keys, thread st
 
 Install both packages in the Worker that hosts your messenger ingress:
 
-```sh
-npm install agents chat
-```
+<PackageManagers pkg="agents chat" />
 
 `agents/chat-sdk` provides durable state for Chat SDK. Use it with any Chat SDK adapter, such as Telegram, Slack, Discord, Teams, or Google Chat.
 

--- a/src/content/docs/agents/api-reference/chat-sdk.mdx
+++ b/src/content/docs/agents/api-reference/chat-sdk.mdx
@@ -1,0 +1,213 @@
+---
+title: Chat SDK
+description: Integrate Chat SDK with Agents, including durable state for subscriptions, locks, queues, and message history.
+pcx_content_type: reference
+sidebar:
+  order: 23
+products:
+  - agents
+---
+
+import { LinkCard, TypeScriptExample, WranglerConfig } from "~/components";
+
+Use `agents/chat-sdk` when you run the [Chat SDK](https://chat-sdk.dev/) inside an Agent. The first integration helper is a Chat SDK `StateAdapter` that stores state in Agents sub-agents.
+
+The adapter stores Chat SDK subscriptions, locks, queues, dedupe keys, thread state, channel state, callback metadata, transcript lists, and thread history in Durable Object SQLite. Each state shard is a `ChatSdkStateAgent` sub-agent under your ingress Agent.
+
+## Install
+
+Install both packages in the Worker that hosts your messenger ingress:
+
+```sh
+npm install agents chat
+```
+
+`agents/chat-sdk` provides durable state for Chat SDK. Use it with any Chat SDK adapter, such as Telegram, Slack, Discord, Teams, or Google Chat.
+
+## Basic setup
+
+Create a parent Agent that owns your Chat SDK runtime. Pass `createChatSdkState()` as the Chat SDK `state` option.
+
+<TypeScriptExample>
+
+```ts
+import { Agent } from "agents";
+import { createChatSdkState } from "agents/chat-sdk";
+import { Chat } from "chat";
+import { createTelegramAdapter } from "@chat-adapter/telegram";
+
+export { ChatSdkStateAgent } from "agents/chat-sdk";
+
+export class MessengerAgent extends Agent<Env> {
+	private chat!: Chat;
+
+	onStart() {
+		const telegram = createTelegramAdapter({
+			botToken: this.env.TELEGRAM_BOT_TOKEN,
+			mode: "webhook",
+			userName: "my_bot",
+		});
+
+		this.chat = new Chat({
+			adapters: { telegram },
+			userName: "my_bot",
+			state: createChatSdkState(),
+			concurrency: { strategy: "burst", debounceMs: 600 },
+		});
+	}
+}
+```
+
+</TypeScriptExample>
+
+Add the parent Agent to your Durable Object migration:
+
+<WranglerConfig>
+
+```toml
+compatibility_date = "$today"
+compatibility_flags = ["nodejs_compat"]
+
+[[durable_objects.bindings]]
+class_name = "MessengerAgent"
+name = "MessengerAgent"
+
+[[migrations]]
+new_sqlite_classes = ["MessengerAgent"]
+tag = "v1"
+```
+
+</WranglerConfig>
+
+Export `ChatSdkStateAgent` from your Worker entry point so sub-agent routing can resolve it. When `createChatSdkState()` is called inside an Agent lifecycle method or request handler, it uses the current Agent as the parent and creates state shards with `this.subAgent()`.
+
+## State sharding
+
+By default, Chat SDK state is sharded by the first two colon-separated segments of a thread-like key.
+
+For example, `telegram:-100123:456` and `telegram:-100123:789` share the same state shard, `telegram:-100123`.
+
+The default key sharder recognizes these Chat SDK key prefixes:
+
+- `thread-state:`
+- `channel-state:`
+- `msg-history:`
+- `transcripts:user:`
+
+Unknown keys use the adapter's default shard name, `default`.
+
+## Custom sharding
+
+Use `shardKey` to control how thread IDs map to state sub-agent names:
+
+<TypeScriptExample>
+
+```ts
+const state = createChatSdkState({
+	shardKey(threadId) {
+		return threadId.split(":").slice(0, 2).join(":");
+	},
+});
+```
+
+</TypeScriptExample>
+
+Use `keyShard` when an adapter stores non-thread-shaped keys that should still route to a provider-specific shard:
+
+<TypeScriptExample>
+
+```ts
+const state = createChatSdkState({
+	keyShard(key) {
+		if (!key.startsWith("dedupe:telegram:")) {
+			return undefined;
+		}
+
+		const chatId = key.slice("dedupe:telegram:".length).split(":")[0];
+		return chatId ? `telegram:${chatId}` : undefined;
+	},
+});
+```
+
+</TypeScriptExample>
+
+Returning `undefined` falls back to the built-in key sharder and then to the default shard.
+
+## API
+
+### `createChatSdkState(options)`
+
+Creates a Chat SDK `StateAdapter` backed by a `ChatSdkStateAgent` sub-agent.
+
+<TypeScriptExample>
+
+```ts
+import { createChatSdkState } from "agents/chat-sdk";
+
+export { ChatSdkStateAgent } from "agents/chat-sdk";
+
+const state = createChatSdkState({
+	// parent: this // Optional. Defaults to the current Agent from getCurrentAgent().
+});
+```
+
+</TypeScriptExample>
+
+Options:
+
+| Option     | Description                                                                                                                       |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `agent`    | Optional custom subclass of `ChatSdkStateAgent`. Defaults to `ChatSdkStateAgent`.                                                 |
+| `parent`   | Optional parent Agent that will call `subAgent()` to create state shards. Defaults to the current Agent from `getCurrentAgent()`. |
+| `name`     | Default shard name for keys that cannot be mapped. Defaults to `default`.                                                         |
+| `shardKey` | Maps Chat SDK thread IDs and lock keys to a shard name.                                                                           |
+| `keyShard` | Maps generic Chat SDK cache or list keys to a shard name.                                                                         |
+
+### `ChatSdkStateAgent`
+
+The sub-agent class that stores state in SQLite. Export it from your Worker entry point so the runtime can create it.
+
+<TypeScriptExample>
+
+```ts
+export { ChatSdkStateAgent } from "agents/chat-sdk";
+```
+
+</TypeScriptExample>
+
+### `ChatSdkStateAdapter`
+
+The concrete `StateAdapter` implementation returned by `createChatSdkState()`. Most applications do not need to instantiate it directly.
+
+## What is stored
+
+The adapter implements the full Chat SDK `StateAdapter` interface:
+
+- Subscriptions for `thread.subscribe()` and `thread.unsubscribe()`.
+- Locks for per-thread or per-channel concurrency.
+- Pending message queues for `queue`, `debounce`, and `burst` concurrency strategies.
+- Generic key-value cache entries with optional TTL.
+- Append-only lists with max-length trimming and list-level TTL refresh.
+
+Chat SDK features built on these primitives include:
+
+- Message deduplication.
+- Thread and channel state.
+- Persistent thread history for adapters that opt in to `persistThreadHistory`.
+- Callback URL token storage.
+- Modal context storage.
+- Cross-platform transcripts.
+
+## Cleanup behavior
+
+TTL reads are strict: expired locks, cache values, queue entries, and list entries are ignored or deleted before they are returned.
+
+Physical cleanup is lazy. `ChatSdkStateAgent` schedules one cleanup callback for the earliest known expiry and reschedules after cleanup runs. This keeps idle shards quiet while preventing expired rows from accumulating indefinitely.
+
+## Example
+
+<LinkCard
+	title="Chat SDK messenger example"
+	href="https://github.com/cloudflare/agents/tree/main/examples/chat-sdk-messenger"
+	description="Build a Telegram messenger bot with Chat SDK state in sub-agents, burst/debounce concurrency, and Think-backed AI replies running in managed fibers."
+/>

--- a/src/content/docs/agents/api-reference/durable-execution.mdx
+++ b/src/content/docs/agents/api-reference/durable-execution.mdx
@@ -1,7 +1,7 @@
 ---
 title: Durable execution
 pcx_content_type: reference
-description: Run work that survives Durable Object eviction with runFiber(), keepAlive(), and crash recovery.
+description: Run work that survives Durable Object eviction with runFiber(), startFiber(), keepAlive(), and crash recovery.
 tags:
   - AI
 sidebar:
@@ -11,6 +11,8 @@ products:
 ---
 
 Run work that survives Durable Object eviction. `runFiber()` registers a task in SQLite, keeps the agent alive during execution, lets you checkpoint intermediate state with `stash()`, and calls `onFiberRecovered()` on the next activation if the agent was evicted mid-task.
+
+Use `startFiber()` when a caller needs to durably accept background work, return quickly, safely dedupe retries, inspect status later, or cancel a running job.
 
 :::note
 
@@ -118,6 +120,7 @@ class MyAgent extends Agent {
 | Streaming an LLM response (via `AIChatAgent`)    | Automatic (built in)        |
 | Multi-step computation with intermediate results | `runFiber()`                |
 | Background research loop that takes 10+ minutes  | `runFiber()` with `stash()` |
+| Webhook job that must be accepted exactly once   | `startFiber()`              |
 
 ## runFiber
 
@@ -126,19 +129,45 @@ Durable execution with checkpointing and recovery.
 ```ts
 class Agent {
 	runFiber<T>(name: string, fn: (ctx: FiberContext) => Promise<T>): Promise<T>;
+	startFiber(
+		name: string,
+		fn: (ctx: FiberContext) => Promise<void>,
+		options?: StartFiberOptions,
+	): Promise<StartFiberResult>;
+	inspectFiber(fiberId: string): Promise<FiberInspection | null>;
+	inspectFiberByKey(idempotencyKey: string): Promise<FiberInspection | null>;
+	listFibers(options?: ListFibersOptions): Promise<FiberInspection[]>;
+	cancelFiber(fiberId: string, reason?: string): Promise<boolean>;
+	cancelFiberByKey(idempotencyKey: string, reason?: string): Promise<boolean>;
+	deleteFibers(options?: DeleteFibersOptions): Promise<number>;
+	resolveFiber(fiberId: string, result: FiberRecoveryResult): Promise<boolean>;
 	stash(data: unknown): void;
-	onFiberRecovered(ctx: FiberRecoveryContext): Promise<void>;
+	onFiberRecovered(
+		ctx: FiberRecoveryContext,
+	): Promise<void | FiberRecoveryResult>;
 }
 
 type FiberContext = {
 	id: string;
+	signal: AbortSignal;
 	stash(data: unknown): void;
 	snapshot: unknown | null;
 };
 
+type FiberStatus =
+	| "pending"
+	| "running"
+	| "completed"
+	| "aborted"
+	| "interrupted"
+	| "error";
+
 type FiberRecoveryContext = {
 	id: string;
 	name: string;
+	status?: FiberStatus;
+	idempotencyKey?: string;
+	metadata?: Record<string, unknown> | null;
 	snapshot: unknown | null;
 	createdAt: number;
 };
@@ -217,7 +246,83 @@ void this.runFiber("background", async (ctx) => {
 });
 ```
 
-If the DO is evicted during an inline `await`, the caller is gone. On recovery, `onFiberRecovered` fires — it cannot return a result to the original caller. This is the inherent limitation of durable execution across process boundaries. For long-running work that is likely to outlive a single DO lifetime, fire-and-forget with checkpoint/recovery is the safer pattern.
+If the DO is evicted during an inline `await`, the caller is gone. On recovery, `onFiberRecovered` fires — it cannot return a result to the original caller. This is the inherent limitation of durable execution across process boundaries. For long-running work that is likely to outlive a single DO lifetime, use `startFiber()` when callers need a retained status record, idempotent acceptance, or cancellation.
+
+## startFiber
+
+Use `startFiber()` when a caller needs to durably accept background work, return quickly, and safely dedupe retries. It stores a retained fiber record before the callback runs, then starts the callback in the background using the same keep-alive and recovery machinery as `runFiber()`.
+
+```ts
+const receipt = await this.startFiber(
+	"reply-to-webhook",
+	async (ctx) => {
+		ctx.stash({ webhookId, threadId });
+		await postReply(threadId);
+	},
+	{
+		idempotencyKey: `webhook:${webhookId}`,
+		metadata: { threadId },
+	},
+);
+
+if (!receipt.accepted) {
+	// This webhook was already accepted by an earlier delivery.
+}
+```
+
+By default, `startFiber()` returns after the work is durably accepted. Pass `waitForCompletion: true` when the caller should remain open until the accepted fiber reaches a terminal status. Duplicate calls with the same idempotency key join an active in-memory execution when possible, then return the retained status with `accepted: false`.
+
+```ts
+const result = await this.startFiber("reply-to-webhook", reply, {
+	idempotencyKey: `webhook:${webhookId}`,
+	waitForCompletion: true,
+});
+
+if (result.status === "error") {
+	console.error(result.error);
+}
+```
+
+`startFiber()` is a durable acceptance API, not a value-return API. It returns the managed fiber status, but not the callback's result. Inspect status later with `inspectFiber()` or `inspectFiberByKey()`.
+
+```ts
+const current = await this.inspectFiberByKey(`webhook:${webhookId}`);
+
+if (current) {
+	await this.cancelFiber(current.fiberId, "No longer needed");
+}
+
+await this.deleteFibers({
+	status: ["completed", "error", "aborted"],
+	settledBefore: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+});
+```
+
+By default, `deleteFibers()` deletes settled `completed`, `error`, and `aborted` rows. It does not delete `interrupted` rows unless you pass that status explicitly, because interrupted rows often need inspection or manual resolution.
+
+Cancellation is cooperative. `cancelFiber()` records an aborted terminal state and aborts `ctx.signal` if the fiber is running in the current isolate. Your callback should check `ctx.signal.aborted` around expensive work and before visible side effects. Callers using `waitForCompletion: true` return when the ledger reaches `aborted`, even if a non-cooperative callback keeps running in the current isolate.
+
+If the Durable Object is evicted mid-fiber, the retained record is marked `interrupted` and `onFiberRecovered()` receives the last checkpoint. The original closure cannot be replayed automatically; use `ctx.name`, `ctx.snapshot`, and metadata to decide whether to resume, compensate, or leave the record for inspection.
+
+Return a `FiberRecoveryResult` from `onFiberRecovered()` to record the policy decision:
+
+```ts
+async onFiberRecovered(ctx: FiberRecoveryContext) {
+	if (ctx.name !== "reply-to-webhook") return;
+
+	const snapshot = ctx.snapshot as { webhookId: string; threadId: string };
+	await postRecoveryMessage(snapshot.threadId);
+
+	return {
+		status: "completed",
+		snapshot: { ...snapshot, recovered: true },
+	};
+}
+```
+
+Returning `undefined` keeps a managed fiber `interrupted`. Throwing leaves it `interrupted` and records the recovery error for inspection. Terminal managed fibers such as `aborted` are not recovered again if a stale run row remains.
+
+If recovery is triggered by a later duplicate webhook instead of `onFiberRecovered()`, use `resolveFiber()` with the same result shape after your application-level recovery succeeds. `resolveFiber()` only updates managed fibers that are currently `interrupted`; it returns `false` for pending, running, or already-terminal rows.
 
 ## Checkpoints with stash
 
@@ -288,9 +393,10 @@ class ResearchAgent extends Agent {
 Key points:
 
 - **The original lambda is gone.** On recovery, you only have the `name` and `snapshot`. The lambda cannot be serialized — recovery logic must be in the hook.
-- **The row is deleted after the hook runs.** If you want to continue the work, call `runFiber()` again inside the hook — this creates a new row.
+- **Unmanaged `runFiber()` rows are deleted after the hook runs.** If you want to continue unmanaged work, call `runFiber()` again inside the hook — this creates a new row.
+- **Managed `startFiber()` rows are retained.** Return a `FiberRecoveryResult` to mark an interrupted managed fiber as `completed`, `error`, `aborted`, or still `interrupted`.
 - **You control what recovery means.** Retry from the beginning, resume from a checkpoint, skip and notify the user, or do nothing. The framework does not impose a strategy.
-- **If the hook throws, the row is still deleted.** You do not get a second chance at recovery. If your recovery logic can fail, catch errors and handle them (for example, schedule a retry, log, or re-create the fiber).
+- **If the hook throws for unmanaged work, the row is still deleted.** If your recovery logic can fail, catch errors and handle them (for example, schedule a retry, log, or re-create the fiber). For managed work, the retained row stays `interrupted` and records the recovery error for inspection.
 
 ### Chat recovery
 
@@ -330,16 +436,49 @@ Execute a durable fiber. The fiber is registered in SQLite before `fn` runs and 
 - **`fn`** — async function receiving a `FiberContext`. Closures work naturally (`this` and local variables are captured).
 - **Returns** — the value returned by `fn`. If the DO is evicted before completion, the return value is lost; recovery happens through the hook.
 
+### startFiber(name, fn, options)
+
+Durably accept a retained background fiber. The returned `StartFiberResult` includes a generated `fiberId`, current `status`, optional `metadata`, and `accepted`, which is `false` when an existing fiber matched the same idempotency key.
+
+- **`name`** — identifier for the managed fiber, used in inspection and recovery.
+- **`fn`** — async function receiving a `FiberContext`. The function result is not stored.
+- **`options.idempotencyKey`** — stable external key used to dedupe retries.
+- **`options.metadata`** — JSON-serializable data stored with the retained row.
+- **`options.waitForCompletion`** — wait for terminal status before returning.
+
+### inspectFiber(fiberId) / inspectFiberByKey(idempotencyKey)
+
+Return the retained status row for a managed fiber, or `null` if no row exists.
+
+### listFibers(options)
+
+List retained managed fibers. Filter by `status` or `name`, and use `limit` to cap the result set.
+
+### cancelFiber(fiberId, reason) / cancelFiberByKey(idempotencyKey, reason)
+
+Mark a managed fiber as `aborted` and abort its in-memory `ctx.signal` when it is running in the current isolate. Returns `false` if the fiber does not exist or is already terminal.
+
+### resolveFiber(fiberId, result)
+
+Resolve an `interrupted` managed fiber after application-level recovery succeeds. Returns `false` for pending, running, or already-terminal rows.
+
+### deleteFibers(options)
+
+Delete retained managed fiber rows. By default, settled `completed`, `error`, and `aborted` rows are eligible. Pass `status`, `settledBefore`, or `limit` to narrow cleanup.
+
 ### stash(data) / ctx.stash(data)
 
 Checkpoint the current fiber's state. Writes synchronously to SQLite. Each call fully replaces the previous snapshot. `data` must be JSON-serializable.
 
 ### onFiberRecovered(ctx)
 
-Called once per orphaned fiber row on agent restart. Override to implement recovery. The row is deleted after this hook returns.
+Called once per orphaned fiber row on agent restart. Override to implement recovery. Unmanaged `runFiber()` rows are deleted after this hook returns. Managed `startFiber()` rows stay retained and can be resolved by returning a `FiberRecoveryResult`.
 
 - **`ctx.id`** — unique fiber ID
 - **`ctx.name`** — the name passed to `runFiber()`
+- **`ctx.status`** — retained status for managed fibers
+- **`ctx.idempotencyKey`** — idempotency key for managed fibers, if supplied
+- **`ctx.metadata`** — metadata for managed fibers, if supplied
 - **`ctx.snapshot`** — the last `stash()` data, or `null` if `stash()` was never called
 - **`ctx.createdAt`** — epoch milliseconds when `runFiber()` started. Compare against `Date.now()` to skip recoveries that are too old to replay safely.
 

--- a/src/content/docs/agents/api-reference/durable-execution.mdx
+++ b/src/content/docs/agents/api-reference/durable-execution.mdx
@@ -10,8 +10,6 @@ products:
   - agents
 ---
 
-import { TypeScriptExample } from "~/components";
-
 Run work that survives Durable Object eviction. `runFiber()` registers a task in SQLite, keeps the agent alive during execution, lets you checkpoint intermediate state with `stash()`, and calls `onFiberRecovered()` on the next activation if the agent was evicted mid-task.
 
 Use `startFiber()` when a caller needs to durably accept background work, return quickly, safely dedupe retries, inspect status later, or cancel a running job.
@@ -254,8 +252,6 @@ If the DO is evicted during an inline `await`, the caller is gone. On recovery, 
 
 Use `startFiber()` when a caller needs to durably accept background work, return quickly, and safely dedupe retries. It stores a retained fiber record before the callback runs, then starts the callback in the background using the same keep-alive and recovery machinery as `runFiber()`.
 
-<TypeScriptExample>
-
 ```ts
 const receipt = await this.startFiber(
 	"reply-to-webhook",
@@ -274,11 +270,7 @@ if (!receipt.accepted) {
 }
 ```
 
-</TypeScriptExample>
-
 By default, `startFiber()` returns after the work is durably accepted. Pass `waitForCompletion: true` when the caller should remain open until the accepted fiber reaches a terminal status. Duplicate calls with the same idempotency key join an active in-memory execution when possible, then return the retained status with `accepted: false`.
-
-<TypeScriptExample>
 
 ```ts
 const result = await this.startFiber("reply-to-webhook", reply, {
@@ -291,11 +283,7 @@ if (result.status === "error") {
 }
 ```
 
-</TypeScriptExample>
-
 `startFiber()` is a durable acceptance API, not a value-return API. It returns the managed fiber status, but not the callback's result. Inspect status later with `inspectFiber()` or `inspectFiberByKey()`.
-
-<TypeScriptExample>
 
 ```ts
 const current = await this.inspectFiberByKey(`webhook:${webhookId}`);
@@ -310,8 +298,6 @@ await this.deleteFibers({
 });
 ```
 
-</TypeScriptExample>
-
 By default, `deleteFibers()` deletes settled `completed`, `error`, and `aborted` rows. It does not delete `interrupted` rows unless you pass that status explicitly, because interrupted rows often need inspection or manual resolution.
 
 Cancellation is cooperative. `cancelFiber()` records an aborted terminal state and aborts `ctx.signal` if the fiber is running in the current isolate. Your callback should check `ctx.signal.aborted` around expensive work and before visible side effects. Callers using `waitForCompletion: true` return when the ledger reaches `aborted`, even if a non-cooperative callback keeps running in the current isolate.
@@ -319,8 +305,6 @@ Cancellation is cooperative. `cancelFiber()` records an aborted terminal state a
 If the Durable Object is evicted mid-fiber, the retained record is marked `interrupted` and `onFiberRecovered()` receives the last checkpoint. The original closure cannot be replayed automatically; use `ctx.name`, `ctx.snapshot`, and metadata to decide whether to resume, compensate, or leave the record for inspection.
 
 Return a `FiberRecoveryResult` from `onFiberRecovered()` to record the policy decision:
-
-<TypeScriptExample>
 
 ```ts
 async onFiberRecovered(ctx: FiberRecoveryContext) {
@@ -335,8 +319,6 @@ async onFiberRecovered(ctx: FiberRecoveryContext) {
 	};
 }
 ```
-
-</TypeScriptExample>
 
 Returning `undefined` keeps a managed fiber `interrupted`. Throwing leaves it `interrupted` and records the recovery error for inspection. Terminal managed fibers such as `aborted` are not recovered again if a stale run row remains.
 

--- a/src/content/docs/agents/api-reference/durable-execution.mdx
+++ b/src/content/docs/agents/api-reference/durable-execution.mdx
@@ -10,6 +10,8 @@ products:
   - agents
 ---
 
+import { TypeScriptExample } from "~/components";
+
 Run work that survives Durable Object eviction. `runFiber()` registers a task in SQLite, keeps the agent alive during execution, lets you checkpoint intermediate state with `stash()`, and calls `onFiberRecovered()` on the next activation if the agent was evicted mid-task.
 
 Use `startFiber()` when a caller needs to durably accept background work, return quickly, safely dedupe retries, inspect status later, or cancel a running job.
@@ -252,6 +254,8 @@ If the DO is evicted during an inline `await`, the caller is gone. On recovery, 
 
 Use `startFiber()` when a caller needs to durably accept background work, return quickly, and safely dedupe retries. It stores a retained fiber record before the callback runs, then starts the callback in the background using the same keep-alive and recovery machinery as `runFiber()`.
 
+<TypeScriptExample>
+
 ```ts
 const receipt = await this.startFiber(
 	"reply-to-webhook",
@@ -270,7 +274,11 @@ if (!receipt.accepted) {
 }
 ```
 
+</TypeScriptExample>
+
 By default, `startFiber()` returns after the work is durably accepted. Pass `waitForCompletion: true` when the caller should remain open until the accepted fiber reaches a terminal status. Duplicate calls with the same idempotency key join an active in-memory execution when possible, then return the retained status with `accepted: false`.
+
+<TypeScriptExample>
 
 ```ts
 const result = await this.startFiber("reply-to-webhook", reply, {
@@ -283,7 +291,11 @@ if (result.status === "error") {
 }
 ```
 
+</TypeScriptExample>
+
 `startFiber()` is a durable acceptance API, not a value-return API. It returns the managed fiber status, but not the callback's result. Inspect status later with `inspectFiber()` or `inspectFiberByKey()`.
+
+<TypeScriptExample>
 
 ```ts
 const current = await this.inspectFiberByKey(`webhook:${webhookId}`);
@@ -298,6 +310,8 @@ await this.deleteFibers({
 });
 ```
 
+</TypeScriptExample>
+
 By default, `deleteFibers()` deletes settled `completed`, `error`, and `aborted` rows. It does not delete `interrupted` rows unless you pass that status explicitly, because interrupted rows often need inspection or manual resolution.
 
 Cancellation is cooperative. `cancelFiber()` records an aborted terminal state and aborts `ctx.signal` if the fiber is running in the current isolate. Your callback should check `ctx.signal.aborted` around expensive work and before visible side effects. Callers using `waitForCompletion: true` return when the ledger reaches `aborted`, even if a non-cooperative callback keeps running in the current isolate.
@@ -305,6 +319,8 @@ Cancellation is cooperative. `cancelFiber()` records an aborted terminal state a
 If the Durable Object is evicted mid-fiber, the retained record is marked `interrupted` and `onFiberRecovered()` receives the last checkpoint. The original closure cannot be replayed automatically; use `ctx.name`, `ctx.snapshot`, and metadata to decide whether to resume, compensate, or leave the record for inspection.
 
 Return a `FiberRecoveryResult` from `onFiberRecovered()` to record the policy decision:
+
+<TypeScriptExample>
 
 ```ts
 async onFiberRecovered(ctx: FiberRecoveryContext) {
@@ -319,6 +335,8 @@ async onFiberRecovered(ctx: FiberRecoveryContext) {
 	};
 }
 ```
+
+</TypeScriptExample>
 
 Returning `undefined` keeps a managed fiber `interrupted`. Throwing leaves it `interrupted` and records the recovery error for inspection. Terminal managed fibers such as `aborted` are not recovered again if a stale run row remains.
 

--- a/src/content/docs/agents/api-reference/sessions.mdx
+++ b/src/content/docs/agents/api-reference/sessions.mdx
@@ -13,6 +13,7 @@ products:
 import {
 	InlineBadge,
 	LinkCard,
+	PackageManagers,
 	TypeScriptExample,
 	WranglerConfig,
 } from "~/components";
@@ -773,9 +774,7 @@ CREATE INDEX IF NOT EXISTS idx_search_entries_fts
 
 Install `pg`, then create a client from the Hyperdrive connection string and pass it to the Postgres providers:
 
-```sh
-npm install pg
-```
+<PackageManagers pkg="pg" />
 
 <TypeScriptExample>
 

--- a/src/content/docs/agents/api-reference/sessions.mdx
+++ b/src/content/docs/agents/api-reference/sessions.mdx
@@ -10,9 +10,14 @@ products:
   - agents
 ---
 
-import { TypeScriptExample, InlineBadge, LinkCard } from "~/components";
+import {
+	InlineBadge,
+	LinkCard,
+	TypeScriptExample,
+	WranglerConfig,
+} from "~/components";
 
-The Session API provides persistent conversation storage for agents, with tree-structured messages (inspired by [Pi](https://pi.dev)), context blocks, compaction, full-text search, and AI-controllable tools. It runs entirely on Durable Object SQLite — no external database needed.
+The Session API provides persistent conversation storage for agents, with tree-structured messages (inspired by [Pi](https://pi.dev)), context blocks, compaction, full-text search, and AI-controllable tools. By default, it uses Durable Object SQLite. External Postgres storage is also available for apps that need shared database access, analytics, or cross-Durable Object queries.
 
 :::caution[Experimental]
 
@@ -41,7 +46,7 @@ class MyAgent extends Agent {
 
 	async onMessage(message: unknown) {
 		await this.session.appendMessage(message);
-		const history = this.session.getHistory();
+		const history = await this.session.getHistory();
 		const system = await this.session.freezeSystemPrompt();
 		const tools = await this.session.tools();
 		// Pass history, system prompt, and tools to your LLM
@@ -123,20 +128,20 @@ await session.appendMessage(message);
 await session.appendMessage(message, parentId);
 
 // Update an existing message (matched by message.id)
-session.updateMessage(message);
+await session.updateMessage(message);
 
 // Delete specific messages
-session.deleteMessages(["msg-1", "msg-2"]);
+await session.deleteMessages(["msg-1", "msg-2"]);
 
 // Clear all messages and skill state
-session.clearMessages();
+await session.clearMessages();
 ```
 
 </TypeScriptExample>
 
 :::note
 
-`appendMessage()` is `async` because it may trigger auto-compaction. The underlying SQLite write is synchronous. All other write methods (`updateMessage`, `deleteMessages`, `clearMessages`) are synchronous.
+Session methods are async. SQLite-backed sessions are usually fast, but external providers may perform network I/O, and `appendMessage()` may also trigger auto-compaction.
 
 :::
 
@@ -146,19 +151,19 @@ session.clearMessages();
 
 ```ts
 // Linear history from root to the latest leaf
-const messages = session.getHistory();
+const messages = await session.getHistory();
 
 // History to a specific leaf (for branching)
-const branch = session.getHistory(leafId);
+const branch = await session.getHistory(leafId);
 
 // Get a single message
-const msg = session.getMessage("msg-1");
+const msg = await session.getMessage("msg-1");
 
 // Get the newest message
-const latest = session.getLatestLeaf();
+const latest = await session.getLatestLeaf();
 
 // Count messages in path
-const count = session.getPathLength();
+const count = await session.getPathLength();
 ```
 
 </TypeScriptExample>
@@ -171,7 +176,7 @@ Messages form a tree. When you `appendMessage` with a `parentId` that already ha
 
 ```ts
 // Get all child messages that branch from messageId
-const branches = session.getBranches(messageId);
+const branches = await session.getBranches(messageId);
 ```
 
 </TypeScriptExample>
@@ -185,13 +190,13 @@ Full-text search over the conversation history using SQLite FTS5:
 <TypeScriptExample>
 
 ```ts
-const results = session.search("deployment Friday", { limit: 10 });
+const results = await session.search("deployment Friday", { limit: 10 });
 // Returns: Array<{ id, role, content, createdAt? }>
 ```
 
 </TypeScriptExample>
 
-Uses porter stemming and unicode tokenization. The search covers all messages in the session.
+SQLite-backed sessions use FTS5 with porter stemming and unicode tokenization. Postgres-backed sessions use the provider's Postgres full-text index. `search()` throws if the session provider does not support search.
 
 ## Context blocks
 
@@ -410,8 +415,8 @@ When `getHistory()` is called, compaction overlays are applied transparently —
 const result = await session.compact();
 
 // Or manage overlays directly
-session.addCompaction("Summary of messages 1-50", "msg-1", "msg-50");
-const overlays = session.getCompactions();
+await session.addCompaction("Summary of messages 1-50", "msg-1", "msg-50");
+const overlays = await session.getCompactions();
 ```
 
 </TypeScriptExample>
@@ -467,26 +472,26 @@ Context blocks, prompt caching, and compaction settings are propagated to all se
 
 ```ts
 // Create a new session
-const info = manager.create("My Chat");
+const info = await manager.create("My Chat");
 
 // Create with metadata
-const info2 = manager.create("My Chat", {
+const info2 = await manager.create("My Chat", {
 	parentSessionId: "parent-id",
 	model: "claude-sonnet-4-20250514",
 	source: "web",
 });
 
 // Get session metadata (null if not found)
-const session = manager.get(sessionId);
+const session = await manager.get(sessionId);
 
 // List all sessions (ordered by updated_at DESC)
-const sessions = manager.list();
+const sessions = await manager.list();
 
 // Rename
-manager.rename(sessionId, "New Name");
+await manager.rename(sessionId, "New Name");
 
 // Delete (clears messages too)
-manager.delete(sessionId);
+await manager.delete(sessionId);
 ```
 
 </TypeScriptExample>
@@ -520,16 +525,16 @@ await manager.upsert(sessionId, message, parentId);
 await manager.appendAll(sessionId, messages, parentId);
 
 // Read history
-const history = manager.getHistory(sessionId, leafId);
+const history = await manager.getHistory(sessionId, leafId);
 
 // Message count
-const count = manager.getMessageCount(sessionId);
+const count = await manager.getMessageCount(sessionId);
 
 // Clear messages
-manager.clearMessages(sessionId);
+await manager.clearMessages(sessionId);
 
 // Delete specific messages
-manager.deleteMessages(sessionId, ["msg-1"]);
+await manager.deleteMessages(sessionId, ["msg-1"]);
 ```
 
 </TypeScriptExample>
@@ -547,12 +552,35 @@ const forked = await manager.fork(sessionId, atMessageId, "Forked Chat");
 
 </TypeScriptExample>
 
+### Compaction helpers
+
+<TypeScriptExample>
+
+```ts
+// Add a compaction overlay
+await manager.addCompaction(sessionId, summary, fromId, toId);
+
+// Get overlays
+const compactions = await manager.getCompactions(sessionId);
+
+// Compact and split — marks old session as ended, creates a continuation
+const continuation = await manager.compactAndSplit(
+	sessionId,
+	summary,
+	"Continued Chat",
+);
+```
+
+</TypeScriptExample>
+
+`compactAndSplit()` creates a new session with a summary message instead of an in-place overlay. The original session is marked with `end_reason: "compaction"`.
+
 ### Usage tracking
 
 <TypeScriptExample>
 
 ```ts
-manager.addUsage(sessionId, inputTokens, outputTokens, cost);
+await manager.addUsage(sessionId, inputTokens, outputTokens, cost);
 ```
 
 </TypeScriptExample>
@@ -563,10 +591,10 @@ manager.addUsage(sessionId, inputTokens, outputTokens, cost);
 
 ```ts
 // Search across all sessions (FTS5)
-const results = manager.search("deployment Friday", { limit: 20 });
+const results = await manager.search("deployment Friday", { limit: 20 });
 
 // Get tools for the model (includes session_search)
-const tools = manager.tools();
+const tools = await manager.tools();
 ```
 
 </TypeScriptExample>
@@ -613,40 +641,40 @@ You can also implement `SessionProvider` to replace the SQLite storage entirely:
 
 ```ts
 const myStorage: SessionProvider = {
-	getMessage(id) {
+	async getMessage(id) {
 		/* ... */
 	},
-	getHistory(leafId?) {
+	async getHistory(leafId?) {
 		/* ... */
 	},
-	getLatestLeaf() {
+	async getLatestLeaf() {
 		/* ... */
 	},
-	getBranches(messageId) {
+	async getBranches(messageId) {
 		/* ... */
 	},
-	getPathLength(leafId?) {
+	async getPathLength(leafId?) {
 		/* ... */
 	},
-	appendMessage(message, parentId?) {
+	async appendMessage(message, parentId?) {
 		/* ... */
 	},
-	updateMessage(message) {
+	async updateMessage(message) {
 		/* ... */
 	},
-	deleteMessages(messageIds) {
+	async deleteMessages(messageIds) {
 		/* ... */
 	},
-	clearMessages() {
+	async clearMessages() {
 		/* ... */
 	},
-	addCompaction(summary, fromId, toId) {
+	async addCompaction(summary, fromId, toId) {
 		/* ... */
 	},
-	getCompactions() {
+	async getCompactions() {
 		/* ... */
 	},
-	searchMessages(query, limit) {
+	async searchMessages(query, limit) {
 		/* ... */
 	},
 };
@@ -654,9 +682,169 @@ const myStorage: SessionProvider = {
 
 </TypeScriptExample>
 
+## Postgres providers
+
+By default, Session storage uses Durable Object SQLite and creates tables lazily. If you need session data in an external Postgres database for cross-agent queries, analytics, or shared storage, use `PostgresSessionProvider`, `PostgresContextProvider`, and `PostgresSearchProvider`.
+
+These providers work with Postgres-compatible databases through [Hyperdrive](/hyperdrive/) for connection pooling.
+
+### 1. Create a Hyperdrive config
+
+Create a Hyperdrive config for your Postgres database:
+
+```sh
+npx wrangler hyperdrive create my-session-db \
+	--connection-string="postgresql://user:password@host:port/dbname"
+```
+
+Then add the Hyperdrive binding to `wrangler.jsonc`:
+
+<WranglerConfig>
+
+```toml
+compatibility_flags = ["nodejs_compat"]
+
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "<your-hyperdrive-id>"
+
+[placement]
+mode = "smart"
+```
+
+</WranglerConfig>
+
+If you know your database region, configure placement close to the database to reduce query latency.
+
+### 2. Create the tables
+
+The Postgres user may not have permission to create tables at runtime. Run the schema once in your database console:
+
+```sql
+CREATE TABLE IF NOT EXISTS assistant_messages (
+	id TEXT NOT NULL,
+	session_id TEXT NOT NULL DEFAULT '',
+	parent_id TEXT,
+	role TEXT NOT NULL,
+	content TEXT NOT NULL,
+	text_content TEXT NOT NULL DEFAULT '',
+	created_at TIMESTAMPTZ DEFAULT NOW(),
+	content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', text_content)) STORED,
+	PRIMARY KEY (session_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_assistant_msg_parent
+	ON assistant_messages (parent_id);
+CREATE INDEX IF NOT EXISTS idx_assistant_msg_session
+	ON assistant_messages (session_id);
+CREATE INDEX IF NOT EXISTS idx_assistant_msg_fts
+	ON assistant_messages USING GIN (content_tsv);
+
+CREATE TABLE IF NOT EXISTS assistant_compactions (
+	id TEXT PRIMARY KEY,
+	session_id TEXT NOT NULL DEFAULT '',
+	summary TEXT NOT NULL,
+	from_message_id TEXT NOT NULL,
+	to_message_id TEXT NOT NULL,
+	created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS cf_agents_context_blocks (
+	label TEXT PRIMARY KEY,
+	content TEXT NOT NULL,
+	updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS cf_agents_search_entries (
+	label TEXT NOT NULL,
+	key TEXT NOT NULL,
+	content TEXT NOT NULL,
+	content_tsv TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
+	created_at TIMESTAMPTZ DEFAULT NOW(),
+	updated_at TIMESTAMPTZ DEFAULT NOW(),
+	PRIMARY KEY (label, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_entries_fts
+	ON cf_agents_search_entries USING GIN (content_tsv);
+```
+
+### 3. Wire it up
+
+Install `pg`, then create a client from the Hyperdrive connection string and pass it to the Postgres providers:
+
+```sh
+npm install pg
+```
+
+<TypeScriptExample>
+
+```ts
+import { Agent } from "agents";
+import {
+	PostgresContextProvider,
+	PostgresSearchProvider,
+	PostgresSessionProvider,
+	Session,
+} from "agents/experimental/memory/session";
+import { Client } from "pg";
+
+export class MyAgent extends Agent<Env> {
+	private session?: Session;
+	private pgClient?: Client;
+
+	async onStart(): Promise<void> {
+		const client = new Client({
+			connectionString: this.env.HYPERDRIVE.connectionString,
+		});
+		await client.connect();
+		this.pgClient = client;
+
+		const sessionId = this.ctx.id.toString();
+		this.session = Session.create(
+			new PostgresSessionProvider(client, sessionId),
+		)
+			.withContext("soul", {
+				provider: {
+					get: async () => "You are a helpful assistant.",
+				},
+			})
+			.withContext("memory", {
+				description: "Short facts",
+				maxTokens: 1100,
+				provider: new PostgresContextProvider(client, `memory_${sessionId}`),
+			})
+			.withContext("knowledge", {
+				description: "Searchable knowledge base",
+				provider: new PostgresSearchProvider(client),
+			})
+			.withCachedPrompt(
+				new PostgresContextProvider(client, `_prompt_${sessionId}`),
+			);
+	}
+}
+```
+
+</TypeScriptExample>
+
+### Behavior differences
+
+When `Session.create()` receives a `SessionProvider` instead of a SQLite-backed provider, it skips SQLite auto-wiring:
+
+- **Context blocks need explicit providers.** Each `withContext()` call that should persist data needs a `provider` option.
+- **`withCachedPrompt()` needs an explicit provider.** Pass a `PostgresContextProvider` to persist the frozen system prompt.
+- **Session methods are async.** Use `await` for reads and writes so the same code works with local SQLite and external storage.
+- **Broadcaster support is skipped.** WebSocket status broadcasts for Session events only work with SQLite-backed sessions.
+
+### System prompt lifecycle
+
+`freezeSystemPrompt()` returns the cached prompt from storage. On first call, it loads context blocks from providers, renders the prompt, and persists it. Subsequent calls return the stored value without re-rendering.
+
+Use `refreshSystemPrompt()` to force reload context blocks, re-render the prompt, and update the stored value.
+
 ## Storage tables
 
-All storage is in Durable Object SQLite. Tables are created lazily on first use.
+By default, storage is in Durable Object SQLite and tables are created lazily on first use. Postgres-backed sessions use the external tables shown in the Postgres providers section.
 
 | Table                                               | Purpose                                                                                                         |
 | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |

--- a/src/content/docs/agents/api-reference/sub-agents.mdx
+++ b/src/content/docs/agents/api-reference/sub-agents.mdx
@@ -43,7 +43,7 @@ export class Researcher extends Agent {
 
 </TypeScriptExample>
 
-Both classes must be exported from the worker entry point. No separate Durable Object bindings are needed — child classes are discovered automatically via `ctx.exports`.
+Both classes must be exported from the worker entry point. No separate Durable Object bindings are needed for child-only classes — child classes are discovered automatically via `ctx.exports`.
 
 <WranglerConfig>
 
@@ -62,7 +62,7 @@ tag = "v1"
 
 </WranglerConfig>
 
-Only the parent agent needs a Durable Object binding and migration. Child agents are created as facets of the parent — they share the same machine but have fully isolated SQLite storage.
+Only the top-level parent agent needs a Durable Object binding and migration. Child agents are created as facets of the parent — they share the same machine but have fully isolated SQLite storage.
 
 ## subAgent
 
@@ -118,8 +118,14 @@ class MyChild extends Agent {
 - The child class must extend `Agent`
 - The child class must be exported from the worker entry point (`export class MyChild extends Agent`)
 - The export name must match the class name — `export { Foo as Bar }` is not supported
-- The parent class must be bound as a Durable Object namespace in `wrangler.jsonc`
+- The top-level parent class must be bound as a Durable Object namespace in `wrangler.jsonc`
+- A facet-only child class does not need to be registered under `new_sqlite_classes` unless the same class is also bound as a top-level Durable Object elsewhere
+- Nested facet parents do not need their own top-level Durable Object bindings; the runtime resolves nested children through the root parent namespace
 - The child class name cannot be `Sub`, because `/sub/` is reserved as the URL separator for nested routes
+
+### Notes for testing
+
+Tests that use `@cloudflare/vitest-pool-workers` may need to list facet classes as test-only Durable Object bindings so `ctx.exports` provides a facet-compatible class value. Keep those facet classes out of `new_sqlite_classes`; the extra binding belongs only in test `wrangler.jsonc` files and is not a production Worker requirement.
 
 ## abortSubAgent
 
@@ -256,6 +262,8 @@ await inbox.recordTurn(this.name, "...");
 ```
 
 </TypeScriptExample>
+
+`parentAgent()` resolves the direct parent even when that parent is itself a facet-only sub-agent, using a root-side RPC bridge under the hood. This gives you typed method calls to the immediate parent without requiring every nested parent class to be bound as a top-level Durable Object.
 
 For grandparents and further ancestors, iterate `this.parentPath` and call `getAgentByName()` directly. If the binding name does not match the class name, call `getAgentByName(env.MY_BINDING, this.parentPath.at(-1)!.name)` instead of `parentAgent()`.
 

--- a/src/content/docs/agents/api-reference/think.mdx
+++ b/src/content/docs/agents/api-reference/think.mdx
@@ -164,19 +164,23 @@ Both Think and [`AIChatAgent`](/agents/api-reference/chat-agents/) extend `Agent
 
 Think has several ways to start or continue a turn. Choose based on who starts the work and what the caller needs back.
 
-| Use case                                                   | API                                             |
-| ---------------------------------------------------------- | ----------------------------------------------- |
-| A browser user sends chat messages                         | `useAgentChat` over the WebSocket chat protocol |
-| Server code can wait for the model response                | `saveMessages()`                                |
-| Server code needs fast durable acceptance and later status | `submitMessages()`                              |
-| Parent code needs direct streaming RPC to a child          | `subAgent(...).chat()`                          |
-| A parent delegates work to a retained child agent          | `agentTool()` or `runAgentTool()`               |
-| Add context without starting a model turn                  | `persistMessages()`                             |
-| Continue after the latest assistant message                | `continueLastTurn()`                            |
+| Use case                                                       | API                                             |
+| -------------------------------------------------------------- | ----------------------------------------------- |
+| A browser user sends chat messages                             | `useAgentChat` over the WebSocket chat protocol |
+| Server code can wait for the model response                    | `saveMessages()`                                |
+| Server code needs fast durable acceptance and later status     | `submitMessages()`                              |
+| Parent code needs direct streaming RPC to a specific child     | `subAgent(...).chat()`                          |
+| A parent delegates work to a retained child agent              | `agentTool()` or `runAgentTool()`               |
+| Surround a turn with idempotent app-owned side effects         | `startFiber()`                                  |
+| Coordinate multi-step durable orchestration                    | Workflows                                       |
+| Add context or messages without starting a model turn          | `persistMessages()`                             |
+| Advanced subclass or recovery code continues an assistant turn | `continueLastTurn()`                            |
 
 Use `saveMessages()` when the caller owns the trigger and can wait for the turn to finish. Use [`submitMessages()`](#submitmessages) when timeout ambiguity would make retries unsafe.
 
 Use `chat()` for low-level parent-to-child streaming when your code owns forwarding, cancellation, and replay policy. Use [Agent tools](/agents/api-reference/agent-tools/) when a parent model or workflow delegates to a child agent and you want retained child runs, event replay, abort bridging, and UI drill-in.
+
+Use [`startFiber()`](/agents/api-reference/durable-execution/#startfiber) outside Think when the durable unit is an application job around a turn: accepting a webhook once, restoring a serialized channel or thread target, posting a visible reply, or recording app-level recovery policy. Think submissions own conversation admission and turn serialization; managed fibers own external job acceptance, idempotent side effects, and application recovery.
 
 ## Configuration overrides
 
@@ -190,7 +194,7 @@ Use `chat()` for low-level parent-to-child streaming when your code owns forward
 | `configureSession()`    | identity                         | Add context blocks, compaction, search, skills — refer to [Sessions](/agents/api-reference/sessions/) |
 | `messageConcurrency`    | `"queue"`                        | How overlapping submits behave — refer to [Message concurrency](#message-concurrency)                 |
 | `waitForMcpConnections` | `false`                          | Wait for MCP servers before inference                                                                 |
-| `chatRecovery`          | `true`                           | Wrap WebSocket, programmatic, and continuation turns in `runFiber` for durable execution              |
+| `chatRecovery`          | `true`                           | Wrap WebSocket, sub-agent, programmatic, and continuation turns in `runFiber` for durable execution   |
 
 ## Dynamic configuration
 
@@ -1127,6 +1131,8 @@ export class SearchAgent extends Think<Env> {
 
 Think broadcasts streaming responses to all connected WebSocket clients. When multiple browser tabs are connected to the same agent, all tabs see the streamed response in real time. Tool call states (pending, result, approval) are broadcast to all tabs.
 
+Programmatic `chat()` turns and `clearMessages()` also broadcast message updates to connected `useAgentChat` clients, so browser clients stay in sync without reconnecting.
+
 ## Agent tools
 
 Use [Agent tools](/agents/api-reference/agent-tools/) when a parent chat agent should run a Think sub-agent as a retained, streaming tool. The parent uses `agentTool()` or `runAgentTool()` from `agents/agent-tools`; the child Think instance keeps its own messages, tools, resumable stream, and storage.
@@ -1149,6 +1155,7 @@ async chat(
 
 | Method             | When it fires                                                   |
 | ------------------ | --------------------------------------------------------------- |
+| `onStart(event)`   | Before work starts; exposes the request ID for cancellation     |
 | `onEvent(json)`    | For each streaming chunk (JSON-serialized `UIMessageChunk`)     |
 | `onDone()`         | After the turn completes and the assistant message is persisted |
 | `onError(message)` | On error during the turn (if not provided, the error is thrown) |
@@ -1159,12 +1166,15 @@ async chat(
 | -------- | ------------------------------------------- |
 | `signal` | `AbortSignal` to cancel the turn mid-stream |
 
+Tools belong to the child agent. Define durable capabilities with the child's `getTools()`, extensions, MCP tools, or client tool schemas. Legacy callers that pass `options.tools` to `chat()` receive a warning and the value is ignored.
+
 #### Example: parent calling a child
 
 <TypeScriptExample>
 
 ```ts
 import { Think } from "@cloudflare/think";
+import type { StreamCallback } from "@cloudflare/think";
 
 export class ParentAgent extends Think<Env> {
 	getModel() {
@@ -1204,9 +1214,41 @@ export class ChildAgent extends Think<Env> {
 
 </TypeScriptExample>
 
-#### Aborting a sub-agent turn
+#### Cancelling a sub-agent turn
 
-Pass an `AbortSignal` to cancel mid-stream. When aborted, the partial assistant message is still persisted.
+Use `onStart` and `cancelChat()` for RPC-safe cancellation across a sub-agent boundary:
+
+<TypeScriptExample>
+
+```ts
+let requestId: string | undefined;
+
+const callback: StreamCallback = {
+	onStart(event) {
+		requestId = event.requestId;
+	},
+	onEvent(json) {
+		// Forward stream chunks.
+	},
+	onDone() {},
+	onError(error) {
+		console.error(error);
+	},
+};
+
+const turn = child.chat("Long analysis task", callback);
+
+// Later, from another RPC call or failure handler:
+if (requestId) {
+	await child.cancelChat(requestId, "client disconnected");
+}
+
+await turn;
+```
+
+</TypeScriptExample>
+
+If the caller and callee are not separated by Workers RPC, you can also pass an `AbortSignal` to cancel mid-stream:
 
 <TypeScriptExample>
 
@@ -1220,6 +1262,8 @@ await child.chat("Long analysis task", callback, {
 ```
 
 </TypeScriptExample>
+
+`cancelChat(requestId, reason?)` is a no-op if the turn already completed or the request ID is unknown. When aborted, the partial assistant message is still persisted.
 
 ### saveMessages
 

--- a/src/content/docs/agents/concepts/long-running-agents.mdx
+++ b/src/content/docs/agents/concepts/long-running-agents.mdx
@@ -17,7 +17,7 @@ The short version:
 - Agents are durable identities, not always-on processes.
 - State, SQL data, schedules, and fiber checkpoints survive hibernation and restarts.
 - In-memory variables, timers, open fetches, and local closures do not survive eviction.
-- Use `keepAlive()` for active work measured in minutes, `runFiber()` when work needs recovery, and Workflows for heavyweight multi-step jobs.
+- Use `keepAlive()` for active work measured in minutes, `runFiber()` when work needs recovery, `startFiber()` when callers need durable acceptance and status, and Workflows for heavyweight multi-step jobs.
 - Use sub-agents when one parent coordinates many long-lived child contexts.
 
 ## Why Cloudflare for long-running agents
@@ -60,7 +60,7 @@ State persists in SQLite. Agent restarts on next event.
 - **`this.sql` data** — all SQLite tables you create
 - **Scheduled tasks** — stored in SQLite, trigger alarms to wake the agent
 - **Connection state** — `connection.setState()` data for each WebSocket client
-- **Fiber checkpoints** — `stash()` data from `runFiber()`
+- **Fiber checkpoints and ledgers** — `stash()` data from `runFiber()` and retained `startFiber()` status rows
 
 Any higher-level abstractions built on SQLite also survive, since they share the same durable storage.
 
@@ -219,6 +219,7 @@ try {
 | ---------------- | ------------------------------------------------------- |
 | Seconds          | Normal request handling                                 |
 | Minutes          | `keepAlive()` / `keepAliveWhile()`                      |
+| Minutes          | `startFiber()` when retryable acceptance matters        |
 | Minutes to hours | [Workflows](/agents/concepts/workflows/)                |
 | Hours to days    | Async pattern: start job, hibernate, wake on completion |
 
@@ -227,6 +228,8 @@ try {
 An agent can be evicted at any time — a deploy, a platform restart, or hitting resource limits. If the agent was mid-task, that work is lost unless it was checkpointed.
 
 [`runFiber()`](/agents/api-reference/durable-execution/) provides crash-recoverable execution. It persists a row in SQLite for the duration of the work, and lets you `stash()` intermediate state. If the agent is evicted, the fiber row survives, and `onFiberRecovered()` is called on the next activation.
+
+Use [`startFiber()`](/agents/api-reference/durable-execution/#startfiber) when the important boundary is durable acceptance. It adds an idempotency key, retained status records, inspection, cancellation, and cleanup on top of the same fiber machinery. By default it returns after acceptance; pass `waitForCompletion: true` when the request should stay open until the accepted job reaches a terminal status. This is a good fit for webhooks where the provider may retry delivery and the agent must avoid starting duplicate visible side effects.
 
 ```ts
 export class ProjectManager extends Agent<ProjectState> {
@@ -670,6 +673,7 @@ Long-running agents on Cloudflare are not long-running processes. They are durab
 | **`schedule()` / `scheduleEvery()`**   | Wake the agent at future times               |
 | **`keepAlive()` / `keepAliveWhile()`** | Prevent eviction during active work          |
 | **`runFiber()` / `stash()`**           | Checkpoint and recover long tasks            |
+| **`startFiber()`**                     | Durably accept, inspect, and cancel jobs     |
 | **`chatRecovery`**                     | Recover interrupted LLM streams              |
 | **`onRequest()` / `onEmail()` / RPC**  | Wake on external events                      |
 | **`runWorkflow()`**                    | Delegate heavyweight multi-step work         |
@@ -690,7 +694,7 @@ The agent does not need to run continuously to do any of this. It just needs to 
 
 ## Related
 
-- [Durable Execution](/agents/api-reference/durable-execution/) — `runFiber()`, `stash()`, and crash recovery
+- [Durable Execution](/agents/api-reference/durable-execution/) — `runFiber()`, `startFiber()`, `stash()`, and crash recovery
 - [Schedule tasks](/agents/api-reference/schedule-tasks/) — delayed, cron, and interval tasks
 - [Retries](/agents/api-reference/retries/) — retry options and patterns
 - [Workflows](/agents/concepts/workflows/) — durable multi-step processing

--- a/src/content/docs/agents/concepts/memory.mdx
+++ b/src/content/docs/agents/concepts/memory.mdx
@@ -41,7 +41,7 @@ await session.appendMessage({
 });
 
 // Read the full conversation history
-const history = session.getHistory();
+const history = await session.getHistory();
 ```
 
 </TypeScriptExample>
@@ -55,7 +55,7 @@ The Session also provides full-text search across the conversation history:
 <TypeScriptExample>
 
 ```ts
-const results = session.search("deployment Friday", { limit: 10 });
+const results = await session.search("deployment Friday", { limit: 10 });
 ```
 
 </TypeScriptExample>
@@ -394,7 +394,7 @@ const allTools = { ...sessionTools, ...myApplicationTools };
 const result = streamText({
 	model: myModel,
 	system: await session.freezeSystemPrompt(),
-	messages: await convertToModelMessages(session.getHistory()),
+	messages: await convertToModelMessages(await session.getHistory()),
 	tools: allTools,
 });
 ```
@@ -543,7 +543,7 @@ Micro-compaction works at the individual message level rather than across ranges
 ```ts
 import { truncateOlderMessages } from "agents/experimental/memory/utils";
 
-const history = session.getHistory();
+const history = await session.getHistory();
 const truncated = truncateOlderMessages(history);
 // Pass truncated history to the LLM
 ```

--- a/src/content/docs/agents/guides/autonomous-responses.mdx
+++ b/src/content/docs/agents/guides/autonomous-responses.mdx
@@ -22,6 +22,7 @@ The key primitives:
 | ------------------- | ---------------------------------------------------------------------------------- |
 | `saveMessages`      | Inject a message and trigger the LLM — the server-side equivalent of `sendMessage` |
 | `submitMessages`    | Durably accept a Think turn for async execution and inspect it later               |
+| `startFiber`        | Durably accept application-owned side effects around a turn                        |
 | `persistMessages`   | Store messages without triggering a response — for injecting context silently      |
 | `onChatResponse`    | React when any response completes, including ones you did not initiate             |
 | `isServerStreaming` | Client-side flag: `true` when a server-initiated stream is active                  |
@@ -64,6 +65,8 @@ return Response.json({
 </TypeScriptExample>
 
 `submitMessages()` stores pending work first and appends the messages to the conversation Session only when the submission starts executing. It accepts serializable `UIMessage[]` values, not the function form supported by `saveMessages((messages) => ...)`.
+
+Use [`startFiber()`](/agents/api-reference/durable-execution/#startfiber) outside Think when the durable unit is a surrounding application job, such as accepting a webhook once, restoring provider state, posting a visible reply, and recording recovery policy. `submitMessages()` owns Think's conversation admission; managed fibers own external side effects around that turn.
 
 For the full Think API, refer to [`submitMessages()`](/agents/api-reference/think/#submitmessages).
 
@@ -470,6 +473,7 @@ The `messageConcurrency` setting on `AIChatAgent` controls how overlapping user 
 | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
 | `schedule()`       | Schedule a callback that calls `saveMessages` — see the cron example above                                        |
 | `queue()`          | Queue a method that calls `saveMessages` for deferred processing                                                  |
+| `startFiber()`     | Durably accept and inspect application-owned work around a message turn                                           |
 | `runWorkflow()`    | Start a Workflow; use `AgentWorkflow.agent` RPC to call a method that triggers `saveMessages` or `submitMessages` |
 | `onEmail()`        | Convert email content to a chat message and call `saveMessages`                                                   |
 | `onRequest()`      | Handle webhooks and call `saveMessages` or `submitMessages`                                                       |
@@ -504,6 +508,8 @@ if (result.status === "aborted") {
 `continueLastTurn()` accepts the same `options.signal` argument. `AbortSignal` objects cannot cross Durable Object RPC boundaries, and the signal is in memory only. If the Durable Object hibernates mid-turn and chat recovery is enabled, the recovered turn runs without the original signal.
 
 Use `cancelSubmission(submissionId)` for durable cancellation when work was accepted with `submitMessages()` or when cancellation must cross Worker and Durable Object RPC boundaries.
+
+Use `cancelFiber(fiberId)` when the durable unit was accepted with `startFiber()` and the cancellation should apply to the surrounding application job rather than a Think turn.
 
 ## Important notes
 

--- a/src/content/docs/agents/guides/webhooks.mdx
+++ b/src/content/docs/agents/guides/webhooks.mdx
@@ -519,6 +519,25 @@ class WebhookAgent extends Agent {
 
 </TypeScriptExample>
 
+If the asynchronous work is a single Think chat turn, use `submitMessages()` instead. It returns a durable submission ID immediately and lets retries use an idempotency key instead of duplicating the message turn:
+
+<TypeScriptExample>
+
+```ts
+const submission = await this.submitMessages(messages, {
+	idempotencyKey: payload.id,
+});
+
+return Response.json(
+	{ submissionId: submission.submissionId },
+	{ status: 202 },
+);
+```
+
+</TypeScriptExample>
+
+If the webhook owns application side effects around a turn, such as restoring a provider thread and posting a visible reply, use [`startFiber()`](/agents/api-reference/durable-execution/#startfiber) around that job. Managed fibers retain status, dedupe provider retries, and let `onFiberRecovered()` or `resolveFiber()` record the app-level recovery outcome.
+
 ### Multi-provider routing
 
 Handle webhooks from multiple services in one Worker:

--- a/src/content/docs/agents/index.mdx
+++ b/src/content/docs/agents/index.mdx
@@ -68,7 +68,7 @@ The starter includes streaming AI chat, server-side and client-side tools, human
 - **Use and serve tools** — Define server-side tools, client-side tools that run in the browser, and [human-in-the-loop](/agents/concepts/human-in-the-loop/) approval flows. Expose your agent's tools to other agents and LLMs via [MCP](/agents/api-reference/mcp-agent-api/).
 - **Act on their own** — [Schedule tasks](/agents/api-reference/schedule-tasks/) on a delay, at a specific time, or on a cron. Agents can wake themselves up, do work, and go back to sleep — without a user present.
 - **Browse the web** — Give your agents [browser tools](/agents/api-reference/browse-the-web/) powered by the Chrome DevTools Protocol to scrape, screenshot, debug, and interact with web pages.
-- **Talk to users** — Build real-time [voice agents](/agents/api-reference/voice/) with speech-to-text, text-to-speech, and conversation persistence — audio streams over WebSocket.
+- **Talk to users** — Build real-time [voice agents](/agents/api-reference/voice/) with speech-to-text, text-to-speech, and conversation persistence, or connect messenger platforms with [Chat SDK](/agents/api-reference/chat-sdk/) and store conversation state in Agents sub-agents.
 - **Orchestrate work** — Run multi-step [workflows](/agents/api-reference/run-workflows/) with automatic retries, coordinate across [sub-agents](/agents/api-reference/sub-agents/), or run chat-capable [agent tools](/agents/api-reference/agent-tools/) with retained streaming timelines.
 - **React to events** — Handle [inbound email](/agents/api-reference/email/) (see the [email agent example](https://github.com/cloudflare/agents/tree/main/examples/email-agent)), HTTP requests, WebSocket messages, and state changes — all from the same class.
 


### PR DESCRIPTION
## Summary
- Add a new Chat SDK reference page for integrating Chat SDK with Agents, including `createChatSdkState()`, `ChatSdkStateAgent`, sharding, cleanup behavior, and the messenger example.
- Document managed fiber APIs in durable execution docs, including `startFiber()`, inspection, cancellation, retained statuses, and recovery outcomes.
- Update Sessions docs for Postgres/Hyperdrive providers and the now-async Session API, including related memory examples.
- Refresh Think and sub-agent docs for RPC-safe `chat()` cancellation, `StreamCallback.onStart()`, programmatic broadcast behavior, `startFiber()` guidance, and facet-only/nested sub-agent configuration.

## Validation
- `pnpm exec prettier --write "src/content/docs/agents/api-reference/agents-api.mdx" "src/content/docs/agents/api-reference/chat-sdk.mdx" "src/content/docs/agents/api-reference/durable-execution.mdx" "src/content/docs/agents/api-reference/sessions.mdx" "src/content/docs/agents/api-reference/sub-agents.mdx" "src/content/docs/agents/api-reference/think.mdx" "src/content/docs/agents/concepts/long-running-agents.mdx" "src/content/docs/agents/concepts/memory.mdx" "src/content/docs/agents/guides/autonomous-responses.mdx" "src/content/docs/agents/guides/webhooks.mdx" "src/content/docs/agents/index.mdx"`
- `pnpm run check`

## Notes
- A full `pnpm run format:content` was attempted, but it hit unrelated pre-existing formatter errors outside the Agents docs tree. The accidental formatter churn was reverted, and only the targeted Agents docs files were formatted.
- A full local build was started and then canceled at request; `pnpm run check` passed.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/cloudflare-docs/pull/30987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->