### PR TITLE
[Access] Add MCP portal request flow architecture diagram

### DIFF
--- a/src/assets/images/cloudflare-one/applications/mcp-portal-request-flow.svg
+++ b/src/assets/images/cloudflare-one/applications/mcp-portal-request-flow.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 520" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="10" markerHeight="7" orient="auto-start-auto">
+      <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#404040"/>
+    </marker>
+    <marker id="arrow-orange" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="10" markerHeight="7" orient="auto-start-auto">
+      <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#f6821f"/>
+    </marker>
+    <marker id="arrow-gray" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="10" markerHeight="7" orient="auto-start-auto">
+      <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#9ca3af"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1100" height="520" fill="white" rx="4"/>
+
+  <!-- Title -->
+  <text x="550" y="32" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">MCP server portal request flow</text>
+
+  <!-- Cloudflare boundary -->
+  <rect x="220" y="55" width="620" height="400" rx="8" fill="#fff8f3" stroke="#f6821f" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="530" y="78" text-anchor="middle" font-size="11" fill="#f6821f" font-weight="600" letter-spacing="0.5">CLOUDFLARE</text>
+
+  <!-- ===== LEFT: MCP Client ===== -->
+  <rect x="30" y="175" width="150" height="90" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="105" y="210" text-anchor="middle" font-weight="600" fill="#1a1a1a">MCP client</text>
+  <text x="105" y="228" text-anchor="middle" font-size="11" fill="#6b7280">Claude, Cursor,</text>
+  <text x="105" y="243" text-anchor="middle" font-size="11" fill="#6b7280">OpenCode, etc.</text>
+
+  <!-- ===== Identity Provider (top-left) ===== -->
+  <rect x="30" y="65" width="150" height="60" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="105" y="92" text-anchor="middle" font-weight="600" fill="#1a1a1a">Identity provider</text>
+  <text x="105" y="108" text-anchor="middle" font-size="11" fill="#6b7280">Okta, Azure AD, etc.</text>
+
+  <!-- ===== RIGHT: Upstream MCP Servers ===== -->
+  <rect x="900" y="105" width="170" height="70" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="985" y="133" text-anchor="middle" font-weight="600" fill="#1a1a1a">Upstream MCP</text>
+  <text x="985" y="150" text-anchor="middle" font-weight="600" fill="#1a1a1a">server (OAuth)</text>
+
+  <rect x="900" y="205" width="170" height="70" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="985" y="233" text-anchor="middle" font-weight="600" fill="#1a1a1a">Upstream MCP</text>
+  <text x="985" y="250" text-anchor="middle" font-weight="600" fill="#1a1a1a">server (unauth)</text>
+
+  <rect x="900" y="305" width="170" height="70" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="985" y="333" text-anchor="middle" font-weight="600" fill="#1a1a1a">Upstream MCP</text>
+  <text x="985" y="350" text-anchor="middle" font-weight="600" fill="#1a1a1a">server (bearer)</text>
+
+  <!-- ===== Cloudflare Access ===== -->
+  <rect x="248" y="155" width="160" height="130" rx="6" fill="white" stroke="#f6821f" stroke-width="1.5"/>
+  <text x="328" y="185" text-anchor="middle" font-weight="600" fill="#f6821f">Cloudflare Access</text>
+  <text x="328" y="208" text-anchor="middle" font-size="11" fill="#6b7280">JWT validation</text>
+  <text x="328" y="224" text-anchor="middle" font-size="11" fill="#6b7280">Policy evaluation</text>
+  <text x="328" y="240" text-anchor="middle" font-size="11" fill="#6b7280">OAuth 2.0 flow</text>
+  <text x="328" y="256" text-anchor="middle" font-size="11" fill="#6b7280">Managed OAuth</text>
+
+  <!-- ===== MCP Portal (DO) ===== -->
+  <rect x="448" y="120" width="170" height="200" rx="6" fill="white" stroke="#f6821f" stroke-width="1.5"/>
+  <text x="533" y="148" text-anchor="middle" font-weight="600" fill="#f6821f">MCP server portal</text>
+  <line x1="458" y1="158" x2="608" y2="158" stroke="#f0e0d0" stroke-width="1"/>
+  <text x="533" y="178" text-anchor="middle" font-size="11" fill="#6b7280">Session management</text>
+  <text x="533" y="196" text-anchor="middle" font-size="11" fill="#6b7280">Tool namespacing</text>
+  <text x="533" y="214" text-anchor="middle" font-size="11" fill="#6b7280">Credential routing</text>
+  <text x="533" y="232" text-anchor="middle" font-size="11" fill="#6b7280">Server toggling</text>
+  <text x="533" y="250" text-anchor="middle" font-size="11" fill="#6b7280">Context optimization</text>
+  <text x="533" y="268" text-anchor="middle" font-size="11" fill="#6b7280">Built-in tools</text>
+  <text x="533" y="286" text-anchor="middle" font-size="11" fill="#6b7280">Code mode sandbox</text>
+  <text x="533" y="304" text-anchor="middle" font-size="11" fill="#6b7280">Transport detection</text>
+
+  <!-- ===== Gateway (optional) ===== -->
+  <rect x="660" y="155" width="160" height="130" rx="6" fill="white" stroke="#f6821f" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="740" y="183" text-anchor="middle" font-weight="600" fill="#f6821f">Gateway</text>
+  <text x="740" y="198" text-anchor="middle" font-size="10" fill="#9ca3af" font-style="italic">(optional)</text>
+  <text x="740" y="222" text-anchor="middle" font-size="11" fill="#6b7280">HTTP logging</text>
+  <text x="740" y="238" text-anchor="middle" font-size="11" fill="#6b7280">DLP inspection</text>
+  <text x="740" y="254" text-anchor="middle" font-size="11" fill="#6b7280">Policy enforcement</text>
+  <text x="740" y="270" text-anchor="middle" font-size="11" fill="#6b7280">Egress IP</text>
+
+  <!-- ===== Background sync (bottom) ===== -->
+  <rect x="448" y="360" width="170" height="70" rx="6" fill="white" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="533" y="388" text-anchor="middle" font-weight="600" fill="#6b7280">Background sync</text>
+  <text x="533" y="406" text-anchor="middle" font-size="11" fill="#9ca3af">~2h interval</text>
+  <text x="533" y="420" text-anchor="middle" font-size="11" fill="#9ca3af">Admin credentials</text>
+
+  <!-- ===== Arrows ===== -->
+
+  <!-- Client -> Access -->
+  <line x1="180" y1="220" x2="245" y2="220" stroke="#404040" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="212" y="212" text-anchor="middle" font-size="10" fill="#6b7280">1</text>
+
+  <!-- IdP <-> Access -->
+  <line x1="180" y1="95" x2="265" y2="155" stroke="#404040" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <text x="210" y="118" text-anchor="middle" font-size="10" fill="#6b7280">2</text>
+
+  <!-- Access -> Portal -->
+  <line x1="408" y1="220" x2="445" y2="220" stroke="#f6821f" stroke-width="1.5" marker-end="url(#arrow-orange)"/>
+  <text x="426" y="212" text-anchor="middle" font-size="10" fill="#f6821f">3</text>
+
+  <!-- Portal -> Gateway -->
+  <line x1="618" y1="220" x2="657" y2="220" stroke="#f6821f" stroke-width="1.5" marker-end="url(#arrow-orange)" stroke-dasharray="5,3"/>
+  <text x="637" y="212" text-anchor="middle" font-size="10" fill="#f6821f">4</text>
+
+  <!-- Gateway -> Upstream servers -->
+  <line x1="820" y1="195" x2="897" y2="155" stroke="#404040" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="820" y1="220" x2="897" y2="240" stroke="#404040" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="820" y1="245" x2="897" y2="325" stroke="#404040" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <text x="862" y="187" text-anchor="middle" font-size="10" fill="#6b7280">5</text>
+
+  <!-- Background sync -> Upstream (direct, bypasses Gateway) -->
+  <path d="M 618 395 Q 760 395 760 340 Q 760 310 897 310" stroke="#9ca3af" stroke-width="1.2" fill="none" marker-end="url(#arrow-gray)" stroke-dasharray="4,3"/>
+  <text x="770" y="370" text-anchor="middle" font-size="10" fill="#9ca3af">direct</text>
+  <text x="770" y="383" text-anchor="middle" font-size="10" fill="#9ca3af">(no Gateway)</text>
+
+  <!-- ===== Legend ===== -->
+  <rect x="248" y="460" width="544" height="40" rx="4" fill="#fafafa" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="268" y1="480" x2="298" y2="480" stroke="#404040" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="306" y="484" font-size="11" fill="#6b7280">Request flow</text>
+  <line x1="410" y1="480" x2="440" y2="480" stroke="#f6821f" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow-orange)"/>
+  <text x="448" y="484" font-size="11" fill="#6b7280">Optional (Gateway)</text>
+  <line x1="580" y1="480" x2="610" y2="480" stroke="#9ca3af" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrow-gray)"/>
+  <text x="618" y="484" font-size="11" fill="#6b7280">Background sync</text>
+
+  <!-- Step labels -->
+  <text x="550" y="500" text-anchor="middle" font-size="10" fill="#9ca3af">1 Connect  |  2 Authenticate  |  3 Session created  |  4 Tool call proxied  |  5 Upstream request</text>
+</svg>

