### PR TITLE
[Browser Run] Add local dev workaround for quickAction() binding

### DIFF
--- a/src/content/changelog/browser-run/2026-05-28-use-browser-run-quick-actions-directly-from-workers.mdx
+++ b/src/content/changelog/browser-run/2026-05-28-use-browser-run-quick-actions-directly-from-workers.mdx
@@ -49,11 +49,3 @@ const screenshot = await env.BROWSER.quickAction("screenshot", {
 </TypeScriptExample>
 
 The `quickAction()` method requires a compatibility date of `2026-03-24` or later.
-
-:::note[Local development]
-
-The `.quickAction()` method is not yet supported in local development mode. Use `npx wrangler dev --remote` or set `"remote": true` in your browser binding configuration when developing locally.
-
-:::
-
-For setup instructions and the full list of available actions, refer to [Browser Run Quick Actions](/browser-run/quick-actions/).

--- a/src/content/changelog/browser-run/2026-05-28-use-browser-run-quick-actions-directly-from-workers.mdx
+++ b/src/content/changelog/browser-run/2026-05-28-use-browser-run-quick-actions-directly-from-workers.mdx
@@ -50,4 +50,10 @@ const screenshot = await env.BROWSER.quickAction("screenshot", {
 
 The `quickAction()` method requires a compatibility date of `2026-03-24` or later.
 
+:::note[Local development]
+
+The `.quickAction()` method is not yet supported in local development mode. Use `npx wrangler dev --remote` or set `"remote": true` in your browser binding configuration when developing locally.
+
+:::
+
 For setup instructions and the full list of available actions, refer to [Browser Run Quick Actions](/browser-run/quick-actions/).

--- a/src/content/changelog/browser-run/2026-05-28-use-browser-run-quick-actions-directly-from-workers.mdx
+++ b/src/content/changelog/browser-run/2026-05-28-use-browser-run-quick-actions-directly-from-workers.mdx
@@ -49,3 +49,5 @@ const screenshot = await env.BROWSER.quickAction("screenshot", {
 </TypeScriptExample>
 
 The `quickAction()` method requires a compatibility date of `2026-03-24` or later.
+
+For setup instructions and the full list of available actions, refer to [Browser Run Quick Actions](/browser-run/quick-actions/).

--- a/src/content/docs/browser-run/quick-actions/index.mdx
+++ b/src/content/docs/browser-run/quick-actions/index.mdx
@@ -41,38 +41,22 @@ To use Quick Actions from a [Worker](/workers/), configure a [browser binding](/
 }
 ```
 
-:::caution[Compatibility date requirement]
+:::caution
 
-Using the `.quickAction()` method requires setting your Worker's compatibility date to `2026-03-24` or later in your `wrangler.json`:
+The `.quickAction()` method has two requirements:
+
+- **Compatibility date:** Your Worker must use a compatibility date of `2026-03-24` or later.
+- **Remote mode for local development:** The `.quickAction()` method is not yet supported in local development mode. When developing locally with `wrangler dev`, you must use `npx wrangler dev --remote` or set `"remote": true` in your browser binding configuration. Without remote mode, you will receive the error: `The RPC receiver does not implement the method "quickAction"`.
 
 ```jsonc
 {
   "compatibility_date": "2026-03-24",
-  "browser": {
-    "binding": "BROWSER"
-  }
-}
-```
-
-:::
-
-:::caution[Local development requires remote mode]
-
-The `.quickAction()` method is not yet supported in local development mode. When developing locally with `wrangler dev`, you must use remote mode by either:
-
-- Running `npx wrangler dev --remote`, or
-- Setting `"remote": true` in your browser binding configuration:
-
-```jsonc
-{
   "browser": {
     "binding": "BROWSER",
     "remote": true
   }
 }
 ```
-
-Without remote mode, you will receive the error: `The RPC receiver does not implement the method "quickAction"`.
 
 :::
 

--- a/src/content/docs/browser-run/quick-actions/index.mdx
+++ b/src/content/docs/browser-run/quick-actions/index.mdx
@@ -56,6 +56,26 @@ Using the `.quickAction()` method requires setting your Worker's compatibility d
 
 :::
 
+:::caution[Local development requires remote mode]
+
+The `.quickAction()` method is not yet supported in local development mode. When developing locally with `wrangler dev`, you must use remote mode by either:
+
+- Running `npx wrangler dev --remote`, or
+- Setting `"remote": true` in your browser binding configuration:
+
+```jsonc
+{
+  "browser": {
+    "binding": "BROWSER",
+    "remote": true
+  }
+}
+```
+
+Without remote mode, you will receive the error: `The RPC receiver does not implement the method "quickAction"`.
+
+:::
+
 :::note[Note]
 
 You can monitor Browser Run (formerly Browser Rendering) usage in two ways:

--- a/src/content/docs/browser-run/reference/wrangler.mdx
+++ b/src/content/docs/browser-run/reference/wrangler.mdx
@@ -79,7 +79,7 @@ Without remote mode, calls to `.quickAction()` will fail with: `The RPC receiver
 
 :::
 
-Run `npx wrangler dev` to test your Worker locally.
+For Puppeteer, Playwright, or CDP-based Workers, run `npx wrangler dev` to test locally. For Quick Actions via `.quickAction()`, use `npx wrangler dev --remote` as noted above.
 
 ### Headful mode (experimental)
 

--- a/src/content/docs/browser-run/reference/wrangler.mdx
+++ b/src/content/docs/browser-run/reference/wrangler.mdx
@@ -62,6 +62,23 @@ The browser binding's `.quickAction()` method requires a compatibility date of `
 
 :::
 
+:::caution[Quick Actions require remote mode for local development]
+
+The `.quickAction()` method is not yet supported in local development mode. When using `wrangler dev`, you must run with `--remote` or set `"remote": true` in your browser binding configuration:
+
+```jsonc
+{
+  "browser": {
+    "binding": "MYBROWSER",
+    "remote": true
+  }
+}
+```
+
+Without remote mode, calls to `.quickAction()` will fail with: `The RPC receiver does not implement the method "quickAction"`.
+
+:::
+
 Run `npx wrangler dev` to test your Worker locally.
 
 ### Headful mode (experimental)


### PR DESCRIPTION
## What

Adds callouts documenting that the `.quickAction()` Workers binding method does not yet work in local development mode (`wrangler dev`). Users must use `--remote` or set `"remote": true` in their browser binding config.

## Why

A customer (Ramp) hit this issue immediately after the changelog post went out. The error message (`The RPC receiver does not implement the method "quickAction"`) is not obvious. This is a temporary workaround until [BRAPI-1213](https://jira.cfdata.org/browse/BRAPI-1213) ships local support.

## Where

- **Quick Actions index** (`/browser-run/quick-actions/`) - new caution callout in Workers binding section
- **Wrangler reference** (`/browser-run/reference/wrangler/`) - new caution callout below compat date note
- **Changelog post** (`2026-05-28`) - new note callout about local dev limitation

## Related

- [BRAPI-1213](https://jira.cfdata.org/browse/BRAPI-1213) - Implement quickActions on local dev browser binding
- Slack thread: https://cloudflare.enterprise.slack.com/archives/C083MC7MATF/p1780075978721999