### PR TITLE
docs(billing): add stablecoin payments documentation

### DIFF
--- a/src/content/docs/billing/payment-methods/stablecoin-payments.mdx
+++ b/src/content/docs/billing/payment-methods/stablecoin-payments.mdx
@@ -69,10 +69,6 @@ Refunds for stablecoin payments are returned as USDC to the wallet you paid from
 
 ## FAQ
 
-<Details header="USDC and the stablecoin standard">
-USDC is a US dollar-backed stablecoin issued by Circle. One USDC is designed to equal one US dollar. Cloudflare accepts USDC on the Base and Polygon networks.
-</Details>
-
 <Details header="Network fees and gas">
 Gas fees for the on-chain transaction are paid by your wallet to the network. Cloudflare does not add a markup or transaction fee for stablecoin payments. The amount charged in USDC matches your invoice amount in USD.
 </Details>

--- a/src/content/docs/billing/payment-methods/stablecoin-payments.mdx
+++ b/src/content/docs/billing/payment-methods/stablecoin-payments.mdx
@@ -56,7 +56,7 @@ If you have a card on file, Cloudflare falls back to it when a stablecoin charge
 
 ## Refunds
 
-Refunds for stablecoin payments are issued as US dollar credit to your Cloudflare account, not as USDC back to your wallet. The credit applies to your next invoice.
+Refunds for stablecoin payments are returned as USDC to the wallet you paid from. Refunds typically arrive within minutes, compared to 5–10 business days for card refunds.
 
 ## View your payment history
 

--- a/src/content/docs/billing/payment-methods/stablecoin-payments.mdx
+++ b/src/content/docs/billing/payment-methods/stablecoin-payments.mdx
@@ -1,0 +1,90 @@
+---
+title: Stablecoin payments
+pcx_content_type: concept
+sidebar:
+  order: 3
+description: Pay for Cloudflare services with USDC stablecoin at the checkout.
+products:
+  - billing
+---
+
+import { Details, DashButton } from "~/components";
+
+You can pay for Cloudflare services with USDC stablecoin at the checkout. Stablecoin payments support one-time charges and recurring billing, including usage-based products.
+
+## How stablecoin payments work
+
+1. **Checkout**: Select **Crypto** in the payment method picker, alongside card, Apple Pay, and Google Pay.
+2. **Wallet connection**: You are redirected to a Stripe-hosted page at `crypto.stripe.com` to connect your wallet.
+3. **Smart contract permit**: Sign a one-time permit to authorize the initial charge and, for recurring subscriptions, future automatic charges.
+4. **On-chain confirmation**: Your subscription activates after on-chain confirmation, typically within seconds.
+
+For recurring billing, Cloudflare charges your saved wallet each cycle. You only need to act if your wallet balance runs out or you revoke the permit.
+
+## Supported stablecoins and wallets
+
+| Item | Value |
+| --- | --- |
+| Stablecoins | USDC on Base and Polygon |
+| Wallets | MetaMask, Phantom, Coinbase Wallet, and 400+ wallets via WalletConnect |
+| Invoice currency | US dollars (USD) |
+| Chargebacks and disputes | Not available. Stablecoin payments are final once confirmed on-chain. |
+
+## Recurring billing
+
+The smart contract permit authorizes future automatic charges for:
+
+- Monthly or annual subscription renewals for paid plans
+- Usage-based charges billed at threshold for Workers, R2, and Stream
+- Prorated charges for plan upgrades
+
+Each charge is processed against the saved permit. No action is required between cycles.
+
+## Payment failures
+
+Stablecoin payments fail for a small number of well-defined reasons:
+
+| Reason | What happens | How to resolve |
+| --- | --- | --- |
+| Insufficient funds | Your wallet does not have enough USDC | Add USDC to the wallet, then retry. Subscriptions enter dunning until the payment succeeds. |
+| Approval revoked | You revoked or reduced the permit below the payment amount | Return to the checkout and reconnect your wallet to issue a new permit |
+| Wallet screening | Pre-transaction screening flagged the wallet | Use a different wallet or payment method |
+
+:::note
+If you have a card on file, Cloudflare falls back to it when a stablecoin charge fails. This protects usage-based products from interruption when your wallet balance fluctuates. Refer to [Additional payment method auto-retry](/billing/payment-methods/additional-payment-method-auto-retry/).
+:::
+
+## Refunds
+
+Refunds for stablecoin payments are issued as US dollar credit to your Cloudflare account, not as USDC back to your wallet. The credit applies to your next invoice.
+
+## View your payment history
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/).
+2. Go to **Manage Account** > **Billing**.
+
+   <DashButton url="/?to=/:account/billing" />
+
+3. Select **Invoices**. Stablecoin payments are listed with payment method `crypto`.
+
+## FAQ
+
+<Details header="USDC and the stablecoin standard">
+USDC is a US dollar-backed stablecoin issued by Circle. One USDC is designed to equal one US dollar. Cloudflare accepts USDC on the Base and Polygon networks.
+</Details>
+
+<Details header="Network fees and gas">
+Gas fees for the on-chain transaction are paid by your wallet to the network. Cloudflare does not add a markup or transaction fee for stablecoin payments. The amount charged in USDC matches your invoice amount in USD.
+</Details>
+
+<Details header="Smart contract permit scope">
+The permit authorizes charges for the specific subscription you are activating. You can revoke it at any time from your wallet. Revoking it stops future automatic charges; existing subscriptions enter dunning until you reconnect a wallet or switch payment methods.
+</Details>
+
+<Details header="Multiple payment methods">
+You can have a crypto wallet and a card on file at the same time. The card serves as a fallback if the wallet charge fails.
+</Details>
+
+<Details header="Pending state during on-chain confirmation">
+Stablecoin payments pass through a `processing` state while the on-chain transaction confirms. This typically takes a few seconds but can take longer if the network is congested. The payment resolves automatically.
+</Details>


### PR DESCRIPTION
## Summary

Adds a new payment-methods page covering stablecoin (USDC) payments via Unified Checkout.

## What this covers

- On-session wallet connection flow via the Stripe-hosted page at `crypto.stripe.com`
- Supported stablecoins: USDC on Base and Polygon
- Supported wallets: MetaMask, Phantom, Coinbase Wallet, 400+ via WalletConnect
- Recurring billing via smart contract permit
- Payment failure handling (insufficient funds, approval revoked, wallet screening)
- Fallback to card on file (links to existing auto-retry doc)
- USD-only refund behaviour
- FAQ in noun-phrase format (per concept content type)

## Style compliance

- No gerunds, questions, or CTAs in headings
- Description colons in numbered steps
- `description` at top level of frontmatter
- `products: [billing]` set
- No internal metrics, gate names, or config IDs

## Related

- Internal wiki: [Stablecoin Payments via Unified Checkout — Rollout](https://wiki.cfdata.org/spaces/BILL/pages/1410575361)
- SHIP-13563 — Accept payments with Stablecoin
- PCX-21819 — PCX docs request
- RFC: [Stablecoin Payments via Unified Checkout](https://wiki.cfdata.org/spaces/BILL/pages/1387666849)
