### PR TITLE
[Cloudflare One] Add Okta Enhanced Dynamic Zone troubleshooting

### DIFF
--- a/src/content/docs/cloudflare-one/integrations/identity-providers/okta.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/okta.mdx
@@ -185,3 +185,17 @@ If you see the error `Failed to fetch user/group information from the identity`,
 
 - If you have more than 100 Okta groups, ensure you include the API token.
 - The request may be blocked by the [ThreatInsights feature](https://help.okta.com/en/prod/Content/Topics/Security/threat-insight/ti-index.htm) within Okta.
+
+### Access login fails due to Okta Enhanced Dynamic Zone
+
+If Okta's **Enhanced Dynamic Zone** (`DefaultEnhancedDynamicZone`) is active with `ALL_ANONYMIZERS` enabled, Okta may block requests from Cloudflare IP addresses. This causes Access logins to fail with the error `Failed to fetch user/group information from the identity provider`.
+
+In the Okta system logs, this appears as:
+
+```txt
+Blocked request from IP: 104.28.171.23, IPServiceCategory: WARP_VPN
+```
+
+This setting is configured in the Okta admin panel under **Security** > **Network**.
+
+To resolve this, add [Cloudflare's IP ranges](https://www.cloudflare.com/ips/) to the **DefaultExemptIpZone** (IP exempt list) in Okta's network zone configuration.

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/okta.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/okta.mdx
@@ -188,14 +188,17 @@ If you see the error `Failed to fetch user/group information from the identity`,
 
 ### Access login fails due to Okta Enhanced Dynamic Zone
 
-If Okta's **Enhanced Dynamic Zone** (`DefaultEnhancedDynamicZone`) is active with `ALL_ANONYMIZERS` enabled, Okta may block requests from Cloudflare IP addresses. This causes Access logins to fail with the error `Failed to fetch user/group information from the identity provider`.
+If Okta's [Enhanced Dynamic Zone](https://help.okta.com/oie/en-us/content/topics/security/network/network-zones.htm) (`DefaultEnhancedDynamicZone`) is active with `ALL_ANONYMIZERS` enabled, Okta may block requests from Cloudflare IP addresses. This causes Access logins to fail with the error `Failed to fetch user/group information from the identity provider`.
 
 In the Okta system logs, this appears as:
 
 ```txt
-Blocked request from IP: 104.28.171.23, IPServiceCategory: WARP_VPN
+Blocked request from IP: <BLOCKED_IP>, IPServiceCategory: WARP_VPN
 ```
 
 This setting is configured in the Okta admin panel under **Security** > **Network**.
 
-To resolve this, add [Cloudflare's IP ranges](https://www.cloudflare.com/ips/) to the **DefaultExemptIpZone** (IP exempt list) in Okta's network zone configuration.
+To resolve this, either:
+
+- [Unblock the false positives](https://help.okta.com/oie/en-us/content/topics/security/network/unblock-false-positives.htm) by adding [Cloudflare's IP ranges](https://www.cloudflare.com/ips/) to the **DefaultExemptIpZone** (IP exempt list) in Okta's network zone configuration.
+- Deactivate the `DefaultEnhancedDynamicZone` in Okta's network zone configuration.


### PR DESCRIPTION
### Summary

Adds a troubleshooting section to the Okta OIDC identity provider page for a known issue where Okta's Enhanced Dynamic Zone (`DefaultEnhancedDynamicZone`) with `ALL_ANONYMIZERS` blocks Cloudflare IP addresses, causing Access logins to fail. Includes the error users see, what to look for in Okta logs, and the workaround (adding Cloudflare IPs to the exempt list).

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
