### PR TITLE
[Workers VPC] Note Cloudflare Source IP prerequisite for WAN destinations

### DIFF
--- a/src/content/changelog/workers-vpc/2026-05-21-vpc-networks-cloudflare-wan.mdx
+++ b/src/content/changelog/workers-vpc/2026-05-21-vpc-networks-cloudflare-wan.mdx
@@ -35,4 +35,10 @@ At runtime, the URL you pass to `fetch()` determines the destination:
 const response = await env.PRIVATE_NETWORK.fetch("http://10.50.0.100:8080/api");
 ```
 
+:::note
+
+For destinations behind Cloudflare WAN on-ramps (GRE, IPsec, or CNI), the same prerequisite that applies to other Cloudflare services applies here: your network must route the [Cloudflare Source IP range](/cloudflare-wan/configuration/manually/how-to/configure-cloudflare-source-ips/) back through the on-ramp so reply traffic returns to Cloudflare. Without this route, stateful flows will fail. This is part of standard Cloudflare WAN onboarding.
+
+:::
+
 For configuration options, refer to [VPC Networks](/workers-vpc/configuration/vpc-networks/).

--- a/src/content/changelog/workers-vpc/2026-05-21-vpc-networks-cloudflare-wan.mdx
+++ b/src/content/changelog/workers-vpc/2026-05-21-vpc-networks-cloudflare-wan.mdx
@@ -37,7 +37,7 @@ const response = await env.PRIVATE_NETWORK.fetch("http://10.50.0.100:8080/api");
 
 :::note
 
-For destinations behind Cloudflare WAN on-ramps (GRE, IPsec, or CNI), the same prerequisite that applies to other Cloudflare services applies here: your network must route the [Cloudflare Source IP range](/cloudflare-wan/configuration/manually/how-to/configure-cloudflare-source-ips/) back through the on-ramp so reply traffic returns to Cloudflare. Without this route, stateful flows will fail. This is part of standard Cloudflare WAN onboarding.
+For destinations behind Cloudflare WAN on-ramps (GRE, IPsec, or CNI), your network must route the [Cloudflare source IP range](/cloudflare-wan/configuration/how-to/configure-cloudflare-source-ips/) back through the on-ramp so reply traffic returns to Cloudflare. Without this route, stateful flows will fail. This is part of standard Cloudflare WAN onboarding.
 
 :::
 

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -66,7 +66,7 @@ Use `cf1:network` when:
 
 Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/), [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) node, or [Cloudflare WAN](/cloudflare-wan/) on-ramp that can reach the target services.
 
-For destinations behind Cloudflare WAN on-ramps (GRE, IPsec, or CNI), your network must also route the [Cloudflare Source IP range](/cloudflare-wan/configuration/manually/how-to/configure-cloudflare-source-ips/) (`100.64.0.0/12` by default) back through the on-ramp so reply traffic returns to Cloudflare. This is part of standard Cloudflare WAN onboarding; if you have already configured this for Gateway, Load Balancing, or other Cloudflare services that reach your private network through Cloudflare WAN, no additional setup is required.
+For destinations behind Cloudflare WAN on-ramps (GRE, IPsec, or CNI), your network must also route the [Cloudflare source IP range](/cloudflare-wan/configuration/how-to/configure-cloudflare-source-ips/) (`100.64.0.0/12` by default) back through the on-ramp so reply traffic returns to Cloudflare. This is part of standard Cloudflare WAN onboarding. If you have already configured this for Gateway, Load Balancing, or other Cloudflare services that reach your private network through Cloudflare WAN, no additional setup is required.
 
 :::
 

--- a/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
+++ b/src/content/docs/workers-vpc/configuration/vpc-networks/index.mdx
@@ -66,6 +66,8 @@ Use `cf1:network` when:
 
 Your account must have at least one active [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/), [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) node, or [Cloudflare WAN](/cloudflare-wan/) on-ramp that can reach the target services.
 
+For destinations behind Cloudflare WAN on-ramps (GRE, IPsec, or CNI), your network must also route the [Cloudflare Source IP range](/cloudflare-wan/configuration/manually/how-to/configure-cloudflare-source-ips/) (`100.64.0.0/12` by default) back through the on-ramp so reply traffic returns to Cloudflare. This is part of standard Cloudflare WAN onboarding; if you have already configured this for Gateway, Load Balancing, or other Cloudflare services that reach your private network through Cloudflare WAN, no additional setup is required.
+
 :::
 
 Bind to Cloudflare Mesh using `network_id: "cf1:network"`:


### PR DESCRIPTION
### Summary

Follow-up to [#30973](https://github.com/cloudflare/cloudflare-docs/pull/30973). Customers reaching Cloudflare WAN destinations from Workers VPC need the [Cloudflare Source IP range](https://developers.cloudflare.com/cloudflare-wan/configuration/manually/how-to/configure-cloudflare-source-ips/) routed back through their on-ramp for stateful flows to work. This is part of standard Cloudflare WAN onboarding, but without it `fetch()` calls hang and developers might get burned.

Adds a small prerequisite note to:

- The VPC Networks concept doc — combined into the existing `:::note` callout
- The 2026-05-21 changelog entry — as a `:::note` after the runtime example

Both point at the existing public Configure Cloudflare source IPs how-to.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
