### PR TITLE
[Sandbox] Clarify user workspace guidance

### DIFF
--- a/src/content/docs/sandbox/api/lifecycle.mdx
+++ b/src/content/docs/sandbox/api/lifecycle.mdx
@@ -28,7 +28,7 @@ const sandbox = getSandbox(
 
 **Parameters**:
 - `binding` - The Durable Object namespace binding from your Worker environment
-- `sandboxId` - Unique identifier for this sandbox. The same ID always returns the same sandbox instance
+- `sandboxId` - Unique identifier for this sandbox. The same ID always returns the same sandbox instance. In user-facing apps, scope IDs to a single user.
 - `options` (optional) - See [SandboxOptions](/sandbox/configuration/sandbox-options/) for all available options:
   - `sleepAfter` - Duration of inactivity before automatic sleep (default: `"10m"`)
   - `keepAlive` - Prevent automatic sleep entirely. Persists across hibernation (default: `false`)
@@ -137,4 +137,4 @@ Containers automatically sleep after 10 minutes of inactivity but still count to
 
 - [Sandbox lifecycle concept](/sandbox/concepts/sandboxes/) - Understanding container lifecycle and state
 - [Sandbox options configuration](/sandbox/configuration/sandbox-options/) - Configure `keepAlive` and other options
-- [Sessions API](/sandbox/api/sessions/) - Create isolated execution contexts within a sandbox
+- [Sessions API](/sandbox/api/sessions/) - Create execution contexts within a sandbox

--- a/src/content/docs/sandbox/api/sessions.mdx
+++ b/src/content/docs/sandbox/api/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sessions
-description: Create isolated execution contexts with independent shell state within a Sandbox SDK container.
+description: Create shell sessions with independent working directories and environment variables within a sandbox.
 pcx_content_type: configuration
 sidebar:
   order: 6
@@ -10,17 +10,17 @@ products:
 
 import { TypeScriptExample } from "~/components";
 
-Create isolated execution contexts within a sandbox. Each session maintains its own shell state, environment variables, and working directory. See [Session management concept](/sandbox/concepts/sessions/) for details.
+Create shell sessions within a sandbox. Each session maintains its own shell state, environment variables, and working directory, while sharing the sandbox filesystem and process space. For more information, refer to [Session management](/sandbox/concepts/sessions/).
 
 :::note
-Every sandbox has a default session that automatically maintains shell state. Create additional sessions when you need isolated shell contexts for different environments or parallel workflows. For sandbox-level operations like creating containers or destroying the entire sandbox, see the [Lifecycle API](/sandbox/api/lifecycle/).
+Every sandbox has a default session that maintains shell state. Create additional sessions for separate workflows inside the same user workspace, such as development and runtime processes. Use separate sandboxes for separate users. For sandbox-level operations like creating containers or destroying the entire sandbox, refer to the [Lifecycle API](/sandbox/api/lifecycle/).
 :::
 
 ## Methods
 
 ### `createSession()`
 
-Create a new isolated execution session.
+Create a new shell session.
 
 ```ts
 const session = await sandbox.createSession(options?: SessionOptions): Promise<ExecutionSession>
@@ -38,7 +38,7 @@ const session = await sandbox.createSession(options?: SessionOptions): Promise<E
 
 <TypeScriptExample>
 ```ts
-// Multiple isolated environments
+// Separate workflow environments
 const prodSession = await sandbox.createSession({
   id: 'prod',
   env: { NODE_ENV: 'production', API_URL: 'https://api.example.com' },
@@ -89,13 +89,13 @@ const session = await sandbox.getSession(sessionId: string): Promise<ExecutionSe
 
 <TypeScriptExample>
 ```ts
-// First request - create session
-const session = await sandbox.createSession({ id: 'user-123' });
+// First request - create a task-specific session
+const session = await sandbox.createSession({ id: 'build' });
 await session.exec('git clone https://github.com/user/repo.git');
 await session.exec('cd repo && npm install');
 
 // Second request - resume session (environment and cwd preserved)
-const session = await sandbox.getSession('user-123');
+const session = await sandbox.getSession('build');
 const result = await session.exec('cd repo && npm run build');
 ```
 </TypeScriptExample>

--- a/src/content/docs/sandbox/concepts/sandboxes.mdx
+++ b/src/content/docs/sandbox/concepts/sandboxes.mdx
@@ -74,7 +74,7 @@ The next request creates a fresh container with a clean environment.
 const sandbox = getSandbox(env.Sandbox, `user-${userId}`);
 ```
 
-User's work persists while actively using the sandbox. Good for interactive environments, playgrounds, and notebooks where users work continuously.
+Use this pattern for interactive environments, playgrounds, and notebooks where each user returns to their own active workspace.
 
 ### Per-session sandboxes
 
@@ -85,7 +85,7 @@ const sandbox = getSandbox(env.Sandbox, sessionId);
 await sandbox.destroy();
 ```
 
-Fresh environment each time. Good for one-time execution, CI/CD, and isolated tests.
+Use this pattern for one-time execution, CI/CD, and tests that need a clean environment.
 
 ### Per-task sandboxes
 
@@ -119,7 +119,7 @@ try {
 
 **Destroy when**: Session ends, task completes, resources no longer needed
 
-**Don't destroy**: Personal environments, long-running services
+**Do not destroy**: Personal environments, long-running services
 
 ### Managing keepAlive containers
 
@@ -158,7 +158,7 @@ The SDK automatically checks that your npm package version matches the Docker co
 **What happens**:
 
 - On sandbox startup, the SDK queries the container's version
-- If versions don't match, a warning is logged
+- If versions do not match, a warning is logged
 - Some features may not work correctly if versions are incompatible
 
 **When you might see warnings**:
@@ -182,7 +182,7 @@ See [Dockerfile reference](/sandbox/configuration/dockerfile/) for details on im
 
 - **Name consistently** - Use clear, predictable naming schemes
 - **Clean up temporary sandboxes** - Always destroy when done
-- **Reuse long-lived sandboxes** - One per user is often sufficient
+- **Reuse user workspaces** - One long-lived sandbox per user is often sufficient
 - **Batch operations** - Combine commands: `npm install && npm test && npm build`
 - **Design for ephemeral state** - Containers restart after inactivity, losing all state
 

--- a/src/content/docs/sandbox/concepts/sessions.mdx
+++ b/src/content/docs/sandbox/concepts/sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Session management
-description: Sandbox SDK sessions are independent shell execution contexts within a single container.
+description: Sandbox SDK sessions are shell execution contexts within a single sandbox.
 pcx_content_type: concept
 sidebar:
   order: 4
@@ -8,10 +8,12 @@ products:
   - sandbox
 ---
 
-Sessions are bash shell execution contexts within a sandbox. Think of them like terminal tabs or panes in the same container.
+Sessions are Bash shell execution contexts within a sandbox. Think of them as terminal tabs in the same computer.
 
-- **Sandbox** = A computer (container)
-- **Session** = A terminal shell session in that computer
+- **Sandbox** = A user or task workspace
+- **Session** = A shell in that workspace
+
+Sessions are useful for organizing work inside one sandbox. They are not a security boundary between users because sessions share the same filesystem and process space.
 
 ## Default session
 
@@ -35,7 +37,7 @@ Working directory, environment variables, and exported variables carry over betw
 The container automatically creates sessions on first use. If you reference a non-existent session ID, the container creates it with default settings:
 
 ```typescript
-// This session doesn't exist yet
+// This session does not exist yet
 const result = await sandbox.exec('echo hello', { sessionId: 'new-session' });
 // Container automatically creates 'new-session' with defaults:
 // - cwd: '/workspace'
@@ -59,11 +61,11 @@ const result = await sandbox.exec('echo $MY_VAR', { sessionId: 'temp' });
 // Output: (empty) - MY_VAR is not set in the freshly created session
 ```
 
-This auto-creation means you can't "break" commands by referencing non-existent sessions. However, custom configuration (environment variables, working directory) is lost after deletion.
+This auto-creation means commands still run when they reference a non-existent session. However, custom configuration (environment variables, working directory) is lost after deletion.
 
 ## Creating sessions
 
-Create additional sessions for isolated shell contexts:
+Create additional sessions for separate workflows in the same sandbox:
 
 ```typescript
 const buildSession = await sandbox.createSession({
@@ -96,7 +98,7 @@ await session.exec("npm test"); // Times out after 30s if still running
 
 Individual commands can override the session timeout with the `timeout` option on `exec()`. For more details, refer to the [Sessions API](/sandbox/api/sessions/) and the [execute commands guide](/sandbox/guides/execute-commands/#timeouts).
 
-## What's isolated per session
+## What is scoped to a session
 
 Each session has its own:
 
@@ -122,7 +124,7 @@ const session2 = await sandbox.createSession({
 });
 ```
 
-## What's shared
+## What is shared across sessions
 
 All sessions in a sandbox share:
 
@@ -141,7 +143,7 @@ await session2.listProcesses();  // Sees the server
 ## When to use sessions
 
 **Use sessions when**:
-- You need isolated shell state for different tasks
+- You need separate shell state for one user's tasks
 - Running parallel operations with different environments
 - Keeping AI agent credentials separate from app runtime
 
@@ -163,8 +165,9 @@ await appSession.exec("node server.js");
 ```
 
 **Use separate sandboxes when**:
-- You need complete isolation (untrusted code)
-- Different users require fully separated environments
+- You need complete isolation for untrusted code
+- Different users need separate workspaces
+- User data must stay separated
 - Independent resource allocation is needed
 
 ## Best practices
@@ -188,15 +191,15 @@ await sandbox.deleteSession('default');
 // Error: Cannot delete default session. Use sandbox.destroy() instead.
 ```
 
-### Filesystem isolation
+### Filesystem scope
 
-**Sessions share filesystem** - file operations affect all sessions:
+**Sessions share the sandbox filesystem** - file operations affect all sessions:
 ```typescript
 // Bad - affects all sessions
 await session.exec('rm -rf /workspace/*');
 
-// For untrusted code isolation, use separate sandboxes
-const userSandbox = getSandbox(env.Sandbox, userId);
+// For user data or untrusted code, use a separate sandbox
+const userSandbox = getSandbox(env.Sandbox, `user-${userId}`);
 ```
 
 ## Related resources

--- a/src/content/docs/sandbox/concepts/sessions.mdx
+++ b/src/content/docs/sandbox/concepts/sessions.mdx
@@ -8,7 +8,7 @@ products:
   - sandbox
 ---
 
-Sessions are Bash shell execution contexts within a sandbox. Think of them as terminal tabs in the same computer.
+Sessions are bash shell execution contexts within a sandbox. Think of them as terminal tabs in the same computer.
 
 - **Sandbox** = A user or task workspace
 - **Session** = A shell in that workspace

--- a/src/content/docs/sandbox/concepts/terminal.mdx
+++ b/src/content/docs/sandbox/concepts/terminal.mdx
@@ -44,7 +44,7 @@ Network interruptions are common in browser-based applications. Terminal connect
 
 The `SandboxAddon` for xterm.js implements this automatically. If you are building a custom client, you are responsible for your own reconnection logic — the server-side buffering works regardless of which client connects. Refer to the [WebSocket protocol reference](/sandbox/api/terminal/#websocket-protocol) for details on the connection lifecycle.
 
-## Session isolation
+## Session-specific terminals
 
 Each [session](/sandbox/concepts/sessions/) can have its own terminal with independent shell state:
 
@@ -65,7 +65,7 @@ const testSession = await sandbox.createSession({
 // environment variables, and command history
 ```
 
-Multiple browser clients can connect to the same session's terminal simultaneously — they all see the same shell output and can all send input. This enables collaborative terminal use cases.
+Multiple browser clients can connect to the same session's terminal simultaneously. They all see the same shell output and can send input. Use this pattern for intentional collaboration inside one workspace, not to separate independent users.
 
 ## WebSocket protocol
 

--- a/src/content/docs/sandbox/get-started.mdx
+++ b/src/content/docs/sandbox/get-started.mdx
@@ -63,7 +63,8 @@ export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		const url = new URL(request.url);
 
-		// Get or create a sandbox instance
+		// Get or create a sandbox instance. For user-facing apps,
+		// derive this ID from the authenticated user.
 		const sandbox = getSandbox(env.Sandbox, "my-sandbox");
 
 		// Execute Python code
@@ -93,7 +94,7 @@ export default {
 
 **Key concepts**:
 
-- `getSandbox()` - Gets or creates a sandbox instance by ID. Use the same ID to reuse the same sandbox instance across requests.
+- `getSandbox()` - Gets or creates a sandbox instance by ID. Use a stable ID to reconnect to the same sandbox. In user-facing apps, scope IDs to a single user.
 - `sandbox.exec()` - Execute shell commands in the sandbox and capture stdout, stderr, and exit codes.
 - `sandbox.writeFile()` / `readFile()` - Write and read files in the sandbox filesystem.
 

--- a/src/content/docs/sandbox/guides/browser-terminals.mdx
+++ b/src/content/docs/sandbox/guides/browser-terminals.mdx
@@ -167,7 +167,7 @@ For the full protocol specification, refer to the [WebSocket protocol section](/
 - **Always use FitAddon** — Without it, terminal dimensions do not match the container and text wraps incorrectly.
 - **Handle resize events** — Call `fitAddon.fit()` on window resize so the terminal and PTY stay in sync.
 - **Clean up on unmount** — Call `addon.disconnect()` when removing the terminal from the page.
-- **Use sessions for isolation** — If users need separate shell environments, create sessions with different working directories and environment variables.
+- **Scope terminals to a user sandbox** — Use sessions for multiple terminal contexts in the same workspace. Use separate sandboxes for separate users.
 
 ## Related resources
 

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -353,7 +353,7 @@ npx wrangler secret put AWS_SECRET_ACCESS_KEY
 - Incorrect endpoint URL
 - Invalid credentials
 - Missing `ContainerProxy` export, or on older Wrangler versions missing `enable_ctx_exports`
-- Bucket doesn't exist
+- Bucket does not exist
 - Network connectivity issues
 
 Verify your binding or endpoint configuration:
@@ -410,7 +410,7 @@ await sandbox.exec('cp', { args: ['/workspace/results.json', '/data/results/outp
 - **Choose the right mount mode** - Use R2 binding mounts when you want Worker-managed R2 access, or use `endpoint` for explicit R2, S3, GCS, and other S3-compatible providers
 - **Secure credentials** - Always use Worker secrets, never hardcode
 - **Read-only when possible** - Protect data with read-only mounts
-- **Use prefixes for isolation** - Mount subdirectories when working with specific datasets
+- **Mount the narrowest path** - Use prefixes to expose only the data a sandbox needs
 - **Mount paths** - Prefer `/data`, `/storage`, or `/mnt/*`; if you mount under `/workspace`, account for the mount overlaying that path in production
 - **Handle errors** - Wrap mount operations in `try...catch` blocks
 - **Optimize access** - Copy frequently accessed files locally


### PR DESCRIPTION
### Summary

Updates Sandbox SDK documentation to clarify how sandbox IDs, sessions, terminals, and mounted storage should be scoped in user-facing applications. The guidance now consistently presents sandboxes as user or workspace boundaries, while sessions remain workflow-level shell contexts inside a sandbox.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
