### PR TITLE
[RealtimeKit] Add Web Core 1.5.0 and Web UI Kit 1.2.0 release notes

### DIFF
--- a/src/content/release-notes/realtimekit-web-core.yaml
+++ b/src/content/release-notes/realtimekit-web-core.yaml
@@ -3,6 +3,26 @@ link: "/realtime/realtimekit/release-notes/"
 productName: RealtimeKit Web Core
 productLink: "/realtime/realtimekit/"
 entries:
+  - publish_date: "2026-05-XX"
+    title: RealtimeKit Web Core 1.5.0
+    description: |-
+      **Compatibility:** Works best with RealtimeKit Web UI Kit 1.2.0 or later.
+
+      **Features**
+
+      - Added a dedicated error code `0014` for media (WebRTC) connection failures during room join, making it easier to distinguish media failures from socket and signaling failures.
+
+      **Enhancements**
+
+      - Init and join failures from `Client.init()` and `meeting.join()` now surface specific error codes and descriptive messages instead of generic or stacked errors.
+      - Telemetry logs are now compressed using gzip when the browser supports the `CompressionStream` API, achieving approximately a 10:1 compression ratio. Older browsers and React Native fall back to uncompressed JSON with smaller batch sizes.
+      - The SDK now attempts to flush queued telemetry logs on page unload using `fetch()` with `keepalive`, reducing data loss when users close the tab.
+
+      **Fixes**
+
+      - Fixed a regex-based issue where the Safari video middleware flag was incorrectly removed, potentially breaking video processing on Safari.
+      - Fixed an issue where `ClientError` objects were wrapped inside each other when the SDK retried failed API requests. This caused nested error messages, duplicate `onError` callbacks, and redundant `window` error events.
+
   - publish_date: "2026-04-20"
     title: RealtimeKit Web Core 1.4.0
     description: |-

--- a/src/content/release-notes/realtimekit-web-ui-kit.yaml
+++ b/src/content/release-notes/realtimekit-web-ui-kit.yaml
@@ -3,6 +3,24 @@ link: "/realtime/realtimekit/release-notes/"
 productName: RealtimeKit Web UI Kit
 productLink: "/realtime/realtimekit/"
 entries:
+  - publish_date: "2026-05-XX"
+    title: RealtimeKit Web UI Kit 1.2.0
+    description: |-
+      **Compatibility:** Works best with RealtimeKit Web Core 1.5.0 or later.
+
+      **Features**
+
+      - When a user fails to join a meeting, `rtk-idle-screen` and `rtk-setup-screen` now display a troubleshooting link to help resolve common connection issues such as firewall restrictions and permission errors.
+      - If the meeting preset allows transcripts, the transcription panel is now shown by default without requiring manual activation.
+
+      **Enhancements**
+
+      - Raw SDK error codes and messages are no longer shown to end users on join failure. Error messages are now mapped to clear, user-friendly, localized text with a small reference code (for example, `Error code: 0002`) for support and debugging.
+
+      **Fixes**
+
+      - Corrected several typos and spacing issues in the default language pack.
+
   - publish_date: "2026-03-31"
     title: RealtimeKit Web UI Kit 1.1.2
     description: |-


### PR DESCRIPTION
### Summary

Adds release notes for RealtimeKit Web Core 1.5.0 and Web UI Kit 1.2.0, covering the upcoming May release.

- Added Web Core 1.5.0 entry: new error code 0014 for media connection failures, improved error messages for Client.init() and meeting.join(), gzip compression for telemetry logs, log flushing on page unload, Safari middleware fix, and API retry error stacking fix.
- Added Web UI Kit 1.2.0 entry: troubleshooting link on join failure screens, transcription panel shown by default when preset allows it, user-friendly localized error messages with reference codes, and language pack typo fixes.

**NOTE**: Publish dates are set to placeholder 2026-05-XX and need to be updated once the release date is finalized.