### PR TITLE
Korinne/realtime websocket adapter reconnects

### DIFF
--- a/src/content/changelog/realtime/2026-05-29-websocket-adapter-auto-reconnect.mdx
+++ b/src/content/changelog/realtime/2026-05-29-websocket-adapter-auto-reconnect.mdx
@@ -1,0 +1,44 @@
+---
+title: Cloudflare's Realtime WebSocket adapter now auto-reconnects and buffers WebRTC media
+description: Realtime SFU WebSocket adapters now automatically reconnect and buffer media after brief endpoint disconnects or restarts when using Stream mode.
+products:
+  - realtime
+date: 2026-05-29
+---
+
+[Cloudflare Realtime SFU](/realtime/sfu/) is a [WebRTC Selective Forwarding Unit that runs on Cloudflare's global network](/realtime/sfu/calls-vs-sfus/), so you can route live audio, video, and data between WebRTC clients around the world without managing SFU infrastructure or regions.
+
+When you use the [WebSocket adapter](/realtime/sfu/media-transport-adapters/websocket-adapter/) to stream WebRTC media to a WebSocket endpoint, the adapter now auto-reconnects and buffers audio and video after brief endpoint disconnects or restarts.
+
+## Streaming WebRTC media to WebSocket endpoints
+
+Many teams also use Realtime SFU as the media layer for backend applications, such as transcription, recording, note-taking, and agentic media-processing services. These systems often need to consume live WebRTC audio or video from the SFU in backend infrastructure, including [Durable Objects](/durable-objects/), [Workers](/workers/), [Containers](/containers/), or external services, without running a WebRTC client themselves.
+
+The [WebSocket adapter](/realtime/sfu/media-transport-adapters/websocket-adapter/) bridges that gap by streaming WebRTC media from the SFU to a standard WebSocket endpoint as application-consumable payloads: [PCM audio frames and JPEG video frames](/realtime/sfu/media-transport-adapters/websocket-adapter/#media-formats).
+
+## What changed
+
+When you use the WebSocket adapter in [Stream mode (egress)](/realtime/sfu/media-transport-adapters/websocket-adapter/#stream-mode-egress) to send live audio or video from the SFU to your own WebSocket endpoint, the SFU now [automatically reconnects](/realtime/sfu/media-transport-adapters/websocket-adapter/#automatic-reconnection-for-streaming) after brief endpoint disconnects or restarts. This is especially helpful for long-running media pipelines where the WebSocket endpoint may briefly restart while a recording, transcription, or live analysis job is still in progress.
+
+Previously, a brief disconnect from your WebSocket endpoint could close the adapter and require your application to recreate it before media could resume. Now, the SFU retries the same endpoint for up to 5 seconds with no API change required. If the endpoint comes back within that window, audio and video delivery resumes automatically.
+
+The reconnect behavior also includes [live-first media buffering](/realtime/sfu/media-transport-adapters/websocket-adapter/#media-buffering-during-reconnect), so brief interruptions reduce media loss without replaying stale video.
+
+## Reconnect behavior
+
+During reconnect:
+
+- Audio uses a short bounded backlog to reduce audible loss. If the interruption lasts longer than the backlog can cover, older audio may be dropped.
+- Video resumes from the [latest available JPEG frame](/realtime/sfu/media-transport-adapters/websocket-adapter/#video-jpeg) instead of replaying stale frames.
+- Recovery is best effort and does not guarantee gapless or exactly-once delivery.
+
+If the endpoint remains unavailable after the 5-second reconnect window, the adapter closes and must be recreated.
+
+## Learn more
+
+- [WebSocket adapter](/realtime/sfu/media-transport-adapters/websocket-adapter/)
+- [Automatic reconnection for streaming](/realtime/sfu/media-transport-adapters/websocket-adapter/#automatic-reconnection-for-streaming)
+- [Get started with Realtime SFU](/realtime/sfu/get-started/)
+- [Realtime SFU example architecture](/realtime/sfu/example-architecture/)
+- [Realtime vs Regular SFUs](/realtime/sfu/calls-vs-sfus/)
+- [Global SFU Network Visualization](https://realtime-sfu.dev-demos.workers.dev/)

--- a/src/content/docs/realtime/sfu/media-transport-adapters/websocket-adapter.mdx
+++ b/src/content/docs/realtime/sfu/media-transport-adapters/websocket-adapter.mdx
@@ -302,15 +302,15 @@ Connects to your WebSocket endpoint:
 
 When you use the WebSocket adapter in [Stream mode (egress)](#stream-mode-egress) to send live audio or video from the SFU to your own WebSocket endpoint (`WebRTC → WebSocket`), the SFU automatically reconnects after brief endpoint disconnects or restarts.
 
-The SFU retries the same WebSocket endpoint for up to 5 seconds. No API changes are required.
+The SFU retries the same WebSocket endpoint for up to 5 seconds. No API changes are required. If the endpoint remains unavailable after the reconnect window, the adapter closes and your application must create a new adapter to resume streaming.
 
-During the automatic reconnect window:
+### Media buffering during reconnect
 
-- Audio uses a short bounded backlog to reduce audible loss during brief interruptions.
-- Video keeps only the latest available JPEG frame, so streaming resumes near-live instead of replaying stale frames.
-- Media delivery near the reconnect boundary is best effort and is not exactly-once.
+Automatic reconnection uses live-first buffering while the WebSocket endpoint is temporarily unavailable:
 
-If the WebSocket endpoint remains unavailable after the 5-second automatic reconnect window, the adapter closes and your application must create a new adapter to resume streaming.
+- **Audio buffering**: The SFU keeps a short, bounded backlog of audio frames. If the interruption lasts longer than the backlog can cover, older audio may be dropped so reconnect recovery stays bounded.
+- **Video buffering**: The SFU keeps only the latest available JPEG frame. Newer frames replace older frames while reconnecting, so video resumes near-live instead of replaying stale frames.
+- **Delivery behavior**: Buffering reduces media loss during brief interruptions, but it is not a replay mechanism and does not guarantee gapless or exactly-once delivery.
 
 Automatic reconnection applies only when using [Stream mode (egress)](#stream-mode-egress). It retries the same endpoint only and does not provide multi-endpoint failover.
 

--- a/src/content/docs/realtime/sfu/media-transport-adapters/websocket-adapter.mdx
+++ b/src/content/docs/realtime/sfu/media-transport-adapters/websocket-adapter.mdx
@@ -79,7 +79,7 @@ graph LR
 - Requires existing session ID with track
 - Audio: Sends individual PCM frames as they are produced; each includes timestamp and sequence number
 - Video: Sends individual JPEG frames at approximately 1 FPS; each includes timestamp (sequence number may be unset)
-- Automatically retries the same WebSocket endpoint for up to 5 seconds after brief disconnects or endpoint restarts
+- Automatically retries the same WebSocket endpoint for up to 5 seconds after brief disconnects or endpoint restarts. Refer to [Automatic reconnection for streaming](#automatic-reconnection-for-streaming).
 
 </TabItem>
 </Tabs>
@@ -300,7 +300,7 @@ Connects to your WebSocket endpoint:
 
 ## Automatic reconnection for streaming
 
-When you use the WebSocket adapter to stream live audio or video from the SFU to your own WebSocket endpoint (`WebRTC → WebSocket`), the SFU automatically reconnects after brief endpoint disconnects or restarts.
+When you use the WebSocket adapter in [Stream mode (egress)](#stream-mode-egress) to send live audio or video from the SFU to your own WebSocket endpoint (`WebRTC → WebSocket`), the SFU automatically reconnects after brief endpoint disconnects or restarts.
 
 The SFU retries the same WebSocket endpoint for up to 5 seconds. No API changes are required.
 
@@ -312,7 +312,7 @@ During the automatic reconnect window:
 
 If the WebSocket endpoint remains unavailable after the 5-second automatic reconnect window, the adapter closes and your application must create a new adapter to resume streaming.
 
-Automatic reconnection applies only when streaming from WebRTC to WebSocket. It retries the same endpoint only and does not provide multi-endpoint failover.
+Automatic reconnection applies only when using [Stream mode (egress)](#stream-mode-egress). It retries the same endpoint only and does not provide multi-endpoint failover.
 
 ## Pricing
 
@@ -328,7 +328,7 @@ Usage counts towards your Cloudflare Realtime free tier of 1,000 GB.
 
 - Closing an already-closed instance returns success
 - Close when sessions end
-- When streaming from WebRTC to WebSocket, handle adapter closure after the 5-second [automatic reconnect window](#automatic-reconnection-for-streaming) is exhausted.
+- When using [Stream mode (egress)](#stream-mode-egress), handle adapter closure after the 5-second [automatic reconnect window](#automatic-reconnection-for-streaming) is exhausted.
 - When ingesting from WebSocket to WebRTC, implement reconnection logic in your WebSocket client if the connection drops.
 - Make your WebSocket endpoint restart-safe so it can accept reconnects to the same URL during brief restarts.
 
@@ -350,7 +350,7 @@ Usage counts towards your Cloudflare Realtime free tier of 1,000 GB.
 - **Beta status**: API may change in future releases
 - **Video support**: Egress only (JPEG)
 - **Video frame rate**: Approximately 1 FPS (beta; not configurable)
-- **Streaming reconnects**: When streaming from WebRTC to WebSocket, the SFU automatically retries the same WebSocket endpoint for short disconnects only. It does not fail over to alternate endpoints.
+- **Streaming reconnects**: When using [Stream mode (egress)](#stream-mode-egress), the SFU automatically retries the same WebSocket endpoint for short disconnects only. It does not fail over to alternate endpoints.
 - **Best-effort recovery**: Brief reconnects reduce media loss, but do not guarantee gapless or exactly-once delivery.
 - **Video reconnect behavior**: Video resumes from the latest available JPEG frame rather than replaying older frames.
 - **Unidirectional flow**: Each instance handles one direction
@@ -382,7 +382,7 @@ A: No, each instance is unidirectional. Create separate adapters for send and re
 
 **Q: What happens if the WebSocket connection drops?**
 
-A: When streaming from WebRTC to WebSocket, the SFU automatically retries the same WebSocket endpoint for up to 5 seconds. If the endpoint comes back within that window, streaming resumes automatically.
+A: When using [Stream mode (egress)](#stream-mode-egress), the SFU automatically retries the same WebSocket endpoint for up to 5 seconds. If the endpoint comes back within that window, streaming resumes automatically.
 
 Audio uses a short bounded backlog to reduce audible loss during brief interruptions. Video resumes from the latest available JPEG frame instead of replaying older frames.
 

--- a/src/content/docs/realtime/sfu/media-transport-adapters/websocket-adapter.mdx
+++ b/src/content/docs/realtime/sfu/media-transport-adapters/websocket-adapter.mdx
@@ -79,6 +79,7 @@ graph LR
 - Requires existing session ID with track
 - Audio: Sends individual PCM frames as they are produced; each includes timestamp and sequence number
 - Video: Sends individual JPEG frames at approximately 1 FPS; each includes timestamp (sequence number may be unset)
+- Automatically retries the same WebSocket endpoint for up to 5 seconds after brief disconnects or endpoint restarts
 
 </TabItem>
 </Tabs>
@@ -191,6 +192,7 @@ POST /v1/apps/{appId}/adapters/websocket/new
 - Video frames are sent individually as JPEG at approximately 1 FPS with timestamp; sequence number may be unset.
 - Each frame is a separate WebSocket message.
 - No mode parameter; frames are sent as produced.
+- The SFU automatically retries the same WebSocket endpoint for up to 5 seconds after brief disconnects.
 :::
 
 </TabItem>
@@ -206,11 +208,11 @@ POST /v1/apps/{appId}/adapters/websocket/close
 
 ```json
 {
-  "tracks": [
-    {
-      "adapterId": "string"
-    }
-  ]
+	"tracks": [
+		{
+			"adapterId": "string"
+		}
+	]
 }
 ```
 
@@ -242,6 +244,7 @@ message Packet {
 **Ingest mode (buffer)**: Only the `payload` field is used, containing chunks of audio data.
 
 **Stream mode (egress)**:
+
 - For audio frames:
   - `sequenceNumber`: Incremental packet counter
   - `timestamp`: Timestamp for synchronization
@@ -267,12 +270,14 @@ Connects to your WebSocket endpoint:
 ### Message format
 
 #### Buffer mode (ingest)
+
 - **Binary messages**: PCM audio data in chunks
 - **Maximum message size**: 32 KB per WebSocket message
 - **Important**: Account for serialization overhead when chunking audio buffers
 - Send audio in small, frequent chunks rather than large batches
 
-#### Stream mode (egress)  
+#### Stream mode (egress)
+
 - **Binary messages**: Individual frames with metadata (audio or video)
 - Audio frames include:
   - Timestamp information
@@ -290,7 +295,24 @@ Connects to your WebSocket endpoint:
 1. Connects to the WebSocket endpoint
 2. Audio streaming begins
 3. Video streaming begins (if configured)
-4. Connection closes when closed or on error
+4. For WebRTC to WebSocket streaming, briefly retries the same endpoint after disconnects
+5. Connection closes when closed, on error, or after the automatic reconnect window is exhausted
+
+## Automatic reconnection for streaming
+
+When you use the WebSocket adapter to stream live audio or video from the SFU to your own WebSocket endpoint (`WebRTC → WebSocket`), the SFU automatically reconnects after brief endpoint disconnects or restarts.
+
+The SFU retries the same WebSocket endpoint for up to 5 seconds. No API changes are required.
+
+During the automatic reconnect window:
+
+- Audio uses a short bounded backlog to reduce audible loss during brief interruptions.
+- Video keeps only the latest available JPEG frame, so streaming resumes near-live instead of replaying stale frames.
+- Media delivery near the reconnect boundary is best effort and is not exactly-once.
+
+If the WebSocket endpoint remains unavailable after the 5-second automatic reconnect window, the adapter closes and your application must create a new adapter to resume streaming.
+
+Automatic reconnection applies only when streaming from WebRTC to WebSocket. It retries the same endpoint only and does not provide multi-endpoint failover.
 
 ## Pricing
 
@@ -306,7 +328,9 @@ Usage counts towards your Cloudflare Realtime free tier of 1,000 GB.
 
 - Closing an already-closed instance returns success
 - Close when sessions end
-- Implement reconnection logic for network failures
+- When streaming from WebRTC to WebSocket, handle adapter closure after the 5-second [automatic reconnect window](#automatic-reconnection-for-streaming) is exhausted.
+- When ingesting from WebSocket to WebRTC, implement reconnection logic in your WebSocket client if the connection drops.
+- Make your WebSocket endpoint restart-safe so it can accept reconnects to the same URL during brief restarts.
 
 ### Performance
 
@@ -326,15 +350,18 @@ Usage counts towards your Cloudflare Realtime free tier of 1,000 GB.
 - **Beta status**: API may change in future releases
 - **Video support**: Egress only (JPEG)
 - **Video frame rate**: Approximately 1 FPS (beta; not configurable)
+- **Streaming reconnects**: When streaming from WebRTC to WebSocket, the SFU automatically retries the same WebSocket endpoint for short disconnects only. It does not fail over to alternate endpoints.
+- **Best-effort recovery**: Brief reconnects reduce media loss, but do not guarantee gapless or exactly-once delivery.
+- **Video reconnect behavior**: Video resumes from the latest available JPEG frame rather than replaying older frames.
 - **Unidirectional flow**: Each instance handles one direction
 
 ## Error handling
 
-| Error Code | Description |
-|------------|-------------|
-| `400` | Invalid request parameters |
-| `404` | Session or track not found |
-| `503` | Adapter not found (for close operations) |
+| Error Code | Description                              |
+| ---------- | ---------------------------------------- |
+| `400`      | Invalid request parameters               |
+| `404`      | Session or track not found               |
+| `503`      | Adapter not found (for close operations) |
 
 ## Reference implementations
 
@@ -354,7 +381,14 @@ Usage counts towards your Cloudflare Realtime free tier of 1,000 GB.
 A: No, each instance is unidirectional. Create separate adapters for send and receive.
 
 **Q: What happens if the WebSocket connection drops?**
-A: The adapter closes and must be recreated. Implement reconnection logic in your app.
+
+A: When streaming from WebRTC to WebSocket, the SFU automatically retries the same WebSocket endpoint for up to 5 seconds. If the endpoint comes back within that window, streaming resumes automatically.
+
+Audio uses a short bounded backlog to reduce audible loss during brief interruptions. Video resumes from the latest available JPEG frame instead of replaying older frames.
+
+If the endpoint remains unavailable after the 5-second [automatic reconnect window](#automatic-reconnection-for-streaming), the adapter closes and must be recreated.
+
+When ingesting from WebSocket to WebRTC, your WebSocket client should reconnect and recreate the adapter as needed.
 
 **Q: Is there a limit on concurrent adapters?**
 A: Limits follow standard Cloudflare Realtime quotas. Contact support for specific requirements.


### PR DESCRIPTION
### Summary

- Documented automatic reconnect behavior for the Realtime SFU WebSocket adapter in Stream mode (egress).
- Added details about the 5-second reconnect window, same-endpoint retry behavior, adapter closure after exhaustion, and no multi-endpoint failover.
- Clarified live-first media buffering during reconnect: short bounded audio backlog and latest-frame-only JPEG video behavior.
- Added a Realtime changelog entry announcing WebSocket adapter auto-reconnect and media buffering.

