### PR TITLE
Add docs for sandbox default session toggle

### DIFF
--- a/src/content/docs/sandbox/api/file-watching.mdx
+++ b/src/content/docs/sandbox/api/file-watching.mdx
@@ -29,7 +29,7 @@ const stream = await sandbox.watch(path: string, options?: WatchOptions): Promis
   - `recursive` - Watch subdirectories recursively (default: `true`)
   - `include` - Glob patterns to include (for example, `['*.ts', '*.js']`). Cannot be used together with `exclude`.
   - `exclude` - Glob patterns to exclude (default: `['.git', 'node_modules', '.DS_Store']`). Cannot be used together with `include`.
-  - `sessionId` - Session to run the watch in (if omitted, the default session is used)
+  - `sessionId` - Session to run the watch in (if omitted, the sandbox's implicit execution mode is used)
 
 **Returns**: `Promise<ReadableStream<Uint8Array>>` — an SSE stream of `FileWatchSSEEvent` objects
 
@@ -142,7 +142,7 @@ interface WatchOptions {
 	include?: string[];
 	/** Glob patterns to exclude. Cannot be used together with `include`. Default: ['.git', 'node_modules', '.DS_Store'] */
 	exclude?: string[];
-	/** Session to run the watch in. If omitted, the default session is used. */
+	/** Session to run the watch in. If omitted, the sandbox's implicit execution mode is used. */
 	sessionId?: string;
 }
 ```

--- a/src/content/docs/sandbox/api/file-watching.mdx
+++ b/src/content/docs/sandbox/api/file-watching.mdx
@@ -29,7 +29,7 @@ const stream = await sandbox.watch(path: string, options?: WatchOptions): Promis
   - `recursive` - Watch subdirectories recursively (default: `true`)
   - `include` - Glob patterns to include (for example, `['*.ts', '*.js']`). Cannot be used together with `exclude`.
   - `exclude` - Glob patterns to exclude (default: `['.git', 'node_modules', '.DS_Store']`). Cannot be used together with `include`.
-  - `sessionId` - Session to run the watch in (if omitted, the sandbox's implicit execution mode is used)
+  - `sessionId` - Session to run the watch in (if omittied, will use the default session unless `enableDefaultSession` is set to false)
 
 **Returns**: `Promise<ReadableStream<Uint8Array>>` — an SSE stream of `FileWatchSSEEvent` objects
 

--- a/src/content/docs/sandbox/api/lifecycle.mdx
+++ b/src/content/docs/sandbox/api/lifecycle.mdx
@@ -30,6 +30,7 @@ const sandbox = getSandbox(
 - `binding` - The Durable Object namespace binding from your Worker environment
 - `sandboxId` - Unique identifier for this sandbox. The same ID always returns the same sandbox instance. In user-facing apps, scope IDs to a single user.
 - `options` (optional) - See [SandboxOptions](/sandbox/configuration/sandbox-options/) for all available options:
+  - `enableDefaultSession` - Use the default session for operations without an explicit `sessionId` (default: `true`)
   - `sleepAfter` - Duration of inactivity before automatic sleep (default: `"10m"`)
   - `keepAlive` - Prevent automatic sleep entirely. Persists across hibernation (default: `false`)
   - `containerTimeouts` - Configure container startup timeouts
@@ -39,6 +40,10 @@ const sandbox = getSandbox(
 
 :::note
 The container starts lazily on first operation. Calling `getSandbox()` returns immediately—the container only spins up when you execute a command, write a file, or perform other operations. See [Sandbox lifecycle](/sandbox/concepts/sandboxes/) for details.
+:::
+
+:::note[Implicit execution mode]
+By default, sandbox methods that do not specify a `sessionId` run in the sandbox's default session and preserve shell state between calls. Set `enableDefaultSession: false` to make those same implicit operations run sessionless instead. This is useful for stateless request handling where one call should not inherit shell state such as a previous `cd` or exported variable.
 :::
 
 <TypeScriptExample>
@@ -54,6 +59,19 @@ export default {
 };
 ```
 </TypeScriptExample>
+
+<TypeScriptExample>
+```
+const sandbox = getSandbox(env.Sandbox, 'stateless-worker', {
+  enableDefaultSession: false
+});
+
+await sandbox.exec('cd /workspace/app');
+await sandbox.exec('pwd');
+```
+</TypeScriptExample>
+
+When `enableDefaultSession` is `false`, the second command does not inherit shell state from the first command. Create or retrieve an explicit session when you want stateful execution.
 
 :::caution
 When using `keepAlive: true`, you **must** call `destroy()` when finished to prevent containers running indefinitely.

--- a/src/content/docs/sandbox/api/lifecycle.mdx
+++ b/src/content/docs/sandbox/api/lifecycle.mdx
@@ -30,7 +30,7 @@ const sandbox = getSandbox(
 - `binding` - The Durable Object namespace binding from your Worker environment
 - `sandboxId` - Unique identifier for this sandbox. The same ID always returns the same sandbox instance. In user-facing apps, scope IDs to a single user.
 - `options` (optional) - See [SandboxOptions](/sandbox/configuration/sandbox-options/) for all available options:
-  - `enableDefaultSession` - Use the default session for operations without an explicit `sessionId` (default: `true`)
+  - `enableDefaultSession` - Use the default session for operations without an explicit `sessionId`. Set to `false` to evaluate each call in isolation (default: `true`)
   - `sleepAfter` - Duration of inactivity before automatic sleep (default: `"10m"`)
   - `keepAlive` - Prevent automatic sleep entirely. Persists across hibernation (default: `false`)
   - `containerTimeouts` - Configure container startup timeouts
@@ -43,7 +43,7 @@ The container starts lazily on first operation. Calling `getSandbox()` returns i
 :::
 
 :::note[Implicit execution mode]
-By default, sandbox methods that do not specify a `sessionId` run in the sandbox's default session and preserve shell state between calls. Set `enableDefaultSession: false` to make those same implicit operations run sessionless instead. This is useful for stateless request handling where one call should not inherit shell state such as a previous `cd` or exported variable.
+By default, sandbox methods that do not specify a `sessionId` run in the sandbox's default session and preserve shell state between calls. It is recommended to set `enableDefaultSession` to `false` to ensure operations run in isolation. The `createSession()` API exists when sessions are required. Default sessions will be removed in a future version of the Sandbox SDK.
 :::
 
 <TypeScriptExample>

--- a/src/content/docs/sandbox/api/lifecycle.mdx
+++ b/src/content/docs/sandbox/api/lifecycle.mdx
@@ -60,19 +60,6 @@ export default {
 ```
 </TypeScriptExample>
 
-<TypeScriptExample>
-```
-const sandbox = getSandbox(env.Sandbox, 'stateless-worker', {
-  enableDefaultSession: false
-});
-
-await sandbox.exec('cd /workspace/app');
-await sandbox.exec('pwd');
-```
-</TypeScriptExample>
-
-When `enableDefaultSession` is `false`, the second command does not inherit shell state from the first command. Create or retrieve an explicit session when you want stateful execution.
-
 :::caution
 When using `keepAlive: true`, you **must** call `destroy()` when finished to prevent containers running indefinitely.
 :::

--- a/src/content/docs/sandbox/api/sessions.mdx
+++ b/src/content/docs/sandbox/api/sessions.mdx
@@ -13,7 +13,7 @@ import { TypeScriptExample } from "~/components";
 Create shell sessions within a sandbox. Each session maintains its own shell state, environment variables, and working directory, while sharing the sandbox filesystem and process space. For more information, refer to [Session management](/sandbox/concepts/sessions/).
 
 :::note
-By default, every sandbox has a default session that maintains shell state. Set `enableDefaultSession: false` on `getSandbox()` if you want operations without an explicit `sessionId` to run sessionless instead. Create additional sessions for separate workflows inside the same user workspace, such as development and runtime processes. Use separate sandboxes for separate users. For sandbox-level operations like creating containers or destroying the entire sandbox, refer to the [Lifecycle API](/sandbox/api/lifecycle/).
+By default, for backwards compatibility, every sandbox has a default session that maintains shell state. It is recommended to set `enableDefaultSession` to `false` on `getSandbox()` so operations without an explicit `sessionId` run in isolation. Create additional sessions for separate workflows inside the same user workspace, such as development and runtime processes using the `createSession()` method. Use separate sandboxes for separate users. For sandbox-level operations like creating containers or destroying the entire sandbox, refer to the [Lifecycle API](/sandbox/api/lifecycle/).
 :::
 
 ## Methods

--- a/src/content/docs/sandbox/api/sessions.mdx
+++ b/src/content/docs/sandbox/api/sessions.mdx
@@ -13,7 +13,7 @@ import { TypeScriptExample } from "~/components";
 Create shell sessions within a sandbox. Each session maintains its own shell state, environment variables, and working directory, while sharing the sandbox filesystem and process space. For more information, refer to [Session management](/sandbox/concepts/sessions/).
 
 :::note
-Every sandbox has a default session that maintains shell state. Create additional sessions for separate workflows inside the same user workspace, such as development and runtime processes. Use separate sandboxes for separate users. For sandbox-level operations like creating containers or destroying the entire sandbox, refer to the [Lifecycle API](/sandbox/api/lifecycle/).
+By default, every sandbox has a default session that maintains shell state. Set `enableDefaultSession: false` on `getSandbox()` if you want operations without an explicit `sessionId` to run sessionless instead. Create additional sessions for separate workflows inside the same user workspace, such as development and runtime processes. Use separate sandboxes for separate users. For sandbox-level operations like creating containers or destroying the entire sandbox, refer to the [Lifecycle API](/sandbox/api/lifecycle/).
 :::
 
 ## Methods

--- a/src/content/docs/sandbox/bridge/http-api.mdx
+++ b/src/content/docs/sandbox/bridge/http-api.mdx
@@ -151,7 +151,7 @@ When `endpoint` is provided, `bucket` means the remote bucket name. Credentials 
 
 Sessions isolate working directory, environment variables, and command execution state within a sandbox. Pass the `Session-Id` header on `/exec`, `/file/*`, and `/pty` requests to scope them to a session.
 
-When no `Session-Id` header is provided, requests use the sandbox default session.
+When no `Session-Id` header is provided, requests use the sandbox's implicit execution mode. By default this is the default session, but SDKs configured with `enableDefaultSession: false` run those implicit operations sessionless instead.
 
 ## Terminal (PTY)
 

--- a/src/content/docs/sandbox/concepts/sessions.mdx
+++ b/src/content/docs/sandbox/concepts/sessions.mdx
@@ -17,7 +17,7 @@ Sessions are useful for organizing work inside one sandbox. They are not a secur
 
 ## Default session
 
-Every sandbox has a default session that maintains shell state between commands while the container is active:
+By default, every sandbox has a default session that maintains shell state between commands while the container is active:
 
 ```typescript
 const sandbox = getSandbox(env.Sandbox, 'my-sandbox');
@@ -31,6 +31,19 @@ await sandbox.exec("echo $MY_VAR");  // Output: hello
 ```
 
 Working directory, environment variables, and exported variables carry over between commands. This state resets if the container restarts due to inactivity.
+
+If you set `enableDefaultSession: false` when calling `getSandbox()`, operations without an explicit `sessionId` run sessionless instead of using the default session:
+
+```typescript
+const sandbox = getSandbox(env.Sandbox, 'my-sandbox', {
+  enableDefaultSession: false
+});
+
+await sandbox.exec("cd /app");
+await sandbox.exec("pwd");
+```
+
+In sessionless mode, the second command does not inherit shell state from the first command. Use this mode for stateless request handling. Create or retrieve an explicit session when you want commands to share shell state.
 
 ### Automatic session creation
 

--- a/src/content/docs/sandbox/concepts/sessions.mdx
+++ b/src/content/docs/sandbox/concepts/sessions.mdx
@@ -32,7 +32,7 @@ await sandbox.exec("echo $MY_VAR");  // Output: hello
 
 Working directory, environment variables, and exported variables carry over between commands. This state resets if the container restarts due to inactivity.
 
-If you set `enableDefaultSession: false` when calling `getSandbox()`, operations without an explicit `sessionId` run sessionless instead of using the default session:
+If you set `enableDefaultSession: false` when calling `getSandbox()`, operations without an explicit `sessionId` run in isolation instead of using the default session:
 
 ```typescript
 const sandbox = getSandbox(env.Sandbox, 'my-sandbox', {
@@ -43,7 +43,7 @@ await sandbox.exec("cd /app");
 await sandbox.exec("pwd");  // Output: /workspace (cd was not inherited)
 ```
 
-In sessionless mode, the second command does not inherit shell state from the first command. Use this mode for stateless request handling. Create or retrieve an explicit session when you want commands to share shell state.
+Without the default session, the second command does not inherit shell state from the first command. It is recommended that you always apply this setting as it will become the default in a future Sandbox SDK release. Create or retrieve an explicit session when you want commands to share shell state.
 
 ### Automatic session creation
 

--- a/src/content/docs/sandbox/concepts/sessions.mdx
+++ b/src/content/docs/sandbox/concepts/sessions.mdx
@@ -40,7 +40,7 @@ const sandbox = getSandbox(env.Sandbox, 'my-sandbox', {
 });
 
 await sandbox.exec("cd /app");
-await sandbox.exec("pwd");
+await sandbox.exec("pwd");  // Output: /workspace (cd was not inherited)
 ```
 
 In sessionless mode, the second command does not inherit shell state from the first command. Use this mode for stateless request handling. Create or retrieve an explicit session when you want commands to share shell state.

--- a/src/content/docs/sandbox/configuration/sandbox-options.mdx
+++ b/src/content/docs/sandbox/configuration/sandbox-options.mdx
@@ -25,9 +25,9 @@ const sandbox = getSandbox(binding, sandboxId, options?: SandboxOptions);
 **Type**: `boolean`
 **Default**: `true`
 
-Controls what happens when you call sandbox methods without an explicit `sessionId`. When `true`, implicit operations use the sandbox's default session and preserve shell state between calls. When `false`, implicit operations run sessionless and do not inherit shell state from prior calls unless you explicitly target a session.
+Controls what happens when you call sandbox methods without an explicit `sessionId`. When `true`, implicit operations use the sandbox's default session and preserve shell state between calls. When `false`, implicit operations run in isolation and do not inherit shell state from prior calls unless you explicitly target a session.
 
-Use `enableDefaultSession: true` for interactive or stateful workflows where commands should share working directory and exported variables. Use `enableDefaultSession: false` for stateless request handling where one call should not affect the next one.
+Use `enableDefaultSession: true` for interactive or stateful workflows where commands should share working directory and exported variables. Use `enableDefaultSession: false` for stateless request handling where one call should not affect the next one. It is recommended to set this to `false` — default session support will be removed in a future version of the Sandbox SDK, and using `createSession()` explicitly is the preferred pattern going forward.
 
 <TypeScriptExample>
 ```ts

--- a/src/content/docs/sandbox/configuration/sandbox-options.mdx
+++ b/src/content/docs/sandbox/configuration/sandbox-options.mdx
@@ -20,6 +20,36 @@ import { getSandbox } from '@cloudflare/sandbox';
 const sandbox = getSandbox(binding, sandboxId, options?: SandboxOptions);
 ```
 
+### enableDefaultSession
+
+**Type**: `boolean`
+**Default**: `true`
+
+Controls what happens when you call sandbox methods without an explicit `sessionId`.
+
+- When `true`, implicit operations use the sandbox's default session and preserve shell state between calls.
+- When `false`, implicit operations run sessionless and do not inherit shell state from prior calls unless you explicitly target a session.
+
+Use `enableDefaultSession: true` for interactive or stateful workflows where commands should share working directory and exported variables. Use `enableDefaultSession: false` for stateless request handling where one call should not affect the next one.
+
+<TypeScriptExample>
+```ts
+// Default behavior: implicit operations use the default session
+const statefulSandbox = getSandbox(env.Sandbox, 'user-123');
+
+await statefulSandbox.exec('cd /workspace/app');
+await statefulSandbox.exec('pwd');
+
+// Sessionless behavior: implicit operations do not share shell state
+const statelessSandbox = getSandbox(env.Sandbox, 'api-worker', {
+  enableDefaultSession: false
+});
+
+await statelessSandbox.exec('cd /workspace/app');
+await statelessSandbox.exec('pwd');
+```
+</TypeScriptExample>
+
 ### keepAlive
 
 **Type**: `boolean`
@@ -206,7 +236,7 @@ The default 10-minute timeout works well for most applications. Adjust based on 
 Use `keepAlive: true` for:
 
 - **Long-running builds** - CI/CD pipelines that may have idle periods between steps
-- **Batch processing** - Jobs that process data in waves with gaps between batches  
+- **Batch processing** - Jobs that process data in waves with gaps between batches
 - **Monitoring tasks** - Processes that periodically check external services
 - **Interactive sessions** - User-driven workflows where the container should remain available
 
@@ -215,7 +245,7 @@ With `keepAlive`, containers send automatic heartbeat pings every 30 seconds to 
 ## Related resources
 
 - [Expose services guide](/sandbox/guides/expose-services/) - Using `normalizeId` with preview URLs
-- [Preview URLs concept](/sandbox/concepts/preview-urls/) - Understanding DNS case-insensitivity  
+- [Preview URLs concept](/sandbox/concepts/preview-urls/) - Understanding DNS case-insensitivity
 - [Background processes guide](/sandbox/guides/background-processes/) - Using `keepAlive` with long-running processes
-- [Lifecycle API](/sandbox/api/lifecycle/) - Create and manage sandboxes with `setKeepAlive()` 
+- [Lifecycle API](/sandbox/api/lifecycle/) - Create and manage sandboxes with `setKeepAlive()`
 - [Sandboxes concept](/sandbox/concepts/sandboxes/) - Understanding sandbox lifecycle

--- a/src/content/docs/sandbox/configuration/sandbox-options.mdx
+++ b/src/content/docs/sandbox/configuration/sandbox-options.mdx
@@ -38,7 +38,9 @@ Use `enableDefaultSession: true` for interactive or stateful workflows where com
 const statefulSandbox = getSandbox(env.Sandbox, 'user-123');
 
 await statefulSandbox.exec('cd /workspace/app');
-await statefulSandbox.exec('pwd');
+const statefulResult = await statefulSandbox.exec('pwd');
+// statefulResult.stdout: "/workspace/app"
+// The second exec inherited the working directory from the first.
 
 // Sessionless behavior: implicit operations do not share shell state
 const statelessSandbox = getSandbox(env.Sandbox, 'api-worker', {
@@ -46,7 +48,9 @@ const statelessSandbox = getSandbox(env.Sandbox, 'api-worker', {
 });
 
 await statelessSandbox.exec('cd /workspace/app');
-await statelessSandbox.exec('pwd');
+const statelessResult = await statelessSandbox.exec('pwd');
+// statelessResult.stdout: "/workspace"
+// The second exec did not inherit shell state from the first.
 ```
 </TypeScriptExample>
 

--- a/src/content/docs/sandbox/configuration/sandbox-options.mdx
+++ b/src/content/docs/sandbox/configuration/sandbox-options.mdx
@@ -25,10 +25,7 @@ const sandbox = getSandbox(binding, sandboxId, options?: SandboxOptions);
 **Type**: `boolean`
 **Default**: `true`
 
-Controls what happens when you call sandbox methods without an explicit `sessionId`.
-
-- When `true`, implicit operations use the sandbox's default session and preserve shell state between calls.
-- When `false`, implicit operations run sessionless and do not inherit shell state from prior calls unless you explicitly target a session.
+Controls what happens when you call sandbox methods without an explicit `sessionId`. When `true`, implicit operations use the sandbox's default session and preserve shell state between calls. When `false`, implicit operations run sessionless and do not inherit shell state from prior calls unless you explicitly target a session.
 
 Use `enableDefaultSession: true` for interactive or stateful workflows where commands should share working directory and exported variables. Use `enableDefaultSession: false` for stateless request handling where one call should not affect the next one.
 


### PR DESCRIPTION
### Summary

This PR adds documentation for the new flag to disable default sessions in Sandbox SDK, implemented in https://github.com/cloudflare/sandbox-sdk/pull/706

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