--- a/src/assets/images/cloudflare-one/applications/mcp-portal-request-flow.svg
+++ b/src/assets/images/cloudflare-one/applications/mcp-portal-request-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 520" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" width="960" height="540" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif">
   <defs>
     <marker id="arrow" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="10" markerHeight="7" orient="auto-start-auto">
       <path d="M 0 0 L 10 3.5 L 0 7 z" fill="#404040"/>
@@ -12,113 +12,114 @@
   </defs>
 
   <!-- Background -->
-  <rect width="1100" height="520" fill="white" rx="4"/>
+  <rect width="960" height="540" fill="white" rx="4"/>
 
   <!-- Title -->
-  <text x="550" y="32" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">MCP server portal request flow</text>
+  <text x="480" y="36" text-anchor="middle" font-size="20" font-weight="600" fill="#1a1a1a">MCP server portal request flow</text>
 
   <!-- Cloudflare boundary -->
-  <rect x="220" y="55" width="620" height="400" rx="8" fill="#fff8f3" stroke="#f6821f" stroke-width="1.5" stroke-dasharray="6,3"/>
-  <text x="530" y="78" text-anchor="middle" font-size="11" fill="#f6821f" font-weight="600" letter-spacing="0.5">CLOUDFLARE</text>
+  <rect x="200" y="60" width="530" height="390" rx="10" fill="#fff8f3" stroke="#f6821f" stroke-width="1.5" stroke-dasharray="8,4"/>
+  <text x="465" y="84" text-anchor="middle" font-size="13" fill="#f6821f" font-weight="600" letter-spacing="1">CLOUDFLARE</text>
 
   <!-- ===== LEFT: MCP Client ===== -->
