### PR TITLE
chore: Add Sandbox SDK to sidebar

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,6 +92,7 @@ const sidebar = [
 					{ label: "Workers AI", link: "/workers-ai/" },
 					{ label: "AI Gateway", link: "/ai-gateway/" },
 					{ label: "Agents", link: "/agents/" },
+					{ label: "Sandbox SDK", link: "/sandbox/" },
 					{ label: "Vectorize", link: "/vectorize/" },
 					{ label: "AI Search", link: "/ai-search/" },
 					{ label: "AI Crawl Control", link: "/ai-crawl-control/" },


### PR DESCRIPTION
### Summary

Adds Sandbox SDK to the homepage sidebar under Build > AI so users can more easily find the Sandbox documentation.
