### PR TITLE
Update profile name limit

### DIFF
--- a/src/content/docs/agent-memory/api/workers-api.mdx
+++ b/src/content/docs/agent-memory/api/workers-api.mdx
@@ -46,7 +46,7 @@ Use namespace methods on the binding to access and manage memory profiles.
 
 Gets a memory profile by name. If the profile does not exist, Agent Memory creates it.
 
-- `profileName` <Type text="string" /> <MetaInfo text="required" />: Name of the profile to access. Maximum 32 characters.
+- `profileName` <Type text="string" /> <MetaInfo text="required" />: Name of the profile to access. Maximum 100 characters.
 - Returns <Type text="Promise<AgentMemoryProfile>" />
 
 The first `getProfile()` call for a new profile may take longer while Agent Memory creates the profile.
@@ -55,7 +55,7 @@ The first `getProfile()` call for a new profile may take longer while Agent Memo
 
 Marks a profile and all its memories and messages for deletion.
 
-- `profileName` <Type text="string" /> <MetaInfo text="required" />: Name of the profile to delete. Maximum 32 characters.
+- `profileName` <Type text="string" /> <MetaInfo text="required" />: Name of the profile to delete. Maximum 100 characters.
 - Returns <Type text="Promise<void>" />
 
 ## Profile methods

--- a/src/content/docs/agent-memory/platform/limits.mdx
+++ b/src/content/docs/agent-memory/platform/limits.mdx
@@ -16,6 +16,6 @@ The following limits apply to Agent Memory operations.
 | Message content size         | 32 KB (32,768 bytes UTF-8) |
 | Recall query size            | 1 KB (1,024 bytes UTF-8)   |
 | Session ID length            | 64 characters              |
-| Profile name length          | 32 characters              |
+| Profile name length          | 100 characters             |
 | Namespace name length        | 32 characters              |
 | List API page size           | 1 to 1,000 (default: 20)   |


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Update the profile name limit from 32 to 100 chars.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
