### PR TITLE
[Access] Add architecture, transport, limits, and built-in tools for MCP portals

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -35,6 +35,70 @@ MCP server portals provide the following capabilities:
 
 - **Observability**: Once the user's AI agent is connected to the portal, Cloudflare Access logs the individual requests made using the tools in the portal. You can optionally route portal traffic through [Cloudflare Gateway](#route-portal-traffic-through-gateway) for richer HTTP logging and data loss prevention (DLP) scanning.
 
+## How it works
+
+When a user connects an MCP client to a portal, the following flow occurs:
+
+1. The MCP client sends a request to the portal URL (`https://<subdomain>.<domain>/mcp`).
+2. Cloudflare Access authenticates the user via a browser-based OAuth 2.0 flow (or [service token](#connect-with-a-service-token) headers).
+3. The portal establishes an MCP session and returns the list of available tools from all enabled upstream servers.
+4. When the user calls a tool, the portal identifies the target upstream MCP server based on the [tool namespace](#tool-namespacing), attaches the appropriate credentials (user OAuth token or admin credential), and proxies the request.
+5. If [Gateway routing](#route-portal-traffic-through-gateway) is turned on, the outbound request passes through Cloudflare Gateway for HTTP logging and DLP inspection before reaching the upstream server.
+6. The upstream server's response is returned to the MCP client.
+
+### Transport
+
+The portal connects to upstream MCP servers using [Streamable HTTP](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/#streamable-http) or [SSE](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#server-sent-events-sse-deprecated) transport. You do not need to specify which transport your upstream server uses. The portal automatically detects the correct transport by trying multiple connection strategies in order:
+
+| Upstream URL pattern | Connection strategies (in order) |
+| -------------------- | -------------------------------- |
+| Ends in `/mcp` | Streamable HTTP only |
+| Ends in `/sse` | SSE (or Streamable HTTP if Gateway routing is turned on) |
+| All other URLs | Streamable HTTP on original URL, then SSE on original URL, then Streamable HTTP on `{url}/mcp`, then SSE on `{url}/sse` |
+
+If a connection attempt returns a `404`, `405`, or `406` error, the portal falls back to the next strategy. All other errors stop the connection attempt.
+
+### Built-in portal tools
+
+Every portal exposes the following built-in tools to MCP clients, in addition to the upstream server tools:
+
+| Tool | Description |
+| ---- | ----------- |
+| `portal_list_servers` | Lists all available upstream servers with their ID, name, and whether they are currently turned on. |
+| `portal_toggle_servers` | Opens a URL-based server selection page where you can turn servers on or off. |
+| `portal_toggle_single_server` | Turns a single server on or off by server ID, without leaving the MCP client. |
+
+When [context optimization](#optimize-context) is turned on, additional tools are exposed depending on the mode:
+
+| Mode | Additional tools |
+| ---- | ---------------- |
+| `minimize_tools` | `portal_query_tools` — Search tools by regex pattern and return full definitions. |
+| `search_and_execute` | `portal_query_tools` and `portal_execute` — Search tools and execute them via proxy. |
+
+### Session lifecycle
+
+Each MCP client connection creates a session that persists until the user disconnects or the session expires due to inactivity. Sessions expire after 24 hours of inactivity.
+
+Within a session, users can turn individual servers on or off without disconnecting. Server toggles are scoped to the session and do not affect other users or sessions on the same portal.
+
+### Naming
+
+MCP server portals were previously referred to as **Agents Gateway** in some contexts. The API paths, Terraform resources, and internal codebases may still use `agents_gateway` or `agw` prefixes. The product name is **MCP server portals** and the dashboard navigation is **AI controls**.
+
+## Limits
+
+| Resource | Limit |
+| -------- | ----- |
+| MCP servers per portal | 20 |
+| Custom domains per portal | 5 |
+| Portal name length | 350 characters |
+| Server name length | 350 characters |
+| Description length | 512 characters |
+| Tool alias length | 40 characters |
+| Portal ID length | 1-32 characters (lowercase alphanumeric and hyphens) |
+| Server ID length | 1-32 characters (lowercase alphanumeric and hyphens) |
+| Session inactivity timeout | 24 hours |
+
 ## Prerequisites
 
 - An [active domain on Cloudflare](/fundamentals/manage-domains/add-site/)

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -85,20 +85,6 @@ Within a session, users can turn individual servers on or off without disconnect
 
 MCP server portals were previously referred to as **Agents Gateway** in some contexts. The API paths, Terraform resources, and internal codebases may still use `agents_gateway` or `agw` prefixes. The product name is **MCP server portals** and the dashboard navigation is **AI controls**.
 
-## Limits
-
-| Resource | Limit |
-| -------- | ----- |
-| MCP servers per portal | 20 |
-| Custom domains per portal | 5 |
-| Portal name length | 350 characters |
-| Server name length | 350 characters |
-| Description length | 512 characters |
-| Tool alias length | 40 characters |
-| Portal ID length | 1-32 characters (lowercase alphanumeric and hyphens) |
-| Server ID length | 1-32 characters (lowercase alphanumeric and hyphens) |
-| Session inactivity timeout | 24 hours |
-
 ## Prerequisites
 
 - An [active domain on Cloudflare](/fundamentals/manage-domains/add-site/)

--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -30,7 +30,9 @@ This page lists the default account limits for rules, applications, fields, and 
 | Domains per application  | 5     |
 | Infrastructure targets   | 5,000 |
 | MCP portals              | 20    |
-| MCP servers per portal   | 10    |
+| MCP servers per portal   | 20    |
+| Custom domains per MCP portal | 5 |
+| MCP portal session inactivity timeout | 24 hours |
 
 ## Gateway
 
@@ -103,6 +105,11 @@ This page lists the default account limits for rules, applications, fields, and 
 | Target name                   | 255             |
 | Application URL               | 63              |
 | Team domain                   | 63              |
+| MCP portal name                 | 350             |
+| MCP server name                 | 350             |
+| MCP server description          | 512             |
+| MCP tool alias                  | 40              |
+| MCP portal/server ID            | 32              |
 | Gateway API policy expression | 140,000         |
 
 ## Cloudflare One Client


### PR DESCRIPTION
## What this PR does

Adds several new sections to the MCP portals page:

- **How it works**: End-to-end request flow from MCP client through Access auth to upstream server
- **Transport**: Auto-detection strategy table showing how the portal tries StreamableHTTP, SSE, and URL suffixes
- **Built-in portal tools**: Documents `portal_list_servers`, `portal_toggle_servers`, `portal_toggle_single_server`, and context optimization tools
- **Session lifecycle**: 24-hour inactivity timeout, per-session server toggles
- **Naming**: Disambiguation note explaining Agents Gateway vs MCP Portal naming
- **Limits**: Resource limits table (20 servers/portal, 5 custom domains, field lengths, etc.)

## Why

These are all P2 gaps identified during a comprehensive docs audit:

- **Architecture**: Internal engineers needed 30+ message threads to explain the routing model (Miguel's question in Core Access Eng, Mar 12)
- **Transport**: Users do not know what URL format to use or how fallback works
- **Built-in tools**: Every portal user sees these tools but they are not documented
- **Limits**: Zero limit documentation existed -- blocks capacity planning
- **Naming**: 'Agents Gateway' appears in API paths and Terraform but the product is called 'MCP Portal' -- users searching for one do not find the other