### PR TITLE
[DNS] Document SOA record TTL vs Minimum TTL logic

### DIFF
--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -409,6 +409,10 @@ Refer to the following list for information about each SOA record field:
 
 </Details>
 
+:::note
+When you query the SOA record itself, the TTL in the response is the smaller of the `Record TTL` and the `Minimum TTL` values. For example, if `Record TTL` is `3600` and `Minimum TTL` is `1800`, the SOA record is returned with a TTL of `1800`.
+:::
+
 ### NS
 
 A [nameserver (NS) record](https://www.cloudflare.com/learning/dns/dns-records/dns-ns-record/) indicates which server should be used for authoritative DNS.

--- a/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
+++ b/src/content/docs/dns/manage-dns-records/reference/dns-record-types.mdx
@@ -358,10 +358,6 @@ With Enterprise accounts, you also have the option to change the SOA record valu
 - As a DNS zone default: Define the SOA record values that Cloudflare will use for all new zones added to your account. Refer to [Configure DNS zone defaults](/dns/additional-options/dns-zone-defaults/) for step-by-step guidance.
 - For existing zones: Override the defaults or Cloudflare-generated values under **DNS record options** on the [**DNS Records**](https://dash.cloudflare.com/?to=/:account/:zone/dns/records) page.
 
-:::note
-If you are an Enterprise customer and these options are not displayed on your Cloudflare dashboard, reach out to your account team.
-:::
-
 Refer to the following list for information about each SOA record field:
 
 <Details header="SOA record fields">


### PR DESCRIPTION
[`#assistedByAI`](https://ai-label.org/)

### Summary

Documents the TTL selection logic for the SOA record: when the SOA record itself is queried, the returned TTL is the smaller of the configured `Record TTL` and `Minimum TTL` values. This behavior was previously only described in internal references and was missing from the public SOA record documentation.

Also removes an obsolete note instructing Enterprise customers to contact their account team if the SOA options are not displayed.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
