### PR TITLE
Add WAF rules creation from Threat Events saved views

### DIFF
--- a/src/content/changelog/security-center/2026-06-08-create-waf-rules-from-threat-events.mdx
+++ b/src/content/changelog/security-center/2026-06-08-create-waf-rules-from-threat-events.mdx
@@ -1,0 +1,24 @@
+---
+title: Create WAF rules directly from Threat Events saved views
+description: Instantly block or challenge malicious traffic by generating WAF rules based on the dynamic IP lists from your Threat Events saved views
+date: 2026-06-08
+---
+Cloudforce One users can now turn [Threat Events indicators](/security-center/cloudforce-one/#analyze-threat-events) into active defense. With this update, users can instantly generate a WAF rule that matches the dynamic list of IP addresses returned by any of their **Saved Views**.
+
+## Why this matters
+
+Threat intelligence is most effective when it is immediately actionable. Previously, blocking threat actors required manually extracting indicators from threat events and copying them into your firewall rules. 
+This new integration bridges the gap between threat discovery and threat mitigation:
+* When you identify an active threat pattern - such as an ongoing campaign targeting a specific industry, or using a known indicator type - you can pivot from investigation to mitigation in a single click.
+* Instead of writing complex, static IP rules, this functionality allows you to leverage the specific filtering logic you have already defined and saved within your Threat Events ecosystem.
+* Automating the generation of the WAF rule expression from your threat views eliminates manual copying errors, ensuring that the right malicious infrastructure is blocked instantly.
+
+## How to use it
+
+You can implement these rules through both the dashboard UI and via the API / Terraform.
+
+Go to **Cloudflare Dashboard** > **Application Security** > **Threat Intelligence** > **Manage Views**, select your desired view, and select **Create WAF Rule**.
+
+This will automatically pre-populate the [WAF rule builder](/firewall/cf-dashboard/create-edit-delete-rules/) with the matching threat event IP indicators.
+
+You can also automate this workflow by utilizing the [**WAF Rule Builder API**](/firewall/api/cf-firewall-rules/) alongside your [Threat Events saved views endpoints](/firewall/api/cf-firewall-rules/).


### PR DESCRIPTION
This update allows Cloudforce One users to create WAF rules directly from Threat Events saved views, enhancing threat mitigation by automating the generation of rules based on dynamic IP lists.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
