### PR TITLE
[Logpush] Add the missing requirement to the Sentinel documentation

### DIFF
--- a/src/content/docs/analytics/analytics-integrations/sentinel.mdx
+++ b/src/content/docs/analytics/analytics-integrations/sentinel.mdx
@@ -25,6 +25,8 @@ This guide provides clear, step-by-step instructions for integrating Cloudflare 
 - Microsoft Sentinel Workspace already set up in your Azure environment.
 - Azure Storage Account with a Blob container for storing Cloudflare logs.
 - Cloudflare Account with access to the domain whose logs you wish to export, and permission to configure Logpush jobs.
+- The Azure Storage account needs to be set to public network access.
+- The Azure Storage account needs to be in the same subscription as the Microsoft Sentinel Workspace. 
 
 ## Step 2: Set up a logpush job
 


### PR DESCRIPTION
On the documentation page: https://developers.cloudflare.com/analytics/analytics-integrations/sentinel/

Prerequisites:

The Azure Storage account needs to be set to public network access The Azure Storage account needs to be in the same subscription as the Microsoft Sentinel Workspace

Without these, the connector will never be onboarded and it would help if the documentation states that per case 01981282.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
