### PR TITLE
[AI Gateway] Document BYOK secret naming

### DIFF
--- a/src/content/docs/ai-gateway/configuration/bring-your-own-keys.mdx
+++ b/src/content/docs/ai-gateway/configuration/bring-your-own-keys.mdx
@@ -30,7 +30,11 @@ The keys are stored securely with [Secrets Store](/secrets-store/) and allows fo
 
 ### Configure API keys
 
-{/* TODO UPDATE */}
+You can configure BYOK from the dashboard or by using the API.
+
+#### Dashboard
+
+When you add a provider key from the dashboard, AI Gateway creates and names the Secrets Store secret automatically.
 
 1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/) and select your account.
 2. Go to **AI** > **AI Gateway**.
@@ -40,6 +44,24 @@ The keys are stored securely with [Secrets Store](/secrets-store/) and allows fo
 6. Select your AI provider from the dropdown.
 7. Enter your API key and optionally provide a description.
 8. Click **Save**.
+
+#### API
+
+If you use the API to configure BYOK, create the Secrets Store secret before you create the provider configuration. Name the secret with this format:
+
+```txt
+{gateway_id}_{provider_slug}_{alias}
+```
+
+For example, for gateway `my-gateway`, provider `anthropic`, and alias `default`, create the Secrets Store secret as:
+
+```txt
+my-gateway_anthropic_default
+```
+
+Then create the provider configuration with the same `provider_slug` and `alias` values.
+
+AI Gateway uses a name-based Secrets Store lookup at the edge. The `secret_id` returned by Secrets Store is not used by AI Gateway for runtime lookup, so API-created secrets must follow the naming convention.
 
 ### Update your applications
 

--- a/src/content/docs/ai-gateway/configuration/bring-your-own-keys.mdx
+++ b/src/content/docs/ai-gateway/configuration/bring-your-own-keys.mdx
@@ -61,7 +61,7 @@ my-gateway_anthropic_default
 
 Then create the provider configuration with the same `provider_slug` and `alias` values.
 
-AI Gateway uses a name-based Secrets Store lookup at the edge. The `secret_id` returned by Secrets Store is not used by AI Gateway for runtime lookup, so API-created secrets must follow the naming convention.
+The `secret_id` returned by Secrets Store is not used by AI Gateway for runtime lookup, so API-created secrets must follow the naming convention.
 
 ### Update your applications
 


### PR DESCRIPTION
### Summary

Updates the AI Gateway BYOK configuration docs to clarify how provider keys are configured from the dashboard or API. Adds the required Secrets Store naming convention for API-created secrets.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
