### PR TITLE
[DNS] Add FAQ entry about TXT record splitting at 255 characters

### DIFF
--- a/src/content/docs/dns/faq.mdx
+++ b/src/content/docs/dns/faq.mdx
@@ -132,9 +132,9 @@ Refer to [Deprecating the DNS ANY meta-query type](https://blog.cloudflare.com/d
 
 ### Why does my TXT record show a double quote in the middle of the value?
 
-This is expected behavior. Per [RFC 4408](https://www.rfc-editor.org/rfc/rfc4408#section-3.1.3) and the DNS protocol specification ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035#section-3.3.14)), a single DNS TXT record is composed of one or more character strings, each with a maximum length of 255 characters. When the value you enter exceeds 255 characters, it must be split into multiple strings. Each string is enclosed in double quotes (`"`), so the resulting record may appear to have a quote in the middle — for example, `"first part""second part"`.
+This is expected behavior. Per [RFC 4408](https://www.rfc-editor.org/rfc/rfc4408#section-3.1.3) and the DNS protocol specification ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035#section-3.3.14)), a single DNS TXT record is composed of one or more character strings, each with a maximum length of 255 characters. When the value you enter exceeds 255 characters, it must be split into multiple strings. Each string is enclosed in double quotes (`"`), so the resulting record may appear to have a quote in the middle — for example, `"first part" "second part"`.
 
-This splitting is handled automatically by Cloudflare and is fully compliant with DNS standards. The receiving application (such as an email server validating an SPF or DKIM record) will concatenate the strings back together, so the behavior of the record is not affected.
+This splitting is required by the DNS protocol and is performed by all DNS providers, even if some do not display it in their UI or API. For all major TXT record use cases (such as SPF, DKIM, and DMARC), the receiving application will concatenate the strings back together, so the behavior of the record is not affected.
 
 ### Why are Cloudflare's A or AAAA records / IP addresses for my domain's DNS responses appearing?
 

--- a/src/content/docs/dns/faq.mdx
+++ b/src/content/docs/dns/faq.mdx
@@ -130,6 +130,12 @@ Refer to [Deprecating the DNS ANY meta-query type](https://blog.cloudflare.com/d
 
 <Render file="aname-alias-callout" product="dns" />
 
+### Why does my TXT record show a double quote in the middle of the value?
+
+This is expected behavior. Per [RFC 4408](https://www.rfc-editor.org/rfc/rfc4408#section-3.1.3) and the DNS protocol specification ([RFC 1035](https://www.rfc-editor.org/rfc/rfc1035#section-3.3.14)), a single DNS TXT record is composed of one or more character strings, each with a maximum length of 255 characters. When the value you enter exceeds 255 characters, it must be split into multiple strings. Each string is enclosed in double quotes (`"`), so the resulting record may appear to have a quote in the middle — for example, `"first part""second part"`.
+
+This splitting is handled automatically by Cloudflare and is fully compliant with DNS standards. The receiving application (such as an email server validating an SPF or DKIM record) will concatenate the strings back together, so the behavior of the record is not affected.
+
 ### Why are Cloudflare's A or AAAA records / IP addresses for my domain's DNS responses appearing?
 
 For DNS records proxied to Cloudflare, Cloudflare's IP addresses are returned in DNS queries instead of your original server IP address. This allows Cloudflare to optimize, cache, and protect all requests for your website.


### PR DESCRIPTION
### Summary

Adds a new FAQ entry to the DNS documentation explaining why TXT records appear split with a double quote in the middle of the value. This is standard DNS behavior per RFC 4408 and RFC 1035 — TXT record strings are limited to 255 characters, so longer values are automatically split into multiple quoted strings.

Addresses DEE-3574.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
