### PR TITLE
[Hyperdrive] Remove nested tabs from overview

### DIFF
--- a/src/content/docs/hyperdrive/index.mdx
+++ b/src/content/docs/hyperdrive/index.mdx
@@ -38,11 +38,13 @@ Hyperdrive is a service that accelerates queries you make to existing databases,
 Hyperdrive supports any Postgres or MySQL database, including those hosted on AWS, Google Cloud, Azure, Neon and PlanetScale. Hyperdrive also supports Postgres-compatible databases like CockroachDB and Timescale.
 You do not need to write new code or replace your favorite tools: Hyperdrive works with your existing code and tools you use.
 
-Use Hyperdrive's connection string from your Cloudflare Workers application with your existing Postgres drivers and object-relational mapping (ORM) libraries:
+Use Hyperdrive's connection details from your Cloudflare Workers application with your existing database drivers and object-relational mapping (ORM) libraries.
+
+## Examples
+
+### PostgreSQL
 
 <Tabs>
-	<TabItem label="PostgreSQL">
-	<Tabs>
 	<TabItem label="index.ts">
 ```ts
 import { Client } from "pg";
@@ -69,8 +71,8 @@ export default {
 } satisfies ExportedHandler<{ HYPERDRIVE: Hyperdrive }>;
 ```
 
-    </TabItem>
-    <TabItem label="wrangler.jsonc">
+	</TabItem>
+	<TabItem label="wrangler.jsonc">
 ```json
 	{
 		"$schema": "node_modules/wrangler/config-schema.json",
@@ -95,9 +97,10 @@ export default {
 
 </TabItem>
 </Tabs>
-</TabItem>
-<TabItem label="MySQL">
-	<Tabs>
+
+### MySQL
+
+<Tabs>
 	<TabItem label="index.ts">
 ```ts
 import { createConnection } from 'mysql2/promise';
@@ -153,9 +156,6 @@ export default {
 		]
 	}
 ```
-
-</TabItem>
-</Tabs>
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
### Summary

Restructures the Hyperdrive overview examples to remove nested tab groups. This keeps the database choice visible in the page flow while preserving file-level tabs for `index.ts` and `wrangler.jsonc`.

### Screenshots

#### Old
<img width="512" height="251" alt="image" src="https://github.com/user-attachments/assets/736cc9e6-9085-4796-9148-56933bc7c20a" />

#### New
<img width="760" height="919" alt="Screenshot 2026-06-02 at 1 41 47 PM" src="https://github.com/user-attachments/assets/44fbf442-77f6-4570-9847-0a7d9f02a489" />
