### PR TITLE
docs: mention json format support for testing cron triggers

### DIFF
--- a/src/content/docs/workers/configuration/cron-triggers.mdx
+++ b/src/content/docs/workers/configuration/cron-triggers.mdx
@@ -192,11 +192,28 @@ Some common time intervals that may be useful for setting up your Cron Trigger:
 
 ## Test Cron Triggers locally
 
-Test Cron Triggers using Wrangler with [`wrangler dev`](/workers/wrangler/commands/general/#dev), or using the [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/). This will expose a `/cdn-cgi/handler/scheduled` route which can be used to test using a HTTP request.
+Test Cron Triggers using Wrangler with [`wrangler dev`](/workers/wrangler/commands/general/#dev), or using the [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/). This exposes a `/cdn-cgi/handler/scheduled` route, which can be used to test using an HTTP request.
 
 ```sh
 curl "http://localhost:8787/cdn-cgi/handler/scheduled"
 ```
+
+By default, the endpoint returns the scheduled handler outcome as text. To return the
+structured scheduled handler result as JSON, pass `?format=json`.
+
+```sh
+curl "http://localhost:8787/cdn-cgi/handler/scheduled?format=json"
+```
+
+```json
+{
+  "outcome": "ok",
+  "noRetry": false
+}
+```
+
+The `noRetry` field is `true` when the scheduled handler calls
+`controller.noRetry()`.
 
 To simulate different cron patterns, a `cron` query parameter can be passed in.
 
@@ -207,7 +224,7 @@ curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=*+*+*+*+*"
 Optionally, you can also pass a `time` query parameter to override `controller.scheduledTime` in your scheduled event listener.
 
 ```sh
-curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=*+*+*+*+*&time=1745856238"
+curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=*+*+*+*+*&time=1745856238000"
 ```
 
 ## View past events

--- a/src/content/docs/workers/runtime-apis/handlers/scheduled.mdx
+++ b/src/content/docs/workers/runtime-apis/handlers/scheduled.mdx
@@ -14,16 +14,10 @@ When a Worker is invoked via a [Cron Trigger](/workers/configuration/cron-trigge
 
 :::note[Testing scheduled() handlers in local development]
 
-You can test the behavior of your `scheduled()` handler in local development using Wrangler.
-
-Cron Triggers can be tested using `Wrangler` by passing in the `--test-scheduled` flag to [`wrangler dev`](/workers/wrangler/commands/general/#dev). This will expose a `/__scheduled` (or `/cdn-cgi/handler/scheduled` for Python Workers) route which can be used to test using a http request. To simulate different cron patterns, a `cron` query parameter can be passed in.
+You can test the behavior of your `scheduled()` handler in local development by sending an HTTP request to `/cdn-cgi/handler/scheduled` to trigger the handler. Pass `?format=json` to return the structured scheduled handler result.
 
 ```sh
-npx wrangler dev --test-scheduled
-
-curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"
-
-curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=*+*+*+*+*" # Python Workers
+curl "http://localhost:8787/cdn-cgi/handler/scheduled?format=json"
 ```
 
 :::


### PR DESCRIPTION
### Summary

- Document the new json output format introduced in https://github.com/cloudflare/workers-sdk/pull/14079
- Recommend `/cdn-cgi/handler/scheduled` instead of `--test-scheduled` going forward as the later one is only supported by Wrangler.


### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
