### PR TITLE
Update limits.mdx

### DIFF
--- a/src/content/docs/r2/platform/limits.mdx
+++ b/src/content/docs/r2/platform/limits.mdx
@@ -14,7 +14,7 @@ import { Render } from "~/components";
 | Number of objects per bucket                                 | Unlimited                                         |
 | Maximum number of buckets per account                        | 1,000,000                                         |
 | Maximum rate of bucket management operations per bucket [^1] | 50 per second                                     |
-| Number of custom domains per bucket                          | 50                                                |
+| Number of custom domains per bucket                          | 100                                                |
 | Object key length                                            | 1,024 bytes                                       |
 | Object metadata size                                         | 8,192 bytes                                       |
 | Object size                                                  | 5 TiB per object [^2]                             |


### PR DESCRIPTION
### Summary

Number of custom domains per bucket should be 100 instead of 50, [ref](https://chat.google.com/room/AAAAJ00jt84/3PkL9Gmq6Pc/3PkL9Gmq6Pc)

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
