### PR TITLE
fix: correct retries.limit description to say retries not attempts

### DIFF
--- a/src/content/docs/workflows/build/sleeping-and-retrying.mdx
+++ b/src/content/docs/workflows/build/sleeping-and-retrying.mdx
@@ -71,7 +71,7 @@ const defaultConfig: WorkflowStepConfig = {
 
 When providing your own `StepConfig`, you can configure:
 
-- The total number of attempts to make for a step (limited to 10,000 retries per step)
+- The total number of retries for a step (limited to 10,000 retries per step)
 - The delay between attempts (accepts both `number` (ms) or a human-readable format)
 - What backoff algorithm to apply between each attempt: any of `constant`, `linear`, or `exponential`
 - When to timeout (in duration) before considering the step as failed (including during a retry attempt, as the timeout is set per attempt)
@@ -83,7 +83,7 @@ let someState = await step.do(
 	"call an API",
 	{
 		retries: {
-			limit: 10, // The total number of attempts
+			limit: 10, // The total number of retries (11 attempts total)
 			delay: "10 seconds", // Delay between each retry
 			backoff: "exponential", // Any of "constant" | "linear" | "exponential";
 		},


### PR DESCRIPTION
## Summary

- Updated the `StepConfig` description to say "retries" instead of "attempts" for the `retries.limit` property
- Updated the code comment from `// The total number of attempts` to `// The total number of retries (11 attempts total)`

The `retries.limit` property specifies the maximum number of **retries**, not the total number of attempts. For example, `limit: 10` means 10 retries (11 attempts total), not 10 attempts.

Fixes #30627