### PR TITLE
CF1: mDNSResponder troubleshooting for Apple/Container

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/client-errors.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/client-errors.mdx
@@ -105,10 +105,10 @@ Below is a non-exhaustive list of third-party software that are known to cause `
   1. Stop/quit all VMs.
   2. Connect the Cloudflare One Client.
   3. Start the VMs again.
-- **Apple/Container** [Apple Container](https://github.com/apple/container) will also bind mDNSResponder to port 53 if started before Cloudflare One Client (or while the Client is stopped).
-  1. on macOS, run this in the terminal to temporarily stop the "container system": `container system stop`
-  2. Cloudflare One Client DNS mode should now start up with no errors.
-  3. You can then restart the container system (`container system start`) and pass explicit DNS flags when running Containers
+- **Apple/Container**: [Apple Container](https://github.com/apple/container) will also bind `mDNSResponder` to port `53` if started before Cloudflare One Client (or while the Client is stopped).
+  1. On macOS, run this in the terminal to temporarily stop the container system: `container system stop`
+  2. Cloudflare One Client DNS mode should now start with no errors.
+  3. You can then restart the container system (`container system start`) and pass explicit DNS flags when running containers.
 
 </Details>
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/client-errors.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/client-errors.mdx
@@ -105,7 +105,7 @@ Below is a non-exhaustive list of third-party software that are known to cause `
   1. Stop/quit all VMs.
   2. Connect the Cloudflare One Client.
   3. Start the VMs again.
-- **Apple Container**: [Apple Container](https://github.com/apple/container) will also bind `mDNSResponder` to port `53` if started before Cloudflare One Client (or while the Client is stopped).
+- **Apple Container**: [Apple Container](https://github.com/apple/container) will also bind `mDNSResponder` to port `53` if started before the Cloudflare One Client (or while the Client is stopped).
   1. On macOS, run this in the terminal to temporarily stop the container system: `container system stop`
   2. Cloudflare One Client DNS mode should now start with no errors.
   3. You can then restart the container system (`container system start`) and pass explicit DNS flags when running containers.

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/client-errors.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/client-errors.mdx
@@ -105,7 +105,7 @@ Below is a non-exhaustive list of third-party software that are known to cause `
   1. Stop/quit all VMs.
   2. Connect the Cloudflare One Client.
   3. Start the VMs again.
-- **Apple/Container**: [Apple Container](https://github.com/apple/container) will also bind `mDNSResponder` to port `53` if started before Cloudflare One Client (or while the Client is stopped).
+- **Apple Container**: [Apple Container](https://github.com/apple/container) will also bind `mDNSResponder` to port `53` if started before Cloudflare One Client (or while the Client is stopped).
   1. On macOS, run this in the terminal to temporarily stop the container system: `container system stop`
   2. Cloudflare One Client DNS mode should now start with no errors.
   3. You can then restart the container system (`container system start`) and pass explicit DNS flags when running containers.

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/client-errors.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/client-errors.mdx
@@ -105,6 +105,10 @@ Below is a non-exhaustive list of third-party software that are known to cause `
   1. Stop/quit all VMs.
   2. Connect the Cloudflare One Client.
   3. Start the VMs again.
+- **Apple/Container** [Apple Container](https://github.com/apple/container) will also bind mDNSResponder to port 53 if started before Cloudflare One Client (or while the Client is stopped).
+  1. on macOS, run this in the terminal to temporarily stop the "container system": `container system stop`
+  2. Cloudflare One Client DNS mode should now start up with no errors.
+  3. You can then restart the container system (`container system start`) and pass explicit DNS flags when running Containers
 
 </Details>
 


### PR DESCRIPTION
Added troubleshooting steps to resolve CF_DNS_PROXY_FAILURE caused by mDNSResponder binding to port :53 when the container system is started before Cloudflare One Client or while CloudFlare One Client is turned off.

### Summary

Reproducing

- Stop Cloudflare One Client
- Start Apple Container Framework
- Launch any container
- Try to start Cloudflare one Client DNS - This should fail
- Stop the container system (This must be completely stopped - stopping just the running container will not do it)
- Cloudflare One Client (DNS) should automatically recover and bind to port :53
- The container system can then be restarted and containers executed with custom DNS flags (known issue) 

### Screenshots (optional)
<img width="523" height="451" alt="Screenshot 2026-05-21 at 18 53 00" src="https://github.com/user-attachments/assets/e0ac6475-fd58-437e-90c9-eb940e370810" />
<img width="618" height="108" alt="Screenshot 2026-05-21 at 18 53 33" src="https://github.com/user-attachments/assets/3d7e1265-f981-479d-9b20-ba3144eef59f" />
<img width="1109" height="244" alt="Screenshot 2026-05-21 at 18 55 05" src="https://github.com/user-attachments/assets/017a6fef-9737-4980-aa6a-cc73be296bfa" />
<img width="613" height="98" alt="Screenshot 2026-05-21 at 18 55 36" src="https://github.com/user-attachments/assets/5502014a-7a55-43b4-8bb3-f9fe2c33eb50" />
<img width="530" height="478" alt="Screenshot 2026-05-21 at 18 56 15" src="https://github.com/user-attachments/assets/749893ff-38d2-4967-aca1-2e27800ef289" />



### Documentation checklist

<!-- Remove items that do not apply -->

- [ x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
