### PR TITLE
Add @ack-cf to CODEOWNERS for cache, speed, automatic-platform-optimization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -237,14 +237,20 @@ package.json @cloudflare/content-engineering
 # Performance products
 
 /src/content/docs/argo-smart-routing/ @cloudflare/product-owners @ncrouch-cflare
-/src/content/docs/automatic-platform-optimization/ @cloudflare/product-owners
-/src/content/docs/cache/ @cloudflare/product-owners
+/src/content/docs/automatic-platform-optimization/ @cloudflare/product-owners @ack-cf
+/src/content/docs/cache/ @cloudflare/product-owners @ack-cf
+/src/content/partials/cache/ @cloudflare/product-owners @ack-cf
+/src/content/changelog/cache/ @cloudflare/pm-changelogs @cloudflare/product-owners @ack-cf
+/src/assets/images/cache/ @cloudflare/product-owners @ack-cf
 /src/content/docs/health-checks/ @cloudflare/product-owners @ncrouch-cflare
 /src/content/docs/load-balancing/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
 /src/content/partials/load-balancing/ @cloudflare/cf1-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
 /src/content/docs/smart-shield/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare
 /src/content/docs/spectrum/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @cansu
-/src/content/docs/speed/ @cloudflare/product-owners
+/src/content/docs/speed/ @cloudflare/product-owners @ack-cf
+/src/content/partials/speed/ @cloudflare/product-owners @ack-cf
+/src/content/changelog/speed/ @cloudflare/pm-changelogs @cloudflare/product-owners @ack-cf
+/src/assets/images/speed/ @cloudflare/product-owners @ack-cf
 /src/content/docs/web3/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
 
 # Privacy


### PR DESCRIPTION
Adds `@ack-cf` (Alex Krivit, PM) as a code owner for the cache, speed, and APO documentation areas in the docs repo.

## Changes

Under the **Performance products** section:

- `/src/content/docs/automatic-platform-optimization/` — added `@ack-cf`
- `/src/content/docs/cache/` — added `@ack-cf`
- `/src/content/partials/cache/` — new entry with `@cloudflare/product-owners @ack-cf`
- `/src/content/changelog/cache/` — new entry with `@cloudflare/pm-changelogs @cloudflare/product-owners @ack-cf`
- `/src/assets/images/cache/` — new entry with `@cloudflare/product-owners @ack-cf`
- `/src/content/docs/speed/` — added `@ack-cf`
- `/src/content/partials/speed/` — new entry with `@cloudflare/product-owners @ack-cf`
- `/src/content/changelog/speed/` — new entry with `@cloudflare/pm-changelogs @cloudflare/product-owners @ack-cf`
- `/src/assets/images/speed/` — new entry with `@cloudflare/product-owners @ack-cf`

APO only has a docs path (no partials/changelog/images directories), so only that line is updated. Cache and speed have partials/changelog/images directories, so explicit CODEOWNERS lines have been added for each (matching the comprehensive pattern used by browser-run, AI Crawl Control, and similar product sections).

The changelog entries also include `@cloudflare/pm-changelogs` to match the convention from the default `/src/content/changelog/` rule (line 70).

## Why

I need review/approval rights on docs changes for these three products so I can self-merge PM-led updates without needing a separate `@cloudflare/product-owners` reviewer on every change.

/cc @cloudflare/content-engineering