### PR TITLE
fix(agents): correct chat agent example for tool approval and coercion

### DIFF
--- a/src/content/docs/agents/communication-channels/chat/chat-agents.mdx
+++ b/src/content/docs/agents/communication-channels/chat/chat-agents.mdx
@@ -1003,7 +1003,7 @@ tools: {
 	processPayment: tool({
 		description: "Process a payment",
 		inputSchema: z.object({
-			amount: z.number(),
+			amount: z.coerce.number(),
 			recipient: z.string(),
 		}),
 		needsApproval: async ({ amount }) => amount > 100,

--- a/src/content/docs/agents/examples/chat-agent.mdx
+++ b/src/content/docs/agents/examples/chat-agent.mdx
@@ -130,8 +130,8 @@ export class ChatAgent extends AIChatAgent {
 						"Perform a math calculation with two numbers. " +
 						"Requires user approval for large numbers.",
 					inputSchema: z.object({
-						a: z.number().describe("First number"),
-						b: z.number().describe("Second number"),
+						a: z.coerce.number().describe("First number"),
+						b: z.coerce.number().describe("Second number"),
 						operator: z
 							.enum(["+", "-", "*", "/", "%"])
 							.describe("Arithmetic operator"),
@@ -191,7 +191,7 @@ Create `src/client.tsx`:
 
 ```ts
 import { useAgent } from "agents/react";
-import { useAgentChat } from "@cloudflare/ai-chat/react";
+import { useAgentChat, getToolApproval } from "@cloudflare/ai-chat/react";
 
 function Chat() {
 	const agent = useAgent({ agent: "ChatAgent" });
@@ -225,10 +225,9 @@ function Chat() {
 							}
 
 							// Render approval UI for tools that need confirmation
-							if (
-								part.type === "tool" &&
-								part.state === "approval-required"
-							) {
+							if (part.state === "approval-requested") {
+								const approval = getToolApproval(part);
+								if (!approval) return null;
 								return (
 									<div key={part.toolCallId}>
 										<p>
@@ -238,7 +237,7 @@ function Chat() {
 										<button
 											onClick={() =>
 												addToolApprovalResponse({
-													id: part.toolCallId,
+													id: approval.id,
 													approved: true,
 												})
 											}
@@ -248,7 +247,7 @@ function Chat() {
 										<button
 											onClick={() =>
 												addToolApprovalResponse({
-													id: part.toolCallId,
+													id: approval.id,
 													approved: false,
 												})
 											}
@@ -260,10 +259,7 @@ function Chat() {
 							}
 
 							// Show completed tool results
-							if (
-								part.type === "tool" &&
-								part.state === "output-available"
-							) {
+							if (part.state === "output-available") {
 								return (
 									<details key={part.toolCallId}>
 										<summary>{part.toolName} result</summary>


### PR DESCRIPTION
## Summary

The chat agent example at `/agents/examples/chat-agent/` contains 4 bugs that prevent the approval flow and tool execution from working correctly.

## Issues Found

### 1. Zod number validation fails with LLM string outputs (line 133-134)
**Problem:** `z.number()` rejects string values like `"4"` and `"23"` that LLMs output when calling tools.
**Fix:** Use `z.coerce.number()` to automatically convert strings to numbers.

### 2. Tool part type is dynamic, not `"tool"` (line 229)
**Problem:** `part.type` is set to dynamic values like `"tool-calculate"`, not the literal string `"tool"`. The condition `part.type === "tool"` never matches.
**Fix:** Check `part.state === "approval-requested"` directly instead of coupling type and state checks.

### 3. Wrong approval state name (line 230)
**Problem:** The state is `"approval-requested"`, not `"approval-required"`. The UI never renders.
**Fix:** Use the correct state name `"approval-requested"`.

### 4. Wrong ID passed to `addToolApprovalResponse` (line 241, 251)
**Problem:** `addToolApprovalResponse` expects the `approval.id` (from `part.approval.id`), not `part.toolCallId`. Passing `toolCallId` causes the warning: "Could not find toolCallId for approval ID" and the server never gets notified.
**Fix:** Use `getToolApproval(part).id` as documented in the API reference.

### 5. Also fixed same `z.number()` issue in chat-agents API reference (line 1006)
The main `/agents/communication-channels/chat/chat-agents/` page had the same Zod schema issue in its `processPayment` example.

## Files Changed

- `src/content/docs/agents/examples/chat-agent.mdx` — Full example fix
- `src/content/docs/agents/communication-channels/chat/chat-agents.mdx` — API reference `z.coerce.number()` fix

## Verification

These changes have been tested and verified to resolve the MissingToolResultsError and make the approval UI render correctly.