### PR TITLE
[Style Guide] Remove hardcoded code block language list

### DIFF
--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -238,9 +238,7 @@ Bullet point rules:
 
 Always specify a language after the opening fence. Language names must be **lowercase**.
 
-Supported languages: `bash` (alias: `curl`), `c`, `css`, `dart`, `diff`, `go`, `graphql`, `hcl` (alias: `tf`), `html`, `ini`, `java`, `js` (alias: `javascript`), `json`, `jsonc`, `kotlin`, `mdx`, `php`, `powershell`, `python` (alias: `py`), `ruby` (alias: `rb`), `rust` (alias: `rs`), `sh` (alias: `shell`), `sql`, `swift`, `toml`, `ts` (alias: `typescript`), `txt` (aliases: `text`, `plaintext`), `xml`, `yaml` (alias: `yml`).
-
-Use `txt` for unsupported languages (e.g., output blocks, Apache config fragments). Do not use `output`, `env`, `csharp`, or `promql` — they fall back to `txt` with a warning.
+Any language in [Shiki's bundled languages](https://shiki.style/languages#bundled-languages) is valid. Unrecognized identifiers fall back to plain text without an error. Use `txt` explicitly for output blocks or content with no appropriate language (aliases: `text`, `plaintext`).
 
 ### Terminal commands
 

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -238,7 +238,7 @@ Bullet point rules:
 
 Always specify a language after the opening fence. Language names must be **lowercase**.
 
-Always specify a language; use `txt` (aliases: `text`, `plaintext`) if no appropriate language exists. Unrecognized identifiers fall back to plain text without an error.
+Always specify a language; use `txt` (aliases: `text`, `plaintext`) if no appropriate language exists.
 
 ### Terminal commands
 

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -238,7 +238,7 @@ Bullet point rules:
 
 Always specify a language after the opening fence. Language names must be **lowercase**.
 
-Any language in [Shiki's bundled languages](https://shiki.style/languages#bundled-languages) is valid. Unrecognized identifiers fall back to plain text without an error. Use `txt` explicitly for output blocks or content with no appropriate language (aliases: `text`, `plaintext`).
+Always specify a language; use `txt` (aliases: `text`, `plaintext`) if no appropriate language exists. Unrecognized identifiers fall back to plain text without an error.
 
 ### Terminal commands
 

--- a/.flue/.agents/reference/style-guide/conditional/code-blocks.md
+++ b/.flue/.agents/reference/style-guide/conditional/code-blocks.md
@@ -5,10 +5,8 @@ description: Rules for fenced code blocks that are not component-specific.
 
 ## Language Identifiers
 
-- If an opening fence has no language identifier (bare ` ``` `) → **warning**: always specify a language.
+- If an opening fence has no language identifier (bare ` ``` `) → **warning**: always specify a language; use `txt` if no appropriate language exists.
 - If a fence uses a capitalized language name (`JSON`, `YAML`, `TypeScript`, `JavaScript`, `Go`) → **warning**: language identifiers must be lowercase (`json`, `yaml`, `ts`, `js`, `go`).
-
-Any language supported by [Shiki's bundled languages](https://shiki.style/languages#bundled-languages) is valid. Unrecognized identifiers fall back to plain text without an error. Use `txt` explicitly for output blocks or content with no appropriate language.
 
 ## Terminal Commands
 

--- a/.flue/.agents/reference/style-guide/conditional/code-blocks.md
+++ b/.flue/.agents/reference/style-guide/conditional/code-blocks.md
@@ -6,12 +6,9 @@ description: Rules for fenced code blocks that are not component-specific.
 ## Language Identifiers
 
 - If an opening fence has no language identifier (bare ` ``` `) → **warning**: always specify a language.
-- If a fence uses an unsupported language identifier (`output`, `env`, `csharp`, `promql`) → **warning**: use `txt` for unsupported types.
 - If a fence uses a capitalized language name (`JSON`, `YAML`, `TypeScript`, `JavaScript`, `Go`) → **warning**: language identifiers must be lowercase (`json`, `yaml`, `ts`, `js`, `go`).
 
-**Supported languages:** `bash` (alias `curl`), `c`, `css`, `dart`, `diff`, `go`, `graphql`, `hcl` (alias `tf`), `html`, `ini`, `java`, `js` (alias `javascript`), `json`, `jsonc`, `kotlin`, `mdx`, `php`, `powershell`, `python` (alias `py`), `ruby` (alias `rb`), `rust` (alias `rs`), `sh` (alias `shell`), `sql`, `swift`, `toml`, `ts` (alias `typescript`), `txt` (aliases `text`, `plaintext`), `xml`, `yaml` (alias `yml`).
-
-Use `txt` for: output blocks, environment configs, Apache config, or anything not in the list above.
+Any language supported by [Shiki's bundled languages](https://shiki.style/languages#bundled-languages) is valid. Unrecognized identifiers fall back to plain text without an error. Use `txt` explicitly for output blocks or content with no appropriate language.
 
 ## Terminal Commands
 

--- a/src/content/docs/style-guide/formatting/code-block-guidelines.mdx
+++ b/src/content/docs/style-guide/formatting/code-block-guidelines.mdx
@@ -71,38 +71,11 @@ index_name = "tutorial-index"
 
 To define the language of your code block, enter the name of the language after the first ` ``` ` fence.
 
-If there is no appropriate syntax language, use `txt` (for example, a fragment of an Apache configuration file).
+Language names must be lowercase. For example, use `javascript`, not `JavaScript`.
 
-Make sure you enter the language name in lower case, since other capitalizations of these names are not supported. For example, entering `JavaScript` would use the `txt` language as a fallback.
+Any language from [Shiki's bundled languages](https://shiki.style/languages#bundled-languages) is supported. If you use an unrecognized identifier, the block falls back to plain text without an error.
 
-Here is a list of supported languages:
-
-- `bash` (alias: `curl`) [Learn more about terminal commands](#terminal-commands)
-- `c`
-- `dart`
-- `diff`
-- `go`
-- `graphql`
-- `hcl` (alias: `tf`)
-- `html`
-- `ini`
-- `java`
-- `js` (alias: `javascript`)
-- `json` [Learn more about JSON code blocks](#json)
-- `kotlin`
-- `php`
-- `powershell` [Learn more about terminal commands](#terminal-commands)
-- `python` (alias: `py`)
-- `ruby` (alias: `rb`)
-- `rust` (alias: `rs`)
-- `sh` (alias: `shell`) [Learn more about terminal commands](#terminal-commands)
-- `sql`
-- `swift`
-- `toml`
-- `ts` (alias: `typescript`)
-- `txt` (aliases: `text`, `plaintext`, no language name)
-- `xml`
-- `yaml` (alias: `yml`)
+Use `txt` (aliases: `text`, `plaintext`) when there is no appropriate syntax language — for example, a fragment of an Apache configuration file or command output.
 
 ### Terminal commands
 

--- a/src/content/docs/style-guide/formatting/code-block-guidelines.mdx
+++ b/src/content/docs/style-guide/formatting/code-block-guidelines.mdx
@@ -73,9 +73,7 @@ To define the language of your code block, enter the name of the language after 
 
 Language names must be lowercase. For example, use `javascript`, not `JavaScript`.
 
-Any language from [Shiki's bundled languages](https://shiki.style/languages#bundled-languages) is supported. If you use an unrecognized identifier, the block falls back to plain text without an error.
-
-Use `txt` (aliases: `text`, `plaintext`) when there is no appropriate syntax language — for example, a fragment of an Apache configuration file or command output.
+Use `txt` (aliases: `text`, `plaintext`) when there is no appropriate syntax language.
 
 ### Terminal commands
 


### PR DESCRIPTION
### Summary

Removes the hardcoded list of ~25 "supported" code block languages from the style guide. The list was a curated subset of Shiki's full ~200-language bundle and was never technically enforced — unrecognized identifiers silently fall back to plain text anyway. Maintaining an incomplete list creates false constraints (e.g. `csharp` and `proto` were labeled unsupported despite being valid Shiki languages). All three locations are updated to point at Shiki's bundled languages reference instead.
