### PR TITLE
Remove note about `wrangler deploy`'s `<PATH>` option only accepting assets in interactive mode

### DIFF
--- a/src/content/docs/workers/wrangler/commands/workers.mdx
+++ b/src/content/docs/workers/wrangler/commands/workers.mdx
@@ -177,7 +177,6 @@ None of the options for this command are required. Also, many can be set in your
       - Visit [assets](/workers/static-assets/) for more information.
       - This overrides the eventual `assets` configuration in your [Wrangler configuration file](/workers/wrangler/configuration/).
       - This is equivalent to the `--assets` option listed below.
-      - Note: this option currently only works only in interactive mode (so not in CI systems).
 
 - `--name` <Type text="string" /> <MetaInfo text="optional" />
   - Name of the Worker.


### PR DESCRIPTION
> [!note]
> To be merged only after the changes in https://github.com/cloudflare/workers-sdk/pull/14153 are released