### PR TITLE
Fix model_id: claude-opus-4.8 → claude-opus-4-8

### DIFF
--- a/src/content/catalog-models/anthropic-claude-opus-4.8.json
+++ b/src/content/catalog-models/anthropic-claude-opus-4.8.json
@@ -1,5 +1,5 @@
 {
-	"model_id": "anthropic/claude-opus-4.8",
+	"model_id": "anthropic/claude-opus-4-8",
 	"provider_id": "anthropic",
 	"name": "Claude Opus 4.8",
 	"description": "Claude Opus 4.8 is Anthropic's most capable generally available model, with a step-change improvement in agentic coding over Claude Opus 4.7. It uses adaptive thinking to calibrate reasoning per task and supports a one million token context window at standard pricing.",


### PR DESCRIPTION
The catalog `model_id` `anthropic/claude-opus-4.8` works on Workers AI's `/ai/v1/messages` (CF normalizes `.` → `-` internally) but **fails through AI Gateway provider routing**, which forwards the id literally to Anthropic:

```json
{
  "request_id": "req_011CbYUJederp2KvDoT8QYJU",
  "error": {
    "type": "not_found_error",
    "message": "model: claude-opus-4.8 was not found. Did you mean claude-opus-4-8?"
  },
  "type": "error"
}
```

Hyphen form works on both paths; dot only works on one. See comment for screenshot + curl evidence.