### PR TITLE
feat: add Dependabot review workflow to docs bot

### DIFF
--- a/.flue/.agents/skills/dependabot-review/SKILL.md
+++ b/.flue/.agents/skills/dependabot-review/SKILL.md
@@ -46,6 +46,7 @@ If a package has no changelog in the PR body, call `get_npm_package_info` to che
 For each package, use `search_repo` and `read_repo_file` to understand usage. **Do not skip this step.**
 
 Key files to check:
+
 - `package.json` — is it a direct dependency?
 - `pnpm-lock.yaml` — who pulls it in if transitive?
 - `src/`, `worker/`, `bin/` — direct imports and callsites
@@ -53,6 +54,7 @@ Key files to check:
 Use `search_repo` with the package name to find import sites. Then inspect found files to understand which APIs are called.
 
 Map files to dependency type:
+
 - `src/content/docs/**/*.{ts,tsx,astro,mdx}` — content/rendering (high impact if broken)
 - `src/components/**`, `src/plugins/**`, `src/util/**` — build/render tooling
 - `worker/**` — Worker runtime (medium impact)
@@ -60,13 +62,13 @@ Map files to dependency type:
 
 ### 4. Rate impact for each package
 
-| Rating | Meaning |
-|--------|---------|
-| **None** | Transitive only; or only internal/type changes; not used by this repo |
-| **Very Low** | Direct dep but changed APIs not called in this repo |
-| **Low** | Changed APIs called only in build/test tooling, not content rendering or Worker |
-| **Medium** | Changed APIs affect Astro components, MDX processing, or Worker behavior |
-| **High** | Changed APIs affect output seen by visitors — rendered HTML, search, routing, Worker responses |
+| Rating       | Meaning                                                                                        |
+| ------------ | ---------------------------------------------------------------------------------------------- |
+| **None**     | Transitive only; or only internal/type changes; not used by this repo                          |
+| **Very Low** | Direct dep but changed APIs not called in this repo                                            |
+| **Low**      | Changed APIs called only in build/test tooling, not content rendering or Worker                |
+| **Medium**   | Changed APIs affect Astro components, MDX processing, or Worker behavior                       |
+| **High**     | Changed APIs affect output seen by visitors — rendered HTML, search, routing, Worker responses |
 
 For security fixes: note what the vulnerability affects and whether usage is in the vulnerable code path.
 
@@ -81,13 +83,16 @@ Produce a Markdown block for each package. All packages must be covered.
 **Dependency type:** [direct | transitive (via <package>)]
 
 ### What changed
+
 - <specific API/behavior change>
 - ...
 
 ### Usage in this repo
+
 <"Not used directly — transitive only" OR specific import sites and callsites>
 
 ### Impact: <None | Very Low | Low | Medium | High>
+
 <1–2 sentence explanation>
 ```
 
@@ -97,14 +102,15 @@ End with a summary table and one overall recommendation:
 ## Summary
 
 | Package | Impact | Recommendation |
-|---------|--------|----------------|
-| `pkg` | Low | ✅ Merge |
-| `pkg` | High | ⚠️ Verify |
+| ------- | ------ | -------------- |
+| `pkg`   | Low    | ✅ Merge       |
+| `pkg`   | High   | ⚠️ Verify      |
 
 **Overall:** [✅ Merge | ✅ Merge + spot-check listed pages | ⚠️ Investigate before merging]
 ```
 
 Recommendation values:
+
 - **✅ Merge** — no action needed
 - **✅ Merge + spot-check** — merge, then manually verify the listed pages/areas
 - **⚠️ Investigate** — high-impact change, needs manual testing before merging

--- a/.flue/.agents/skills/dependabot-review/SKILL.md
+++ b/.flue/.agents/skills/dependabot-review/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: dependabot-review
+description: Reviews a Dependabot PR for the cloudflare/cloudflare-docs repo. Analyzes every bumped package — what changed upstream, how this repo uses it, and whether the bump requires action beyond merging.
+---
+
+You are reviewing a Dependabot PR for the `cloudflare/cloudflare-docs` repository. You are running as a Cloudflare Worker with no shell access. Use only the provided tools.
+
+## Goal
+
+Give the reviewer a clear answer for **every** bumped package: does this version bump require any action beyond merging?
+
+## Tools available
+
+- `get_pr_context` — PR title, body, author, base/head refs.
+- `get_pr_files` — changed files and patches in the PR.
+- `read_repo_file` — read any file from the repo via GitHub API.
+- `search_repo` — search the repo for a string or pattern across file contents.
+- `get_npm_package_info` — fetch npm registry metadata for a package.
+
+## Process
+
+### 1. Identify the packages being bumped
+
+Use `args.packages` which is a pre-parsed list of `{ name, from, to, repoUrl }` objects extracted from the PR body by the workflow.
+
+If `args.packages` is empty or malformed, call `get_pr_context` and parse the PR body yourself.
+
+### 2. For each package, extract what changed
+
+The PR body already contains Dependabot-generated release notes, changelogs, and commits for each package. Use `args.prBody` as the primary source.
+
+From the PR body, identify:
+
+- **Breaking changes** — removed or renamed exports, changed function signatures, dropped Node/browser support
+- **Behavior changes** — anything that alters output, side effects, or defaults
+- **New APIs** — new exports, methods, or options
+- **Bug fixes** — especially if they fix incorrect output this repo depends on
+- **Security fixes** — note the CVE/GHSA ID and what it affects
+
+Ignore: internal refactors, CI changes, test changes, type-only changes that don't affect emitted JS.
+
+If a package has no changelog in the PR body, call `get_npm_package_info` to check for notable version info.
+
+### 3. Determine how this repo uses each package
+
+For each package, use `search_repo` and `read_repo_file` to understand usage. **Do not skip this step.**
+
+Key files to check:
+- `package.json` — is it a direct dependency?
+- `pnpm-lock.yaml` — who pulls it in if transitive?
+- `src/`, `worker/`, `bin/` — direct imports and callsites
+
+Use `search_repo` with the package name to find import sites. Then inspect found files to understand which APIs are called.
+
+Map files to dependency type:
+- `src/content/docs/**/*.{ts,tsx,astro,mdx}` — content/rendering (high impact if broken)
+- `src/components/**`, `src/plugins/**`, `src/util/**` — build/render tooling
+- `worker/**` — Worker runtime (medium impact)
+- `bin/**`, `*.config.{ts,mjs}`, `vitest.config.ts` — build/test tooling (lower impact)
+
+### 4. Rate impact for each package
+
+| Rating | Meaning |
+|--------|---------|
+| **None** | Transitive only; or only internal/type changes; not used by this repo |
+| **Very Low** | Direct dep but changed APIs not called in this repo |
+| **Low** | Changed APIs called only in build/test tooling, not content rendering or Worker |
+| **Medium** | Changed APIs affect Astro components, MDX processing, or Worker behavior |
+| **High** | Changed APIs affect output seen by visitors — rendered HTML, search, routing, Worker responses |
+
+For security fixes: note what the vulnerability affects and whether usage is in the vulnerable code path.
+
+### 5. Output format
+
+Produce a Markdown block for each package. All packages must be covered.
+
+```markdown
+## `<package-name>`: <old> → <new>
+
+**Type:** [security fix | bug fix | feature | breaking change | dependency bump]
+**Dependency type:** [direct | transitive (via <package>)]
+
+### What changed
+- <specific API/behavior change>
+- ...
+
+### Usage in this repo
+<"Not used directly — transitive only" OR specific import sites and callsites>
+
+### Impact: <None | Very Low | Low | Medium | High>
+<1–2 sentence explanation>
+```
+
+End with a summary table and one overall recommendation:
+
+```markdown
+## Summary
+
+| Package | Impact | Recommendation |
+|---------|--------|----------------|
+| `pkg` | Low | ✅ Merge |
+| `pkg` | High | ⚠️ Verify |
+
+**Overall:** [✅ Merge | ✅ Merge + spot-check listed pages | ⚠️ Investigate before merging]
+```
+
+Recommendation values:
+- **✅ Merge** — no action needed
+- **✅ Merge + spot-check** — merge, then manually verify the listed pages/areas
+- **⚠️ Investigate** — high-impact change, needs manual testing before merging

