### PR TITLE
[Email Service] Document support for RFC5322 named addresses

### DIFF
--- a/src/content/changelog/email-service/2026-05-28-named-email-recipients.mdx
+++ b/src/content/changelog/email-service/2026-05-28-named-email-recipients.mdx
@@ -1,0 +1,39 @@
+---
+title: Send emails with named recipient addresses
+description: You can now include display names on to, cc, bcc, and from addresses when sending emails via the Workers binding or REST API.
+products:
+  - email-service
+date: 2026-05-28
+---
+
+import { TypeScriptExample } from "~/components";
+
+You can now send emails with display names on recipient addresses in addition to the existing `from` support. Pass an object with `email` and an optional `name` field for `to`, `cc`, `bcc`, `replyTo`, or `from`:
+
+<TypeScriptExample filename="src/index.ts">
+
+```ts
+export default {
+	async fetch(request, env): Promise<Response> {
+		const response = await env.EMAIL.send({
+			from: { email: "support@example.com", name: "Support Team" },
+			to: { email: "jane@example.com", name: "Jane Doe" },
+			cc: [
+				"manager@company.com",
+				{ email: "team@company.com", name: "Engineering Team" },
+			],
+			subject: "Welcome!",
+			html: "<h1>Thanks for joining!</h1>",
+			text: "Thanks for joining!",
+		});
+
+		return Response.json({ messageId: response.messageId });
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+Plain strings remain fully supported for backward compatibility, and you can mix strings and named objects in the same array.
+
+Refer to the [Workers API](/email-service/api/send-emails/workers-api/) and [REST API](/email-service/api/send-emails/rest-api/) documentation for full request examples.

--- a/src/content/docs/agents/api-reference/email.mdx
+++ b/src/content/docs/agents/api-reference/email.mdx
@@ -646,19 +646,28 @@ export default {
 
 ## API reference
 
+### `EmailAddress`
+
+```ts
+interface EmailAddress {
+	email: string;
+	name?: string;
+}
+```
+
 ### `sendEmail`
 
 ```ts
 async sendEmail(options: {
 	binding: EmailSendBinding;
-	to: string | string[];
-	from: string | { email: string; name?: string };
+	to: string | EmailAddress | (string | EmailAddress)[];
+	from: string | EmailAddress;
 	subject: string;
 	text?: string;
 	html?: string;
-	replyTo?: string | { email: string; name?: string };
-	cc?: string | string[];
-	bcc?: string | string[];
+	replyTo?: string | EmailAddress;
+	cc?: string | EmailAddress | (string | EmailAddress)[];
+	bcc?: string | EmailAddress | (string | EmailAddress)[];
 	inReplyTo?: string;
 	headers?: Record<string, string>;
 	secret?: string;
@@ -670,14 +679,14 @@ Send an outbound email through the Email Service binding. Automatically injects 
 | Option      | Description                                                               |
 | ----------- | ------------------------------------------------------------------------- |
 | `binding`   | The `send_email` binding (for example, `this.env.EMAIL`). Required.       |
-| `to`        | Recipient address or array of addresses                                   |
-| `from`      | Sender address, or `\{ email, name \}` object                             |
+| `to`        | Recipient address, array of addresses, or `EmailAddress` object(s)        |
+| `from`      | Sender address or `EmailAddress` object                                   |
 | `subject`   | Email subject line                                                        |
 | `text`      | Plain text body (at least one of `text`/`html` required)                  |
 | `html`      | HTML body (at least one of `text`/`html` required)                        |
-| `replyTo`   | Reply-to address for the recipient                                        |
-| `cc`        | CC recipient(s)                                                           |
-| `bcc`       | BCC recipient(s)                                                          |
+| `replyTo`   | Reply-to address or `EmailAddress` object                                 |
+| `cc`        | CC recipient address, array of addresses, or `EmailAddress` object(s)     |
+| `bcc`       | BCC recipient address, array of addresses, or `EmailAddress` object(s)    |
 | `inReplyTo` | Message-ID for threading (sets the `In-Reply-To` header)                  |
 | `headers`   | Additional custom headers (agent headers take precedence if they collide) |
 | `secret`    | Secret for HMAC signing of agent routing headers                          |

--- a/src/content/docs/email-service/api/send-emails/rest-api.mdx
+++ b/src/content/docs/email-service/api/send-emails/rest-api.mdx
@@ -82,6 +82,41 @@ curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/email/sending/s
 ```
 
 </TabItem>
+<TabItem label="Named recipients">
+
+```bash
+curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/email/sending/send" \
+  --header "Authorization: Bearer <API_TOKEN>" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "to": { "address": "jane@example.com", "name": "Jane Doe" },
+    "from": { "address": "support@example.com", "name": "Support Team" },
+    "subject": "Welcome!",
+    "html": "<h1>Thanks for joining!</h1>",
+    "text": "Thanks for joining!"
+  }'
+```
+
+</TabItem>
+<TabItem label="Mixed recipients">
+
+```bash
+curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/email/sending/send" \
+  --header "Authorization: Bearer <API_TOKEN>" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "to": [
+      "plain@example.com",
+      { "address": "jane@example.com", "name": "Jane Doe" }
+    ],
+    "from": "support@yourdomain.com",
+    "subject": "Team update",
+    "html": "<h1>Monthly update</h1>",
+    "text": "Monthly update"
+  }'
+```
+
+</TabItem>
 </Tabs>
 
 ## Attachments

--- a/src/content/docs/email-service/api/send-emails/workers-api.mdx
+++ b/src/content/docs/email-service/api/send-emails/workers-api.mdx
@@ -42,16 +42,21 @@ interface SendEmail {
 	send(message: EmailMessage | EmailMessageBuilder): Promise<EmailSendResult>;
 }
 
+interface EmailAddress {
+	email: string;
+	name?: string;
+}
+
 // Structured email builder (recommended)
 interface EmailMessageBuilder {
-	to: string | string[]; // Max 50 recipients
-	from: string | { email: string; name: string };
+	to: string | EmailAddress | (string | EmailAddress)[]; // Max 50 recipients
+	from: string | EmailAddress;
 	subject: string;
 	html?: string;
 	text?: string;
-	cc?: string | string[];
-	bcc?: string | string[];
-	replyTo?: string | { email: string; name: string };
+	cc?: string | EmailAddress | (string | EmailAddress)[];
+	bcc?: string | EmailAddress | (string | EmailAddress)[];
+	replyTo?: string | EmailAddress;
 	attachments?: Attachment[];
 	headers?: { [key: string]: string }; // See /email-service/reference/headers/
 }
@@ -110,6 +115,35 @@ const response = await env.EMAIL.send({
 	subject: "Order Confirmation #12345",
 	html: "<h1>Your order is confirmed</h1>",
 	text: "Your order is confirmed",
+});
+```
+
+</TabItem>
+<TabItem label="Named recipients">
+
+```ts
+const response = await env.EMAIL.send({
+	to: { email: "jane@example.com", name: "Jane Doe" },
+	from: { email: "support@example.com", name: "Support Team" },
+	subject: "Welcome!",
+	html: "<h1>Thanks for joining!</h1>",
+	text: "Thanks for joining!",
+});
+```
+
+</TabItem>
+<TabItem label="Mixed recipients">
+
+```ts
+const response = await env.EMAIL.send({
+	to: [
+		"plain@example.com",
+		{ email: "jane@example.com", name: "Jane Doe" },
+	],
+	from: "support@yourdomain.com",
+	subject: "Team update",
+	html: "<h1>Monthly update</h1>",
+	text: "Monthly update",
 });
 ```
 


### PR DESCRIPTION
### Summary

Document that Email Sending now supports named addresses in to/cc/bcc fields, like `from` and `replyTo` do.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
