### PR TITLE
Fix API path for endpoint-healthchecks in examples

### DIFF
--- a/src/content/docs/magic-transit/network-health/run-endpoint-health-checks.mdx
+++ b/src/content/docs/magic-transit/network-health/run-endpoint-health-checks.mdx
@@ -43,7 +43,7 @@ Refer to the [API documentation](/api/resources/diagnostics/subresources/endpoin
 <Render file="account-id-api-key" product="networking-services" />
 
 <CURL
-  url="https://api.cloudflare.com/client/v4/accounts/account_id/diagnostics/endpoint-healthcheck"
+  url="https://api.cloudflare.com/client/v4/accounts/account_id/diagnostics/endpoint-healthchecks"
   method="POST"
   json={{
     "check_type": "icmp",
@@ -77,7 +77,7 @@ You can set up alerts to be notified when the state of your endpoint's health is
 1. Make a `GET` request to get a list of IDs for all of the endpoint health checks configured:
 
 <CURL
-  url="https://api.cloudflare.com/client/v4/accounts/account_id/diagnostics/endpoint-healthcheck"
+  url="https://api.cloudflare.com/client/v4/accounts/account_id/diagnostics/endpoint-healthchecks"
   method="GET"
 />
 

--- a/src/content/docs/magic-transit/network-health/run-endpoint-health-checks.mdx
+++ b/src/content/docs/magic-transit/network-health/run-endpoint-health-checks.mdx
@@ -77,7 +77,7 @@ You can set up alerts to be notified when the state of your endpoint's health is
 1. Make a `GET` request to get a list of IDs for all of the endpoint health checks configured:
 
 <CURL
-  url="https://api.cloudflare.com/client/v4/accounts/account_id/diagnostics/endpoint-healthchecks"
+  url="https://api.cloudflare.com/client/v4/accounts/account_id/diagnostics/endpoint-healthchecks" 
   method="GET"
 />
 

--- a/src/content/docs/magic-transit/network-health/run-endpoint-health-checks.mdx
+++ b/src/content/docs/magic-transit/network-health/run-endpoint-health-checks.mdx
@@ -77,7 +77,7 @@ You can set up alerts to be notified when the state of your endpoint's health is
 1. Make a `GET` request to get a list of IDs for all of the endpoint health checks configured:
 
 <CURL
-  url="https://api.cloudflare.com/client/v4/accounts/account_id/diagnostics/endpoint-healthchecks" 
+  url="https://api.cloudflare.com/client/v4/accounts/account_id/diagnostics/endpoint-healthchecks"
   method="GET"
 />
 


### PR DESCRIPTION
### Summary

Update the endpoint healthcheck API path in the example to match our API docs https://developers.cloudflare.com/api/resources/diagnostics/subresources/endpoint-healthchecks/

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
