### PR TITLE
RULES: add query string restriction note to CSV format page

### DIFF
--- a/src/content/docs/rules/url-forwarding/bulk-redirects/reference/csv-file-format.mdx
+++ b/src/content/docs/rules/url-forwarding/bulk-redirects/reference/csv-file-format.mdx
@@ -31,6 +31,7 @@ example.com/docs,https://example.com/draft-docs,302,,TRUE
 
 ## Important remarks
 
+- The source URL cannot include a query string. For details on which URL components are supported in source URLs, refer to [Supported URL components in Bulk Redirects](/rules/url-forwarding/bulk-redirects/reference/url-components/).
 - The CSV file must not include a header row with column names.
 - A source/target URL must be enclosed in quotes (`"`) when it includes a comma (`,`). You can always enclose URL values in quotes, but it is not required.
 - You can skip an optional value by immediately entering a comma (the delimiter) without entering any value.


### PR DESCRIPTION
### Summary

The CSV file format reference page did not mention that source URLs cannot include a query string. This omission caused customer confusion, as the restriction was only documented on the dashboard creation guide and not on the CSV reference page that customers link when filing tickets (e.g. case `02142476`).

Adds a note to the Important remarks section pointing to the supported URL components reference for full details.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
