### PR TITLE
[Access] Add API reference examples for MCP portal and server management

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -230,9 +230,10 @@ Unlike the dashboard, the API does not automatically create a DNS record for you
 
 ### Create an MCP server
 
-<APIRequest
-	path="/accounts/{account_id}/access/ai-controls/mcp/servers"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/ai-controls/mcp/servers"
 	method="POST"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 	json={{
 		name: "GitHub MCP Server",
 		hostname: "https://github-mcp.example.workers.dev/mcp",

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -11,7 +11,7 @@ sidebar:
   label: MCP server portals
 ---
 
-import { Render, Tabs, TabItem, APIRequest } from "~/components";
+import { Render, Tabs, TabItem, APIRequest, CURL } from "~/components";
 
 An MCP server portal centralizes multiple [Model Context Protocol (MCP) servers](https://www.cloudflare.com/learning/ai/what-is-model-context-protocol-mcp/) onto a single HTTP endpoint.
 
@@ -209,9 +209,10 @@ Unlike the dashboard, the API does not automatically create a DNS record for you
 
 ### Create a portal
 
-<APIRequest
-	path="/accounts/{account_id}/access/ai-controls/mcp/portals"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/ai-controls/mcp/portals"
 	method="POST"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 	json={{
 		name: "Engineering Portal",
 		hostname: "mcp.example.com",
@@ -323,9 +324,10 @@ To turn off code mode for a portal:
 
 2. Send a `PUT` request to the [Update a MCP Portal](/api/resources/zero_trust/subresources/access/subresources/ai_controls/subresources/mcp/subresources/portals/methods/update/) endpoint with `allow_code_mode` set to `false`. To avoid overwriting your existing configuration, the `PUT` request body should contain all fields returned by the previous `GET` request.
 
-   <APIRequest
-   	path="/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
+   <CURL
+   	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
    	method="PUT"
+   	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
    	json={{
    		allow_code_mode: false,
    	}}

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -11,7 +11,7 @@ sidebar:
   label: MCP server portals
 ---
 
-import { Render, Tabs, TabItem, APIRequest, CURL } from "~/components";
+import { Render, Tabs, TabItem, CURL } from "~/components";
 
 An MCP server portal centralizes multiple [Model Context Protocol (MCP) servers](https://www.cloudflare.com/learning/ai/what-is-model-context-protocol-mcp/) onto a single HTTP endpoint.
 
@@ -202,9 +202,10 @@ Unlike the dashboard, the API does not automatically create a DNS record for you
 
 ### List portals
 
-<APIRequest
-	path="/accounts/{account_id}/access/ai-controls/mcp/portals"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/ai-controls/mcp/portals"
 	method="GET"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
 ### Create a portal
@@ -223,9 +224,10 @@ Unlike the dashboard, the API does not automatically create a DNS record for you
 
 ### List MCP servers
 
-<APIRequest
-	path="/accounts/{account_id}/access/ai-controls/mcp/servers"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/ai-controls/mcp/servers"
 	method="GET"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
 ### Create an MCP server
@@ -253,16 +255,18 @@ The `auth_type` field accepts the following values:
 
 To manually trigger a synchronization of tools and prompts from an upstream MCP server:
 
-<APIRequest
-	path="/accounts/{account_id}/access/ai-controls/mcp/servers/{server_id}/sync"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/ai-controls/mcp/servers/{server_id}/sync"
 	method="POST"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
 ### Delete a portal
 
-<APIRequest
-	path="/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
+<CURL
+	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
 	method="DELETE"
+	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
 />
 
 ## Code mode
@@ -318,9 +322,10 @@ To turn off code mode for a portal:
 
 1. Get your existing MCP portal configuration:
 
-   <APIRequest
-   	path="/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
+   <CURL
+   	url="https://api.cloudflare.com/client/v4/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
    	method="GET"
+   	headers={{ Authorization: "Bearer $CLOUDFLARE_API_TOKEN" }}
    />
 
 2. Send a `PUT` request to the [Update a MCP Portal](/api/resources/zero_trust/subresources/access/subresources/ai_controls/subresources/mcp/subresources/portals/methods/update/) endpoint with `allow_code_mode` set to `false`. To avoid overwriting your existing configuration, the `PUT` request body should contain all fields returned by the previous `GET` request.

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -192,6 +192,77 @@ Alias values must be 1-40 characters and can only contain letters, numbers, hyph
 
 All tools exposed through a portal are automatically namespaced with the server ID as a prefix. For example, a tool named `list_issues` on a server with ID `github` will appear as `github_list_issues` in the portal. This prevents name collisions when multiple MCP servers expose tools with the same name.
 
+## Manage portals via API
+
+In addition to the dashboard, you can manage MCP server portals programmatically using the Cloudflare API. The following examples show common operations.
+
+:::caution
+Unlike the dashboard, the API does not automatically create a DNS record for your portal hostname. After creating a portal via the API, you must create a proxied CNAME record that points your portal subdomain to `gateway.agents.cloudflare.com`. Without this record, the portal will return `522` errors.
+:::
+
+### List portals
+
+<APIRequest
+	path="/accounts/{account_id}/access/ai-controls/mcp/portals"
+	method="GET"
+/>
+
+### Create a portal
+
+<APIRequest
+	path="/accounts/{account_id}/access/ai-controls/mcp/portals"
+	method="POST"
+	json={{
+		name: "Engineering Portal",
+		hostname: "mcp.example.com",
+		allow_code_mode: true,
+		secure_web_gateway: false,
+	}}
+/>
+
+### List MCP servers
+
+<APIRequest
+	path="/accounts/{account_id}/access/ai-controls/mcp/servers"
+	method="GET"
+/>
+
+### Create an MCP server
+
+<APIRequest
+	path="/accounts/{account_id}/access/ai-controls/mcp/servers"
+	method="POST"
+	json={{
+		name: "GitHub MCP Server",
+		hostname: "https://github-mcp.example.workers.dev/mcp",
+		auth_type: "oauth",
+	}}
+/>
+
+The `auth_type` field accepts the following values:
+
+| Value | Description |
+| ----- | ----------- |
+| `oauth` | The server requires OAuth authentication. After creating the server, you will need to authenticate via the dashboard to establish admin credentials. |
+| `bearer` | The server uses a static bearer token for authentication. Provide the token in `auth_credentials`. |
+| `unauthenticated` | The server does not require authentication. |
+
+### Force sync an MCP server
+
+To manually trigger a synchronization of tools and prompts from an upstream MCP server:
+
+<APIRequest
+	path="/accounts/{account_id}/access/ai-controls/mcp/servers/{server_id}/sync"
+	method="POST"
+/>
+
+### Delete a portal
+
+<APIRequest
+	path="/accounts/{account_id}/access/ai-controls/mcp/portals/{id}"
+	method="DELETE"
+/>
+
 ## Code mode
 
 [Code mode](/agents/api-reference/codemode/) is turned on by default on all MCP server portals. It reduces context window usage by collapsing all tools in the portal into a single `code` tool. Instead of loading a separate tool definition for each upstream MCP server tool, the connected AI agent writes JavaScript that calls typed `codemode.*` methods. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, which keeps authentication credentials and environment variables out of the model context.


### PR DESCRIPTION
## What this PR does

Adds a new 'Manage portals via API' section with inline API examples for:

- List portals
- Create a portal
- List MCP servers
- Create an MCP server (with `auth_type` reference table: `oauth`, `bearer`, `unauthenticated`)
- Force sync an MCP server
- Delete a portal

## Why

The existing docs only showed API examples for toggling code mode (GET + PUT). Users who want to automate portal management via API had no examples for the core CRUD operations. This blocks CI/CD pipelines and programmatic portal management.