### PR TITLE
Add `devOnly` option to Vite plugin API reference

### DIFF
--- a/src/content/docs/workers/vite-plugin/reference/api.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/api.mdx
@@ -113,6 +113,16 @@ It accepts an optional `PluginConfig` parameter.
   You can inspect the `dist` directory and then run `wrangler deploy -c dist/<auxiliary-worker>/wrangler.json` for each.
   :::
 
+- `devOnly` <Type text='boolean | (() => boolean)' /> <MetaInfo text='optional' />
+
+  Whether the Worker is only used during development.
+  When set to `true`, the Worker runs during `vite dev` but is excluded from the production build.
+
+  Accepts a boolean or a function that returns a boolean.
+  The function is evaluated lazily at build time, which allows frameworks to determine the value after initialization.
+
+  When the entry Worker is marked `devOnly`, the plugin writes an assets-only Wrangler config to the client output directory so the build can be deployed as a static application.
+
 - `remoteBindings` <Type text='boolean' /> <MetaInfo text='optional' />
 
   Whether or not [remote bindings](/workers/development-testing/#remote-bindings) should be enabled. Defaults to `true`.
@@ -147,3 +157,11 @@ Auxiliary Workers require a `configPath`, a `config` option, or both.
   This enables embedding additional environments with separate module graphs inside a single Worker.
 
   See [Vite Environments](/workers/vite-plugin/reference/vite-environments/) for more information.
+
+- `devOnly` <Type text='boolean | (() => boolean)' /> <MetaInfo text='optional' />
+
+  Whether the auxiliary Worker is only used during development.
+  When set to `true`, the Worker runs during `vite dev` but is excluded from the production build.
+
+  Accepts a boolean or a function that returns a boolean.
+  The function is evaluated lazily at build time, which allows frameworks to determine the value after initialization.


### PR DESCRIPTION
### Summary

Add `devOnly` option to Vite plugin API reference

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
