### PR TITLE
Update limits on secrets bulk

### DIFF
--- a/src/content/docs/workers/configuration/secrets.mdx
+++ b/src/content/docs/workers/configuration/secrets.mdx
@@ -117,7 +117,7 @@ To add a secret via the dashboard:
 
 #### Upload secrets alongside code
 
-You can upload secrets at the same time as your Worker code using the `--secrets-file` flag on [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) or [`wrangler versions upload`](/workers/wrangler/commands/workers/#versions-upload). This accepts a path to a JSON or `.env` file — the same formats accepted by [`wrangler secret bulk`](/workers/wrangler/commands/workers/#secret-bulk).
+You can upload secrets at the same time as your Worker code using the `--secrets-file` flag on [`wrangler deploy`](/workers/wrangler/commands/workers/#deploy) or [`wrangler versions upload`](/workers/wrangler/commands/workers/#versions-upload). This accepts a path to a JSON or `.env` file — the same formats accepted by [`wrangler secret bulk`](/workers/wrangler/commands/workers/#secret-bulk). The maximum number of secrets that can be uploaded at once in a bulk request for a single version is 100.
 
 ```sh
 npx wrangler deploy --secrets-file .env.production


### PR DESCRIPTION
### Summary

We've recently encountered users who have attempted and failed to upload large numbers of secrets in bulk. This clarifies what our API supports.

### Documentation checklist
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).