### PR TITLE
[Stream] Google Drive share links are error-prone

### DIFF
--- a/src/content/docs/stream/uploading-videos/upload-via-link.mdx
+++ b/src/content/docs/stream/uploading-videos/upload-via-link.mdx
@@ -14,7 +14,7 @@ import {
 	LinkButton,
 } from "~/components"
 
-If you have videos stored in a cloud storage bucket (R2, S3, GCS) or hosted in by a service that exposes a download link, you can pass its URL. Stream will fetch the file on your behalf.
+If you have videos stored in a cloud storage bucket (R2, S3, GCS) or hosted by a service that exposes a download link, you can pass its URL. Stream will fetch the file on your behalf.
 
 :::note
 

--- a/src/content/docs/stream/uploading-videos/upload-via-link.mdx
+++ b/src/content/docs/stream/uploading-videos/upload-via-link.mdx
@@ -14,7 +14,13 @@ import {
 	LinkButton,
 } from "~/components"
 
-If you have videos stored in a cloud storage bucket, you can pass a HTTP link for the file, and Stream will fetch the file on your behalf.
+If you have videos stored in a cloud storage bucket (R2, S3, GCS) or hosted in by a service that exposes a download link, you can pass its URL. Stream will fetch the file on your behalf.
+
+::: note
+
+Google Drive share links are <em>not</em> recommended for this purpose. They are prone to rate limiting and access restrictions imposed by Google that may prevent Stream from downloading the file.
+
+:::
 
 <Tabs>
 <TabItem label="REST API">
@@ -25,7 +31,7 @@ If you have videos stored in a cloud storage bucket, you can pass a HTTP link fo
 			Make a `POST` request to the Stream API using the link to your video.
     	```bash
 				curl \
-				--data '{"url":"https://storage.googleapis.com/zaid-test/Watermarks%20Demo/cf-ad-original.mp4","meta":{"name":"My First Stream Video"}}' \
+				--data '{"url":"https://pub-2da57dbfcf5f4369863991d59747d686.r2.dev/acadia.mp4","meta":{"name":"My First Stream Video"}}' \
 				--header "Authorization: Bearer <API_TOKEN>" \
 				https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/copy
 			```
@@ -39,7 +45,7 @@ If you have videos stored in a cloud storage bucket, you can pass a HTTP link fo
 
     		const video = await client.stream.copy.create({
     			account_id: '<ACCOUNT_ID>',
-    			url: 'https://storage.googleapis.com/zaid-test/Watermarks%20Demo/cf-ad-original.mp4',
+    			url: 'https://pub-2da57dbfcf5f4369863991d59747d686.r2.dev/acadia.mp4',
     		});
     		```
     	</TabItem>
@@ -56,7 +62,7 @@ export default {
 	async fetch(request, env, ctx): Promise<Response> {
 		// upload a video with a link
 		const videoDetails = await env.STREAM.upload(
-			"https://storage.googleapis.com/zaid-test/Watermarks%20Demo/cf-ad-original.mp4",
+			"https://pub-2da57dbfcf5f4369863991d59747d686.r2.dev/acadia.mp4",
 			// (optional) attach metadata
 			{ meta: { name: "My First Stream Video" } }
 		);
@@ -117,7 +123,7 @@ You can optionally use [webhooks](/stream/manage-video-library/using-webhooks/) 
       "state": "downloading"
     },
     "meta": {
-      "downloaded-from": "https://storage.googleapis.com/zaid-test/Watermarks%20Demo/cf-ad-original.mp4",
+      "downloaded-from": "https://pub-2da57dbfcf5f4369863991d59747d686.r2.dev/acadia.mp4",
       "name": "My First Stream Video"
     },
     "created": "2020-10-16T20:20:17.872170843Z",

--- a/src/content/docs/stream/uploading-videos/upload-via-link.mdx
+++ b/src/content/docs/stream/uploading-videos/upload-via-link.mdx
@@ -16,9 +16,9 @@ import {
 
 If you have videos stored in a cloud storage bucket (R2, S3, GCS) or hosted in by a service that exposes a download link, you can pass its URL. Stream will fetch the file on your behalf.
 
-::: note
+:::note
 
-Google Drive share links are <em>not</em> recommended for this purpose. They are prone to rate limiting and access restrictions imposed by Google that may prevent Stream from downloading the file.
+Google Drive share links are _not_ recommended for this purpose. They are prone to rate limiting and access restrictions imposed by Google that may prevent Stream from downloading the file.
 
 :::
 


### PR DESCRIPTION
### Summary

Agents are recommending Google Drive share links for Stream ingress, which frequently fail upstream because of, essentially, automated traffic prevention and rate limiting on Google's end. Added warning about it.

Will follow up with alternatives, but trying to steer solutions away from this path.
