### PR TITLE
[Smart Shield] Clarify Smart Shield Advanced availability for PayGo vs Enterprise

### DIFF
--- a/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
+++ b/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
@@ -13,7 +13,7 @@ tags:
 import { Render } from "~/components";
 
 :::note[Availability]
-Included with Enterprise plans. Available to Free, Pro, and Business plans through Smart Shield Advanced.
+Regional Tiered Cache is included with Enterprise plans. Smart Shield Advanced, which includes Regional Tiered Cache, is currently only available to contracted (Enterprise) customers. If you are interested in Smart Shield Advanced, please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
 :::
 
 <Render file="regional-tiered-cache" product="cache" />

--- a/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
+++ b/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
@@ -13,7 +13,7 @@ tags:
 import { Render } from "~/components";
 
 :::note[Availability]
-Regional Tiered Cache is included with Enterprise plans. Smart Shield Advanced, which includes Regional Tiered Cache, is currently only available to contracted (Enterprise) customers. If you are interested in Smart Shield Advanced, please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
+Regional Tiered Cache is included with Enterprise plans. Smart Shield Advanced, which includes Regional Tiered Cache, is currently only available to Enterprise customers. If you are interested in Smart Shield Advanced, please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
 :::
 
 <Render file="regional-tiered-cache" product="cache" />

--- a/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
+++ b/src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx
@@ -13,7 +13,7 @@ tags:
 import { Render } from "~/components";
 
 :::note[Availability]
-Regional Tiered Cache is included with Enterprise plans. Smart Shield Advanced, which includes Regional Tiered Cache, is currently only available to Enterprise customers. If you are interested in Smart Shield Advanced, please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
+Regional Tiered Cache is included with Enterprise plans. Smart Shield Advanced, which includes Regional Tiered Cache, is currently only available to Enterprise customers. If you are interested in Smart Shield Advanced, contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
 :::
 
 <Render file="regional-tiered-cache" product="cache" />

--- a/src/content/docs/smart-shield/get-started.mdx
+++ b/src/content/docs/smart-shield/get-started.mdx
@@ -8,7 +8,7 @@ sidebar:
   order: 2
 ---
 
-import { GlossaryTooltip, DirectoryListing } from "~/components";
+import { GlossaryTooltip, DirectoryListing, Tabs, TabItem } from "~/components";
 
 Smart Shield reduces the load on your origin server and improves content delivery by consolidating requests through Cloudflare's caching infrastructure. It is available to all customers as an opt-in configuration.
 
@@ -30,6 +30,10 @@ After setup, you can monitor origin performance and cache effectiveness through 
 
 Pro, Business, and Enterprise customers have access to [Health Checks](/smart-shield/configuration/health-checks/) for monitoring origin availability across all packages.
 
+<Tabs> <TabItem label="Contracted customers">
+
+Contracted customers (Enterprise) have access to all Smart Shield packages, including Smart Shield Advanced.
+
 ### Smart Shield
 
 The base package for reducing origin load through caching and connection optimization.
@@ -48,13 +52,31 @@ The full package with additional caching customization through regional and pers
 
 - Includes [Smart Tiered Cache](/smart-shield/configuration/smart-tiered-cache/), [Connection Reuse](/smart-shield/concepts/connection-reuse/), [Argo Smart Routing](/smart-shield/configuration/argo/), [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/), and [Cache Reserve](/smart-shield/configuration/cache-reserve/).
 
-:::note[Regional Tiered Cache for Enterprise]
-Enterprise customers have access to [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) as part of their plan, regardless of which Smart Shield package they use. Free, Pro, and Business plans receive Regional Tiered Cache through Smart Shield Advanced.
-:::
+Enterprise customers have access to [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) as part of their plan, regardless of which Smart Shield package they use.
 
