### PR TITLE
chore(realtimekit): added realtimekit release notes for 28-may-2026 release

### DIFF
--- a/src/content/docs/realtime/realtimekit/core/error-codes.mdx
+++ b/src/content/docs/realtime/realtimekit/core/error-codes.mdx
@@ -80,6 +80,12 @@ await meeting.leave();
 - **Possible reason**: SDK API that you are calling is being called too often
 - **Possible solution**: API rate limiting generally occurs when the webpage is making an unusually high number of requests within a short period. To resolve this, analyze your code to determine why so many requests are being sent and implement optimizations to reduce unnecessary calls.
 
+#### Error code: 0014
+
+- **Error message**: Media connection failed
+- **Possible reason**: ICE (Interactive Connectivity Establishment) connection failed
+- **Possible solution**: Make sure your network allows WebRTC connections and turn.cloudflare.com & stun.cloudflare.com are accessible.
+
 ## Controller
 
 #### Error code: 0100

--- a/src/content/release-notes/realtimekit-web-core.yaml
+++ b/src/content/release-notes/realtimekit-web-core.yaml
@@ -3,6 +3,28 @@ link: "/realtime/realtimekit/release-notes/"
 productName: RealtimeKit Web Core
 productLink: "/realtime/realtimekit/"
 entries:
+  - publish_date: "2026-05-28"
+    title: RealtimeKit Web Core 1.5.1
+    description: |-
+      **Compatibility:** Works best with RealtimeKit Web UI Kit 1.2.0 or later.
+
+      **Features**
+
+      - Added a dedicated error code `0014` for media (WebRTC) connection failures during room join, making it easier to distinguish media failures from socket and signaling failures.
+
+      **Enhancements**
+
+      - Init and join failures from `Client.init()` and `meeting.join()` now surface specific error codes and descriptive messages instead of generic or stacked errors.
+      - Telemetry logs are now compressed using gzip when the browser supports the `CompressionStream` API, achieving approximately a 10:1 compression ratio. Older browsers and React Native fall back to uncompressed JSON with smaller batch sizes.
+
+      **Fixes**
+
+      - Fixed a regex-based issue where the Safari video middleware flag was incorrectly removed, potentially breaking video processing on Safari.
+      - Fixed an issue where `ClientError` objects were wrapped inside each other when the SDK retried failed API requests. This caused nested error messages, duplicate `onError` callbacks, and redundant `window` error events.
+
+      **Removed APIs**
+      - Removed the third party flag service. `meeting.__internals__.features` is now deprecated and will be removed in a future release.
+
   - publish_date: "2026-04-20"
     title: RealtimeKit Web Core 1.4.0
     description: |-

--- a/src/content/release-notes/realtimekit-web-core.yaml
+++ b/src/content/release-notes/realtimekit-web-core.yaml
@@ -23,7 +23,8 @@ entries:
       - Fixed an issue where `ClientError` objects were wrapped inside each other when the SDK retried failed API requests. This caused nested error messages, duplicate `onError` callbacks, and redundant `window` error events.
 
       **Removed APIs**
-      - Removed the third party flag service. `meeting.__internals__.features` is now deprecated and will be removed in a future release.
+
+      - Removed the third-party flag service. `meeting.__internals__.features` is now deprecated and will be removed in a future release.
 
   - publish_date: "2026-04-20"
     title: RealtimeKit Web Core 1.4.0

--- a/src/content/release-notes/realtimekit-web-ui-kit.yaml
+++ b/src/content/release-notes/realtimekit-web-ui-kit.yaml
@@ -3,6 +3,24 @@ link: "/realtime/realtimekit/release-notes/"
 productName: RealtimeKit Web UI Kit
 productLink: "/realtime/realtimekit/"
 entries:
+  - publish_date: "2026-05-28"
+    title: RealtimeKit Web UI Kit 1.2.0
+    description: |-
+      **Compatibility:** Works best with RealtimeKit Web Core 1.5.1 or later.
+
+      **Features**
+
+      - When a user fails to join a meeting, `rtk-idle-screen` and `rtk-setup-screen` now display a troubleshooting link to help resolve common connection issues such as firewall restrictions and permission errors.
+      - If the meeting preset allows transcripts, the transcription panel is now shown by default without requiring manual activation.
+
+      **Enhancements**
+
+      - Raw SDK error codes and messages are no longer shown to end users on join failure. Error messages are now mapped to clear, user-friendly, localized text with a small reference code (for example, `Error code: 0002`) for support and debugging.
+
+      **Fixes**
+
+      - Corrected several typos and spacing issues in the default language pack.
+
   - publish_date: "2026-03-31"
     title: RealtimeKit Web UI Kit 1.1.2
     description: |-


### PR DESCRIPTION
### Summary

Added RealtimeKit Web release notes for 28 May 2026

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