--- a/.flue/bin/sync-agents.ts
+++ b/.flue/bin/sync-agents.ts
@@ -40,51 +40,9 @@ const localFlag = isLocal
 	? "--local --persist-to .flue/.wrangler/state"
 	: "--remote";
 
-// Stale R2 keys to delete — files that have been removed from the repo
-// but may still exist in R2 from previous syncs.
-const staleKeys = [
-	// Old flat style-guide reference files replaced by always/+conditional/+components/ structure
-	".agents/reference/style-guide/code-blocks.md",
-	".agents/reference/style-guide/components.md",
-	".agents/reference/style-guide/formatting.md",
-	".agents/reference/style-guide/headings.md",
-	".agents/reference/style-guide/links.md",
-	".agents/reference/style-guide/mdx-syntax.md",
-	".agents/reference/style-guide/terminology.md",
-	".agents/reference/style-guide/writing.md",
-	// Component reference files removed — import-only rules are handled by CI build
-	".agents/reference/style-guide/components/available-notifications.md",
-	".agents/reference/style-guide/components/badge.md",
-	".agents/reference/style-guide/components/card-grid.md",
-	".agents/reference/style-guide/components/card.md",
-	".agents/reference/style-guide/components/description.md",
-	".agents/reference/style-guide/components/directory-listing.md",
-	".agents/reference/style-guide/components/external-resources.md",
-	".agents/reference/style-guide/components/feature-table.md",
-	".agents/reference/style-guide/components/feature.md",
-	".agents/reference/style-guide/components/glossary-definition.md",
-	".agents/reference/style-guide/components/glossary-tooltip.md",
-	".agents/reference/style-guide/components/glossary.md",
-	".agents/reference/style-guide/components/inline-badge.md",
-	".agents/reference/style-guide/components/link-button.md",
-	".agents/reference/style-guide/components/link-card.md",
-	".agents/reference/style-guide/components/link-title-card.md",
-	".agents/reference/style-guide/components/list-card.md",
-	".agents/reference/style-guide/components/list-tutorials.md",
-	".agents/reference/style-guide/components/pages-build-preset.md",
-	".agents/reference/style-guide/components/plan.md",
-	".agents/reference/style-guide/components/product-availability-text.md",
-	".agents/reference/style-guide/components/product-changelog.md",
-	".agents/reference/style-guide/components/product-features.md",
-	".agents/reference/style-guide/components/public-stats.md",
-	".agents/reference/style-guide/components/related-product.md",
-	".agents/reference/style-guide/components/resources-by-selector.md",
-	".agents/reference/style-guide/components/rule-id.md",
-	".agents/reference/style-guide/components/tab-item.md",
-	".agents/reference/style-guide/components/width.md",
-	".agents/reference/style-guide/components/wrangler-namespace.md",
-	".agents/reference/style-guide/components/youtube.md",
-];
+// Stale R2 keys to delete — add entries here when files are removed from
+// .flue/.agents/ so they get cleaned up from the bucket on next sync.
+const staleKeys: string[] = [];
 
 for (const key of staleKeys) {
 	const r2Key = `${bucket}/${key}`;

--- a/.flue/lib/github-repo-tools.ts
+++ b/.flue/lib/github-repo-tools.ts
@@ -1,0 +1,342 @@
+/**
+ * GitHub API-backed Flue tools for the Dependabot review agent.
+ *
+ * These tools expose repo access to the model as structured tool calls,
+ * using a GitHub App installation token from trusted workflow code.
+ * The token never crosses into the agent sandbox — only results do.
+ */
+import { Type, type ToolDefinition } from "@flue/runtime";
+
+const REPO = "cloudflare/cloudflare-docs";
+const DEFAULT_REF = "production";
+
+function apiHeaders(token: string): Record<string, string> {
+	return {
+		Authorization: `Bearer ${token}`,
+		Accept: "application/vnd.github+json",
+		"X-GitHub-Api-Version": "2022-11-28",
+		"User-Agent": "cloudflare-docs-agents",
+	};
+}
+
+// ── Tool: get_pr_context ──────────────────────────────────────────────────────
+
+export function makeGetPrContextTool(
+	token: string,
+	prNumber: number,
+): ToolDefinition {
+	return {
+		name: "get_pr_context",
+		description:
+			"Fetch the Dependabot PR metadata: title, body, author, base/head refs.",
+		parameters: Type.Object({}),
+		async execute() {
+			const res = await fetch(
+				`https://api.github.com/repos/${REPO}/pulls/${prNumber}`,
+				{ headers: apiHeaders(token) },
+			);
+			if (!res.ok)
+				throw new Error(
+					`get_pr_context failed: ${res.status} ${await res.text()}`,
+				);
+			const pr = (await res.json()) as Record<string, unknown>;
+			return JSON.stringify({
+				number: pr.number,
+				title: pr.title,
+				body: pr.body,
+				author: (pr.user as Record<string, unknown>)?.login,
+				base: (pr.base as Record<string, unknown>)?.ref,
+				head: (pr.head as Record<string, unknown>)?.ref,
+				headSha: (pr.head as Record<string, unknown>)?.sha,
+			});
+		},
+	};
+}
+
+// ── Tool: get_pr_files ────────────────────────────────────────────────────────
+
+export function makeGetPrFilesTool(
+	token: string,
+	prNumber: number,
+): ToolDefinition {
+	return {
+		name: "get_pr_files",
+		description:
+			"Fetch the list of files changed in the Dependabot PR, including patches.",
+		parameters: Type.Object({}),
+		async execute() {
+			const res = await fetch(
+				`https://api.github.com/repos/${REPO}/pulls/${prNumber}/files?per_page=100`,
+				{ headers: apiHeaders(token) },
+			);
+			if (!res.ok)
+				throw new Error(
+					`get_pr_files failed: ${res.status} ${await res.text()}`,
+				);
+			const files = (await res.json()) as Array<Record<string, unknown>>;
+			return JSON.stringify(
+				files.map((f) => ({
+					filename: f.filename,
+					status: f.status,
+					additions: f.additions,
+					deletions: f.deletions,
+					patch: f.patch,
+				})),
+			);
+		},
+	};
+}
+
+// ── Tool: read_repo_file ──────────────────────────────────────────────────────
+
+export function makeReadRepoFileTool(token: string): ToolDefinition {
+	return {
+		name: "read_repo_file",
+		description: `Read any text file from the cloudflare/cloudflare-docs repo. Use for package.json, tsconfig, source files, etc. The default ref is "${DEFAULT_REF}".`,
+		parameters: Type.Object({
+			path: Type.String({
+				description:
+					"File path relative to repo root, e.g. 'package.json' or 'src/util/algolia.ts'",
+			}),
+			ref: Type.Optional(
+				Type.String({ description: `Git ref. Defaults to "${DEFAULT_REF}".` }),
+			),
+		}),
+		async execute({ path, ref = DEFAULT_REF }: { path: string; ref?: string }) {
+			const res = await fetch(
+				`https://api.github.com/repos/${REPO}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+				{ headers: apiHeaders(token) },
+			);
+			if (res.status === 404) return `File not found: ${path}`;
+			if (!res.ok)
+				throw new Error(
+					`read_repo_file failed for ${path}: ${res.status} ${await res.text()}`,
+				);
+			const data = (await res.json()) as Record<string, unknown>;
+			if (data.encoding === "base64" && typeof data.content === "string") {
+				const text = atob((data.content as string).replace(/\n/g, ""));
+				// Cap at 32 KB to avoid bloating context
+				if (text.length > 32768) {
+					return (
+						text.slice(0, 32768) +
+						`\n\n[...truncated at 32 KB — file is ${text.length} bytes total]`
+					);
+				}
+				return text;
+			}
+			return JSON.stringify(data);
+		},
+	};
+}
+
+// ── Tool: search_repo ─────────────────────────────────────────────────────────
+//
+// Uses the GitHub code search API. Falls back to recursive tree scan + content
+// fetch for queries that GitHub search doesn't index well (e.g. lock file
+// package names).
+
+export function makeSearchRepoTool(token: string): ToolDefinition {
+	return {
+		name: "search_repo",
+		description: `Search the cloudflare/cloudflare-docs repo for a string or pattern. Returns matching file paths and line snippets. Use to find import sites, usages, and configuration for a package. Limited to 20 results.`,
+		parameters: Type.Object({
+			query: Type.String({
+				description:
+					"Search term, e.g. a package name, import path, or function name.",
+			}),
+			path: Type.Optional(
+				Type.String({
+					description:
+						"Restrict search to this path prefix, e.g. 'src/' or 'worker/'.",
+				}),
+			),
+		}),
+		async execute({ query, path }: { query: string; path?: string }) {
+			const q = `${query} repo:${REPO}${path ? ` path:${path}` : ""}`;
+			const res = await fetch(
+				`https://api.github.com/search/code?q=${encodeURIComponent(q)}&per_page=20`,
+				{
+					headers: {
+						...apiHeaders(token),
+						Accept: "application/vnd.github.text-match+json",
+					},
+				},
+			);
+			if (!res.ok) {
+				// Code search can 403/422 on some queries — return a descriptive message
+				return `search_repo: GitHub code search returned ${res.status}. Try read_repo_file on specific paths instead.`;
+			}
+			const data = (await res.json()) as {
+				total_count: number;
+				items: Array<{
+					path: string;
+					name: string;
+					text_matches?: Array<{ fragment: string }>;
+				}>;
+			};
+			if (data.total_count === 0) return "No results found.";
+			return JSON.stringify({
+				total: data.total_count,
+				shown: data.items.length,
+				results: data.items.map((item) => ({
+					path: item.path,
+					snippets: (item.text_matches ?? [])
+						.slice(0, 3)
+						.map((m) => m.fragment),
+				})),
+			});
+		},
+	};
+}
+
+// ── Tool: get_npm_package_info ────────────────────────────────────────────────
+
+export function makeGetNpmPackageInfoTool(): ToolDefinition {
+	return {
+		name: "get_npm_package_info",
+		description:
+			"Fetch npm registry metadata for a package version — description, homepage, repository, keywords, and any dist-tags. Useful when the PR body lacks release notes.",
+		parameters: Type.Object({
+			packageName: Type.String({
+				description: "npm package name, e.g. 'astro' or '@astrojs/react'",
+			}),
+			version: Type.Optional(
+				Type.String({
+					description:
+						"Specific version to fetch. Omit to get latest dist-tag info.",
+				}),
+			),
+		}),
+		async execute({
+			packageName,
+			version,
+		}: {
+			packageName: string;
+			version?: string;
+		}) {
+			const encoded = encodeURIComponent(packageName);
+			const url = version
+				? `https://registry.npmjs.org/${encoded}/${encodeURIComponent(version)}`
+				: `https://registry.npmjs.org/${encoded}`;
+			const res = await fetch(url, {
+				headers: { Accept: "application/json" },
+			});
+			if (!res.ok)
+				return `npm registry returned ${res.status} for ${packageName}`;
+			const data = (await res.json()) as Record<string, unknown>;
+			// Return only useful fields to avoid context bloat
+			return JSON.stringify({
+				name: data.name,
+				version: data.version,
+				description: data.description,
+				homepage: data.homepage,
+				repository: data.repository,
+				keywords: data.keywords,
+				"dist-tags": version ? undefined : data["dist-tags"],
+			});
+		},
+	};
+}
+
+// ── Tool: trace_dependency ────────────────────────────────────────────────────
+//
+// Reads package.json and the top of pnpm-lock.yaml to determine whether a
+// package is a direct or transitive dependency, and which direct dep pulls it
+// in if transitive. More reliable than code-searching the lockfile.
+
+export function makeTraceDependencyTool(token: string): ToolDefinition {
+	return {
+		name: "trace_dependency",
+		description:
+			"Determine whether a package is a direct or transitive dependency of this repo by reading package.json and pnpm-lock.yaml from the production branch.",
+		parameters: Type.Object({
+			packageName: Type.String({
+				description:
+					"npm package name, e.g. 'algoliasearch' or '@astrojs/react'",
+			}),
+		}),
+		async execute({ packageName }: { packageName: string }) {
+			// 1. Check package.json for direct dep
+			const pkgRes = await fetch(
+				`https://api.github.com/repos/${REPO}/contents/package.json?ref=${DEFAULT_REF}`,
+				{ headers: apiHeaders(token) },
+			);
+			let directDep = false;
+			let depType: "dependencies" | "devDependencies" | null = null;
+			if (pkgRes.ok) {
+				const pkgData = (await pkgRes.json()) as Record<string, unknown>;
+				if (
+					pkgData.encoding === "base64" &&
+					typeof pkgData.content === "string"
+				) {
+					const pkgJson = JSON.parse(
+						atob((pkgData.content as string).replace(/\n/g, "")),
+					) as Record<string, Record<string, string>>;
+					if (pkgJson.dependencies?.[packageName]) {
+						directDep = true;
+						depType = "dependencies";
+					} else if (pkgJson.devDependencies?.[packageName]) {
+						directDep = true;
+						depType = "devDependencies";
+					}
+				}
+			}
+
+			if (directDep) {
+				return JSON.stringify({
+					direct: true,
+					type: depType,
+					note: `${packageName} is a direct ${depType} of this repo.`,
+				});
+			}
+
+			// 2. Check pnpm-lock.yaml importers section for transitive resolution
+			// The lock file is large; fetch only enough to check the importers block.
+			// We use the raw API to avoid base64 size limits.
+			const lockRes = await fetch(
+				`https://raw.githubusercontent.com/${REPO}/${DEFAULT_REF}/pnpm-lock.yaml`,
+				{ headers: { Authorization: `Bearer ${token}` } },
+			);
+			if (!lockRes.ok) {
+				return JSON.stringify({
+					direct: false,
+					transitive: true,
+					note: "Could not read pnpm-lock.yaml to trace transitive dep.",
+				});
+			}
+			// Read enough of the lockfile to find the package in snapshots
+			const lockText = await lockRes.text();
+			const escapedName = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+			// Check if it appears in the snapshots section (transitive)
+			const inSnapshots = new RegExp(`^\\s+${escapedName}@`, "m").test(
+				lockText,
+			);
+
+			// Find which direct deps pull it in by searching snapshot dependencies
+			// This is a heuristic: look for the package name near other known deps
+			return JSON.stringify({
+				direct: false,
+				transitive: inSnapshots,
+				note: inSnapshots
+					? `${packageName} appears to be a transitive dependency. Use read_repo_file to inspect specific snapshot entries in pnpm-lock.yaml for the full dependency chain.`
+					: `${packageName} was not found in pnpm-lock.yaml — it may not be installed at all.`,
+			});
+		},
+	};
+}
+
+// ── Factory: all tools ────────────────────────────────────────────────────────
+
+export function makeDependabotReviewTools(
+	token: string,
+	prNumber: number,
+): ToolDefinition[] {
+	return [
+		makeGetPrContextTool(token, prNumber),
+		makeGetPrFilesTool(token, prNumber),
+		makeReadRepoFileTool(token),
+		makeSearchRepoTool(token),
+		makeTraceDependencyTool(token),
+		makeGetNpmPackageInfoTool(),
+	];
+}

--- a/.flue/lib/github-repo-tools.ts
+++ b/.flue/lib/github-repo-tools.ts
@@ -131,14 +131,13 @@ export function makeReadRepoFileTool(token: string): ToolDefinition {
 
 // ── Tool: search_repo ─────────────────────────────────────────────────────────
 //
-// Uses the GitHub code search API. Falls back to recursive tree scan + content
-// fetch for queries that GitHub search doesn't index well (e.g. lock file
-// package names).
+// Uses the GitHub code search API. If search returns no results or errors,
+// use read_repo_file on specific paths instead.
 
 export function makeSearchRepoTool(token: string): ToolDefinition {
 	return {
 		name: "search_repo",
-		description: `Search the cloudflare/cloudflare-docs repo for a string or pattern. Returns matching file paths and line snippets. Use to find import sites, usages, and configuration for a package. Limited to 20 results.`,
+		description: `Search the cloudflare/cloudflare-docs repo for a string or pattern using GitHub code search. Returns matching file paths and line snippets. Use to find import sites, usages, and configuration for a package. Limited to 20 results. If code search returns an error or no results, use read_repo_file on specific paths instead.`,
 		parameters: Type.Object({
 			query: Type.String({
 				description:

--- a/.flue/workflows/dependabot-review.ts
+++ b/.flue/workflows/dependabot-review.ts
@@ -1,0 +1,430 @@
+/**
+ * Dependabot review workflow
+ *
+ * Triggered from the orchestrator when a pull_request event comes in from
+ * dependabot[bot]. Analyzes every bumped package — what changed upstream,
+ * how this repo uses it, and whether action is needed beyond merging.
+ *
+ * Posts a single "## Dependabot review" comment on the PR (create or update).
+ *
+ * Behavior is controlled by DOCS_FLUE_REVIEW_MODE:
+ *   "log"     — run analysis and log the rendered comment. Does NOT post.
+ *   "comment" — create or update the single bot review comment on the PR.
+ *
+ * POST /workflows/dependabot-review
+ */
+import type { FlueContext, WorkflowRouteHandler } from "@flue/runtime";
+import { createAgent } from "@flue/runtime";
+import * as v from "valibot";
+import {
+	getDefaultWorkspace,
+	getShellSandbox,
+} from "../connectors/cloudflare-shell";
+import {
+	getInstallationToken,
+	getIssueComments,
+	postComment,
+	updateIssueComment,
+	type GitHubIssueComment,
+} from "../lib/github";
+import { makeDependabotReviewTools } from "../lib/github-repo-tools";
+
+export const route: WorkflowRouteHandler = async (_c, next) => next();
+
+// ── Marker / schema ───────────────────────────────────────────────────────────
+
+const BOT_COMMENT_MARKER = "<!-- cloudflare-docs-flue-dependabot-review -->";
+
+interface DependabotPackage {
+	name: string;
+	from: string;
+	to: string;
+	repoUrl?: string;
+}
+
+interface DependabotReviewPayload {
+	eventType: "pull_request";
+	number: number;
+	/** Comment ID that triggered /review — swap 👀 → 👍 when done. */
+	triggerCommentId?: number;
+	/** Reaction ID to remove when done. */
+	triggerEyesReactionId?: number | null;
+}
+
+const DependabotReviewResultSchema = v.object({
+	summary: v.string(),
+	recommendation: v.picklist(["merge", "merge-verify", "investigate"]),
+	packageReviews: v.array(
+		v.object({
+			name: v.string(),
+			from: v.string(),
+			to: v.string(),
+			type: v.string(),
+			dependencyType: v.string(),
+			whatChanged: v.array(v.string()),
+			repoUsage: v.string(),
+			impact: v.picklist(["None", "Very Low", "Low", "Medium", "High"]),
+			impactReason: v.string(),
+		}),
+	),
+});
+
+type DependabotReviewResult = v.InferOutput<
+	typeof DependabotReviewResultSchema
+>;
+
+// ── Dependabot PR body parser ─────────────────────────────────────────────────
+
+/**
+ * Parse the Dependabot PR body for the package bump table.
+ * Dependabot always includes a markdown table of the form:
+ *   | Package | From | To |
+ *   | --- | --- | --- |
+ *   | [name](url) | `old` | `new` |
+ */
+function parseDependabotPackages(body: string): DependabotPackage[] {
+	const packages: DependabotPackage[] = [];
+	const tableRowRe =
+		/^\|\s*\[([^\]]+)\]\(([^)]+)\)\s*\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|/gm;
+	let m: RegExpExecArray | null;
+	while ((m = tableRowRe.exec(body)) !== null) {
+		packages.push({
+			name: m[1],
+			repoUrl: m[2],
+			from: m[3],
+			to: m[4],
+		});
+	}
+	return packages;
+}
+
+// ── Render comment ────────────────────────────────────────────────────────────
+
+function renderComment(
+	result: DependabotReviewResult,
+	prNumber: number,
+): string {
+	const recLabel = {
+		merge: "✅ Merge",
+		"merge-verify": "✅ Merge + spot-check",
+		investigate: "⚠️ Investigate before merging",
+	}[result.recommendation];
+
+	const impactEmoji: Record<string, string> = {
+		None: "⬜",
+		"Very Low": "🟢",
+		Low: "🟡",
+		Medium: "🟠",
+		High: "🔴",
+	};
+
+	const lines: string[] = [
+		BOT_COMMENT_MARKER,
+		`<!-- pr: ${prNumber} -->`,
+		`<!-- updated-at: ${new Date().toISOString()} -->`,
+		"",
+		"## Dependabot review",
+		"",
+	];
+
+	// Per-package blocks
+	for (const pkg of result.packageReviews) {
+		const emoji = impactEmoji[pkg.impact] ?? "⬜";
+		lines.push(`### \`${pkg.name}\`: ${pkg.from} → ${pkg.to}`);
+		lines.push("");
+		lines.push(`**Type:** ${pkg.type}`);
+		lines.push(`**Dependency type:** ${pkg.dependencyType}`);
+		lines.push("");
+		if (pkg.whatChanged.length > 0) {
+			lines.push("**What changed**");
+			for (const change of pkg.whatChanged) {
+				lines.push(`- ${change}`);
+			}
+			lines.push("");
+		}
+		lines.push("**Usage in this repo**");
+		lines.push(pkg.repoUsage);
+		lines.push("");
+		lines.push(`**Impact:** ${emoji} ${pkg.impact} — ${pkg.impactReason}`);
+		lines.push("");
+		lines.push("---");
+		lines.push("");
+	}
+
+	// Summary table
+	lines.push("## Summary");
+	lines.push("");
+	lines.push("| Package | Impact | Recommendation |");
+	lines.push("|---------|--------|----------------|");
+	for (const pkg of result.packageReviews) {
+		const emoji = impactEmoji[pkg.impact] ?? "⬜";
+		const pkgRec =
+			pkg.impact === "High" || pkg.impact === "Medium"
+				? "⚠️ Verify"
+				: "✅ Merge";
+		lines.push(`| \`${pkg.name}\` | ${emoji} ${pkg.impact} | ${pkgRec} |`);
+	}
+	lines.push("");
+	lines.push(`**Overall:** ${recLabel}`);
+	if (result.summary) {
+		lines.push("");
+		lines.push(result.summary);
+	}
+
+	return lines.join("\n");
+}
+
+// ── Comment helpers ───────────────────────────────────────────────────────────
+
+async function findExistingBotComment(
+	token: string,
+	prNumber: number,
+): Promise<GitHubIssueComment | null> {
+	const comments = await getIssueComments(token, prNumber);
+	return comments.findLast((c) => c.body?.includes(BOT_COMMENT_MARKER)) ?? null;
+}
+
+async function postOrUpdateComment(
+	token: string,
+	prNumber: number,
+	existing: GitHubIssueComment | null,
+	body: string,
+): Promise<void> {
+	if (existing) {
+		await updateIssueComment(token, existing.id, body);
+	} else {
+		await postComment(token, prNumber, body);
+	}
+}
+
+// ── run() ─────────────────────────────────────────────────────────────────────
+
+export async function run({ init, payload, env, runId }: FlueContext) {
+	const input = parsePayload(payload);
+	const typedEnv = env as Record<string, string & unknown>;
+	const reviewMode =
+		(typedEnv.DOCS_FLUE_REVIEW_MODE as string | undefined) ?? "log";
+	const bucket = typedEnv.DOCS_FLUE_BUCKET as unknown as R2Bucket;
+	const loader = typedEnv.LOADER as Parameters<
+		typeof getShellSandbox
+	>[0]["loader"];
+
+	const token = await getInstallationToken(typedEnv as Record<string, string>);
+
+	// ── 1. Fetch PR metadata to extract packages and body ─────────────────────
+	const prRes = await fetch(
+		`https://api.github.com/repos/cloudflare/cloudflare-docs/pulls/${input.number}`,
+		{
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+				"User-Agent": "cloudflare-docs-agents",
+			},
+		},
+	);
+	if (!prRes.ok) {
+		throw new Error(
+			`Failed to fetch PR ${input.number}: ${prRes.status} ${await prRes.text()}`,
+		);
+	}
+	const pr = (await prRes.json()) as {
+		number: number;
+		title: string;
+		body: string | null;
+		user: { login: string };
+		head: { sha: string };
+	};
+
+	// Verify this is actually a Dependabot PR
+	if (pr.user.login !== "dependabot[bot]") {
+		return {
+			acted: false,
+			summary: `PR #${input.number} is not from dependabot[bot] (author: ${pr.user.login}).`,
+		};
+	}
+
+	const prBody = pr.body ?? "";
+	const packages = parseDependabotPackages(prBody);
+
+	console.log({
+		message: `Dependabot review started: PR #${input.number} — ${packages.length} package(s)`,
+		event: "dependabot_review",
+		number: input.number,
+		packages: packages.map((p) => `${p.name} ${p.from}→${p.to}`),
+		runId,
+		action: "started",
+	});
+
+	// ── 2. Hydrate the skill before init() ────────────────────────────────────
+	const workspace = getDefaultWorkspace();
+	const skillObj = await bucket.get(
+		".agents/skills/dependabot-review/SKILL.md",
+	);
+	if (!skillObj) {
+		throw new Error(
+			"Missing .agents/skills/dependabot-review/SKILL.md in DOCS_FLUE_BUCKET. " +
+				"Run `pnpm run flue:sync-agents:local` before invoking the workflow.",
+		);
+	}
+	await workspace.mkdir("/.agents/skills/dependabot-review", {
+		recursive: true,
+	});
+	await workspace.writeFile(
+		"/.agents/skills/dependabot-review/SKILL.md",
+		await skillObj.text(),
+	);
+
+	// ── 3. Create agent with GitHub repo tools ────────────────────────────────
+	const repoTools = makeDependabotReviewTools(token, input.number);
+
+	const agent = createAgent(() => ({
+		sandbox: getShellSandbox({ workspace, loader }),
+		model: "cloudflare/@cf/moonshotai/kimi-k2.6",
+		tools: repoTools,
+	}));
+	const harness = await init(agent);
+	const session = await harness.session(
+		`dependabot-review:${input.number}:${pr.head.sha}:${runId}`,
+	);
+
+	// ── 4. Post a "review in progress" placeholder if in comment mode ─────────
+	let existingComment: GitHubIssueComment | null = null;
+	if (reviewMode === "comment") {
+		existingComment = await findExistingBotComment(token, input.number);
+		await postOrUpdateComment(
+			token,
+			input.number,
+			existingComment,
+			[
+				BOT_COMMENT_MARKER,
+				`<!-- pr: ${input.number} -->`,
+				`<!-- updated-at: ${new Date().toISOString()} -->`,
+				"",
+				"## Dependabot review",
+				"",
+				`⏳ Review in progress for **${packages.length}** package${packages.length !== 1 ? "s" : ""}…`,
+			].join("\n"),
+		);
+	}
+
+	// ── 5. Run the skill ───────────────────────────────────────────────────────
+	let reviewResult: DependabotReviewResult | null = null;
+	try {
+		const { data } = await session.skill("dependabot-review", {
+			result: DependabotReviewResultSchema,
+			args: {
+				prNumber: input.number,
+				prTitle: pr.title,
+				prBody,
+				packages,
+			},
+		});
+		reviewResult = data ?? null;
+	} catch (err) {
+		const errMsg = err instanceof Error ? err.message : String(err);
+		console.log({
+			message: `Dependabot review skill failed: PR #${input.number} — ${errMsg}`,
+			event: "dependabot_review",
+			number: input.number,
+			error: errMsg,
+			runId,
+			action: "skill_failed",
+		});
+
+		if (reviewMode === "comment") {
+			const failureBody = [
+				BOT_COMMENT_MARKER,
+				`<!-- pr: ${input.number} -->`,
+				`<!-- updated-at: ${new Date().toISOString()} -->`,
+				"",
+				"## Dependabot review",
+				"",
+				"❌ Review failed — this is usually a transient error. It will retry on the next push.",
+			].join("\n");
+			const fresh = await findExistingBotComment(token, input.number);
+			await postOrUpdateComment(token, input.number, fresh, failureBody).catch(
+				() => {},
+			);
+		}
+
+		return {
+			mode: reviewMode,
+			summary: "Dependabot review skill failed.",
+			packageCount: packages.length,
+			commentBody: null,
+		};
+	}
+
+	if (!reviewResult) {
+		return {
+			mode: reviewMode,
+			summary: "Dependabot review produced no result.",
+			packageCount: packages.length,
+			commentBody: null,
+		};
+	}
+
+	// ── 6. Render and post the final comment ──────────────────────────────────
+	const commentBody = renderComment(reviewResult, input.number);
+
+	if (reviewMode === "log") {
+		console.log({
+			message: `Dependabot review complete (log mode): PR #${input.number} — ${packages.length} packages, recommendation: ${reviewResult.recommendation}`,
+			event: "dependabot_review",
+			number: input.number,
+			mode: reviewMode,
+			recommendation: reviewResult.recommendation,
+			packageCount: packages.length,
+			runId,
+			action: "complete_log_mode",
+			commentBody,
+		});
+	} else {
+		const fresh =
+			existingComment ?? (await findExistingBotComment(token, input.number));
+		await postOrUpdateComment(token, input.number, fresh, commentBody);
+
+		console.log({
+			message: `Dependabot review complete: PR #${input.number} — ${reviewResult.recommendation}`,
+			event: "dependabot_review",
+			number: input.number,
+			mode: reviewMode,
+			recommendation: reviewResult.recommendation,
+			packageCount: packages.length,
+			runId,
+			action: "complete_comment_posted",
+		});
+	}
+
+	return {
+		mode: reviewMode,
+		recommendation: reviewResult.recommendation,
+		packageCount: packages.length,
+		summary: reviewResult.summary,
+		commentBody,
+	};
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function parsePayload(payload: unknown): DependabotReviewPayload {
+	const input = payload as Partial<DependabotReviewPayload>;
+	if (input.eventType !== "pull_request" || typeof input.number !== "number") {
+		throw new Error(
+			'[flue] dependabot-review requires payload { eventType: "pull_request", number: number }.',
+		);
+	}
+	return {
+		eventType: input.eventType,
+		number: input.number,
+		triggerCommentId:
+			typeof input.triggerCommentId === "number"
+				? input.triggerCommentId
+				: undefined,
+		triggerEyesReactionId:
+			typeof input.triggerEyesReactionId === "number"
+				? input.triggerEyesReactionId
+				: null,
+	};
+}

--- a/.flue/workflows/dependabot-review.ts
+++ b/.flue/workflows/dependabot-review.ts
@@ -127,7 +127,32 @@ function renderComment(
 		"",
 	];
 
-	// Per-package blocks
+	// ── Summary table (always visible) ───────────────────────────────────────
+	lines.push("| Package | Impact | Recommendation |");
+	lines.push("|---------|--------|----------------|");
+	for (const pkg of result.packageReviews) {
+		const emoji = impactEmoji[pkg.impact] ?? "⬜";
+		const pkgRec =
+			pkg.impact === "High" || pkg.impact === "Medium"
+				? "⚠️ Verify"
+				: "✅ Merge";
+		lines.push(
+			`| \`${pkg.name}\` ${pkg.from} → ${pkg.to} | ${emoji} ${pkg.impact} | ${pkgRec} |`,
+		);
+	}
+	lines.push("");
+	lines.push(`**Overall:** ${recLabel}`);
+	if (result.summary) {
+		lines.push("");
+		lines.push(result.summary);
+	}
+	lines.push("");
+
+	// ── Per-package detail blocks (collapsed) ─────────────────────────────────
+	lines.push("<details>");
+	lines.push("<summary>Package details</summary>");
+	lines.push("<br/>");
+	lines.push("");
 	for (const pkg of result.packageReviews) {
 		const emoji = impactEmoji[pkg.impact] ?? "⬜";
 		lines.push(`### \`${pkg.name}\`: ${pkg.from} → ${pkg.to}`);
@@ -150,26 +175,7 @@ function renderComment(
 		lines.push("---");
 		lines.push("");
 	}
-
-	// Summary table
-	lines.push("## Summary");
-	lines.push("");
-	lines.push("| Package | Impact | Recommendation |");
-	lines.push("|---------|--------|----------------|");
-	for (const pkg of result.packageReviews) {
-		const emoji = impactEmoji[pkg.impact] ?? "⬜";
-		const pkgRec =
-			pkg.impact === "High" || pkg.impact === "Medium"
-				? "⚠️ Verify"
-				: "✅ Merge";
-		lines.push(`| \`${pkg.name}\` | ${emoji} ${pkg.impact} | ${pkgRec} |`);
-	}
-	lines.push("");
-	lines.push(`**Overall:** ${recLabel}`);
-	if (result.summary) {
-		lines.push("");
-		lines.push(result.summary);
-	}
+	lines.push("</details>");
 
 	return lines.join("\n");
 }

--- a/.flue/workflows/dependabot-review.ts
+++ b/.flue/workflows/dependabot-review.ts
@@ -21,9 +21,11 @@ import {
 	getShellSandbox,
 } from "../connectors/cloudflare-shell";
 import {
+	addReactionToComment,
 	getInstallationToken,
 	getIssueComments,
 	postComment,
+	removeReactionFromComment,
 	updateIssueComment,
 	type GitHubIssueComment,
 } from "../lib/github";
@@ -207,7 +209,7 @@ async function postOrUpdateComment(
 
 export async function run({ init, payload, env, runId }: FlueContext) {
 	const input = parsePayload(payload);
-	const typedEnv = env as Record<string, string & unknown>;
+	const typedEnv = env as Record<string, unknown>;
 	const reviewMode =
 		(typedEnv.DOCS_FLUE_REVIEW_MODE as string | undefined) ?? "log";
 	const bucket = typedEnv.DOCS_FLUE_BUCKET as unknown as R2Bucket;
@@ -252,6 +254,13 @@ export async function run({ init, payload, env, runId }: FlueContext) {
 
 	const prBody = pr.body ?? "";
 	const packages = parseDependabotPackages(prBody);
+
+	if (packages.length === 0) {
+		return {
+			acted: false,
+			summary: `Could not parse any packages from Dependabot PR body for #${input.number}.`,
+		};
+	}
 
 	console.log({
 		message: `Dependabot review started: PR #${input.number} — ${packages.length} package(s)`,
@@ -390,6 +399,20 @@ export async function run({ init, payload, env, runId }: FlueContext) {
 		const fresh =
 			existingComment ?? (await findExistingBotComment(token, input.number));
 		await postOrUpdateComment(token, input.number, fresh, commentBody);
+
+		// Swap 👀 → 👍 on the trigger comment if this was a slash-command run
+		if (input.triggerCommentId) {
+			if (input.triggerEyesReactionId) {
+				await removeReactionFromComment(
+					token,
+					input.triggerCommentId,
+					input.triggerEyesReactionId,
+				).catch(() => {}); // non-fatal
+			}
+			await addReactionToComment(token, input.triggerCommentId, "+1").catch(
+				() => {},
+			); // non-fatal
+		}
 
 		console.log({
 			message: `Dependabot review complete: PR #${input.number} — ${reviewResult.recommendation}`,

--- a/.flue/workflows/orchestrate.ts
+++ b/.flue/workflows/orchestrate.ts
@@ -4,9 +4,10 @@
  * Receives GitHub webhooks (issues, pull_request events), verifies the
  * signature, and dispatches to the appropriate subagents:
  *
- * - spam-and-off-topic-filter: runs on opened/reopened/synchronize/ready_for_review
+ * - dependabot-review: runs on PRs from dependabot[bot] (skips spam filter)
+ * - spam-and-off-topic-filter: runs on opened/reopened/synchronize/ready_for_review (non-Dependabot)
  * - code-review-orchestrator: runs on PR opened/reopened/synchronize/ready_for_review
- *   (only if spam filter did not close the item)
+ *   (only if spam filter did not close the item, non-Dependabot)
  *
  * POST /workflows/orchestrate
  */
@@ -75,13 +76,32 @@ export async function run({ payload, env, req }: FlueContext) {
 	// });
 
 	// ── 2. Route to the right pipeline ─────────────────────────────────────
+
+	// Detect Dependabot PRs — route to the Dependabot review workflow instead
+	// of the normal spam-filter → code-review pipeline.
+	const prAuthorLogin = (
+		(body.pull_request as Record<string, unknown> | undefined)?.user as
+			| Record<string, unknown>
+			| undefined
+	)?.login as string | undefined;
+	const isDependabotPr =
+		eventType === "pull_request" && prAuthorLogin === "dependabot[bot]";
+
 	const isSpamFilterEvent =
+		!isDependabotPr &&
 		["issues", "pull_request"].includes(eventType) &&
 		(["opened", "reopened", "synchronize"].includes(webhookAction as string) ||
 			(eventType === "pull_request" && webhookAction === "ready_for_review"));
 
 	const isCodeReviewEvent =
+		!isDependabotPr &&
 		eventType === "pull_request" &&
+		["opened", "reopened", "synchronize", "ready_for_review"].includes(
+			webhookAction as string,
+		);
+
+	const isDependabotReviewEvent =
+		isDependabotPr &&
 		["opened", "reopened", "synchronize", "ready_for_review"].includes(
 			webhookAction as string,
 		);
@@ -103,6 +123,7 @@ export async function run({ payload, env, req }: FlueContext) {
 		!req ||
 		(!isSpamFilterEvent &&
 			!isCodeReviewEvent &&
+			!isDependabotReviewEvent &&
 			!isFullReviewCommand &&
 			!isReviewCommand)
 	) {
@@ -111,6 +132,33 @@ export async function run({ payload, env, req }: FlueContext) {
 
 	if (!number) {
 		return { acted: false, summary: "No issue or PR number found." };
+	}
+
+	// ── 3a. Handle Dependabot PR events ─────────────────────────────────────
+	if (isDependabotReviewEvent) {
+		const baseUrl = new URL(req.url);
+		const dependabotUrl = new URL(baseUrl);
+		dependabotUrl.pathname = `/workflows/dependabot-review`;
+		dependabotUrl.searchParams.set("wait", "result");
+		const dependabotResponse = await fetch(dependabotUrl, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ eventType: "pull_request", number }),
+		});
+		if (!dependabotResponse.ok) {
+			console.log({
+				message: `Dependabot review dispatch failed: ${webhookLabel}`,
+				event: "github_webhook_orchestrator",
+				delivery,
+				number,
+				action: "dependabot_review_dispatch_failed",
+				status: dependabotResponse.status,
+			});
+		}
+		return {
+			acted: true,
+			summary: `Dependabot review dispatched for PR #${number}.`,
+		};
 	}
 
 	// ── 3. Handle /full-review command ──────────────────────────────────────
@@ -141,23 +189,39 @@ export async function run({ payload, env, req }: FlueContext) {
 		// Acknowledge immediately with 👀 so the user knows we saw it
 		const eyesReactionId = await addReactionToComment(token, commentId, "eyes");
 
-		// Dispatch full review, passing comment info so orchestrator can swap reaction
+		// Check if the PR is from Dependabot — if so route to dependabot-review
+		const prAuthorForSlash = await fetchPrAuthor(token, number);
 		const baseUrl = new URL(req.url);
 		const reviewUrl = new URL(baseUrl);
-		reviewUrl.pathname = `/workflows/code-review-orchestrator`;
-		reviewUrl.searchParams.set("wait", "result");
-		const _reviewResponse = await fetch(reviewUrl, {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				eventType: "pull_request",
-				number,
-				forceFullReview: true,
-				bypassReviewLimit: true,
-				triggerCommentId: commentId,
-				triggerEyesReactionId: eyesReactionId,
-			}),
-		});
+		if (prAuthorForSlash === "dependabot[bot]") {
+			reviewUrl.pathname = `/workflows/dependabot-review`;
+			reviewUrl.searchParams.set("wait", "result");
+			const _reviewResponse = await fetch(reviewUrl, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					eventType: "pull_request",
+					number,
+					triggerCommentId: commentId,
+					triggerEyesReactionId: eyesReactionId,
+				}),
+			});
+		} else {
+			reviewUrl.pathname = `/workflows/code-review-orchestrator`;
+			reviewUrl.searchParams.set("wait", "result");
+			const _reviewResponse = await fetch(reviewUrl, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					eventType: "pull_request",
+					number,
+					forceFullReview: true,
+					bypassReviewLimit: true,
+					triggerCommentId: commentId,
+					triggerEyesReactionId: eyesReactionId,
+				}),
+			});
+		}
 
 		// console.log({
 		// 	message: `Full review dispatched by ${senderLogin}: PR #${number}`,
@@ -202,22 +266,38 @@ export async function run({ payload, env, req }: FlueContext) {
 		// Acknowledge immediately with 👀
 		const eyesReactionId = await addReactionToComment(token, commentId, "eyes");
 
-		// Dispatch a normal review (incremental if prior review exists, full if not)
+		// Check if the PR is from Dependabot — if so route to dependabot-review
+		const prAuthorForReview = await fetchPrAuthor(token, number);
 		const baseUrl = new URL(req.url);
 		const reviewUrl = new URL(baseUrl);
-		reviewUrl.pathname = `/workflows/code-review-orchestrator`;
-		reviewUrl.searchParams.set("wait", "result");
-		const _reviewResponse = await fetch(reviewUrl, {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				eventType: "pull_request",
-				number,
-				bypassReviewLimit: true,
-				triggerCommentId: commentId,
-				triggerEyesReactionId: eyesReactionId,
-			}),
-		});
+		if (prAuthorForReview === "dependabot[bot]") {
+			reviewUrl.pathname = `/workflows/dependabot-review`;
+			reviewUrl.searchParams.set("wait", "result");
+			const _reviewResponse = await fetch(reviewUrl, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					eventType: "pull_request",
+					number,
+					triggerCommentId: commentId,
+					triggerEyesReactionId: eyesReactionId,
+				}),
+			});
+		} else {
+			reviewUrl.pathname = `/workflows/code-review-orchestrator`;
+			reviewUrl.searchParams.set("wait", "result");
+			const _reviewResponse = await fetch(reviewUrl, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					eventType: "pull_request",
+					number,
+					bypassReviewLimit: true,
+					triggerCommentId: commentId,
+					triggerEyesReactionId: eyesReactionId,
+				}),
+			});
+		}
 
 		// console.log({
 		// 	message: `Review dispatched by ${senderLogin}: PR #${number}`,
