### PR TITLE
fix: remove transform on scroll-to-top button on mobile to fix DocSearch positioning

### DIFF
--- a/src/styles/scroll-to-top-button.css
+++ b/src/styles/scroll-to-top-button.css
@@ -10,6 +10,16 @@ button#scroll-to-top-button .scroll-progress-ring {
 	transform: translate(-50%, -50%) scale(0.85) !important;
 }
 
+@media (max-width: 768px) {
+	button#scroll-to-top-button {
+		transform: none !important;
+	}
+
+	.DocSearch-Container {
+		position: fixed !important;
+	}
+}
+
 :root[data-theme="dark"] {
 	button#scroll-to-top-button {
 		background-color: var(--color-cl1-brand-orange);


### PR DESCRIPTION
### Summary

Fixes a mobile Safari bug where opening DocSearch while the scroll-to-top button is visible causes the search modal to render off-screen with no way to dismiss it. Repros on real iOS devices but not in browser devtools mobile simulation.

**Root cause:** DocSearch's mobile CSS (`@media (max-width: 768px)`) switches `.DocSearch-Container` from `position: fixed` to `position: absolute`. A `position: absolute` element anchors to the document origin, not the viewport. When the user has scrolled 300px+ down (enough to trigger the scroll-to-top button), the DocSearch container is positioned 300px above the visible viewport — off-screen with no way to dismiss it.

**Fix:** Two overrides in the `@media (max-width: 768px)` block:

1. Force `.DocSearch-Container` back to `position: fixed` so it always covers the visible viewport regardless of scroll position.
2. Remove `transform` from the scroll-to-top button on mobile — the button's `transform: scale()` animation creates a new CSS stacking context on iOS Safari which can also interfere with fixed/absolute positioning of sibling elements.

fixes #31160 
