### PR TITLE
[Access] Document NameID transform for SAML SaaS applications

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/applications/http-apps/saas-apps/generic-saml-saas.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/http-apps/saas-apps/generic-saml-saas.mdx
@@ -107,9 +107,11 @@ To send additional SAML attributes to your SaaS application, configure the follo
 	- **Required**: If an attribute is marked as required but is not provided by an IdP, Cloudflare will fail the authentication request and show an error page.
 	- **Add per IdP claim**: (Optional) If you turned on multiple identity providers for the SaaS application, you can choose different attribute mappings for each IdP. These values will override the parent **IdP claim**.
 
-### JSONata transforms
+### JSONata attribute transforms
 
 In **Advanced settings** > **Transformation**, you can enter a [JSONata](https://jsonata.org/) script that modifies a copy of the [User Registry identity](/cloudflare-one/team-and-resources/users/users/). This is useful for setting default values, excluding email addresses, or ensuring usernames meet arbitrary criteria. Access will send the modified user identity to the SaaS application as SAML attributes.
+
+This corresponds to the `saml_attribute_transform_jsonata` field in the [Access applications API](/api/resources/zero_trust/subresources/access/subresources/applications/methods/create/).
 
 :::note
 JSONata transformations are not compatible with [SAML attribute statements](#saml-attribute-statements). JSONata transformations will override any specified SAML attributes.
@@ -390,6 +392,73 @@ Result after applying the JSONata transform:
   }
 }
 ```
+</Details>
+
+### NameID transform
+
+By default, Access sends the user's email address as the SAML `NameID`. Some SaaS applications require a different value, such as an employee ID, a modified email address, or a username from a legacy system.
+
+You can customize the `NameID` by setting the `name_id_transform_jsonata` field on the SaaS application via the [Access applications API](/api/resources/zero_trust/subresources/access/subresources/applications/methods/create/). This field accepts a [JSONata](https://jsonata.org/) expression that evaluates against the user's identity and must return a single string value. The result replaces the default `NameID` in the SAML assertion.
+
+:::note
+The NameID transform is only available through the API. To configure it, update the `saas_app.name_id_transform_jsonata` field on your Access application.
+:::
+
+For example, to modify the user's email so that it includes a `+sandbox` suffix (useful when connecting multiple instances of the same SaaS app):
+
+```bash title="Set a NameID transform via the API"
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/access/apps/{app_id} \
+--header "Authorization: Bearer {api_token}" \
+--header "Content-Type: application/json" \
+--data '{
+  "saas_app": {
+    "auth_type": "saml",
+    "name_id_transform_jsonata": "$substringBefore(email, '\''@'\'') & '\''+sandbox@'\'' & $substringAfter(email, '\''@'\'')"
+  }
+}'
+```
+
+Given a user with the email `jdoe@company.com`, this expression produces a `NameID` of `jdoe+sandbox@company.com`.
+
+<Details header="Use employee ID as NameID">
+
+To send a non-email attribute such as an employee ID, reference the attribute name directly in the JSONata expression. The attribute must be available in the user's identity from the IdP.
+
+```bash title="Set employee_id as NameID"
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/access/apps/{app_id} \
+--header "Authorization: Bearer {api_token}" \
+--header "Content-Type: application/json" \
+--data '{
+  "saas_app": {
+    "auth_type": "saml",
+    "name_id_transform_jsonata": "employee_id"
+  }
+}'
+```
+
+Given a user identity that contains `"employee_id": "efgh5678"`, the `NameID` sent in the SAML assertion will be `efgh5678`.
+
+</Details>
+
+<Details header="Remove NameID transform">
+
+To revert to the default behavior (sending the user's email as the `NameID`), set the field to an empty string:
+
+```bash title="Remove NameID transform"
+curl --request PUT \
+https://api.cloudflare.com/client/v4/accounts/{account_id}/access/apps/{app_id} \
+--header "Authorization: Bearer {api_token}" \
+--header "Content-Type: application/json" \
+--data '{
+  "saas_app": {
+    "auth_type": "saml",
+    "name_id_transform_jsonata": ""
+  }
+}'
+```
+
 </Details>
 
 


### PR DESCRIPTION
Adds documentation for the `name_id_transform_jsonata` API field on Access for SaaS SAML applications. This lets customers customize the SAML NameID value sent to a SaaS app using a JSONata expression -- for example, appending a sandbox suffix to emails, or sending an employee ID instead of an email address.

**Changes:**

- Renamed the existing `JSONata transforms` section to `JSONata attribute transforms` and added a callout linking it to the `saml_attribute_transform_jsonata` API field
- Added a new `NameID transform` section with:
  - Explanation of the `name_id_transform_jsonata` API field
  - curl example for setting a sandbox email suffix transform
  - Expandable example for using employee ID as NameID
  - Expandable example for removing a NameID transform

**Why:** The NameID transform was previously undocumented in the dev docs. The feature exists in the API (`saas_app.name_id_transform_jsonata`) and is used by customers who need non-email NameID values for SaaS integrations (multiple app instances, HR systems, M&A scenarios).