### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-06-01)

### DIFF
--- a/src/content/changelog/logs/2026-06-01-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-06-01-log-fields-updated.mdx
@@ -1,0 +1,13 @@
+---
+title: New Turnstile Events Logpush dataset in Cloudflare Logs
+description: The Turnstile Events Logpush dataset is now available in Cloudflare Logs.
+date: 2026-06-01
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### New datasets
+
+- **Turnstile Events**: A new dataset with fields including `ASN`, `Action`, `BrowserMajor`, `BrowserName`, `ClientIP`, `CountryCode`, `EventType`, `Hostname`, `OSMajor`, `OSName`, `Sitekey`, `Timestamp`, and `UserAgent`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/turnstile_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/turnstile_events.md
@@ -1,0 +1,88 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: Turnstile Events
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `turnstile_events`.
+
+## ASN
+
+Type: `int`
+
+The visitor's autonomous system number (ASN).
+
+## Action
+
+Type: `string`
+
+The Turnstile widget action string configured by the customer.
+
+## BrowserMajor
+
+Type: `int`
+
+The major version of the visitor's browser.
+
+## BrowserName
+
+Type: `string`
+
+The name of the visitor's browser (for example, 'Chrome', 'Firefox').
+
+## ClientIP
+
+Type: `string`
+
+IP address of the visitor.
+
+## CountryCode
+
+Type: `string`
+
+The 2-letter ISO-3166 country code of the visitor.
+
+## EventType
+
+Type: `string`
+
+The type of Turnstile event. Possible values are <em>challenge_issued</em> \| <em>challenge_non_interactive_solved</em> \| <em>challenge_interactive_solved</em> \| <em>challenge_non_interactive_siteverify_solved</em> \| <em>challenge_interactive_siteverify_solved</em> \| <em>challenge_clearance_siteverify_solved</em> \| <em>challenge_siteverify_failed_double_redemption</em> \| <em>challenge_siteverify_failed_invalid_token</em> \| <em>challenge_siteverify_failed_other</em> \| <em>challenge_siteverify_ratelimited</em>.
+
+## Hostname
+
+Type: `string`
+
+The hostname where the Turnstile widget was loaded.
+
+## OSMajor
+
+Type: `int`
+
+The major version of the visitor's operating system.
+
+## OSName
+
+Type: `string`
+
+The name of the visitor's operating system (for example, 'Windows', 'macOS').
+
+## Sitekey
+
+Type: `string`
+
+The Turnstile sitekey (widget identifier).
+
+## Timestamp
+
+Type: `int or string`
+
+The date and time the event was logged.
+
+## UserAgent
+
+Type: `string`
+
+The visitor's full user agent string.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -457,7 +457,7 @@ Result of the check for [leaked credentials](/waf/detections/leaked-credentials/
 
 Type: `array[object]`
 
-Array of matched Cloudflare Rules product rules grouped by product. Each object contains: <em>product</em> (string, e.g. snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
+Array of matched Cloudflare Rules product rules grouped by product. Each object contains: <em>product</em> (string, for example snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
 
 ## OriginDNSResponseTimeMs
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### New datasets

- **Turnstile Events**: A new dataset with fields including `ASN`, `Action`, `BrowserMajor`, `BrowserName`, `ClientIP`, `CountryCode`, `EventType`, `Hostname`, `OSMajor`, `OSName`, `Sitekey`, `Timestamp`, and `UserAgent`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/{account,zone}/` — dataset pages
- `src/content/changelog/logs/2026-06-01-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
