### PR TITLE
Images: Updates the documentation with aspect-crop and decimal nuance…

### DIFF
--- a/src/content/docs/images/optimization/transformations/draw-overlays.mdx
+++ b/src/content/docs/images/optimization/transformations/draw-overlays.mdx
@@ -43,7 +43,7 @@ The `draw` property is an array. Overlays are drawn in the order they appear in 
   - Absolute URL of the image file to use for the drawing. It can be any of the supported file formats. For drawing watermarks or non-rectangular overlays, Cloudflare recommends that you use PNG or WebP images.
 
 - `width` and `height`
-  - Maximum size of the overlay image. Can be an integer (pixels) or a decimal between `0` and `1` representing a fraction of the parent image's dimension. For example, `height: 0.25` sets the overlay height to 25% of the parent image's height.
+  - Maximum size of the overlay image. Accepts an integer (pixels) or a decimal between `0` and `1` representing a fraction of the original image's dimension. For example, `height: 0.25` sets the overlay height to 25% of the parent image's height.
 
 - `fit` and `gravity`
   - Affects interpretation of `width` and `height`. Same as [for the main image](/images/optimization/features/).

--- a/src/content/docs/images/optimization/transformations/draw-overlays.mdx
+++ b/src/content/docs/images/optimization/transformations/draw-overlays.mdx
@@ -43,7 +43,7 @@ The `draw` property is an array. Overlays are drawn in the order they appear in 
   - Absolute URL of the image file to use for the drawing. It can be any of the supported file formats. For drawing watermarks or non-rectangular overlays, Cloudflare recommends that you use PNG or WebP images.
 
 - `width` and `height`
-  - Maximum size of the overlay image, in pixels. It must be an integer.
+  - Maximum size of the overlay image. Can be an integer (pixels) or a decimal between `0` and `1` representing a fraction of the parent image's dimension. For example, `height: 0.25` sets the overlay height to 25% of the parent image's height.
 
 - `fit` and `gravity`
   - Affects interpretation of `width` and `height`. Same as [for the main image](/images/optimization/features/).

--- a/src/content/partials/images/fit.mdx
+++ b/src/content/partials/images/fit.mdx
@@ -160,11 +160,11 @@ In the example below, the original image (1080x720) is smaller than the target a
 When the original image is larger than the target area, it behaves like `cover` (fills the target area and crops the rest) instead.
 
 #### `aspect-crop`
-Crops the image to match the target aspect ratio, scaling down if needed but never enlarging the image.
+Crops the image to match the target aspect ratio, scaling down if needed but never upscaling.
 
-When the original image is larger than the target area, it behaves like `cover` — the image is scaled down to the smallest size that still covers the target dimensions, then cropped to match.
+When the original image is larger than the target area, it downscales to the smallest size that still fills the target dimensions, then is cropped to match the target aspect ratio (like `cover`).
 
