### PR TITLE
[Agents] Add changelog for Sandbox named tunnels

### DIFF
--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -1,5 +1,5 @@
 ---
-title: Named tunnels for stable Sandbox URLs
+title: Named tunnels for Sandbox preview URLs
 description: sandbox.tunnels.get() now supports named tunnels that bind a user-controlled hostname to a persistent URL backed by a Cloudflare Tunnel, surviving container restarts and shared sandboxes.
 products:
   - agents

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -25,10 +25,9 @@ Calling `sandbox.destroy()` tears down the Cloudflare Tunnel and the associated 
 
 ## Other changes in this release
 
-This release of `@cloudflare/sandbox` also includes:
+This release of `@cloudflare/sandbox` also includes stale preview URL protection. Invalid, revoked, or destroyed preview URLs now return `404 INVALID_TOKEN`, and authorized URLs that are not activated for the current runtime return `410 STALE_PREVIEW_URL` until the port is exposed again. `getExposedPorts()` and `isPortExposed()` report only ports that are currently preview-forwardable in the active runtime, and `unexposePort()` is now idempotent.
 
-- **Stale preview URL protection** — Invalid, revoked, or destroyed preview URLs now return `404 INVALID_TOKEN`, and authorized URLs that are not activated for the current runtime return `410 STALE_PREVIEW_URL` until the port is exposed again. `getExposedPorts()` and `isPortExposed()` report only ports that are currently preview-forwardable in the active runtime, and `unexposePort()` is now idempotent.
-- **Binary handling for Office Open XML files** — Files such as `.xlsx` and `.docx` are now classified as binary when read, so they are returned with base64 encoding instead of being text-decoded.
+Files such as `.xlsx` and `.docx` are now classified as binary when read, so they are returned with base64 encoding instead of being text-decoded.
 
 ## Upgrade
 

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -1,6 +1,6 @@
 ---
 title: Named tunnels for stable Sandbox URLs
-description: sandbox.tunnels.get() now supports named tunnels that bind a user-controlled hostname to a stable URL backed by a Cloudflare Tunnel, surviving container restarts and shared sandboxes.
+description: sandbox.tunnels.get() now supports named tunnels that bind a user-controlled hostname to a persistent URL backed by a Cloudflare Tunnel, surviving container restarts and shared sandboxes.
 products:
   - agents
 date: 2026-05-29
@@ -10,7 +10,7 @@ import { TypeScriptExample } from "~/components";
 
 [Sandboxes](/sandbox/) now support **named tunnels** through `sandbox.tunnels.get(port, { name })`. A named tunnel binds a user-controlled hostname (`<name>.<your-zone>`) backed by a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) and a proxied CNAME record on your zone.
 
-Unlike quick tunnels, which generate a new random URL each time, a named tunnel produces a **stable URL** that survives container restarts and is shared across any sandboxes that use the same name. This makes named tunnels suitable for use cases that need a predictable, long-lived address — such as webhooks, OAuth callbacks, or sharing a running service with collaborators.
+Unlike quick tunnels, which generate a new random URL each time, a named tunnel produces a **persistent URL** that survives container restarts and is shared across any sandboxes that use the same name. This makes named tunnels suitable for use cases that need a predictable, long-lived address — such as webhooks, OAuth callbacks, or sharing a running service with collaborators.
 
 <TypeScriptExample>
 

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -1,0 +1,41 @@
+---
+title: Named tunnels for stable Sandbox URLs
+description: sandbox.tunnels.get() now supports named tunnels that bind a user-controlled hostname to a stable URL backed by a Cloudflare Tunnel, surviving container restarts and shared sandboxes.
+products:
+  - agents
+date: 2026-05-29
+---
+
+import { TypeScriptExample } from "~/components";
+
+[Sandboxes](/sandbox/) now support **named tunnels** through `sandbox.tunnels.get(port, { name })`. A named tunnel binds a user-controlled hostname (`<name>.<your-zone>`) backed by a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) and a proxied CNAME record on your zone.
+
+Unlike quick tunnels, which generate a new random URL each time, a named tunnel produces a **stable URL** that survives container restarts and is shared across any sandboxes that use the same name. This makes named tunnels suitable for use cases that need a predictable, long-lived address — such as webhooks, OAuth callbacks, or sharing a running service with collaborators.
+
+<TypeScriptExample>
+
+```ts
+const tunnel = await sandbox.tunnels.get(8080, { name: "app" });
+console.log(tunnel.url); // → https://app.example.com
+```
+
+</TypeScriptExample>
+
+Calling `sandbox.destroy()` tears down the Cloudflare tunnel and the associated DNS record alongside the container, so you do not leave dangling tunnels or records behind.
+
+## Other changes in this release
+
+This release of `@cloudflare/sandbox` also includes:
+
+- **Stale preview URL protection** — Invalid, revoked, or destroyed preview URLs now return `404 INVALID_TOKEN`, and authorized URLs that are not activated for the current runtime return `410 STALE_PREVIEW_URL` until the port is exposed again. `getExposedPorts()` and `isPortExposed()` report only ports that are currently preview-forwardable in the active runtime, and `unexposePort()` is now idempotent.
+- **Binary handling for Office Open XML files** — Files such as `.xlsx` and `.docx` are now classified as binary when read, so they are returned with base64 encoding instead of being text-decoded.
+
+## Upgrade
+
+To update to the latest version:
+
+```sh
+npm i @cloudflare/sandbox@latest
+```
+
+For full API details, refer to the [Sandbox tunnels reference](/sandbox/api/tunnels/).

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -8,9 +8,9 @@ date: 2026-05-29
 
 import { PackageManagers, TypeScriptExample } from "~/components";
 
