### PR TITLE
[AI] Add Models entry to homepage AI sidebar

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -89,6 +89,7 @@ const sidebar = [
 				collapsed: true,
 				badge: groupIcon("workers-ai"),
 				items: [
+					{ label: "Models", link: "/ai/models/" },
 					{ label: "Workers AI", link: "/workers-ai/" },
 					{ label: "AI Gateway", link: "/ai-gateway/" },
 					{ label: "Agents", link: "/agents/" },


### PR DESCRIPTION
Adds a `Models` entry pointing to `/ai/models/` as the first item under **Build → AI** in the homepage left-rail sidebar (`src/pages/index.astro`).

Resulting order: **Models**, Workers AI, AI Gateway, Agents, Sandbox SDK, Vectorize, AI Search, AI Crawl Control.

The per-section `/ai/` sidebar already surfaces Models (via `src/content/docs/ai/models/index.mdx` with `sidebar.order: 2`); this PR adds parity to the homepage curated sidebar so the Models catalog is reachable one click away from `/`.

Independent of #31176 (the Hosted-vs-Proxied filter on `/workers-ai/models/`); different files, no overlap.