### PR TITLE
fix: move Astro cache outside node_modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
-            node_modules/.astro/assets
+            .astro-cache/assets
           key: astro-assets-${{ hashFiles('src/assets/**') }}
           restore-keys: |
             astro-assets-

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
-            node_modules/.astro/assets
+            .astro-cache/assets
           key: astro-assets-${{ hashFiles('src/assets/**') }}
           restore-keys: |
             astro-assets-

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ distllms/
 # generated types
 .astro/
 
+# Astro build cache
+.astro-cache/
+
 # skills/ is fetched from middlecache via bin/fetch-skills.ts
 skills/
 !.agents/skills/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -100,6 +100,7 @@ const RUN_LINK_CHECK =
 // https://astro.build/config
 export default defineConfig({
 	site: "https://developers.cloudflare.com",
+	cacheDir: ".astro-cache",
 	markdown: {
 		smartypants: false,
 		remarkPlugins: [remarkValidateImages],


### PR DESCRIPTION
### Summary

Moves Astro's build cache out of `node_modules/.astro` and into `.astro-cache` so the `node_modules` cache cannot preserve stale content-layer state. Updates CI and publish workflows to cache Astro image assets from the new cache directory.