-  <rect x="30" y="175" width="150" height="90" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
-  <text x="105" y="210" text-anchor="middle" font-weight="600" fill="#1a1a1a">MCP client</text>
-  <text x="105" y="228" text-anchor="middle" font-size="11" fill="#6b7280">Claude, Cursor,</text>
-  <text x="105" y="243" text-anchor="middle" font-size="11" fill="#6b7280">OpenCode, etc.</text>
+  <rect x="24" y="190" width="150" height="90" rx="8" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="99" y="225" text-anchor="middle" font-size="16" font-weight="600" fill="#1a1a1a">MCP client</text>
+  <text x="99" y="246" text-anchor="middle" font-size="13" fill="#6b7280">Claude, Cursor,</text>
+  <text x="99" y="263" text-anchor="middle" font-size="13" fill="#6b7280">OpenCode, etc.</text>
 
   <!-- ===== Identity Provider (top-left) ===== -->
-  <rect x="30" y="65" width="150" height="60" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
-  <text x="105" y="92" text-anchor="middle" font-weight="600" fill="#1a1a1a">Identity provider</text>
-  <text x="105" y="108" text-anchor="middle" font-size="11" fill="#6b7280">Okta, Azure AD, etc.</text>
-
-  <!-- ===== RIGHT: Upstream MCP Servers ===== -->
-  <rect x="900" y="105" width="170" height="70" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
-  <text x="985" y="133" text-anchor="middle" font-weight="600" fill="#1a1a1a">Upstream MCP</text>
-  <text x="985" y="150" text-anchor="middle" font-weight="600" fill="#1a1a1a">server (OAuth)</text>
-
-  <rect x="900" y="205" width="170" height="70" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
-  <text x="985" y="233" text-anchor="middle" font-weight="600" fill="#1a1a1a">Upstream MCP</text>
-  <text x="985" y="250" text-anchor="middle" font-weight="600" fill="#1a1a1a">server (unauth)</text>
-
-  <rect x="900" y="305" width="170" height="70" rx="6" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
-  <text x="985" y="333" text-anchor="middle" font-weight="600" fill="#1a1a1a">Upstream MCP</text>
-  <text x="985" y="350" text-anchor="middle" font-weight="600" fill="#1a1a1a">server (bearer)</text>
+  <rect x="24" y="70" width="150" height="64" rx="8" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="99" y="98" text-anchor="middle" font-size="15" font-weight="600" fill="#1a1a1a">Identity provider</text>
+  <text x="99" y="118" text-anchor="middle" font-size="13" fill="#6b7280">Okta, Azure AD, etc.</text>
 
   <!-- ===== Cloudflare Access ===== -->
