### PR TITLE
fix: update retired /email-routing/ links to /email-service/

### DIFF
--- a/public/__redirects
+++ b/public/__redirects
@@ -1282,7 +1282,7 @@
 /learning-paths/get-started-free/other-features/redirects/ /fundamentals/reference/redirects/ 301
 /learning-paths/get-started-free/other-features/analytics/ /analytics/account-and-zone-analytics/ 301
 /learning-paths/get-started-free/other-features/account-profile/ /fundamentals/account/ 301
-/learning-paths/get-started-free/other-features/email-routing/ /email-routing/ 301
+/learning-paths/get-started-free/other-features/email-routing/ /email-service/ 301
 /learning-paths/get-started-free/other-features/resources/ /fundamentals/#additional-resources 301
 /learning-paths/get-started-free/other-features/product-lines/ /directory/ 301
 

--- a/src/content/docs/dns/faq.mdx
+++ b/src/content/docs/dns/faq.mdx
@@ -109,7 +109,7 @@ Free zones created before 2024-09-01 00:00:00 UTC have an increased limit of 1,0
 If you are an Enterprise customer and require more DNS records, contact your account team. Cloudflare can support millions of DNS records on a single zone.
 :::
 
-DNS records that other Cloudflare services create on your behalf — for example, the `TXT` and `MX` records added by [Email Routing](/email-routing/) — also count toward this limit. To avoid disrupting those services, they are enforced against your record limit with a small buffer, so a zone may occasionally hold slightly more records than its limit would otherwise allow.
+DNS records that other Cloudflare services create on your behalf — for example, the `TXT` and `MX` records added by [Email Routing](/email-service/) — also count toward this limit. To avoid disrupting those services, they are enforced against your record limit with a small buffer, so a zone may occasionally hold slightly more records than its limit would otherwise allow.
 
 To create new records yourself through the dashboard or API, your zone must still be within its record limit.
 
@@ -128,7 +128,6 @@ If changes to records with large TTLs are anticipated, it may make sense to redu
 Because of Cloudflare's many advanced DNS features like CNAME flattening, it can be complex and even impossible to give correct answers to `ANY` queries. For example, when DNS records dynamically come and go or are stored remotely, it can be taxing or even impossible to get all the results at the same time.
 
 Refer to [Deprecating the DNS ANY meta-query type](https://blog.cloudflare.com/deprecating-dns-any-meta-query-type/) for details. The decision to block `ANY` does not affect DNS Firewall customers.
-
 
 ### How do I add ANAME records on Cloudflare?
 


### PR DESCRIPTION
### Summary

Fixes a broken link introduced by #31082, which retired `/email-routing/` but missed a reference in `dns/faq.mdx`. The `starlight-links-validator` plugin flags `/email-routing/` as invalid because the page no longer exists in the content collection — redirects in `__redirects` are not followed by the validator.

Two changes:
- `src/content/docs/dns/faq.mdx` — update `/email-routing/` link to `/email-service/`
- `public/__redirects` — fix `/learning-paths/get-started-free/other-features/email-routing/` to point directly to `/email-service/` rather than chaining through the now-retired `/email-routing/` redirect
