### PR TITLE
Add documentation note for Sandbox backup bucket endpoint override

### DIFF
--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -67,6 +67,8 @@ Use backup and restore when you want workspace state, such as `/workspace`, to c
 
    </WranglerConfig>
 
+   If your R2 bucket uses a jurisdiction-specific endpoint, you can also add `BACKUP_BUCKET_ENDPOINT` to `vars` to override the default presigned URL endpoint (for example, `https://<ACCOUNT_ID>.eu.r2.cloudflarestorage.com` for an EU-region bucket).
+
 3. Set your R2 API credentials as secrets:
 
    ```sh
@@ -78,10 +80,6 @@ Use backup and restore when you want workspace state, such as `/workspace`, to c
 
 :::note
 The `vars` and API secrets in steps 2 and 3 are only required for production. For local development with `wrangler dev`, only the `BACKUP_BUCKET` R2 binding is required. Refer to [Local development](#local-development) for details.
-:::
-
-:::note[Jurisdiction-specific R2 buckets]
-If your R2 bucket uses a jurisdiction-specific endpoint, set the optional `BACKUP_BUCKET_ENDPOINT` variable to override the default presigned URL endpoint used for backup and restore. For example, for an EU-region bucket: `https://<account_id>.eu.r2.cloudflarestorage.com`.
 :::
 
 ## Create a backup

--- a/src/content/docs/sandbox/guides/backup-restore.mdx
+++ b/src/content/docs/sandbox/guides/backup-restore.mdx
@@ -80,6 +80,10 @@ Use backup and restore when you want workspace state, such as `/workspace`, to c
 The `vars` and API secrets in steps 2 and 3 are only required for production. For local development with `wrangler dev`, only the `BACKUP_BUCKET` R2 binding is required. Refer to [Local development](#local-development) for details.
 :::
 
+:::note[Jurisdiction-specific R2 buckets]
+If your R2 bucket uses a jurisdiction-specific endpoint, set the optional `BACKUP_BUCKET_ENDPOINT` variable to override the default presigned URL endpoint used for backup and restore. For example, for an EU-region bucket: `https://<account_id>.eu.r2.cloudflarestorage.com`.
+:::
+
 ## Create a backup
 
 Use `createBackup()` to snapshot a directory and upload it to R2:


### PR DESCRIPTION
### Summary

This PR adds a note to document the new `BACKUP_BUCKET_ENDPOINT` override variable for sandbox backup/restore flow, implemented in https://github.com/cloudflare/sandbox-sdk/pull/733

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
