### PR TITLE
[Gateway] Document traffic source and destination selectors

### DIFF
--- a/src/content/changelog/gateway/2026-06-10-traffic-source-destination-selectors.mdx
+++ b/src/content/changelog/gateway/2026-06-10-traffic-source-destination-selectors.mdx
@@ -1,0 +1,25 @@
+---
+title: Filter Gateway policies by traffic source and destination
+description: Cloudflare Gateway now supports the Traffic sources and Traffic destinations selectors, allowing administrators to scope policies by where traffic enters and exits Gateway.
+products:
+  - gateway
+date: 2026-06-10
+---
+
+Cloudflare Gateway now supports the **Traffic sources** and **Traffic destinations** selectors in the policy builder. Administrators can use these selectors to scope policies by where traffic enters Gateway and where Gateway sends traffic next.
+
+Traffic sources are available in [HTTP](/cloudflare-one/traffic-policies/http-policies/), [Network](/cloudflare-one/traffic-policies/network-policies/), and [Egress](/cloudflare-one/traffic-policies/egress-policies/) policies. Traffic destinations are available in HTTP and Network policies, except Network Override policies.
+
+For example, you can match traffic from Cloudflare One Client devices to the public Internet:
+
+```txt
+net.onramp.type == "device_client" and net.offramp.type == "internet"
+```
+
+You can also use these selectors to:
+
+- Apply controls only to traffic from Browser Isolation.
+- Apply Data Loss Prevention (DLP) only to Internet-bound traffic.
+- Exclude Cloudflare Tunnel traffic from TLS inspection.
+
+For more information, refer to [Network policy selectors](/cloudflare-one/traffic-policies/network-policies/#selectors), [HTTP policy selectors](/cloudflare-one/traffic-policies/http-policies/#selectors), and [Egress policy selectors](/cloudflare-one/traffic-policies/egress-policies/#selectors).

--- a/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-private-hostname.mdx
+++ b/src/content/docs/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-private-hostname.mdx
@@ -128,6 +128,8 @@ You can create an [Access self-hosted application](/cloudflare-one/access-contro
 
 If you prefer to secure the application using a traditional firewall model, you can build Gateway network policies using the [SNI](/cloudflare-one/traffic-policies/network-policies/#sni) or [SNI Domain](/cloudflare-one/traffic-policies/network-policies/#sni-domain) selector. For an additional layer of protection, add a Gateway DNS policy to allow or block the [Host](/cloudflare-one/traffic-policies/dns-policies/#host) or [Domain](/cloudflare-one/traffic-policies/dns-policies/#domain) from resolving.
 
+Use [Traffic sources](/cloudflare-one/traffic-policies/network-policies/#traffic-sources) to scope a Network policy to one on-ramp type. Use [Traffic destinations](/cloudflare-one/traffic-policies/network-policies/#traffic-destinations) to match traffic that exits through Cloudflare Tunnel. Traffic destinations do not apply to Network Override policies.
+
     <Details header="Example network policies">
     The following example consists of two policies: the first allows specific users to reach your application, and the second blocks all other traffic.
 

--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/index.mdx
@@ -215,6 +215,10 @@ The country of the user making the request. <Render file="gateway/selectors/sour
 
 <Render file="gateway/selectors/source-port" product="cloudflare-one" />
 
+### Traffic sources
+
+<Render file="gateway/selectors/traffic-sources" product="cloudflare-one" />
+
 ### Users
 
 <Render file="gateway/selectors/users-http" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/traffic-policies/http-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/http-policies/index.mdx
@@ -115,6 +115,8 @@ API value: `redirect`
 - [Source Country IP Geolocation](#source-country)
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [URL](#url)
 - [URL Path](#url-path)
 - [URL Path & Query](#url-path-and-query)
@@ -174,6 +176,8 @@ API value: `isolate`
 - [Security Risks](#security-risks)
 - [Source Continent IP Geolocation](#source-continent)
 - [Source Country IP Geolocation](#source-country)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [URL](#url)
 - [URL Path](#url-path)
 - [URL Path & Query](#url-path-and-query)
@@ -217,6 +221,8 @@ API value: `off`
 - [Source Country IP Geolocation](#source-country)
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [Virtual Network](#virtual-network)
 
 **Identity**
@@ -264,6 +270,8 @@ API value: `noisolate`
 - [Security Risks](#security-risks)
 - [Source Continent IP Geolocation](#source-continent)
 - [Source Country IP Geolocation](#source-country)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [URL](#url)
 - [URL Path](#url-path)
 - [URL Path & Query](#url-path-and-query)
@@ -308,6 +316,8 @@ API value: `noscan`
 - [Source Country IP Geolocation](#source-country)
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [URL](#url)
 - [URL Path](#url-path)
 - [URL Path & Query](#url-path-and-query)
@@ -359,6 +369,8 @@ API value: `quarantine`
 - [Source Country IP Geolocation](#source-country)
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [URL](#url)
 - [URL Path](#url-path)
 - [URL Path & Query](#url-path-and-query)
@@ -688,6 +700,17 @@ The country of the user making the request. <Render file="gateway/selectors/sour
 	product="cloudflare-one"
 	params={{ APIendpoint: "http.conn.src_ip" }}
 />
+
+### Traffic destinations
+
+<Render
+	file="gateway/selectors/traffic-destinations"
+	product="cloudflare-one"
+/>
+
+### Traffic sources
+
+<Render file="gateway/selectors/traffic-sources" product="cloudflare-one" />
 
 ### URL
 

--- a/src/content/docs/cloudflare-one/traffic-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/index.mdx
@@ -171,6 +171,8 @@ The connection method (on-ramp) you use determines which policy types Gateway ca
 
 You can combine multiple on-ramps. For example, use the Cloudflare One Client for remote employees and network tunnels for branch offices.
 
+When you combine on-ramps, you can scope policies by traffic path. Use [Traffic sources](/cloudflare-one/traffic-policies/network-policies/#traffic-sources) to match how traffic enters Gateway. Use [Traffic destinations](/cloudflare-one/traffic-policies/network-policies/#traffic-destinations) to match where Gateway sends traffic next.
+
 ## How Gateway processes traffic
 
 When a user makes a request, Gateway inspects it at multiple layers before allowing the connection through. The following diagram shows the end-to-end flow:

--- a/src/content/docs/cloudflare-one/traffic-policies/network-policies/index.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/network-policies/index.mdx
@@ -67,6 +67,8 @@ API value: `allow`
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
 - [Source Port](#source-port)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [Virtual Network](#virtual-network)
 
 **Identity**
@@ -108,6 +110,8 @@ API value: `audit_ssh`
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
 - [Source Port](#source-port)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [Virtual Network](#virtual-network)
 
 **Identity**
@@ -166,6 +170,8 @@ API value: `block`
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
 - [Source Port](#source-port)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [Virtual Network](#virtual-network)
 
 **Identity**
@@ -217,6 +223,7 @@ API value: `l4_override`
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
 - [Source Port](#source-port)
+- [Traffic sources](#traffic-sources)
 - [Virtual Network](#virtual-network)
 
 **Identity**
@@ -389,6 +396,14 @@ The country of the user making the request. <Render file="gateway/selectors/sour
 ### Source Port
 
 <Render file="gateway/selectors/source-port" product="cloudflare-one" />
+
+### Traffic destinations
+
+<Render file="gateway/selectors/traffic-destinations" product="cloudflare-one" />
+
+### Traffic sources
+
+<Render file="gateway/selectors/traffic-sources" product="cloudflare-one" />
 
 ### Users
 

--- a/src/content/docs/learning-paths/secure-internet-traffic/build-egress-policies/egress-policies.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/build-egress-policies/egress-policies.mdx
@@ -36,6 +36,8 @@ To create a new egress policy:
    	product="cloudflare-one"
    />
 
+   To limit an egress policy to one on-ramp type, add the [Traffic sources](/cloudflare-one/traffic-policies/egress-policies/#traffic-sources) selector.
+
 5. Select **Create policy**.
 
 For more information, refer to [Egress policies](/cloudflare-one/traffic-policies/egress-policies/).

--- a/src/content/docs/learning-paths/secure-internet-traffic/connect-devices-networks/choose-on-ramp.mdx
+++ b/src/content/docs/learning-paths/secure-internet-traffic/connect-devices-networks/choose-on-ramp.mdx
@@ -16,6 +16,8 @@ import { GlossaryDefinition, GlossaryTooltip, Badge } from "~/components";
 
 Similar to the network onboarding practices in the [Replace your VPN](/learning-paths/replace-vpn/connect-private-network/) implementation guide, there are a number of ways to on-ramp your network traffic to the Cloudflare global network. This guide will quickly explore all of the options to on-ramp traffic to Cloudflare Gateway to inspect, apply policies, and filter.
 
+After you choose an on-ramp, you can scope Gateway policies by traffic path. Use [Traffic sources](/cloudflare-one/traffic-policies/network-policies/#traffic-sources) to match how traffic enters Gateway. Use [Traffic destinations](/cloudflare-one/traffic-policies/network-policies/#traffic-destinations) to match where Gateway sends traffic next.
+
 :::note
 The following steps are identical to [Connect user devices](/learning-paths/replace-vpn/connect-devices/) in the Replace your VPN implementation guide. If you have already completed Replace your VPN, you can skip ahead to [Network on-ramps](#network-on-ramps).
 :::

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/zero_trust_network_sessions.md
@@ -141,7 +141,7 @@ The IP used to correlate existing FQDN matching policy between Gateway DNS and G
 
 Type: `string`
 
-The type of destination to which the network session was routed. <br />Possible values are <em>INTERNET</em> \| <em>MAGIC</em> \| <em>CFD_TUNNEL</em> \| <em>WARP</em>.
+The type of destination to which the network session was routed. <br />Possible values are <em>INTERNET</em> \| <em>MAGIC</em> \| <em>CFD_TUNNEL</em> \| <em>DEVICE_CLIENT</em> \| <em>MESH</em>.
 
 ## OriginIP
 

--- a/src/content/partials/cloudflare-one/gateway/http-allow-block-selectors.mdx
+++ b/src/content/partials/cloudflare-one/gateway/http-allow-block-selectors.mdx
@@ -24,6 +24,8 @@
 - [Source Country IP Geolocation](#source-country)
 - [Source Internal IP](#source-internal-ip)
 - [Source IP](#source-ip)
+- [Traffic destinations](#traffic-destinations)
+- [Traffic sources](#traffic-sources)
 - [Upload File Types](#download-and-upload-file-types)
 - [Upload Mime Type](#download-and-upload-mime-type)
 - [URL](#url)

--- a/src/content/partials/cloudflare-one/gateway/selectors/traffic-destinations.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/traffic-destinations.mdx
@@ -1,0 +1,20 @@
+---
+{}
+---
+
+Use this selector to match Gateway policies by the type of path Gateway uses to send traffic onward.
+
+
+| UI name              | API example                      |
+| -------------------- | -------------------------------- |
+| Traffic destinations | `net.offramp.type == "internet"` |
+
+| Display label         | API value           | Meaning                                                                                                                                         |
+| --------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Internet              | `internet`          | Traffic that exits to the public Internet, with or without Dedicated Egress IP. Dedicated Egress IP is not a separate traffic destination type. |
+| Cloudflare WAN        | `cloudflare_wan`    | Traffic that exits through a Cloudflare WAN connection.                                                                                         |
+| Cloudflare Tunnel     | `cloudflare_tunnel` | Traffic that exits through a `cloudflared` tunnel to a private origin.                                                                          |
+| Cloudflare One Client | `device_client`     | Traffic that exits to another device running the Cloudflare One Client.                                                                         |
+| Mesh                  | `mesh`              | Traffic that exits through any Mesh node in your Mesh network. This is type-level, not a specific node.                                         |
+
+Workers VPC is not a traffic destination value. Dedicated Egress IP is an attribute of Internet egress, not a separate traffic destination type.

--- a/src/content/partials/cloudflare-one/gateway/selectors/traffic-sources.mdx
+++ b/src/content/partials/cloudflare-one/gateway/selectors/traffic-sources.mdx
@@ -1,0 +1,19 @@
+---
+{}
+---
+
+Use this selector to match Gateway policies by the type of path that carried traffic into Gateway.
+
+| UI name         | API example                          |
+| --------------- | ------------------------------------ |
+| Traffic sources | `net.onramp.type == "device_client"` |
+
+| Display label         | API value           | Meaning                                                                                                        |
+| --------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Cloudflare One Client | `device_client`     | Traffic that entered through a managed device running the Cloudflare One Client.                               |
+| Mesh                  | `mesh`              | Traffic that entered through any Mesh node in your Mesh network. This is type-level, not a specific node.      |
+| Cloudflare WAN        | `cloudflare_wan`    | Traffic that entered through a Cloudflare WAN connection, such as IPsec, GRE, or CNI.                          |
+| Clientless RDP        | `clientless_rdp`    | Traffic that entered through a clientless Remote Desktop Protocol session.                                     |
+| Proxy Endpoint        | `proxy_endpoint`    | Traffic that entered through a Cloudflare-managed Gateway proxy endpoint, including PAC-driven configurations. |
+| Browser Isolation     | `browser_isolation` | Traffic that originated in a Browser Isolation session.                                                        |
+| MCP Portal            | `mcp_portal`        | Traffic that entered through a Cloudflare MCP server portal.                                                   |


### PR DESCRIPTION
### Summary

Adds Gateway policy selector documentation for Traffic sources and Traffic destinations, including supported policy types, selector values, API examples, and limitations.

Also adds brief context to related Gateway and learning path pages so administrators can understand how to scope policies by where traffic enters and exits Gateway.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
