### PR TITLE
[AI Gateway] Add wrangler auth token hint to cURL examples

### DIFF
--- a/src/content/docs/ai-gateway/configuration/authentication.mdx
+++ b/src/content/docs/ai-gateway/configuration/authentication.mdx
@@ -9,6 +9,8 @@ products:
   - ai-gateway
 ---
 
+import { Render } from "~/components";
+
 AI Gateway requires a valid Cloudflare API token for each request. This prevents unauthorized access and protects against invalid requests that can inflate log storage usage.
 
 When using the [REST API](/ai-gateway/usage/rest-api/), pass your Cloudflare API token in the standard `Authorization` header. When using [provider-native endpoints](/ai-gateway/usage/providers/) at `gateway.ai.cloudflare.com`, use the `cf-aig-authorization` header instead.
@@ -28,7 +30,10 @@ The `cf-aig-authorization` header is used with the `gateway.ai.cloudflare.com` e
 
 ## Example requests
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/configuration/authentication.mdx
+++ b/src/content/docs/ai-gateway/configuration/authentication.mdx
@@ -33,7 +33,8 @@ The `cf-aig-authorization` header is used with the `gateway.ai.cloudflare.com` e
 <Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -71,7 +72,7 @@ const openai = createOpenAI({
 
 :::note
 When an AI Gateway is accessed from a Cloudflare Worker using a **binding**, the `cf-aig-authorization` header does not need to be manually included.  
-Requests made through bindings are **pre-authenticated** within the associated Cloudflare account. 
+Requests made through bindings are **pre-authenticated** within the associated Cloudflare account.
 :::
 
 The following table outlines gateway behavior based on the authentication settings and header status:

--- a/src/content/docs/ai-gateway/configuration/authentication.mdx
+++ b/src/content/docs/ai-gateway/configuration/authentication.mdx
@@ -9,8 +9,6 @@ products:
   - ai-gateway
 ---
 
-import { Render } from "~/components";
-
 AI Gateway requires a valid Cloudflare API token for each request. This prevents unauthorized access and protects against invalid requests that can inflate log storage usage.
 
 When using the [REST API](/ai-gateway/usage/rest-api/), pass your Cloudflare API token in the standard `Authorization` header. When using [provider-native endpoints](/ai-gateway/usage/providers/) at `gateway.ai.cloudflare.com`, use the `cf-aig-authorization` header instead.
@@ -29,8 +27,6 @@ The `cf-aig-authorization` header is used with the `gateway.ai.cloudflare.com` e
 4. Return to the settings page and toggle on Authenticated Gateway.
 
 ## Example requests
-
-<Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,

--- a/src/content/docs/ai-gateway/configuration/custom-providers.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-providers.mdx
@@ -54,8 +54,6 @@ To create a new custom provider using the API:
 
 2. Send a `POST` request to create a new custom provider:
 
-<Render file="auth-token-hint" product="ai-gateway" />
-
 ```bash title="Create Custom Provider"
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
 # and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.

--- a/src/content/docs/ai-gateway/configuration/custom-providers.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-providers.mdx
@@ -9,7 +9,7 @@ products:
   - ai-gateway
 ---
 
-import { TabItem, Tabs } from "~/components";
+import { Render, TabItem, Tabs } from "~/components";
 
 ## Overview
 
@@ -54,7 +54,10 @@ To create a new custom provider using the API:
 
 2. Send a `POST` request to create a new custom provider:
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash title="Create Custom Provider"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -134,6 +137,7 @@ To create a new custom provider using the dashboard:
 Retrieve all custom providers with optional filtering and pagination:
 
 ```bash title="List all providers"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
@@ -150,12 +154,14 @@ curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custo
 
 List only enabled providers:
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers?enable=true" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 Search for specific providers:
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers?search=custom" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
@@ -205,6 +211,7 @@ To view all your custom providers:
 Retrieve details for a specific custom provider by its ID:
 
 ```bash title="Get provider by ID"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
@@ -245,6 +252,7 @@ curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custo
 Update an existing custom provider. All fields are optional - only include the fields you want to change:
 
 ```bash title="Update provider"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -270,6 +278,7 @@ curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gate
 
 Enable a provider:
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -278,6 +287,7 @@ curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gate
 
 Update provider URL:
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -310,6 +320,7 @@ To update an existing custom provider:
 Delete a custom provider:
 
 ```bash title="Delete provider"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
@@ -389,6 +400,7 @@ Use the **provider-specific endpoint** when your custom provider uses a non-stan
 The Unified API sends requests to the provider's chat completions endpoint using the OpenAI-compatible format. Specify the model using the format `custom-{slug}/{model-name}`.
 
 ```bash title="Request using custom provider via Unified API"
+# Run `wrangler auth token` to get an auth token to replace $CF_AIG_TOKEN for use with the API.
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions \
   -H "Authorization: Bearer $PROVIDER_API_KEY" \
   -H "cf-aig-authorization: Bearer $CF_AIG_TOKEN" \
@@ -404,6 +416,7 @@ curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/
 The provider-specific endpoint gives you full control over the upstream path. Everything after `custom-{slug}/` in the URL is appended to the `base_url`.
 
 ```bash title="Direct provider endpoint"
+# Run `wrangler auth token` to get an auth token to replace $CF_AIG_TOKEN for use with the API.
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/custom-some-provider/v1/chat/completions \
   -H "Authorization: Bearer $PROVIDER_API_KEY" \
   -H "cf-aig-authorization: Bearer $CF_AIG_TOKEN" \

--- a/src/content/docs/ai-gateway/configuration/custom-providers.mdx
+++ b/src/content/docs/ai-gateway/configuration/custom-providers.mdx
@@ -57,7 +57,8 @@ To create a new custom provider using the API:
 <Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash title="Create Custom Provider"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -137,7 +138,8 @@ To create a new custom provider using the dashboard:
 Retrieve all custom providers with optional filtering and pagination:
 
 ```bash title="List all providers"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
@@ -154,14 +156,16 @@ curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custo
 
 List only enabled providers:
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers?enable=true" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
 
 Search for specific providers:
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers?search=custom" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
@@ -211,7 +215,8 @@ To view all your custom providers:
 Retrieve details for a specific custom provider by its ID:
 
 ```bash title="Get provider by ID"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
@@ -252,7 +257,8 @@ curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custo
 Update an existing custom provider. All fields are optional - only include the fields you want to change:
 
 ```bash title="Update provider"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -278,7 +284,8 @@ curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gate
 
 Enable a provider:
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -287,7 +294,8 @@ curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gate
 
 Update provider URL:
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   -H "Content-Type: application/json" \
@@ -320,7 +328,8 @@ To update an existing custom provider:
 Delete a custom provider:
 
 ```bash title="Delete provider"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/ai-gateway/custom-providers/{provider_id}" \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
 ```
@@ -384,12 +393,12 @@ Everything after `custom-{slug}/` in your request URL is appended directly to th
 
 ### Choosing between Unified API and provider-specific endpoint
 
-| | Unified API (`/compat`) | Provider-specific endpoint |
-|---|---|---|
-| **Best for** | Providers with OpenAI-compatible APIs | Providers with any API structure |
-| **Request format** | Must follow the OpenAI `/chat/completions` schema | Uses the provider's native request format |
-| **Path control** | Fixed to `/compat/chat/completions` | Full control over the upstream path |
-| **How to specify the provider** | `model` field: `custom-{slug}/{model-name}` | URL path: `/custom-{slug}/{path}` |
+|                                 | Unified API (`/compat`)                           | Provider-specific endpoint                |
+| ------------------------------- | ------------------------------------------------- | ----------------------------------------- |
+| **Best for**                    | Providers with OpenAI-compatible APIs             | Providers with any API structure          |
+| **Request format**              | Must follow the OpenAI `/chat/completions` schema | Uses the provider's native request format |
+| **Path control**                | Fixed to `/compat/chat/completions`               | Full control over the upstream path       |
+| **How to specify the provider** | `model` field: `custom-{slug}/{model-name}`       | URL path: `/custom-{slug}/{path}`         |
 
 Use the **Unified API** when your custom provider accepts the OpenAI-compatible `/chat/completions` request format. This is the simplest option and works well with OpenAI SDKs.
 
@@ -438,10 +447,12 @@ The following examples show how to configure `base_url` and construct request UR
 Many providers follow the OpenAI convention of hosting their API at `{domain}/v1/chat/completions`.
 
 **Configuration:**
+
 - `slug`: `my-openai-compat`
 - `base_url`: `https://api.example-provider.com`
 
 **Provider-specific endpoint:**
+
 ```bash
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/custom-my-openai-compat/v1/chat/completions \
   -H "Authorization: Bearer $PROVIDER_API_KEY" \
@@ -461,6 +472,7 @@ curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/custom-my-op
 | Upstream URL | `https://api.example-provider.com/v1/chat/completions` |
 
 Since this provider is OpenAI-compatible, you could also use the Unified API:
+
 ```bash
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions \
   -H "Authorization: Bearer $PROVIDER_API_KEY" \
@@ -476,10 +488,12 @@ curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/
 Some providers use API paths that don't follow the `/v1/` convention. For example, a provider whose chat endpoint is at `https://api.custom-ai.com/api/coding/paas/v4/chat/completions`.
 
 **Configuration:**
+
 - `slug`: `custom-ai`
 - `base_url`: `https://api.custom-ai.com`
 
 **Provider-specific endpoint:**
+
 ```bash
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/custom-custom-ai/api/coding/paas/v4/chat/completions \
   -H "Authorization: Bearer $PROVIDER_API_KEY" \
@@ -507,10 +521,12 @@ For providers with non-standard paths, you must use the provider-specific endpoi
 If you host your own model behind a reverse proxy or on a platform that adds a path prefix, include only the fixed prefix portion in `base_url` if all your endpoints share it. Otherwise, keep `base_url` as just the domain.
 
 **Configuration (domain-only `base_url`):**
+
 - `slug`: `internal-llm`
 - `base_url`: `https://ml.internal.example.com`
 
 **Provider-specific endpoint:**
+
 ```bash
 curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/custom-internal-llm/serving/models/my-model:predict \
   -H "Authorization: Bearer $INTERNAL_API_KEY" \
@@ -533,10 +549,12 @@ curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/custom-inter
 When using the OpenAI SDK to connect to a custom provider through AI Gateway, set the SDK's `base_url` to the gateway's provider-specific endpoint path (up to and including the API version prefix that your provider expects).
 
 **Configuration:**
+
 - `slug`: `alt-provider`
 - `base_url`: `https://api.alt-provider.com`
 
 **Python (OpenAI SDK):**
+
 ```python title="Using OpenAI SDK with a custom provider"
 from openai import OpenAI
 
@@ -572,14 +590,14 @@ response = client.chat.completions.create(
 
 ```json
 {
-  "success": false,
-  "errors": [
-    {
-      "code": 1003,
-      "message": "A custom provider with this slug already exists",
-      "path": ["body", "slug"]
-    }
-  ]
+	"success": false,
+	"errors": [
+		{
+			"code": 1003,
+			"message": "A custom provider with this slug already exists",
+			"path": ["body", "slug"]
+		}
+	]
 }
 ```
 
@@ -589,13 +607,13 @@ Each custom provider slug must be unique within your account. Choose a different
 
 ```json
 {
-  "success": false,
-  "errors": [
-    {
-      "code": 1004,
-      "message": "Custom Provider not found"
-    }
-  ]
+	"success": false,
+	"errors": [
+		{
+			"code": 1004,
+			"message": "Custom Provider not found"
+		}
+	]
 }
 ```
 
@@ -605,14 +623,14 @@ The specified provider ID does not exist or you don't have access to it. Verify 
 
 ```json
 {
-  "success": false,
-  "errors": [
-    {
-      "code": 1002,
-      "message": "base_url must be a valid HTTPS URL starting with https://",
-      "path": ["body", "base_url"]
-    }
-  ]
+	"success": false,
+	"errors": [
+		{
+			"code": 1002,
+			"message": "base_url must be a valid HTTPS URL starting with https://",
+			"path": ["body", "base_url"]
+		}
+	]
 }
 ```
 

--- a/src/content/docs/ai-gateway/configuration/request-handling.mdx
+++ b/src/content/docs/ai-gateway/configuration/request-handling.mdx
@@ -8,8 +8,6 @@ products:
   - ai-gateway
 ---
 
-import { Render } from "~/components";
-
 :::note
 
 [Dynamic Routing](/ai-gateway/features/dynamic-routing/) also offers timeouts and retries per model, along with conditional routing, rate limiting, and budget limiting through a visual interface. This page documents request-handling configuration available through per-request `cf-aig-*` headers that work with any provider endpoint. You can also configure retries at the [gateway level](/ai-gateway/configuration/manage-gateway/#retry-requests).
@@ -32,8 +30,6 @@ A timeout is set in milliseconds. The timeout is based on when the first part of
 ### Configuration
 
 For a provider-specific endpoint, configure the timeout value by adding a `cf-aig-request-timeout` header.
-
-<Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash title="Request with timeout" {6}
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,

--- a/src/content/docs/ai-gateway/configuration/request-handling.mdx
+++ b/src/content/docs/ai-gateway/configuration/request-handling.mdx
@@ -35,8 +35,9 @@ For a provider-specific endpoint, configure the timeout value by adding a `cf-ai
 
 <Render file="auth-token-hint" product="ai-gateway" />
 
-```bash title="Request with timeout" {4}
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+```bash title="Request with timeout" {6}
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/configuration/request-handling.mdx
+++ b/src/content/docs/ai-gateway/configuration/request-handling.mdx
@@ -33,7 +33,10 @@ A timeout is set in milliseconds. The timeout is based on when the first part of
 
 For a provider-specific endpoint, configure the timeout value by adding a `cf-aig-request-timeout` header.
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash title="Request with timeout" {4}
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/features/caching.mdx
+++ b/src/content/docs/ai-gateway/features/caching.mdx
@@ -98,7 +98,8 @@ As an example, when submitting a request to OpenAI, include the header in the fo
 <Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash title="Request skipping the cache"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -123,7 +124,8 @@ For example, if you set a TTL of one hour, it means that a request is kept in th
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 
 ```bash title="Request to be cached for an hour"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -148,7 +150,8 @@ When you use the **cf-aig-cache-key** header for the first time, you will receiv
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 
 ```bash title="Request with custom cache key"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/features/caching.mdx
+++ b/src/content/docs/ai-gateway/features/caching.mdx
@@ -95,8 +95,6 @@ You can use the header **cf-aig-skip-cache** to bypass the cached version of the
 
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 
-<Render file="auth-token-hint" product="ai-gateway" />
-
 ```bash title="Request skipping the cache"
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
 # and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.

--- a/src/content/docs/ai-gateway/features/caching.mdx
+++ b/src/content/docs/ai-gateway/features/caching.mdx
@@ -9,7 +9,7 @@ products:
   - ai-gateway
 ---
 
-import { TabItem, Tabs } from "~/components";
+import { Render, TabItem, Tabs } from "~/components";
 
 AI Gateway can cache responses from your AI model providers, serving them directly from Cloudflare's cache for identical requests.
 
@@ -95,7 +95,10 @@ You can use the header **cf-aig-skip-cache** to bypass the cached version of the
 
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash title="Request skipping the cache"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -120,6 +123,7 @@ For example, if you set a TTL of one hour, it means that a request is kept in th
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 
 ```bash title="Request to be cached for an hour"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -144,6 +148,7 @@ When you use the **cf-aig-cache-key** header for the first time, you will receiv
 As an example, when submitting a request to OpenAI, include the header in the following manner:
 
 ```bash title="Request with custom cache key"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/features/unified-billing.mdx
+++ b/src/content/docs/ai-gateway/features/unified-billing.mdx
@@ -85,8 +85,6 @@ Call a supported provider through the AI Gateway REST API without passing a prov
 
 Use the Cloudflare API to call third-party models. Pass your Cloudflare API token in the `Authorization` header:
 
-<Render file="auth-token-hint" product="ai-gateway" />
-
 ```bash
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
 # and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.

--- a/src/content/docs/ai-gateway/features/unified-billing.mdx
+++ b/src/content/docs/ai-gateway/features/unified-billing.mdx
@@ -11,7 +11,7 @@ products:
   - ai-gateway
 ---
 
-import { DashButton, TabItem, Tabs } from "~/components";
+import { DashButton, Render, TabItem, Tabs } from "~/components";
 
 Unified Billing allows users to connect to various AI providers (such as OpenAI, Anthropic, and Google AI Studio) and receive a single Cloudflare bill. To use Unified Billing, you must purchase and load credits into your Cloudflare account in the Cloudflare dashboard, which you can then spend with AI Gateway.
 
@@ -85,7 +85,10 @@ Call a supported provider through the AI Gateway REST API without passing a prov
 
 Use the Cloudflare API to call third-party models. Pass your Cloudflare API token in the `Authorization` header:
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -160,6 +163,7 @@ To set ZDR as the default for Unified Billing using the API:
 Use the `cf-aig-zdr` header to override the gateway default for a single Unified Billing request. Set it to `true` to force ZDR, or `false` to disable ZDR for the request.
 
 ```bash title="Unified Billing request with ZDR"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/features/unified-billing.mdx
+++ b/src/content/docs/ai-gateway/features/unified-billing.mdx
@@ -88,7 +88,8 @@ Use the Cloudflare API to call third-party models. Pass your Cloudflare API toke
 <Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -163,7 +164,8 @@ To set ZDR as the default for Unified Billing using the API:
 Use the `cf-aig-zdr` header to override the gateway default for a single Unified Billing request. Set it to `true` to force ZDR, or `false` to disable ZDR for the request.
 
 ```bash title="Unified Billing request with ZDR"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/get-started.mdx
+++ b/src/content/docs/ai-gateway/get-started.mdx
@@ -31,8 +31,6 @@ Before making requests, you need two things:
 
 Run the following command to make your first request through AI Gateway. This example calls a Workers AI model, which requires the `@cf/` model prefix and the `cf-aig-gateway-id` header.
 
-<Render file="auth-token-hint" product="ai-gateway" />
-
 ```bash
 # Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN,
 # and `wrangler whoami` to replace $CLOUDFLARE_ACCOUNT_ID.

--- a/src/content/docs/ai-gateway/get-started.mdx
+++ b/src/content/docs/ai-gateway/get-started.mdx
@@ -31,7 +31,10 @@ Before making requests, you need two things:
 
 Run the following command to make your first request through AI Gateway. This example calls a Workers AI model, which requires the `@cf/` model prefix and the `cf-aig-gateway-id` header.
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "cf-aig-gateway-id: default" \
@@ -74,6 +77,7 @@ Authenticate with your upstream AI provider using one of the following options:
 Call any model — whether hosted on Cloudflare or by a third-party provider — through the same Cloudflare API. No provider SDKs or API keys needed — authentication and billing are handled through your Cloudflare account. Three endpoints are available: `/ai/run` for all modalities, `/ai/v1/chat/completions` for OpenAI SDK compatibility, and `/ai/v1/responses` for agentic workflows.
 
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/get-started.mdx
+++ b/src/content/docs/ai-gateway/get-started.mdx
@@ -34,7 +34,8 @@ Run the following command to make your first request through AI Gateway. This ex
 <Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN,
+# and `wrangler whoami` to replace $CLOUDFLARE_ACCOUNT_ID.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "cf-aig-gateway-id: default" \
@@ -77,7 +78,8 @@ Authenticate with your upstream AI provider using one of the following options:
 Call any model — whether hosted on Cloudflare or by a third-party provider — through the same Cloudflare API. No provider SDKs or API keys needed — authentication and billing are handled through your Cloudflare account. Three endpoints are available: `/ai/run` for all modalities, `/ai/v1/chat/completions` for OpenAI SDK compatibility, and `/ai/v1/responses` for agentic workflows.
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/observability/custom-metadata.mdx
+++ b/src/content/docs/ai-gateway/observability/custom-metadata.mdx
@@ -8,7 +8,7 @@ products:
   - ai-gateway
 ---
 
-import { Render, TypeScriptExample } from "~/components";
+import { TypeScriptExample } from "~/components";
 
 Custom metadata in AI Gateway allows you to tag requests with user IDs or other identifiers, enabling better tracking and analysis of your requests. Metadata values can be strings, numbers, or booleans, and will appear in your logs, making it easy to search and filter through your data.
 
@@ -41,8 +41,6 @@ Objects are not supported as metadata values.
 ### Using cURL
 
 To include custom metadata in your request using cURL:
-
-<Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,

--- a/src/content/docs/ai-gateway/observability/custom-metadata.mdx
+++ b/src/content/docs/ai-gateway/observability/custom-metadata.mdx
@@ -8,7 +8,7 @@ products:
   - ai-gateway
 ---
 
-import { TypeScriptExample } from "~/components";
+import { Render, TypeScriptExample } from "~/components";
 
 Custom metadata in AI Gateway allows you to tag requests with user IDs or other identifiers, enabling better tracking and analysis of your requests. Metadata values can be strings, numbers, or booleans, and will appear in your logs, making it easy to search and filter through your data.
 
@@ -45,7 +45,10 @@ Objects are not supported as metadata values.
 
 To include custom metadata in your request using cURL:
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/observability/custom-metadata.mdx
+++ b/src/content/docs/ai-gateway/observability/custom-metadata.mdx
@@ -14,12 +14,11 @@ Custom metadata in AI Gateway allows you to tag requests with user IDs or other 
 
 ## Key Features
 
-* **Custom Tagging**: Add user IDs, team names, test indicators, and other relevant information to your requests.
-* **Enhanced Logging**: Metadata appears in your logs, allowing for detailed inspection and troubleshooting.
-* **Search and Filter**: Use metadata to efficiently search and filter through logged requests.
+- **Custom Tagging**: Add user IDs, team names, test indicators, and other relevant information to your requests.
+- **Enhanced Logging**: Metadata appears in your logs, allowing for detailed inspection and troubleshooting.
+- **Search and Filter**: Use metadata to efficiently search and filter through logged requests.
 
 :::note
-
 
 AI Gateway allows you to pass up to five custom metadata entries per request. If more than five entries are provided, only the first five will be saved; additional entries will be ignored. Ensure your custom metadata is limited to five entries to avoid unprocessed or lost data.
 
@@ -27,15 +26,13 @@ AI Gateway allows you to pass up to five custom metadata entries per request. If
 
 ## Supported Metadata Types
 
-* String
-* Number
-* Boolean
+- String
+- Number
+- Boolean
 
 :::note
 
-
 Objects are not supported as metadata values.
-
 
 :::
 
@@ -48,7 +45,8 @@ To include custom metadata in your request using cURL:
 <Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -108,14 +106,19 @@ To include custom metadata in your request using [Bindings](/workers/runtime-api
 
 ```javascript
 export default {
- async fetch(request, env, ctx) {
-   const aiResp = await env.AI.run(
-       '@cf/mistral/mistral-7b-instruct-v0.1',
-       { prompt: 'What should I eat for lunch?' },
-       { gateway: { id: 'gateway_id', metadata: { "team": "AI", "user": 12345, "test": true} } }
-   );
+	async fetch(request, env, ctx) {
+		const aiResp = await env.AI.run(
+			"@cf/mistral/mistral-7b-instruct-v0.1",
+			{ prompt: "What should I eat for lunch?" },
+			{
+				gateway: {
+					id: "gateway_id",
+					metadata: { team: "AI", user: 12345, test: true },
+				},
+			},
+		);
 
-   return new Response(aiResp);
- },
+		return new Response(aiResp);
+	},
 };
 ```

--- a/src/content/docs/ai-gateway/observability/logging/index.mdx
+++ b/src/content/docs/ai-gateway/observability/logging/index.mdx
@@ -36,7 +36,8 @@ In the example below, we use `cf-aig-collect-log` to bypass the default setting 
 <Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -58,15 +59,16 @@ The `cf-aig-collect-log-payload` header allows you to control whether the raw re
 
 This is useful when you want to maintain visibility into usage metrics and request metadata without persisting sensitive prompt or completion data.
 
-| Header value | Behavior |
-| ------------ | -------- |
-| `true`       | Request and response payloads are stored. |
+| Header value | Behavior                                                               |
+| ------------ | ---------------------------------------------------------------------- |
+| `true`       | Request and response payloads are stored.                              |
 | `false`      | Payload storage is skipped. Metadata-only log entries are still saved. |
 
 In the example below, we use `cf-aig-collect-log-payload` to skip storing the request and response bodies while keeping the metadata log.
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/observability/logging/index.mdx
+++ b/src/content/docs/ai-gateway/observability/logging/index.mdx
@@ -33,8 +33,6 @@ The `cf-aig-collect-log` header allows you to bypass the default log setting for
 
 In the example below, we use `cf-aig-collect-log` to bypass the default setting to avoid saving the log.
 
-<Render file="auth-token-hint" product="ai-gateway" />
-
 ```bash
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
 # and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.

--- a/src/content/docs/ai-gateway/observability/logging/index.mdx
+++ b/src/content/docs/ai-gateway/observability/logging/index.mdx
@@ -33,7 +33,10 @@ The `cf-aig-collect-log` header allows you to bypass the default log setting for
 
 In the example below, we use `cf-aig-collect-log` to bypass the default setting to avoid saving the log.
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -63,6 +66,7 @@ This is useful when you want to maintain visibility into usage metrics and reque
 In the example below, we use `cf-aig-collect-log-payload` to skip storing the request and response bodies while keeping the metadata log.
 
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \

--- a/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
+++ b/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
@@ -36,7 +36,10 @@ Then, create a new AI Gateway.
 2. Select **Use REST API** and follow the steps to create and copy the API token and Account ID.
 3. Send a request using the [REST API](/ai-gateway/usage/rest-api/). Replace `$CLOUDFLARE_ACCOUNT_ID` and `$CLOUDFLARE_API_TOKEN` with your actual account ID and API token:
 
+   <Render file="auth-token-hint" product="ai-gateway" />
+
    ```bash
+   # Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
    curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
      --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
      --header "cf-aig-gateway-id: default" \

--- a/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
+++ b/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
@@ -36,8 +36,6 @@ Then, create a new AI Gateway.
 2. Select **Use REST API** and follow the steps to create and copy the API token and Account ID.
 3. Send a request using the [REST API](/ai-gateway/usage/rest-api/). Replace `$CLOUDFLARE_ACCOUNT_ID` and `$CLOUDFLARE_API_TOKEN` with your actual account ID and API token:
 
-   <Render file="auth-token-hint" product="ai-gateway" />
-
    ```bash
    # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
    # and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.

--- a/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
+++ b/src/content/docs/ai-gateway/tutorials/create-first-aig-workers.mdx
@@ -39,7 +39,8 @@ Then, create a new AI Gateway.
    <Render file="auth-token-hint" product="ai-gateway" />
 
    ```bash
-   # Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+   # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+   # and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
    curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
      --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
      --header "cf-aig-gateway-id: default" \

--- a/src/content/docs/ai-gateway/usage/providers/workersai.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/workersai.mdx
@@ -18,7 +18,10 @@ Use AI Gateway for analytics, caching, and security on requests to [Workers AI](
 
 Use the [REST API](/ai-gateway/usage/rest-api/) to call Workers AI models. Workers AI models use the `@cf/` prefix in the model name and require the `cf-aig-gateway-id` header to specify which gateway to route through.
 
+<Render file="auth-token-hint" product="ai-gateway" />
+
 ```bash title="Request to Workers AI Kimi model"
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "cf-aig-gateway-id: default" \

--- a/src/content/docs/ai-gateway/usage/providers/workersai.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/workersai.mdx
@@ -21,7 +21,8 @@ Use the [REST API](/ai-gateway/usage/rest-api/) to call Workers AI models. Worke
 <Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash title="Request to Workers AI Kimi model"
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "cf-aig-gateway-id: default" \

--- a/src/content/docs/ai-gateway/usage/providers/workersai.mdx
+++ b/src/content/docs/ai-gateway/usage/providers/workersai.mdx
@@ -10,15 +10,13 @@ products:
   - ai-gateway
 ---
 
-import { Render, TypeScriptExample } from "~/components";
+import { TypeScriptExample } from "~/components";
 
 Use AI Gateway for analytics, caching, and security on requests to [Workers AI](/workers-ai/).
 
 ## REST API
 
 Use the [REST API](/ai-gateway/usage/rest-api/) to call Workers AI models. Workers AI models use the `@cf/` prefix in the model name and require the `cf-aig-gateway-id` header to specify which gateway to route through.
-
-<Render file="auth-token-hint" product="ai-gateway" />
 
 ```bash title="Request to Workers AI Kimi model"
 # Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,

--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -20,12 +20,12 @@ No provider SDKs or API keys are needed. Authentication and billing are handled 
 
 Four endpoints are available, each suited to different use cases:
 
-| Endpoint | Format | Use case |
-| -------- | ------ | -------- |
-| `POST /ai/run` | Envelope with `model`, `input` | All models and modalities (LLM, image, TTS, ASR) |
-| `POST /ai/v1/chat/completions` | OpenAI chat completions | LLMs — OpenAI SDK compatible |
-| `POST /ai/v1/responses` | OpenAI Responses API | Agentic workflows — OpenAI SDK compatible |
-| `POST /ai/v1/messages` | Anthropic Messages API | LLMs — Anthropic SDK compatible |
+| Endpoint                       | Format                         | Use case                                         |
+| ------------------------------ | ------------------------------ | ------------------------------------------------ |
+| `POST /ai/run`                 | Envelope with `model`, `input` | All models and modalities (LLM, image, TTS, ASR) |
+| `POST /ai/v1/chat/completions` | OpenAI chat completions        | LLMs — OpenAI SDK compatible                     |
+| `POST /ai/v1/responses`        | OpenAI Responses API           | Agentic workflows — OpenAI SDK compatible        |
+| `POST /ai/v1/messages`         | Anthropic Messages API         | LLMs — Anthropic SDK compatible                  |
 
 ## Authentication
 
@@ -55,7 +55,8 @@ Browse available models in the [model catalog](/ai/models/).
 Accepts any model with its per-model schema. Model-specific parameters go inside `input`.
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -78,7 +79,8 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 To call a Workers AI model, use the `@cf/` prefix in the model name and include the `cf-aig-gateway-id` header to specify which gateway to route through.
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "cf-aig-gateway-id: default" \
@@ -99,7 +101,8 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 The existing Workers AI endpoint with the model ID in the URL path also continues to work:
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/@cf/moonshotai/kimi-k2.6" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -118,7 +121,8 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 Uses the standard OpenAI chat completions format. The `model` field uses the same `author/model` naming. This endpoint is compatible with the OpenAI SDK and other OpenAI-compatible clients.
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -148,13 +152,13 @@ Point the OpenAI SDK `baseURL` at the Cloudflare API:
 import OpenAI from "openai";
 
 const openai = new OpenAI({
-  apiKey: CLOUDFLARE_API_TOKEN,
-  baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
+	apiKey: CLOUDFLARE_API_TOKEN,
+	baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
 });
 
 const response = await openai.chat.completions.create({
-  model: "openai/gpt-4.1",
-  messages: [{ role: "user", content: "What is Cloudflare?" }],
+	model: "openai/gpt-4.1",
+	messages: [{ role: "user", content: "What is Cloudflare?" }],
 });
 ```
 
@@ -166,13 +170,13 @@ Uses the OpenAI Responses API format for agentic workflows. Compatible with the 
 import OpenAI from "openai";
 
 const openai = new OpenAI({
-  apiKey: CLOUDFLARE_API_TOKEN,
-  baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
+	apiKey: CLOUDFLARE_API_TOKEN,
+	baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
 });
 
 const response = await openai.responses.create({
-  model: "openai/gpt-4.1",
-  input: "What is Cloudflare?",
+	model: "openai/gpt-4.1",
+	input: "What is Cloudflare?",
 });
 ```
 
@@ -181,7 +185,8 @@ const response = await openai.responses.create({
 Uses the Anthropic Messages API format. Compatible with the Anthropic SDK.
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/messages" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -203,14 +208,14 @@ Point the Anthropic SDK `baseURL` at the Cloudflare API:
 import Anthropic from "@anthropic-ai/sdk";
 
 const anthropic = new Anthropic({
-  apiKey: CLOUDFLARE_API_TOKEN,
-  baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
+	apiKey: CLOUDFLARE_API_TOKEN,
+	baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
 });
 
 const message = await anthropic.messages.create({
-  model: "anthropic/claude-sonnet-4-5",
-  max_tokens: 512,
-  messages: [{ role: "user", content: "What is Cloudflare?" }],
+	model: "anthropic/claude-sonnet-4-5",
+	max_tokens: 512,
+	messages: [{ role: "user", content: "What is Cloudflare?" }],
 });
 ```
 
@@ -219,7 +224,8 @@ const message = await anthropic.messages.create({
 By default, third-party model requests route through your account's default AI Gateway. To use a specific gateway, include the `cf-aig-gateway-id` header. Workers AI requests always require this header.
 
 ```bash
-# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
+# Run `wrangler whoami` to get your account ID to replace $CLOUDFLARE_ACCOUNT_ID,
+# and `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "cf-aig-gateway-id: default" \
@@ -239,11 +245,11 @@ With the OpenAI SDK, set the header via `defaultHeaders`:
 
 ```javascript
 const openai = new OpenAI({
-  apiKey: CLOUDFLARE_API_TOKEN,
-  baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
-  defaultHeaders: {
-    "cf-aig-gateway-id": "default",
-  },
+	apiKey: CLOUDFLARE_API_TOKEN,
+	baseURL: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/ai/v1`,
+	defaultHeaders: {
+		"cf-aig-gateway-id": "default",
+	},
 });
 ```
 
@@ -253,17 +259,17 @@ All AI Gateway features configured on that gateway — caching, rate limiting, g
 
 Use `cf-aig-*` headers to control AI Gateway behavior on a per-request basis:
 
-| Header | Type | Description |
-| ------ | ---- | ----------- |
-| `cf-aig-skip-cache` | boolean | Skip the cache for this request. |
-| `cf-aig-cache-ttl` | number | Cache TTL in seconds. |
-| `cf-aig-cache-key` | string | Custom cache key. |
-| `cf-aig-collect-log` | boolean | Turn logging on or off for this request. |
-| `cf-aig-request-timeout` | number | Request timeout in milliseconds. |
-| `cf-aig-max-attempts` | number | Retry attempts (max 5). |
-| `cf-aig-retry-delay` | number | Retry delay in milliseconds (max 5000). |
-| `cf-aig-backoff` | string | Backoff method: `constant`, `linear`, or `exponential`. |
-| `cf-aig-metadata` | JSON string | Custom metadata to attach to the log entry. |
+| Header                   | Type        | Description                                             |
+| ------------------------ | ----------- | ------------------------------------------------------- |
+| `cf-aig-skip-cache`      | boolean     | Skip the cache for this request.                        |
+| `cf-aig-cache-ttl`       | number      | Cache TTL in seconds.                                   |
+| `cf-aig-cache-key`       | string      | Custom cache key.                                       |
+| `cf-aig-collect-log`     | boolean     | Turn logging on or off for this request.                |
+| `cf-aig-request-timeout` | number      | Request timeout in milliseconds.                        |
+| `cf-aig-max-attempts`    | number      | Retry attempts (max 5).                                 |
+| `cf-aig-retry-delay`     | number      | Retry delay in milliseconds (max 5000).                 |
+| `cf-aig-backoff`         | string      | Backoff method: `constant`, `linear`, or `exponential`. |
+| `cf-aig-metadata`        | JSON string | Custom metadata to attach to the log entry.             |
 
 For more details on these options, refer to [Request handling](/ai-gateway/configuration/request-handling/) and [Caching](/ai-gateway/features/caching/).
 

--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -10,8 +10,6 @@ products:
   - ai-gateway
 ---
 
-import { Render } from "~/components";
-
 The REST API lets you call any model — whether hosted on Cloudflare or by a third-party provider like OpenAI, Anthropic, or Google — through the same Cloudflare API, with all AI Gateway features — logging, caching, rate limiting, and more — applied automatically.
 
 No provider SDKs or API keys are needed. Authentication and billing are handled through your Cloudflare account. Third-party models are billed via [Unified Billing](/ai-gateway/features/unified-billing/), while Workers AI models follow [Workers AI pricing](/workers-ai/platform/pricing/).
@@ -30,8 +28,6 @@ Four endpoints are available, each suited to different use cases:
 ## Authentication
 
 Authenticate with a [Cloudflare API token](/fundamentals/api/get-started/create-token/) that has `AI Gateway` permission. Pass it in the `Authorization` header.
-
-<Render file="auth-token-hint" product="ai-gateway" />
 
 :::note
 Ensure your Cloudflare account has [sufficient credits loaded](/ai-gateway/features/unified-billing/#load-credits) before calling third-party models.

--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -10,6 +10,8 @@ products:
   - ai-gateway
 ---
 
+import { Render } from "~/components";
+
 The REST API lets you call any model — whether hosted on Cloudflare or by a third-party provider like OpenAI, Anthropic, or Google — through the same Cloudflare API, with all AI Gateway features — logging, caching, rate limiting, and more — applied automatically.
 
 No provider SDKs or API keys are needed. Authentication and billing are handled through your Cloudflare account. Third-party models are billed via [Unified Billing](/ai-gateway/features/unified-billing/), while Workers AI models follow [Workers AI pricing](/workers-ai/platform/pricing/).
@@ -28,6 +30,8 @@ Four endpoints are available, each suited to different use cases:
 ## Authentication
 
 Authenticate with a [Cloudflare API token](/fundamentals/api/get-started/create-token/) that has `AI Gateway` permission. Pass it in the `Authorization` header.
+
+<Render file="auth-token-hint" product="ai-gateway" />
 
 :::note
 Ensure your Cloudflare account has [sufficient credits loaded](/ai-gateway/features/unified-billing/#load-credits) before calling third-party models.
@@ -51,6 +55,7 @@ Browse available models in the [model catalog](/ai/models/).
 Accepts any model with its per-model schema. Model-specific parameters go inside `input`.
 
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -73,6 +78,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 To call a Workers AI model, use the `@cf/` prefix in the model name and include the `cf-aig-gateway-id` header to specify which gateway to route through.
 
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "cf-aig-gateway-id: default" \
@@ -93,6 +99,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 The existing Workers AI endpoint with the model ID in the URL path also continues to work:
 
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/run/@cf/moonshotai/kimi-k2.6" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -111,6 +118,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_
 Uses the standard OpenAI chat completions format. The `model` field uses the same `author/model` naming. This endpoint is compatible with the OpenAI SDK and other OpenAI-compatible clients.
 
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -173,6 +181,7 @@ const response = await openai.responses.create({
 Uses the Anthropic Messages API format. Compatible with the Anthropic SDK.
 
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/messages" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "Content-Type: application/json" \
@@ -210,6 +219,7 @@ const message = await anthropic.messages.create({
 By default, third-party model requests route through your account's default AI Gateway. To use a specific gateway, include the `cf-aig-gateway-id` header. Workers AI requests always require this header.
 
 ```bash
+# Run `wrangler auth token` to get an auth token to replace $CLOUDFLARE_API_TOKEN for use with the API.
 curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/ai/v1/chat/completions" \
   --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
   --header "cf-aig-gateway-id: default" \

--- a/src/content/partials/ai-gateway/auth-token-hint.mdx
+++ b/src/content/partials/ai-gateway/auth-token-hint.mdx
@@ -1,0 +1,5 @@
+---
+{}
+---
+
+Run [`wrangler auth token`](/workers/wrangler/commands/general/#auth-token) to get an auth token to replace `$CLOUDFLARE_API_TOKEN` for use with the API.

--- a/src/content/partials/ai-gateway/auth-token-hint.mdx
+++ b/src/content/partials/ai-gateway/auth-token-hint.mdx
@@ -1,5 +1,0 @@
----
-{}
----
-
-Run [`wrangler whoami`](/workers/wrangler/commands/general/#whoami) to get your account ID to replace `$CLOUDFLARE_ACCOUNT_ID`, and [`wrangler auth token`](/workers/wrangler/commands/general/#auth-token) to get an auth token you can use to replace `$CLOUDFLARE_API_TOKEN`.

--- a/src/content/partials/ai-gateway/auth-token-hint.mdx
+++ b/src/content/partials/ai-gateway/auth-token-hint.mdx
@@ -2,4 +2,4 @@
 {}
 ---
 
-Run [`wrangler auth token`](/workers/wrangler/commands/general/#auth-token) to get an auth token to replace `$CLOUDFLARE_API_TOKEN` for use with the API.
+Run [`wrangler whoami`](/workers/wrangler/commands/general/#whoami) to get your account ID to replace `$CLOUDFLARE_ACCOUNT_ID`, and [`wrangler auth token`](/workers/wrangler/commands/general/#auth-token) to get an auth token you can use to replace `$CLOUDFLARE_API_TOKEN`.


### PR DESCRIPTION
The AI Gateway cURL code examples reference `$CLOUDFLARE_API_TOKEN` / `$CF_AIG_TOKEN` but never tell readers how to mint one. This surfaces `wrangler auth token` in two places per page so readers hit it whichever way they read the block.

This pairs with a dashboard change that adds the same hint to the AI Gateway in-app code examples: [stratus!39025](https://gitlab.cfdata.org/cloudflare/fe/stratus/-/merge_requests/39025) ([AIG-1220](https://jira.cfdata.org/browse/AIG-1220)).

## What changed

- New partial at `src/content/partials/ai-gateway/auth-token-hint.mdx` with one sentence linking `wrangler auth token` to the wrangler CLI reference.
- Rendered the partial once above the first cURL block on each affected page (11 pages).
- Added a `# Run \`wrangler auth token\` to get an auth token to replace $TOKEN for use with the API.` shell comment as the first line inside every cURL block that references one of the two env vars (31 blocks). The token name in each comment matches the block — `$CLOUDFLARE_API_TOKEN` for most blocks, `$CF_AIG_TOKEN` for the two blocks in `configuration/custom-providers.mdx` that use the per-gateway auth header.

## Pages touched

- `ai-gateway/get-started.mdx`
- `ai-gateway/usage/rest-api.mdx`
- `ai-gateway/configuration/custom-providers.mdx`
- `ai-gateway/configuration/authentication.mdx`
- `ai-gateway/configuration/request-handling.mdx`
- `ai-gateway/features/caching.mdx`
- `ai-gateway/features/unified-billing.mdx`
- `ai-gateway/observability/custom-metadata.mdx`
- `ai-gateway/observability/logging/index.mdx`
- `ai-gateway/tutorials/create-first-aig-workers.mdx`
- `ai-gateway/usage/providers/workersai.mdx`

## Out of scope

- 4 cURL blocks in `configuration/custom-providers.mdx` that only reference `$PROVIDER_API_KEY` or `$INTERNAL_API_KEY` (not Cloudflare-issued tokens) — these aren't replaced by `wrangler auth token`.
- 4 prettier warnings on touched files are pre-existing on `production` — left alone to keep this diff focused.

[View AI session](https://share.opencode.cloudflare.dev/share/gG4d9hHJ)
