### PR TITLE
Durable Objects: document the RangeError when a KV storage value exceeds 128 KiB

### DIFF
--- a/src/content/partials/durable-objects/api-async-kv-legacy.mdx
+++ b/src/content/partials/durable-objects/api-async-kv-legacy.mdx
@@ -27,7 +27,9 @@ import {Type, MetaInfo, AnchorHeading} from "~/components";
 
     The size of keys and values have different limits depending on the Durable Object storage backend you are using. Refer to either:
     - [SQLite-backed Durable Object limits](/durable-objects/platform/limits/#sqlite-backed-durable-objects-general-limits)
-    - [KV-backed Durable Object limits](/durable-objects/platform/limits/#key-value-backed-durable-objects-general-limits).<br/><br/>
+    - [KV-backed Durable Object limits](/durable-objects/platform/limits/#key-value-backed-durable-objects-general-limits).
+
+    On a KV-backed Durable Object, if the serialized value exceeds the 128 KiB (131072 bytes) value-size limit, `put()` throws a `RangeError` (for example, `Values cannot be larger than 131072 bytes.`) before the write is applied.<br/><br/>
 
 - <code>put(entries <Type text="Object" />, options <Type text="Object" /> <MetaInfo text="optional" />)</code>: <Type text="Promise" />
   - Takes an Object and stores each of its keys and values to storage.


### PR DESCRIPTION
### Summary

The KV-backed Durable Object `put()` documentation and the Limits page state the 128 KiB value-size cap but do not name the error thrown when it is exceeded. By contrast, the SQLite full-storage case is already documented with the `SQLITE_FULL` error and an example, so this adds the parallel for KV-backed storage.

Verified: a value whose serialized size exceeds 131072 bytes makes `put()` throw `RangeError: Values cannot be larger than 131072 bytes.` before the write is applied (values at and just under the cap succeed).

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