@@ -435,4 +515,32 @@ function getIssueOrPullRequestTitle(
 
 function truncateLogValue(value: string) {
 	return value.length > 100 ? `${value.slice(0, 97)}...` : value;
+}
+
+/**
+ * Fetch the author login of a pull request.
+ * Used by slash-command handlers to route Dependabot PRs correctly.
+ */
+async function fetchPrAuthor(
+	token: string,
+	prNumber: number,
+): Promise<string | null> {
+	try {
+		const res = await fetch(
+			`https://api.github.com/repos/cloudflare/cloudflare-docs/pulls/${prNumber}`,
+			{
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: "application/vnd.github+json",
+					"X-GitHub-Api-Version": "2022-11-28",
+					"User-Agent": "cloudflare-docs-agents",
+				},
+			},
+		);
+		if (!res.ok) return null;
+		const pr = (await res.json()) as { user?: { login?: string } };
+		return pr.user?.login ?? null;
+	} catch {
+		return null;
+	}
 }

--- a/.flue/workflows/orchestrate.ts
+++ b/.flue/workflows/orchestrate.ts
@@ -15,6 +15,7 @@ import type { FlueContext, WorkflowRouteHandler } from "@flue/runtime";
 import {
 	addReactionToComment,
 	getInstallationToken,
+	getPullRequest,
 	isCodeOwner,
 	verifyGitHubSignature,
 } from "../lib/github";
