### PR TITLE
Fix incorrect header names in mTLS Managed Transform documentation

### DIFF
--- a/src/content/docs/rules/transform/managed-transforms/reference.mdx
+++ b/src/content/docs/rules/transform/managed-transforms/reference.mdx
@@ -57,8 +57,8 @@ Adds HTTP headers with [Mutual TLS](/api-shield/security/mtls/) (mTLS) client au
 - `cf-cert-subject-dn-legacy`: Value from the [`cf.tls_client_auth.cert_subject_dn_legacy`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_subject_dn_legacy/) field.
 - `cf-cert-serial`: Value from the [`cf.tls_client_auth.cert_serial`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_serial/) field.
 - `cf-cert-issuer-serial`: Value from the [`cf.tls_client_auth.cert_issuer_serial`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_issuer_serial/) field.
-- `cf-cert-fingerprint-sha256`: Value from the [`cf.tls_client_auth.cert_fingerprint_sha256`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_fingerprint_sha256/) field.
-- `cf-cert-fingerprint-sha1`: Value from the [`cf.tls_client_auth.cert_fingerprint_sha1`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_fingerprint_sha1/) field.
+- `cf-cert-sha256`: Value from the [`cf.tls_client_auth.cert_fingerprint_sha256`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_fingerprint_sha256/) field.
+- `cf-cert-sha1`: Value from the [`cf.tls_client_auth.cert_fingerprint_sha1`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_fingerprint_sha1/) field.
 - `cf-cert-not-before`: Value from the [`cf.tls_client_auth.cert_not_before`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_not_before/) field.
 - `cf-cert-not-after`: Value from the [`cf.tls_client_auth.cert_not_after`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_not_after/) field.
 - `cf-cert-ski`: Value from the [`cf.tls_client_auth.cert_ski`](/ruleset-engine/rules-language/fields/reference/cf.tls_client_auth.cert_ski/) field.


### PR DESCRIPTION
### Summary

The documentation for the "Add TLS client auth headers" Managed Transform Rule is incorrect. It is not possible to build a functional implementation against this documentation, because the header names are wrong.

Cloudflare does not send any header named `cf-cert-fingerprint-sha256` or `cf-cert-fingerprint-sha1`. Instead, the headers are named `cf-cert-sha256` and `cf-cert-sha1`.