### PR TITLE
Document use of "wrangler containers ssh" with ProxyCommand

### DIFF
--- a/src/content/changelog/containers/2026-05-28-ssh-proxy-command.mdx
+++ b/src/content/changelog/containers/2026-05-28-ssh-proxy-command.mdx
@@ -1,0 +1,17 @@
+---
+title: Wrangler supports SSH ProxyCommand for Containers
+description: Use OpenSSH ProxyCommand with wrangler containers ssh.
+products:
+  - containers
+date: 2026-05-28
+---
+
+[Wrangler](/workers/wrangler/) supports using `wrangler containers ssh` as an OpenSSH `ProxyCommand` for [Containers](/containers/). This lets your local SSH client connect to a running Container through Wrangler.
+
+```sh
+ssh -o ProxyCommand="wrangler containers ssh %h" cloudchamber@<INSTANCE_ID>
+```
+
+When standard input and output are piped, Wrangler forwards data to the SSH server in the Container. You can also pass `--stdio` to force this mode.
+
+For more information, refer to the [SSH documentation](/containers/ssh/).

--- a/src/content/docs/containers/ssh.mdx
+++ b/src/content/docs/containers/ssh.mdx
@@ -56,6 +56,16 @@ Once SSH is configured and the Container is running, open the SSH connection wit
 wrangler containers ssh <INSTANCE_ID>
 ```
 
+## Use as SSH proxy
+
+You can use `wrangler containers ssh` as an OpenSSH `ProxyCommand`. This lets your local SSH client connect through Wrangler.
+
+```sh
+ssh -o ProxyCommand="wrangler containers ssh %h" cloudchamber@<INSTANCE_ID>
+```
+
+When used this way, Wrangler pipes standard input and output to the SSH server in the running Container. You can also pass `--stdio` to force this mode.
+
 ## Process visibility
 
 Without the [`containers_pid_namespace`](/workers/configuration/compatibility-flags/#use-an-isolated-pid-namespace-for-containers) compatibility flag, all processes inside the VM are visible when you connect to your Container through SSH. This flag is turned on by default for Workers with a [compatibility date](/workers/configuration/compatibility-dates/) of `2026-04-01` or later.


### PR DESCRIPTION
### Summary

Document use of `wrangler containers ssh` with the `ProxyCommand` SSH option

https://github.com/cloudflare/workers-sdk/pull/14091

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
