### PR TITLE
[Zaraz] Fix debug mode settings page URL

### DIFF
--- a/src/content/docs/zaraz/web-api/debug-mode.mdx
+++ b/src/content/docs/zaraz/web-api/debug-mode.mdx
@@ -16,7 +16,7 @@ You can set this cookie manually or via the `zaraz.debug` helper function availa
 
 1. In the Cloudflare dashboard, go to the **Settings** page.
 
-	<DashButton url="/?to=/:account/tag-management/settings" />
+	<DashButton url="/?to=/:account/tag-management/zaraz/:zone/tools-config/settings" />
 2. Copy your **Debug Key**.
 3. Open a web browser and access its Developer Tools. For example, to access Developer Tools in Google Chrome, select **View** > **Developer** > **Developer Tools**.
 4. Select the **Console** pane and enter the following command to create a debug cookie:


### PR DESCRIPTION
Summary
Fixes the settings page URL in the Zaraz debug mode documentation :https://developers.cloudflare.com/zaraz/web-api/debug-mode/ . The current link points to the wrong location — the debug key is not found at the generic tag management settings page.

Problem
The docs say: "In the Cloudflare dashboard, go to the Settings page" with a link to /?to=/:account/tag-management/settings. However, the debug key is actually located under:
Web tag management > Tag setup > <domain> > Settings tab
Which corresponds to: https://dash.cloudflare.com/<accounttag>/tag-management/zaraz/<domain>/tools-config/settings


Change
Update the DashButton URL from:
<DashButton url="/?to=/:account/tag-management/settings" />
to:
<DashButton url="/?to=/:account/tag-management/zaraz/:zone/tools-config/settings" />
