### PR TITLE
[Agents] Move Chat SDK to Runtime Communication and rename Agent tools

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -229,6 +229,7 @@
 /agents/api-reference/agents-api/ /agents/runtime/agents-api/ 301
 /agents/api-reference/ /agents/runtime/ 301
 /agents/api-reference/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
+/agents/runtime/execution/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
 /agents/api-reference/agent-tools/ /agents/runtime/execution/agent-tools/ 301
 /agents/api-reference/browse-the-web/ /agents/tools/browser/ 301
 /agents/api-reference/callable-methods/ /agents/runtime/lifecycle/callable-methods/ 301

--- a/public/__redirects
+++ b/public/__redirects
@@ -230,7 +230,6 @@
 /agents/api-reference/ /agents/runtime/ 301
 /agents/api-reference/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
 /agents/runtime/execution/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
-/agents/runtime/execution/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
 /agents/api-reference/agent-tools/ /agents/runtime/execution/agent-tools/ 301
 /agents/api-reference/browse-the-web/ /agents/tools/browser/ 301
 /agents/api-reference/callable-methods/ /agents/runtime/lifecycle/callable-methods/ 301

--- a/public/__redirects
+++ b/public/__redirects
@@ -228,7 +228,7 @@
 /agents/concepts/long-running-agents/ /agents/concepts/agentic-patterns/long-running-agents/ 301
 /agents/api-reference/agents-api/ /agents/runtime/agents-api/ 301
 /agents/api-reference/ /agents/runtime/ 301
-/agents/api-reference/chat-sdk/ /agents/runtime/execution/chat-sdk/ 301
+/agents/api-reference/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
 /agents/api-reference/agent-tools/ /agents/runtime/execution/agent-tools/ 301
 /agents/api-reference/browse-the-web/ /agents/tools/browser/ 301
 /agents/api-reference/callable-methods/ /agents/runtime/lifecycle/callable-methods/ 301

--- a/public/__redirects
+++ b/public/__redirects
@@ -230,6 +230,7 @@
 /agents/api-reference/ /agents/runtime/ 301
 /agents/api-reference/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
 /agents/runtime/execution/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
+/agents/runtime/execution/chat-sdk/ /agents/runtime/communication/chat-sdk/ 301
 /agents/api-reference/agent-tools/ /agents/runtime/execution/agent-tools/ 301
 /agents/api-reference/browse-the-web/ /agents/tools/browser/ 301
 /agents/api-reference/callable-methods/ /agents/runtime/lifecycle/callable-methods/ 301

