### PR TITLE
Document granular permissions for Cloudflare Tunnel and Cloudflare Mesh

### DIFF
--- a/src/content/changelog/fundamentals/2026-05-21-tunnel-mesh-granular-permissions.mdx
+++ b/src/content/changelog/fundamentals/2026-05-21-tunnel-mesh-granular-permissions.mdx
@@ -1,0 +1,35 @@
+---
+title: Granular permissions for Cloudflare Tunnel and Cloudflare Mesh
+description: New resource-scoped permissions allow administrators to grant access to specific Cloudflare Tunnel instances and Cloudflare Mesh nodes instead of all tunnels and nodes in an account.
+products:
+  - fundamentals
+  - cloudflare-one
+  - cloudflare-tunnel-sase
+  - tunnel
+  - mesh
+date: 2026-05-21
+---
+
+You can now scope Cloudflare permissions to individual [Cloudflare Tunnel](/tunnel/) instances and [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) nodes. Administrators can delegate access to specific Tunnels or Mesh nodes without granting account-wide control over private networking.
+
+### What is new
+
+When you [add a member](/fundamentals/manage-members/manage/) or create a [permission policy](/fundamentals/manage-members/policies/), the resource picker now lists [Cloudflare Tunnel](/tunnel/) instances and [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) nodes as scopable resource types. You can:
+
+- Grant a read-only role on a single Cloudflare Tunnel instance to a support operator for log streaming and diagnostics — without exposing other Tunnels or destructive actions.
+- Grant a write role on a specific Cloudflare Mesh node to an application team — without giving them access to the rest of your private network.
+- Scope a single policy to one or many Tunnels and Mesh nodes at once.
+
+### How it works
+
+Granular permissions are a parallel layer to existing account-level roles — they do not replace them.
+
+- **Existing account-level roles continue to work.** A member with `Cloudflare Access` or `Cloudflare Zero Trust` retains write access to every Tunnel and Mesh node in the account. This ensures backward compatibility for existing automation and tokens.
+- **Granular permissions are additive.** For any API request on a specific Tunnel or Mesh node, access is granted if the principal has **either** the account-level role **or** a granular permission for that resource.
+- **Resource enumeration is authorization-aware.** Listing endpoints (`GET /accounts/{id}/cfd_tunnel`, `GET /accounts/{id}/warp_connector`) return only the resources the principal has at least read access to.
+
+### Get started
+
+- Configure [granular permissions for Cloudflare Tunnel](/tunnel/advanced/granular-permissions/).
+- Configure [granular permissions for Cloudflare Tunnel and Cloudflare Mesh in Cloudflare One](/cloudflare-one/networks/connectors/granular-permissions/).
+- Review the [resource-scoped roles](/fundamentals/manage-members/roles/#resource-scoped-roles) on the Cloudflare role reference.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx
@@ -115,3 +115,4 @@ Key differences:
 3. [**Add routes**](/cloudflare-one/networks/connectors/cloudflare-mesh/routes/) (optional) — Make subnets behind a Mesh node reachable from any device.
 4. [**Enable high availability**](/cloudflare-one/networks/connectors/cloudflare-mesh/high-availability/) (optional) — Run multiple replicas of a node for failover.
 5. [**Connect from Workers**](/workers-vpc/examples/connect-to-cloudflare-mesh/) (optional) — Use VPC Network bindings to reach private services from Cloudflare Workers.
+6. [**Delegate access**](/cloudflare-one/networks/connectors/granular-permissions/) (optional) — Scope member permissions to specific Mesh nodes instead of granting account-wide control.

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions.mdx
@@ -177,3 +177,7 @@ The tunnel token is now fully rotated. The old token is no longer in use.
 ## Account-scoped roles
 
 <Render file="tunnel/account-scoped-roles" product="cloudflare-one" />
+
+## Resource-scoped permissions
+
+You can also scope permissions to individual [Cloudflare Tunnel](/tunnel/) instances instead of granting account-wide access. Refer to [Granular permissions for Tunnels and Mesh nodes](/cloudflare-one/networks/connectors/granular-permissions/).

--- a/src/content/docs/cloudflare-one/networks/connectors/granular-permissions.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/granular-permissions.mdx
@@ -1,0 +1,67 @@
+---
+pcx_content_type: how-to
+title: Granular permissions for Tunnels and Mesh nodes
+description: Scope Cloudflare member permissions to individual Cloudflare Tunnel instances and Cloudflare Mesh nodes.
+sidebar:
+  order: 10
+products:
+  - cloudflare-one
+---
+
+import { Steps } from '~/components';
+
+You can scope Cloudflare member permissions to individual [Cloudflare Tunnel](/tunnel/) instances and [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) nodes, instead of granting account-wide access to every Tunnel and Mesh node. This enables least-privilege delegation for private networking operations — for example, letting a support operator stream logs from a single Tunnel without exposing the rest of your account.
+
+Granular permissions are a parallel layer to [account-scoped roles](/fundamentals/manage-members/roles/#account-scoped-roles) — they do not replace them. Members who already hold an account-level role like `Cloudflare Access` or `Cloudflare Zero Trust` continue to have write access to every Tunnel and Mesh node in the account.
+
+## How it works
+
+For any API request on a specific Tunnel or Mesh node, access is granted if the principal has **either**:
+
+- An account-level role that covers the resource (for example, `Cloudflare Access` or `Cloudflare Zero Trust`), **or**
+- A [resource-scoped role](/fundamentals/manage-members/roles/#resource-scoped-roles) bound to that specific Tunnel or Mesh node.
+
+[Resource enumeration endpoints](#resource-enumeration) (`GET /accounts/{id}/cfd_tunnel`, `GET /accounts/{id}/warp_connector`) return only the resources the principal has at least read access to.
+
+## Grant a granular permission
+
+Granular permissions are assigned through the standard [member management](/fundamentals/manage-members/manage/) flow.
+
+<Steps>
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Manage Account** > **Members** and select **Invite Members**, or open an existing member to edit their permissions.
+2. Add a permission policy and choose a [resource-scoped role](/fundamentals/manage-members/roles/#resource-scoped-roles) that targets Tunnels or Mesh nodes.
+3. In the **Scope** section, choose **Specific resources**.
+4. Set **Resource type** to one of:
+   - **Cloudflare Tunnel instances** — for individual [Cloudflare Tunnel](/tunnel/) instances.
+   - **Cloudflare Mesh nodes** — for individual [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) nodes.
+5. Select one or more specific Tunnels or Mesh nodes from the resource picker.
+6. Save the policy.
+</Steps>
+
+You can attach multiple granular policies to the same member to cover different Tunnels and Mesh nodes with different roles.
+
+## Resource enumeration
+
+Listing endpoints are authorization-aware. When a principal calls a listing endpoint, the response is filtered to the resources they have at least read access to.
+
+| Endpoint                                | Method | Returns                                                       |
+| --------------------------------------- | ------ | ------------------------------------------------------------- |
+| `/accounts/{account_id}/cfd_tunnel`     | `GET`  | Cloudflare Tunnel instances the principal can read or manage. |
+| `/accounts/{account_id}/warp_connector` | `GET`  | Cloudflare Mesh nodes the principal can read or manage.       |
+| `/accounts/{account_id}/teamnet/routes` | `GET`  | Routes attached to Tunnels the principal can read or manage.  |
+
+Members with an account-level role that covers Tunnels and Mesh continue to see all resources in the account.
+
+## Backward compatibility
+
+- Existing account-level roles and API tokens continue to function as before.
+- Existing automation that authenticates with an account-level token (for example, Terraform pipelines using a `Cloudflare Access` token) is unaffected.
+- Granular permissions are opt-in. Granting one to a member adds capability; it never removes capability that the member already has from an account-level role.
+
+## Related resources
+
+- [Roles reference](/fundamentals/manage-members/roles/) — the full list of Cloudflare roles, including resource-scoped roles for Tunnels and Mesh nodes.
+- [Role scopes](/fundamentals/manage-members/scope/) — how policy scopes work across account, domain, and resource layers.
+- [Manage account members](/fundamentals/manage-members/manage/) — the member invite and edit flow.
+- [Cloudflare Tunnel](/tunnel/)
+- [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/)

--- a/src/content/docs/fundamentals/manage-members/roles.mdx
+++ b/src/content/docs/fundamentals/manage-members/roles.mdx
@@ -130,6 +130,8 @@ Resource-scoped roles apply for a specific resource within an account.
 Resource-scoped roles is currently in Beta.
 :::
 
+You can also scope permissions to individual [Cloudflare Tunnel](/tunnel/) instances and [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) nodes. Refer to [Granular permissions for Cloudflare Tunnel](/tunnel/advanced/granular-permissions/) and [Granular permissions for Cloudflare Tunnel and Cloudflare Mesh in Cloudflare One](/cloudflare-one/networks/connectors/granular-permissions/).
+
 | Role                                      | Description                                                                                                                                       |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cloudflare Access App Admin               | Can edit a specific [Access application](/cloudflare-one/access-controls/applications/) in an account.                                            |

--- a/src/content/docs/fundamentals/manage-members/scope.mdx
+++ b/src/content/docs/fundamentals/manage-members/scope.mdx
@@ -116,6 +116,8 @@ You can assign the following resource-specific scopes to members:
 | Individual Access policies                   | Grant access to manage a specific [Access policy](/cloudflare-one/access-controls/policies/).                                                            |
 | Individual Access service tokens             | Grant access to manage a specific [Access service token](/cloudflare-one/access-controls/service-credentials/service-tokens/).                           |
 | Individual Access infrastructure targets     | Grant access to manage a specific [Access for Infrastructure target](/cloudflare-one/access-controls/applications/non-http/infrastructure-apps/).        |
+| Individual Cloudflare Tunnel instances       | Grant access to manage a specific [Cloudflare Tunnel](/tunnel/) instance.                                                                                |
+| Individual Cloudflare Mesh nodes             | Grant access to manage a specific [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) node.                                          |
 
 :::note
 When using scopes for specific resources, you can only assign [resource-scoped roles](/fundamentals/manage-members/roles/#resource-scoped-roles) to these members.

--- a/src/content/docs/tunnel/advanced/granular-permissions.mdx
+++ b/src/content/docs/tunnel/advanced/granular-permissions.mdx
@@ -1,0 +1,58 @@
+---
+title: Granular permissions
+pcx_content_type: how-to
+description: Scope Cloudflare member permissions to individual Cloudflare Tunnel instances.
+products:
+  - tunnel
+sidebar:
+  order: 5
+---
+
+You can scope Cloudflare member permissions to individual [Cloudflare Tunnel](/tunnel/) instances instead of granting account-wide access. This lets you delegate management of specific Tunnels — for example, letting an application team manage one Tunnel for its service without exposing every Tunnel in the account.
+
+Granular permissions are a parallel layer to account-level roles — they do not replace them. Members who already hold an account-level role like `Cloudflare Access` retain write access to every Tunnel in the account.
+
+## How it works
+
+For any API request on a specific Cloudflare Tunnel, access is granted if the principal has **either**:
+
+- An account-level role that covers Tunnels (for example, `Cloudflare Access`), **or**
+- A [resource-scoped role](/fundamentals/manage-members/roles/#resource-scoped-roles) bound to that specific Tunnel.
+
+[Listing endpoints](#resource-enumeration) (`GET /accounts/{id}/cfd_tunnel`, `GET /accounts/{id}/teamnet/routes`) return only the Tunnels and routes the principal has at least read access to.
+
+## Grant a granular permission
+
+Granular permissions are assigned through the standard [member management](/fundamentals/manage-members/manage/) flow.
+
+1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Manage Account** > **Members** and select **Invite Members**, or open an existing member to edit their permissions.
+2. Add a permission policy and choose a [resource-scoped role](/fundamentals/manage-members/roles/#resource-scoped-roles) that targets Cloudflare Tunnel instances.
+3. In the **Scope** section, choose **Specific resources**.
+4. Set **Resource type** to **Cloudflare Tunnel instances**.
+5. Select one or more specific Tunnels from the resource picker.
+6. Save the policy.
+
+You can attach multiple granular policies to the same member to cover different Tunnels with different roles.
+
+## Resource enumeration
+
+Listing endpoints are authorization-aware. When a principal calls a listing endpoint, the response is filtered to the Tunnels and routes they have at least read access to.
+
+| Endpoint                                | Method | Returns                                                       |
+| --------------------------------------- | ------ | ------------------------------------------------------------- |
+| `/accounts/{account_id}/cfd_tunnel`     | `GET`  | Cloudflare Tunnel instances the principal can read or manage. |
+| `/accounts/{account_id}/teamnet/routes` | `GET`  | Routes attached to Tunnels the principal can read or manage.  |
+
+Members with an account-level role that covers Tunnels continue to see all Tunnels in the account.
+
+## Backward compatibility
+
+- Existing account-level roles and API tokens continue to function as before.
+- Existing automation that authenticates with an account-level token (for example, Terraform pipelines using a `Cloudflare Access` token) is unaffected.
+- Granular permissions are opt-in. Granting one to a member adds capability; it never removes capability that the member already has from an account-level role.
+
+## Related resources
+
+- [Roles reference](/fundamentals/manage-members/roles/) — the full list of Cloudflare roles, including resource-scoped roles for Cloudflare Tunnel instances.
+- [Manage account members](/fundamentals/manage-members/manage/) — the member invite and edit flow.
+- [Granular permissions for Cloudflare Tunnel and Cloudflare Mesh in Cloudflare One](/cloudflare-one/networks/connectors/granular-permissions/) — the same RBAC capability applied to Cloudflare Mesh nodes alongside Tunnels.

--- a/src/content/docs/tunnel/configuration.mdx
+++ b/src/content/docs/tunnel/configuration.mdx
@@ -145,3 +145,9 @@ The most commonly used parameters:
 | [`connectTimeout`](/tunnel/advanced/origin-parameters/#connecttimeout)     | `30s`   | TCP connection timeout to origin          |
 
 For the complete list of origin parameters and setup instructions, refer to [Origin parameters](/tunnel/advanced/origin-parameters/).
+
+## Permissions
+
+You can scope Cloudflare member permissions to individual [Cloudflare Tunnel](/tunnel/) instances instead of granting account-wide access. This lets you delegate management of specific Tunnels — for example, letting an application team manage one Tunnel without exposing the rest of your account.
+
+Refer to [Granular permissions](/tunnel/advanced/granular-permissions/).


### PR DESCRIPTION
### Summary

Documents the granular resource-based RBAC capability for Cloudflare Tunnel instances and Cloudflare Mesh nodes. The RBAC change applies across Cloudflare One private networking, Cloudflare Tunnel for origin protection, and Workers VPC — this PR documents it for all three audiences.

**What ships with this PR**

- **Changelog entry** — `src/content/changelog/fundamentals/2026-05-21-tunnel-mesh-granular-permissions.mdx`, tagged across `fundamentals`, `cloudflare-one`, `cloudflare-tunnel-sase`, `tunnel`, and `mesh` so the entry appears on every relevant product feed. Leads with the new capability rather than a status badge.

- **Cloudflare One how-to** — `src/content/docs/cloudflare-one/networks/connectors/granular-permissions.mdx`. Covers both Tunnel and Mesh in a single page since the Cloudflare One dashboard surfaces them as siblings in the resource picker.

- **Cloudflare Tunnel-specific how-to** — `src/content/docs/tunnel/advanced/granular-permissions.mdx`. Tunnel-only framing for developers using Tunnel for origin protection or Workers VPC. Cross-links to the Cloudflare One how-to as the related Mesh resource.

- **Cross-links** added from:
  - `cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/remote-tunnel-permissions.mdx` — new "Resource-scoped permissions" section.
  - `cloudflare-one/networks/connectors/cloudflare-mesh/index.mdx` — added a "Delegate access" bullet to the Mesh overview "Next steps" list.
  - `tunnel/configuration.mdx` — new "Permissions" section pointing to the Tunnel-only how-to.

Each audience lands on the page that matches their product framing. The changelog "Get started" list surfaces both how-tos.

**Deliberately out of scope for this PR**

- `src/content/docs/fundamentals/manage-members/roles.mdx` is not modified. The existing Resource-scoped roles table enumerates each role by exact dashboard name. The Tunnel/Mesh role names are owned by the backend IAM catalog and will be added in a follow-up once the exact strings are confirmed. The existing `Resource-scoped roles is currently in Beta` note covers the umbrella RBAC capability and is left untouched.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry?
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] Larger change with an issue: tracked under [SHIP-12258](https://jira.cfdata.org/browse/SHIP-12258).
- [x] No file moves; no redirects needed.

### Validation

- `prettier --check` passes for all new files and the changelog. `tunnel/configuration.mdx` reports pre-existing tab-vs-space style warnings on lines I did not touch; the appended Permissions section is prettier-clean.
- `astro check` is currently failing across the entire repo on Starlight sidebar schema validation (`autogenerate` shape) — this is pre-existing and unrelated to the files in this PR.
