### PR TITLE
Add @deannalam and @dochne to Images CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,7 @@ package.json @cloudflare/content-engineering
 /src/assets/images/changelog/ @cloudflare/pm-changelogs @cloudflare/product-owners
 /src/assets/images/changelog/dns/ @cloudflare/pm-changelogs @cloudflare/product-owners @hannes-cf @fattouche @xofyarg @dklbreitling @chreo @svenr-cf @kerolasa @matildeopbravo @vavrusa @mworsley-cloudflare @sebastiaanyn @vendemiat @Woutifier
 /src/assets/images/ @cloudflare/pm-changelogs @cloudflare/product-owners
+/src/assets/images/images/ @dcpena @cloudflare/product-owners @renandincer @third774 @deannalam @dochne
 
 # Cloudflare One
 
@@ -139,7 +140,8 @@ package.json @cloudflare/content-engineering
 /src/content/docs/hyperdrive/ @elithrar @rita3ko @irvinebroque @vy-ton @ivoryibu @thomasgauvin @sejoker @oxyjun @knickish @cloudflare/product-owners
 /src/content/release-notes/hyperdrive.yaml @elithrar @rita3ko @irvinebroque @vy-ton @ivoryibu @thomasgauvin @sejoker @oxyjun @knickish @cloudflare/product-owners
 /src/content/partials/hyperdrive/ @elithrar @rita3ko @irvinebroque @vy-ton @ivoryibu @thomasgauvin @sejoker @oxyjun @knickish @cloudflare/product-owners
-/src/content/docs/images/ @dcpena @cloudflare/product-owners @renandincer @third774
+/src/content/docs/images/ @dcpena @cloudflare/product-owners @renandincer @third774 @deannalam @dochne
+/src/content/partials/images/ @dcpena @cloudflare/product-owners @renandincer @third774 @deannalam @dochne
 /src/content/docs/pages/ @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @irvinebroque @cloudflare/product-owners @MattieTK
 /src/content/partials/pages/ @elithrar @rita3ko @irvinebroque @vy-ton @cloudflare/product-owners @MattieTK
 /src/assets/images/pages/ @cloudflare/workers-docs @GregBrimble @WalshyDev @aninibread @cloudflare/product-owners @MattieTK


### PR DESCRIPTION
Adds @deannalam and @dochne as codeowners for the Images product:

- `/src/content/docs/images/` — docs pages (updated existing line)
- `/src/content/partials/images/` — reusable partials (new line)
- `/src/assets/images/images/` — image assets (new line, overrides broad `/src/assets/images/` rule)