### PR TITLE
[Tunnel] Document IPv6 service address format

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/protocols-table.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/protocols-table.mdx
@@ -19,3 +19,17 @@ The table below lists the service types you can route to a public hostname. Non-
 | HTTP_STATUS  | Responds to all requests with a fixed HTTP status code. | `http_status:404` |
 | BASTION      | Allows `cloudflared` to act as a jump host, providing access to any local address. | `bastion` |
 | HELLO_WORLD  | Test server for validating your Cloudflare Tunnel connection (for <a href={props.locallyManagedTunnelsURL}>locally managed tunnels</a> only). | `hello_world` |
+
+## IPv6 service addresses
+
+When the service value is an IPv6 literal, wrap the address in square brackets as defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2). The brackets are required so that the `:` characters in the address are not confused with the port separator.
+
+| Service type | Example `service` value     |
+| ------------ | --------------------------- |
+| HTTP         | `http://[2001:db8::1]:8000` |
+| HTTPS        | `https://[2001:db8::1]:443` |
+| TCP          | `tcp://[2001:db8::1]:2222`  |
+| SSH          | `ssh://[2001:db8::1]:22`    |
+| RDP          | `rdp://[2001:db8::1]:3389`  |
+
+Hostnames and IPv4 addresses do not need brackets — `http://localhost:8000` and `http://192.0.2.1:8000` are valid as-is.


### PR DESCRIPTION
Adds an **IPv6 service addresses** section to the shared `protocols-table.mdx` partial used by both `/tunnel/routing/` and `/cloudflare-one/networks/connectors/cloudflare-tunnel/routing-to-tunnel/protocols/`.

## What it documents

When the service value for a published application is an IPv6 literal, the address must be wrapped in square brackets (`[ ]`) per [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2). The brackets are required so the `:` characters in the address are not confused with the port separator.

Example: `https://[2001:db8::1]:443`

## Why

The dashboard requires bracketed IPv6 service URLs but the docs did not mention IPv6 anywhere in the tunnel routing / protocols pages, leading users to think it might be a UI quirk. It is not — `cloudflared` parses the service value through Go's standard `net/url.Parse`, which follows RFC 3986 and requires the bracket form (verified in [`ingress/ingress.go`](https://github.com/cloudflare/cloudflared/blob/master/ingress/ingress.go) `validateIngress`).

## Scope

Single partial edit, +14 lines, no other files touched. The partial is rendered in both products so the docs change ships in `/tunnel/` and the CF1 Tunnel docs in one commit.