-  <rect x="248" y="155" width="160" height="130" rx="6" fill="white" stroke="#f6821f" stroke-width="1.5"/>
-  <text x="328" y="185" text-anchor="middle" font-weight="600" fill="#f6821f">Cloudflare Access</text>
-  <text x="328" y="208" text-anchor="middle" font-size="11" fill="#6b7280">JWT validation</text>
-  <text x="328" y="224" text-anchor="middle" font-size="11" fill="#6b7280">Policy evaluation</text>
-  <text x="328" y="240" text-anchor="middle" font-size="11" fill="#6b7280">OAuth 2.0 flow</text>
-  <text x="328" y="256" text-anchor="middle" font-size="11" fill="#6b7280">Managed OAuth</text>
+  <rect x="224" y="170" width="160" height="130" rx="8" fill="white" stroke="#f6821f" stroke-width="1.5"/>
+  <text x="304" y="198" text-anchor="middle" font-size="15" font-weight="600" fill="#f6821f">Cloudflare Access</text>
+  <text x="304" y="222" text-anchor="middle" font-size="13" fill="#6b7280">JWT validation</text>
+  <text x="304" y="240" text-anchor="middle" font-size="13" fill="#6b7280">Policy evaluation</text>
+  <text x="304" y="258" text-anchor="middle" font-size="13" fill="#6b7280">OAuth 2.0 flow</text>
+  <text x="304" y="276" text-anchor="middle" font-size="13" fill="#6b7280">Managed OAuth</text>
 
-  <!-- ===== MCP Portal (DO) ===== -->
-  <rect x="448" y="120" width="170" height="200" rx="6" fill="white" stroke="#f6821f" stroke-width="1.5"/>
-  <text x="533" y="148" text-anchor="middle" font-weight="600" fill="#f6821f">MCP server portal</text>
-  <line x1="458" y1="158" x2="608" y2="158" stroke="#f0e0d0" stroke-width="1"/>
-  <text x="533" y="178" text-anchor="middle" font-size="11" fill="#6b7280">Session management</text>
-  <text x="533" y="196" text-anchor="middle" font-size="11" fill="#6b7280">Tool namespacing</text>
-  <text x="533" y="214" text-anchor="middle" font-size="11" fill="#6b7280">Credential routing</text>
-  <text x="533" y="232" text-anchor="middle" font-size="11" fill="#6b7280">Server toggling</text>
-  <text x="533" y="250" text-anchor="middle" font-size="11" fill="#6b7280">Context optimization</text>
-  <text x="533" y="268" text-anchor="middle" font-size="11" fill="#6b7280">Built-in tools</text>
-  <text x="533" y="286" text-anchor="middle" font-size="11" fill="#6b7280">Code mode sandbox</text>
-  <text x="533" y="304" text-anchor="middle" font-size="11" fill="#6b7280">Transport detection</text>
+  <!-- ===== MCP Portal ===== -->
+  <rect x="414" y="130" width="170" height="210" rx="8" fill="white" stroke="#f6821f" stroke-width="1.5"/>
+  <text x="499" y="158" text-anchor="middle" font-size="15" font-weight="600" fill="#f6821f">MCP server portal</text>
+  <line x1="424" y1="168" x2="574" y2="168" stroke="#f0e0d0" stroke-width="1"/>
+  <text x="499" y="190" text-anchor="middle" font-size="13" fill="#6b7280">Session management</text>
+  <text x="499" y="210" text-anchor="middle" font-size="13" fill="#6b7280">Tool namespacing</text>
+  <text x="499" y="230" text-anchor="middle" font-size="13" fill="#6b7280">Credential routing</text>
+  <text x="499" y="250" text-anchor="middle" font-size="13" fill="#6b7280">Server toggling</text>
+  <text x="499" y="270" text-anchor="middle" font-size="13" fill="#6b7280">Context optimization</text>
+  <text x="499" y="290" text-anchor="middle" font-size="13" fill="#6b7280">Code mode sandbox</text>
+  <text x="499" y="310" text-anchor="middle" font-size="13" fill="#6b7280">Transport detection</text>
 
   <!-- ===== Gateway (optional) ===== -->
