### PR TITLE
[Cloudflare One] Document TLS inspection requirement for authorization proxy endpoints

### DIFF
--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -314,7 +314,7 @@ Each account has a maximum number of proxy endpoints:
 
 ### 3a. Install Cloudflare certificate
 
-You must [install a Cloudflare certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/) on your devices. For [authorization endpoints](#authorization-endpoint), TLS inspection is always performed to read the authorization cookie, so the certificate is required for the endpoint to function. For [source IP endpoints](#source-ip-endpoint), the certificate is required to apply Gateway HTTP policies such as blocking specific domains or displaying the Gateway block page.
+You must [install a Cloudflare certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/) on your devices. For [authorization endpoints](#authorization-endpoint), Gateway always performs TLS inspection to read the authorization cookie, so the certificate is required for the endpoint to function. For [source IP endpoints](#source-ip-endpoint), the certificate is required to apply Gateway HTTP policies such as blocking specific domains or displaying the Gateway block page.
 
 ### 3b. Configure browser to use PAC file
 
@@ -500,7 +500,7 @@ When using [authorization endpoints](#authorization-endpoint), be aware of the f
 
 #### TLS inspection required
 
-Authorization endpoints require [TLS inspection](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) on all proxied traffic. Gateway must decrypt HTTPS requests to read the authorization cookie that identifies each user session. This means TLS decryption is always performed for traffic routed through an authorization endpoint, even if TLS decryption is turned off at the account level. You cannot selectively bypass TLS inspection for specific destinations when using an authorization endpoint.
+Authorization endpoints require [TLS inspection](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) on all proxied traffic. Gateway must decrypt HTTPS requests to read the authorization cookie that identifies each user session. Gateway always performs TLS decryption for traffic routed through an authorization endpoint, even if you turn off TLS decryption at the account level. You cannot selectively bypass TLS inspection for specific destinations when using an authorization endpoint.
 
 #### Plaintext HTTP traffic
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -314,7 +314,7 @@ Each account has a maximum number of proxy endpoints:
 
 ### 3a. Install Cloudflare certificate
 
-To use Gateway HTTP policies with proxy endpoints, you must [install a Cloudflare certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/) on your devices. This allows Gateway to inspect HTTPS traffic and apply policies such as blocking specific domains or displaying the Gateway block page.
+You must [install a Cloudflare certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/) on your devices. For [authorization endpoints](#authorization-endpoint), TLS inspection is always performed to read the authorization cookie, so the certificate is required for the endpoint to function. For [source IP endpoints](#source-ip-endpoint), the certificate is required to apply Gateway HTTP policies such as blocking specific domains or displaying the Gateway block page.
 
 ### 3b. Configure browser to use PAC file
 
@@ -497,6 +497,10 @@ Each user who authenticates through an authorization proxy endpoint occupies a [
 ### Authorization endpoint limitations
 
 When using [authorization endpoints](#authorization-endpoint), be aware of the following limitations. For configuration guidance on apps with certificate pinning, refer to [PAC file best practices](/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/best-practices/#apps-with-certificate-pinning).
+
+#### TLS inspection required
+
+Authorization endpoints require [TLS inspection](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) on all proxied traffic. Gateway must decrypt HTTPS requests to read the authorization cookie that identifies each user session. This means TLS decryption is always performed for traffic routed through an authorization endpoint, even if TLS decryption is turned off at the account level. You cannot selectively bypass TLS inspection for specific destinations when using an authorization endpoint.
 
 #### Plaintext HTTP traffic
 

--- a/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
+++ b/src/content/docs/cloudflare-one/networks/resolvers-and-proxies/proxy-endpoints/index.mdx
@@ -314,7 +314,7 @@ Each account has a maximum number of proxy endpoints:
 
 ### 3a. Install Cloudflare certificate
 
-You must [install a Cloudflare certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/) on your devices. For [authorization endpoints](#authorization-endpoint), Gateway always performs TLS inspection to read the authorization cookie, so the certificate is required for the endpoint to function. For [source IP endpoints](#source-ip-endpoint), the certificate is required to apply Gateway HTTP policies such as blocking specific domains or displaying the Gateway block page.
+You must [install a Cloudflare certificate](/cloudflare-one/team-and-resources/devices/user-side-certificates/) on your devices. Authorization endpoints use the certificate to inspect TLS traffic and read the authorization cookie. Source IP endpoints use the certificate to apply Gateway HTTP policies such as blocking specific domains or displaying the Gateway block page.
 
 ### 3b. Configure browser to use PAC file
 


### PR DESCRIPTION
## Summary

- Adds a new "TLS inspection required" limitation under authorization endpoint limitations, documenting that TLS decryption is always performed to read the auth cookie - even if TLS decryption is turned off at the account level.
- Clarifies the certificate installation step (3a) to explain that the Cloudflare certificate is mandatory for authorization endpoints to function, not just for HTTP policy enforcement.

Context: a customer discovered during testing that TLS decryption happens by default on authorization proxy endpoints despite being disabled at the account level. This is expected behavior - the auth cookie can only be read from decrypted requests - but it was not documented.