### PR TITLE
fix: restore GFM table rendering broken by astro 6.4.0

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
 	site: "https://developers.cloudflare.com",
 	cacheDir: ".astro-cache",
 	markdown: {
+		gfm: true,
 		smartypants: false,
 		remarkPlugins: [remarkValidateImages],
 		rehypePlugins: [


### PR DESCRIPTION
### Summary

Fixes broken table rendering introduced by the `astro@6.3.8` → `6.4.4` bump in #31244.

Astro 6.4.0 changed the `markdown.gfm` config schema from `.default(true)` to `.optional()` as part of the new `markdown.processor` API. When `gfm` is not explicitly set, it is now `undefined` instead of `true`. The `@astrojs/mdx` integration resolves `gfm` via a `??` chain that bottoms out at `undefined`, so `remark-gfm` is never added and GFM table syntax goes unprocessed — tables render as raw pipe-delimited text.

Fix is to explicitly set `gfm: true` in the `markdown` block of `astro.config.ts`, restoring the previously-implicit behavior.