-[Sandboxes](/sandbox/) can expose a service running inside the container on a public preview URL through the `sandbox.tunnels` namespace. The SDK runs `cloudflared` inside the sandbox and opens a persistent QUIC connection to Cloudflare's edge, so you can share a running service without configuring `exposePort()` or a custom domain.
+[Sandboxes](/sandbox/) can expose a service running inside the container on a public preview URL through the `sandbox.tunnels` namespace. The SDK uses `cloudflared` inside the sandbox so you can share a running service without configuring `exposePort()` or a custom domain.
 
-By default, `sandbox.tunnels.get(port)` creates a **quick tunnel** on a zero-config `*.trycloudflare.com` URL — no Cloudflare account, DNS record, or custom domain required. This is ideal for quick development and for `.workers.dev` deployments, where wildcard DNS is not available.
+By default, `sandbox.tunnels.get(port)` creates a [quick tunnel](https://try.cloudflare.com/) on a zero-config `*.trycloudflare.com` URL — no Cloudflare account, DNS record, or custom domain required. This is perfect for quick development and for `.workers.dev` deployments.
 
 <TypeScriptExample>
 
@@ -28,26 +28,20 @@ console.log(tunnel.url); // → https://random-words-here.trycloudflare.com
 
 ## Named tunnels
 
-This release adds **named tunnels** through `sandbox.tunnels.get(port, { name })`. A named tunnel binds a user-controlled hostname (`<name>.<your-zone>`) backed by a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) and a proxied CNAME record on your zone.
+For more control you can create a named tunnel through `sandbox.tunnels.get(port, { name })`. A named tunnel binds a hostname (`<name>.<your-zone>`) backed by a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) and a CNAME record on your zone resulting in something like https://my-app-preview.example.com.
 
-Unlike quick tunnels, which generate a new random URL each time, a named tunnel produces a **persistent URL** that survives container restarts and is shared across any sandboxes that use the same name. This makes named tunnels suitable for use cases that need a predictable, long-lived address — such as webhooks, OAuth callbacks, or sharing a running service with collaborators.
+Unlike quick tunnels, which generate a new random URL each time, a named tunnel produces a persistent URL that survives container restarts. This makes named tunnels suitable for production use cases where you want control over the tunnel and it's origin.
 
 <TypeScriptExample>
 
 ```ts
-const tunnel = await sandbox.tunnels.get(8080, { name: "app" });
-console.log(tunnel.url); // → https://app.example.com
+const tunnel = await sandbox.tunnels.get(8080, { name: "my-app-preview" });
+console.log(tunnel.url); // → https://my-app-preview.example.com
 ```
 
 </TypeScriptExample>
 
 Calling `sandbox.destroy()` tears down the Cloudflare Tunnel and the associated DNS record alongside the container, so you do not leave dangling tunnels or records behind.
-
-## Other changes in this release
-
-This release of `@cloudflare/sandbox` also includes stale preview URL protection. Invalid, revoked, or destroyed preview URLs now return `404 INVALID_TOKEN`, and authorized URLs that are not activated for the current runtime return `410 STALE_PREVIEW_URL` until the port is exposed again. `getExposedPorts()` and `isPortExposed()` report only ports that are currently preview-forwardable in the active runtime, and `unexposePort()` is now idempotent.
-
-Files such as `.xlsx` and `.docx` are now classified as binary when read, so they are returned with base64 encoding instead of being text-decoded.
 
 ## Upgrade
 

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -1,6 +1,6 @@
 ---
 title: Named tunnels for Sandbox preview URLs
-description: sandbox.tunnels.get() now supports named tunnels that bind a user-controlled hostname to a persistent URL backed by a Cloudflare Tunnel, surviving container restarts and shared sandboxes.
+description: Expose Sandbox services on public preview URLs with sandbox.tunnels — zero-config quick tunnels on *.trycloudflare.com, plus named tunnels that bind a persistent custom hostname backed by a Cloudflare Tunnel.
 products:
   - agents
 date: 2026-05-29
