### PR TITLE
[WAF] Add threat intelligence detection docs

### DIFF
--- a/src/content/docs/waf/detections/threat-intelligence/example-rules.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/example-rules.mdx
@@ -1,0 +1,64 @@
+---
+title: Example rules
+pcx_content_type: configuration
+description: Mitigate high-risk traffic using threat intelligence fields in WAF rules.
+products:
+  - waf
+tags:
+  - Threat Intelligence
+sidebar:
+  order: 3
+head:
+  - tag: title
+    content: Example rules using threat intelligence
+---
+
+[Custom rule](/waf/custom-rules/) and [rate limiting rule](/waf/rate-limiting-rules/) examples using [threat intelligence fields](/waf/detections/threat-intelligence/fields/). All fields are arrays — use [`any()`](/ruleset-engine/rules-language/functions/#any) with `[*]`.
+
+:::caution
+Test rules with _Log_ before enforcing. IP-based threat intelligence is a seven-day lookback over shared infrastructure — combine with other signals such as [attack score](/waf/detections/attack-score/) before you block.
+:::
+
+## Log matches before blocking
+
+Deploy with _Log_ (Enterprise plans) to review matches before enforcing:
+
+- **Expression:**<br/>
+  `any(cf.intel.ip.attacker_names[*] != "")`
+- **Action:** _Log_
+
+Review matches in [Security Events](/waf/analytics/security-events/), then change the action to _Block_ or _Managed Challenge_.
+
+## Block DDoS participants targeting your region
+
+- **Expression:**<br/>
+  `any(cf.intel.ip.target_countries[*] == "FR") and any(cf.intel.ip.datasets[*] == "ddos")`
+- **Action:** _Block_
+
+## Challenge a threat actor targeting the finance sector
+
+- **Expression:**<br/>
+  `any(cf.intel.ip.target_industries[*] == "Banking & Financial Services") and any(cf.intel.ip.attacker_names[*] == "BLACKBASTA")`
+- **Action:** _Managed Challenge_
+
+## Filter by attacker country
+
+- **Expression:**<br/>
+  `any(cf.intel.ip.attacker_countries[*] == "CN")`
+- **Action:** _Block_
+
+## Combine with attack score
+
+Block requests flagged by the WAF threat intelligence dataset that also have a low [attack score](/waf/detections/attack-score/):
+
+- **Expression:**<br/>
+  `any(cf.intel.ip.datasets[*] == "waf") and cf.waf.score lt 20`
+- **Action:** _Block_
+
+## Rate limit threat actors on API paths
+
+[Rate limiting rule](/waf/rate-limiting-rules/) applying a stricter rate to flagged IPs on your API:
+
+- **Expression:**<br/>
+  `any(cf.intel.ip.datasets[*] == "ddos") and starts_with(http.request.uri.path, "/api/")`
+- **Action:** _Block_ when the rate is exceeded.

--- a/src/content/docs/waf/detections/threat-intelligence/fields.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/fields.mdx
@@ -1,0 +1,59 @@
+---
+pcx_content_type: reference
+description: Fields available for threat intelligence detection in rule expressions.
+products:
+  - waf
+title: Threat intelligence fields
+tags:
+  - Threat Intelligence
+sidebar:
+  order: 10
+  label: Available fields
+---
+
+import { Type } from "~/components";
+
+The threat intelligence detection populates the following fields when the client IP address is found in the threat intelligence database. If the IP address is not found, the fields are empty.
+
+All fields are arrays. Use the [`any()`](/ruleset-engine/rules-language/functions/#any) function with the `[*]` wildcard to match values.
+
+:::note
+These five fields are available in rule expressions. Security Analytics logs only the dataset and threat event identifiers for each match. You can view the threat event details — including attacker names, industries, and countries — directly in [Security Analytics](/waf/analytics/security-analytics/).
+:::
+
+| Field | Description |
+| ----- | ----------- |
+| Threat intelligence datasets <br/> `cf.intel.ip.datasets` <br/> <Type text="Array<String>" /> | Dataset that flagged the IP address. Values: `ddos`, `waf`. |
+| Target industries <br/> `cf.intel.ip.target_industries` <br/> <Type text="Array<String>" /> | Industries this IP address has targeted. Refer to [target industries](#target-industries) for valid values. |
+| Attacker names <br/> `cf.intel.ip.attacker_names` <br/> <Type text="Array<String>" /> | Threat actor names associated with this IP address (for example, `CONVOLUTEDKRILL`). |
+| Attacker countries <br/> `cf.intel.ip.attacker_countries` <br/> <Type text="Array<String>" /> | Source countries of the threat activity, as [ISO 3166-1 Alpha 2](https://www.iso.org/obp/ui/#search/code/) codes. |
+| Target countries <br/> `cf.intel.ip.target_countries` <br/> <Type text="Array<String>" /> | Countries this IP address has targeted, as [ISO 3166-1 Alpha 2](https://www.iso.org/obp/ui/#search/code/) codes. |
+
+## Case sensitivity
+
+Values are case-sensitive. Use the casing shown in the examples: `ddos` (lowercase), `FR` (uppercase country codes), `Banking & Financial Services` (title case), `BLACKBASTA` (uppercase attacker names).
+
+To discover valid values for your traffic, use the [Threat Events](/security-center/cloudforce-one/) dashboard.
+
+## Matching behavior
+
+Fields reflect all threat activity for an IP address over the past seven days, flattened into a single set of values per field.
+
+A value in one field does not have to come from the same threat event as a value in another field. For example, this expression matches if the IP has _any_ China-origin activity **and** _any_ banking-targeted activity — even from separate events:
+
+```txt
+any(cf.intel.ip.attacker_countries[*] == "CN") and any(cf.intel.ip.target_industries[*] == "Banking & Financial Services")
+```
+
+Combining fields across dimensions produces broader matches than you might expect. Test combined rules with the _Log_ action first.
+
+## Target industries
+
+The `cf.intel.ip.target_industries` field uses a fixed set of industry names. Examples:
+
+- `Automotive`
+- `Banking & Financial Services`
+- `Cryptocurrency`
+- `Telecommunications`
+
+For the complete list, refer to [Threat Events](/security-center/cloudforce-one/).

--- a/src/content/docs/waf/detections/threat-intelligence/get-started.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/get-started.mdx
@@ -1,0 +1,104 @@
+---
+pcx_content_type: get-started
+description: Create a WAF rule using Cloudforce One threat intelligence fields.
+products:
+  - waf
+title: Get started
+tags:
+  - Threat Intelligence
+sidebar:
+  order: 2
+  label: Get started
+---
+
+import { Tabs, TabItem, Steps, DashButton } from "~/components";
+
+## Before you begin
+
+- Your account must have an active [Cloudforce One subscription](/security-center/cloudforce-one/). Contact your account team for access.
+- The [WAF](/waf/) must be enabled on your zone.
+
+## 1. Create a rule in Log mode
+
+Start by creating a rule with the _Log_ action to surface matches in [Security Analytics](/waf/analytics/security-analytics/) without affecting traffic.
+
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+
+<Steps>
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account and domain.
+
+2. Go to **Security** > **Security rules**.
+
+3. Select **Create rule** > **Custom rules**.
+
+4. Enter a rule name.
+
+5. Select **Edit expression** and enter an expression using threat intelligence fields. For example, to match IP addresses associated with DDoS activity targeting your region:
+
+   ```txt
+   any(cf.intel.ip.target_countries[*] == "FR") and any(cf.intel.ip.datasets[*] == "ddos")
+   ```
+
+6. Set the action to _Log_.
+
+7. Select **Deploy**.
+
+</Steps>
+
+</TabItem> <TabItem label="API">
+
+Threat intelligence fields work with the [Cloudflare API](/api/resources/rulesets/) and the [Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs).
+
+```bash
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/rulesets/phases/http_request_firewall_custom/entrypoint" \
+--request PUT \
+--header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+--json '{
+  "rules": [
+    {
+      "expression": "any(cf.intel.ip.target_countries[*] == \"FR\") and any(cf.intel.ip.datasets[*] == \"ddos\")",
+      "action": "log",
+      "description": "Log DDoS threat actors targeting France"
+    }
+  ]
+}'
+```
+
+</TabItem> </Tabs>
+
+## 2. Review matches in Security Analytics
+
+Once the Log rule is deployed, matches appear in [Security Analytics](/waf/analytics/security-analytics/). You can see the threat event details — including threat actors, target industries, and countries — directly in the analytics view.
+
+<Steps>
+
+1. In the Cloudflare dashboard, go to the **Analytics** page.
+
+   <DashButton url="/?to=/:account/:zone/security/analytics" />
+
+2. Review the threat intelligence matches. Use the threat event details to decide which categories of traffic to block or challenge.
+
+</Steps>
+
+If no matches appear after deploying the rule, contact your account team to verify your Cloudforce One subscription is active.
+
+## 3. Switch to Block or Managed Challenge
+
+Once you are confident in the match patterns, update the rule action from _Log_ to _Block_ or _Managed Challenge_.
+
+For more examples, refer to [Example rules](/waf/detections/threat-intelligence/example-rules/). For the full field list, refer to [Threat intelligence fields](/waf/detections/threat-intelligence/fields/).
+
+## 4. (Optional) Create a rule from Threat Events
+
+You can create a WAF rule directly from a saved view in [Threat Events](/security-center/cloudforce-one/) instead of writing the expression yourself.
+
+<Steps>
+
+1. In Threat Events, build a saved view with the filters you want (for example, _IPs targeting the financial sector in the last seven days_).
+
+2. Export the saved view to a WAF rule.
+
+3. Review the generated rule, set an action, and deploy.
+
+</Steps>

--- a/src/content/docs/waf/detections/threat-intelligence/get-started.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/get-started.mdx
@@ -48,22 +48,15 @@ Start by creating a rule with the _Log_ action to surface matches in [Security A
 
 </TabItem> <TabItem label="API">
 
-Threat intelligence fields work with the [Cloudflare API](/api/resources/rulesets/) and the [Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs).
+Threat intelligence fields work with the [Cloudflare API](/api/resources/rulesets/) and the [Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs). To create a custom rule via the API, refer to [Create a custom rule via API](/waf/custom-rules/create-api/).
 
-```bash
-curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/rulesets/phases/http_request_firewall_custom/entrypoint" \
---request PUT \
---header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
---json '{
-  "rules": [
-    {
-      "expression": "any(cf.intel.ip.target_countries[*] == \"FR\") and any(cf.intel.ip.datasets[*] == \"ddos\")",
-      "action": "log",
-      "description": "Log DDoS threat actors targeting France"
-    }
-  ]
-}'
+Use the following expression to match IP addresses associated with DDoS activity targeting France:
+
+```txt
+any(cf.intel.ip.target_countries[*] == "FR") and any(cf.intel.ip.datasets[*] == "ddos")
 ```
+
+Set the action to `log` to validate matches before enforcing.
 
 </TabItem> </Tabs>
 

--- a/src/content/docs/waf/detections/threat-intelligence/get-started.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/get-started.mdx
@@ -18,51 +18,25 @@ import { Tabs, TabItem, Steps, DashButton } from "~/components";
 - Your account must have an active [Cloudforce One subscription](/security-center/cloudforce-one/). Contact your account team for access.
 - The [WAF](/waf/) must be enabled on your zone.
 
-## 1. Create a rule in Log mode
+## 1. Create a rule from Threat Events
 
-Start by creating a rule with the _Log_ action to surface matches in [Security Analytics](/waf/analytics/security-analytics/) without affecting traffic.
-
-<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
+The fastest way to create a threat intelligence rule is from a saved view in the [Threat Events](/security-center/cloudforce-one/) dashboard. Filter the threats you care about, then export the filters directly to a WAF rule.
 
 <Steps>
 
-1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account and domain.
+1. In the Threat Events dashboard, build a saved view with the filters you want to act on (for example, _IPs targeting the financial sector in the last seven days_).
 
-2. Go to **Security** > **Security rules**.
+2. Export the saved view to a WAF rule. Cloudflare generates a custom rule expression that matches the saved view filters.
 
-3. Select **Create rule** > **Custom rules**.
+3. Review the generated rule. Set the action to _Log_ to validate matches before enforcing.
 
-4. Enter a rule name.
-
-5. Select **Edit expression** and enter an expression using threat intelligence fields. For example, to match IP addresses associated with DDoS activity targeting your region:
-
-   ```txt
-   any(cf.intel.ip.target_countries[*] == "FR") and any(cf.intel.ip.datasets[*] == "ddos")
-   ```
-
-6. Set the action to _Log_.
-
-7. Select **Deploy**.
+4. Deploy the rule.
 
 </Steps>
 
-</TabItem> <TabItem label="API">
-
-Threat intelligence fields work with the [Cloudflare API](/api/resources/rulesets/) and the [Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs). To create a custom rule via the API, refer to [Create a custom rule via API](/waf/custom-rules/create-api/).
-
-Use the following expression to match IP addresses associated with DDoS activity targeting France:
-
-```txt
-any(cf.intel.ip.target_countries[*] == "FR") and any(cf.intel.ip.datasets[*] == "ddos")
-```
-
-Set the action to `log` to validate matches before enforcing.
-
-</TabItem> </Tabs>
-
 ## 2. Review matches in Security Analytics
 
-Once the Log rule is deployed, matches appear in [Security Analytics](/waf/analytics/security-analytics/). You can see the threat event details — including threat actors, target industries, and countries — directly in the analytics view.
+Once the rule is deployed, matches appear in [Security Analytics](/waf/analytics/security-analytics/). You can see the threat event details — including threat actors, target industries, and countries — directly in the analytics view.
 
 <Steps>
 
@@ -82,16 +56,44 @@ Once you are confident in the match patterns, update the rule action from _Log_ 
 
 For more examples, refer to [Example rules](/waf/detections/threat-intelligence/example-rules/). For the full field list, refer to [Threat intelligence fields](/waf/detections/threat-intelligence/fields/).
 
-## 4. (Optional) Create a rule from Threat Events
+## 4. (Alternative) Create a rule manually
 
-You can create a WAF rule directly from a saved view in [Threat Events](/security-center/cloudforce-one/) instead of writing the expression yourself.
+If you prefer to write expressions directly, you can create a rule from the dashboard or the API.
+
+<Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
 <Steps>
 
-1. In Threat Events, build a saved view with the filters you want (for example, _IPs targeting the financial sector in the last seven days_).
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login) and select your account and domain.
 
-2. Export the saved view to a WAF rule.
+2. Go to **Security** > **Security rules**.
 
-3. Review the generated rule, set an action, and deploy.
+3. Select **Create rule** > **Custom rules**.
+
+4. Enter a rule name.
+
+5. Select **Edit expression** and enter an expression using threat intelligence fields. For example:
+
+   ```txt
+   any(cf.intel.ip.target_countries[*] == "FR") and any(cf.intel.ip.datasets[*] == "ddos")
+   ```
+
+6. Set the action to _Log_ to validate matches before enforcing.
+
+7. Select **Deploy**.
 
 </Steps>
+
+</TabItem> <TabItem label="API">
+
+Threat intelligence fields work with the [Cloudflare API](/api/resources/rulesets/) and the [Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs). To create a custom rule via the API, refer to [Create a custom rule via API](/waf/custom-rules/create-api/).
+
+Use the following expression to match IP addresses associated with DDoS activity targeting France:
+
+```txt
+any(cf.intel.ip.target_countries[*] == "FR") and any(cf.intel.ip.datasets[*] == "ddos")
+```
+
+Set the action to `log` to validate matches before enforcing.
+
+</TabItem> </Tabs>

--- a/src/content/docs/waf/detections/threat-intelligence/index.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/index.mdx
@@ -12,7 +12,7 @@ sidebar:
     label: Threat intelligence
 ---
 
-The threat intelligence detection matches incoming requests against indicators in the [Cloudforce One](/security-center/cloudforce-one/) threat intelligence database. Today, the detection matches on client IP address. If the IP was involved in threat activity in the past seven days, Cloudflare populates [threat intelligence fields](/waf/detections/threat-intelligence/fields/) you can use in WAF rule expressions.
+The threat intelligence detection matches incoming requests against indicators in the [Cloudforce One](/security-center/cloudforce-one/) threat intelligence database. The detection matches on client IP address. If the IP was involved in threat activity in the past seven days, Cloudflare populates [threat intelligence fields](/waf/detections/threat-intelligence/fields/) you can use in WAF rule expressions.
 
 You can use these fields in [custom rules](/waf/custom-rules/) and [rate limiting rules](/waf/rate-limiting-rules/) to match on:
 

--- a/src/content/docs/waf/detections/threat-intelligence/index.mdx
+++ b/src/content/docs/waf/detections/threat-intelligence/index.mdx
@@ -1,0 +1,47 @@
+---
+pcx_content_type: concept
+description: Match incoming requests against Cloudforce One threat intelligence in WAF rules.
+products:
+  - waf
+title: Threat intelligence
+tags:
+  - Threat Intelligence
+sidebar:
+  order: 6
+  group:
+    label: Threat intelligence
+---
+
+The threat intelligence detection matches incoming requests against indicators in the [Cloudforce One](/security-center/cloudforce-one/) threat intelligence database. Today, the detection matches on client IP address. If the IP was involved in threat activity in the past seven days, Cloudflare populates [threat intelligence fields](/waf/detections/threat-intelligence/fields/) you can use in WAF rule expressions.
+
+You can use these fields in [custom rules](/waf/custom-rules/) and [rate limiting rules](/waf/rate-limiting-rules/) to match on:
+
+- Known threat actor names (`cf.intel.ip.attacker_names`)
+- Industries the IP address has targeted (`cf.intel.ip.target_industries`)
+- Source and target countries of threat activity (`cf.intel.ip.attacker_countries`, `cf.intel.ip.target_countries`)
+- The dataset that flagged the IP address (`cf.intel.ip.datasets` — values: `ddos`, `waf`)
+
+You can review matches in [Security Analytics](/waf/analytics/security-analytics/) to see which threat actors and campaigns are reaching your application.
+
+:::caution
+IP addresses are often shared through NAT, proxies, and cloud providers. Test rules with the _Log_ action first and combine threat intelligence with other signals — such as [attack score](/waf/detections/attack-score/) — before you block.
+:::
+
+## Data freshness
+
+The threat intelligence database reflects a rolling seven-day window:
+
+- An IP address flagged earlier in the window still matches, even if the threat is no longer active.
+- An IP address ages out seven days after the last observed activity. Rules that matched it stop matching with no notification.
+
+## Availability
+
+Requires an active [Cloudforce One](/security-center/cloudforce-one/) subscription. Contact your account team for access.
+
+The WAF must be enabled on your zone before threat intelligence fields can be used in rule expressions.
+
+## More resources
+
+- [Threat intelligence fields](/waf/detections/threat-intelligence/fields/) — Available fields and matching behavior.
+- [Get started](/waf/detections/threat-intelligence/get-started/) — Create your first threat intelligence rule.
+- [Threat Events](/security-center/cloudforce-one/) — Investigate threats in the Cloudforce One dashboard.


### PR DESCRIPTION
### Summary

New documentation section at `/waf/detections/threat-intelligence/` for the threat intelligence WAF detection (SHIP-11629). Four pages:

- **Overview** (`index.mdx`) — what the detection does, data freshness (seven-day window), availability (Cloudforce One subscription)
- **Get started** (`get-started.mdx`) — create a rule in Log mode, review matches in Security Analytics, switch to Block/Challenge, optional Saved Views export
- **Available fields** (`fields.mdx`) — five `cf.intel.ip.*` fields, case sensitivity, union/flattened matching behavior, analytics gap (rule fields vs logged fields)
- **Example rules** (`example-rules.mdx`) — six recipes covering Log, Block, Challenge, rate limiting, and combining with attack score

### Documentation checklist

- [ ] Is there a changelog entry? Separate PR: see the companion changelog PR.
- [x] The change adheres to the documentation style guide.
- [ ] If a larger change — an issue has been opened. N/A — new section for a new feature.
- [ ] Files which have changed name or location have redirects. N/A — all new files.