### PR TITLE
[Sandbox] Add docs for Sandbox S3 credential proxy

### DIFF
--- a/src/content/docs/sandbox/api/storage.mdx
+++ b/src/content/docs/sandbox/api/storage.mdx
@@ -116,6 +116,7 @@ interface RemoteMountBucketOptions {
   endpoint: string;
   provider?: BucketProvider;
   credentials?: BucketCredentials;
+  credentialProxy?: boolean;
   readOnly?: boolean;
   s3fsOptions?: string[];
   prefix?: string;
@@ -152,6 +153,7 @@ type MountBucketOptions =
 
 - **Remote endpoint mount** - Set `endpoint` to mount any S3-compatible provider
   - Supports explicit `credentials` or environment variable auto-detection
+  - Set `credentialProxy: true` to keep credentials out of the container (egress interception)
   - Supports `provider`, `prefix`, `readOnly`, and `s3fsOptions`
 
 **Field details**:
@@ -171,6 +173,12 @@ type MountBucketOptions =
 - `credentials` (remote endpoint mode only) - API credentials
   - Contains `accessKeyId` and `secretAccessKey`
   - If not provided, uses environment variables
+
+- `credentialProxy` (remote endpoint mode only) - Route S3 requests through the Durable Object for signing
+  - When `true`, credentials are never written to the container's disk; the Durable Object intercepts and re-signs all outbound S3 requests at the network layer before forwarding them upstream
+  - Supports AWS SigV4 signing for S3-compatible endpoints (including R2) and HMAC signing for Google Cloud Storage
+  - Requires `ContainerProxy` to be exported from your Worker entrypoint
+  - Default: `false`
 
 - `readOnly` (optional) - Mount in read-only mode
   - Default: `false`

--- a/src/content/docs/sandbox/api/storage.mdx
+++ b/src/content/docs/sandbox/api/storage.mdx
@@ -176,9 +176,9 @@ type MountBucketOptions =
 
 - `credentialProxy` (remote endpoint mode only) - Route S3 requests through the Durable Object for signing
   - When `true`, credentials are never written to the container's disk. The Durable Object intercepts and re-signs all outbound S3 requests at the network layer before forwarding them upstream.
-  - Supports AWS SigV4 signing for S3-compatible endpoints (including R2) and HMAC signing for Google Cloud Storage
+  - Supports [AWS SigV4](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) signing for S3-compatible endpoints (including R2) and HMAC signing for Google Cloud Storage
   - Requires `ContainerProxy` to be exported from your Worker entrypoint
-  - Default: `false`
+  - Default: `false` (backwards compatibility — recommended to set to `true`; will become the default in a future version)
 
 - `readOnly` (optional) - Mount in read-only mode
   - Default: `false`

--- a/src/content/docs/sandbox/api/storage.mdx
+++ b/src/content/docs/sandbox/api/storage.mdx
@@ -175,7 +175,7 @@ type MountBucketOptions =
   - If not provided, uses environment variables
 
 - `credentialProxy` (remote endpoint mode only) - Route S3 requests through the Durable Object for signing
-  - When `true`, credentials are never written to the container's disk; the Durable Object intercepts and re-signs all outbound S3 requests at the network layer before forwarding them upstream
+  - When `true`, credentials are never written to the container's disk. The Durable Object intercepts and re-signs all outbound S3 requests at the network layer before forwarding them upstream.
   - Supports AWS SigV4 signing for S3-compatible endpoints (including R2) and HMAC signing for Google Cloud Storage
   - Requires `ContainerProxy` to be exported from your Worker entrypoint
   - Default: `false`

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -129,7 +129,7 @@ When you mount with explicit credentials, s3fs writes those credentials to a pas
 
 Set `credentialProxy: true` to keep credentials out of the container entirely. Instead of passing real credentials into the container, the Durable Object intercepts all outbound S3 requests at the network layer, re-signs them with the real credentials, and forwards them upstream. The container only ever holds dummy credentials that are useless outside the proxy.
 
-This works with AWS SigV4 signing for S3-compatible endpoints (including R2) and HMAC signing for Google Cloud Storage.
+This works with [AWS SigV4](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) signing for S3-compatible endpoints (including R2) and HMAC signing for Google Cloud Storage. It is recommended to set `credentialProxy: true` for all endpoint mounts. The option defaults to `false` for backwards compatibility and will become the default in a future version of the Sandbox SDK.
 
 <TypeScriptExample>
 ```typescript

--- a/src/content/docs/sandbox/guides/mount-buckets.mdx
+++ b/src/content/docs/sandbox/guides/mount-buckets.mdx
@@ -123,6 +123,38 @@ await sandbox.mountBucket('my-r2-bucket', '/data', {
 ```
 </TypeScriptExample>
 
+### Credential proxy
+
+When you mount with explicit credentials, s3fs writes those credentials to a password file on the container's disk. A compromised container process can read and exfiltrate the credentials, or use them to access storage outside the intended bucket scope.
+
+Set `credentialProxy: true` to keep credentials out of the container entirely. Instead of passing real credentials into the container, the Durable Object intercepts all outbound S3 requests at the network layer, re-signs them with the real credentials, and forwards them upstream. The container only ever holds dummy credentials that are useless outside the proxy.
+
+This works with AWS SigV4 signing for S3-compatible endpoints (including R2) and HMAC signing for Google Cloud Storage.
+
+<TypeScriptExample>
+```typescript
+await sandbox.mountBucket('my-bucket', '/data', {
+	endpoint: 'https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com',
+	provider: 'r2',
+	credentials: {
+		accessKeyId: env.R2_ACCESS_KEY_ID,
+		secretAccessKey: env.R2_SECRET_ACCESS_KEY
+	},
+	credentialProxy: true
+});
+```
+</TypeScriptExample>
+
+:::caution[ContainerProxy export required]
+Credential proxy mounts use egress interception and require `ContainerProxy` to be exported from your Worker entrypoint. Without this export, the proxy cannot intercept requests and the mount will fail.
+
+```typescript
+import { ContainerProxy } from "@cloudflare/sandbox";
+
+export { ContainerProxy };
+```
+:::
+
 ## Mount bucket subdirectories
 
 Mount a specific subdirectory within a bucket using the `prefix` option. Only contents under the prefix are visible at the mount point:


### PR DESCRIPTION
### Summary

This PR adds documentation for the S3 mount credential proxy implemented in https://github.com/cloudflare/sandbox-sdk/pull/727

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
