### PR TITLE
[Browser Run] Add Workers binding example to Quick Actions get-started

### DIFF
--- a/src/content/docs/browser-run/get-started.mdx
+++ b/src/content/docs/browser-run/get-started.mdx
@@ -8,7 +8,7 @@ products:
   - browser-run
 ---
 
-import { Render } from "~/components";
+import { Render, Tabs, TabItem } from "~/components";
 
 Cloudflare Browser Run (formerly Browser Rendering) allows you to programmatically control a headless browser, enabling you to do things like take screenshots, generate PDFs, and perform automated browser tasks. This guide will help you choose the right integration method and get you started with your first project.
 
@@ -16,14 +16,31 @@ Cloudflare Browser Run (formerly Browser Rendering) allows you to programmatical
 
 ## Quick Actions
 
+Quick Actions can be used via the REST API or directly from a Cloudflare Worker using a browser binding.
+
+<Tabs> <TabItem label="REST API">
+
 ### Prerequisites
 
 - Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages).
 - Create a [Cloudflare API Token](/fundamentals/api/get-started/create-token/) with `Browser Rendering - Edit` permissions.
 
-### Example: Take a screenshot of the Cloudflare homepage
+### Example: Take a screenshot
 
 <Render file="example-screenshot-from-url" product="browser-run" />
+
+</TabItem> <TabItem label="Workers binding">
+
+### Prerequisites
+
+- Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages).
+- Install [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+
+### Example: Take a screenshot from a Worker
+
+<Render file="example-quick-action-binding" product="browser-run" />
+
+</TabItem> </Tabs>
 
 Other Quick Actions endpoints include:
 

--- a/src/content/partials/browser-run/example-quick-action-binding.mdx
+++ b/src/content/partials/browser-run/example-quick-action-binding.mdx
@@ -1,0 +1,85 @@
+import {
+	Render,
+	PackageManagers,
+	TypeScriptExample,
+	WranglerConfig,
+} from "~/components";
+
+#### 1. Create a Worker project
+
+Create a new Worker project named `browser-quick-action` by running:
+
+<PackageManagers
+	type="create"
+	pkg="cloudflare@latest"
+	args={"browser-quick-action"}
+/>
+
+<Render
+	file="c3-post-run-steps"
+	product="workers"
+	params={{
+		category: "hello-world",
+		type: "Worker only",
+		lang: "TypeScript",
+	}}
+/>
+
+#### 2. Configure the browser binding
+
+Update your [Wrangler configuration file](/workers/wrangler/configuration/) with a browser [binding](/browser-run/reference/wrangler/#bindings):
+
+<WranglerConfig>
+
+```toml
+name = "browser-quick-action"
+main = "src/index.ts"
+compatibility_date = "$today"
+
+[browser]
+binding = "BROWSER"
+```
+
+</WranglerConfig>
+
+:::caution
+
+Using the `.quickAction()` method requires a `compatibility_date` of `2026-03-24` or later.
+
+:::
+
+#### 3. Write the Worker code
+
+Replace the contents of `src/index.ts` with the following:
+
+<TypeScriptExample>
+
+```ts
+interface Env {
+	BROWSER: BrowserRun;
+}
+
+export default {
+	async fetch(request, env): Promise<Response> {
+		return await env.BROWSER.quickAction("screenshot", {
+			url: "https://example.com",
+		});
+	},
+} satisfies ExportedHandler<Env>;
+```
+
+</TypeScriptExample>
+
+This Worker uses the browser binding to take a screenshot of `example.com` and returns the image directly in the response.
+
+#### 4. Test
+
+Run `npx wrangler dev --remote` to test your Worker locally.
+
+<Render file="remote-binding-note" product="workers" />
+
+Visit your local URL to see the screenshot.
+
+#### 5. Deploy
+
+Run `npx wrangler deploy` to deploy your Worker to the Cloudflare global network.


### PR DESCRIPTION
## What this PR does

Adds a **Workers binding** tab to the Quick Actions section of the Browser Run [get-started page](/browser-run/get-started/). Previously, the get-started flow only showed Quick Actions via the REST API (curl). Now developers can also see how to use `env.BROWSER.quickAction()` directly from a Worker.

### Changes

- **`get-started.mdx`**: Wraps the Quick Actions section in `<Tabs>` with two tabs:
  - **REST API** — existing curl example (unchanged)
  - **Workers binding** — new 5-step tutorial
- **New partial `example-quick-action-binding.mdx`**: Step-by-step tutorial covering project creation, wrangler config with browser binding, TypeScript code using `quickAction("screenshot")`, local testing, and deployment.

### Why

Quick Actions with Workers bindings [launched May 28, 2026](https://developers.cloudflare.com/changelog/browser-run/2026-05-28-use-browser-run-quick-actions-directly-from-workers/). The get-started page is the first place new developers land, and should surface both integration methods so developers can pick the right one for their use case.

### Style guide compliance

- Uses `PackageManagers`, `WranglerConfig`, `TypeScriptExample`, and `Render` components per style guide requirements
- Uses `$today` for compatibility_date in WranglerConfig
- Includes caution callout about the `2026-03-24` minimum compatibility date requirement
- Follows the same structural pattern as the existing Browser Sessions tutorial partial