### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-06-09)

### DIFF
--- a/src/content/changelog/logs/2026-06-09-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-06-09-log-fields-updated.mdx
@@ -1,0 +1,14 @@
+---
+title: New Logpush datasets in Cloudflare Logs
+description: New Logpush datasets are now available in Cloudflare Logs.
+date: 2026-06-09
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### New datasets
+
+- **WebSocket Analytics**: A new dataset with fields including `BytesReceivedClient`, `BytesReceivedOrigin`, `BytesSentClient`, `BytesSentOrigin`, `ClientASN`, `ClientIP`, `ClientRequestHost`, `ClientRequestPath`, `ClientRequestUserAgent`, `ColoCode`, `ConnectionCloseReason`, `ConnectionCloseSource`, `ConnectionID`, `ConnectionTransportCloseCode`, `EdgeEndTimestamp`, `EdgeStartTimestamp`, and `RayID`.
+- **WebSocket Analytics**: A new dataset with fields including `BytesReceivedClient`, `BytesReceivedOrigin`, `BytesSentClient`, `BytesSentOrigin`, `ClientASN`, `ClientIP`, `ClientRequestHost`, `ClientRequestPath`, `ClientRequestUserAgent`, `ColoCode`, `ConnectionCloseReason`, `ConnectionCloseSource`, `ConnectionID`, `ConnectionTransportCloseCode`, `EdgeEndTimestamp`, `EdgeStartTimestamp`, and `RayID`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/websocket_analytics.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/websocket_analytics.md
@@ -1,0 +1,112 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: WebSocket Analytics
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `websocket_analytics`.
+
+## BytesReceivedClient
+
+Type: `int`
+
+Number of bytes received from the client.
+
+## BytesReceivedOrigin
+
+Type: `int`
+
+Number of bytes received from the origin.
+
+## BytesSentClient
+
+Type: `int`
+
+Number of bytes sent to the client.
+
+## BytesSentOrigin
+
+Type: `int`
+
+Number of bytes sent to the origin.
+
+## ClientASN
+
+Type: `int`
+
+The client's autonomous system number (ASN).
+
+## ClientIP
+
+Type: `string`
+
+The client IP address.
+
+## ClientRequestHost
+
+Type: `string`
+
+The host requested by the client in the WebSocket upgrade request.
+
+## ClientRequestPath
+
+Type: `string`
+
+The path requested by the client in the WebSocket upgrade request.
+
+## ClientRequestUserAgent
+
+Type: `string`
+
+The user agent reported by the client.
+
+## ColoCode
+
+Type: `string`
+
+IATA airport code of the data center that handled the connection.
+
+## ConnectionCloseReason
+
+Type: `string`
+
+The reason the WebSocket connection ended. Possible values are <em>none</em> \| <em>unspecifiedError</em> \| <em>timedOut</em> \| <em>peerReset</em> \| <em>upstreamReset</em> \| <em>protocolViolation</em> \| <em>peerNoError</em>.
+
+## ConnectionCloseSource
+
+Type: `string`
+
+Which side initiated the connection close; <em>upstream</em> \| <em>downstream</em> \| <em>me</em> \| <em>both</em>, or the raw internal value if unrecognized.
+
+## ConnectionID
+
+Type: `string`
+
+Unique identifier of the WebSocket connection, hex-encoded.
+
+## ConnectionTransportCloseCode
+
+Type: `int`
+
+The first transport-level close code observed. For TLS connections this is the TLS alert code; for plain TCP connections (no TLS) it is always 0. The most significant bit indicates the source: 0 = proxy-initiated, 1 = eyeball-initiated.
+
+## EdgeEndTimestamp
+
+Type: `int or string`
+
+Timestamp at which the WebSocket connection closed.
+
+## EdgeStartTimestamp
+
+Type: `int or string`
+
+Timestamp at which the WebSocket connection was established.
+
+## RayID
+
+Type: `string`
+
+The Ray ID of the WebSocket upgrade request.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/websocket_analytics.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/websocket_analytics.md
@@ -1,0 +1,112 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: WebSocket Analytics
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `websocket_analytics`.
+
+## BytesReceivedClient
+
+Type: `int`
+
+Number of bytes received from the client.
+
+## BytesReceivedOrigin
+
+Type: `int`
+
+Number of bytes received from the origin.
+
+## BytesSentClient
+
+Type: `int`
+
+Number of bytes sent to the client.
+
+## BytesSentOrigin
+
+Type: `int`
+
+Number of bytes sent to the origin.
+
+## ClientASN
+
+Type: `int`
+
+The client's autonomous system number (ASN).
+
+## ClientIP
+
+Type: `string`
+
+The client IP address.
+
+## ClientRequestHost
+
+Type: `string`
+
+The host requested by the client in the WebSocket upgrade request.
+
+## ClientRequestPath
+
+Type: `string`
+
+The path requested by the client in the WebSocket upgrade request.
+
+## ClientRequestUserAgent
+
+Type: `string`
+
+The user agent reported by the client.
+
+## ColoCode
+
+Type: `string`
+
+IATA airport code of the data center that handled the connection.
+
+## ConnectionCloseReason
+
+Type: `string`
+
+The reason the WebSocket connection ended. Possible values are <em>none</em> \| <em>unspecifiedError</em> \| <em>timedOut</em> \| <em>peerReset</em> \| <em>upstreamReset</em> \| <em>protocolViolation</em> \| <em>peerNoError</em>.
+
+## ConnectionCloseSource
+
+Type: `string`
+
+Which side initiated the connection close; <em>upstream</em> \| <em>downstream</em> \| <em>me</em> \| <em>both</em>, or the raw internal value if unrecognized.
+
+## ConnectionID
+
+Type: `string`
+
+Unique identifier of the WebSocket connection, hex-encoded.
+
+## ConnectionTransportCloseCode
+
+Type: `int`
+
+The first transport-level close code observed. For TLS connections this is the TLS alert code; for plain TCP connections (no TLS) it is always 0. The most significant bit indicates the source: 0 = proxy-initiated, 1 = eyeball-initiated.
+
+## EdgeEndTimestamp
+
+Type: `int or string`
+
+Timestamp at which the WebSocket connection closed.
+
+## EdgeStartTimestamp
+
+Type: `int or string`
+
+Timestamp at which the WebSocket connection was established.
+
+## RayID
+
+Type: `string`
+
+The Ray ID of the WebSocket upgrade request.


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### New datasets

- **WebSocket Analytics**: A new dataset with fields including `BytesReceivedClient`, `BytesReceivedOrigin`, `BytesSentClient`, `BytesSentOrigin`, `ClientASN`, `ClientIP`, `ClientRequestHost`, `ClientRequestPath`, `ClientRequestUserAgent`, `ColoCode`, `ConnectionCloseReason`, `ConnectionCloseSource`, `ConnectionID`, `ConnectionTransportCloseCode`, `EdgeEndTimestamp`, `EdgeStartTimestamp`, and `RayID`.
- **WebSocket Analytics**: A new dataset with fields including `BytesReceivedClient`, `BytesReceivedOrigin`, `BytesSentClient`, `BytesSentOrigin`, `ClientASN`, `ClientIP`, `ClientRequestHost`, `ClientRequestPath`, `ClientRequestUserAgent`, `ColoCode`, `ConnectionCloseReason`, `ConnectionCloseSource`, `ConnectionID`, `ConnectionTransportCloseCode`, `EdgeEndTimestamp`, `EdgeStartTimestamp`, and `RayID`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/docs/logs/logpush/logpush-job/datasets/zone/` — dataset pages
- `src/content/changelog/logs/2026-06-09-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
