### PR TITLE
Email Service: document E_TOO_MANY_ATTACHMENTS error code

### DIFF
--- a/src/content/docs/email-service/api/send-emails/workers-api.mdx
+++ b/src/content/docs/email-service/api/send-emails/workers-api.mdx
@@ -240,6 +240,7 @@ The following error codes may be returned when sending emails:
 | `E_VALIDATION_ERROR`            | Validation error in the payload         | Invalid email format, missing required fields, malformed data |
 | `E_FIELD_MISSING`               | Required field is missing               | Missing `to`, `from`, or `subject` fields                     |
 | `E_TOO_MANY_RECIPIENTS`         | Too many recipients in to/cc/bcc arrays | Combined recipients exceed 50 limit                           |
+| `E_TOO_MANY_ATTACHMENTS`        | Too many attachments in `attachments` array | `attachments` array exceeds 32 entries                    |
 | `E_SENDER_NOT_VERIFIED`         | Sender domain not verified              | Attempting to send from unverified domain                     |
 | `E_RECIPIENT_NOT_ALLOWED`       | Recipient not in allowed list           | Recipient address not in `allowed_destination_addresses`      |
 | `E_RECIPIENT_SUPPRESSED`        | Recipient is on suppression list        | Email address has bounced or reported your emails as spam     |


### PR DESCRIPTION
## What's changed

Adds the new `E_TOO_MANY_ATTACHMENTS` error code to the Workers API error code table in `workers-api.mdx`.

This code is returned by `env.EMAIL.send()` when the `attachments` array in an `EmailMessageBuilder` payload exceeds **32 entries**. The limit is enforced server-side to bound per-message resource consumption in the Email Service RPC layer.

## Why

The `E_TOO_MANY_ATTACHMENTS` code was just added on the backend (Email Service RPC). Without this row, Workers callers that hit the cap will see an undocumented `error.code`, making it harder to handle the error programmatically (e.g. in the existing `switch (error.code)` example in the same page).

Placed right after `E_TOO_MANY_RECIPIENTS` since both are per-message resource caps with the same shape.

## Scope

- Workers API only. The REST API doc (`rest-api.mdx`) already cross-references this table for string codes and does not need an update.
- One-line addition to an existing table. No structural changes.