### PR TITLE
Fix grammar and consistency issues in AI Search docs

### DIFF
--- a/src/content/docs/ai-search/api/migration/rest-api.mdx
+++ b/src/content/docs/ai-search/api/migration/rest-api.mdx
@@ -19,7 +19,7 @@ The legacy AutoRAG API endpoints under `/autorag/rags/` have been replaced by ne
 | Chat completions | `/ai-search/instances/{name}/chat/completions` | [API reference](/api/resources/ai_search/subresources/instances/methods/chat_completions/) |
 | Search           | `/ai-search/instances/{name}/search`           | [API reference](/api/resources/ai_search/subresources/instances/methods/search/)           |
 
-The new API also includes endpoints for [instance management](/ai-search/api/instances/rest-api/), [items](/ai-search/api/items/rest-api/), and [namespace-level search](/ai-search/api/search/rest-api/#namespace-level) that are not available in the legacy API. For the legacy endpoints, refer to the [AutoRAG API reference](/api/resources/autorag/).
+The new API also includes endpoints for [instance management](/ai-search/api/instances/rest-api/), [items](/ai-search/api/items/rest-api/), and [namespace-level search](/ai-search/api/search/rest-api/#cross-instance-search-and-chat) that are not available in the legacy API. For the legacy endpoints, refer to the [AutoRAG API reference](/api/resources/autorag/).
 
 ## Chat completions
 

--- a/src/content/docs/ai-search/api/search/rest-api.mdx
+++ b/src/content/docs/ai-search/api/search/rest-api.mdx
@@ -36,7 +36,7 @@ AI Search APIs are available at two base paths:
 | `/accounts/{account_id}/ai-search/instances/{id}/`                        | Operates on a specific instance                                             |
 | `/accounts/{account_id}/ai-search/namespaces/{namespace}/instances/{id}/` | Operates on instances within a [namespace](/ai-search/concepts/namespaces/) |
 
-The below operations are the same for both paths. For the namespace-scoped API, refer to the [Namespace API reference](/api/resources/ai_search/subresources/namespaces/).
+The following operations are the same for both paths. For the namespace-scoped API, refer to the [Namespace API reference](/api/resources/ai_search/subresources/namespaces/).
 
 ### Search
 

--- a/src/content/docs/ai-search/configuration/data-source/website.mdx
+++ b/src/content/docs/ai-search/configuration/data-source/website.mdx
@@ -41,7 +41,7 @@ AI Search supports `.gz` compressed sitemaps. Both `robots.txt` and sitemaps can
 
 ### Sync and updates
 
-During scheduled or manual [sync jobs](/ai-search/configuration/indexing/syncing/), the crawler will check for changes to the `<lastmod>` attribute in your sitemap. If it has been changed to a date occurring after the last sync date, then the page will be crawled, the updated version is stored, and automatically reindexed so that your search results always reflect the latest content.
+During scheduled or manual [sync jobs](/ai-search/configuration/indexing/syncing/), the crawler will check for changes to the `<lastmod>` attribute in your sitemap. If it has been changed to a date occurring after the last sync date, then the page is crawled, the updated version is stored, and the page is automatically reindexed so that your search results always reflect the latest content.
 
 If the `<lastmod>` attribute is not defined, AI Search uses the `<changefreq>` attribute to determine how often to re-crawl the URL. If neither `<lastmod>` nor `<changefreq>` is defined, AI Search automatically crawls each link once a day.
 
@@ -93,7 +93,7 @@ You can choose how pages are parsed during crawling:
 
 ### Extra headers
 
-If your website has pages behind authentication or are only visible to logged-in users, you can configure custom HTTP headers to allow the AI Search crawler to access this protected content. You can add up to five custom HTTP headers to the requests AI Search sends when crawling your site.
+If your website has pages behind authentication or pages that are only visible to logged-in users, you can configure custom HTTP headers to allow the AI Search crawler to access this protected content. You can add up to five custom HTTP headers to the requests AI Search sends when crawling your site.
 
 #### Providing access to sites protected by Cloudflare Access
 
@@ -113,7 +113,7 @@ Service tokens bypass user authentication, so ensure your Access policies are co
 2. [Create a policy](/cloudflare-one/access-controls/policies/policy-management/#create-a-policy) with the following configuration:
    - Add an **Include** rule with **Selector** set to **Service token**.
    - In **Value**, select the Service Token you created in step 1.
-3. [Add your self-hosted application to Access](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) and with the following configuration:
+3. [Add your self-hosted application to Access](/cloudflare-one/access-controls/applications/http-apps/self-hosted-public-app/) with the following configuration:
    - In Access policies, click **Select existing policies**.
    - Select the policy that you have just created and select **Confirm**.
 4. In the Cloudflare dashboard, go to the **AI Search** page.
@@ -374,7 +374,7 @@ Use these attributes to control crawling behavior:
 | `<changefreq>` | Expected change frequency     | Use when `<lastmod>` is not available. Values: `always`, `hourly`, `daily`, `weekly`, `monthly`, `yearly`, `never`. |
 | `<priority>`   | Relative importance (0.0-1.0) | Set higher values for important pages. AI Search indexes pages in priority order.                                   |
 
-You can also use a Sitemap Index to bundle other, domain specific sitemaps:
+You can also use a Sitemap Index to bundle other domain-specific sitemaps:
 
 ```xml title="sitemap-index.xml"
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/content/docs/ai-search/configuration/models/supported-models.mdx
+++ b/src/content/docs/ai-search/configuration/models/supported-models.mdx
@@ -16,7 +16,7 @@ If you would like to use a model that is not currently supported, reach out to u
 
 ## Production models
 
-Production models are the actively supported and recommended models that are stable, fully available.
+Production models are the actively supported and recommended models that are stable and fully available.
 
 ### Text generation
 

--- a/src/content/docs/ai-search/configuration/retrieval/query-rewriting.mdx
+++ b/src/content/docs/ai-search/configuration/retrieval/query-rewriting.mdx
@@ -19,7 +19,7 @@ The wording of a user's question may not match how your documents are written. Q
 - Removing filler words or irrelevant details
 - Resolving follow-up queries that reference previous messages (for example, "tell me more about that" becomes a specific query based on conversation history)
 
-This leads to more relevant search matches which improves the accuracy of results and generated responses.
+This leads to more relevant search matches, which improves the accuracy of results and generated responses.
 
 ## How it works
 

--- a/src/content/docs/ai-search/configuration/retrieval/reranking.mdx
+++ b/src/content/docs/ai-search/configuration/retrieval/reranking.mdx
@@ -42,4 +42,4 @@ const results = await instance.search({
 
 ### Considerations
 
-Adding reranking will include an additional step to the query request, as a result, there may be an increase in the latency of the request.
+Adding reranking will include an additional step to the query request. As a result, there may be an increase in the latency of the request.

--- a/src/content/docs/ai-search/how-to/nlweb.mdx
+++ b/src/content/docs/ai-search/how-to/nlweb.mdx
@@ -40,7 +40,7 @@ You can deploy NLWeb on your website directly through the AI Search dashboard:
 6. Go to the **Settings** for the instance
 7. Find **NLWeb Worker** and select "Enable AI Search for your website".
 
-Once complete, AI Search will deploy an NLWeb Worker for you that enables you to use the NLWeb API Endpoints.
+Once complete, AI Search will deploy an NLWeb Worker for you that enables you to use the NLWeb API endpoints.
 
 ## What this template includes
 
@@ -61,7 +61,7 @@ Your deployed Worker provides two endpoints:
 
 These endpoints give both people and agents structured access to your content.
 
-## Using It on Your Website
+## Using it on your website
 
 You can use the embeddable snippet to add a search UI directly into your website. For example:
 

--- a/src/content/docs/ai-search/how-to/per-tenant-search.mdx
+++ b/src/content/docs/ai-search/how-to/per-tenant-search.mdx
@@ -14,7 +14,7 @@ AI Search supports per-tenant search isolation. You can either create a separate
 
 ## Instance per tenant
 
-Create isolated AI Search instances for each tenant at runtime using the [namespace binding](/ai-search/concepts/namespaces/). Each tenant gets their own instance with separate storage and search index.
+Create isolated AI Search instances for each tenant at runtime using the [namespace binding](/ai-search/concepts/namespaces/). Each tenant gets its own instance with separate storage and a search index.
 
 <WranglerConfig>
 

--- a/src/content/partials/ai-search/ai-search-api-params.mdx
+++ b/src/content/partials/ai-search/ai-search-api-params.mdx
@@ -12,7 +12,7 @@ The input query.
 
 `model` <Type text="string" /> <MetaInfo text="optional" />
 
-The text-generation model that is used to generate the response for the query. For a list of valid options, check the AI Search Generation model Settings. Defaults to the generation model selected in the AI Search Settings.
+The text-generation model used to generate the response for the query. For a list of valid options, check the AI Search generation model settings. Defaults to the generation model selected in the AI Search settings.
 
 ---
 


### PR DESCRIPTION
## What this PR does

Applies the **13 high-confidence** copy-editing fixes from a grammar/consistency review of the AI Search docs (`src/content/docs/ai-search/` and `src/content/partials/ai-search/`), plus one broken in-page anchor repair. All changes are prose-only; no code, identifiers, API paths, or behavior are affected.

Each fix below is shown as **before → after**.

### `configuration/data-source/website.mdx`
- **Grammar (parallelism), L96:** `pages behind authentication or are only visible to logged-in users` → `pages behind authentication or pages that are only visible to logged-in users`
- **Grammar (tense/dangling clause), L44:** `then the page will be crawled, the updated version is stored, and automatically reindexed` → `then the page is crawled, the updated version is stored, and the page is automatically reindexed`
- **Punctuation (stray word), L116:** `...to Access](...) and with the following configuration:` → `...to Access](...) with the following configuration:`
- **Punctuation (hyphenation + stray comma), L377:** `bundle other, domain specific sitemaps` → `bundle other domain-specific sitemaps`

### `configuration/retrieval/query-rewriting.mdx`
- **Grammar (non-restrictive comma), L22:** `more relevant search matches which improves the accuracy` → `more relevant search matches, which improves the accuracy`

### `api/search/rest-api.mdx`
- **Grammar (attributive "below"), L39:** `The below operations are the same for both paths.` → `The following operations are the same for both paths.`

### `how-to/per-tenant-search.mdx`
- **Grammar (agreement + article), L17:** `Each tenant gets their own instance with separate storage and search index.` → `Each tenant gets its own instance with separate storage and a search index.`

### `configuration/retrieval/reranking.mdx`
- **Punctuation (comma splice), L45:** `...an additional step to the query request, as a result, there may be an increase...` → `...an additional step to the query request. As a result, there may be an increase...`

### `configuration/models/supported-models.mdx`
- **Punctuation (missing conjunction), L19:** `models that are stable, fully available.` → `models that are stable and fully available.`

### `partials/ai-search/ai-search-api-params.mdx`
- **Word choice + capitalization, L15:** `The text-generation model that is used to generate the response for the query. For a list of valid options, check the AI Search Generation model Settings. Defaults to the generation model selected in the AI Search Settings.` → `The text-generation model used to generate the response for the query. For a list of valid options, check the AI Search generation model settings. Defaults to the generation model selected in the AI Search settings.`

### `how-to/nlweb.mdx`
- **Capitalization (common noun), L43:** `...use the NLWeb API Endpoints.` → `...use the NLWeb API endpoints.`
- **Capitalization (sentence-case heading), L64:** `## Using It on Your Website` → `## Using it on your website`

### `api/migration/rest-api.mdx` (broken-link repair)
- **L22:** The link text "namespace-level search" pointed to `#namespace-level`, which does not exist in the target file. The target page's section covering namespace-level search/chat is `## Cross-instance search and chat` (slug `#cross-instance-search-and-chat`). Anchor updated:
  `.../api/search/rest-api/#namespace-level` → `.../api/search/rest-api/#cross-instance-search-and-chat`

---

## Optional follow-ups (NOT applied)

These were flagged in the review as low-confidence nits or judgment calls and are intentionally left out of this PR for reviewers to pick up if desired:

1. `platform/limits-pricing.mdx:11` — missing article: "built-in storage and vector index" → "...and a vector index".
2. `how-to/nlweb.mdx:49` — missing article: "as data source option" → "as a data source option".
3. `concepts/how-ai-search-works.mdx:43` — awkward possessive after "either": "either the AI Search's [Chat Completions] ... or [Search] ... endpoints".
4. `index.mdx:54` — missing article: "managed storage, vector index, and web crawling" → "..., a vector index, ...".
5. `concepts/search-modes.mdx:23` — comma splice: "Vector search understands intent, keyword search matches specific terms."
6. `how-to/bring-your-own-generation-model.mdx:15` — repetition: "When using AI Search, AI Search uses..." → "By default, AI Search uses...".
7. `platform/limits-pricing.mdx:11` — "going on the dashboard" → "going to the dashboard".
8. `configuration/retrieval/reranking.mdx:45` — collocation: "include an additional step **to**" → "**add** an additional step to" / "include ... **in**".
9. `configuration/retrieval/cache.mdx:15` — convoluted "this is what happens when..." construction.
10. `partials/ai-search/ai-search-api-params.mdx:27` — hyphenation: "search optimized query" → "search-optimized query".
11. `configuration/models/index.mdx` — feature-name casing/number drift: heading "Smart default" vs body "Smart Default"/"Smart Defaults".
12. `configuration/data-source/index.mdx` (table headers) — "Data Source"/"Mime Type" → "Data source"/"MIME type".

Product-naming note: no leftover "AutoRAG" was found in prose; all remaining `AutoRAG`/`autorag` occurrences are intentional legacy/migration references, code identifiers, paths, slugs, or URLs and were left unchanged.
