### PR TITLE
Smart Shield: correct DNS Internal error description for proxied hostnames

### DIFF
--- a/src/content/partials/smart-shield/health-checks-analytics.mdx
+++ b/src/content/partials/smart-shield/health-checks-analytics.mdx
@@ -180,11 +180,11 @@ Review your Health Check configuration to ensure it matches an expected request 
 
 #### Cause
 
-The origin web server’s hostname resolves to an internal or restricted address. No checks are run against this origin.
+The origin web server's hostname resolves to a non-publicly-routable or restricted IP address (for example, a localhost address). No checks are run against this origin.
 
 #### Solution
 
-Cloudflare does not allow use of an origin web server hostname that resolves to a Cloudflare IP.
+Confirm the origin web server hostname resolves to a publicly routable IP address. Note that if the hostname resolves to a public Cloudflare anycast IP (because the hostname is proxied through Cloudflare), the health check will run but will probe Cloudflare's edge rather than your actual origin server. To monitor your origin server directly, configure the health check to use the origin IP address or a non-proxied hostname.
 
 ### Other Failure
 


### PR DESCRIPTION
### Summary

The DNS Internal error code documentation incorrectly stated that health checks cannot run against hostnames that resolve to a Cloudflare IP.

In practice, health checks against proxied (orange-clouded) hostnames do run - but they probe Cloudflare's edge rather than the actual origin server.

Updated the cause and solution text to reflect the actual behaviour, and added a note clarifying what proxied hostname health checks measure so customers understand the limitation.

Triggering ticket: `02125886`

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
