### PR TITLE
chore: respect .prettierignore in auto-format workflow

### DIFF
--- a/.github/workflows/auto-format-build.yml
+++ b/.github/workflows/auto-format-build.yml
@@ -79,7 +79,7 @@ jobs:
           fi
           printf 'Formatting %d file(s):\n' "${#files[@]}"
           printf '  %s\n' "${files[@]}"
-          pnpm exec prettier --write "${files[@]}"
+          pnpm exec prettier --write --ignore-path .prettierignore "${files[@]}"
 
       - name: Check for changes
         id: diff


### PR DESCRIPTION
### Summary

The auto-format workflow builds an explicit file list from `git diff` and passes it directly to `prettier --write`, which bypasses `.prettierignore`. 

Adding `--ignore-path .prettierignore` makes prettier respect the ignore file even when files are passed explicitly.
