### PR TITLE
fix: reset FlueRegistry DO and clean up migration history

### DIFF
--- a/.flue/bin/sync-agents.ts
+++ b/.flue/bin/sync-agents.ts
@@ -40,51 +40,9 @@ const localFlag = isLocal
 	? "--local --persist-to .flue/.wrangler/state"
 	: "--remote";
 
-// Stale R2 keys to delete — files that have been removed from the repo
-// but may still exist in R2 from previous syncs.
-const staleKeys = [
-	// Old flat style-guide reference files replaced by always/+conditional/+components/ structure
-	".agents/reference/style-guide/code-blocks.md",
-	".agents/reference/style-guide/components.md",
-	".agents/reference/style-guide/formatting.md",
-	".agents/reference/style-guide/headings.md",
-	".agents/reference/style-guide/links.md",
-	".agents/reference/style-guide/mdx-syntax.md",
-	".agents/reference/style-guide/terminology.md",
-	".agents/reference/style-guide/writing.md",
-	// Component reference files removed — import-only rules are handled by CI build
-	".agents/reference/style-guide/components/available-notifications.md",
-	".agents/reference/style-guide/components/badge.md",
-	".agents/reference/style-guide/components/card-grid.md",
-	".agents/reference/style-guide/components/card.md",
-	".agents/reference/style-guide/components/description.md",
-	".agents/reference/style-guide/components/directory-listing.md",
-	".agents/reference/style-guide/components/external-resources.md",
-	".agents/reference/style-guide/components/feature-table.md",
-	".agents/reference/style-guide/components/feature.md",
-	".agents/reference/style-guide/components/glossary-definition.md",
-	".agents/reference/style-guide/components/glossary-tooltip.md",
-	".agents/reference/style-guide/components/glossary.md",
-	".agents/reference/style-guide/components/inline-badge.md",
-	".agents/reference/style-guide/components/link-button.md",
-	".agents/reference/style-guide/components/link-card.md",
-	".agents/reference/style-guide/components/link-title-card.md",
-	".agents/reference/style-guide/components/list-card.md",
-	".agents/reference/style-guide/components/list-tutorials.md",
-	".agents/reference/style-guide/components/pages-build-preset.md",
-	".agents/reference/style-guide/components/plan.md",
-	".agents/reference/style-guide/components/product-availability-text.md",
-	".agents/reference/style-guide/components/product-changelog.md",
-	".agents/reference/style-guide/components/product-features.md",
-	".agents/reference/style-guide/components/public-stats.md",
-	".agents/reference/style-guide/components/related-product.md",
-	".agents/reference/style-guide/components/resources-by-selector.md",
-	".agents/reference/style-guide/components/rule-id.md",
-	".agents/reference/style-guide/components/tab-item.md",
-	".agents/reference/style-guide/components/width.md",
-	".agents/reference/style-guide/components/wrangler-namespace.md",
-	".agents/reference/style-guide/components/youtube.md",
-];
+// Stale R2 keys to delete — add entries here when files are removed from
+// .flue/.agents/ so they get cleaned up from the bucket on next sync.
+const staleKeys: string[] = [];
 
 for (const key of staleKeys) {
 	const r2Key = `${bucket}/${key}`;

--- a/.flue/wrangler.jsonc
+++ b/.flue/wrangler.jsonc
@@ -58,6 +58,13 @@
 				"StyleGuideReview",
 			],
 		},
+		// FlueRegistry schema changed in 0.9.1 (added owner_kind column).
+		// Delete the old instance so 0.9.1 recreates tables on first request.
+		{
+			"tag": "flue-reset-registry-schema",
+			"deleted_classes": ["FlueRegistry"],
+			"new_sqlite_classes": ["FlueRegistry"],
+		},
 	],
 	"observability": {
 		"enabled": true,

--- a/.flue/wrangler.jsonc
+++ b/.flue/wrangler.jsonc
@@ -14,56 +14,15 @@
 		},
 	],
 	"migrations": [
-		// Previous agent class migrations — kept for deployed history, classes are removed.
 		{
-			"tag": "flue-class-CodeReviewOrchestrator",
-			"new_sqlite_classes": ["CodeReviewOrchestrator"],
-		},
-		{
-			"tag": "flue-class-FlueRegistry",
-			"new_sqlite_classes": ["FlueRegistry"],
-		},
-		{ "tag": "flue-class-Orchestrate", "new_sqlite_classes": ["Orchestrate"] },
-		{
-			"tag": "flue-class-SpamAndOffTopicFilter",
-			"new_sqlite_classes": ["SpamAndOffTopicFilter"],
-		},
-		{
-			"tag": "flue-class-StyleGuideReview",
-			"new_sqlite_classes": ["StyleGuideReview"],
-		},
-		// New workflow classes added in 0.9.1 upgrade.
-		{
-			"tag": "flue-class-OrchestrateWorkflow",
-			"new_sqlite_classes": ["OrchestrateWorkflow"],
-		},
-		{
-			"tag": "flue-class-CodeReviewOrchestratorWorkflow",
-			"new_sqlite_classes": ["CodeReviewOrchestratorWorkflow"],
-		},
-		{
-			"tag": "flue-class-SpamAndOffTopicFilterWorkflow",
-			"new_sqlite_classes": ["SpamAndOffTopicFilterWorkflow"],
-		},
-		{
-			"tag": "flue-class-StyleGuideReviewWorkflow",
-			"new_sqlite_classes": ["StyleGuideReviewWorkflow"],
-		},
-		{
-			"tag": "flue-delete-old-agent-classes",
-			"deleted_classes": [
-				"CodeReviewOrchestrator",
-				"Orchestrate",
-				"SpamAndOffTopicFilter",
-				"StyleGuideReview",
+			"tag": "v1",
+			"new_sqlite_classes": [
+				"FlueRegistry",
+				"OrchestrateWorkflow",
+				"CodeReviewOrchestratorWorkflow",
+				"SpamAndOffTopicFilterWorkflow",
+				"StyleGuideReviewWorkflow",
 			],
-		},
-		// FlueRegistry schema changed in 0.9.1 (added owner_kind column).
-		// Delete the old instance so 0.9.1 recreates tables on first request.
-		{
-			"tag": "flue-reset-registry-schema",
-			"deleted_classes": ["FlueRegistry"],
-			"new_sqlite_classes": ["FlueRegistry"],
 		},
 	],
 	"observability": {


### PR DESCRIPTION
### Summary

Fixes a prod error caused by the `FlueRegistry` Durable Object having a stale SQLite schema from the 0.7.x era, which was missing the `owner_kind` column added in 0.9.1.

The error manifested as:

```
no such column: owner_kind at offset 85: SQLITE_ERROR
  at ensureRegistryTables
  at new FlueRegistry
```

**Resolution:** Deleted the Worker and all DO namespaces from the Cloudflare dashboard to fully reset migration state, then redeployed with a clean `v1` migration that initializes all five classes fresh (`FlueRegistry` + the four workflow DOs). The 0.9.1 runtime creates the correct schema on first request.

Also cleaned up:
- Condensed the long migration history (old 0.7.x agent classes, intermediate tags, failed reset attempts) down to a single `v1` tag
- Cleared the `staleKeys` list in `sync-agents.ts` — those R2 keys were already deleted in previous syncs; the infrastructure to add future entries remains
