### PR TITLE
Changelog + docs update: Removing compressed Worker size limits

### DIFF
--- a/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
+++ b/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy larger Workers on all plans
+title: Deploy larger Workers — up to 64 MiB for both free and paid plans
 description: The compressed Worker size limits (3 MB free / 10 MB paid) have been removed. Cloudflare now only checks the uncompressed bundle size, which is 64 MiB across all plans.
 products:
   - workers

--- a/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
+++ b/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
@@ -25,6 +25,6 @@ wrangler deploy --outdir bundled/ --dry-run
 Total Upload: 259.61 KiB / gzip: 47.23 KiB
 ```
 
-`Total Upload` is your uncompressed bundle size and is what counts against the 64 MiB limit. `gzip` is shown for reference but is no longer checked.
+The `Total Upload` value is your uncompressed bundle size. This is what counts against the 64 MiB limit. The `gzip` value is shown for reference but is no longer a limit.
 
 For more information, refer to the [Worker size limits documentation](/workers/platform/limits/#worker-size).

--- a/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
+++ b/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
@@ -1,0 +1,31 @@
+---
+title: Worker size limit increased to 64 MiB for all plans
+description: The compressed Worker size limits (3 MB free / 10 MB paid) have been removed. Workers now support a single 64 MiB uncompressed size limit across all plans.
+products:
+  - workers
+date: 2026-05-22
+---
+
+You can now deploy Workers up to **64 MiB uncompressed** on all plans, up from 3 MB compressed on the Free plan and 10 MB compressed on the Paid plan.
+
+Workers are no longer limited by compressed bundle size. Only the uncompressed size counts, giving you ~21x more room on the Free plan and ~6x more on the Paid plan.
+
+| Limit | Previous | New |
+|---|---|---|
+| Free plan | 3 MB compressed | 64 MiB uncompressed |
+| Paid plan | 10 MB compressed | 64 MiB uncompressed |
+
+To check your Worker's bundle size before deploying:
+
+```sh
+wrangler deploy --outdir bundled/ --dry-run
+```
+
+```txt
+# Output resembles:
+Total Upload: 259.61 KiB / gzip: 47.23 KiB
+```
+
+The `Total Upload` value is your uncompressed bundle size — this is what counts against the 64 MiB limit. The `gzip` value is shown for reference but is no longer a limit.
+
+For more information, refer to the [Worker size limits documentation](/workers/platform/limits/#worker-size).

--- a/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
+++ b/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
@@ -6,14 +6,14 @@ products:
 date: 2026-05-22
 ---
 
-You can now deploy Workers up to **64 MiB uncompressed** on all plans, up from 3 MB compressed on the Free plan and 10 MB compressed on the Paid plan.
+You can now deploy Workers up to **64 MiB** on all plans, up from an effective limit of 3 MB on Free and 10 MB on Paid.
 
-Workers are no longer limited by compressed bundle size. Only the uncompressed size counts, giving you ~21x more room on the Free plan and ~6x more on the Paid plan.
+When you deploy a Worker, Wrangler bundles your code and compresses it before uploading. Previously, Cloudflare checked that compressed size and rejected deploys over 3 MB (Free) or 10 MB (Paid). That compressed limit is now gone. Cloudflare only checks the full, uncompressed size of your bundle against a 64 MiB limit, giving you much more room to work with.
 
 | Limit | Previous | New |
 |---|---|---|
-| Free plan | 3 MB compressed | 64 MiB uncompressed |
-| Paid plan | 10 MB compressed | 64 MiB uncompressed |
+| Free plan | 3 MB (compressed) | 64 MiB (uncompressed) |
+| Paid plan | 10 MB (compressed) | 64 MiB (uncompressed) |
 
 To check your Worker's bundle size before deploying:
 
@@ -21,11 +21,10 @@ To check your Worker's bundle size before deploying:
 wrangler deploy --outdir bundled/ --dry-run
 ```
 
