### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-06-04)

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/biso_user_actions.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/biso_user_actions.md
@@ -43,7 +43,7 @@ The date and time.
 
 Type: `string`
 
-The user action type ('copy', 'paste', 'download', etc.).
+The user action type (for example, 'copy', 'paste', 'download').
 
 ## URL
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/mnm_flow_logs.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/mnm_flow_logs.md
@@ -61,13 +61,13 @@ The number of egress packets transmitted.
 
 Type: `int`
 
-The ethertype of the packet (2048 for IPv4, 34525 for IPv6, etc.).
+The ethertype of the packet (for example, 2048 for IPv4, 34525 for IPv6).
 
 ## FlowProtocol
 
 Type: `string`
 
-The flow protocol (e.g., 'AWS_VPC', 'IPFIX', 'SFLOW_5', 'NETFLOW_V9', etc.).
+The flow protocol (for example, 'AWS_VPC', 'IPFIX', 'SFLOW_5', 'NETFLOW_V9').
 
 ## FlowTimestamp
 
@@ -97,7 +97,7 @@ The number of packets transmitted.
 
 Type: `int`
 
-The protocol number (e.g., 6 for TCP, 17 for UDP).
+The protocol number (for example, 6 for TCP, 17 for UDP).
 
 ## RuleIDs
 
@@ -115,7 +115,7 @@ The sample rate of the flow set by the sampler (1, 100, 1000, 1024, 2000 are com
 
 Type: `string`
 
-The type of sample rate (e.g. 'flow', 'default', 'propagated').
+The type of sample rate (for example, 'flow', 'default', 'propagated').
 
 ## SamplerAddress
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/http_requests.md
@@ -457,7 +457,7 @@ Result of the check for [leaked credentials](/waf/detections/leaked-credentials/
 
 Type: `array[object]`
 
-Array of matched Cloudflare Rules product rules grouped by product. Each object contains: <em>product</em> (string, e.g. snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
+Array of matched Cloudflare Rules product rules grouped by product. Each object contains: <em>product</em> (string, for example snippets, transform, redirects), <em>rulesetId</em> (string), <em>rulesetVersion</em> (int), and <em>rules</em> (array of objects, each with <em>id</em> (string) and optional <em>metadata</em> (object with string key-value pairs)).
 
 ## OriginDNSResponseTimeMs
 


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/docs/logs/logpush/logpush-job/datasets/zone/` — dataset pages

### Documentation checklist
- [ ] Changelog entry — not applicable (no field additions or removals)
- [x] Content generated by code generator (DO NOT EDIT manually)