@@ -190,10 +191,10 @@ export async function run({ payload, env, req }: FlueContext) {
 		const eyesReactionId = await addReactionToComment(token, commentId, "eyes");
 
 		// Check if the PR is from Dependabot — if so route to dependabot-review
-		const prAuthorForSlash = await fetchPrAuthor(token, number);
+		const prForSlash = await getPullRequest(token, number).catch(() => null);
 		const baseUrl = new URL(req.url);
 		const reviewUrl = new URL(baseUrl);
-		if (prAuthorForSlash === "dependabot[bot]") {
+		if (prForSlash?.user?.login === "dependabot[bot]") {
 			reviewUrl.pathname = `/workflows/dependabot-review`;
 			reviewUrl.searchParams.set("wait", "result");
 			const _reviewResponse = await fetch(reviewUrl, {
@@ -267,10 +268,10 @@ export async function run({ payload, env, req }: FlueContext) {
 		const eyesReactionId = await addReactionToComment(token, commentId, "eyes");
 
 		// Check if the PR is from Dependabot — if so route to dependabot-review
-		const prAuthorForReview = await fetchPrAuthor(token, number);
+		const prForReview = await getPullRequest(token, number).catch(() => null);
 		const baseUrl = new URL(req.url);
 		const reviewUrl = new URL(baseUrl);
-		if (prAuthorForReview === "dependabot[bot]") {
+		if (prForReview?.user?.login === "dependabot[bot]") {
 			reviewUrl.pathname = `/workflows/dependabot-review`;
 			reviewUrl.searchParams.set("wait", "result");
 			const _reviewResponse = await fetch(reviewUrl, {
@@ -515,32 +516,4 @@ function getIssueOrPullRequestTitle(
 
 function truncateLogValue(value: string) {
 	return value.length > 100 ? `${value.slice(0, 97)}...` : value;
-}
-
-/**
- * Fetch the author login of a pull request.
- * Used by slash-command handlers to route Dependabot PRs correctly.
- */
-async function fetchPrAuthor(
-	token: string,
-	prNumber: number,
-): Promise<string | null> {
-	try {
-		const res = await fetch(
-			`https://api.github.com/repos/cloudflare/cloudflare-docs/pulls/${prNumber}`,
-			{
-				headers: {
-					Authorization: `Bearer ${token}`,
-					Accept: "application/vnd.github+json",
-					"X-GitHub-Api-Version": "2022-11-28",
-					"User-Agent": "cloudflare-docs-agents",
-				},
-			},
-		);
-		if (!res.ok) return null;
-		const pr = (await res.json()) as { user?: { login?: string } };
-		return pr.user?.login ?? null;
-	} catch {
-		return null;
-	}
 }

--- a/.flue/wrangler.jsonc
+++ b/.flue/wrangler.jsonc
@@ -29,8 +29,6 @@
 			"new_sqlite_classes": ["DependabotReviewWorkflow"],
 		},
 	],
-		},
-	],
 	"observability": {
 		"enabled": true,
 		"head_sampling_rate": 1,

--- a/.flue/wrangler.jsonc
+++ b/.flue/wrangler.jsonc
@@ -14,49 +14,21 @@
 		},
 	],
 	"migrations": [
-		// Previous agent class migrations — kept for deployed history, classes are removed.
 		{
-			"tag": "flue-class-CodeReviewOrchestrator",
-			"new_sqlite_classes": ["CodeReviewOrchestrator"],
-		},
-		{
-			"tag": "flue-class-FlueRegistry",
-			"new_sqlite_classes": ["FlueRegistry"],
-		},
-		{ "tag": "flue-class-Orchestrate", "new_sqlite_classes": ["Orchestrate"] },
-		{
-			"tag": "flue-class-SpamAndOffTopicFilter",
-			"new_sqlite_classes": ["SpamAndOffTopicFilter"],
-		},
-		{
-			"tag": "flue-class-StyleGuideReview",
-			"new_sqlite_classes": ["StyleGuideReview"],
-		},
-		// New workflow classes added in 0.9.1 upgrade.
-		{
-			"tag": "flue-class-OrchestrateWorkflow",
-			"new_sqlite_classes": ["OrchestrateWorkflow"],
-		},
-		{
-			"tag": "flue-class-CodeReviewOrchestratorWorkflow",
-			"new_sqlite_classes": ["CodeReviewOrchestratorWorkflow"],
-		},
-		{
-			"tag": "flue-class-SpamAndOffTopicFilterWorkflow",
-			"new_sqlite_classes": ["SpamAndOffTopicFilterWorkflow"],
-		},
-		{
-			"tag": "flue-class-StyleGuideReviewWorkflow",
-			"new_sqlite_classes": ["StyleGuideReviewWorkflow"],
-		},
-		{
-			"tag": "flue-delete-old-agent-classes",
-			"deleted_classes": [
-				"CodeReviewOrchestrator",
-				"Orchestrate",
-				"SpamAndOffTopicFilter",
-				"StyleGuideReview",
+			"tag": "v1",
+			"new_sqlite_classes": [
+				"FlueRegistry",
+				"OrchestrateWorkflow",
+				"CodeReviewOrchestratorWorkflow",
+				"SpamAndOffTopicFilterWorkflow",
+				"StyleGuideReviewWorkflow",
 			],
+		},
+		{
+			"tag": "v2",
+			"new_sqlite_classes": ["DependabotReviewWorkflow"],
+		},
+	],
 		},
 	],
 	"observability": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "tuesday"
+    cooldown:
+      default-days: 1
     assignees:
       - "kodster28"
       - "mvvmm"

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ CLAUDE.md
 .flue/dist/
 .flue/.env*
 .flue/.wrangler/
+.flue/.wrangler/tmp/
 .flue/.flue-vite/
 .flue/.flue-vite.wrangler.jsonc
 .flue/node_modules/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,7 @@ export default [
 			".wrangler/",
 			".flue/dist/",
 			".flue/.flue-vite/",
+			".flue/.wrangler/",
 			"dist/",
 			".github/",
 		],


### PR DESCRIPTION
### Summary

Adds a Dependabot review workflow to the Flue docs bot. When a PR from `dependabot[bot]` is opened, synchronized, or rebased, the orchestrator now routes it to a new `/workflows/dependabot-review` workflow instead of the normal spam-filter → style-guide-review pipeline.

The review agent analyzes every bumped package using GitHub API-backed tools (`search_repo`, `read_repo_file`, `trace_dependency`, `get_npm_package_info`) to determine what changed upstream, how this repo uses each package, and whether any action is needed beyond merging. Results are posted as a single `## Dependabot review` comment on the PR with a summary table at the top and per-package details collapsed by default.

Also adds a `cooldown: default-days: 1` to `.github/dependabot.yml` to align Dependabot's PR creation timing with pnpm's existing `minimumReleaseAge: 1440` policy.

**What's new:**

- `.flue/.agents/skills/dependabot-review/SKILL.md` — skill instructions for the review agent
- `.flue/lib/github-repo-tools.ts` — five GitHub API / npm registry tools exposed to the agent
- `.flue/workflows/dependabot-review.ts` — new workflow: fetches PR metadata, hydrates skill, runs analysis, posts comment
- `.flue/workflows/orchestrate.ts` — detects `dependabot[bot]` PRs and routes them to the new workflow; `/review` and `/full-review` commands on Dependabot PRs also route there
- `.flue/wrangler.jsonc` — adds `DependabotReviewWorkflow` to migrations
- `.github/dependabot.yml` — adds `cooldown: default-days: 1`

#### Images
<img width="712" height="940" alt="Screenshot 2026-06-05 at 11 59 32 AM" src="https://github.com/user-attachments/assets/a5b7ca03-5eec-4b39-a64c-a6b0911dbe5b" />
<img width="842" height="494" alt="Screenshot 2026-06-05 at 11 59 54 AM" src="https://github.com/user-attachments/assets/71d93aa9-4cad-4efc-a588-3ad0dd1b48f7" />

