### PR TITLE
Workers Observability: link the Query Builder page to the REST query API

### DIFF
--- a/src/content/docs/workers/observability/query-builder.mdx
+++ b/src/content/docs/workers/observability/query-builder.mdx
@@ -22,6 +22,8 @@ import {
 
 The Query Builder helps you write structured queries to investigate and visualize your telemetry data. The Query Builder searches the Workers Observability dataset, which currently includes all logs stored by [Workers Logs](/workers/observability/logs/workers-logs/).
 
+You can also run the same queries programmatically with the [Workers Observability REST API](/api/resources/workers/subresources/observability/), which exposes endpoints to list dataset keys, run a query, and list the values for a key.
+
 The Query Builder can be found in the **Observability** page of the Cloudflare dashboard:
 
 <DashButton url="/?to=/:account/workers-and-pages/observability" />

--- a/src/content/docs/workers/observability/query-builder.mdx
+++ b/src/content/docs/workers/observability/query-builder.mdx
@@ -22,7 +22,7 @@ import {
 
 The Query Builder helps you write structured queries to investigate and visualize your telemetry data. The Query Builder searches the Workers Observability dataset, which currently includes all logs stored by [Workers Logs](/workers/observability/logs/workers-logs/).
 
-You can also run the same queries programmatically with the [Workers Observability REST API](/api/resources/workers/subresources/observability/), which exposes endpoints to list dataset keys, run a query, and list the values for a key.
+You can also run the same queries programmatically using the [Workers Observability REST API](/api/resources/workers/subresources/observability/), which exposes endpoints to list dataset keys, run a query, and list the values for a key.
 
 The Query Builder can be found in the **Observability** page of the Cloudflare dashboard:
 


### PR DESCRIPTION
### Summary

The Workers Observability telemetry query REST API (list keys, run a query, list values) exists in the API reference but is not linked from any prose documentation page, so developers looking for programmatic access to their logs do not find it. This adds a one-sentence cross-link from the Query Builder page to the REST API reference.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
