### PR TITLE
[Workers] Fix grammar mistakes in Builds docs

### DIFF
--- a/src/content/docs/workers/ci-cd/builds/advanced-setups.mdx
+++ b/src/content/docs/workers/ci-cd/builds/advanced-setups.mdx
@@ -17,7 +17,7 @@ A monorepo is a single repository that contains multiple applications. This setu
 - **Simplified dependency management**: Manage dependencies across all your workers and shared packages from a single place using tools like [pnpm workspaces](https://pnpm.io/workspaces) and [syncpack](https://syncpack.dev/).
 - **Code sharing and reuse**: Easily create and share common logic, types, and utilities between workers by creating shared packages.
 - **Atomic commits**: Changes affecting multiple workers or shared libraries can be committed together, making the history easier to understand and reducing the risk of inconsistencies.
-- **Consistent tooling**: Apply the same build, test, linting, and formatting configurations (e.g., via [Turborepo](https://turborepo.com) in for task orchestration and shared configs in `packages/`) across all projects, ensuring consistent tooling and code quality across Workers.
+- **Consistent tooling**: Apply the same build, test, linting, and formatting configurations (e.g., via [Turborepo](https://turborepo.com) for task orchestration and shared configs in `packages/`) across all projects, ensuring consistent tooling and code quality across Workers.
 - **Easier refactoring**: Refactoring code that spans multiple Workers or shared packages is significantly easier within a single repository.
 
 #### Example Workers monorepos:

--- a/src/content/docs/workers/ci-cd/builds/api-reference.mdx
+++ b/src/content/docs/workers/ci-cd/builds/api-reference.mdx
@@ -16,7 +16,7 @@ This guide shows you how to use the [Workers Builds REST API](/api/resources/wor
 
 ### 1. Create an API token with the correct permissions
 
-To use the Builds API, you need an API token to authenticate your requests. The Builds API requires a **user-scoped** API token, account-scoped tokens are not supported and will return "Invalid token" errors.
+To use the Builds API, you need an API token to authenticate your requests. The Builds API requires a **user-scoped** API token. Account-scoped tokens are not supported and will return "Invalid token" errors.
 
 Create your token at [dash.cloudflare.com/profile/api-tokens](https://dash.cloudflare.com/profile/api-tokens) with the following permissions:
 

--- a/src/content/docs/workers/ci-cd/builds/build-watch-paths.mdx
+++ b/src/content/docs/workers/ci-cd/builds/build-watch-paths.mdx
@@ -8,7 +8,7 @@ products:
   - workers
 ---
 
-When you connect a git repository to Workers, by default a change to any file in the repository will trigger a build. You can configure Workers to include or exclude specific paths to specify if Workers should skip a build for a given path. This can be especially helpful if you are using a monorepo project structure and want to limit the amount of builds being kicked off.
+When you connect a git repository to Workers, by default a change to any file in the repository will trigger a build. You can configure Workers to include or exclude specific paths to specify if Workers should skip a build for a given path. This can be especially helpful if you are using a monorepo project structure and want to limit the number of builds being kicked off.
 
 ## Configure Paths
 
@@ -24,7 +24,7 @@ The configuration fields can be filled in two ways:
 
 :::note[Wildcard syntax]
 
-A wildcard (`*`) is a character that is used within rules. It can be placed alone to match anything or placed at the start or end of a rule to allow for better control over branch configuration. A wildcard will match zero or more characters.For example, if you wanted to match all branches that started with `fix/` then you would create the rule `fix/*` to match strings like `fix/1`, `fix/bugs`or `fix/`.
+A wildcard (`*`) is a character that is used within rules. It can be placed alone to match anything or placed at the start or end of a rule to allow for better control over branch configuration. A wildcard will match zero or more characters. For example, if you wanted to match all branches that started with `fix/` then you would create the rule `fix/*` to match strings like `fix/1`, `fix/bugs`, or `fix/`.
 
 :::
 
@@ -36,7 +36,7 @@ For each path in a push event, build watch paths will be evaluated as follows:
 
 Workers will bypass the path matching for a push event and default to building the project if:
 
-- A push event contains 0 file changes, in case a user pushes a empty push event to trigger a build
+- A push event contains 0 file changes, in case a user pushes an empty push event to trigger a build
 - A push event contains 3000+ file changes or 20+ commits
 
 ## Examples

--- a/src/content/docs/workers/ci-cd/builds/git-integration/github-integration.mdx
+++ b/src/content/docs/workers/ci-cd/builds/git-integration/github-integration.mdx
@@ -70,7 +70,7 @@ To remove access to an individual GitHub repository, you can navigate to **Repos
 
 To remove Cloudflare Workers and Pages access to your entire Git account, you can navigate to **Uninstall "Cloudflare Workers and Pages"**, then select **Uninstall**. Removing access to the Cloudflare Workers and Pages app will revoke Cloudflare's access to _all repositories_ from that GitHub account. If you want to only disable automatic builds and deployments, follow the [Disable Build](/workers/ci-cd/builds/#disconnecting-builds) instructions.
 
-Note that removing access to GitHub will disable new builds for Workers and Pages project that were connected to those repositories, though your previous deployments will continue to be hosted by Cloudflare Workers.
+Note that removing access to GitHub will disable new builds for Workers and Pages projects that were connected to those repositories, though your previous deployments will continue to be hosted by Cloudflare Workers.
 
 ### Reinstall the Cloudflare GitHub App
 

--- a/src/content/docs/workers/ci-cd/builds/git-integration/index.mdx
+++ b/src/content/docs/workers/ci-cd/builds/git-integration/index.mdx
@@ -18,7 +18,7 @@ Adding a Git integration also lets you monitor build statuses directly in your G
 
 Cloudflare supports connecting Cloudflare Workers to your GitHub and GitLab repositories. Workers Builds does not currently support connecting self-hosted instances of GitHub or GitLab.
 
-If you using a different Git provider (e.g. Bitbucket), you can use an [external CI/CD provider (e.g. GitHub Actions)](/workers/ci-cd/external-cicd/) and deploy using [Wrangler CLI](/workers/wrangler/commands/general/#deploy).
+If you are using a different Git provider (e.g. Bitbucket), you can use an [external CI/CD provider (e.g. GitHub Actions)](/workers/ci-cd/external-cicd/) and deploy using [Wrangler CLI](/workers/wrangler/commands/general/#deploy).
 
 ## Add a Git Integration
 

--- a/src/content/docs/workers/ci-cd/builds/limits-and-pricing.mdx
+++ b/src/content/docs/workers/ci-cd/builds/limits-and-pricing.mdx
@@ -24,7 +24,7 @@ Workers Builds has the following limits.
 
 ## Definitions
 
-- **Build minutes**: The amount of minutes that it takes to build a project.
+- **Build minutes**: The number of minutes that it takes to build a project.
 - **Concurrent builds**: The number of builds that can run in parallel across an account.
 - **Build timeout**: The amount of time that a build can be run before it is terminated.
 - **Deploy Hooks**: The rate limit for builds triggered by [Deploy Hooks](/workers/ci-cd/builds/deploy-hooks/).


### PR DESCRIPTION
## Summary

Fixes nine small grammar mistakes in the Workers Builds documentation (`src/content/docs/workers/ci-cd/builds/`). Prose-only edits — no changes to code samples, frontmatter, imports, or product terminology.

## Changes

| File | Fix |
| ---- | --- |
| `advanced-setups.mdx` | Remove stray "in" — "...Turborepo) in for task orchestration" → "...for task orchestration" |
| `build-watch-paths.mdx` | "limit the amount of builds" → "limit the number of builds" (countable) |
| `build-watch-paths.mdx` | "characters.For example" → "characters. For example" (missing space) |
| `build-watch-paths.mdx` | "\`fix/bugs\`or \`fix/\`" → "\`fix/bugs\`, or \`fix/\`" (missing comma/space) |
| `build-watch-paths.mdx` | "a empty push event" → "an empty push event" (article) |
| `limits-and-pricing.mdx` | "The amount of minutes" → "The number of minutes" (countable) |
| `git-integration/index.mdx` | "If you using a different Git provider" → "If you are using..." (missing verb) |
| `git-integration/github-integration.mdx` | "Workers and Pages project that were connected" → "...projects that were connected" (number agreement) |
| `api-reference.mdx` | Fix comma splice — "...user-scoped API token, account-scoped tokens are not supported" → "...user-scoped API token. Account-scoped tokens are not supported" |

No functional or stylistic changes beyond these corrections.