### PR TITLE
[AI Search] Add changelog for namespace Wrangler commands

### DIFF
--- a/src/content/changelog/ai-search/2026-06-08-ai-search-namespace-wrangler-commands.mdx
+++ b/src/content/changelog/ai-search/2026-06-08-ai-search-namespace-wrangler-commands.mdx
@@ -1,0 +1,41 @@
+---
+title: Manage AI Search namespaces with Wrangler CLI
+description: Use new namespace-level Wrangler commands to create, list, inspect, update, and delete AI Search namespaces from the CLI.
+products:
+  - ai-search
+date: 2026-06-08
+---
+
+[AI Search](/ai-search/) now supports namespace-level Wrangler commands, making it easier to manage [namespaces](/ai-search/concepts/namespaces/) from your terminal, scripts, and agent workflows.
+
+The following commands are available:
+
+| Command                               | Description                      |
+| ------------------------------------- | -------------------------------- |
+| `wrangler ai-search namespace list`   | List AI Search namespaces        |
+| `wrangler ai-search namespace create` | Create a new AI Search namespace |
+| `wrangler ai-search namespace get`    | Get details for a namespace      |
+| `wrangler ai-search namespace update` | Update a namespace description   |
+| `wrangler ai-search namespace delete` | Delete an AI Search namespace    |
+
+Create a namespace for a new application or tenant directly from the CLI:
+
+```sh
+wrangler ai-search namespace create docs-production --description "Production documentation search"
+```
+
+List namespaces with pagination or filter by name or description:
+
+```sh
+wrangler ai-search namespace list --search docs --page 1 --per-page 10
+```
+
+Use `--json` with `list`, `create`, `get`, and `update` to return structured output that automation and AI agents can parse directly. The same commands also provide readable output for humans working interactively in a terminal.
+
+Instance-level commands also now support a `--namespace` flag, so you can interact with instances inside a specific namespace from the CLI:
+
+```sh
+wrangler ai-search list --namespace docs-production
+```
+
+For full usage details, refer to the [AI Search Wrangler commands documentation](/ai-search/wrangler-commands/).

--- a/src/content/changelog/ai-search/2026-06-10-ai-search-namespace-wrangler-commands.mdx
+++ b/src/content/changelog/ai-search/2026-06-10-ai-search-namespace-wrangler-commands.mdx
@@ -30,7 +30,7 @@ List namespaces with pagination or filter by name or description:
 wrangler ai-search namespace list --search docs --page 1 --per-page 10
 ```
 
-Use `--json` with `list`, `create`, `get`, and `update` to return structured output that automation and AI agents can parse directly. The same commands also provide readable output for humans working interactively in a terminal.
+Use `--json` with `list`, `create`, `get`, and `update` to return structured output that automation and AI agents can parse directly.
 
 Instance-level commands also now support a `--namespace` flag, so you can interact with instances inside a specific namespace from the CLI:
 

--- a/src/content/changelog/ai-search/2026-06-10-ai-search-namespace-wrangler-commands.mdx
+++ b/src/content/changelog/ai-search/2026-06-10-ai-search-namespace-wrangler-commands.mdx
@@ -3,7 +3,7 @@ title: Manage AI Search namespaces with Wrangler CLI
 description: Use new namespace-level Wrangler commands to create, list, inspect, update, and delete AI Search namespaces from the CLI.
 products:
   - ai-search
-date: 2026-06-08
+date: 2026-06-10
 ---
 
 [AI Search](/ai-search/) now supports namespace-level Wrangler commands, making it easier to manage [namespaces](/ai-search/concepts/namespaces/) from your terminal, scripts, and agent workflows.

--- a/src/content/changelog/ai-search/2026-06-10-ai-search-namespace-wrangler-commands.mdx
+++ b/src/content/changelog/ai-search/2026-06-10-ai-search-namespace-wrangler-commands.mdx
@@ -1,6 +1,6 @@
 ---
 title: Manage AI Search namespaces with Wrangler CLI
-description: Use new namespace-level Wrangler commands to create, list, inspect, update, and delete AI Search namespaces from the CLI.
+description: Use new namespace-level Wrangler commands to create, list, update, and delete AI Search namespaces from the CLI.
 products:
   - ai-search
 date: 2026-06-10

--- a/src/content/release-notes/ai-search.yaml
+++ b/src/content/release-notes/ai-search.yaml
@@ -6,7 +6,7 @@ entries:
   - publish_date: "2026-06-08"
     title: Manage AI Search namespaces with Wrangler CLI
     description: |-
-      AI Search now supports namespace-level Wrangler commands to create, list, inspect, update, and delete [namespaces](/ai-search/concepts/namespaces/) from the command line. Instance-level commands also accept a `--namespace` flag to target instances within a specific namespace, and `--json` output is available for automation and AI agent workflows. Refer to [Wrangler commands](/ai-search/wrangler-commands/) for full usage details.
+      AI Search now supports namespace-level Wrangler commands to create, list, update, and delete [namespaces](/ai-search/concepts/namespaces/) from the command line. Instance-level commands also accept a `--namespace` flag to target instances within a specific namespace, and `--json` output is available for automation and agent workflows. Refer to [Wrangler commands](/ai-search/wrangler-commands/) for full usage details.
   - publish_date: "2026-05-12"
     title: Automatic migration to managed infrastructure on June 3, 2026
     description: |-

--- a/src/content/release-notes/ai-search.yaml
+++ b/src/content/release-notes/ai-search.yaml
@@ -3,6 +3,10 @@ link: "/ai-search/platform/release-note/"
 productName: AI Search
 productLink: "/ai-search/"
 entries:
+  - publish_date: "2026-06-08"
+    title: Manage AI Search namespaces with Wrangler CLI
+    description: |-
+      AI Search now supports namespace-level Wrangler commands to create, list, inspect, update, and delete [namespaces](/ai-search/concepts/namespaces/) from the command line. Instance-level commands also accept a `--namespace` flag to target instances within a specific namespace, and `--json` output is available for automation and AI agent workflows. Refer to [Wrangler commands](/ai-search/wrangler-commands/) for full usage details.
   - publish_date: "2026-05-12"
     title: Automatic migration to managed infrastructure on June 3, 2026
     description: |-

--- a/src/content/release-notes/ai-search.yaml
+++ b/src/content/release-notes/ai-search.yaml
@@ -3,7 +3,7 @@ link: "/ai-search/platform/release-note/"
 productName: AI Search
 productLink: "/ai-search/"
 entries:
-  - publish_date: "2026-06-08"
+  - publish_date: "2026-06-10"
     title: Manage AI Search namespaces with Wrangler CLI
     description: |-
       AI Search now supports namespace-level Wrangler commands to create, list, update, and delete [namespaces](/ai-search/concepts/namespaces/) from the command line. Instance-level commands also accept a `--namespace` flag to target instances within a specific namespace, and `--json` output is available for automation and agent workflows. Refer to [Wrangler commands](/ai-search/wrangler-commands/) for full usage details.


### PR DESCRIPTION
### Summary

Adds a changelog entry announcing namespace-level Wrangler commands for AI Search (`wrangler ai-search namespace list/create/get/update/delete`), plus the new `--namespace` flag on instance-level commands. Documents `--json` output support for automation and agent workflows, and links to the AI Search Wrangler commands documentation.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
