### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-06-04)

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -457,7 +457,7 @@ Result of the check for [leaked credentials](/waf/detections/leaked-credentials/
 
 Type: `array[object]`
 
-Array of matched Cloudflare Rules product rules grouped by product. Each object contains: <em>product</em> (string, e.g. snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
+Array of matched Cloudflare Rules product rules grouped by product. Each object contains: <em>product</em> (string, for example snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
 
 ## OriginDNSResponseTimeMs
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/{account,zone}/` — dataset pages

### Documentation checklist
- [ ] Changelog entry — not applicable (no field additions or removals)
- [x] Content generated by code generator (DO NOT EDIT manually)
