### PR TITLE
[AI Gateway] Add coding agents integration page

### DIFF
--- a/src/content/docs/ai-gateway/integrations/coding-agents.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents.mdx
@@ -23,7 +23,6 @@ Routing a coding agent through AI Gateway gives you:
 - **Rate limiting** — cap request volume with [rate limiting](/ai-gateway/features/rate-limiting/).
 - **Cost tracking** — attribute spend across sessions and models.
 - **Data Loss Prevention** — scan prompts and responses for secrets, credentials, and other sensitive data with [DLP](/ai-gateway/features/dlp/).
-- **Guardrails** — flag or block harmful prompts and model responses with [Guardrails](/ai-gateway/features/guardrails/).
 
 ## Prerequisites
 
@@ -76,21 +75,15 @@ This configuration uses your Anthropic API key, so Anthropic bills you for model
 
 </Steps>
 
-## Protect sensitive code and data
+## Protect sensitive code with DLP
 
 Coding agents routinely send source code, configuration files, and snippets to model providers. That traffic can include API keys, customer data, or other sensitive material. Because AI Gateway sits between the agent and the provider, you can inspect and control it without changing the agent.
-
-### Scan prompts and responses with DLP
 
 [Data Loss Prevention (DLP)](/ai-gateway/features/dlp/) scans request and response bodies against [detection profiles](/cloudflare-one/data-loss-prevention/dlp-profiles/) and either flags or blocks matches. Use it to catch secrets, credentials, or regulated data leaving (or returning to) the agent.
 
 :::note
 Claude Code streams responses by default. When DLP response scanning is enabled, AI Gateway buffers the full provider response before returning it, which increases time-to-first-token. If you need low-latency streaming, set the DLP policy **Check** to **Request** only, or use a separate gateway for latency-sensitive traffic. Refer to [streaming behavior](/ai-gateway/features/dlp/#streaming-behavior).
 :::
-
-### Moderate content with Guardrails
-
-[Guardrails](/ai-gateway/features/guardrails/) evaluate prompts and model responses against safety categories (such as violence, hate, or sexual content) and either flag or block them. This gives you a consistent moderation layer across every provider your coding agents use.
 
 ## Verify it works
 

--- a/src/content/docs/ai-gateway/integrations/coding-agents.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents.mdx
@@ -30,19 +30,20 @@ Before you start, you need:
 
 1. An [authenticated gateway](/ai-gateway/configuration/authentication/) and its gateway token. The gateway token must have `Run` permissions.
 2. Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
-3. Claude Code installed and updated to the latest version.
+3. An Anthropic API key. To create one, go to [Account Settings](https://platform.claude.com/settings/keys) in the Claude Console. For more information, refer to [Anthropic's API overview](https://docs.anthropic.com/en/api/overview).
+4. Claude Code installed and updated to the latest version.
 
 ## Claude Code
 
-Claude Code reads its endpoint and credentials from environment variables. This configuration sends requests to AI Gateway's [Anthropic endpoint](/ai-gateway/usage/providers/anthropic/) using your own Anthropic API key. The Anthropic endpoint exposes the same `/v1/messages` API that Claude Code expects.
+Claude Code reads its endpoint and credentials from environment variables. This configuration sends requests to AI Gateway's [Anthropic endpoint](/ai-gateway/usage/providers/anthropic/) using your own Anthropic API key, passed directly in the `ANTHROPIC_API_KEY` environment variable. The Anthropic endpoint exposes the same `/v1/messages` API that Claude Code expects.
 
 :::note
-This configuration uses your Anthropic API key, so Anthropic bills you for model usage. AI Gateway provides observability, caching, and rate limiting for the traffic.
+This configuration does not use [BYOK (Store Keys)](/ai-gateway/configuration/bring-your-own-keys/). The Anthropic API key comes from the environment variable you set below, not from a key stored in AI Gateway. Anthropic bills you for model usage, and AI Gateway provides observability, caching, and rate limiting for the traffic. For details on where Claude Code reads credentials from, refer to [Anthropic's authentication documentation](https://docs.anthropic.com/en/docs/claude-code/iam#credential-management).
 :::
 
 <Steps>
 
-1. Set the base URL to your gateway's Anthropic endpoint, pass your Anthropic API key, and send your gateway token in the `cf-aig-authorization` header.
+1. Set the base URL to your gateway's Anthropic endpoint, pass your Anthropic API key, and send your gateway token in the `cf-aig-authorization` header. The commands below set these as shell environment variables for the current session. To persist them, add them to your shell profile (for example, `~/.zshrc` or `~/.bashrc`) or to Claude Code's [`settings.json`](https://docs.anthropic.com/en/docs/claude-code/settings#settings-files) under the `env` key.
 
    Replace `<ACCOUNT_ID>`, `<GATEWAY_ID>`, `<ANTHROPIC_API_KEY>`, and `<CF_AIG_TOKEN>` with your values.
 

--- a/src/content/docs/ai-gateway/integrations/coding-agents.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents.mdx
@@ -27,7 +27,7 @@ Routing a coding agent through AI Gateway gives you:
 
 Before you start, you need:
 
-1. An AI Gateway gateway. To create one, refer to [Getting started](/ai-gateway/get-started/).
+1. A gateway. To create one, refer to [Getting started](/ai-gateway/get-started/).
 2. Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
 3. Claude Code installed and updated to the latest version.
 
@@ -43,22 +43,22 @@ This configuration uses your Anthropic API key, so Anthropic bills you for model
 
 1. Set the base URL to your gateway's Anthropic endpoint and pass your Anthropic API key.
 
-   Replace `{account_id}` and `{gateway_id}` with your values.
+   Replace `<ACCOUNT_ID>` and `<GATEWAY_ID>` with your values.
 
    <Tabs syncKey="os">
    <TabItem label="macOS / Linux">
 
    ```bash
-   export ANTHROPIC_BASE_URL=https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/anthropic
-   export ANTHROPIC_API_KEY={your_anthropic_api_key}
+   export ANTHROPIC_BASE_URL=https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/anthropic
+   export ANTHROPIC_API_KEY=<ANTHROPIC_API_KEY>
    ```
 
    </TabItem>
    <TabItem label="Windows (PowerShell)">
 
    ```powershell
-   $env:ANTHROPIC_BASE_URL = "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/anthropic"
-   $env:ANTHROPIC_API_KEY = "{your_anthropic_api_key}"
+   $env:ANTHROPIC_BASE_URL = "https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/anthropic"
+   $env:ANTHROPIC_API_KEY = "<ANTHROPIC_API_KEY>"
    ```
 
    </TabItem>
@@ -76,17 +76,19 @@ If your gateway requires authentication, refer to [Authenticated Gateway](/ai-ga
 
 ## Any OpenAI-compatible coding tool
 
-Tools that speak the OpenAI chat completions format can route through AI Gateway's [REST API](/ai-gateway/usage/rest-api/). Point the tool's base URL at the following endpoint:
+Tools that speak the OpenAI chat completions format can route through AI Gateway's [REST API](/ai-gateway/usage/rest-api/). Set the tool's base URL to:
 
 ```txt
-https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1/chat/completions
+https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai/v1
 ```
+
+Most OpenAI-compatible tools append `/chat/completions` to the base URL automatically.
 
 Authenticate with a [Cloudflare API token](/fundamentals/api/get-started/create-token/) that has the `AI Gateway Run` permission, and pass it in the `Authorization` header. Specify the model in `author/model` format, such as `openai/gpt-4.1` or `anthropic/claude-sonnet-4-5`.
 
 ```bash
-curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1/chat/completions" \
-  --header "Authorization: Bearer {cloudflare_api_token}" \
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai/v1/chat/completions" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
   --data '{
     "model": "openai/gpt-4.1",

--- a/src/content/docs/ai-gateway/integrations/coding-agents.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents.mdx
@@ -22,6 +22,8 @@ Routing a coding agent through AI Gateway gives you:
 - **Caching** — return [cached responses](/ai-gateway/features/caching/) for repeated prompts.
 - **Rate limiting** — cap request volume with [rate limiting](/ai-gateway/features/rate-limiting/).
 - **Cost tracking** — attribute spend across sessions and models.
+- **Data Loss Prevention** — scan prompts and responses for secrets, credentials, and other sensitive data with [DLP](/ai-gateway/features/dlp/).
+- **Guardrails** — flag or block harmful prompts and model responses with [Guardrails](/ai-gateway/features/guardrails/).
 
 ## Prerequisites
 
@@ -104,6 +106,22 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai/v1/ch
 :::note
 Claude Code does not use the OpenAI chat completions format, so it cannot call this endpoint directly. Use the Claude Code configuration on this page instead.
 :::
+
+## Protect sensitive code and data
+
+Coding agents routinely send source code, configuration files, and snippets to model providers. That traffic can include API keys, customer data, or other sensitive material. Because AI Gateway sits between the agent and the provider, you can inspect and control it without changing the agent.
+
+### Scan prompts and responses with DLP
+
+[Data Loss Prevention (DLP)](/ai-gateway/features/dlp/) scans request and response bodies against [detection profiles](/cloudflare-one/data-loss-prevention/dlp-profiles/) and either flags or blocks matches. Use it to catch secrets, credentials, or regulated data leaving (or returning to) the agent.
+
+:::note
+Claude Code streams responses by default. When DLP response scanning is enabled, AI Gateway buffers the full provider response before returning it, which increases time-to-first-token. If you need low-latency streaming, set the DLP policy **Check** to **Request** only, or use a separate gateway for latency-sensitive traffic. Refer to [streaming behavior](/ai-gateway/features/dlp/#streaming-behavior).
+:::
+
+### Moderate content with Guardrails
+
+[Guardrails](/ai-gateway/features/guardrails/) evaluate prompts and model responses against safety categories (such as violence, hate, or sexual content) and either flag or block them. This gives you a consistent moderation layer across every provider your coding agents use.
 
 ## Verify it works
 

--- a/src/content/docs/ai-gateway/integrations/coding-agents.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents.mdx
@@ -12,7 +12,7 @@ import { Tabs, TabItem, Steps, DashButton } from "~/components";
 
 Coding agents send model requests to a provider on your behalf. By pointing the agent at AI Gateway instead of the provider, you observe and control that traffic without changing how you work.
 
-This page uses [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) as the worked example, then shows how to connect any tool that speaks the OpenAI chat completions format.
+This page uses [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) as the worked example.
 
 ## Why route a coding agent through AI Gateway
 
@@ -75,37 +75,6 @@ This configuration uses your Anthropic API key, so Anthropic bills you for model
 </Steps>
 
 If your gateway requires authentication, refer to [Authenticated Gateway](/ai-gateway/configuration/authentication/) for the header AI Gateway expects.
-
-## Any OpenAI-compatible coding tool
-
-Tools that speak the OpenAI chat completions format can route through AI Gateway's [REST API](/ai-gateway/usage/rest-api/). Set the tool's base URL to:
-
-```txt
-https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/ai/v1
-```
-
-Most OpenAI-compatible tools append `/chat/completions` to the base URL automatically.
-
-Authenticate with a [Cloudflare API token](/fundamentals/api/get-started/create-token/) that has the `AI Gateway Run` permission, and pass it in the `Authorization` header. Specify the model in `author/model` format, such as `openai/gpt-4.1` or `anthropic/claude-sonnet-4-5`.
-
-```bash
-curl -X POST "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai/v1/chat/completions" \
-  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
-  --header "Content-Type: application/json" \
-  --data '{
-    "model": "openai/gpt-4.1",
-    "messages": [
-      {
-        "role": "user",
-        "content": "What is Cloudflare?"
-      }
-    ]
-  }'
-```
-
-:::note
-Claude Code does not use the OpenAI chat completions format, so it cannot call this endpoint directly. Use the Claude Code configuration on this page instead.
-:::
 
 ## Protect sensitive code and data
 

--- a/src/content/docs/ai-gateway/integrations/coding-agents.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents.mdx
@@ -1,0 +1,122 @@
+---
+title: Coding agents
+description: Route coding agents such as Claude Code through AI Gateway for observability, caching, rate limiting, and cost tracking.
+pcx_content_type: configuration
+sidebar:
+  order: 5
+products:
+  - ai-gateway
+---
+
+import { Tabs, TabItem, Steps, DashButton } from "~/components";
+
+Coding agents send model requests to a provider on your behalf. By pointing the agent at AI Gateway instead of the provider, you observe and control that traffic without changing how you work.
+
+This page uses [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) as the worked example, then shows how to connect any tool that speaks the OpenAI chat completions format.
+
+## Why route a coding agent through AI Gateway
+
+Routing a coding agent through AI Gateway gives you:
+
+- **Observability** — view every request, token count, and latency in the dashboard.
+- **Caching** — return [cached responses](/ai-gateway/features/caching/) for repeated prompts.
+- **Rate limiting** — cap request volume with [rate limiting](/ai-gateway/features/rate-limiting/).
+- **Cost tracking** — attribute spend across sessions and models.
+
+## Prerequisites
+
+Before you start, you need:
+
+1. An AI Gateway gateway. To create one, refer to [Getting started](/ai-gateway/get-started/).
+2. Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
+3. Claude Code installed and updated to the latest version.
+
+## Claude Code
+
+Claude Code reads its endpoint and credentials from environment variables. This configuration sends requests to AI Gateway's [Anthropic endpoint](/ai-gateway/usage/providers/anthropic/) using your own Anthropic API key. The Anthropic endpoint exposes the same `/v1/messages` API that Claude Code expects.
+
+:::note
+This configuration uses your Anthropic API key, so Anthropic bills you for model usage. AI Gateway provides observability, caching, and rate limiting for the traffic.
+:::
+
+<Steps>
+
+1. Set the base URL to your gateway's Anthropic endpoint and pass your Anthropic API key.
+
+   Replace `{account_id}` and `{gateway_id}` with your values.
+
+   <Tabs syncKey="os">
+   <TabItem label="macOS / Linux">
+
+   ```bash
+   export ANTHROPIC_BASE_URL=https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/anthropic
+   export ANTHROPIC_API_KEY={your_anthropic_api_key}
+   ```
+
+   </TabItem>
+   <TabItem label="Windows (PowerShell)">
+
+   ```powershell
+   $env:ANTHROPIC_BASE_URL = "https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/anthropic"
+   $env:ANTHROPIC_API_KEY = "{your_anthropic_api_key}"
+   ```
+
+   </TabItem>
+   </Tabs>
+
+2. Start Claude Code and send a prompt. Requests now route through AI Gateway.
+
+   ```bash
+   claude
+   ```
+
+</Steps>
+
+If your gateway requires authentication, refer to [Authenticated Gateway](/ai-gateway/configuration/authentication/) for the header AI Gateway expects.
+
+## Any OpenAI-compatible coding tool
+
+Tools that speak the OpenAI chat completions format can route through AI Gateway's [REST API](/ai-gateway/usage/rest-api/). Point the tool's base URL at the following endpoint:
+
+```txt
+https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1/chat/completions
+```
+
+Authenticate with a [Cloudflare API token](/fundamentals/api/get-started/create-token/) that has the `AI Gateway Run` permission, and pass it in the `Authorization` header. Specify the model in `author/model` format, such as `openai/gpt-4.1` or `anthropic/claude-sonnet-4-5`.
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1/chat/completions" \
+  --header "Authorization: Bearer {cloudflare_api_token}" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "model": "openai/gpt-4.1",
+    "messages": [
+      {
+        "role": "user",
+        "content": "What is Cloudflare?"
+      }
+    ]
+  }'
+```
+
+:::note
+Claude Code does not use the OpenAI chat completions format, so it cannot call this endpoint directly. Use the Claude Code configuration on this page instead.
+:::
+
+## Verify it works
+
+After you configure a tool, confirm that traffic reaches AI Gateway.
+
+<Steps>
+
+1. Send a prompt from the coding agent.
+
+2. In the Cloudflare dashboard, go to the **AI Gateway** page.
+
+   <DashButton url="/?to=/:account/ai/ai-gateway" />
+
+3. Select your gateway, then select **Logs**. Confirm that the request appears with its model, token count, and latency.
+
+</Steps>
+
+For more information on logs, refer to [Logging](/ai-gateway/observability/logging/).

--- a/src/content/docs/ai-gateway/integrations/coding-agents.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents.mdx
@@ -29,7 +29,7 @@ Routing a coding agent through AI Gateway gives you:
 
 Before you start, you need:
 
-1. A gateway. To create one, refer to [Getting started](/ai-gateway/get-started/).
+1. An [authenticated gateway](/ai-gateway/configuration/authentication/) and its gateway token. The gateway token must have `Run` permissions.
 2. Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
 3. Claude Code installed and updated to the latest version.
 
@@ -43,16 +43,17 @@ This configuration uses your Anthropic API key, so Anthropic bills you for model
 
 <Steps>
 
-1. Set the base URL to your gateway's Anthropic endpoint and pass your Anthropic API key.
+1. Set the base URL to your gateway's Anthropic endpoint, pass your Anthropic API key, and send your gateway token in the `cf-aig-authorization` header.
 
-   Replace `<ACCOUNT_ID>` and `<GATEWAY_ID>` with your values.
+   Replace `<ACCOUNT_ID>`, `<GATEWAY_ID>`, `<ANTHROPIC_API_KEY>`, and `<CF_AIG_TOKEN>` with your values.
 
    <Tabs syncKey="os">
    <TabItem label="macOS / Linux">
 
    ```bash
-   export ANTHROPIC_BASE_URL=https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/anthropic
-   export ANTHROPIC_API_KEY=<ANTHROPIC_API_KEY>
+   export ANTHROPIC_BASE_URL="https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/anthropic"
+   export ANTHROPIC_API_KEY="<ANTHROPIC_API_KEY>"
+   export ANTHROPIC_CUSTOM_HEADERS="cf-aig-authorization: Bearer <CF_AIG_TOKEN>"
    ```
 
    </TabItem>
@@ -61,6 +62,7 @@ This configuration uses your Anthropic API key, so Anthropic bills you for model
    ```powershell
    $env:ANTHROPIC_BASE_URL = "https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/anthropic"
    $env:ANTHROPIC_API_KEY = "<ANTHROPIC_API_KEY>"
+   $env:ANTHROPIC_CUSTOM_HEADERS = "cf-aig-authorization: Bearer <CF_AIG_TOKEN>"
    ```
 
    </TabItem>
@@ -73,8 +75,6 @@ This configuration uses your Anthropic API key, so Anthropic bills you for model
    ```
 
 </Steps>
-
-If your gateway requires authentication, refer to [Authenticated Gateway](/ai-gateway/configuration/authentication/) for the header AI Gateway expects.
 
 ## Protect sensitive code and data
 


### PR DESCRIPTION
## Summary

Adds a new integration page — **Coding agents** — under AI Gateway → Integrations, documenting how to route coding agents (Claude Code and any OpenAI-compatible tool) through AI Gateway for observability, caching, rate limiting, and cost tracking.

- New page: `src/content/docs/ai-gateway/integrations/coding-agents.mdx`
- URL: `/ai-gateway/integrations/coding-agents/`

## What it covers

- Why route a coding agent through AI Gateway
- Prerequisites
- **Claude Code** — set `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` to use the gateway's Anthropic endpoint with your own Anthropic key
- **Any OpenAI-compatible coding tool** — route via the REST API (`/ai/v1/chat/completions`) using `author/model` naming
- Verify traffic in the dashboard logs

## Notes

- Uses the current REST API endpoint; avoids the deprecated Universal Endpoint and `/compat` path.
- All cross-links resolve to existing AI Gateway / Fundamentals pages.
- Scope is intentionally limited to configurations verified against existing public docs. A Vertex AI (BYOK) configuration and a translation-proxy path for Cloudflare-billed usage are planned follow-ups.