### PR TITLE
[SSL] Remove troubleshooting info for origin server certificates

### DIFF
--- a/src/content/docs/ssl/origin-configuration/origin-ca/troubleshooting.mdx
+++ b/src/content/docs/ssl/origin-configuration/origin-ca/troubleshooting.mdx
@@ -68,13 +68,3 @@ Make sure that the user creating the certificate has access to the API. You can 
 
 - The default setting for the account is specified in the card **Enable API Access**.
 - Specific user API Access (which can override the default setting) is presented after selecting the user in the list of members.
-
-## Origin Server page displays origin certificates for another zone in the account
-
-### Cause
-
-This is a known issue where, when the Origin Server page is opened for different zones in sequence, it displays the certificates from the first zone.
-
-### Solution
-
-Refresh the page in your browser to get the correct origin certificates list for current zone.


### PR DESCRIPTION
Removed troubleshooting section about origin server certificates displaying incorrectly.
SECENG-11914
This bug has been fixed!