### PR TITLE
[AI Gateway] Use 'default' as gateway ID in cf-aig-gateway-id examples

### DIFF
--- a/src/content/docs/ai-gateway/get-started.mdx
+++ b/src/content/docs/ai-gateway/get-started.mdx
@@ -34,7 +34,7 @@ Run the following command to make your first request through AI Gateway. This ex
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  --header "cf-aig-gateway-id: my-gateway" \
+  --header "cf-aig-gateway-id: default" \
   --header "Content-Type: application/json" \
   --data '{
     "model": "@cf/moonshotai/kimi-k2.6",

--- a/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
+++ b/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
@@ -39,7 +39,7 @@ Then, create a new AI Gateway.
    ```bash
    curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
      --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-     --header "cf-aig-gateway-id: my-gateway" \
+     --header "cf-aig-gateway-id: default" \
      --header "Content-Type: application/json" \
      --data '{
        "model": "@cf/moonshotai/kimi-k2.6",

--- a/src/content/docs/ai-gateway/usage/providers/workersai.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/workersai.mdx
@@ -21,7 +21,7 @@ Use the [REST API](/ai-gateway/usage/rest-api/) to call Workers AI models. Worke
 ```bash title="Request to Workers AI Kimi model"
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  --header "cf-aig-gateway-id: my-gateway" \
+  --header "cf-aig-gateway-id: default" \
   --header "Content-Type: application/json" \
   --data '{
     "model": "@cf/moonshotai/kimi-k2.6",

--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -75,7 +75,7 @@ To call a Workers AI model, use the `@cf/` prefix in the model name and include 
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  --header "cf-aig-gateway-id: my-gateway" \
+  --header "cf-aig-gateway-id: default" \
   --header "Content-Type: application/json" \
   --data '{
     "model": "@cf/moonshotai/kimi-k2.6",
@@ -212,7 +212,7 @@ By default, third-party model requests route through your account's default AI G
 ```bash
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  --header "cf-aig-gateway-id: my-gateway" \
+  --header "cf-aig-gateway-id: default" \
   --header "Content-Type: application/json" \
   --data '{
     "model": "anthropic/claude-sonnet-4",
@@ -232,7 +232,7 @@ const openai = new OpenAI({
   apiKey: CLOUDFLARE_API_TOKEN,
   baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
   defaultHeaders: {
-    "cf-aig-gateway-id": "my-gateway",
+    "cf-aig-gateway-id": "default",
   },
 });
 ```


### PR DESCRIPTION
### Summary
use default as the gateway id in docs so it gets auto created if people are copy and pasting 

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
