### PR TITLE
[DLP] Improve DLP profiles documentation

### DIFF
--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
@@ -69,7 +69,7 @@ When you set a confidence threshold on a profile, DLP only triggers on detection
 
 - **Low** (default) — Based on regular expressions with few proximity keywords. This is the most inclusive setting, with high tolerance for false positives
 - **Medium** — Applies additional validations, to filter out low confidence detections. This setting has a medium tolerance for false positives.
-- **High** — Applies rigorous contextual validation for minimal false positives (has a higher likelihood of accuracy).
+- **Medium** — Applies additional validations to filter out low confidence detections. This setting has a medium tolerance for false positives.
 
 Confidence threshold is set on the DLP profile. Not all detection entries support confidence thresholds — when you select a threshold in the dashboard, entries that support confidence scoring display their current level. Entries without a displayed confidence level either do not support this feature or use detection methods (such as exact match) where confidence scoring does not apply.
 

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings.mdx
@@ -10,7 +10,9 @@ tags:
   - Compliance
 ---
 
-This page lists the profile settings available when configuring a [predefined](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/) or [custom](/cloudflare-one/data-loss-prevention/dlp-profiles/#build-a-custom-profile) DLP profile. You can configure profile settings when you create a custom profile or [edit profile settings](#edit-profile-settings) for an existing predefined or custom profile.
+Profile settings control detection behavior for an individual DLP profile. You configure these settings when you [build a custom profile](/cloudflare-one/data-loss-prevention/dlp-profiles/#build-a-custom-profile) or edit an existing [predefined](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/) or custom profile.
+
+Profile settings are distinct from [DLP settings](/cloudflare-one/data-loss-prevention/dlp-settings/), which are account-level settings that apply across all profiles and policies.
 
 ## Edit profile settings
 
@@ -27,7 +29,9 @@ The following advanced detection settings are available for predefined and custo
 
 ### Match count
 
-Match count sets a minimum threshold for detections. DLP does not trigger an action (such as blocking or logging) until the number of detections exceeds the match count. For example, if you set a match count of 10, the scanned file or HTTP body must contain 11 or more matching strings before the action triggers. Detections do not have to be unique.
+Match count sets a minimum threshold for the number of detections required to trigger an action. DLP does not block or log content until the detection count reaches this threshold.
+
+For example, if you set a match count of `10`, DLP takes action when it finds 10 or more matches in a single file or HTTP body. Matches do not have to be unique — the same credit card number appearing 10 times counts as 10 matches.
 
 ### Optical Character Recognition (OCR)
 
@@ -35,7 +39,7 @@ Match count sets a minimum threshold for detections. DLP does not trigger an act
 Profile-level OCR settings will be deprecated in a future release. We recommend configuring OCR in [DLP settings](/cloudflare-one/data-loss-prevention/dlp-settings/#optical-character-recognition-ocr) instead.
 :::
 
-Optical Character Recognition (OCR) analyzes and interprets text within image files. When used with DLP profiles, OCR can detect sensitive data within images your users upload.
+Optical Character Recognition (OCR) extracts and analyzes text within image files. When enabled, DLP can detect sensitive data within images that users upload or download.
 
 OCR supports scanning `.jpg`/`.jpeg` and `.png` files between 4 KB and 1 MB in size. Text is encoded in UTF-8 format, including support for non-Latin characters.
 
@@ -51,7 +55,9 @@ Profile-level AI context analysis settings will be deprecated in a future releas
 AI context analysis only supports Gateway HTTP and HTTPS traffic.
 :::
 
-AI context analysis uses a pretrained model to analyze surrounding context and adjust the confidence level of a detection. For example, a number that matches a credit card pattern may receive a lower confidence score if it appears in a context where credit card numbers are unlikely. DLP will log any matches that are above your confidence threshold.
+AI context analysis uses a machine learning model to evaluate the surrounding context of a detection and adjust its confidence level. The model examines nearby text to determine whether a pattern match is likely to be genuine sensitive data or a false positive.
+
+For example, a 16-digit number that matches a credit card pattern may receive a lower confidence score if it appears in a context where credit card numbers are unlikely (such as a product SKU list). Conversely, the same number appearing near terms like "payment" or "billing" would receive a higher confidence score. DLP logs matches that meet or exceed your configured [confidence threshold](#confidence-thresholds).
 
 For full documentation on AI context analysis, refer to [DLP settings](/cloudflare-one/data-loss-prevention/dlp-settings/#ai-context-analysis).
 
@@ -65,7 +71,7 @@ When you set a confidence threshold on a profile, DLP only triggers on detection
 - **Medium** — Applies additional validations, to filter out low confidence detections. This setting has a medium tolerance for false positives.
 - **High** — Applies rigorous contextual validation for minimal false positives (has a higher likelihood of accuracy).
 
-Confidence threshold is set on the DLP profile. When you select a confidence threshold in the Cloudflare dashboard, you will see which DLP entries will be affected by the confidence threshold. Entries that do not reflect a confidence threshold in the dashboard are not yet supported or are not applicable.
+Confidence threshold is set on the DLP profile. Not all detection entries support confidence thresholds — when you select a threshold in the dashboard, entries that support confidence scoring display their current level. Entries without a displayed confidence level either do not support this feature or use detection methods (such as exact match) where confidence scoring does not apply.
 
 To change the confidence threshold of a DLP profile:
 
@@ -74,14 +80,23 @@ To change the confidence threshold of a DLP profile:
 3. In **Settings** > **Confidence threshold**, choose a new confidence threshold from the dropdown menu.
 4. Select **Save profile**.
 
-#### Gateway detections
+## Gateway detections
 
-For inline detections in Gateway, to display Low and Medium confidence detections but block High confidence detections, Cloudflare recommends creating two HTTP policies. The first policy should use a Low confidence DLP profile with an Allow action. The second policy should use a High confidence DLP profile with a Block action. For example:
+For inline detections in Gateway, you can log lower-confidence matches while blocking only high-confidence detections. This approach requires two HTTP policies with different DLP profiles:
 
-| Selector    | Operator | Value                       | Action |
-| ----------- | -------- | --------------------------- | ------ |
-| DLP Profile | in       | _Low Confidence Detections_ | Allow  |
+1. A Low or Medium confidence profile with an Allow action — logs the detection without blocking.
+2. A High confidence profile with a Block action — blocks the request.
 
-| Selector    | Operator | Value                        | Action |
-| ----------- | -------- | ---------------------------- | ------ |
-| DLP Profile | in       | _High Confidence Detections_ | Block  |
+For example:
+
+| Selector    | Operator | Value                          | Action |
+| ----------- | -------- | ------------------------------ | ------ |
+| DLP Profile | in       | _Low Confidence Detections_    | Allow  |
+
+| Selector    | Operator | Value                          | Action |
+| ----------- | -------- | ------------------------------ | ------ |
+| DLP Profile | in       | _Medium Confidence Detections_ | Allow  |
+
+| Selector    | Operator | Value                          | Action |
+| ----------- | -------- | ------------------------------ | ------ |
+| DLP Profile | in       | _High Confidence Detections_   | Block  |

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/index.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/index.mdx
@@ -13,9 +13,17 @@ tags:
 
 import { Render } from "~/components";
 
-A DLP profile defines what sensitive data Cloudflare should detect in your traffic. Profiles can combine [detection entries](/cloudflare-one/data-loss-prevention/detection-entries/configure-detection-entries/) with [Data Classification](/cloudflare-one/data-loss-prevention/data-classification/) objects such as data classes, sensitivity levels, and data tags.
+A DLP profile defines what sensitive data Cloudflare detects in your traffic. A profile combines one or more of the following building blocks:
 
-Cloudflare DLP provides [predefined profiles](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/) for common sensitive data types such as credit card numbers and national identifiers. You can also build custom DLP profiles specific to your data, organization, and risk tolerance by using direct detection entries, data classes, and labels.
+- **[Detection entries](/cloudflare-one/data-loss-prevention/detection-entries/configure-detection-entries/)** — reusable detection logic that identifies sensitive content, such as patterns, datasets, document fingerprints, predefined detections, and AI prompt topics.
+- **Data classes** — reusable classification rules that combine detection entries and other signals into a single rule.
+- **Labels** — sensitivity levels and data tags that describe matched content.
+
+Data classes and labels are part of [Data Classification](/cloudflare-one/data-loss-prevention/data-classification/). Cloudflare DLP offers three types of profiles:
+
+- **[Predefined profiles](/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles/)** — Cloudflare-managed profiles for common sensitive data types such as credit card numbers, national identifiers, and AI prompts.
+- **Custom profiles** — profiles you [build](#build-a-custom-profile) from detection entries, data classes, and labels, specific to your data, organization, and risk tolerance.
+- **[Integration profiles](/cloudflare-one/data-loss-prevention/dlp-profiles/integration-profiles/)** — profiles populated with data classifications from a third-party platform, such as Microsoft Purview sensitivity labels (requires Cloudflare CASB).
 
 ## Configure a predefined profile
 
@@ -24,10 +32,10 @@ Cloudflare DLP provides [predefined profiles](/cloudflare-one/data-loss-preventi
 	product="cloudflare-one"
 />
 
-You can now use this profile in a [DLP policy](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy), [CASB integration](/cloudflare-one/cloud-and-saas-findings/casb-dlp/), or [AI Gateway DLP policy](/ai-gateway/features/dlp/set-up-dlp/).
+You can now use this profile in a [DLP policy](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy), [CASB integration](/cloudflare-one/cloud-and-saas-findings/casb-dlp/), [AI Gateway DLP policy](/ai-gateway/features/dlp/set-up-dlp/), or [Email Security outbound DLP policy](/cloudflare-one/email-security/outbound-dlp/).
 
 ## Build a custom profile
 
 <Render file="data-loss-prevention/custom-profile" product="cloudflare-one" />
 
-You can now use this profile in a [DLP policy](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy), [CASB integration](/cloudflare-one/cloud-and-saas-findings/casb-dlp/), or [AI Gateway DLP policy](/ai-gateway/features/dlp/set-up-dlp/).
+You can now use this profile in a [DLP policy](/cloudflare-one/data-loss-prevention/dlp-policies/#2-create-a-dlp-policy), [CASB integration](/cloudflare-one/cloud-and-saas-findings/casb-dlp/), [AI Gateway DLP policy](/ai-gateway/features/dlp/set-up-dlp/), or [Email Security outbound DLP policy](/cloudflare-one/email-security/outbound-dlp/).

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/integration-profiles.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/integration-profiles.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: concept
-description: How Integration profiles works in Cloudflare One.
+description: How integration profiles work in Cloudflare One.
 products:
   - cloudflare-one
 title: Integration profiles
@@ -17,7 +17,7 @@ import { Render } from "~/components";
 Integration profiles require [Cloudflare CASB](/cloudflare-one/integrations/cloud-and-saas/).
 :::
 
-Integration profiles let you use data classifications from a third-party platform (such as Microsoft Purview sensitivity labels) directly in Cloudflare DLP. Instead of recreating classification rules in Cloudflare, DLP retrieves them from the third-party platform and populates them as detection entries in a DLP profile. You can then enable the entries you want and create a DLP policy to allow or block matching data.
+Integration profiles let you use data classifications from a third-party platform (such as Microsoft Purview sensitivity labels) directly in Cloudflare DLP. Instead of recreating classification rules yourself, Cloudflare retrieves them from the third-party platform and populates them as [detection entries](/cloudflare-one/data-loss-prevention/detection-entries/configure-detection-entries/) in a DLP profile. You can then enable the entries you want and create a DLP policy to allow or block matching data.
 
 Detection entries in integration profiles are managed by the third-party platform. You cannot manually add, edit, or delete these entries within Cloudflare DLP.
 
@@ -29,10 +29,10 @@ Microsoft provides [Purview Information Protection sensitivity labels](https://l
 
 ### Setup
 
-To add MIP sensitivity labels to a DLP Profile, integrate your Microsoft account with [Cloudflare CASB](/cloudflare-one/integrations/cloud-and-saas/microsoft-365/). A new integration profile will appear under **Data loss prevention** > **DLP profiles**. The profile is named **MIP Sensitivity Labels** followed by the name of the CASB integration.
+To add MIP sensitivity labels to a DLP profile, integrate your Microsoft account with [Cloudflare CASB](/cloudflare-one/integrations/cloud-and-saas/microsoft-365/). A new integration profile will appear under **Zero Trust** > **Data loss prevention** > **Profiles**. The profile is named **MIP Sensitivity Labels** followed by the name of the CASB integration.
 
 MIP sensitivity labels can also be added to a [custom DLP profile](/cloudflare-one/data-loss-prevention/dlp-profiles/#build-a-custom-profile) as an existing entry.
 
 ### Syncing
 
-Allow 24 hours for label additions and edits in your Microsoft account to propagate to Cloudflare DLP. Deletions in your Microsoft account will not delete entries in your Cloudflare DLP Profile.
+Allow 24 hours for label additions and edits in your Microsoft account to propagate to Cloudflare DLP. Deletions in your Microsoft account will not delete entries in your Cloudflare DLP profile.

--- a/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/dlp-profiles/predefined-profiles.mdx
@@ -12,19 +12,23 @@ tags:
 
 import { Render } from "~/components";
 
-Cloudflare Zero Trust provides predefined DLP profiles for common types of sensitive data. Some profiles include built-in validation checks to increase detection accuracy. Others use profile-specific matching logic to reduce false positives. You can also configure [advanced settings](/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings/) for predefined profiles.
+Cloudflare Zero Trust provides predefined DLP profiles for common types of sensitive data, such as credit card numbers, national identifiers, and credentials. Each predefined profile groups related [detection entries](/cloudflare-one/data-loss-prevention/detection-entries/configure-detection-entries/) which can be turned on or off individually.
+
+To use a predefined profile, [enable the detection entries you want](/cloudflare-one/data-loss-prevention/dlp-profiles/#configure-a-predefined-profile) and add the profile to a [DLP policy](/cloudflare-one/data-loss-prevention/dlp-policies/). You can tune accuracy with [confidence thresholds](/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings/#confidence-thresholds) and other [profile settings](/cloudflare-one/data-loss-prevention/dlp-profiles/advanced-settings/).
+
+Most profiles match when any enabled detection entry matches. Some add validation checks to improve accuracy, and a few use profile-specific matching logic to reduce false positives — for example, the [PII Record](#personally-identifiable-information-pii-record) profile requires multiple entries in close proximity.
 
 ## AI Prompt
 
-DLP provides AI prompt protection with the following predefined profiles:
+DLP provides AI prompt protection profiles that detect sensitive prompts submitted to generative AI tools such as ChatGPT, Google Gemini, Perplexity, and Claude. Each profile evaluates prompts for **Content** (sensitive data within the prompt) and **Intent** (what the user wants the model to do):
 
-- AI Prompt: AI Security
-- AI Prompt: Customer
-- AI Prompt: Financial Information
-- AI Prompt: PII
-- AI Prompt: Technical
+- **AI Prompt: AI Security** — Prompts that attempt to circumvent AI security policies or request malicious code.
+- **AI Prompt: Customer** — Prompts that contain customer names, projects, business activities, or confidential customer contexts.
+- **AI Prompt: Financial Information** — Prompts that contain financial numbers or confidential business data.
+- **AI Prompt: PII** — Prompts that contain or request personal information such as names, SSNs, or email addresses.
+- **AI Prompt: Technical** — Prompts that contain source code, code snippets, proprietary algorithms, or credentials such as API keys and passwords.
 
-For more information on included detection entries, refer to [AI prompt topics](/cloudflare-one/data-loss-prevention/detection-entries/configure-detection-entries/#ai-prompt-topics).
+For the full list of underlying topics, refer to [AI prompt topics](/cloudflare-one/data-loss-prevention/detection-entries/configure-detection-entries/#ai-prompt-topics).
 
 ## Credentials and Secrets
 
@@ -70,7 +74,16 @@ In the table below, entries use one of three validation methods. [Luhn's algorit
 | United States ABA Routing Number | Validated algorithmically with checksum.                                          |
 | IBAN                             | Validated with checksum.                                                          |
 
-## HTTP Archive
+## Health Information
+
+The following diagnosis and medication names are checked for surrounding ASCII characters to prevent false positives.
+
+- FDA active ingredients
+- FDA drug names
+- ICD-10 FY2023 short descriptions
+- ICD-11 short descriptions
+
+## HTTP Archive (HAR) files
 
 The **Unsanitized HAR** predefined profile detects HTTP Archive (HAR) files in traffic that have not been processed by Cloudflare's HAR sanitizer. HAR files frequently contain sensitive data such as session cookies, authorization headers, and other credentials.
 
@@ -79,14 +92,6 @@ The **Unsanitized HAR** predefined profile detects HTTP Archive (HAR) files in t
 | Unsanitized HAR file  | Detects HAR files that do not carry a Cloudflare sanitized marker. Files processed by the Cloudflare HAR sanitizer and unmodified since will not match this entry. |
 
 You can use this profile in a Gateway HTTP policy to block HAR file uploads or redirect users to `https://har-sanitizer.pages.dev/` to sanitize the file before uploading. For more information, refer to [common DLP policies](/cloudflare-one/data-loss-prevention/dlp-policies/common-policies/).
-
-## Health Information
-
-The following diagnosis and medication names are checked for surrounding ASCII characters to prevent false positives.
-
-- FDA active ingredients
-- FDA drug names
-- ICD-10 FY2023 short descriptions
 
 ## Personally Identifiable Information (PII) Record
 
@@ -138,6 +143,8 @@ The following national identifier detections are validated algorithmically when 
 | United Kingdom National Insurance Number             | Validated with regex.                                                                                                                                                                                                               |
 
 ## Source Code
+
+The **Source Code** profile detects source code in common programming languages.
 
 <Render
 	file="data-loss-prevention/programming-language-list"

--- a/src/content/docs/cloudflare-one/data-loss-prevention/troubleshoot-dlp.mdx
+++ b/src/content/docs/cloudflare-one/data-loss-prevention/troubleshoot-dlp.mdx
@@ -63,6 +63,12 @@ If DLP detects sensitive data in plain text but not within images or certain app
 - **Application-specific behavior**: Some applications, such as WhatsApp Web, use protocols or encryption methods (such as WebSocket connections) that Gateway may not be able to fully inspect with HTTP policies.
 - **Supported file types**: Content must be in a [supported file type](/cloudflare-one/data-loss-prevention/#supported-file-types) for DLP inspection.
 
+## PII Record profile does not match
+
+The **Personally Identifiable Information (PII) Record** predefined profile does not match isolated values. Unlike most profiles, it matches only when at least three unique detection entries appear in close proximity, which reduces false positives from single, unrelated matches.
+
+If you need to detect an individual data type (such as a single email address or credit card number), use a different predefined profile or a [custom profile](/cloudflare-one/data-loss-prevention/dlp-profiles/#build-a-custom-profile) with the specific detection entries you want.
+
 ## DLP options are missing or you cannot create custom profiles
 
 If you cannot use the _DLP Profile_ selector when creating an HTTP policy or are blocked from creating a custom DLP profile, it typically means one of two things:

--- a/src/content/partials/cloudflare-one/data-loss-prevention/custom-profile.mdx
+++ b/src/content/partials/cloudflare-one/data-loss-prevention/custom-profile.mdx
@@ -10,11 +10,11 @@ import { Details } from "~/components";
 
 3. Enter a name and optional description for the profile.
 
-4. Add new or existing detection entries to the profile.
+4. Add detection entries to the profile.
 
-   <Details header="Add a custom entry">
+   <Details header="Create a custom entry">
 
-   1. Select **Add custom entry**.
+   1. Select **Create custom entry**.
 
    2. Choose the type of detection entry you want to create and configure its values.
 
@@ -30,14 +30,14 @@ import { Details } from "~/components";
 
    1. Select **Add existing entries**.
    2. Choose which entries you want to add, then select **Confirm**.
-   3. To save the detection entry, select **Done**.
+   3. To finish, select **Done**.
 
    </Details>
 
 5. (Optional) Add data classes to include reusable classification rules.
 
-   1. Select **Add data classes**.
-   2. Choose the data classes you want to add, then select **Confirm**.
+   - Select **Add data classes**.
+   - Choose the data classes you want to add, then select **Confirm**.
 
 6. (Optional) Use labels as match criteria for the profile.
 

--- a/src/content/partials/cloudflare-one/data-loss-prevention/custom-profile.mdx
+++ b/src/content/partials/cloudflare-one/data-loss-prevention/custom-profile.mdx
@@ -36,8 +36,8 @@ import { Details } from "~/components";
 
 5. (Optional) Add data classes to include reusable classification rules.
 
-   - Select **Add data classes**.
-   - Choose the data classes you want to add, then select **Confirm**.
+   - Select **Add data classes**
+   - Choose the data classes you want to add, then select **Confirm**
 
 6. (Optional) Use labels as match criteria for the profile.
 


### PR DESCRIPTION
### Summary

- Rewrote the DLP profiles overview and predefined profiles intros to define the building blocks (detection entries, data classes, labels), name all three profile types (predefined, custom, integration), and add enable/policy/confidence-threshold links.
- Described each AI Prompt profile by Content/Intent, added ICD-11 to Health Information, renamed "HTTP Archive" to "HTTP Archive (HAR) files," alphabetized sections, and added Email Security as a fourth place profiles can be used.
- Cleaned up the custom profile steps (button labels, copy-paste fix, consistent bullets — note these partial edits also render on the CASB "Scan for sensitive data" page) and added a PII Record troubleshooting entry.