-  <rect x="660" y="155" width="160" height="130" rx="6" fill="white" stroke="#f6821f" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <text x="740" y="183" text-anchor="middle" font-weight="600" fill="#f6821f">Gateway</text>
-  <text x="740" y="198" text-anchor="middle" font-size="10" fill="#9ca3af" font-style="italic">(optional)</text>
-  <text x="740" y="222" text-anchor="middle" font-size="11" fill="#6b7280">HTTP logging</text>
-  <text x="740" y="238" text-anchor="middle" font-size="11" fill="#6b7280">DLP inspection</text>
-  <text x="740" y="254" text-anchor="middle" font-size="11" fill="#6b7280">Policy enforcement</text>
-  <text x="740" y="270" text-anchor="middle" font-size="11" fill="#6b7280">Egress IP</text>
+  <rect x="614" y="170" width="100" height="130" rx="8" fill="white" stroke="#f6821f" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="664" y="198" text-anchor="middle" font-size="15" font-weight="600" fill="#f6821f">Gateway</text>
+  <text x="664" y="215" text-anchor="middle" font-size="11" fill="#9ca3af" font-style="italic">(optional)</text>
+  <text x="664" y="238" text-anchor="middle" font-size="13" fill="#6b7280">HTTP logging</text>
+  <text x="664" y="256" text-anchor="middle" font-size="13" fill="#6b7280">DLP inspection</text>
+  <text x="664" y="274" text-anchor="middle" font-size="13" fill="#6b7280">Egress IP</text>
 
-  <!-- ===== Background sync (bottom) ===== -->
-  <rect x="448" y="360" width="170" height="70" rx="6" fill="white" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <text x="533" y="388" text-anchor="middle" font-weight="600" fill="#6b7280">Background sync</text>
-  <text x="533" y="406" text-anchor="middle" font-size="11" fill="#9ca3af">~2h interval</text>
-  <text x="533" y="420" text-anchor="middle" font-size="11" fill="#9ca3af">Admin credentials</text>
+  <!-- ===== Upstream MCP Servers ===== -->
+  <rect x="776" y="110" width="160" height="60" rx="8" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="856" y="138" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a1a">Upstream (OAuth)</text>
+  <text x="856" y="158" text-anchor="middle" font-size="12" fill="#6b7280">User token or admin cred</text>
+
+  <rect x="776" y="200" width="160" height="60" rx="8" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="856" y="228" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a1a">Upstream (unauth)</text>
+  <text x="856" y="248" text-anchor="middle" font-size="12" fill="#6b7280">No credentials</text>
+
+  <rect x="776" y="290" width="160" height="60" rx="8" fill="white" stroke="#d1d5db" stroke-width="1.5"/>
+  <text x="856" y="318" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a1a">Upstream (bearer)</text>
+  <text x="856" y="338" text-anchor="middle" font-size="12" fill="#6b7280">Static token</text>
+
+  <!-- ===== Background sync ===== -->
+  <rect x="414" y="370" width="170" height="65" rx="8" fill="white" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="499" y="396" text-anchor="middle" font-size="14" font-weight="600" fill="#6b7280">Background sync</text>
+  <text x="499" y="416" text-anchor="middle" font-size="13" fill="#9ca3af">~2h interval, admin creds</text>
 
   <!-- ===== Arrows ===== -->
 
