### PR TITLE
[Flagship] Warn against using client provider API

### DIFF
--- a/src/content/docs/flagship/sdk/client-provider.mdx
+++ b/src/content/docs/flagship/sdk/client-provider.mdx
@@ -14,8 +14,8 @@ The `FlagshipClientProvider` implements the OpenFeature web provider interface f
 
 This makes the provider suitable for client-side rendering where synchronous access to flag values is required.
 
-:::caution[Important]
-The client provider requires an API token to fetch flag values. This token is not scoped to a single app, so anyone with the token can **evaluate flags** across all apps in your account. Use the client provider with caution in public-facing applications.
+:::caution
+We do not recommend using the client provider in public-facing apps right now. It requires a Cloudflare API token, which would be exposed in client-side code and visible to anyone who inspects your application. We are working on a safer solution for client-side flag evaluation — in the meantime, use the [Worker binding](/flagship/binding/) or the [server provider](/flagship/sdk/server-provider/).
 :::
 
 ## prefetchFlags


### PR DESCRIPTION
### Summary

Updates the caution on the Flagship client provider page to more clearly advise against using it in public-facing apps. The previous wording understated the risk — an API token passed to `FlagshipClientProvider` is visible in client-side code to anyone who inspects the page. The updated note explains this and points users to the Worker binding or server provider until a safer client-side solution is available.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
