### PR TITLE
[Cloudflare One] Document VNET availability and DNS search suffixes

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/index.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/index.mdx
@@ -94,7 +94,9 @@ flowchart TD
 
 ## Add a DNS suffix
 
-Support for DNS suffix search lists in the Cloudflare One Client is currently in development. You can manually configure DNS suffixes at the device level using the following instructions.
+To deploy a DNS suffix search list to all devices on a [device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/), configure [DNS search suffixes](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#dns-search-suffixes) in your Cloudflare One Client settings.
+
+For older client versions, you can manually configure DNS suffixes at the device level using the following instructions.
 
 ### macOS
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/index.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/index.mdx
@@ -603,3 +603,49 @@ Unknown adapter CloudflareWARP:
     																		127.0.2.3
     NetBIOS over Tcpip. . . . . . . . : Enabled
 ```
+
+### VNET availability <Badge text="Beta" variant="caution" size="small" />
+
+<Details header="Feature availability">
+
+| [Client modes](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/) | [Zero Trust plans](https://www.cloudflare.com/teams-pricing/) |
+| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| <ul><li> Traffic and DNS mode</li><li> Traffic only mode </li></ul>                               | All plans                                                     |
+
+| System   | Availability | Minimum client version |
+| -------- | ------------ | ---------------------- |
+| Windows  | ✅           | 2026.5.0               |
+| macOS    | ✅           | 2026.5.0               |
+| Linux    | ✅           | 2026.5.0               |
+| iOS      | ❌           |                        |
+| Android  | ❌           |                        |
+| ChromeOS | ❌           |                        |
+
+</Details>
+
+By default, the Cloudflare One Client shows every [virtual network](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/tunnel-virtual-networks/) (VNET) in your account in the [VNET dropdown](/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/tunnel-virtual-networks/#connect-to-a-virtual-network). **VNET availability** restricts the dropdown to a subset of VNETs and chooses a default VNET on a per-[device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) basis. The active profile controls which VNETs devices can see and switch between.
+
+For example, if your QA team uses a `staging-vnet` and your sales team should never reach it, you can assign the sales device profile to only include `production-vnet`. Sales users will not see `staging-vnet` in the dropdown.
+
+### DNS search suffixes <Badge text="Beta" variant="caution" size="small" />
+
+<Details header="Feature availability">
+
+| [Client modes](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/modes/) | [Zero Trust plans](https://www.cloudflare.com/teams-pricing/) |
+| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| <ul><li> Traffic and DNS mode</li><li> DNS only mode </li></ul>                                   | All plans                                                     |
+
+| System   | Availability | Minimum client version |
+| -------- | ------------ | ---------------------- |
+| Windows  | ✅           | 2026.5.0               |
+| macOS    | ✅           | 2026.5.0               |
+| Linux    | ✅           | 2026.5.0               |
+| iOS      | ❌           |                        |
+| Android  | ❌           |                        |
+| ChromeOS | ❌           |                        |
+
+</Details>
+
+A DNS search suffix (also known as a search domain) automatically appends a domain to single-label names so that users can type `jira` into a browser and the operating system resolves `jira.internal.example`. Search suffixes are typically advertised by the local network over DHCP, but devices connected to the Cloudflare One Client use the WARP virtual interface instead, which does not inherit network-advertised suffixes.
+
+Use **DNS search suffixes** to deploy an ordered list of up to 25 suffixes to the Cloudflare One Client on a per-[device profile](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles/) basis. The client appends each suffix in order to single-label name queries until one resolves successfully. This setting replaces the per-device manual configuration described in [Add a DNS suffix](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/route-traffic/#add-a-dns-suffix).


### PR DESCRIPTION
### Summary

Adds two new device profile settings under [Device client settings](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#device-profile-settings) for the Cloudflare One Client features landing in 2026.5.0:

- **VNET availability** (SHIP-8695) — per-profile filtering of the VNET dropdown and a default VNET selection.
- **DNS search suffixes** (SHIP-6337) — per-profile ordered list of up to 25 DNS search domains, replacing the per-device manual workaround for everything but older clients.

Both are documented as Beta and scoped to Windows, macOS, and Linux. Mobile and ChromeOS are marked unsupported (mobile client work is still backlogged). The existing **Add a DNS suffix** section on the route-traffic page now points at the new setting and keeps the manual macOS/Windows steps as a fallback for older clients.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
