### PR TITLE
[R2] Correct Trino project name

### DIFF
--- a/src/content/docs/r2/data-catalog/config-examples/trino.mdx
+++ b/src/content/docs/r2/data-catalog/config-examples/trino.mdx
@@ -1,6 +1,6 @@
 ---
-title: Apache Trino
-description: Connect Apache Trino to R2 Data Catalog using the Iceberg REST catalog connector.
+title: Trino
+description: Connect Trino to R2 Data Catalog using the Iceberg REST catalog connector.
 pcx_content_type: example
 reviewed: 2025-09-05
 products:
@@ -9,7 +9,7 @@ products:
 
 import { Steps } from "~/components";
 
-Below is an example of using [Apache Trino](https://trino.io/) to connect to R2 Data Catalog. For more information on connecting to R2 Data Catalog with Trino, refer to [Trino documentation](https://trino.io/docs/current/connector/iceberg.html).
+Below is an example of using [Trino](https://trino.io/) to connect to R2 Data Catalog. For more information on connecting to R2 Data Catalog with Trino, refer to [Trino documentation](https://trino.io/docs/current/connector/iceberg.html).
 
 ## Prerequisites
 


### PR DESCRIPTION
### Summary

The R2 example page for Trino refers to it as "Apache Trino" but Trino is not an Apache Software Foundation project. This removes the "Apache".