-When the original image is smaller than the target area, it is kept at its original size but cropped to match the target aspect ratio. Unlike `crop`, which leaves smaller images completely untouched, `aspect-crop` always enforces the target aspect ratio.
+When the original image is smaller than the target area, it keeps its original size but is cropped to match the target aspect ratio. Unlike `crop`, which preserves the original size and dimensions of smaller images, `aspect-crop` always enforces the target aspect ratio.
 
 For example, a 612x613 image requested at 1920x1120 will not be upscaled. Instead, it stays at its original size and is cropped to 612x357, matching the 1920:1120 aspect ratio. Use the [`gravity`](#gravity) parameter to control which part of the image is preserved during cropping.
 

--- a/src/content/partials/images/fit.mdx
+++ b/src/content/partials/images/fit.mdx
@@ -24,6 +24,7 @@ Fit is performed after setting the [`width`](#width) and [`height`](#height) dim
 | `contain` | Show entire image without cropping | Yes | Yes |
 | `cover` | Fill the entire requested area, cropping if needed | No | Yes |
 | `crop` | Fill the entire requested area, but never upscales | No | No |
+| `aspect-crop` | Crop to match the target aspect ratio, but never upscales | No | No |
 | `pad` | Fit within the target area, adding space for remaining area | Yes | Yes |
 | `squeeze` | Scale to exact dimensions, distorting if needed | No | Yes |
 
@@ -157,6 +158,15 @@ In the example below, the original image (1080x720) is smaller than the target a
 </table>
 
 When the original image is larger than the target area, it behaves like `cover` (fills the target area and crops the rest) instead.
+
+#### `aspect-crop`
+Crops the image to match the target aspect ratio, scaling down if needed but never enlarging the image.
+
+When the original image is larger than the target area, it behaves like `cover` — the image is scaled down to the smallest size that still covers the target dimensions, then cropped to match.
+
+When the original image is smaller than the target area, it is kept at its original size but cropped to match the target aspect ratio. Unlike `crop`, which leaves smaller images completely untouched, `aspect-crop` always enforces the target aspect ratio.
+
+For example, a 612x613 image requested at 1920x1120 will not be upscaled. Instead, it stays at its original size and is cropped to 612x357, matching the 1920:1120 aspect ratio. Use the [`gravity`](#gravity) parameter to control which part of the image is preserved during cropping.
 
 #### `pad`
 Resizes the image to be as large as possible within the dimensions. If applicable, the output area will be expanded to match the `width` and `height` dimensions exactly.

--- a/src/content/partials/images/trim.mdx
+++ b/src/content/partials/images/trim.mdx
@@ -23,14 +23,16 @@ The `trim=border` option can be further adjusted using the following parameters:
 
 #### `top;right;bottom;left`
 
-Specifies the number of pixels to remove from the sides of an image. Accepts four integers, separated by a semicolon, to set the trim on all four sides of an image at once.
+Specifies the number of pixels to remove from the sides of an image. Accepts four values, separated by a semicolon, to set the trim on all four sides of an image at once.
+
+All trim values accept either an integer (pixel count) or a decimal between `0` and `1` representing a fraction of the image dimension. For example, `0.25` trims 25% from that side.
 
 Trim can also be applied to a specific side using the following parameters:
 
-- `trim.top` — Specifies the number of pixels to remove from the top side of the image.
-- `trim.left` — Specifies the number of pixels to remove from the left side of the image
-- `trim.height` — Sets the height, in pixels, of the image from the top edge, then trims everything below the specified value.
-- `trim.width` — Sets the width of the image from the left edge, then trims everything to the right of the specified value.
+- `trim.top` — Removes pixels from the top of the image.
+- `trim.left` — Removes pixels from the left of the image.
+- `trim.height` — Sets the height of the image from the top edge, then trims everything below.
+- `trim.width` — Sets the width of the image from the left edge, then trims everything to the right.
 
 <Tabs>
   <TabItem label="URL format">
@@ -42,11 +44,18 @@ Trim can also be applied to a specific side using the following parameters:
     trim.left=800
     // This removes 800 pixels from the left of the image
 
+    trim=0.1;0.2;0.1;0.2
+    // This trims 10% from the top and bottom, and 20% from the left and right
+
+    trim.top=0.25
+    // This trims 25% of the image height from the top
     ```
   </TabItem>
   <TabItem label="Workers">
   ```js
-  cf: {image: {trim: {top: 12,  right: 78, bottom: 34, left: 56, width:678, height:678}}}
+  cf: {image: {trim: {top: 12, right: 78, bottom: 34, left: 56, width: 678, height: 678}}}
+  // Using decimals to trim 10% from each side:
+  cf: {image: {trim: {top: 0.1, right: 0.1, bottom: 0.1, left: 0.1}}}
   ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
…s for trim and draw width/height

### Summary

This is documenting three changes/things that have previously not been documented correctly:
1. a new fit type named aspect-crop
2. that you can use decimals for trim
3. that you can use decimals for width/height in the context of draw

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
