### PR TITLE
Docs FEDRAMP R2 - Endpoint Discrepancy

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/r2.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/r2.mdx
@@ -17,7 +17,7 @@ For more information about R2, refer to the [Cloudflare R2](/r2/) documentation.
 
 :::note
 If you want to set up R2 as destination for a zone on [FedRAMP High](https://www.cloudflare.com/cloudflare-for-government/), you need to use an [S3-compatible endpoint](/logs/logpush/logpush-job/enable-destinations/s3-compatible-endpoints/) with the following `Endpoint URL`:
-`<ACCOUNT_ID>.r2.fed.cloudflarestorage.com`
+`<ACCOUNT_ID>.fedramp.r2.cloudflarestorage.com`
 :::
 
 ## Automatic setup


### PR DESCRIPTION
Two Cloudflare docs give different FedRAMP R2 endpoints:

https://developers.cloudflare.com/r2/api/tokens/#:~:text=FedRAMP%3A%20https%3A%2F%2F%3CACCOUNT%5FID%3E%2Efedramp%2Er2%2Ecloudflarestorage%2Ecom

https://developers.cloudflare.com/logs/logpush/logpush-job/enable-destinations/r2/#:~:text=%3CACCOUNT%5FID%3E%2Er2%2Efed%2Ecloudflarestorage%2Ecom

.fedramp.r2. should be the correct one:

- The R2 API Tokens doc (authoritative R2 source)
- Customer's working jobs
- Internal FedRAMP LogPush (ZERO-3553)
- Follows the EU pattern (.eu.r2.)

The LogPush R2 doc saying .r2.fed. appears outdated/wrong — worth filing a docs fix.

Could trip up other customers.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
