### PR TITLE
[Artifacts] Document namespace routes, repo content routes, and binding read methods

### DIFF
--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -43,6 +43,7 @@ export ARTIFACTS_NAMESPACE="default"
 export ARTIFACTS_REPO="starter-repo"
 export CLOUDFLARE_API_TOKEN="<YOUR_API_TOKEN>"
 export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts/namespaces/$ARTIFACTS_NAMESPACE"
+export ARTIFACTS_ACCOUNT_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts"
 ```
 
 All responses use the standard Cloudflare v4 envelope.
@@ -122,6 +123,28 @@ export interface TokenInfo {
 	created_at: string;
 	expires_at: string;
 }
+```
+
+## Namespaces
+
+### List namespaces
+
+Route: `GET /artifacts/namespaces?limit=&cursor=`
+
+Use the account-level base URL.
+
+```sh
+curl "$ARTIFACTS_ACCOUNT_BASE_URL/namespaces?limit=20" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+### Get a namespace
+
+Route: `GET /artifacts/namespaces/:namespace`
+
+```sh
+curl "$ARTIFACTS_ACCOUNT_BASE_URL/namespaces/$ARTIFACTS_NAMESPACE" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 ## Repos
@@ -426,6 +449,70 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos/react-mirror/import" \
 
 If a repo exists but is still importing or forking, this route can return `409 Conflict` with a retriable error message.
 
+## Repo content
+
+These routes read Git objects and files from an existing repo. Object routes use immutable Git SHA-1 hashes. File routes resolve a path at a branch, tag, or commit hash.
+
+### Read commit history
+
+Route: `GET /repos/:name/log?ref=&limit=&offset=`
+
+```sh
+curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/log?ref=main&limit=10" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+### Read a commit
+
+Route: `GET /repos/:name/commit/:hash`
+
+```sh
+curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/commit/$COMMIT_HASH" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+### Read a tree
+
+Route: `GET /repos/:name/tree/:hash`
+
+```sh
+curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/tree/$TREE_HASH" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+### Read a blob
+
+Route: `GET /repos/:name/blob/:hash`
+
+Returns raw blob bytes.
+
+```sh
+curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/blob/$BLOB_HASH" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+### Read a file
+
+Route: `GET /repos/:name/file?ref=&path=`
+
+Returns raw file bytes as `application/octet-stream`.
+
+```sh
+curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/file?ref=main&path=README.md" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+### Read a raw file
+
+Route: `GET /repos/:name/raw/:ref/:path`
+
+Returns file bytes with a sniffed `Content-Type`.
+
+```sh
+curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/raw/main/README.md" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
 ## Tokens
 
 These tokens are for Git routes. They do not authenticate REST API requests.