--- a/src/content/docs/agents/communication-channels/chat/chat-agents.mdx
+++ b/src/content/docs/agents/communication-channels/chat/chat-agents.mdx
@@ -1582,7 +1582,7 @@ export class ChatAgent extends AIChatAgent {
 
 :::note
 
-This section covers **in-process** subagents using the AI SDK's `ToolLoopAgent`. For **Durable Object sub-agents** with their own isolated storage and typed RPC, refer to [Sub-agents](/agents/runtime/execution/sub-agents/). To run Think or `AIChatAgent` sub-agents as retained, streaming tools, refer to [Agent tools](/agents/runtime/execution/agent-tools/).
+This section covers **in-process** subagents using the AI SDK's `ToolLoopAgent`. For **Durable Object sub-agents** with their own isolated storage and typed RPC, refer to [Sub-agents](/agents/runtime/execution/sub-agents/). To run Think or `AIChatAgent` sub-agents as retained, streaming tools, refer to [Agents as tools](/agents/runtime/execution/agent-tools/).
 
 :::
 

--- a/src/content/docs/agents/communication-channels/chat/client-sdk.mdx
+++ b/src/content/docs/agents/communication-channels/chat/client-sdk.mdx
@@ -616,7 +616,7 @@ client.addEventListener("message", () => {});
 
 ## Agent-tool events
 
-If your chat UI renders retained child runs from [Agent tools](/agents/runtime/execution/agent-tools/), use `useAgentToolEvents()` alongside `useAgent()` and `useAgentChat()`. The hook subscribes to the parent connection, replays retained child timelines, and groups runs by parent tool call ID.
+If your chat UI renders retained child runs from [Agents as tools](/agents/runtime/execution/agent-tools/), use `useAgentToolEvents()` alongside `useAgent()` and `useAgentChat()`. The hook subscribes to the parent connection, replays retained child timelines, and groups runs by parent tool call ID.
 
 <TypeScriptExample>
 

--- a/src/content/docs/agents/concepts/tools.mdx
+++ b/src/content/docs/agents/concepts/tools.mdx
@@ -16,13 +16,13 @@ Tools enable AI systems to interact with external services and perform actions. 
 
 Cloudflare Agents support several tool patterns. Choose the smallest one that fits the job:
 
-| Pattern           | Use when                                                                                  | Start here                                                          |
-| ----------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Pattern           | Use when                                                                                  | Start here                                                                        |
+| ----------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | Server-side tools | The tool can run entirely in the Worker, such as fetching an API or querying SQL          | [Chat agents](/agents/communication-channels/chat/chat-agents/#server-side-tools) |
 | Client-side tools | The tool needs browser APIs such as geolocation, clipboard, or local storage              | [Chat agents](/agents/communication-channels/chat/chat-agents/#client-side-tools) |
-| Human approvals   | The tool is sensitive and needs a user decision before it runs                            | [Human-in-the-loop](/agents/concepts/agentic-patterns/human-in-the-loop/)            |
-| MCP tools         | You want to expose or consume tools through the Model Context Protocol                    | [Model Context Protocol](/agents/model-context-protocol/)           |
-| Agent tools       | You want a chat agent to run another chat-capable sub-agent as a retained, streaming tool | [Agent tools](/agents/runtime/execution/agent-tools/)                   |
+| Human approvals   | The tool is sensitive and needs a user decision before it runs                            | [Human-in-the-loop](/agents/concepts/agentic-patterns/human-in-the-loop/)         |
+| MCP tools         | You want to expose or consume tools through the Model Context Protocol                    | [Model Context Protocol](/agents/model-context-protocol/)                         |
+| Agents as tools   | You want a chat agent to run another chat-capable sub-agent as a retained, streaming tool | [Agents as tools](/agents/runtime/execution/agent-tools/)                         |
 
 ### Understanding tools
 

--- a/src/content/docs/agents/harnesses/think/index.mdx
+++ b/src/content/docs/agents/harnesses/think/index.mdx
@@ -185,7 +185,7 @@ Think has several ways to start or continue a turn. Choose based on who starts t
 
 Use `saveMessages()` when the caller owns the trigger and can wait for the turn to finish. Use [`submitMessages()`](/agents/harnesses/think/programmatic-submissions/) when timeout ambiguity would make retries unsafe.
 
-Use `chat()` for low-level parent-to-child streaming when your code owns forwarding, cancellation, and replay policy. Use [Agent tools](/agents/runtime/execution/agent-tools/) when a parent model or workflow delegates to a child agent and you want retained child runs, event replay, abort bridging, and UI drill-in.
+Use `chat()` for low-level parent-to-child streaming when your code owns forwarding, cancellation, and replay policy. Use [Agents as tools](/agents/runtime/execution/agent-tools/) when a parent model or workflow delegates to a child agent and you want retained child runs, event replay, abort bridging, and UI drill-in.
 
 Use [`startFiber()`](/agents/runtime/execution/durable-execution/#startfiber) outside Think when the durable unit is an application job around a turn: accepting a webhook once, restoring a serialized channel or thread target, posting a visible reply, or recording app-level recovery policy. Think submissions own conversation admission and turn serialization; managed fibers own external job acceptance, idempotent side effects, and application recovery.
 

--- a/src/content/docs/agents/harnesses/think/messengers.mdx
+++ b/src/content/docs/agents/harnesses/think/messengers.mdx
@@ -196,4 +196,4 @@ Every custom messenger must provide `verifyWebhook` or explicitly use `verifyWeb
 
 The `examples/think-chat-sdk` example demonstrates the Think-native `getMessengers()` path with a small Vite dashboard that inspects the root Think conversation over the Agent WebSocket.
 
-The `examples/chat-sdk-messenger` example demonstrates a larger manual ingress agent with an admin dashboard, menu handling, and application-owned reply fibers. Use `getMessengers()` for the simple Think-native path. Use the example when you need to own the Chat SDK runtime and control-plane UI yourself. Refer to [Chat SDK state](/agents/runtime/execution/chat-sdk/) for the underlying state adapter.
+The `examples/chat-sdk-messenger` example demonstrates a larger manual ingress agent with an admin dashboard, menu handling, and application-owned reply fibers. Use `getMessengers()` for the simple Think-native path. Use the example when you need to own the Chat SDK runtime and control-plane UI yourself. Refer to [Chat SDK state](/agents/runtime/communication/chat-sdk/) for the underlying state adapter.

--- a/src/content/docs/agents/harnesses/think/tools.mdx
+++ b/src/content/docs/agents/harnesses/think/tools.mdx
@@ -24,7 +24,7 @@ On every turn, Think merges tools from multiple sources. Later sources override 
 6. **MCP tools** — from connected MCP servers
 7. **Client tools** — from the browser (refer to [Client tools](/agents/harnesses/think/client-tools/))
 
-Tools belong to the agent running the turn. For parent-child orchestration, use [Agent tools](/agents/runtime/execution/agent-tools/) instead of passing one-off tools through `chat()`.
+Tools belong to the agent running the turn. For parent-child orchestration, use [Agents as tools](/agents/runtime/execution/agent-tools/) instead of passing one-off tools through `chat()`.
 
 ## Built-in workspace tools
 

--- a/src/content/docs/agents/runtime/agents-api.mdx
+++ b/src/content/docs/agents/runtime/agents-api.mdx
@@ -63,16 +63,16 @@ flowchart TD
     E --> F["onClose"]
 ```
 
-| Method                                        | When it runs                                                                                                                                                                            |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Method                                        | When it runs                                                                                                                                                                                    |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `onStart(props?)`                             | When the instance starts, or wakes from hibernation. Receives optional [initialization props](/agents/runtime/communication/routing/#props) passed via `getAgentByName` or `routeAgentRequest`. |
-| `onRequest(request)`                          | For each HTTP request to the instance                                                                                                                                                   |
-| `onConnect(connection, ctx)`                  | When a WebSocket connection is established                                                                                                                                              |
-| `onMessage(connection, message)`              | For each WebSocket message received                                                                                                                                                     |
-| `onError(connection, error)`                  | When a WebSocket error occurs                                                                                                                                                           |
-| `onClose(connection, code, reason, wasClean)` | When a WebSocket connection closes                                                                                                                                                      |
-| `onEmail(email)`                              | When an email is routed to the instance                                                                                                                                                 |
-| `onStateChanged(state, source)`               | When state changes (from server or client)                                                                                                                                              |
+| `onRequest(request)`                          | For each HTTP request to the instance                                                                                                                                                           |
+| `onConnect(connection, ctx)`                  | When a WebSocket connection is established                                                                                                                                                      |
+| `onMessage(connection, message)`              | For each WebSocket message received                                                                                                                                                             |
+| `onError(connection, error)`                  | When a WebSocket error occurs                                                                                                                                                                   |
+| `onClose(connection, code, reason, wasClean)` | When a WebSocket connection closes                                                                                                                                                              |
+| `onEmail(email)`                              | When an email is routed to the instance                                                                                                                                                         |
+| `onStateChanged(state, source)`               | When state changes (from server or client)                                                                                                                                                      |
 
 ## Core properties
 
@@ -85,28 +85,28 @@ flowchart TD
 
 ## Server-side API reference
 
-| Feature               | Methods                                                                                          | Documentation                                                       |
-| --------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| **State**             | `setState()`, `onStateChanged()`, `initialState`                                                 | [Store and sync state](/agents/runtime/lifecycle/state/)                     |
-| **Callable methods**  | `@callable()` decorator                                                                          | [Callable methods](/agents/runtime/lifecycle/callable-methods/)             |
-| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getScheduleById()`, `listSchedules()`                          | [Schedule tasks](/agents/runtime/execution/schedule-tasks/)                 |
-| **Durable execution** | `runFiber()`, `startFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()`, `keepAliveWhile()` | [Durable execution](/agents/runtime/execution/durable-execution/)           |
-| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                                             | [Queue tasks](/agents/runtime/execution/queue-tasks/)                       |
-| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                                         | [WebSockets](/agents/runtime/communication/websockets/)                     |
-| **HTTP/SSE**          | `onRequest()`                                                                                    | [HTTP and SSE](/agents/runtime/communication/http-sse/)                     |
-| **Email**             | `onEmail()`, `replyToEmail()`                                                                    | [Email routing](/agents/communication-channels/email/)                      |
-| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                                             | [Run Workflows](/agents/runtime/execution/run-workflows/)                   |
-| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                                         | [MCP Client API](/agents/model-context-protocol/apis/client-api/)           |
-| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                                           | [Using AI models](/agents/runtime/operations/using-ai-models/)              |
-| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`                                  | [Protocol messages](/agents/runtime/communication/protocol-messages/)       |
-| **Context**           | `getCurrentAgent()`                                                                              | [getCurrentAgent()](/agents/runtime/lifecycle/get-current-agent/)           |
-| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                                | [Observability](/agents/runtime/operations/observability/)                  |
-| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                                              | [Sub-agents](/agents/runtime/execution/sub-agents/)                         |
-| **Agent tools**       | `runAgentTool()`, `clearAgentToolRuns()`, `hasAgentToolRun()`                                    | [Agent tools](/agents/runtime/execution/agent-tools/)                       |
-| **Agent Skills**      | `skills` registry, bundled skill sources, script runners                                         | [Agent Skills](/agents/runtime/execution/agent-skills/)                     |
-| **Sessions**          | `Session.create()`, context blocks, compaction, search                                           | [Sessions](/agents/runtime/lifecycle/sessions/)                             |
-| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions                                 | [Think](/agents/harnesses/think/)                                                     |
-| **Chat SDK**          | `createChatSdkState()`, `ChatSdkStateAgent`                                                      | [Chat SDK](/agents/runtime/execution/chat-sdk/)                             |
+| Feature               | Methods                                                                                          | Documentation                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| **State**             | `setState()`, `onStateChanged()`, `initialState`                                                 | [Store and sync state](/agents/runtime/lifecycle/state/)              |
+| **Callable methods**  | `@callable()` decorator                                                                          | [Callable methods](/agents/runtime/lifecycle/callable-methods/)       |
+| **Scheduling**        | `schedule()`, `scheduleEvery()`, `getScheduleById()`, `listSchedules()`                          | [Schedule tasks](/agents/runtime/execution/schedule-tasks/)           |
+| **Durable execution** | `runFiber()`, `startFiber()`, `stash()`, `onFiberRecovered()`, `keepAlive()`, `keepAliveWhile()` | [Durable execution](/agents/runtime/execution/durable-execution/)     |
+| **Queue**             | `queue()`, `dequeue()`, `dequeueAll()`, `getQueue()`                                             | [Queue tasks](/agents/runtime/execution/queue-tasks/)                 |
+| **WebSockets**        | `onConnect()`, `onMessage()`, `onClose()`, `broadcast()`                                         | [WebSockets](/agents/runtime/communication/websockets/)               |
+| **HTTP/SSE**          | `onRequest()`                                                                                    | [HTTP and SSE](/agents/runtime/communication/http-sse/)               |
+| **Email**             | `onEmail()`, `replyToEmail()`                                                                    | [Email routing](/agents/communication-channels/email/)                |
+| **Workflows**         | `runWorkflow()`, `waitForApproval()`                                                             | [Run Workflows](/agents/runtime/execution/run-workflows/)             |
+| **MCP Client**        | `addMcpServer()`, `removeMcpServer()`, `getMcpServers()`                                         | [MCP Client API](/agents/model-context-protocol/apis/client-api/)     |
+| **AI Models**         | Workers AI, OpenAI, Anthropic bindings                                                           | [Using AI models](/agents/runtime/operations/using-ai-models/)        |
+| **Protocol messages** | `shouldSendProtocolMessages()`, `isConnectionProtocolEnabled()`                                  | [Protocol messages](/agents/runtime/communication/protocol-messages/) |
+| **Context**           | `getCurrentAgent()`                                                                              | [getCurrentAgent()](/agents/runtime/lifecycle/get-current-agent/)     |
+| **Observability**     | `subscribe()`, diagnostics channels, Tail Workers                                                | [Observability](/agents/runtime/operations/observability/)            |
+| **Sub-agents**        | `subAgent()`, `abortSubAgent()`, `deleteSubAgent()`                                              | [Sub-agents](/agents/runtime/execution/sub-agents/)                   |
+| **Agents as tools**   | `runAgentTool()`, `clearAgentToolRuns()`, `hasAgentToolRun()`                                    | [Agents as tools](/agents/runtime/execution/agent-tools/)             |
+| **Agent Skills**      | `skills` registry, bundled skill sources, script runners                                         | [Agent Skills](/agents/runtime/execution/agent-skills/)               |
+| **Sessions**          | `Session.create()`, context blocks, compaction, search                                           | [Sessions](/agents/runtime/lifecycle/sessions/)                       |
+| **Think**             | `Think` base class, workspace tools, lifecycle hooks, extensions                                 | [Think](/agents/harnesses/think/)                                     |
+| **Chat SDK**          | `createChatSdkState()`, `ChatSdkStateAgent`                                                      | [Chat SDK](/agents/runtime/communication/chat-sdk/)                   |
 
 ## SQL API
 
@@ -127,13 +127,13 @@ For state that needs to sync with clients, use the [State API](/agents/runtime/l
 
 ## Client-side API reference
 
-| Feature               | Methods                | Documentation                                                                     |
-| --------------------- | ---------------------- | --------------------------------------------------------------------------------- |
-| **WebSocket client**  | `AgentClient`          | [Client SDK](/agents/communication-channels/chat/client-sdk/)                                   |
-| **HTTP client**       | `agentFetch()`         | [Client SDK](/agents/communication-channels/chat/client-sdk/#http-requests-with-agentfetch)     |
-| **React hook**        | `useAgent()`           | [Client SDK](/agents/communication-channels/chat/client-sdk/#react)                             |
-| **Chat hook**         | `useAgentChat()`       | [Client SDK](/agents/communication-channels/chat/client-sdk/)                                   |
-| **Agent tool events** | `useAgentToolEvents()` | [Agent tools](/agents/runtime/execution/agent-tools/#render-child-timelines-in-react) |
+| Feature               | Methods                | Documentation                                                                               |
+| --------------------- | ---------------------- | ------------------------------------------------------------------------------------------- |
+| **WebSocket client**  | `AgentClient`          | [Client SDK](/agents/communication-channels/chat/client-sdk/)                               |
+| **HTTP client**       | `agentFetch()`         | [Client SDK](/agents/communication-channels/chat/client-sdk/#http-requests-with-agentfetch) |
+| **React hook**        | `useAgent()`           | [Client SDK](/agents/communication-channels/chat/client-sdk/#react)                         |
+| **Chat hook**         | `useAgentChat()`       | [Client SDK](/agents/communication-channels/chat/client-sdk/)                               |
+| **Agent tool events** | `useAgentToolEvents()` | [Agents as tools](/agents/runtime/execution/agent-tools/#render-child-timelines-in-react)   |
 
 Module-level helper exports include `agentTool()` from `agents/agent-tools`, which converts a Think or `AIChatAgent` subclass into an AI SDK tool definition.
 

--- a/src/content/docs/agents/runtime/communication/chat-sdk.mdx
+++ b/src/content/docs/agents/runtime/communication/chat-sdk.mdx
@@ -3,7 +3,7 @@ title: Chat SDK
 description: Integrate Chat SDK with Agents, including durable state for subscriptions, locks, queues, and message history.
 pcx_content_type: reference
 sidebar:
-  order: 23
+  order: 10
 products:
   - agents
 ---

--- a/src/content/docs/agents/runtime/execution/agent-tools.mdx
+++ b/src/content/docs/agents/runtime/execution/agent-tools.mdx
@@ -1,5 +1,5 @@
 ---
-title: Agent tools
+title: Agents as tools
 description: Run Think and AIChatAgent sub-agents as retained, streaming tools from a parent agent.
 pcx_content_type: reference
 sidebar:

--- a/src/content/docs/agents/runtime/execution/agent-tools.mdx
+++ b/src/content/docs/agents/runtime/execution/agent-tools.mdx
@@ -10,11 +10,11 @@ products:
 
 import { TypeScriptExample, LinkCard } from "~/components";
 
-Agent tools let one chat agent dispatch another chat-capable sub-agent as part of its work. The child is a real sub-agent with its own Durable Object storage, messages, tools, resumable stream, and drill-in URL. The parent keeps a small run registry so clients can render the child timeline, replay it after refresh, and clean it up later.
+Agents as tools let one chat agent dispatch another chat-capable sub-agent as part of its work. The child is a real sub-agent with its own Durable Object storage, messages, tools, resumable stream, and drill-in URL. The parent keeps a small run registry so clients can render the child timeline, replay it after refresh, and clean it up later.
 
-Agent tools support `@cloudflare/think` agents and `AIChatAgent` subclasses. `AIChatAgent` children run headlessly through `saveMessages()`, so they should use server-side tools. Browser-provided client tools are not available during an agent-tool turn unless you model that interaction as server-side state or a separate parent-mediated workflow.
+Agents as tools support `@cloudflare/think` agents and `AIChatAgent` subclasses. `AIChatAgent` children run headlessly through `saveMessages()`, so they should use server-side tools. Browser-provided client tools are not available during an agent-tool turn unless you model that interaction as server-side state or a separate parent-mediated workflow.
 
-## Agent tools vs sub-agent RPC
+## Agents as tools vs sub-agent RPC
 
 Use `subAgent(...).chat()` when parent code needs direct streaming RPC to a specific child and your code owns forwarding, cancellation, and replay policy.
 
@@ -207,7 +207,7 @@ Imperative runs without a parent tool call are available as `agentTools.unboundR
 
 ## Drill in and gate access
 
-Agent tools are normal sub-agents. Connect to a retained child through the parent route:
+Agents as tools are normal sub-agents. Connect to a retained child through the parent route:
 
 <TypeScriptExample>
 

--- a/src/content/docs/agents/runtime/execution/sub-agents.mdx
+++ b/src/content/docs/agents/runtime/execution/sub-agents.mdx
@@ -16,7 +16,7 @@ Spawn child agents as co-located Durable Objects with their own isolated SQLite 
 
 Use sub-agents when a single user or entity owns an open-ended set of long-lived agents, such as chats, documents, sessions, shards, or projects. Each sub-agent runs in parallel with its own state while the parent coordinates discovery, access control, and lifecycle.
 
-If you want a parent chat agent to dispatch another chat-capable agent during a single turn and render that child's progress inline, use [Agent tools](/agents/runtime/execution/agent-tools/). Agent tools are built on sub-agents, but add a parent-side run registry, streaming `agent-tool-event` frames, replay, cancellation, and cleanup.
+If you want a parent chat agent to dispatch another chat-capable agent during a single turn and render that child's progress inline, use [Agents as tools](/agents/runtime/execution/agent-tools/). Agents as tools are built on sub-agents, but add a parent-side run registry, streaming `agent-tool-event` frames, replay, cancellation, and cleanup.
 
 ## Quick start
 
@@ -519,5 +519,5 @@ Calling `this.destroy()` inside a sub-agent delegates cleanup to the parent. The
 - [Think](/agents/harnesses/think/) — `chat()` method for streaming AI turns through sub-agents
 - [Long-running agents](/agents/concepts/agentic-patterns/long-running-agents/) — sub-agent delegation in the context of multi-week agent lifetimes
 - [Callable methods](/agents/runtime/lifecycle/callable-methods/) — RPC via `@callable` and service bindings
-- [Agent tools](/agents/runtime/execution/agent-tools/) — run Think or `AIChatAgent` sub-agents as retained, streaming tools
+- [Agents as tools](/agents/runtime/execution/agent-tools/) — run Think or `AIChatAgent` sub-agents as retained, streaming tools
 - [Schedule tasks](/agents/runtime/execution/schedule-tasks/) — scheduling primitives for top-level agents and sub-agents


### PR DESCRIPTION
### Summary

Moves the Chat SDK documentation from the Runtime Execution section to the Runtime Communication section, since Chat SDK is a communication channel integration. Also renames "Agent tools" to "Agents as tools" for consistency.

- Moved `chat-sdk.mdx` from `/agents/runtime/execution/` to `/agents/runtime/communication/`
- Renamed page title in `agent-tools.mdx` from "Agent tools" to "Agents as tools"
- Updated all internal links and references across the Agents documentation
- Updated the redirect in `public/__redirects` for the old Chat SDK path

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
