### PR TITLE
[Radar] Add bot vs. human traffic glossary entry

### DIFF
--- a/src/content/docs/radar/glossary.mdx
+++ b/src/content/docs/radar/glossary.mdx
@@ -95,6 +95,12 @@ Hovering over a link in the diagram reveals a tooltip with the connected ASNs, t
 [rpki]: https://blog.cloudflare.com/rpki-details/
 [tier-1]: https://en.wikipedia.org/wiki/Tier_1_network
 
+## Bot vs. human traffic
+
+The percentage of HTTP requests classified as bot versus human, based on [bot scores](/bots/concepts/bot-score/). Requests with a bot score between 1 and 29 are classified as likely automated (bot), while requests with a score of 30 or above are classified as likely human. Refer to [bot classes](/radar/concepts/bot-classes/) for more details.
+
+By default, Radar shows bot vs. human traffic for requests to HTML content. This filter is meant to represent traditional web traffic by excluding API calls, asset requests (images, scripts, fonts), and other machine-to-machine requests.
+
 ## Certificates
 
 Encryption is a critical part of a safe Internet. SSL/TLS is the standard security technology for establishing an encrypted link between a client and a server.


### PR DESCRIPTION
### Summary

Adds a "Bot vs. human traffic" glossary entry to the Radar glossary page. This clarifies how Radar classifies traffic as bot or human (based on bot scores) and documents that Radar defaults to showing HTML content type only — which is relevant because the bot-vs-human ratio differs significantly depending on whether you look at all request types or HTML only.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

<img width="1480" height="657" alt="image" src="https://github.com/user-attachments/assets/4d9c0805-af04-4e0e-a4b6-d09279ad1def" />