@@ -461,7 +548,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/tokens?state=all&per_page=30&pag
 {
 	"result": [
 		{
-			"id": "tok_123",
+			"id": "0123456789abcdef",
 			"scope": "read",
 			"state": "active",
 			"created_at": "<ISO_TIMESTAMP>",
@@ -524,7 +611,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/tokens" \
 ```json
 {
 	"result": {
-		"id": "tok_123",
+		"id": "0123456789abcdef",
 		"plaintext": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
 		"scope": "read",
 		"expires_at": "<ISO_TIMESTAMP>"
@@ -550,14 +637,14 @@ export type DeleteTokenResponse = ApiEnvelope<DeleteTokenResult>;
 ```
 
 ```bash
-curl --request DELETE "$ARTIFACTS_BASE_URL/tokens/tok_123" \
+curl --request DELETE "$ARTIFACTS_BASE_URL/tokens/0123456789abcdef" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 ```json
 {
 	"result": {
-		"id": "tok_123"
+		"id": "0123456789abcdef"
 	},
 	"success": true,
 	"errors": [],

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -33,7 +33,9 @@ Authorization: Bearer $CLOUDFLARE_API_TOKEN
 
 Route paths below are shown relative to `/accounts/$ACCOUNT_ID`. Curl examples use `ARTIFACTS_BASE_URL` or `ARTIFACTS_ACCOUNT_BASE_URL` to keep commands shorter.
 
+:::note[Token types]
 Cloudflare API tokens authenticate REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
+:::
 
 The following examples assume:
 

--- a/src/content/docs/artifacts/api/rest-api.mdx
+++ b/src/content/docs/artifacts/api/rest-api.mdx
@@ -31,7 +31,7 @@ Requests use Bearer authentication:
 Authorization: Bearer $CLOUDFLARE_API_TOKEN
 ```
 
-All routes below are relative to this base URL.
+Route paths below are shown relative to `/accounts/$ACCOUNT_ID`. Curl examples use `ARTIFACTS_BASE_URL` or `ARTIFACTS_ACCOUNT_BASE_URL` to keep commands shorter.
 
 Cloudflare API tokens authenticate REST control-plane routes. Repo tokens authenticate Git operations against the returned `remote` URL.
 
@@ -46,7 +46,32 @@ export ARTIFACTS_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUN
 export ARTIFACTS_ACCOUNT_BASE_URL="https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/artifacts"
 ```
 
-All responses use the standard Cloudflare v4 envelope.
+All JSON responses use the standard Cloudflare v4 envelope:
+
+```json
+{
+	"result": {},
+	"success": true,
+	"errors": [],
+	"messages": []
+}
+```
+
+Successful blob, file, and raw responses return file bytes directly instead of JSON. For example, `GET /artifacts/namespaces/:namespace/repos/:name/file?ref=main&path=README.md` returns the contents of `README.md` with `Content-Type: application/octet-stream`. Error responses still use the standard envelope:
+
+```json
+{
+	"result": null,
+	"success": false,
+	"errors": [
+		{
+			"code": 10200,
+			"message": "File not found"
+		}
+	],
+	"messages": []
+}
+```
 
 Returned repo tokens are secrets. Do not log them or store them in long-lived remotes unless your workflow requires it.
 
@@ -151,7 +176,7 @@ curl "$ARTIFACTS_ACCOUNT_BASE_URL/namespaces/$ARTIFACTS_NAMESPACE" \
 
 ### Create a repo
 
-Route: `POST /repos`
+Route: `POST /artifacts/namespaces/:namespace/repos`
 
 Request body:
 
@@ -214,7 +239,7 @@ Create, fork, and import responses return the token string only. The token encod
 
 ### List repos
 
-Route: `GET /repos?limit=&cursor=&search=&sort=&direction=`
+Route: `GET /artifacts/namespaces/:namespace/repos?limit=&cursor=&search=&sort=&direction=`
 
 Query parameters:
 
@@ -272,7 +297,7 @@ curl "$ARTIFACTS_BASE_URL/repos?limit=20&sort=updated_at&direction=desc" \
 
 ### Get a repo
 
-Route: `GET /repos/:name`
+Route: `GET /artifacts/namespaces/:namespace/repos/:name`
 
 Response type:
 
@@ -307,7 +332,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
 
 ### Delete a repo
 
-Route: `DELETE /repos/:name`
+Route: `DELETE /artifacts/namespaces/:namespace/repos/:name`
 
 This route returns `202 Accepted`.
 
@@ -339,7 +364,7 @@ curl --request DELETE "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO" \
 
 ### Fork a repo
 
-Route: `POST /repos/:name/fork`
+Route: `POST /artifacts/namespaces/:namespace/repos/:name/fork`
 
 Request body:
 
@@ -396,7 +421,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/fork" \
 
 ### Import a public HTTPS remote
 
-Route: `POST /repos/:name/import`
+Route: `POST /artifacts/namespaces/:namespace/repos/:name/import`
 
 Request body:
 
@@ -455,7 +480,7 @@ These routes read Git objects and files from an existing repo. Object routes use
 
 ### Read commit history
 
-Route: `GET /repos/:name/log?ref=&limit=&offset=`
+Route: `GET /artifacts/namespaces/:namespace/repos/:name/log?ref=&limit=&offset=`
 
 ```sh
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/log?ref=main&limit=10" \
@@ -464,7 +489,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/log?ref=main&limit=10" \
 
 ### Read a commit
 
-Route: `GET /repos/:name/commit/:hash`
+Route: `GET /artifacts/namespaces/:namespace/repos/:name/commit/:hash`
 
 ```sh
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/commit/$COMMIT_HASH" \
@@ -473,7 +498,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/commit/$COMMIT_HASH" \
 
 ### Read a tree
 
-Route: `GET /repos/:name/tree/:hash`
+Route: `GET /artifacts/namespaces/:namespace/repos/:name/tree/:hash`
 
 ```sh
 curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/tree/$TREE_HASH" \
@@ -482,7 +507,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/tree/$TREE_HASH" \
 
 ### Read a blob
 
-Route: `GET /repos/:name/blob/:hash`
+Route: `GET /artifacts/namespaces/:namespace/repos/:name/blob/:hash`
 
 Returns raw blob bytes.
 
@@ -493,7 +518,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/blob/$BLOB_HASH" \
 
 ### Read a file
 
-Route: `GET /repos/:name/file?ref=&path=`
+Route: `GET /artifacts/namespaces/:namespace/repos/:name/file?ref=&path=`
 
 Returns raw file bytes as `application/octet-stream`.
 
@@ -504,7 +529,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/file?ref=main&path=README.md" \
 
 ### Read a raw file
 
-Route: `GET /repos/:name/raw/:ref/:path`
+Route: `GET /artifacts/namespaces/:namespace/repos/:name/raw/:ref/:path`
 
 Returns file bytes with a sniffed `Content-Type`.
 
@@ -519,7 +544,7 @@ These tokens are for Git routes. They do not authenticate REST API requests.
 
 ### List tokens for a repo
 
-Route: `GET /repos/:name/tokens?state=&per_page=&page=`
+Route: `GET /artifacts/namespaces/:namespace/repos/:name/tokens?state=&per_page=&page=`
 
 Query parameters:
 
@@ -570,7 +595,7 @@ curl "$ARTIFACTS_BASE_URL/repos/$ARTIFACTS_REPO/tokens?state=all&per_page=30&pag
 
 ### Create a token
 
-Route: `POST /tokens`
+Route: `POST /artifacts/namespaces/:namespace/tokens`
 
 Request body:
 
@@ -624,7 +649,7 @@ curl --request POST "$ARTIFACTS_BASE_URL/tokens" \
 
 ### Revoke a token
 
-Route: `DELETE /tokens/:id`
+Route: `DELETE /artifacts/namespaces/:namespace/tokens/:id`
 
 Response type:
 

--- a/src/content/docs/artifacts/api/workers-binding.mdx
+++ b/src/content/docs/artifacts/api/workers-binding.mdx
@@ -271,6 +271,57 @@ async function forkRepo(artifacts: Artifacts) {
 
 </TypeScriptExample>
 
+### `log(opts?)`
+
+- `opts.ref` <Type text="string" /> <MetaInfo text="optional" /> — Branch, tag, or commit hash.
+- `opts.limit` <Type text="number" /> <MetaInfo text="optional" />
+- `opts.offset` <Type text="number" /> <MetaInfo text="optional" />
+- Returns <Type text="Promise<ArtifactsLogResult>" />
+
+<TypeScriptExample>
+
+```ts
+async function readCommitHistory(artifacts: Artifacts) {
+	const repo = await artifacts.get("starter-repo");
+	const history = await repo.log({ ref: "main", limit: 10 });
+	return history;
+}
+```
+
+</TypeScriptExample>
+
+### `readCommit(hash)`
+
+- `hash` <Type text="string" /> <MetaInfo text="required" /> — Commit SHA-1 hash.
+- Returns <Type text="Promise<ArtifactsCommit>" />
+
+<TypeScriptExample>
+
+```ts
+async function readCommit(artifacts: Artifacts, hash: string) {
+	const repo = await artifacts.get("starter-repo");
+	return repo.readCommit(hash);
+}
+```
+
+</TypeScriptExample>
+
+### `readTree(hash)`
+
+- `hash` <Type text="string" /> <MetaInfo text="required" /> — Tree SHA-1 hash.
+- Returns <Type text="Promise<ArtifactsTree>" />
+
+<TypeScriptExample>
+
+```ts
+async function readTree(artifacts: Artifacts, hash: string) {
+	const repo = await artifacts.get("starter-repo");
+	return repo.readTree(hash);
+}
+```
+
+</TypeScriptExample>
+
 ## Worker example
 
 This example combines the binding methods in one Worker route.


### PR DESCRIPTION
### Summary

Updates the Artifacts REST API and Workers binding reference docs to document new namespace routes, repo content routes, and content-read binding methods.

Changes to `rest-api.mdx`:
- Adds `ARTIFACTS_ACCOUNT_BASE_URL` for account-level API calls
- Adds Namespaces section (`GET /artifacts/namespaces`, `GET /artifacts/namespaces/:namespace`) before Repos
- Adds Repo content section (commit history, commit, tree, blob, file, raw routes) between repo management and Tokens
- Updates all Route: labels to show explicit full paths (`/artifacts/namespaces/:namespace/...`)
- Adds JSON response envelope documentation, noting that blob/file/raw routes return bytes directly
- Moves token authentication distinction into a note
- Replaces `tok_123` token IDs with 16-character lowercase alphanumeric IDs per OpenAPI spec

Changes to `workers-binding.mdx`:
- Adds `repo.log()`, `repo.readCommit()`, and `repo.readTree()` content-read methods under Repo handle methods

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
