### PR TITLE
[Spectrum] Clarify UDP support: BYOIP yes, Magic Transit bindings no

### DIFF
--- a/src/content/docs/spectrum/reference/limitations.mdx
+++ b/src/content/docs/spectrum/reference/limitations.mdx
@@ -15,7 +15,7 @@ At the moment, HTTPS applications do not support HTTP/3.
 
 ## UDP
 
-At the moment, Cloudflare does not support packet fragmentation for UDP packets. If packets are fragmented, they will be dropped at Cloudflare’s edge.
+Cloudflare does not support packet fragmentation for UDP packets. If packets are fragmented, they will be dropped at Cloudflare’s edge.
 
 Spectrum UDP applications are supported with [BYOIP](/spectrum/about/byoip/), including [CDN and Spectrum service bindings](/byoip/service-bindings/cdn-and-spectrum/). They are not currently supported with [Magic Transit service bindings](/byoip/service-bindings/).
 

--- a/src/content/docs/spectrum/reference/limitations.mdx
+++ b/src/content/docs/spectrum/reference/limitations.mdx
@@ -15,7 +15,9 @@ At the moment, HTTPS applications do not support HTTP/3.
 
 ## UDP
 
-At the moment, Cloudflare does not support packet fragmentation for UDP packets. If packets are fragmented, they will be dropped at Cloudflare’s edge. Additionally, UDP Spectrum applications are not supported on Magic Transit, BYOIP, Spectrum, and Bindings.
+At the moment, Cloudflare does not support packet fragmentation for UDP packets. If packets are fragmented, they will be dropped at Cloudflare’s edge.
+
+Spectrum UDP applications are supported with [BYOIP](/spectrum/about/byoip/), including [CDN and Spectrum service bindings](/byoip/service-bindings/cdn-and-spectrum/). They are not currently supported with [Magic Transit service bindings](/byoip/service-bindings/).
 
 ## Minecraft
 

--- a/src/content/partials/byoip/spectrum-udp-byoip-limitation.mdx
+++ b/src/content/partials/byoip/spectrum-udp-byoip-limitation.mdx
@@ -3,5 +3,5 @@
 ---
 
 :::note[UDP applications]
-Spectrum UDP applications are [not supported](/spectrum/reference/limitations/#udp) when using Spectrum with BYOIP.
+Spectrum UDP applications are supported with BYOIP, including [CDN and Spectrum service bindings](/byoip/service-bindings/cdn-and-spectrum/). However, they are [not currently supported with Magic Transit service bindings](/spectrum/reference/limitations/#udp).
 :::


### PR DESCRIPTION
### Summary

Corrects the Spectrum UDP support documentation. 

Previously the docs incorrectly stated that Spectrum UDP applications were unsupported with BYOIP. UDP **is** supported with BYOIP (including CDN and Spectrum service bindings). The actual limitation is that Spectrum UDP applications are not currently supported with **Magic Transit service bindings**.

Changes:
- `spectrum/reference/limitations.mdx` — UDP section now clarifies BYOIP (and CDN/Spectrum service bindings) is supported.
- `partials/byoip/spectrum-udp-byoip-limitation.mdx` — note rewritten to reflect the same correction. This partial renders on `spectrum/about/byoip.mdx`, `byoip/service-bindings/cdn-and-spectrum.mdx`, and `byoip/service-bindings/index.mdx`.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).