### PR TITLE
[WARP] Remove WebView2 known issue from Windows beta 2026.5.1155.1

### DIFF
--- a/src/content/warp-releases/windows/beta/2026.5.1155.1.yaml
+++ b/src/content/warp-releases/windows/beta/2026.5.1155.1.yaml
@@ -22,7 +22,6 @@ releaseNotes: |-
   **Known issues**
 
 
-  - Registration authentication for devices via the integrated WebView2 browser is unavailable in this version as a temporary measure. As a result, the client will utilize the default browser on the device to complete the authentication process.
   - An error indicating that Microsoft Edge can't read and write to its data directory may be displayed during captive portal login; this error is benign and can be dismissed.
   - Registration may hang at "Checking your organization configuration" due to IPC errors. A system reboot should resolve the error, allowing registration to proceed.
   - Split tunnel list configuration is not available in the new UI. Management of Split Tunnel entries is currently only possible via `warp-cli tunnel ip` and `warp-cli tunnel host`. UI support will be added in a future release.


### PR DESCRIPTION
### Summary

Removes the "Registration authentication for devices via the integrated WebView2 browser is unavailable in this version as a temporary measure" known issue from the Windows beta release notes for `2026.5.1155.1`. That release re-enabled the WebView2 sign-in path — its own changelog entry notes that the `UseWebView2` registry value "is once again honored by the new GUI for authentication" — so the known issue no longer applies.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
