### PR TITLE
Update Quick Actions intro and FAQ data retention

### DIFF
--- a/src/content/docs/browser-run/faq.mdx
+++ b/src/content/docs/browser-run/faq.mdx
@@ -187,7 +187,10 @@ Yes. If your webpage or PDF requires a font that is not pre-installed, you can l
 
 For [Quick Actions](/browser-run/quick-actions/) (except the [`/crawl` endpoint](/browser-run/quick-actions/crawl-endpoint/)), [Puppeteer](/browser-run/puppeteer/), [Playwright](/browser-run/playwright/), and [CDP](/browser-run/cdp/), Cloudflare processes content ephemerally and does not retain customer-submitted HTML or generated output (such as PDFs or screenshots) beyond what is required to perform the rendering operation. Once the response is returned, the content is immediately discarded from the rendering environment.
 
-The [`/crawl` endpoint](/browser-run/quick-actions/crawl-endpoint/) is an exception. Because crawl jobs run asynchronously, job results (including crawled page content in HTML, Markdown, or JSON format) are stored for 14 days after the job completes, after which the data is deleted. Crawl jobs have a maximum run time of seven days.
+There are two exceptions where data is retained beyond the session:
+
+- **Crawl endpoint**: The [`/crawl` Quick Actions endpoint](/browser-run/quick-actions/crawl-endpoint/) runs jobs asynchronously, so job results (including crawled page content in HTML, Markdown, or JSON format) are stored for 14 days after the job completes, after which the data is deleted. Crawl jobs have a maximum run time of seven days.
+- **Session recording**: Puppeteer, Playwright, and CDP sessions support an opt-in [session recording](/browser-run/features/session-recording/) feature. When enabled, DOM changes, mouse and keyboard events, and page navigation are captured as structured JSON events and retained for 30 days. Input field content is masked by default. Recordings are accessible through the [dashboard](/browser-run/features/session-recording/#view-recordings) and [API](/browser-run/features/session-recording/#retrieve-a-recording-via-api), and are automatically deleted after the retention period.
 
 ### Is there any temporary caching of submitted content?
 

--- a/src/content/docs/browser-run/quick-actions/index.mdx
+++ b/src/content/docs/browser-run/quick-actions/index.mdx
@@ -12,8 +12,8 @@ import { DashButton, DirectoryListing } from "~/components";
 
 Quick Actions provide simple interfaces for common browser tasks like capturing screenshots, extracting HTML content, generating PDFs, and more. You can use Quick Actions in two ways:
 
-- REST API — HTTP endpoints for one-off requests or external integration
-- Workers binding — Call Quick Actions directly from a [Cloudflare Worker](/workers/) using `env.BROWSER.quickAction()`
+- **REST API**: HTTP endpoints for one-off requests or external integration.
+- **Workers Bindings**: Call Quick Actions directly from a [Cloudflare Worker](/workers/) using `env.BROWSER.quickAction()`.
 
 The following are the available options:
 

--- a/src/content/partials/browser-run/rest-api-token-permissions.mdx
+++ b/src/content/partials/browser-run/rest-api-token-permissions.mdx
@@ -2,4 +2,9 @@
 {}
 ---
 
-You can use this endpoint in two ways. To use the REST API, [create a custom API Token](/fundamentals/api/get-started/create-token/) with `Browser Rendering - Edit` permission. To use the [Workers binding](/browser-run/reference/wrangler/#bindings) from a [Cloudflare Worker](/workers/), no API token is needed. For more information, refer to [Quick Actions — Before you begin](/browser-run/quick-actions/#before-you-begin).
+You can use this endpoint in two ways:
+
+- **REST API**: [Create a custom API Token](/fundamentals/api/get-started/create-token/) with `Browser Rendering - Edit` permission.
+- **Workers Bindings**: Call the endpoint directly from a [Cloudflare Worker](/workers/) using the [Workers Bindings](/browser-run/reference/wrangler/#bindings). No API token is needed.
+
+For more information, refer to [Quick Actions: Before you begin](/browser-run/quick-actions/#before-you-begin).


### PR DESCRIPTION
- Reformat Quick Actions index intro to list REST API and Workers Bindings as bullet points
- Reformat rest-api-token-permissions partial as a bulleted list with both methods
- Add session recording as a second data retention exception in FAQ storage question
- Clarify crawl endpoint is a Quick Actions endpoint in FAQ

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
