### PR TITLE
[Flagship] Add API reference changelog

### DIFF
--- a/src/content/changelog/flagship/2026-06-10-api-reference.mdx
+++ b/src/content/changelog/flagship/2026-06-10-api-reference.mdx
@@ -1,0 +1,33 @@
+---
+title: Flagship API reference now available
+description: Manage Flagship apps and feature flags programmatically with the Cloudflare API.
+products:
+  - flagship
+date: 2026-06-10
+---
+
+The **[Flagship API reference](/api/resources/flagship/)** is now available. You can use the Cloudflare API to create and update apps, and to create, update, delete, and list feature flags without using the dashboard.
+
+For example, create a new boolean flag with the API:
+
+```bash
+curl https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/flagship/apps/$APP_ID/flags \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -d '{
+    "key": "new-checkout",
+    "enabled": true,
+    "default_variation": "off",
+    "variations": {
+      "off": false,
+      "on": true
+    },
+    "rules": []
+  }'
+```
+
+To create an API token, go to [Account API Tokens](https://dash.cloudflare.com/?to=/:account/api-tokens) in the Cloudflare dashboard and search for Flagship.
+
+The API reference includes endpoints for Flagship apps, flags, changelog entries, and flag evaluation. Agents can also use the [Flagship reference in the Cloudflare skill](https://github.com/cloudflare/skills/tree/main/skills/cloudflare/references/flagship) to create and manage Flagship resources.
+
+Refer to the [Flagship documentation](/flagship/) to learn more about evaluating feature flags from your applications.


### PR DESCRIPTION
### Summary

Adds a Flagship changelog entry announcing that the generated API reference is available for managing apps and feature flags through the Cloudflare API.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
