### PR TITLE
chore: enable auto-format on PRs targeting production

### DIFF
--- a/.github/workflows/auto-format-build.yml
+++ b/.github/workflows/auto-format-build.yml
@@ -4,7 +4,7 @@ name: Auto Format (Build)
 
 on:
   pull_request:
-    branches: [auto-format-canary]
+    branches: [production]
     types: [opened, synchronize]
     paths:
       - "**/*.js"


### PR DESCRIPTION
### Summary


Flips the auto-format build workflow's `branches:` filter from `[auto-format-canary]` to `[production]`, so the bot now runs on real PRs.

Verified end-to-end against canary PRs: prettier produces a diff for changed files, the patch is validated against the path allowlist, and `cloudflare-docs-bot[bot]` pushes a `style: format` commit back to the PR branch.

## Effect

The auto-format bot will now fire on every PR opened against `production` that touches a prettier-scoped file (`.js .jsx .ts .tsx .mjs .css .json .yaml .yml .md .astro`). When prettier produces a diff, `cloudflare-docs-bot[bot]` pushes a `style: format` commit back to the PR branch (same-repo or fork), CI re-runs against the formatted code.

The CI safety net (`Check formatting (changed files)` in `ci.yml`) is retained — it'll be removed in a follow-up after a soak period.

## Verification

The workflow has been tested against [PR](https://github.com/cloudflare/cloudflare-docs/pull/31207) targeting `auto-format-canary` without any issues: 

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
