### PR TITLE
chore: Enable codeowner-gated previews on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
       - name: Deploy to Cloudflare Workers
         id: deploy
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |

--- a/.github/workflows/preview-command.yml
+++ b/.github/workflows/preview-command.yml
@@ -1,0 +1,99 @@
+name: Preview Command
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: preview-command-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-codeowner:
+    if: |
+      github.event.issue.pull_request &&
+      github.event.sender.type != 'Bot' &&
+      contains(github.event.comment.body, '/preview')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      is-codeowner: ${{ steps.check.outputs.is-codeowner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Check CODEOWNERS
+        id: check
+        uses: ./.github/actions/check-codeowner
+        with:
+          GH_ORG_TOKEN: ${{ secrets.GH_ORG_TOKEN }}
+
+  preview:
+    needs: check-codeowner
+    # A codeowner typing /preview is the only thing standing between an
+    # untrusted fork's build scripts and the preview deploy token. Keep this
+    # gate; do not widen it to all commenters or all PRs.
+    if: needs.check-codeowner.outputs.is-codeowner == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 11
+
+      - name: Set up node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        id: setup-node
+        with:
+          node-version: 24.x
+          cache: pnpm
+
+      - name: Restore node_modules (cache hit)
+        id: node-modules-cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
+
+      - name: Install node_modules (cache miss)
+        run: pnpm install --frozen-lockfile
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+
+      - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm run build
+
+      - name: Deploy to Cloudflare Workers
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          SHORT_SHA=$(git rev-parse --short=8 HEAD)
+          BRANCH_SLUG="pr-$PR_NUMBER"
+
+          echo "branch_slug=$BRANCH_SLUG" >> "$GITHUB_OUTPUT"
+
+          pnpm exec wrangler deploy --dispatch-namespace preview-deployments --name $SHORT_SHA
+          pnpm exec wrangler deploy --dispatch-namespace preview-deployments --name $BRANCH_SLUG
+
+      - name: Post preview URL on PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_SLUG: ${{ steps.deploy.outputs.branch_slug }}
+        run: pnpm exec tsx bin/post-preview-url-comment/index.ts
+        continue-on-error: true

--- a/bin/post-preview-url-comment/index.ts
+++ b/bin/post-preview-url-comment/index.ts
@@ -30,6 +30,14 @@ async function run(): Promise<void> {
 			branch = payload.pull_request.head.ref;
 			commitSha = payload.pull_request.head.sha;
 			pull_number = payload.pull_request.number;
+		} else if (payload.issue?.pull_request) {
+			const { data: pull } = await octokit.rest.pulls.get({
+				...ctx.repo,
+				pull_number: payload.issue.number,
+			});
+			branch = pull.head.ref;
+			commitSha = pull.head.sha;
+			pull_number = pull.number;
 		} else {
 			branch = ctx.ref.replace("refs/heads/", "");
 			commitSha = ctx.sha;


### PR DESCRIPTION
### Summary

Today, previews only deploy for PRs whose branch lives in this repository. Fork PRs are skipped — the `publish-preview` job is gated on `head.repo == base.repo`, and GitHub withholds repository secrets from fork-triggered `pull_request` runs regardless.

This adds a `/preview` slash command so a codeowner can generate a preview for any PR, including those from forks. It triggers on `issue_comment`, verifies the commenter is listed in `CODEOWNERS` (reusing the same `check-codeowner` action the `/bonk` command relies on, which reads `CODEOWNERS` from the base branch via the API so a fork branch cannot tamper with it), then checks out the PR head, builds, and deploys to the `preview-deployments` dispatch namespace.

Because building a fork's head runs untrusted build scripts, the preview deploy is split off the shared production token onto a dedicated `CLOUDFLARE_PREVIEW_API_TOKEN`. This lets the credential that fork build scripts can reach be scoped to preview deploys only, away from production worker writes and the `developers.cloudflare.com` route.

> [!IMPORTANT]
> This requires a new `CLOUDFLARE_PREVIEW_API_TOKEN` secret, scoped to Workers Scripts edit + Workers for Platforms on the docs account, with **no** Workers Routes edit on the production zone. The existing internal-branch preview job switches to this secret too, so it must exist before merge.
