### PR TITLE
[Magic Transit] Clarify that Cloudflare-originated traffic counts toward bandwidth

### DIFF
--- a/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
+++ b/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
@@ -11,3 +11,13 @@ sidebar:
 Cloudflare measures Magic Transit usage based on the 95th percentile of clean bandwidth for your network. "Clean bandwidth" refers to the egress traffic Cloudflare routes to your network after applying all Distributed Denial of Service ([DDoS](/ddos-protection/)) mitigation and firewall functions. The usage measurement explicitly excludes attack traffic we block at our global network.
 
 To measure 95th percentile bandwidth, Cloudflare records clean bandwidth leaving our global network at five-minute intervals, sorts these measurements in descending order, and discards the top 5% of measurements it recorded. The highest remaining value constitutes the 95th percentile bandwidth measurement for that time period.
+
+#### Cloudflare-originated traffic
+
+Clean bandwidth includes all egress traffic Cloudflare routes to your network through Magic Transit tunnels and interconnects. This includes traffic that originated from the public Internet, as well as response traffic from services within the Cloudflare network (such as Cloudflare CDN) destined to your servers.
+
+For example, if you have onboarded 10.0.0.0/20 to Magic Transit and are advertising it from the Cloudflare edge, but have also advertised a more specific 10.0.1.0/24 via your ISP, the following applies:
+ - **Internet traffic** to 10.0.1.0/24 reaches you via your ISP because the global Internet routing table uses Longest Prefix Match.
+ - **Cloudflare-originated traffic** to 10.0.1.0/24 is routed through your Magic Transit tunnels and interconnects because Cloudflare keeps that traffic inside its own network when the covering /20 prefix is onboarded. This traffic counts toward your bandwidth usage.
+
+**To avoid this:** If you do not want Cloudflare-originated traffic flowing through your Magic Transit tunnel, withdraw the prefix from Cloudflare. The traffic will then egress to the Internet and follow standard Internet routing (including your more specific ISP routes). 

--- a/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
+++ b/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
@@ -18,6 +18,6 @@ Clean bandwidth includes all egress traffic Cloudflare routes to your network th
 
 For example, if you have onboarded 10.0.0.0/20 to Magic Transit and are advertising it from the Cloudflare edge, but have also advertised a more specific 10.0.1.0/24 via your ISP, the following applies:
  - **Internet traffic** to 10.0.1.0/24 reaches you via your ISP because the global Internet routing table uses Longest Prefix Match.
- - **Cloudflare-originated traffic** to 10.0.1.0/24 is routed through your Magic Transit tunnels and interconnects because Cloudflare keeps that traffic inside its own network when the covering /20 prefix is onboarded. This traffic counts toward your bandwidth usage.
+ - **Cloudflare-originated traffic** to 10.0.1.0/24 is routed through your Magic Transit tunnels and interconnects because Cloudflare keeps that traffic inside its own network when the covering /20 prefix is advertised from Cloudflare. This traffic counts toward your bandwidth usage.
 
 **To avoid this:** If you do not want Cloudflare-originated traffic flowing through your Magic Transit tunnel, withdraw the prefix from Cloudflare. The traffic will then egress to the Internet and follow standard Internet routing (including your more specific ISP routes). 

--- a/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
+++ b/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
@@ -16,8 +16,8 @@ To measure 95th percentile bandwidth, Cloudflare records clean bandwidth leaving
 
 Clean bandwidth includes all egress traffic Cloudflare routes to your network through Magic Transit tunnels and interconnects. This includes traffic that originated from the public Internet, as well as response traffic from services within the Cloudflare network (such as Cloudflare CDN) destined to your servers.
 
-For example, if you have onboarded 10.0.0.0/20 to Magic Transit and are advertising it from the Cloudflare edge, but have also advertised a more specific 10.0.1.0/24 via your ISP, the following applies:
- - **Internet traffic** to 10.0.1.0/24 reaches you via your ISP because the global Internet routing table uses Longest Prefix Match.
- - **Cloudflare-originated traffic** to 10.0.1.0/24 is routed through your Magic Transit tunnels and interconnects because Cloudflare keeps that traffic inside its own network when the covering /20 prefix is advertised from Cloudflare. This traffic counts toward your bandwidth usage.
+For example, if you have onboarded `10.0.0.0/20` to Magic Transit and are advertising it from the Cloudflare edge, but have also advertised a more specific `10.0.1.0/24` via your ISP, the following applies:
+ - **Internet traffic** to `10.0.1.0/24` reaches you via your ISP because the global Internet routing table uses Longest Prefix Match.
+ - **Cloudflare-originated traffic** to `10.0.1.0/24` is routed through your Magic Transit tunnels and interconnects because Cloudflare keeps that traffic inside its own network when the covering /20 prefix is advertised from Cloudflare. This traffic counts toward your bandwidth usage.
 
 **To avoid this:** If you do not want Cloudflare-originated traffic flowing through your Magic Transit tunnel, withdraw the prefix from Cloudflare. The traffic will then egress to the Internet and follow standard Internet routing (including your more specific ISP routes). 

--- a/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
+++ b/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
@@ -12,7 +12,7 @@ Cloudflare measures Magic Transit usage based on the 95th percentile of clean ba
 
 To measure 95th percentile bandwidth, Cloudflare records clean bandwidth leaving our global network at five-minute intervals, sorts these measurements in descending order, and discards the top 5% of measurements it recorded. The highest remaining value constitutes the 95th percentile bandwidth measurement for that time period.
 
-#### Cloudflare-originated traffic
+## Cloudflare-originated traffic
 
 Clean bandwidth includes all egress traffic Cloudflare routes to your network through Magic Transit tunnels and interconnects. This includes traffic that originated from the public Internet, as well as response traffic from services within the Cloudflare network (such as Cloudflare CDN) destined to your servers.
 

--- a/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
+++ b/src/content/docs/magic-transit/reference/bandwidth-measurement.mdx
@@ -20,4 +20,4 @@ For example, if you have onboarded `10.0.0.0/20` to Magic Transit and are advert
  - **Internet traffic** to `10.0.1.0/24` reaches you via your ISP because the global Internet routing table uses Longest Prefix Match.
  - **Cloudflare-originated traffic** to `10.0.1.0/24` is routed through your Magic Transit tunnels and interconnects because Cloudflare keeps that traffic inside its own network when the covering /20 prefix is advertised from Cloudflare. This traffic counts toward your bandwidth usage.
 
-**To avoid this:** If you do not want Cloudflare-originated traffic flowing through your Magic Transit tunnel, withdraw the prefix from Cloudflare. The traffic will then egress to the Internet and follow standard Internet routing (including your more specific ISP routes). 
+**To avoid this:** If you do not want Cloudflare-originated traffic flowing through your Magic Transit tunnel, withdraw the covering prefix from Cloudflare. The traffic will then egress to the Internet and follow standard Internet routing (including your more specific ISP routes).


### PR DESCRIPTION
## Summary
Customers have reported unexpected bandwidth charges because it was not documented that traffic originating from Cloudflare services (for example, CDN) is routed through Magic Transit tunnels when the destination prefix is onboarded and advertised, even if a more specific route exists via their ISP.
## Changes
- **Bandwidth measurement** (`bandwidth-measurement.mdx`): Added section explaining that Cloudflare-originated traffic counts toward bandwidth, with a `/20` and `/24` example. Also added guidance on how to avoid this traffic pattern.
## Related
This addresses customer confusion where more specific ISP routes do not affect how Cloudflare delivers traffic that originates from our own network.