### PR TITLE
[DNS] Document DNS record limit buffer

### DIFF
--- a/src/content/docs/dns/faq.mdx
+++ b/src/content/docs/dns/faq.mdx
@@ -109,6 +109,10 @@ Free zones created before 2024-09-01 00:00:00 UTC have an increased limit of 1,0
 If you are an Enterprise customer and require more DNS records, contact your account team. Cloudflare can support millions of DNS records on a single zone.
 :::
 
+DNS records that other Cloudflare services create on your behalf — for example, the `TXT` and `MX` records added by [Email Routing](/email-routing/) — also count toward this limit. To avoid disrupting those services, they are enforced against your record limit with a small buffer, so a zone may occasionally hold slightly more records than its limit would otherwise allow.
+
+To create new records yourself through the dashboard or API, your zone must still be within its record limit.
+
 ### How long does it take for a DNS change I made to push out?
 
 By default, any changes or additions you make to your Cloudflare zone file will take effect globally within 5 minutes, usually much less.


### PR DESCRIPTION
### Summary

Updates the DNS FAQ record limits section to clarify that DNS records created by Cloudflare services on behalf of a customer, such as Email Routing `TXT` and `MX` records, also count toward DNS record limits.

Also documents that these service-created records are enforced with a small buffer to avoid disrupting Cloudflare services, while customer-created records through the dashboard or API still require the zone to be within its record limit.

### Screenshots (optional)

N/A

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).