-  <!-- Client -> Access -->
-  <line x1="180" y1="220" x2="245" y2="220" stroke="#404040" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="212" y="212" text-anchor="middle" font-size="10" fill="#6b7280">1</text>
+  <!-- 1: Client -> Access -->
+  <line x1="174" y1="235" x2="221" y2="235" stroke="#404040" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="188" y="215" width="22" height="18" rx="9" fill="#f3f4f6"/>
+  <text x="199" y="228" text-anchor="middle" font-size="12" font-weight="600" fill="#404040">1</text>
 
-  <!-- IdP <-> Access -->
-  <line x1="180" y1="95" x2="265" y2="155" stroke="#404040" stroke-width="1.2" marker-end="url(#arrow)"/>
-  <text x="210" y="118" text-anchor="middle" font-size="10" fill="#6b7280">2</text>
+  <!-- 2: IdP <-> Access -->
+  <line x1="174" y1="102" x2="240" y2="170" stroke="#404040" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <rect x="194" y="122" width="22" height="18" rx="9" fill="#f3f4f6"/>
+  <text x="205" y="135" text-anchor="middle" font-size="12" font-weight="600" fill="#404040">2</text>
 
-  <!-- Access -> Portal -->
-  <line x1="408" y1="220" x2="445" y2="220" stroke="#f6821f" stroke-width="1.5" marker-end="url(#arrow-orange)"/>
-  <text x="426" y="212" text-anchor="middle" font-size="10" fill="#f6821f">3</text>
+  <!-- 3: Access -> Portal -->
+  <line x1="384" y1="235" x2="411" y2="235" stroke="#f6821f" stroke-width="2" marker-end="url(#arrow-orange)"/>
+  <rect x="387" y="215" width="22" height="18" rx="9" fill="#fff8f3"/>
+  <text x="398" y="228" text-anchor="middle" font-size="12" font-weight="600" fill="#f6821f">3</text>
 
-  <!-- Portal -> Gateway -->
-  <line x1="618" y1="220" x2="657" y2="220" stroke="#f6821f" stroke-width="1.5" marker-end="url(#arrow-orange)" stroke-dasharray="5,3"/>
-  <text x="637" y="212" text-anchor="middle" font-size="10" fill="#f6821f">4</text>
+  <!-- 4: Portal -> Gateway -->
+  <line x1="584" y1="235" x2="611" y2="235" stroke="#f6821f" stroke-width="2" marker-end="url(#arrow-orange)" stroke-dasharray="6,3"/>
+  <rect x="587" y="215" width="22" height="18" rx="9" fill="#fff8f3"/>
+  <text x="598" y="228" text-anchor="middle" font-size="12" font-weight="600" fill="#f6821f">4</text>
 
-  <!-- Gateway -> Upstream servers -->
-  <line x1="820" y1="195" x2="897" y2="155" stroke="#404040" stroke-width="1.2" marker-end="url(#arrow)"/>
-  <line x1="820" y1="220" x2="897" y2="240" stroke="#404040" stroke-width="1.2" marker-end="url(#arrow)"/>
-  <line x1="820" y1="245" x2="897" y2="325" stroke="#404040" stroke-width="1.2" marker-end="url(#arrow)"/>
-  <text x="862" y="187" text-anchor="middle" font-size="10" fill="#6b7280">5</text>
+  <!-- 5: Gateway -> Upstream servers -->
+  <line x1="714" y1="210" x2="773" y2="155" stroke="#404040" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="714" y1="235" x2="773" y2="235" stroke="#404040" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="714" y1="260" x2="773" y2="315" stroke="#404040" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <rect x="734" y="193" width="22" height="18" rx="9" fill="#f3f4f6"/>
+  <text x="745" y="206" text-anchor="middle" font-size="12" font-weight="600" fill="#404040">5</text>
 
   <!-- Background sync -> Upstream (direct, bypasses Gateway) -->
-  <path d="M 618 395 Q 760 395 760 340 Q 760 310 897 310" stroke="#9ca3af" stroke-width="1.2" fill="none" marker-end="url(#arrow-gray)" stroke-dasharray="4,3"/>
-  <text x="770" y="370" text-anchor="middle" font-size="10" fill="#9ca3af">direct</text>
-  <text x="770" y="383" text-anchor="middle" font-size="10" fill="#9ca3af">(no Gateway)</text>
+  <path d="M 584 402 Q 700 402 700 360 Q 700 330 773 320" stroke="#9ca3af" stroke-width="1.5" fill="none" marker-end="url(#arrow-gray)" stroke-dasharray="5,3"/>
+  <text x="700" y="420" text-anchor="middle" font-size="12" fill="#9ca3af">direct (no Gateway)</text>
 
   <!-- ===== Legend ===== -->
