### PR TITLE
[DNS] Document account-level DNS records quota

### DIFF
--- a/src/content/changelog/dns/2026-06-09-account-level-record-quota.mdx
+++ b/src/content/changelog/dns/2026-06-09-account-level-record-quota.mdx
@@ -1,0 +1,11 @@
+---
+title: Account-level DNS records quota
+description: Enterprise accounts now have a single DNS records quota across all of their zones.
+date: 2026-06-09
+---
+
+Cloudflare now enforces DNS records quotas at the account level for Enterprise accounts. Instead of a per-zone limit, these accounts have a quota on the total number of records across all of their zones, letting you distribute records across your zones however you like — regardless of each zone's plan. Public and internal zones are counted separately, each with a default quota of 1,000,000 records.
+
+Accounts without an account-level quota are unaffected: existing per-zone quotas behave exactly as before.
+
+For more details, refer to [DNS records quota](/dns/manage-dns-records/#dns-records-quota).

--- a/src/content/changelog/dns/2026-06-10-account-level-record-quota.mdx
+++ b/src/content/changelog/dns/2026-06-10-account-level-record-quota.mdx
@@ -1,7 +1,7 @@
 ---
 title: Account-level DNS records quota
 description: Enterprise accounts now have a single DNS records quota across all of their zones.
-date: 2026-06-09
+date: 2026-06-10
 ---
 
 Cloudflare now enforces DNS records quotas at the account level for Enterprise accounts. Instead of a per-zone limit, these accounts have a quota on the total number of records across all of their zones, letting you distribute records across your zones however you like — regardless of each zone's plan. Public and internal zones are counted separately, each with a default quota of 1,000,000 records.

--- a/src/content/docs/dns/faq.mdx
+++ b/src/content/docs/dns/faq.mdx
@@ -109,7 +109,7 @@ Free zones created before 2024-09-01 00:00:00 UTC have an increased limit of 1,0
 If you are an Enterprise customer and require more DNS records, contact your account team. Cloudflare can support millions of DNS records on a single zone.
 :::
 
-DNS records that other Cloudflare services create on your behalf — for example, the `TXT` and `MX` records added by [Email Routing](/email-routing/) — also count toward this limit. To avoid disrupting those services, they are enforced against your record limit with a small buffer, so a zone may occasionally hold slightly more records than its limit would otherwise allow.
+DNS records that other Cloudflare services create on your behalf — for example, the `TXT` and `MX` records added by [Email Routing](/email-service/) — also count toward this limit. To avoid disrupting those services, they are enforced against your record limit with a small buffer, so a zone may occasionally hold slightly more records than its limit would otherwise allow.
 
 To create new records yourself through the dashboard or API, your zone must still be within its record limit.
 

--- a/src/content/docs/dns/manage-dns-records/index.mdx
+++ b/src/content/docs/dns/manage-dns-records/index.mdx
@@ -48,7 +48,13 @@ Also, as this record is <GlossaryTooltip term="proxy status" link="/dns/proxy-st
 
 ## DNS records quota
 
-There is a limit to the number of records you can create on a single <GlossaryTooltip term="DNS zone">zone</GlossaryTooltip>.
+Cloudflare limits the number of DNS records you can create. Depending on your plan, this limit is enforced either per zone or per account — not both.
+
+DNS records that other Cloudflare services create on your behalf also count toward your quota.
+
+### Per-zone quota
+
+By default, there is a limit to the number of records you can create on a single <GlossaryTooltip term="DNS zone">zone</GlossaryTooltip>.
 
 - Free zones created before `2024-09-01 00:00:00 UTC`: 1,000
 - Free zones created on or after `2024-09-01 00:00:00 UTC`: 200
@@ -56,9 +62,19 @@ There is a limit to the number of records you can create on a single <GlossaryTo
 - Business: 3,500
 - Enterprise: 3,500
 
+You can retrieve a zone's current quota (if applicable) and usage [via the API](/api/resources/dns/subresources/usage/subresources/zone/methods/get/).
+
+### Per-account quota
+
+Enterprise accounts have a quota on the total number of records across all of their zones, instead of the per-zone limit. This lets you distribute records across your zones however you like, regardless of each zone's plan.
+
+Public zones and [internal zones](/dns/internal-dns/) are counted separately, each with a default account quota of 1,000,000 records.
+
+You can retrieve your current account quota and usage [via the API](/api/resources/dns/subresources/usage/subresources/account/methods/get/).
+
 :::note[For more DNS records]
 
-If you are an Enterprise customer and require more DNS records, contact your account team. Cloudflare can support millions of DNS records on a single zone.
+If you are an Enterprise customer and require a higher account quota, contact your account team. Cloudflare can support millions of DNS records.
 
 :::
 


### PR DESCRIPTION
### Summary

Documents the new account-level DNS records quota (DNS-13029), enforced as of 2026-06-05.

- `manage-dns-records/index.mdx`: splits the **DNS records quota** section into **Per-zone** and **Per-account**. Account-level quota applies to Enterprise accounts and replaces the per-zone limit (either/or — account-level wins when the entitlement is present). Public and internal zones are counted separately, each with a default quota of 1,000,000 records. Adds zone- and account-level usage API links.
- Adds a changelog entry pointing to the dev docs section.

Buffer / system-actor detail lives in the FAQ (#31299); this page just notes that records other services create also count toward your quota.

### Screenshots (optional)

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).