-:::note[Dedicated CDN Egress IPs]
 Enterprise customers also have the option to configure [Dedicated CDN Egress IPs](/smart-shield/configuration/dedicated-egress-ips/), allowing you to increase origin security by only allowing traffic from a small list of IP addresses. If you are interested, reach out to your account team.
-:::
+
+</TabItem> <TabItem label="Pay-as-you-go customers">
+
+Pay-as-you-go (self-serve) customers on Free, Pro, or Business plans can purchase Smart Shield and Smart Shield + Argo packages.
+
+### Smart Shield
+
+The base package for reducing origin load through caching and connection optimization.
+
+- Includes [Smart Tiered Cache](/smart-shield/configuration/smart-tiered-cache/) and [Connection Reuse](/smart-shield/concepts/connection-reuse/).
+
+### Smart Shield + Argo
+
+Adds network path optimization on top of the base package. Use when visitors are geographically distant from the origin server.
+
+- Includes [Smart Tiered Cache](/smart-shield/configuration/smart-tiered-cache/), [Connection Reuse](/smart-shield/concepts/connection-reuse/), and [Argo Smart Routing](/smart-shield/configuration/argo/).
+
+### Smart Shield Advanced
+
+Smart Shield Advanced is not currently available for pay-as-you-go customers. If you are interested in Smart Shield Advanced features such as [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) and [Cache Reserve](/smart-shield/configuration/cache-reserve/), please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
+
+</TabItem> </Tabs>
 
 ## Further reading
 

--- a/src/content/docs/smart-shield/get-started.mdx
+++ b/src/content/docs/smart-shield/get-started.mdx
@@ -30,7 +30,7 @@ After setup, you can monitor origin performance and cache effectiveness through 
 
 Pro, Business, and Enterprise customers have access to [Health Checks](/smart-shield/configuration/health-checks/) for monitoring origin availability across all packages.
 
-<Tabs> 
+<Tabs>
 <TabItem label="Enterprise">
 
 Enterprise customers have access to all Smart Shield packages, including Smart Shield Advanced.
