### PR TITLE
fix: hide acknowledged findings from warnings, add br after summary in docs-bot code review

### DIFF
--- a/.flue/agents/code-review-orchestrator.ts
+++ b/.flue/agents/code-review-orchestrator.ts
@@ -932,11 +932,18 @@ function renderComment(
 	forceFullReview?: boolean,
 ): string {
 	const shortSha = reviewedHeadSha.slice(0, 7);
-	const warnings = reconciled.active.filter((f) => f.severity === "warning");
-	const suggestions = reconciled.active.filter(
+	// Exclude anything acknowledged by the reviewer from active sections
+	const ignoredPaths = new Set(
+		reconciled.ignored_by_reviewer.map((f) => `${f.path}:${f.line}:${f.rule}`),
+	);
+	const activeFindings = reconciled.active.filter(
+		(f) => !ignoredPaths.has(`${f.path}:${f.line}:${f.rule}`),
+	);
+	const warnings = activeFindings.filter((f) => f.severity === "warning");
+	const suggestions = activeFindings.filter(
 		(f) => f.severity === "suggestion",
 	);
-	const totalActive = reconciled.active.length;
+	const totalActive = activeFindings.length;
 	const scope = forceFullReview ? "full PR diff" : `commit \`${shortSha}\``;
 
 	// Status line
@@ -996,6 +1003,7 @@ function renderComment(
 		lines.push(
 			`<summary>Acknowledged by author (${reconciled.ignored_by_reviewer.length})</summary>`,
 		);
+		lines.push("<br/>");
 		lines.push("");
 		lines.push("| File | Issue | Note |");
 		lines.push("|---|---|---|");

--- a/.flue/agents/code-review-orchestrator.ts
+++ b/.flue/agents/code-review-orchestrator.ts
@@ -940,9 +940,7 @@ function renderComment(
 		(f) => !ignoredPaths.has(`${f.path}:${f.line}:${f.rule}`),
 	);
 	const warnings = activeFindings.filter((f) => f.severity === "warning");
-	const suggestions = activeFindings.filter(
-		(f) => f.severity === "suggestion",
-	);
+	const suggestions = activeFindings.filter((f) => f.severity === "suggestion");
 	const totalActive = activeFindings.length;
 	const scope = forceFullReview ? "full PR diff" : `commit \`${shortSha}\``;
 


### PR DESCRIPTION
### Summary

Two fixes to the bot review comment rendering in `renderComment()`:

1. **Acknowledged items no longer appear in Warnings/Suggestions.** The reconciler can return the same finding in both `active` and `ignored_by_reviewer`. The renderer now builds a set of acknowledged item keys and filters them out of `activeFindings` before populating the warning/suggestion sections. `totalActive` is also updated to use the filtered count so the status line stays accurate.

2. **Added `<br/>` after the "Acknowledged by author" `<summary>`.** The Warnings and Suggestions sections already had this break; the Acknowledged section was missing it, causing the table to render flush against the header.