-```txt
-# Output resembles:
+```sh output
 Total Upload: 259.61 KiB / gzip: 47.23 KiB
 ```
 
-The `Total Upload` value is your uncompressed bundle size — this is what counts against the 64 MiB limit. The `gzip` value is shown for reference but is no longer a limit.
+`Total Upload` is your uncompressed bundle size and is what counts against the 64 MiB limit. `gzip` is shown for reference but is no longer checked.
 
 For more information, refer to the [Worker size limits documentation](/workers/platform/limits/#worker-size).

--- a/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
+++ b/src/content/changelog/workers/2026-05-22-increased-worker-size-limit.mdx
@@ -1,19 +1,14 @@
 ---
-title: Worker size limit increased to 64 MiB for all plans
-description: The compressed Worker size limits (3 MB free / 10 MB paid) have been removed. Workers now support a single 64 MiB uncompressed size limit across all plans.
+title: Deploy larger Workers on all plans
+description: The compressed Worker size limits (3 MB free / 10 MB paid) have been removed. Cloudflare now only checks the uncompressed bundle size, which is 64 MiB across all plans.
 products:
   - workers
 date: 2026-05-22
 ---
 
-You can now deploy Workers up to **64 MiB** on all plans, up from an effective limit of 3 MB on Free and 10 MB on Paid.
+You can now deploy Workers with larger dependencies, heavier frameworks, and more code without hitting size limits.
 
-When you deploy a Worker, Wrangler bundles your code and compresses it before uploading. Previously, Cloudflare checked that compressed size and rejected deploys over 3 MB (Free) or 10 MB (Paid). That compressed limit is now gone. Cloudflare only checks the full, uncompressed size of your bundle against a 64 MiB limit, giving you much more room to work with.
-
-| Limit | Previous | New |
-|---|---|---|
-| Free plan | 3 MB (compressed) | 64 MiB (uncompressed) |
-| Paid plan | 10 MB (compressed) | 64 MiB (uncompressed) |
+When you deploy a Worker, Wrangler bundles your code and compresses it before uploading. Previously, Cloudflare checked that compressed size and rejected deploys over 3 MB (Free) or 10 MB (Paid). That limit has been removed. Cloudflare now only checks the uncompressed size of your bundle, which is 64 MiB across all plans.
 
 To check your Worker's bundle size before deploying:
 

--- a/src/content/changelog/workers/2026-09-04-increased-worker-size-limit.mdx
+++ b/src/content/changelog/workers/2026-09-04-increased-worker-size-limit.mdx
@@ -3,7 +3,7 @@ title: Deploy larger Workers — up to 64 MiB for both free and paid plans
 description: The compressed Worker size limits (3 MB free / 10 MB paid) have been removed. Cloudflare now only checks the uncompressed bundle size, which is 64 MiB across all plans.
 products:
   - workers
-date: 2026-05-22
+date: 2026-09-04
 ---
 
 You can now deploy Workers with larger dependencies, heavier frameworks, and more code without hitting size limits.

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -27,7 +27,7 @@ import {
 | [Simultaneous outgoing<br/>connections/request](#simultaneous-open-connections)  | 6            | 6              |
 | [Environment variables](#environment-variables)                                  | 64/Worker    | 128/Worker     |
 | [Environment variable<br/>size](#environment-variables)                          | 5 KB         | 5 KB           |
-| [Worker size](#worker-size)                                                      | 3 MB         | 10 MB          |
+| [Worker size](#worker-size)                                                      | 64 MiB       | 64 MiB         |
 | [Worker startup time](#worker-startup-time)                                      | 1 second     | 1 second       |
 | [Number of Workers](#number-of-workers)<sup>1</sup>                              | 100          | 500            |
 | Number of [Cron Triggers](/workers/configuration/cron-triggers/)<br/>per account | 5            | 250            |
@@ -258,21 +258,24 @@ The runtime measures simultaneous open connections from the top-level request. W
 
 ## Worker size
 
-| Limit                    | Workers Free | Workers Paid |
-| ------------------------ | ------------ | ------------ |
-| After compression (gzip) | 3 MB         | 10 MB        |
-| Before compression       | 64 MB        | 64 MB        |
+| Limit                          | Workers Free | Workers Paid |
+| ------------------------------ | ------------ | ------------ |
+| Worker size before compression | 64 MiB       | 64 MiB       |
 
-Larger Worker bundles can impact startup time. To check your compressed bundle size:
+Workers do not have a separate compressed size limit. Only the uncompressed bundle size is checked.
+
+Larger Worker bundles can impact startup time. To check your Worker bundle size:
 
 ```sh
 wrangler deploy --outdir bundled/ --dry-run
 ```
 
-```sh output
-# Output will resemble the below:
+```txt
+# Output resembles:
 Total Upload: 259.61 KiB / gzip: 47.23 KiB
 ```
+
+The `Total Upload` value is your uncompressed bundle size. The `gzip` value is shown for reference but is not a limit.
 
 To reduce Worker size:
 

--- a/src/content/docs/workers/platform/limits.mdx
+++ b/src/content/docs/workers/platform/limits.mdx
@@ -258,11 +258,11 @@ The runtime measures simultaneous open connections from the top-level request. W
 
 ## Worker size
 
-| Limit                          | Workers Free | Workers Paid |
-| ------------------------------ | ------------ | ------------ |
-| Worker size before compression | 64 MiB       | 64 MiB       |
+| Limit                    | Workers Free | Workers Paid |
+| ------------------------ | ------------ | ------------ |
+| Worker size (uncompressed) | 64 MiB     | 64 MiB       |
 
-Workers do not have a separate compressed size limit. Only the uncompressed bundle size is checked.
+There is no compressed size limit. Only the uncompressed bundle size counts.
 
 Larger Worker bundles can impact startup time. To check your Worker bundle size:
 
@@ -270,8 +270,7 @@ Larger Worker bundles can impact startup time. To check your Worker bundle size:
 wrangler deploy --outdir bundled/ --dry-run
 ```
 
-```txt
-# Output resembles:
+```sh output
 Total Upload: 259.61 KiB / gzip: 47.23 KiB
 ```
 


### PR DESCRIPTION
Adds a changelog entry and updates the Worker size limits documentation for the removal of compressed size limits (WC-4489).

**Related PRs:**
- Wrangler: https://github.com/cloudflare/workers-sdk/pull/14001
- Docs (Matt's limit page updates): https://github.com/cloudflare/cloudflare-docs/pull/31002
