### PR TITLE
AI Gateway: distinguish gateway-level 401s (AiGatewayError 2009) from provider 401s

### DIFF
--- a/src/content/docs/ai-gateway/reference/troubleshooting.mdx
+++ b/src/content/docs/ai-gateway/reference/troubleshooting.mdx
@@ -32,6 +32,13 @@ For provider-specific authentication issues:
 
 - [Google Vertex AI troubleshooting](/ai-gateway/usage/providers/vertex/#troubleshooting)
 
+#### Telling gateway-level from provider-level 401s
+
+A 401 can come from either AI Gateway or the upstream provider. Use the response body to tell them apart:
+
+- If the body is an AI Gateway error (`name: "AiGatewayError"` with `internalCode: 2009`), the gateway rejected the request before reaching the provider. This means your `cf-aig-authorization` token is missing or invalid — it is not a provider-credential problem.
+- If the body is the provider's own error (for example, an OpenAI error stating an API key was not provided), the request reached the provider but no usable provider credential was applied. Check your stored provider credentials or [BYOK](/ai-gateway/configuration/bring-your-own-keys/) configuration. This is also what you see when a model is not enrolled in [Unified Billing](/ai-gateway/features/unified-billing/): the gateway forwards the request without a wholesale credential and the provider rejects it.
+
 ## DLP issues
 
 For troubleshooting Data Loss Prevention issues such as DLP not triggering or unexpected blocking, refer to [DLP troubleshooting](/ai-gateway/features/dlp/set-up-dlp/#troubleshooting).


### PR DESCRIPTION
### Summary

A 401 from AI Gateway can originate either from the gateway itself or be passed through from the upstream provider, and the two have different response bodies. The gateway-level error (`name: "AiGatewayError"`, `internalCode: 2009`) is not documented anywhere, so it is hard to tell it apart from a provider-credential rejection. This adds a short subsection to the "401 or unauthenticated errors" troubleshooting section. It documents the stable `name`/`internalCode` fields rather than reproducing a full response body.

Verified live:
- A missing/invalid `cf-aig-authorization` token on a Unified Billing gateway returns a 401 with `name: "AiGatewayError"` / `internalCode: 2009`.
- A request whose model is **not** enrolled in Unified Billing (with a valid `cf-aig-authorization` token) does **not** return 2009 — it is forwarded to the provider without a wholesale credential and returns the provider's own error (for example, an OpenAI "You didn't provide an API key" `invalid_request_error`). So that case is documented under the provider-level branch, not the 2009 branch.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).