-  <rect x="248" y="460" width="544" height="40" rx="4" fill="#fafafa" stroke="#e5e7eb" stroke-width="1"/>
-  <line x1="268" y1="480" x2="298" y2="480" stroke="#404040" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="306" y="484" font-size="11" fill="#6b7280">Request flow</text>
-  <line x1="410" y1="480" x2="440" y2="480" stroke="#f6821f" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow-orange)"/>
-  <text x="448" y="484" font-size="11" fill="#6b7280">Optional (Gateway)</text>
-  <line x1="580" y1="480" x2="610" y2="480" stroke="#9ca3af" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#arrow-gray)"/>
-  <text x="618" y="484" font-size="11" fill="#6b7280">Background sync</text>
+  <rect x="200" y="468" width="560" height="50" rx="6" fill="#fafafa" stroke="#e5e7eb" stroke-width="1"/>
+  <line x1="224" y1="493" x2="260" y2="493" stroke="#404040" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="497" font-size="13" fill="#6b7280">Request flow</text>
+  <line x1="386" y1="493" x2="422" y2="493" stroke="#f6821f" stroke-width="2" stroke-dasharray="6,3" marker-end="url(#arrow-orange)"/>
+  <text x="432" y="497" font-size="13" fill="#6b7280">Optional (Gateway)</text>
+  <line x1="570" y1="493" x2="606" y2="493" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow-gray)"/>
+  <text x="616" y="497" font-size="13" fill="#6b7280">Background sync</text>
 
   <!-- Step labels -->
-  <text x="550" y="500" text-anchor="middle" font-size="10" fill="#9ca3af">1 Connect  |  2 Authenticate  |  3 Session created  |  4 Tool call proxied  |  5 Upstream request</text>
+  <text x="480" y="530" text-anchor="middle" font-size="13" fill="#9ca3af">1 Connect  |  2 Authenticate  |  3 Session created  |  4 Tool call proxied  |  5 Upstream request</text>
 </svg>

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -19,20 +19,6 @@ An MCP server portal centralizes multiple [Model Context Protocol (MCP) servers]
 
 This guide explains how to add MCP servers to Cloudflare Access, create an MCP portal with customized tools and policies, and connect users to the portal using an MCP client.
 
-## How it works
-
-The following diagram shows how requests flow through an MCP server portal.
-
-![Request flow diagram showing how an MCP client connects through Cloudflare Access and the MCP server portal to reach upstream MCP servers, with an optional Gateway path for DLP inspection.](~/assets/images/cloudflare-one/applications/mcp-portal-request-flow.svg)
-
-1. An MCP client connects to the portal URL and receives a `401` with OAuth discovery metadata.
-2. The user authenticates through Cloudflare Access via their identity provider.
-3. Access validates the JWT and creates a portal session. The portal fetches the tool list from all enabled upstream servers.
-4. When the user calls a tool, the portal identifies the target server from the tool's namespace prefix, attaches the appropriate credentials (user OAuth token or admin credential), and proxies the request. If [Gateway routing](#route-portal-traffic-through-gateway) is turned on, the request passes through Cloudflare Gateway for HTTP logging and DLP inspection.
-5. The upstream server processes the request and returns a response through the same path.
-
-Background synchronization of tools and prompts runs approximately every two hours using admin credentials. This sync connects directly to upstream servers and does not route through Gateway.
-
 ## Key features
 
 MCP server portals provide the following capabilities:
@@ -53,14 +39,17 @@ MCP server portals provide the following capabilities:
 
 ## How it works
 
-When a user connects an MCP client to a portal, the following flow occurs:
+The following diagram shows how requests flow through an MCP server portal.
 
