### PR TITLE
Fix duplicated "unexpected shutdowns" paragraph in Rules of Durable Objects

### DIFF
--- a/src/content/docs/durable-objects/best-practices/rules-of-durable-objects.mdx
+++ b/src/content/docs/durable-objects/best-practices/rules-of-durable-objects.mdx
@@ -1441,8 +1441,6 @@ export class ChatRoom extends DurableObject<Env> {
 
 ### Design for unexpected shutdowns
 
-Durable Objects may shut down at any time due to deployments, inactivity, or runtime decisions. Rather than relying on shutdown hooks (which are not provided), design your application to write state incrementally.
-
 <Render file="working-without-shutdown-hooks" product="durable-objects" />
 
 ## Anti-patterns to avoid

--- a/src/content/partials/durable-objects/working-without-shutdown-hooks.mdx
+++ b/src/content/partials/durable-objects/working-without-shutdown-hooks.mdx
@@ -2,7 +2,7 @@
 {}
 ---
 
-Durable Objects may shut down due to deployments, inactivity, or runtime decisions. Rather than relying on shutdown hooks (which are not provided), design your application to write state incrementally.
+Durable Objects may shut down at any time due to deployments, inactivity, or runtime decisions. Rather than relying on shutdown hooks (which are not provided), design your application to write state incrementally.
 
 Shutdown hooks or lifecycle callbacks that run before shutdown are not provided because Cloudflare cannot guarantee these hooks would execute in all cases, and external software may rely too heavily on these (unreliable) hooks.
 


### PR DESCRIPTION
**Bug:** On the Rules of Durable Objects page, the paragraph under "Design for unexpected shutdowns" rendered twice — an inline hardcoded copy plus the `working-without-shutdown-hooks` partial, which begins with the same sentence.

**Fix:** Removed the inline hardcoded paragraph so the partial is the single source of truth. Preserved the slightly stronger "at any time" wording by adding it to the partial's first paragraph.

**Blast radius:** This partial is also rendered by `durable-objects/concepts/durable-object-lifecycle.mdx` (under its "Working without shutdown hooks" heading). The "at any time" wording now appears there too and reads correctly in context; that page has no inline copy, so no new duplication is introduced.