### PR TITLE
feat(waf): add OWASP Top 10 vs Cloudflare products comparison table

### DIFF
--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/index.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/index.mdx
@@ -18,17 +18,37 @@ The Cloudflare OWASP Core Ruleset is designed to work as a single entity to calc
 
 <Render file="owasp-false-positives-warning" product="waf" />
 
-## Cloudflare OWASP Core Ruleset versus OWASP Top 10
+## OWASP Top 10 versus Cloudflare Rulesets
 
 The Cloudflare OWASP Core Ruleset is Cloudflare's implementation of the OWASP ModSecurity Core Rule Set version {owaspCrsVersion}, which is different from the [OWASP Top 10](https://owasp.org/www-project-top-ten/).
 
-The OWASP Top 10 is a list of the most severe security risks that can affect applications. Some of the identified security risks can be addressed by the OWASP Core Ruleset, but other risks cannot be protected by a web application firewall, such as the following:
+The [OWASP Top 10](https://owasp.org/www-project-top-ten/) is a list of the most severe application security risks, designed to raise awareness among practitioners and developers. While some risks can be addressed by a web application firewall, others require different solutions or must be mitigated during application development. Specifically:
 
+- Cryptographic Failures
 - Insecure Design
 - Identification and Authentication Failures
 - Security Logging and Monitoring Failures
 
 These risks depend more on how the application is built or how the entire monitoring pipeline is set up.
+
+### Cloudflare products versus OWASP Top 10
+
+While both the Cloudflare Managed Ruleset and OWASP CRS aim to mitigate several categories of the OWASP Top 10, their approaches differ. OWASP CRS v3.3 is a generalized, "scoring-based" open-source ruleset that often requires manual tuning. In contrast, the Cloudflare Managed Ruleset is a proprietary, signature-heavy engine backed by Cloudflare's massive global threat intelligence. Furthermore, Cloudflare rapidly deploys protections for new CVEs through its managed ruleset, whereas the OWASP CRS remains relatively static.
+
+The table below outlines how Cloudflare products map to the OWASP categories.
+
+| OWASP Top 10 Category | OWASP Core Rule Set (v3.3) | Cloudflare Managed Ruleset | Other Cloudflare products |
+| --- | --- | --- | --- |
+| A01: Broken Access Control | Targets Path Traversal (930XXX) and App Defect detection (e.g., .env, .git access). | Uses proprietary signatures for Insecure Direct Object References and Directory Traversal. | Security Rules are used for granular IP/Geo/ASN enforcement. |
+| A02: Cryptographic Failures | N/A | N/A | The Cloudflare platform provides platform-level controls for HTTP Strict Transport Security, Minimum TLS versions, and automated certificate management. Post Quantum encryption ready. |
+| A03: Injection (SQLi, XSS) | Comprehensive: Uses Regex-based scoring for SQLi (942XXX), XSS (941XXX), and RCE (932XXX). | Combines fast signature matching with Attack Score to catch highly obfuscated payloads. Smart decoding pre-processing is applied to prevent obfuscation. | The ML-based Cloudflare Attack Score complements managed rulesets by detecting attack variations and bypasses. |
+| A04: Insecure Design | N/A | N/A | API Schema Validation helps mitigate protocol enforcement that might stem from poor design (e.g. HTTP Method enforcement) |
+| A05: Security Misconfiguration | Detects directory indexing, default error messages, and protocol violations via 920XXX. | Includes a broad suite of Managed Rules for hardening specific CMS platforms (WordPress, Magento, etc.) against known misconfigs. |  |
+| A06: Outdated Components | General rules may catch exploits, but it does not maintain a database of specific software versions. | Proactive Virtual Patching for newly discovered CVEs (e.g., Log4Shell, React2Shell) often deployed within minutes or hours of disclosure. | The ML-based Cloudflare Attack Score complements managed rulesets by detecting attack variations and bypasses. |
+| A07: Identification & Auth | N/A | N/A | Leaked Credential Check, Bot Management and Account Abuse Protection are designed to stop automated stuffing attacks and other auth-based vulnerabilities. |
+| A08: Software & Data Integrity | Dedicated rules for Insecure Deserialization (944XXX) and PHP injection. | Signatures for common serialization exploits and supply chain attack patterns (e.g., SolarWinds/Mimecast). | Cloudflare Client-side security monitors scripts, connections, and cookies loaded by your website visitors |
+| A09: Logging & Monitoring | N/A | N/A | The Cloudflare platform offers integrated dashboard with real-time analytics, Logpush to SIEMs, and automated anomaly alerting. LogExplorer is Cloudflare observability and forensics tool. |
+| A10: SSRF | Rules (934XXX) block requests to internal IPs and cloud metadata services (AWS, Azure, GCP). | Identifies SSRF signatures and allows users to easily block outbound requests to sensitive metadata endpoints. |  |
 
 ## Resources
 

--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/index.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/index.mdx
@@ -35,7 +35,7 @@ These risks depend more on how the application is built or how the entire monito
 
 While both the Cloudflare Managed Ruleset and OWASP CRS aim to mitigate several categories of the OWASP Top 10, their approaches differ. OWASP CRS v3.3 is a generalized, "scoring-based" open-source ruleset that often requires manual tuning. In contrast, the Cloudflare Managed Ruleset is a proprietary, signature-heavy engine backed by Cloudflare's massive global threat intelligence. Furthermore, Cloudflare rapidly deploys protections for new CVEs through its managed ruleset, whereas the OWASP CRS remains relatively static.
 
-The table below outlines how Cloudflare products map to the OWASP categories.
+The following table outlines how Cloudflare products map to the OWASP categories.
 
 | OWASP Top 10 category | OWASP Core Rule Set (v3.3) | Cloudflare Managed Ruleset | Other Cloudflare products |
 | --- | --- | --- | --- |

--- a/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/index.mdx
+++ b/src/content/docs/waf/managed-rules/reference/owasp-core-ruleset/index.mdx
@@ -37,18 +37,18 @@ While both the Cloudflare Managed Ruleset and OWASP CRS aim to mitigate several 
 
 The table below outlines how Cloudflare products map to the OWASP categories.
 
-| OWASP Top 10 Category | OWASP Core Rule Set (v3.3) | Cloudflare Managed Ruleset | Other Cloudflare products |
+| OWASP Top 10 category | OWASP Core Rule Set (v3.3) | Cloudflare Managed Ruleset | Other Cloudflare products |
 | --- | --- | --- | --- |
-| A01: Broken Access Control | Targets Path Traversal (930XXX) and App Defect detection (e.g., .env, .git access). | Uses proprietary signatures for Insecure Direct Object References and Directory Traversal. | Security Rules are used for granular IP/Geo/ASN enforcement. |
-| A02: Cryptographic Failures | N/A | N/A | The Cloudflare platform provides platform-level controls for HTTP Strict Transport Security, Minimum TLS versions, and automated certificate management. Post Quantum encryption ready. |
+| A01: Broken Access Control | Targets Path Traversal (930XXX) and App Defect detection (for example, .env, .git access). | Uses proprietary signatures for Insecure Direct Object References and Directory Traversal. | Security Rules are used for granular IP/Geo/ASN enforcement. |
+| A02: Cryptographic Failures | N/A | N/A | The Cloudflare platform provides platform-level controls for HTTP Strict Transport Security, Minimum TLS versions, and automated certificate management. Post-quantum encryption ready. |
 | A03: Injection (SQLi, XSS) | Comprehensive: Uses Regex-based scoring for SQLi (942XXX), XSS (941XXX), and RCE (932XXX). | Combines fast signature matching with Attack Score to catch highly obfuscated payloads. Smart decoding pre-processing is applied to prevent obfuscation. | The ML-based Cloudflare Attack Score complements managed rulesets by detecting attack variations and bypasses. |
-| A04: Insecure Design | N/A | N/A | API Schema Validation helps mitigate protocol enforcement that might stem from poor design (e.g. HTTP Method enforcement) |
-| A05: Security Misconfiguration | Detects directory indexing, default error messages, and protocol violations via 920XXX. | Includes a broad suite of Managed Rules for hardening specific CMS platforms (WordPress, Magento, etc.) against known misconfigs. |  |
-| A06: Outdated Components | General rules may catch exploits, but it does not maintain a database of specific software versions. | Proactive Virtual Patching for newly discovered CVEs (e.g., Log4Shell, React2Shell) often deployed within minutes or hours of disclosure. | The ML-based Cloudflare Attack Score complements managed rulesets by detecting attack variations and bypasses. |
+| A04: Insecure Design | N/A | N/A | API Schema Validation helps mitigate protocol enforcement that might stem from poor design (for example HTTP Method enforcement) |
+| A05: Security Misconfiguration | Detects directory indexing, default error messages, and protocol violations via 920XXX. | Includes a broad suite of Managed Rules for hardening specific CMS platforms (such as WordPress and Magento) against known misconfigs. |  |
+| A06: Outdated Components | General rules may catch exploits, but it does not maintain a database of specific software versions. | Proactive Virtual Patching for newly discovered CVEs (for example, Log4Shell, React2Shell) often deployed within minutes or hours of disclosure. | The ML-based Cloudflare Attack Score complements managed rulesets by detecting attack variations and bypasses. |
 | A07: Identification & Auth | N/A | N/A | Leaked Credential Check, Bot Management and Account Abuse Protection are designed to stop automated stuffing attacks and other auth-based vulnerabilities. |
-| A08: Software & Data Integrity | Dedicated rules for Insecure Deserialization (944XXX) and PHP injection. | Signatures for common serialization exploits and supply chain attack patterns (e.g., SolarWinds/Mimecast). | Cloudflare Client-side security monitors scripts, connections, and cookies loaded by your website visitors |
-| A09: Logging & Monitoring | N/A | N/A | The Cloudflare platform offers integrated dashboard with real-time analytics, Logpush to SIEMs, and automated anomaly alerting. LogExplorer is Cloudflare observability and forensics tool. |
-| A10: SSRF | Rules (934XXX) block requests to internal IPs and cloud metadata services (AWS, Azure, GCP). | Identifies SSRF signatures and allows users to easily block outbound requests to sensitive metadata endpoints. |  |
+| A08: Software & Data Integrity | Dedicated rules for Insecure Deserialization (944XXX) and PHP injection. | Signatures for common serialization exploits and supply chain attack patterns (for example, SolarWinds/Mimecast). | Cloudflare Client-side security monitors scripts, connections, and cookies loaded by your website visitors |
+| A09: Logging & Monitoring | N/A | N/A | The Cloudflare platform offers integrated dashboard with real-time analytics, Logpush to SIEMs, and automated anomaly alerting. LogExplorer is Cloudflare's observability and forensics tool. |
+| A10: SSRF | Rules (934XXX) block requests to internal IPs and cloud metadata services (AWS, Azure, GCP). | Identifies SSRF signatures and allows users to easily block outbound requests to sensitive metadata endpoints. | - |
 
 ## Resources
 


### PR DESCRIPTION
## Summary

Updates the OWASP Core Ruleset page to add a comprehensive comparison between OWASP Top 10 categories and Cloudflare products.

### Changes

- Renamed section to **OWASP Top 10 versus Cloudflare Rulesets**
- Added **Cryptographic Failures** to the list of risks requiring non-WAF solutions
- Added new **Cloudflare products versus OWASP Top 10** subsection with:
  - Intro paragraph comparing OWASP CRS v3.3 vs Cloudflare Managed Ruleset approaches
  - Full A01–A10 comparison table mapping OWASP CRS, Cloudflare Managed Ruleset, and other Cloudflare products

### Preview

Page: https://developers.cloudflare.com/waf/managed-rules/reference/owasp-core-ruleset/