### PR TITLE
[Access] Expand tool namespacing docs for MCP server portals

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -326,6 +326,42 @@ If you are building an MCP client with the [Agents SDK](/agents/model-context-pr
 The Agents SDK uses a `tool_{server_id}_{tool_name}` format (with a `tool_` prefix) when returning tools from `getAITools()`. This differs from the portal format, which uses `{server_id}_{tool_name}` without the prefix.
 :::
 
+### Portal-native tools
+
+In addition to upstream MCP server tools, the portal exposes its own built-in tools that let AI agents manage server connections and discover tools during a session. These tools use the `portal_` prefix and are not associated with any upstream server.
+
+#### Always available
+
+The following tools are available in every portal session, regardless of the connection mode:
+
+| Tool | Description |
+| --- | --- |
+| `portal_list_servers` | Lists all upstream MCP servers with their IDs, names, and whether they are currently enabled in the session. |
+| `portal_toggle_servers` | Opens a server selection flow. Returns a URL that the user visits in a browser to enable or disable servers and manage OAuth credentials. |
+| `portal_toggle_single_server` | Toggles a single server on or off without requiring a browser visit. Accepts a `server_id` and an `action` (`toggle` or `untoggle`). If the server requires OAuth and the user has not authenticated yet, the portal falls back to the browser-based `portal_toggle_servers` flow. |
+
+These tools power the [session management](#manage-portal-sessions) features described later in this guide. AI agents call them automatically when you ask to enable a server, disable a server, or return to the server selection page.
+
+#### Context optimization tools
+
+When you connect with the [`optimize_context`](#optimize-context) query parameter, the portal exposes additional tools for discovering and calling upstream tools:
+
+| Tool | Available in | Description |
+| --- | --- | --- |
+| `portal_query_tools` | `minimize_tools`, `search_and_execute` | Searches upstream tools by name, description, or schema using a regex pattern. Returns full tool definitions so the agent can call them. Required in `minimize_tools` mode because upstream tool schemas are stripped to reduce context size. |
+| `portal_execute` | `search_and_execute` | Calls an upstream tool by name with the provided arguments. In `search_and_execute` mode, upstream tools are hidden from the tool list entirely, so agents must use `portal_query_tools` to discover them and `portal_execute` to call them. |
+
+#### Code mode tools
+
+When you connect with [code mode](#code-mode) enabled, the portal replaces all upstream tools with two code execution tools:
+
+| Tool | Description |
+| --- | --- |
+| `portal_codemode_search` | Searches available tools by running JavaScript in a sandboxed Worker. The sandbox provides a `codemode.tools()` function that returns all upstream tool definitions with sanitized names. |
+| `portal_codemode_execute` | Calls upstream tools by running JavaScript in a sandboxed Worker. The sandbox provides a `codemode` proxy object where each property maps to an upstream tool. Supports `Promise.all()` for parallel tool calls. |
+
+Refer to the [code mode SDK reference](/agents/model-context-protocol/protocol/codemode/) for details on writing code for these tools.
+
 ## Manage portals via API
 
 In addition to the dashboard, you can manage MCP server portals programmatically using the Cloudflare API. The following examples show common operations.

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -278,9 +278,53 @@ If you change an alias while a user has an active session, the user must reauthe
 If the upstream server renames a tool or prompt, your alias for it will be removed on the next sync. Verify that your aliases still apply after each sync.
 :::
 
-### Tool namespacing
+### Tool and prompt namespacing
 
-All tools exposed through a portal are automatically namespaced with the server ID as a prefix. For example, a tool named `list_issues` on a server with ID `github` will appear as `github_list_issues` in the portal. This prevents name collisions when multiple MCP servers expose tools with the same name.
+All tools and prompts exposed through a portal are automatically namespaced with the server ID as a prefix. The format is `{server_id}_{original_name}`. For example, a tool named `list_issues` on a server with ID `github` appears as `github_list_issues` in the portal. This prevents name collisions when multiple MCP servers expose tools with the same name.
+
+Prompts follow the same pattern. A prompt named `summarize` on a server with ID `github` appears as `github_summarize`.
+
+#### How the server ID is determined
+
+The server ID used for namespacing comes from the **Server ID** field you set when [adding an MCP server](#add-an-mcp-server). You can enter a custom server ID in step 5 of the setup process, or let Cloudflare generate one automatically.
+
+Choose short, descriptive server IDs when you plan to expose the server through a portal. The server ID becomes part of every tool name that MCP clients and AI agents see.
+
+#### Parsing namespaced names
+
+The portal splits namespaced names on the **first** underscore only. Everything before the first underscore is the server ID, and everything after it is the tool or prompt name. This means tool names can contain underscores without ambiguity.
+
+| Namespaced name | Server ID | Tool name |
+| --- | --- | --- |
+| `github_list_issues` | `github` | `list_issues` |
+| `github_create_pull_request` | `github` | `create_pull_request` |
+| `sentry_get_issue_details` | `sentry` | `get_issue_details` |
+
+Because the split happens on the first underscore, server IDs themselves cannot contain underscores. Use hyphens instead when you need a multi-word server ID (for example, `my-server`).
+
+#### Namespacing with aliases
+
+If you [rename a tool with an alias](#rename-tools-and-prompts-with-aliases), the alias replaces the original tool name in the namespaced format. The server ID prefix still applies.
+
+For example, if you alias the tool `list_issues` to `issues` on a server with ID `github`, the namespaced name becomes `github_issues`.
+
+#### Namespacing in code mode
+
+When [code mode](#code-mode) is active, the portal applies an additional transformation to make namespaced tool names safe for use as JavaScript identifiers. Hyphens and dots in the namespaced name are replaced with underscores, names that start with a digit get a `_` prefix, and JavaScript reserved words get a `_` suffix. For example, a server with ID `my-server` and a tool named `get-data` would appear as `my_server_get_data` in the code mode sandbox.
+
+This sanitization happens automatically. You do not need to call any helper functions when using code mode as an end user.
+
+#### Helper functions in the Agents SDK
+
+If you are building an MCP client with the [Agents SDK](/agents/model-context-protocol/apis/client-api/), the SDK provides helper functions for working with server IDs and tool names:
+
+- **`normalizeServerId`** (exported from `agents/mcp/client`) normalizes a caller-supplied server ID into a safe string. For example, `"GitHub MCP!"` becomes `"github-mcp"`. The SDK calls this automatically when you pass an `id` option to `addMcpServer()`.
+
+- **`sanitizeToolName`** (exported from `@cloudflare/codemode`) converts a tool name into a valid JavaScript identifier by replacing hyphens and dots with underscores. This is called automatically in code mode contexts. Refer to the [code mode SDK reference](/agents/model-context-protocol/protocol/codemode/#sanitizetoolnamename) for details.
+
+:::note
+The Agents SDK uses a `tool_{server_id}_{tool_name}` format (with a `tool_` prefix) when returning tools from `getAITools()`. This differs from the portal format, which uses `{server_id}_{tool_name}` without the prefix.
+:::
 
 ## Manage portals via API
 


### PR DESCRIPTION
Expands the brief 3-line tool namespacing section in the MCP server portals docs into a full subsection covering:

- How the server ID prefix is determined (custom vs auto-generated)
- Parsing behavior (first-underscore split, underscore restriction on server IDs)
- How aliases interact with namespaced names
- Code mode sanitization (hyphens/dots to underscores, digit prefix, reserved word suffix)
- Helper functions in the Agents SDK (normalizeServerId, sanitizeToolName)
- Difference between portal naming format and Agents SDK getAITools() format