-1. The MCP client sends a request to the portal URL (`https://<subdomain>.<domain>/mcp`).
-2. Cloudflare Access authenticates the user via a browser-based OAuth 2.0 flow (or [service token](#connect-with-a-service-token) headers).
-3. The portal establishes an MCP session and returns the list of available tools from all enabled upstream servers.
-4. When the user calls a tool, the portal identifies the target upstream MCP server based on the [tool namespace](#tool-namespacing), attaches the appropriate credentials (user OAuth token or admin credential), and proxies the request.
-5. If [Gateway routing](#route-portal-traffic-through-gateway) is turned on, the outbound request passes through Cloudflare Gateway for HTTP logging and DLP inspection before reaching the upstream server.
-6. The upstream server's response is returned to the MCP client.
+![Request flow diagram showing how an MCP client connects through Cloudflare Access and the MCP server portal to reach upstream MCP servers, with an optional Gateway path for DLP inspection.](~/assets/images/cloudflare-one/applications/mcp-portal-request-flow.svg)
+
+1. An MCP client connects to the portal URL and receives a `401` response with OAuth discovery metadata.
+2. The user authenticates through Cloudflare Access via their identity provider or uses [service token](#connect-with-a-service-token) headers.
+3. Access validates the user's identity, and the portal establishes an MCP session and returns the tools available from enabled upstream servers.
+4. When the user calls a tool, the portal identifies the target server from the [tool namespace](#tool-namespacing), attaches the appropriate credentials, and proxies the request. If [Gateway routing](#route-portal-traffic-through-gateway) is turned on, the request passes through Cloudflare Gateway for HTTP logging and DLP inspection.
+5. The upstream server processes the request and returns a response through the same path.
+
+Background synchronization of tools and prompts runs approximately every two hours using admin credentials. This sync connects directly to upstream servers and does not route through Gateway.
 
 ### Transport
 

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -19,6 +19,20 @@ An MCP server portal centralizes multiple [Model Context Protocol (MCP) servers]
 
 This guide explains how to add MCP servers to Cloudflare Access, create an MCP portal with customized tools and policies, and connect users to the portal using an MCP client.
 
+## How it works
+
+The following diagram shows how requests flow through an MCP server portal.
+
+![Request flow diagram showing how an MCP client connects through Cloudflare Access and the MCP server portal to reach upstream MCP servers, with an optional Gateway path for DLP inspection.](~/assets/images/cloudflare-one/applications/mcp-portal-request-flow.svg)
+
+1. An MCP client connects to the portal URL and receives a `401` with OAuth discovery metadata.
+2. The user authenticates through Cloudflare Access via their identity provider.
+3. Access validates the JWT and creates a portal session. The portal fetches the tool list from all enabled upstream servers.
+4. When the user calls a tool, the portal identifies the target server from the tool's namespace prefix, attaches the appropriate credentials (user OAuth token or admin credential), and proxies the request. If [Gateway routing](#route-portal-traffic-through-gateway) is turned on, the request passes through Cloudflare Gateway for HTTP logging and DLP inspection.
+5. The upstream server processes the request and returns a response through the same path.
+
+Background synchronization of tools and prompts runs approximately every two hours using admin credentials. This sync connects directly to upstream servers and does not route through Gateway.
+
 ## Key features
 
 MCP server portals provide the following capabilities:


### PR DESCRIPTION
## What this PR does

Adds an SVG architecture diagram and a new 'How it works' section to the MCP portals page. The diagram shows:

- **MCP client** connecting to the portal
- **Cloudflare Access** handling authentication (JWT validation, policy evaluation, OAuth 2.0, Managed OAuth)
- **MCP server portal** handling session management, tool namespacing, credential routing, server toggling, context optimization, built-in tools, code mode sandbox, and transport detection
- **Gateway** (optional, dashed) handling HTTP logging, DLP inspection, policy enforcement, and egress IP
- **Upstream MCP servers** in three auth flavors: OAuth, unauthenticated, bearer
- **Background sync** path showing direct connection to upstream servers (bypasses Gateway, ~2h interval)
- A **legend** distinguishing request flow, optional Gateway path, and background sync
- Numbered **step labels** (Connect, Authenticate, Session created, Tool call proxied, Upstream request)

The accompanying text walks through the 5-step flow and calls out that background sync does not route through Gateway.

## Why

No architecture diagram existed. Internal engineers needed 30+ message threads to explain the CNAME/routing model. This diagram gives users a mental model of how the portal proxies requests, where auth happens, and what the optional Gateway path adds.