### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-05-28)

### DIFF
--- a/src/content/changelog/logs/2026-05-28-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-05-28-log-fields-updated.mdx
@@ -6,9 +6,18 @@ date: 2026-05-28
 
 Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
 
-### Updated fields in existing datasets
+### New fields
 
 - **DEX Device State Events** (added): `DeviceRegistrationProfileID`.
 - **HTTP requests** (added): `MatchedRules`.
+
+### Updated field descriptions
+
+- **HTTP requests**: `OriginResponseBytes` description now includes guidance on using `CacheResponseBytes` with `OriginResponseStatus` filtering to calculate origin-served bytes.
+- **Magic Network Monitoring Flow Logs**: Updated descriptions for `DeviceID`, `FlowTimestamp`, `RuleIDs`, and `Timestamp`.
+
+### Deprecations
+
+- **Firewall Events**: `FirewallForAIInjectionScore`, `FirewallForAIPIICategories`, `FirewallForAITokenCount`, and `FirewallForAIUnsafeTopicCategories` are now marked as deprecated.
 
 For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/changelog/logs/2026-05-28-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-05-28-log-fields-updated.mdx
@@ -1,0 +1,14 @@
+---
+title: Updated fields across multiple Logpush datasets in Cloudflare Logs
+description: Fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-05-28
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### Updated fields in existing datasets
+
+- **DEX Device State Events** (added): `DeviceRegistrationProfileID`.
+- **HTTP requests** (added): `MatchedRules`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/dex_device_state_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/dex_device_state_events.md
@@ -111,6 +111,12 @@ Type: `string`
 
 The unique ID for the device registration.
 
+## DeviceRegistrationProfileID
+
+Type: `string`
+
+The ID for the Device Profile used for the device registration.
+
 ## DiskReadBPS
 
 Type: `int`

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/mnm_flow_logs.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/mnm_flow_logs.md
@@ -43,7 +43,7 @@ The destination port number.
 
 Type: `string`
 
-If the flow is routed through a WARP device, the device ID.
+The ID of the network device (such as a router or switch) that originated the flow.
 
 ## EgressBits
 
@@ -73,7 +73,7 @@ The flow protocol (e.g., 'AWS_VPC', 'IPFIX', 'SFLOW_5', 'NETFLOW_V9', etc.).
 
 Type: `int or string`
 
-The timestamp of the flow.
+The timestamp of the flow. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).
 
 ## NumFlows
 
@@ -103,7 +103,7 @@ The protocol number (e.g., 6 for TCP, 17 for UDP).
 
 Type: `string`
 
-Comma-separated list of rule IDs associated with the flow if any.
+Comma-separated list of Magic Network Monitoring rule IDs associated with the flow, if any.
 
 ## SampleRate
 
@@ -151,4 +151,4 @@ The TCP flags.
 
 Type: `int or string`
 
-The date and time of the event.
+The date and time of the event. To specify the timestamp format, refer to [Output types](/logs/logpush/logpush-job/log-output-options/#output-types).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
@@ -7,6 +7,8 @@ sidebar:
   order: 21
 ---
 
+Network session logs are generated for all traffic proxied through Cloudflare Gateway across all supported [on-ramps](/cloudflare-one/networks/connectivity-options/), such as the Cloudflare One Client (WARP), proxy endpoints (PAC files), Browser Isolation, and Cloudflare Tunnel.
+
 The descriptions below detail the fields available for `zero_trust_network_sessions`.
 
 ## AccountID

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
@@ -177,25 +177,25 @@ Type: `int`
 
 HTTP response status code returned to browser.
 
-## FirewallForAIInjectionScore
+## FirewallForAIInjectionScore (deprecated)
 
 Type: `int`
 
 The score indicating the likelihood of a prompt injection attack in the request, as determined by Firewall for AI. Deprecated: Use AISecurityInjectionScore instead.
 
-## FirewallForAIPIICategories
+## FirewallForAIPIICategories (deprecated)
 
 Type: `array[string]`
 
 List of PII categories detected in the request by Firewall for AI. Deprecated: Use AISecurityPIICategories instead.
 
-## FirewallForAITokenCount
+## FirewallForAITokenCount (deprecated)
 
 Type: `int`
 
 The number of tokens in the request, as counted by Firewall for AI. Deprecated: Use AISecurityTokenCount instead.
 
-## FirewallForAIUnsafeTopicCategories
+## FirewallForAIUnsafeTopicCategories (deprecated)
 
 Type: `array[string]`
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -453,6 +453,12 @@ Type: `string`
 
 Result of the check for [leaked credentials](/waf/detections/leaked-credentials/). <br />Possible results are: <em>password_leaked</em> \| <em>username_and_password_leaked</em> \| <em>username_password_similar</em> \| <em>username_leaked</em> \| <em>clean</em>.
 
+## MatchedRules
+
+Type: `array[object]`
+
+Array of matched FL product rules grouped by product. Each object contains: <em>product</em> (string, e.g. snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
+
 ## OriginDNSResponseTimeMs
 
 Type: `int`
@@ -475,7 +481,7 @@ Time taken to send request headers to origin after establishing a connection. No
 
 Type: `int`
 
-Number of bytes returned by the origin server.
+Number of bytes returned by the origin server. Consider using CacheResponseBytes and filtering out OriginResponseStatus with values 0 and 304, which indicate a revalidated response. Read more [here](/logs/faq/common-calculations/#how-can-i-calculate-bytes-served-by-the-origin-from-cloudflare-logs).
 
 ## OriginResponseDurationMs
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -457,7 +457,7 @@ Result of the check for [leaked credentials](/waf/detections/leaked-credentials/
 
 Type: `array[object]`
 
-Array of matched FL product rules grouped by product. Each object contains: <em>product</em> (string, e.g. snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
+Array of matched Cloudflare Rules product rules grouped by product. Each object contains: <em>product</em> (string, e.g. snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
 
 ## OriginDNSResponseTimeMs
 
@@ -481,7 +481,7 @@ Time taken to send request headers to origin after establishing a connection. No
 
 Type: `int`
 
-Number of bytes returned by the origin server. Consider using CacheResponseBytes and filtering out OriginResponseStatus with values 0 and 304, which indicate a revalidated response. Read more [here](/logs/faq/common-calculations/#how-can-i-calculate-bytes-served-by-the-origin-from-cloudflare-logs).
+Number of bytes returned by the origin server. Consider using CacheResponseBytes and filtering out OriginResponseStatus with values 0 and 304, which indicate a revalidated response. Refer to [Calculating origin-served bytes](/logs/faq/common-calculations/#how-can-i-calculate-bytes-served-by-the-origin-from-cloudflare-logs).
 
 ## OriginResponseDurationMs
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Updated fields in existing datasets

- **DEX Device State Events** (added): `DeviceRegistrationProfileID`.
- **HTTP requests** (added): `MatchedRules`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/{account,zone}/` — dataset pages
- `src/content/changelog/logs/2026-05-28-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
