### PR TITLE
[Cloudflare for SaaS] Note pre-validation is not supported for O2O 

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/pre-validation.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/pre-validation.mdx
@@ -14,6 +14,14 @@ head:
 
 Pre-validation methods help verify domain ownership before your customer's traffic is proxying through Cloudflare.
 
+:::caution[Not supported for O2O custom hostnames]
+
+Pre-validation (TXT and HTTP token methods) is not supported when the custom hostname belongs to a zone that is already on Cloudflare — also known as an [Orange-to-Orange (O2O)](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) setup.
+
+In an O2O setup, the customer's authoritative DNS is already on Cloudflare, so there is no separate cutover step from a non-Cloudflare provider to Cloudflare. Activating the custom hostname immediately routes traffic through the SaaS zone, which means pre-validation tokens cannot be used to verify ownership ahead of the cutover. For these custom hostnames, use a [real-time validation method](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/realtime-validation/) instead.
+
+:::
+
 ## Use when
 
 Use pre-validation methods when your customers cannot tolerate any downtime, which often occurs with production domains.


### PR DESCRIPTION
### Summary

Adds a callout to the documentation that pre-validation is not supported for the o2o case

### Screenshots (optional)
The yellow warning box here is new.

<img width="1516" height="1102" alt="Screenshot 2026-06-11 at 1 28 37 PM" src="https://github.com/user-attachments/assets/51e5eb77-303c-4db4-a8a9-506fd12bc7a4" />


### Documentation checklist

<!-- Remove items that do not apply -->

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
