### PR TITLE
[AI Gateway] Add Beta badge to Spend Limits

### DIFF
--- a/src/content/docs/ai-gateway/features/index.mdx
+++ b/src/content/docs/ai-gateway/features/index.mdx
@@ -30,7 +30,7 @@ Serve identical requests directly from Cloudflare's global cache, reducing laten
 
 </Feature>
 
-<Feature header="Spend Limits" href="/ai-gateway/features/spend-limits/" badge="Beta">
+<Feature header="Spend Limits" href="/ai-gateway/features/spend-limits/">
 
 Set cost-based budgets that track cumulative dollar spend across requests. Scope limits by model, provider, or custom metadata dimensions like user, team, or application.
 
@@ -187,13 +187,13 @@ Override default pricing with your negotiated rates or custom cost models. Apply
 
 ## Feature Comparison by Use Case
 
-| Use Case                   | Recommended Features                               |
-| -------------------------- | -------------------------------------------------- |
+| Use Case                   | Recommended Features                            |
+| -------------------------- | ----------------------------------------------- |
 | **Cost Optimization**      | Caching, Spend Limits, Rate Limiting, Custom Costs |
-| **High Availability**      | Fallbacks using Dynamic Routing                    |
-| **Security & Compliance**  | Guardrails, DLP, Authentication, BYOK, Logging     |
-| **Performance Monitoring** | Analytics, Logging, Custom Metadata                |
-| **A/B Testing**            | Dynamic Routing, Custom Metadata, Analytics        |
+| **High Availability**      | Fallbacks using Dynamic Routing                 |
+| **Security & Compliance**  | Guardrails, DLP, Authentication, BYOK, Logging  |
+| **Performance Monitoring** | Analytics, Logging, Custom Metadata             |
+| **A/B Testing**            | Dynamic Routing, Custom Metadata, Analytics     |
 
 ## Getting Started with Features
 

--- a/src/content/docs/ai-gateway/features/index.mdx
+++ b/src/content/docs/ai-gateway/features/index.mdx
@@ -30,7 +30,7 @@ Serve identical requests directly from Cloudflare's global cache, reducing laten
 
 </Feature>
 
-<Feature header="Spend Limits" href="/ai-gateway/features/spend-limits/">
+<Feature header="Spend Limits" href="/ai-gateway/features/spend-limits/" badge="Beta">
 
 Set cost-based budgets that track cumulative dollar spend across requests. Scope limits by model, provider, or custom metadata dimensions like user, team, or application.
 
@@ -187,13 +187,13 @@ Override default pricing with your negotiated rates or custom cost models. Apply
 
 ## Feature Comparison by Use Case
 
-| Use Case                   | Recommended Features                            |
-| -------------------------- | ----------------------------------------------- |
+| Use Case                   | Recommended Features                               |
+| -------------------------- | -------------------------------------------------- |
 | **Cost Optimization**      | Caching, Spend Limits, Rate Limiting, Custom Costs |
-| **High Availability**      | Fallbacks using Dynamic Routing                 |
-| **Security & Compliance**  | Guardrails, DLP, Authentication, BYOK, Logging  |
-| **Performance Monitoring** | Analytics, Logging, Custom Metadata             |
-| **A/B Testing**            | Dynamic Routing, Custom Metadata, Analytics     |
+| **High Availability**      | Fallbacks using Dynamic Routing                    |
+| **Security & Compliance**  | Guardrails, DLP, Authentication, BYOK, Logging     |
+| **Performance Monitoring** | Analytics, Logging, Custom Metadata                |
+| **A/B Testing**            | Dynamic Routing, Custom Metadata, Analytics        |
 
 ## Getting Started with Features
 

--- a/src/content/docs/ai-gateway/features/spend-limits.mdx
+++ b/src/content/docs/ai-gateway/features/spend-limits.mdx
@@ -4,6 +4,8 @@ title: Spend limits
 description: Set cost-based budgets on your AI Gateway to control spending by model, provider, or custom metadata dimensions like user or team.
 sidebar:
   order: 3
+  group:
+    badge: Beta
 products:
   - ai-gateway
 ---
@@ -32,9 +34,9 @@ Spend limits are eventually consistent. The current request's cost is recorded a
 
 Each rule can be scoped by model, provider, or custom metadata dimensions. Each dimension can be configured in one of two modes:
 
-| Mode | Behavior | Example |
-| --- | --- | --- |
-| **Split by value** | Each distinct value gets its own independent budget bucket. | Splitting by `metadata.user_id` gives every user their own budget. |
+| Mode                | Behavior                                                          | Example                                                                                    |
+| ------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **Split by value**  | Each distinct value gets its own independent budget bucket.       | Splitting by `metadata.user_id` gives every user their own budget.                         |
 | **Filter by value** | The rule applies only when the dimension equals a specific value. | Filtering `metadata.team` to `engineering` limits only requests from the engineering team. |
 
 If a dimension is not configured on a rule, all values share one budget bucket. For example, a rule without a `provider` dimension tracks spend across all providers together.
@@ -43,13 +45,13 @@ If a dimension is not configured on a rule, all values share one budget bucket. 
 
 Given a request with `model=openai/gpt-5.5` and `metadata.user_id=u_42`:
 
-| Scenario | Dimensions | Budget bucket |
-| --- | --- | --- |
-| Global budget for everyone | None | One shared bucket |
-| Per-user budget | `metadata.user_id`: split by value | Separate bucket per user |
-| Per-provider, per-user | `metadata.user_id`: split by value, `provider`: split by value | Separate bucket per user+provider combination |
-| Specific model only | `model`: filter by value `openai/gpt-5.5` | Only applies to `openai/gpt-5.5` requests |
-| Per-user, per-model | `metadata.user_id`: split by value, `model`: split by value | Separate bucket per user+model combination |
+| Scenario                   | Dimensions                                                     | Budget bucket                                 |
+| -------------------------- | -------------------------------------------------------------- | --------------------------------------------- |
+| Global budget for everyone | None                                                           | One shared bucket                             |
+| Per-user budget            | `metadata.user_id`: split by value                             | Separate bucket per user                      |
+| Per-provider, per-user     | `metadata.user_id`: split by value, `provider`: split by value | Separate bucket per user+provider combination |
+| Specific model only        | `model`: filter by value `openai/gpt-5.5`                      | Only applies to `openai/gpt-5.5` requests     |
+| Per-user, per-model        | `metadata.user_id`: split by value, `model`: split by value    | Separate bucket per user+model combination    |
 
 ## Configure spend limits
 

--- a/src/content/docs/ai-gateway/features/spend-limits.mdx
+++ b/src/content/docs/ai-gateway/features/spend-limits.mdx
@@ -4,8 +4,7 @@ title: Spend limits
 description: Set cost-based budgets on your AI Gateway to control spending by model, provider, or custom metadata dimensions like user or team.
 sidebar:
   order: 3
-  group:
-    badge: Beta
+  badge: Beta
 products:
   - ai-gateway
 ---


### PR DESCRIPTION
### Summary

Marks Spend Limits as Beta in the AI Gateway docs to match its current product status. Adds the `badge="Beta"` prop on the Spend Limits Feature card in the features overview, and adds a `Beta` sidebar badge on the Spend Limits page itself — matching the pattern used by Dynamic Routing, Guardrails, DLP, and Unified Billing.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
