### PR TITLE
[Workers, Workflows] Fix spelling typos in RPC, streaming, and Workflows docs

### DIFF
--- a/src/content/docs/workers/examples/openai-sdk-streaming.mdx
+++ b/src/content/docs/workers/examples/openai-sdk-streaming.mdx
@@ -56,7 +56,7 @@ export default {
 					stream: true,
 				});
 
-				// loop over the data as it is streamed and write to the writeable
+				// loop over the data as it is streamed and write to the writable
 				for await (const part of stream) {
 					writer.write(
 						textEncoder.encode(part.choices[0]?.delta?.content || ""),

--- a/src/content/docs/workers/runtime-apis/rpc/index.mdx
+++ b/src/content/docs/workers/runtime-apis/rpc/index.mdx
@@ -53,7 +53,7 @@ The RPC system also supports a number of types that are not Structured Cloneable
 
 - Functions, which are replaced by stubs that call back to the sender.
 - Application-defined classes that extend `RpcTarget`, which are similarly replaced by stubs.
-- [ReadableStream](/workers/runtime-apis/streams/readablestream/) and [WriteableStream](/workers/runtime-apis/streams/writablestream/), with automatic streaming flow control.
+- [ReadableStream](/workers/runtime-apis/streams/readablestream/) and [WritableStream](/workers/runtime-apis/streams/writablestream/), with automatic streaming flow control.
 - [Request](/workers/runtime-apis/request/) and [Response](/workers/runtime-apis/response/), for conveniently representing HTTP messages.
 - RPC stubs themselves, even if the stub was received from a third Worker.
 
@@ -252,9 +252,9 @@ export default {
 
 If the initial RPC ends up throwing an exception, then any pipelined calls will also fail with the same exception
 
-## ReadableStream, WriteableStream, Request and Response
+## ReadableStream, WritableStream, Request and Response
 
-You can send and receive [`ReadableStream`](/workers/runtime-apis/streams/readablestream/), [`WriteableStream`](/workers/runtime-apis/streams/writablestream/), [`Request`](/workers/runtime-apis/request/), and [`Response`](/workers/runtime-apis/response/) using RPC methods. When doing so, bytes in the body are automatically streamed with appropriate flow control. This allows you to send messages over RPC which are larger than [the typical 32 MiB limit](#limitations).
+You can send and receive [`ReadableStream`](/workers/runtime-apis/streams/readablestream/), [`WritableStream`](/workers/runtime-apis/streams/writablestream/), [`Request`](/workers/runtime-apis/request/), and [`Response`](/workers/runtime-apis/response/) using RPC methods. When doing so, bytes in the body are automatically streamed with appropriate flow control. This allows you to send messages over RPC which are larger than [the typical 32 MiB limit](#limitations).
 
 Only [byte-oriented streams](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams) (streams with an underlying byte source of `type: "bytes"`) are supported.
 

--- a/src/content/docs/workflows/build/rules-of-workflows.mdx
+++ b/src/content/docs/workflows/build/rules-of-workflows.mdx
@@ -383,7 +383,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export class MyWorkflow extends WorkflowEntrypoint {
 	async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
-		// 🔴 Bad: The `Promise.race` is not surrounded by a `step.do`, which may cause undeterministic caching behavior.
+		// 🔴 Bad: The `Promise.race` is not surrounded by a `step.do`, which may cause non-deterministic caching behavior.
 		const race_return = await Promise.race([
 			step.do("Promise first race", async () => {
 				await sleep(1000);


### PR DESCRIPTION
### Summary

Corrects spelling typos in Workers and Workflows documentation, found via a `typos` scan of current production and manually verified to avoid false positives (product names, code identifiers, locale strings, and quoted source text were all left untouched).

- **Workers** — `WriteableStream` → `WritableStream` in the [RPC docs](https://developers.cloudflare.com/workers/runtime-apis/rpc/) (the linked URLs already used the correct spelling) and a code comment in the OpenAI SDK streaming example (`writeable` → `writable`, matching the actual `writable` variable).
- **Workflows** — `undeterministic` → `non-deterministic` in a code comment in [Rules of Workflows](https://developers.cloudflare.com/workflows/build/rules-of-workflows/), using the repo's standard spelling.

These are intentionally small and targeted, split out from the previously closed bulk spelling PR (#29981).

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).