### PR TITLE
chore: Add cdeath and rubenalex to Radar CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -254,8 +254,8 @@ package.json @cloudflare/content-engineering
 
 # Radar
 
-/src/content/docs/radar/ @cloudflare/radar @cloudflare/product-owners
-/src/content/release-notes/radar.yaml @cloudflare/radar @cloudflare/product-owners
+/src/content/docs/radar/ @cdeath @rubenalex @cloudflare/radar @cloudflare/product-owners
+/src/content/release-notes/radar.yaml @cdeath @rubenalex @cloudflare/radar @cloudflare/product-owners
 
 # Reference architecture
 


### PR DESCRIPTION
### Summary

Adds `@cdeath` and `@rubenalex` as individual code owners for the Radar docs and release notes paths, alongside the existing `@cloudflare/radar` and `@cloudflare/product-owners` teams.
