### PR TITLE
Remove PHP from supported languages list

### DIFF
--- a/src/content/docs/pages/configuration/build-image.mdx
+++ b/src/content/docs/pages/configuration/build-image.mdx
@@ -14,7 +14,7 @@ import {
 	DashButton,
 } from "~/components";
 
-Cloudflare Pages' build environment has broad support for a variety of languages, such as Ruby, Node.js, Python, PHP, and Go.
+Cloudflare Pages' build environment has broad support for a variety of languages, such as Ruby, Node.js, Python, and Go.
 
 If you need to use a [specific version](#override-default-versions) of a language, (for example, Node.js or Ruby) you can specify it by providing an associated environment variable in your build configuration, or setting the relevant file in your source code.
 


### PR DESCRIPTION
This pull request makes a minor update to the documentation for Cloudflare Pages by removing PHP from the list of supported languages in the build environment.

- Documentation update:
  * Removed PHP from the list of languages supported by Cloudflare Pages' build environment in `build-image.mdx`.