### PR TITLE
Adds changelog to highlight the removal of Python built-in packages.

### DIFF
--- a/src/content/changelog/workers/2026-06-10-python-requirements-txt-removal.mdx
+++ b/src/content/changelog/workers/2026-06-10-python-requirements-txt-removal.mdx
@@ -1,0 +1,14 @@
+---
+title: Python packages included using requirements.txt are no longer supported
+description: Support for `requirements.txt` has been removed and any running Workers using it will need to be updated to use the new package system.
+products:
+  - workers
+date: 2026-06-10
+---
+
+As part of a closed private beta, Python Workers supported a limited set of packages as built-ins via `requirements.txt`.
+
+On the path to GA, Python Workers now have package support via `pyproject.toml` and `pywrangler`, see our documentation [here](/workers/languages/python/packages/).
+This support is available to the public as part of an open Python Workers public beta.
+
+Support for `requirements.txt` has been removed and any running Workers using it will need to be updated to use the new package system.


### PR DESCRIPTION
### Summary

These have been removed and are no longer supported. They were only ever supported as part of a private beta. 