### PR TITLE
Fix typo in secrets-in-dev partial

### DIFF
--- a/src/content/partials/workers/secrets-in-dev.mdx
+++ b/src/content/partials/workers/secrets-in-dev.mdx
@@ -24,7 +24,7 @@ API_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
 ```
 
 :::caution[Do not commit secrets to git]
-The `.dev.vars` and `.env` files should not committed to git. Add `.dev.vars*` and `.env*` to your project's `.gitignore` file.
+The `.dev.vars` and `.env` files should not be committed to git. Add `.dev.vars*` and `.env*` to your project's `.gitignore` file.
 :::
 
 To set different secrets for each Cloudflare environment, create files named `.dev.vars.<environment-name>` or `.env.<environment-name>`.


### PR DESCRIPTION
Fix grammar typo in warning about committing secrets to git.

### Summary

This PR fixes a minor typo I found in the secrets documentation for Workers which I found while reading. 

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
