### PR TITLE
Fix model_id: claude-opus-4.8 → claude-opus-4-8

### DIFF
--- a/src/content/catalog-models/anthropic-claude-opus-4.8.json
+++ b/src/content/catalog-models/anthropic-claude-opus-4.8.json
@@ -1,5 +1,5 @@
 {
-	"model_id": "anthropic/claude-opus-4.8",
+	"model_id": "anthropic/claude-opus-4-8",
 	"provider_id": "anthropic",
 	"name": "Claude Opus 4.8",
 	"description": "Claude Opus 4.8 is Anthropic's most capable generally available model, with a step-change improvement in agentic coding over Claude Opus 4.7. It uses adaptive thinking to calibrate reasoning per task and supports a one million token context window at standard pricing.",


### PR DESCRIPTION
The `model_id` in `anthropic-claude-opus-4.8.json` uses `.` instead of `-`, which 404s upstream:

```json
{
  "request_id": "req_011CbYUJederp2KvDoT8QYJU",
  "error": {
    "type": "not_found_error",
    "message": "model: claude-opus-4.8 was not found. Did you mean claude-opus-4-8?"
  },
  "type": "error"
}
```