### PR TITLE
[SSL for SaaS] Add CODEOWNERS for partials, clarify Enterprise-only custom hostname options

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -191,6 +191,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/cloudflare-for-platforms/ @irvinebroque @dinasaur404 @cloudflare/product-owners
 /src/content/docs/cloudflare-for-platforms/workers-for-platforms/ @irvinebroque @dinasaur404 @cloudflare/deploy-config @cloudflare/product-owners
 /src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/ @baubuchon-cf @irvinebroque @dinasaur404 @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
+/src/content/partials/cloudflare-for-platforms/ @baubuchon-cf @irvinebroque @dinasaur404 @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/workers/observability/ @irvinebroque @mikenomitch @nevikashah @cloudflare/product-owners @vy-ton
 /src/content/docs/workers/static-assets @irvinebroque @GregBrimble @WalshyDev @cloudflare/deploy-config @cloudflare/product-owners @MattieTK @vy-ton
 /src/content/docs/workers-vpc/ @nikitacano @elithrar @thomasgauvin @cloudflare/product-owners

--- a/src/content/partials/cloudflare-for-platforms/create-custom-hostname-api.mdx
+++ b/src/content/partials/cloudflare-for-platforms/create-custom-hostname-api.mdx
@@ -4,7 +4,7 @@
 ---
 
 1. To create a custom hostname using the API, use the [Create Custom Hostname](/api/resources/custom_hostnames/methods/create/) endpoint.
-
+   * Only Enterprise customers can use the `certificate_authority` parameter to specify a CA, the `custom_certificate`/`custom_cert_bundle` to upload a custom certificate, or `wildcard` to create a wildcard certificate. Refer to [Plans](/cloudflare-for-platforms/cloudflare-for-saas/plans/).
    * You can leave the `certificate_authority` parameter empty to set it to "default CA". With this option, Cloudflare checks the CAA records before requesting the certificates, which helps ensure the certificates can be issued from the CA.
 
 2. For the newly created custom hostname, the `POST` response may not return the DCV validation token `validation_records`.  It is recommended to make a second [`GET` command](/api/resources/custom_hostnames/methods/list/) (with a delay) to retrieve these details.

--- a/src/content/partials/cloudflare-for-platforms/create-custom-hostname.mdx
+++ b/src/content/partials/cloudflare-for-platforms/create-custom-hostname.mdx
@@ -11,9 +11,9 @@ import { DashButton } from "~/components";
 
 2. Select **Add Custom Hostname**.
 3. Add your customer's hostname `app.customer.com` and set the relevant options, including:
-    - The [minimum TLS version](/ssl/reference/protocols/).
+    - Select the [minimum TLS version](/ssl/reference/protocols/).
     - Select the [validation method](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/).
     - Define a [custom origin server](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/).
-    - Enterprise customers can also select the [certificate authority (CA)](/ssl/reference/certificate-authorities/) that will issue the certificate, [upload a custom certificate](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/uploading-certificates/), or enable wildcard which adds a `*.<custom-hostname>` SAN to the custom hostname certificate (for more details, refer to [Hostname priority](/ssl/reference/certificate-and-hostname-priority/#hostname-priority)). Refer to [Plans](/cloudflare-for-platforms/cloudflare-for-saas/plans/).
+    - Enterprise customers can also select the [certificate authority (CA)](/ssl/reference/certificate-authorities/), [upload a custom certificate](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/uploading-certificates/), or enable wildcard, which adds a `*.<custom-hostname>` SAN to the custom hostname certificate. For more details, refer to [Hostname priority](/ssl/reference/certificate-and-hostname-priority/#hostname-priority) and [Plans](/cloudflare-for-platforms/cloudflare-for-saas/plans/).
 
 4. Select **Add Custom Hostname**.

--- a/src/content/partials/cloudflare-for-platforms/create-custom-hostname.mdx
+++ b/src/content/partials/cloudflare-for-platforms/create-custom-hostname.mdx
@@ -12,9 +12,8 @@ import { DashButton } from "~/components";
 2. Select **Add Custom Hostname**.
 3. Add your customer's hostname `app.customer.com` and set the relevant options, including:
     - The [minimum TLS version](/ssl/reference/protocols/).
-    - Defining whether you want to use a certificate provided by Cloudflare or [upload a custom certificate](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/uploading-certificates/).
-    - Selecting the [certificate authority (CA)](/ssl/reference/certificate-authorities/) that will issue the certificate.
-    - Choosing the [validation method](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/).
-    - Whether you want to **Enable wildcard**, which adds a `*.<custom-hostname>` SAN to the custom hostname certificate. For more details, refer to [Hostname priority](/ssl/reference/certificate-and-hostname-priority/#hostname-priority).
-    - Choosing a value for [Custom origin server](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/).
+    - Select the [validation method](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/).
+    - Define a [custom origin server](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/).
+    - Enterprise customers can also select the [certificate authority (CA)](/ssl/reference/certificate-authorities/) that will issue the certificate, [upload a custom certificate](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/custom-certificates/uploading-certificates/), or enable wildcard which adds a `*.<custom-hostname>` SAN to the custom hostname certificate (for more details, refer to [Hostname priority](/ssl/reference/certificate-and-hostname-priority/#hostname-priority)). Refer to [Plans](/cloudflare-for-platforms/cloudflare-for-saas/plans/).
+
 4. Select **Add Custom Hostname**.


### PR DESCRIPTION
### Summary

Adds CODEOWNERS coverage for SSL for SaaS partials and clarifies Enterprise-only custom hostname options in the dashboard and API instructions.

- Adds `/src/content/partials/cloudflare-for-platforms/` to CODEOWNERS with the same reviewer set as the `cloudflare-for-saas/` docs path
- Restructures the dashboard custom hostname creation steps to separate universally available options from Enterprise-only features (CA selection, custom certificates, wildcard)
- Adds an Enterprise-only note to the API partial for `certificate_authority`, `custom_certificate`/`custom_cert_bundle`, and `wildcard` parameters
- Fixes docs-bot style nits: "See [Plans]" → "Refer to [Plans]", adds Oxford comma

Replaces #30375.

DEE-3554

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
