### PR TITLE
[Containers] Remove duplicate Container-DurableObject paragraph in get-started

### DIFF
--- a/src/content/docs/containers/get-started.mdx
+++ b/src/content/docs/containers/get-started.mdx
@@ -180,8 +180,8 @@ This defines basic configuration for the container:
 - `sleepAfter` sets the timeout for the container to sleep after it has been idle for a certain amount of time.
 - `envVars` sets environment variables that will be passed to the container when it starts.
 - `onStart`, `onStop`, and `onError` are hooks that run when the container starts, stops, or errors, respectively.
+
 The `Container` class itself extends [`DurableObject`](/durable-objects/), so your subclass has access to the full Durable Object API. The Durable Object handles routing, lifecycle, and persistent state, while the container process runs your image inside a Linux VM. This means you can use [`this.ctx.storage`](/durable-objects/api/sqlite-storage-api/) to persist data that survives container restarts and resides close to the container itself.
-The `Container` class itself extends [`DurableObject`](/durable-objects/), so your subclass has access to the full Durable Object API. The Durable Object handles routing, lifecycle, and persistent state, while the container process runs your image inside a microVM. This means you can use [`this.ctx.storage`](/durable-objects/api/sqlite-storage-api/) to persist data that survives container restarts and resides close to the container itself.
 
 Refer to the [Container class reference](/containers/container-class/) and the [low-level Durable Object container API](/durable-objects/api/container/) for more details.
 

--- a/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
+++ b/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
@@ -34,6 +34,8 @@ Per-namespace analytics for Durable Objects are available in the Cloudflare dash
 
 You can optionally select a time window to query. This defaults to the last 24 hours.
 
+You can also filter the charts to a single Durable Object by entering its [ID](/durable-objects/api/id/) or [name](/durable-objects/api/id/#name) and selecting a match. Clear the filter to return to namespace-level metrics.
+
 ## View logs
 
 You can view Durable Object logs from the Cloudflare dashboard. Logs are aggregated by the script name and the Durable Object class name.

--- a/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
+++ b/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
@@ -34,8 +34,6 @@ Per-namespace analytics for Durable Objects are available in the Cloudflare dash
 
 You can optionally select a time window to query. This defaults to the last 24 hours.
 
-You can also filter the charts to a single Durable Object by entering its [ID](/durable-objects/api/id/) or [name](/durable-objects/api/id/#name) and selecting a match. Clear the filter to return to namespace-level metrics.
-
 ## View logs
 
 You can view Durable Object logs from the Cloudflare dashboard. Logs are aggregated by the script name and the Durable Object class name.


### PR DESCRIPTION
### Summary

Removes a duplicated paragraph in the Containers get-started guide. The "`Container` class itself extends `DurableObject`..." paragraph was added twice in #31029 — once ending in "Linux VM" and once in "microVM". This keeps the "Linux VM" version for consistency with `container-class.mdx` and `durable-objects/api/container.mdx`, and adds a blank line so the paragraph renders separately from the preceding bullet list.

Addresses review feedback on #31029.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
