### PR TITLE
Tweaks to clarify DO-Container class relationship

### DIFF
--- a/src/content/docs/containers/container-class.mdx
+++ b/src/content/docs/containers/container-class.mdx
@@ -10,11 +10,9 @@ products:
 
 import { PackageManagers, TypeScriptExample } from "~/components";
 
-The [`Container` class](https://github.com/cloudflare/containers) from [`@cloudflare/containers`](https://www.npmjs.com/package/@cloudflare/containers) is the standard way to interact with container instances from a Worker. It wraps the underlying [Durable Object interface](/containers/platform-details/durable-object-methods) and provides a higher-level API for common container behaviors.
+The [`Container` class](https://github.com/cloudflare/containers) from [`@cloudflare/containers`](https://www.npmjs.com/package/@cloudflare/containers) is the most common way to interact with container instances from a Worker.
 
-:::note
-If you are using containers to run sandboxed code execution — for example, inside an AI agent — consider the [Sandbox SDK](/sandbox/) instead. It builds on top of Containers and provides a higher-level API for common sandbox workflows.
-:::
+**`Container` extends [`DurableObject`](/durable-objects/api/base/).** The Durable Object manages routing, persistent state, and lifecycle hooks, while the container process runs your image inside a Linux VM. Because your subclass is a Durable Object, you have access to the full Durable Object API — including [`this.ctx.storage`](/durable-objects/api/sqlite-storage-api/) for persistent SQLite-backed storage and [`this.ctx.id`](/durable-objects/api/id/) for the unique instance identifier. Use Durable Object storage to persist state that should survive container restarts, such as configuration, user data, or task results.
 
 <PackageManagers pkg="@cloudflare/containers" />
 
@@ -45,7 +43,26 @@ export default {
 ```
 </TypeScriptExample>
 
-The `Container` class extends `DurableObject`, so all [Durable Object](/durable-objects) functionality is available.
+The `Container` class extends `DurableObject`, so all [Durable Object](/durable-objects/) functionality is available — including [SQLite storage](/durable-objects/api/sqlite-storage-api/), [alarms](/durable-objects/api/alarms/), and [RPC methods](/durable-objects/api/base/#rpc-methods). Container disk is ephemeral by default, but Durable Object storage persists across container restarts.
+
+<TypeScriptExample>
+```
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	defaultPort = 8080;
+
+	async runAndPersist() {
+		const res = await this.fetch("/run-task");
+		await this.ctx.storage.sql.exec(
+			"INSERT OR REPLACE INTO results (value) VALUES (?)",
+			res,
+		);
+		return res;
+	}
+}
+```
+</TypeScriptExample>
 
 ## Properties
 

--- a/src/content/docs/containers/container-class.mdx
+++ b/src/content/docs/containers/container-class.mdx
@@ -54,11 +54,12 @@ export class MyContainer extends Container {
 
 	async runAndPersist() {
 		const res = await this.fetch("/run-task");
+		const body = await res.text();
 		await this.ctx.storage.sql.exec(
 			"INSERT OR REPLACE INTO results (value) VALUES (?)",
-			res,
+			body,
 		);
-		return res;
+		return body;
 	}
 }
 ```

--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -82,28 +82,6 @@ You can confirm this behavior by reading the output of each request.
 
 Now that you've deployed your first container, let's explain what is happening in your Worker's code, in your configuration file, in your container's code, and how requests are routed.
 
-## Each Container is backed by its own Durable Object
-
-Incoming requests are initially handled by the Worker, then passed to a container-enabled [Durable Object](/durable-objects).
-To simplify and reduce boilerplate code, Cloudflare provides a [`Container` class](https://github.com/cloudflare/containers) as part of the `@cloudflare/containers` NPM package.
-
-You don't have to be familiar with Durable Objects to use Containers, but it may be helpful
-to understand the basics.
-
-Each Durable Object runs alongside an individual container instance, manages starting and stopping it, and
-can interact with the container through its ports. Containers will likely run near the Worker instance
-requesting them, but not necessarily. Refer to ["How Locations are Selected"](/containers/platform-details/#how-are-locations-are-selected)
-for details.
-
-In a simple app, the Durable Object may just boot the container and proxy requests to it.
-
-In a more complex app, having container-enabled Durable Objects allows you to route requests to individual stateful container
-instances, manage the container lifecycle, pass in custom starting commands and environment variables to containers, run hooks
-on container status changes, and more.
-
-See the [documentation for Durable Object container methods](/durable-objects/api/container/) and the
-[`Container` class repository](https://github.com/cloudflare/containers) for more details.
-
 ### Configuration
 
 Your [Wrangler configuration file](/workers/wrangler/configuration/) defines the configuration for both your Worker and your container:
@@ -203,7 +181,9 @@ This defines basic configuration for the container:
 - `envVars` sets environment variables that will be passed to the container when it starts.
 - `onStart`, `onStop`, and `onError` are hooks that run when the container starts, stops, or errors, respectively.
 
-See the [Container class documentation](/containers/container-class/) for more details and configuration options.
+The `Container` class itself extends [`DurableObject`](/durable-objects/), so your subclass has access to the full Durable Object API. The Durable Object handles routing, lifecycle, and persistent state, while the container process runs your image inside a microVM. This means you can use [`this.ctx.storage`](/durable-objects/api/sqlite-storage-api/) to persist data that survives container restarts and resides close to the container itself.
+
+Refer to the [Container class reference](/containers/container-class/) and the [low-level Durable Object container API](/durable-objects/api/container/) for more details.
 
 #### Routing to Containers
 

--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -180,7 +180,7 @@ This defines basic configuration for the container:
 - `sleepAfter` sets the timeout for the container to sleep after it has been idle for a certain amount of time.
 - `envVars` sets environment variables that will be passed to the container when it starts.
 - `onStart`, `onStop`, and `onError` are hooks that run when the container starts, stops, or errors, respectively.
-
+The `Container` class itself extends [`DurableObject`](/durable-objects/), so your subclass has access to the full Durable Object API. The Durable Object handles routing, lifecycle, and persistent state, while the container process runs your image inside a Linux VM. This means you can use [`this.ctx.storage`](/durable-objects/api/sqlite-storage-api/) to persist data that survives container restarts and resides close to the container itself.
 The `Container` class itself extends [`DurableObject`](/durable-objects/), so your subclass has access to the full Durable Object API. The Durable Object handles routing, lifecycle, and persistent state, while the container process runs your image inside a microVM. This means you can use [`this.ctx.storage`](/durable-objects/api/sqlite-storage-api/) to persist data that survives container restarts and resides close to the container itself.
 
 Refer to the [Container class reference](/containers/container-class/) and the [low-level Durable Object container API](/durable-objects/api/container/) for more details.

--- a/src/content/docs/containers/index.mdx
+++ b/src/content/docs/containers/index.mdx
@@ -152,6 +152,15 @@ regional placement, Workflow and Queue integrations, AI-generated code execution
 	Learn about what limits Containers have and how to work within them.
 </LinkTitleCard>
 
+<LinkTitleCard
+	title="Durable Object Container API"
+	href="/durable-objects/api/container/"
+	icon="document"
+>
+	Low-level runtime API for starting, stopping, and communicating with the
+	container process directly from a Durable Object.
+</LinkTitleCard>
+
 <LinkTitleCard title="SSH" href="/containers/ssh/" icon="seti:shell">
 	Connect to running Container instances with SSH through Wrangler.
 </LinkTitleCard>

--- a/src/content/docs/containers/platform-details/limits.mdx
+++ b/src/content/docs/containers/platform-details/limits.mdx
@@ -42,16 +42,16 @@ For workloads requiring less than 1 vCPU, use the predefined instance types such
 If you need larger instance sizes or higher account-level limits, contact your account team, file a
 support ticket, or fill out [this form](https://forms.gle/CscdaEGuw5Hb6H2s7).
 
-## Limits
+## Account limits
 
-The following limits currently apply:
+The following limits apply per account:
 
-| Feature                                             | Workers Paid                                   |
-| --------------------------------------------------- | ---------------------------------------------- |
-| Memory for all concurrent live Container instances  | 6TiB                                           |
-| vCPU for all concurrent live Container instances    | 1,500                                          |
-| TB Disk for all concurrent live Container instances | 30TB                                           |
-| Image size                                          | Same as [instance disk space](#instance-types) |
-| Total image storage per account                     | 50 GB [^1]                                     |
+| Resource                        | Limit                                          |
+| ------------------------------- | ---------------------------------------------- |
+| Concurrent memory               | 6 TiB                                          |
+| Concurrent vCPU                 | 1,500                                          |
+| Concurrent disk                 | 30 TB                                          |
+| Image size                      | Same as [instance disk space](#instance-types) |
+| Total image storage per account | 50 GB [^1]                                     |
 
 [^1]: Delete container images with `wrangler containers delete` to free up space. If you delete a container image and then [roll back](/workers/configuration/versions-and-deployments/rollbacks/) your Worker to a previous version, this version may no longer work.

--- a/src/content/docs/durable-objects/api/container.mdx
+++ b/src/content/docs/durable-objects/api/container.mdx
@@ -20,13 +20,11 @@ import {
 
 ## Description
 
-When using a [Container-enabled Durable Object](/containers), you can access the Durable Object's associated container via
-the `container` object which is on the `ctx` property. This allows you to start, stop, and interact with the container.
+Each [container](/containers/) is managed by a Durable Object. The [`Container` class](/containers/container-class/) from `@cloudflare/containers` extends `DurableObject` and handles lifecycle management, port readiness, and sleep timeouts for you. The Durable Object manages routing, persistent state, and lifecycle hooks, while the container process runs your image inside a Linux VM.
 
-:::note
-It is likely preferable to use the official `Container` class, which provides helper methods and
-a more idiomatic API for working with containers on top of Durable Objects.
-:::
+The low-level API documented on this page is available on `this.ctx.container` inside any Durable Object class that has a container binding. Use it when you need direct control over the container process or cannot use the `Container` class.
+
+Because the `Container` class extends `DurableObject`, you also have access to [SQLite storage](/durable-objects/api/sqlite-storage-api/) via `this.ctx.storage`, [alarms](/durable-objects/api/alarms/), and all other Durable Object APIs.
 
 <TypeScriptExample filename="index.ts">
 ```ts
@@ -259,5 +257,8 @@ this.ctx.container.interceptOutboundHttps("*", worker);
 
 ## Related resources
 
-- [Containers](/containers)
-- [Get Started With Containers](/containers/get-started)
+- [Container class reference](/containers/container-class/) — the recommended high-level API built on top of this interface
+- [Containers overview](/containers/)
+- [Get started with Containers](/containers/get-started/)
+- [SQLite storage API](/durable-objects/api/sqlite-storage-api/) — persist state across container restarts
+- [Durable Objects](/durable-objects/) — the underlying platform that powers Containers


### PR DESCRIPTION
### Summary

Explains DurableObject-Container class relationship a bit more clearly.

Occasionally users (both human and AI) would get confused and use a DO in addition to Container when they could just use one. This is meant to stop that from happening and make things generally more clear.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
