### PR TITLE
[D1] Document migrations_pattern config option

### DIFF
--- a/src/content/changelog/d1/2026-06-04-migrations-pattern.mdx
+++ b/src/content/changelog/d1/2026-06-04-migrations-pattern.mdx
@@ -1,0 +1,27 @@
+---
+title: D1 migrations support nested layouts via `migrations_pattern`
+description: Configure `wrangler d1 migrations apply` to discover migrations in nested layouts produced by ORMs like Drizzle.
+products:
+  - d1
+date: 2026-05-29
+---
+
+You can now point `wrangler d1 migrations apply` at a nested migrations layout — such as the one produced by [Drizzle](https://orm.drizzle.team/) (`migrations/0001_init/migration.sql`) — using the new `migrations_pattern` D1 binding config:
+
+```jsonc
+{
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "my-database",
+			"database_id": "<UUID>",
+			"migrations_dir": "migrations",
+			"migrations_pattern": "migrations/*/migration.sql",
+		},
+	],
+}
+```
+
+`migrations_pattern` is a glob (relative to your Wrangler config file) used to discover migration files. It defaults to `${migrations_dir}/*.sql`, so existing projects keep working unchanged. Each migration's name is recorded in the migrations table as a path relative to `migrations_dir`.
+
+To learn more, visit D1's [migrations documentation](/d1/reference/migrations/#nested-migration-layouts).

--- a/src/content/docs/d1/reference/migrations.mdx
+++ b/src/content/docs/d1/reference/migrations.mdx
@@ -45,13 +45,46 @@ This location and table name can be customized in your Wrangler file, inside the
 			"database_id": "<UUID>",
 			"preview_database_id": "<UUID>",
 			"migrations_table": "<d1_migrations>", // Customize this value to change your applied migrations table name
-			"migrations_dir": "<FOLDER_NAME>" // Specify your custom migration directory
+			"migrations_dir": "<FOLDER_NAME>", // Specify your custom migration directory
+			"migrations_pattern": "<GLOB>" // Optional: discover migrations using a glob pattern (see below)
 		}
 	]
 }
 ```
 
 </WranglerConfig>
+
+## Nested migration layouts
+
+By default, `wrangler d1 migrations apply` looks for top-level `.sql` files inside `migrations_dir`. If you use an ORM such as [Drizzle](https://orm.drizzle.team/) that writes each migration as its own subdirectory (for example, `migrations/0001_init/migration.sql`), set `migrations_pattern` to the glob that matches your layout:
+
+<WranglerConfig>
+
+```jsonc
+{
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "my-database",
+			"database_id": "<UUID>",
+			"migrations_dir": "migrations",
+			"migrations_pattern": "migrations/*/migration.sql"
+		}
+	]
+}
+```
+
+</WranglerConfig>
+
+Rules for `migrations_pattern`:
+
+- When set, `migrations_dir` must also be set.
+- The pattern must start with whatever `migrations_dir` is set to.
+- Each migration's name is recorded in the migrations table as the path relative to `migrations_dir` (for example, `0001_init/migration.sql`). This keeps the table portable across machines.
+
+The pattern is a standard glob — `*` matches one path segment, `**` matches any number of segments. `migrations/**/*.sql` will pick up arbitrarily deep `.sql` files.
+
+`wrangler d1 migrations create` only writes top-level files inside `migrations_dir`, so if your `migrations_pattern` only matches nested files (as with the Drizzle layout), generate new migrations using your ORM's command (for example, `drizzle-kit generate`) instead.
 
 ## Foreign key constraints
 

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -569,6 +569,11 @@ To bind D1 databases to your Worker, assign an array of the below object to the 
   - The migration directory containing the migration files. By default, `wrangler d1 migrations create` creates a folder named `migrations`. You can use `migrations_dir` to specify a different folder containing the migration files (for example, if you have a mono-repo setup, and want to use a single D1 instance across your apps/packages).
   - For more information, refer to [D1 Wrangler `migrations` commands](/workers/wrangler/commands/d1/#d1-migrations-create) and [D1 migrations](/d1/reference/migrations/).
 
+- `migrations_pattern` <Type text="string" /> <MetaInfo text="optional" />
+  - A glob pattern (relative to your Wrangler config file) used to discover migration files. Defaults to `migrations/*.sql`.
+  - Use this to opt in to nested layouts produced by ORMs like Drizzle (for example, `migrations/*/migration.sql`).
+  - When `migrations_pattern` is set, `migrations_dir` must also be set, and `migrations_pattern` must start with whatever `migrations_dir` is set to. Each migration is recorded in the migrations table as a path relative to `migrations_dir`.
+
 :::note
 
 When using Wrangler in the default local development mode, files will be written to local storage instead of the preview or production database. Refer to [Local development and testing](/workers/development-testing/) for more details.


### PR DESCRIPTION


### Summary

Adds documentation for the new `migrations_pattern` D1 binding config field landing in wrangler PR
cloudflare/workers-sdk#14089.

Updates:

  - `d1/reference/migrations.mdx` \u2014 `migrations_pattern` shown in the example config, plus a new "Nested migration layouts" section that explains the default behaviour, shows the Drizzle-style nested example, lists the rules (`migrations_dir` required, pattern must start with `${migrations_dir}/`, recorded names are relative to `migrations_dir`), and notes that `wrangler d1 migrations create` only writes top-level files so ORM users should use their ORM's generate command.

  - `workers/wrangler/configuration.mdx` \u2014 `migrations_pattern` bullet next to the existing `migrations_dir` bullet in the D1 bindings reference.

  - changelog entry
 
### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry
  - [ ] change the date on the changelog entry to whenever we release the wrangler PR? Or do we want to just rely on the wrangler changelog instead
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
  - Opencode assures me it does. I'm afraid this whole PR is pure slop, but it's correct from my reading of it. Feel free to tweak.