@@ -57,7 +57,7 @@ Enterprise customers have access to [Regional Tiered Cache](/smart-shield/config
 
 Enterprise customers also have the option to configure [Dedicated CDN Egress IPs](/smart-shield/configuration/dedicated-egress-ips/), allowing you to increase origin security by only allowing traffic from a small list of IP addresses. If you are interested, reach out to your account team.
 
-</TabItem> 
+</TabItem>
 <TabItem label="Free / Pro / Business">
 
 Free, Pro, and Business customers can purchase Smart Shield and Smart Shield + Argo packages.
@@ -76,9 +76,9 @@ Adds network path optimization on top of the base package. Use when visitors are
 
 ### Smart Shield Advanced
 
-Smart Shield Advanced is not currently available for Free, Pro, and Business customers. If you are interested in Smart Shield Advanced features such as [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) and [Cache Reserve](/smart-shield/configuration/cache-reserve/), please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
+Smart Shield Advanced is not currently available for Free, Pro, and Business customers. If you are interested in Smart Shield Advanced features such as [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) and [Cache Reserve](/smart-shield/configuration/cache-reserve/), contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
 
-</TabItem> 
+</TabItem>
 </Tabs>
 
 ## Further reading

--- a/src/content/docs/smart-shield/get-started.mdx
+++ b/src/content/docs/smart-shield/get-started.mdx
@@ -30,7 +30,8 @@ After setup, you can monitor origin performance and cache effectiveness through 
 
 Pro, Business, and Enterprise customers have access to [Health Checks](/smart-shield/configuration/health-checks/) for monitoring origin availability across all packages.
 
-<Tabs> <TabItem label="Enterprise">
+<Tabs> 
+<TabItem label="Enterprise">
 
 Enterprise customers have access to all Smart Shield packages, including Smart Shield Advanced.
 
@@ -56,7 +57,8 @@ Enterprise customers have access to [Regional Tiered Cache](/smart-shield/config
 
 Enterprise customers also have the option to configure [Dedicated CDN Egress IPs](/smart-shield/configuration/dedicated-egress-ips/), allowing you to increase origin security by only allowing traffic from a small list of IP addresses. If you are interested, reach out to your account team.
 
-</TabItem> <TabItem label="Free / Pro / Business">
+</TabItem> 
+<TabItem label="Free / Pro / Business">
 
 Free, Pro, and Business customers can purchase Smart Shield and Smart Shield + Argo packages.
 
@@ -76,7 +78,8 @@ Adds network path optimization on top of the base package. Use when visitors are
 
 Smart Shield Advanced is not currently available for Free, Pro, and Business customers. If you are interested in Smart Shield Advanced features such as [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) and [Cache Reserve](/smart-shield/configuration/cache-reserve/), please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
 
-</TabItem> </Tabs>
+</TabItem> 
+</Tabs>
 
 ## Further reading
 

--- a/src/content/docs/smart-shield/get-started.mdx
+++ b/src/content/docs/smart-shield/get-started.mdx
@@ -30,9 +30,9 @@ After setup, you can monitor origin performance and cache effectiveness through 
 
 Pro, Business, and Enterprise customers have access to [Health Checks](/smart-shield/configuration/health-checks/) for monitoring origin availability across all packages.
 
-<Tabs> <TabItem label="Contracted customers">
+<Tabs> <TabItem label="Enterprise">
 
-Contracted customers (Enterprise) have access to all Smart Shield packages, including Smart Shield Advanced.
+Enterprise customers have access to all Smart Shield packages, including Smart Shield Advanced.
 
 ### Smart Shield
 
@@ -56,9 +56,9 @@ Enterprise customers have access to [Regional Tiered Cache](/smart-shield/config
 
 Enterprise customers also have the option to configure [Dedicated CDN Egress IPs](/smart-shield/configuration/dedicated-egress-ips/), allowing you to increase origin security by only allowing traffic from a small list of IP addresses. If you are interested, reach out to your account team.
 
-</TabItem> <TabItem label="Pay-as-you-go customers">
+</TabItem> <TabItem label="Free / Pro / Business">
 
-Pay-as-you-go (self-serve) customers on Free, Pro, or Business plans can purchase Smart Shield and Smart Shield + Argo packages.
+Free, Pro, and Business customers can purchase Smart Shield and Smart Shield + Argo packages.
 
 ### Smart Shield
 
@@ -74,7 +74,7 @@ Adds network path optimization on top of the base package. Use when visitors are
 
 ### Smart Shield Advanced
 
-Smart Shield Advanced is not currently available for pay-as-you-go customers. If you are interested in Smart Shield Advanced features such as [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) and [Cache Reserve](/smart-shield/configuration/cache-reserve/), please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
+Smart Shield Advanced is not currently available for Free, Pro, and Business customers. If you are interested in Smart Shield Advanced features such as [Regional Tiered Cache](/smart-shield/configuration/regional-tiered-cache/) and [Cache Reserve](/smart-shield/configuration/cache-reserve/), please contact our [Enterprise Sales team](https://www.cloudflare.com/resource/contact-enterprise-sales/).
 
 </TabItem> </Tabs>
 


### PR DESCRIPTION
### Summary

Updates the Smart Shield get-started page and Regional Tiered Cache page to clarify that Smart Shield Advanced is currently only available to contracted (Enterprise) customers, not pay-as-you-go customers.

**Changes:**
- **`get-started.mdx`** — Replaced the existing notes with a Tabs component separating "Contracted customers" and "Pay-as-you-go customers", making it clear that PayGo customers can only purchase Smart Shield and Smart Shield + Argo packages
- **`regional-tiered-cache.mdx`** — Updated the availability note to state Smart Shield Advanced is Enterprise-only with a link to contact the Enterprise Sales team

Addresses DEE-3569.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
