### PR TITLE
Add Tunnel and Mesh to Networking tab on landing page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -180,6 +180,8 @@ const sidebar = [
 				collapsed: true,
 				badge: groupIcon("network"),
 				items: [
+					{ label: "Tunnel", link: "/tunnel/" },
+					{ label: "Mesh", link: "/mesh/" },
 					{ label: "Magic Transit", link: "/magic-transit/" },
 					{ label: "Magic WAN", link: "/cloudflare-wan/" },
 					{ label: "Network Interconnect", link: "/network-interconnect/" },


### PR DESCRIPTION
### Summary

Adds Tunnel (`/tunnel/`) and Mesh (`/mesh/`) as the first two items in the Networking tab on the landing page sidebar, matching the Cloudflare dashboard navigation order.

`/mesh/` currently redirects to `/cloudflare-one/networks/connectors/cloudflare-mesh/` — using the short path now so no nav change is needed when the docs move out of CF1 later.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