@@ -8,7 +8,27 @@ date: 2026-05-29
 
 import { PackageManagers, TypeScriptExample } from "~/components";
 
-[Sandboxes](/sandbox/) now support **named tunnels** through `sandbox.tunnels.get(port, { name })`. A named tunnel binds a user-controlled hostname (`<name>.<your-zone>`) backed by a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) and a proxied CNAME record on your zone.
+[Sandboxes](/sandbox/) can expose a service running inside the container on a public preview URL through the `sandbox.tunnels` namespace. The SDK runs `cloudflared` inside the sandbox and opens a persistent QUIC connection to Cloudflare's edge, so you can share a running service without configuring `exposePort()` or a custom domain.
+
+By default, `sandbox.tunnels.get(port)` creates a **quick tunnel** on a zero-config `*.trycloudflare.com` URL — no Cloudflare account, DNS record, or custom domain required. This is ideal for quick development and for `.workers.dev` deployments, where wildcard DNS is not available.
+
+<TypeScriptExample>
+
+```ts
+import { getSandbox } from "@cloudflare/sandbox";
+
+const sandbox = getSandbox(env.Sandbox, "my-sandbox");
+await sandbox.startProcess("python -m http.server 8080");
+
+const tunnel = await sandbox.tunnels.get(8080);
+console.log(tunnel.url); // → https://random-words-here.trycloudflare.com
+```
+
+</TypeScriptExample>
+
+## Named tunnels
+
+This release adds **named tunnels** through `sandbox.tunnels.get(port, { name })`. A named tunnel binds a user-controlled hostname (`<name>.<your-zone>`) backed by a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) and a proxied CNAME record on your zone.
 
 Unlike quick tunnels, which generate a new random URL each time, a named tunnel produces a **persistent URL** that survives container restarts and is shared across any sandboxes that use the same name. This makes named tunnels suitable for use cases that need a predictable, long-lived address — such as webhooks, OAuth callbacks, or sharing a running service with collaborators.
 

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -6,7 +6,7 @@ products:
 date: 2026-05-29
 ---
 
-import { TypeScriptExample } from "~/components";
+import { PackageManagers, TypeScriptExample } from "~/components";
 
 [Sandboxes](/sandbox/) now support **named tunnels** through `sandbox.tunnels.get(port, { name })`. A named tunnel binds a user-controlled hostname (`<name>.<your-zone>`) backed by a [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) and a proxied CNAME record on your zone.
 

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -1,5 +1,5 @@
 ---
-title: Expose services with tunnels in Sandboxes
+title: Share sandbox previews through Cloudflare Tunnel
 description: Expose Sandbox services on public preview URLs with sandbox.tunnels — zero-config quick tunnels on *.trycloudflare.com, plus named tunnels that bind a persistent custom hostname backed by a Cloudflare Tunnel.
 products:
   - agents

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -21,7 +21,7 @@ console.log(tunnel.url); // → https://app.example.com
 
 </TypeScriptExample>
 
-Calling `sandbox.destroy()` tears down the Cloudflare tunnel and the associated DNS record alongside the container, so you do not leave dangling tunnels or records behind.
+Calling `sandbox.destroy()` tears down the Cloudflare Tunnel and the associated DNS record alongside the container, so you do not leave dangling tunnels or records behind.
 
 ## Other changes in this release
 

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -1,5 +1,5 @@
 ---
-title: Named tunnels for Sandbox preview URLs
+title: Expose services with tunnels in Sandboxes
 description: Expose Sandbox services on public preview URLs with sandbox.tunnels — zero-config quick tunnels on *.trycloudflare.com, plus named tunnels that bind a persistent custom hostname backed by a Cloudflare Tunnel.
 products:
   - agents

--- a/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
+++ b/src/content/changelog/agents/2026-05-29-sandbox-named-tunnels.mdx
@@ -34,8 +34,6 @@ This release of `@cloudflare/sandbox` also includes:
 
 To update to the latest version:
 
-```sh
-npm i @cloudflare/sandbox@latest
-```
+<PackageManagers pkg="@cloudflare/sandbox@latest" />
 
 For full API details, refer to the [Sandbox tunnels reference](/sandbox/api/tunnels/).


### PR DESCRIPTION
### Summary

Adds a changelog entry for the `@cloudflare/sandbox@0.11.0` release, focused on **named tunnels** — `sandbox.tunnels.get(port, { name })` now binds a user-controlled hostname (`<name>.<your-zone>`) backed by a Cloudflare Tunnel and a proxied CNAME, giving a stable URL across container restarts and shared sandboxes. The entry also briefly notes the stale preview URL protection and Office Open XML binary handling changes from the same release.

Release reference: https://github.com/cloudflare/sandbox-sdk/pull/729

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
