### PR TITLE
[Workers AI] Add Hosted vs Proxied filter to AI model catalog

### DIFF
--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -204,11 +204,12 @@ function CheckIcon() {
 }
 
 // Two-option facet that surfaces the existing ModelCardData.hosting field.
-// Labels match the "Hosted" / "Proxied" text already rendered by ModelInfo.tsx
-// so the filter chip vocabulary lines up with each card's subtitle.
+// Labels match the "Cloudflare Hosted" / "Third-Party" text rendered by
+// ModelInfo.tsx so the filter chip vocabulary lines up with each card's
+// subtitle.
 const hostingItems: FilterItem[] = [
-	{ value: "hosted", label: "Hosted" },
-	{ value: "proxied", label: "Proxied" },
+	{ value: "hosted", label: "Cloudflare Hosted" },
+	{ value: "proxied", label: "Third-Party" },
 ];
 
 // List of model names to pin at the top
@@ -453,7 +454,7 @@ const ModelCatalog = ({
 					/>
 					{showHostingFilter && (
 						<FilterDropdown
-							label="Hosting"
+							label="Providers"
 							items={hostingItems}
 							selected={filters.hosting}
 							onChange={(hosting) => setFilters({ ...filters, hosting })}

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -204,12 +204,12 @@ function CheckIcon() {
 }
 
 // Two-option facet that surfaces the existing ModelCardData.hosting field.
-// Labels match the "Cloudflare Hosted" / "Third-Party" text rendered by
-// ModelInfo.tsx so the filter chip vocabulary lines up with each card's
-// subtitle.
+// Labels match the "Cloudflare hosted" / "Third-party" badge text rendered by
+// ModelBadges.tsx so the filter chip vocabulary lines up with each card's
+// provider badge.
 const hostingItems: FilterItem[] = [
-	{ value: "hosted", label: "Cloudflare Hosted" },
-	{ value: "proxied", label: "Third-Party" },
+	{ value: "hosted", label: "Cloudflare hosted" },
+	{ value: "proxied", label: "Third-party" },
 ];
 
 // List of model names to pin at the top

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -18,6 +18,7 @@ type Filters = {
 	authors: string[];
 	tasks: string[];
 	capabilities: string[];
+	hosting: string[];
 };
 
 type SortOrder = "newest" | "oldest";
@@ -195,6 +196,14 @@ function CheckIcon() {
 	);
 }
 
+// Two-option facet that surfaces the existing ModelCardData.hosting field.
+// Labels match the "Hosted" / "Proxied" text already rendered by ModelInfo.tsx
+// so the filter chip vocabulary lines up with each card's subtitle.
+const hostingItems: FilterItem[] = [
+	{ value: "hosted", label: "Hosted" },
+	{ value: "proxied", label: "Proxied" },
+];
+
 // List of model names to pin at the top
 const pinnedModelNames = [
 	"@cf/moonshotai/kimi-k2.6",
@@ -215,6 +224,7 @@ const ModelCatalog = ({
 		authors: [],
 		tasks: [],
 		capabilities: [],
+		hosting: [],
 	});
 	const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
 	const initializedRef = useRef(false);
@@ -253,12 +263,14 @@ const ModelCatalog = ({
 		const authors = params.getAll("authors");
 		const tasks = params.getAll("tasks");
 		const capabilities = params.getAll("capabilities");
+		const hosting = params.getAll("hosting");
 
 		setFilters({
 			search,
 			authors,
 			tasks,
 			capabilities,
+			hosting,
 		});
 		initializedRef.current = true;
 	}, []);
@@ -284,6 +296,10 @@ const ModelCatalog = ({
 			filters.capabilities.forEach((capability) =>
 				params.append("capabilities", capability),
 			);
+		}
+
+		if (filters.hosting.length > 0) {
+			filters.hosting.forEach((hosting) => params.append("hosting", hosting));
 		}
 
 		setSearchParams(params);
@@ -332,6 +348,14 @@ const ModelCatalog = ({
 		[models],
 	);
 
+	// Hide the Hosting facet when the incoming list is uniform on that axis
+	// (e.g. /workers-ai/models/ is 100% hosted). Future-proofs for when the
+	// hosting field moves to the Deus CMS and may diverge from data source.
+	const showHostingFilter = useMemo(
+		() => new Set(models.map((m) => m.hosting)).size > 1,
+		[models],
+	);
+
 	const modelList = mapped.filter(({ model }) => {
 		if (filters.authors.length > 0) {
 			const selectedAuthorNames = new Set(
@@ -355,6 +379,12 @@ const ModelCatalog = ({
 			}
 		}
 
+		if (filters.hosting.length > 0) {
+			if (!filters.hosting.includes(model.hosting)) {
+				return false;
+			}
+		}
+
 		if (filters.search) {
 			if (!model.name.toLowerCase().includes(filters.search.toLowerCase())) {
 				return false;
@@ -367,7 +397,8 @@ const ModelCatalog = ({
 	const hasActiveFilters =
 		filters.authors.length > 0 ||
 		filters.tasks.length > 0 ||
-		filters.capabilities.length > 0;
+		filters.capabilities.length > 0 ||
+		filters.hosting.length > 0;
 
 	return (
 		<div className="not-content">
@@ -413,6 +444,14 @@ const ModelCatalog = ({
 							setFilters({ ...filters, capabilities })
 						}
 					/>
+					{showHostingFilter && (
+						<FilterDropdown
+							label="Hosting"
+							items={hostingItems}
+							selected={filters.hosting}
+							onChange={(hosting) => setFilters({ ...filters, hosting })}
+						/>
+					)}
 					<FilterDropdown
 						label="Authors"
 						items={authorItems}
@@ -441,6 +480,7 @@ const ModelCatalog = ({
 								authors: [],
 								tasks: [],
 								capabilities: [],
+								hosting: [],
 							})
 						}
 						className="cursor-pointer text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -403,7 +403,7 @@ const ModelCatalog = ({
 	return (
 		<div className="not-content">
 			{/* Toolbar */}
-			<div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center">
+			<div className="mb-4 flex flex-col gap-3 md:flex-row md:flex-wrap md:items-center">
 				{/* Search input */}
 				<div className="relative flex-1 md:min-w-[300px]">
 					<svg

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -211,11 +211,11 @@ function CheckIcon() {
 }
 
 // Two-option facet that surfaces the existing ModelCardData.hosting field.
-// Labels match the "Cloudflare hosted" / "Third-party" badge text rendered by
+// Labels match the "Cloudflare-hosted" / "Third-party" badge text rendered by
 // ModelBadges.tsx so the filter chip vocabulary lines up with each card's
 // provider badge. Slug values double as URL query string values.
 const providerItems: FilterItem[] = [
-	{ value: "cloudflare-hosted", label: "Cloudflare hosted" },
+	{ value: "cloudflare-hosted", label: "Cloudflare-hosted" },
 	{ value: "third-party", label: "Third-party" },
 ];
 

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -405,7 +405,7 @@ const ModelCatalog = ({
 			{/* Toolbar */}
 			<div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center">
 				{/* Search input */}
-				<div className="relative flex-1">
+				<div className="relative flex-1 md:min-w-[300px]">
 					<svg
 						className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-400"
 						fill="none"

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -40,7 +40,14 @@ function FilterDropdown({
 	onChange: (selected: string[]) => void;
 }) {
 	const hasSelection = selected.length > 0;
-	const triggerLabel = hasSelection ? `${label} (+${selected.length})` : label;
+	const triggerContent = (
+		<span className="inline-flex items-center gap-1.5">
+			{label}
+			{hasSelection && (
+				<span className="sl-badge default">{selected.length}</span>
+			)}
+		</span>
+	);
 
 	const selectedItems = items.filter((item) => selected.includes(item.value));
 
@@ -61,8 +68,8 @@ function FilterDropdown({
 						: "border-gray-200 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
 				}`}
 			>
-				<Combobox.Value placeholder={<span>{label}</span>}>
-					{() => triggerLabel}
+				<Combobox.Value placeholder={triggerContent}>
+					{() => triggerContent}
 				</Combobox.Value>
 				<Combobox.Icon className="flex">
 					<ChevronUpDownIcon />

--- a/src/components/ModelCatalog.tsx
+++ b/src/components/ModelCatalog.tsx
@@ -18,7 +18,14 @@ type Filters = {
 	authors: string[];
 	tasks: string[];
 	capabilities: string[];
-	hosting: string[];
+	providers: string[];
+};
+
+// URL/filter values are slugged (e.g. "cloudflare-hosted") while the underlying
+// model.hosting field stays "hosted" | "proxied". This map bridges the two.
+const PROVIDER_TO_HOSTING: Record<string, "hosted" | "proxied"> = {
+	"cloudflare-hosted": "hosted",
+	"third-party": "proxied",
 };
 
 type SortOrder = "newest" | "oldest";
@@ -206,10 +213,10 @@ function CheckIcon() {
 // Two-option facet that surfaces the existing ModelCardData.hosting field.
 // Labels match the "Cloudflare hosted" / "Third-party" badge text rendered by
 // ModelBadges.tsx so the filter chip vocabulary lines up with each card's
-// provider badge.
-const hostingItems: FilterItem[] = [
-	{ value: "hosted", label: "Cloudflare hosted" },
-	{ value: "proxied", label: "Third-party" },
+// provider badge. Slug values double as URL query string values.
+const providerItems: FilterItem[] = [
+	{ value: "cloudflare-hosted", label: "Cloudflare hosted" },
+	{ value: "third-party", label: "Third-party" },
 ];
 
 // List of model names to pin at the top
@@ -232,7 +239,7 @@ const ModelCatalog = ({
 		authors: [],
 		tasks: [],
 		capabilities: [],
-		hosting: [],
+		providers: [],
 	});
 	const [sortOrder, setSortOrder] = useState<SortOrder>("newest");
 	const initializedRef = useRef(false);
@@ -271,14 +278,16 @@ const ModelCatalog = ({
 		const authors = params.getAll("authors");
 		const tasks = params.getAll("tasks");
 		const capabilities = params.getAll("capabilities");
-		const hosting = params.getAll("hosting");
+		const providers = params
+			.getAll("providers")
+			.filter((p) => p in PROVIDER_TO_HOSTING);
 
 		setFilters({
 			search,
 			authors,
 			tasks,
 			capabilities,
-			hosting,
+			providers,
 		});
 		initializedRef.current = true;
 	}, []);
@@ -306,8 +315,10 @@ const ModelCatalog = ({
 			);
 		}
 
-		if (filters.hosting.length > 0) {
-			filters.hosting.forEach((hosting) => params.append("hosting", hosting));
+		if (filters.providers.length > 0) {
+			filters.providers.forEach((provider) =>
+				params.append("providers", provider),
+			);
 		}
 
 		setSearchParams(params);
@@ -387,8 +398,9 @@ const ModelCatalog = ({
 			}
 		}
 
-		if (filters.hosting.length > 0) {
-			if (!filters.hosting.includes(model.hosting)) {
+		if (filters.providers.length > 0) {
+			const allowed = filters.providers.map((p) => PROVIDER_TO_HOSTING[p]);
+			if (!allowed.includes(model.hosting)) {
 				return false;
 			}
 		}
@@ -406,7 +418,7 @@ const ModelCatalog = ({
 		filters.authors.length > 0 ||
 		filters.tasks.length > 0 ||
 		filters.capabilities.length > 0 ||
-		filters.hosting.length > 0;
+		filters.providers.length > 0;
 
 	return (
 		<div className="not-content">
@@ -455,9 +467,9 @@ const ModelCatalog = ({
 					{showHostingFilter && (
 						<FilterDropdown
 							label="Providers"
-							items={hostingItems}
-							selected={filters.hosting}
-							onChange={(hosting) => setFilters({ ...filters, hosting })}
+							items={providerItems}
+							selected={filters.providers}
+							onChange={(providers) => setFilters({ ...filters, providers })}
 						/>
 					)}
 					<FilterDropdown
@@ -488,7 +500,7 @@ const ModelCatalog = ({
 								authors: [],
 								tasks: [],
 								capabilities: [],
-								hosting: [],
+								providers: [],
 							})
 						}
 						className="cursor-pointer text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"

--- a/src/components/models/ModelBadges.tsx
+++ b/src/components/models/ModelBadges.tsx
@@ -10,7 +10,16 @@ const CATEGORY_BADGE: Record<string, string> = {
 type ModelType = WorkersAIModelsSchema | ResolvedModel | ModelCardData;
 
 const ModelBadges = ({ model }: { model: ModelType }) => {
-	const badges = model.properties.flatMap(({ property_id, value }) => {
+	// Provider badge: every card surfaces where the model runs (Cloudflare's
+	// infrastructure vs proxied to a third-party). Defaults to "Cloudflare
+	// hosted" for legacy models that pre-date the hosting field.
+	const isProxied = "hosting" in model && model.hosting === "proxied";
+	const providerBadge = {
+		variant: "default",
+		text: isProxied ? "Third-party" : "Cloudflare hosted",
+	};
+
+	const propertyBadges = model.properties.flatMap(({ property_id, value }) => {
 		// Boolean capability badges (data-driven)
 		if (property_id in CAPABILITY_PROPERTIES && value === "true") {
 			const def = CAPABILITY_PROPERTIES[property_id];
@@ -33,6 +42,8 @@ const ModelBadges = ({ model }: { model: ModelType }) => {
 
 		return [];
 	});
+
+	const badges = [providerBadge, ...propertyBadges];
 
 	return (
 		<ul className="m-0 flex list-none flex-wrap items-center gap-1.5 p-0 text-xs [&>li]:m-0">

--- a/src/components/models/ModelBadges.tsx
+++ b/src/components/models/ModelBadges.tsx
@@ -11,12 +11,12 @@ type ModelType = WorkersAIModelsSchema | ResolvedModel | ModelCardData;
 
 const ModelBadges = ({ model }: { model: ModelType }) => {
 	// Provider badge: every card surfaces where the model runs (Cloudflare's
-	// infrastructure vs proxied to a third-party). Defaults to "Cloudflare
-	// hosted" for legacy models that pre-date the hosting field.
+	// infrastructure vs proxied to a third-party). Defaults to
+	// "Cloudflare-hosted" for legacy models that pre-date the hosting field.
 	const isProxied = "hosting" in model && model.hosting === "proxied";
 	const providerBadge = {
 		variant: "default",
-		text: isProxied ? "Third-party" : "Cloudflare hosted",
+		text: isProxied ? "Third-party" : "Cloudflare-hosted",
 	};
 
 	const propertyBadges = model.properties.flatMap(({ property_id, value }) => {

--- a/src/components/models/ModelInfo.tsx
+++ b/src/components/models/ModelInfo.tsx
@@ -11,9 +11,9 @@ const ModelInfo = ({ model }: { model: ModelType }) => {
 	const hosting =
 		"hosting" in model
 			? model.hosting === "proxied"
-				? "Proxied"
-				: "Hosted"
-			: "Hosted";
+				? "Third-Party"
+				: "Cloudflare Hosted"
+			: "Cloudflare Hosted";
 	return (
 		<span className="mt-2 block! leading-5 text-gray-400">
 			{model.task.name} • {author} • {hosting}

--- a/src/components/models/ModelInfo.tsx
+++ b/src/components/models/ModelInfo.tsx
@@ -8,15 +8,11 @@ type ModelType = WorkersAIModelsSchema | ResolvedModel | ModelCardData;
 const ModelInfo = ({ model }: { model: ModelType }) => {
 	const authorId = getModelAuthor(model.name);
 	const author = authorData[authorId]?.name ?? authorId;
-	const hosting =
-		"hosting" in model
-			? model.hosting === "proxied"
-				? "Third-Party"
-				: "Cloudflare Hosted"
-			: "Cloudflare Hosted";
+	// Hosting is now surfaced as a badge by ModelBadges, so it is intentionally
+	// omitted here to avoid duplicating the same string on every card.
 	return (
 		<span className="mt-2 block! leading-5 text-gray-400">
-			{model.task.name} • {author} • {hosting}
+			{model.task.name} • {author}
 		</span>
 	);
 };


### PR DESCRIPTION
## What

Adds a "Hosting" filter to the unified AI model catalog at https://developers.cloudflare.com/ai/models/. Users can narrow to:

- **Hosted** — Workers AI models running on Cloudflare GPUs (legacy `/ai/models/search`)
- **Proxied** — third-party providers (Anthropic, OpenAI, Google, ByteDance, Alibaba, etc.) served via the unified catalog / AI Gateway

## Why

User-requested. A parallel filter is being added to the dashboard's AI Models page in [stratus!38465](https://gitlab.cfdata.org/cloudflare/fe/stratus/-/merge_requests/38465).

## How it works

Surfaces the existing `ModelCardData.hosting` field (`"hosted" | "proxied"`, assigned in `src/util/model-resolver.ts`) as a new multi-select facet on `/ai/models/`, slotting in between Capabilities and Authors. Items are "Hosted" and "Proxied" to match the subtitle text already rendered by `ModelInfo` on every card. State persists to the `hosting` query parameter alongside the other filters.

The dropdown **auto-hides when the incoming model list is uniform** on the hosting axis (e.g. `/workers-ai/models/`, which today is 100% hosted via `getLegacyModels`). It will reappear automatically if/when that data source becomes mixed.

## Scope

Single-file change to `src/components/ModelCatalog.tsx` (+41 / −1). No schema, resolver, page, or styling changes.

## Validation

- `pnpm run format:core:check` ✅
- `pnpm run lint` ✅
- `pnpm run check` ✅ 362 files, 0 errors, 0 warnings
- `pnpm run test:prebuild` ✅ 40/40

## Known nit (non-blocking)

Deep-linking `/workers-ai/models/?hosting=proxied` applies the filter silently (auto-hide hides the dropdown) and shows the empty-state. Recoverable via the "Clear filters" button. Matches existing behavior for `?tasks=garbage` etc. Worth a follow-up if product wants URL validation across all facets.
