### PR TITLE
chore: clean up Flue routing and workflow state

### DIFF
--- a/.flue/.agents/skills/dependabot-review/SKILL.md
+++ b/.flue/.agents/skills/dependabot-review/SKILL.md
@@ -74,43 +74,30 @@ For security fixes: note what the vulnerability affects and whether usage is in 
 
 ### 5. Output format
 
-Produce a Markdown block for each package. All packages must be covered.
+Return structured data matching the workflow schema. Do not write Markdown. All packages must be covered in `packageReviews`.
 
-```markdown
-## `<package-name>`: <old> → <new>
-
-**Type:** [security fix | bug fix | feature | breaking change | dependency bump]
-**Dependency type:** [direct | transitive (via <package>)]
-
-### What changed
-
-- <specific API/behavior change>
-- ...
-
-### Usage in this repo
-
-<"Not used directly — transitive only" OR specific import sites and callsites>
-
-### Impact: <None | Very Low | Low | Medium | High>
-
-<1–2 sentence explanation>
-```
-
-End with a summary table and one overall recommendation:
-
-```markdown
-## Summary
-
-| Package | Impact | Recommendation |
-| ------- | ------ | -------------- |
-| `pkg`   | Low    | ✅ Merge       |
-| `pkg`   | High   | ⚠️ Verify      |
-
-**Overall:** [✅ Merge | ✅ Merge + spot-check listed pages | ⚠️ Investigate before merging]
+```json
+{
+	"summary": "One concise paragraph summarizing the overall risk and what, if anything, should be verified.",
+	"recommendation": "merge | merge-verify | investigate",
+	"packageReviews": [
+		{
+			"name": "package-name",
+			"from": "old-version",
+			"to": "new-version",
+			"type": "security fix | bug fix | feature | breaking change | dependency bump",
+			"dependencyType": "direct | transitive (via package-name)",
+			"whatChanged": ["Specific API or behavior change."],
+			"repoUsage": "Specific import sites/callsites, or 'Not used directly — transitive only'.",
+			"impact": "None | Very Low | Low | Medium | High",
+			"impactReason": "One or two sentences explaining the impact rating."
+		}
+	]
+}
 ```
 
 Recommendation values:
 
-- **✅ Merge** — no action needed
-- **✅ Merge + spot-check** — merge, then manually verify the listed pages/areas
-- **⚠️ Investigate** — high-impact change, needs manual testing before merging
+- `merge` — no action needed
+- `merge-verify` — merge is likely safe, but manually spot-check the listed pages/areas
+- `investigate` — high-impact change, needs manual testing before merging

--- a/.flue/AGENTS.md
+++ b/.flue/AGENTS.md
@@ -2,8 +2,34 @@
 
 This directory contains the Flue-powered docs bot for `cloudflare-docs`, deployed as a Cloudflare Worker.
 
+## Reading Flue documentation
+
+Use the installed Flue CLI for docs so guidance matches the version in `.flue/package.json`:
+
+```bash
+pnpm exec flue docs search "workflow routing"
+pnpm exec flue docs read guide/workflows
+pnpm exec flue docs read ecosystem/deploy/cloudflare
+```
+
+Do not rely on pre-trained Flue knowledge. Flue has changed substantially across the 0.5-0.11 releases.
+
+## Flue Patterns
+
+- Use the Hono `app.ts` pattern from current Flue docs: mount `flue()` explicitly and put auth middleware before `/workflows/*` and `/runs/*`.
+- Keep GitHub webhook verification before privileged work. Sub-workflows should not be directly callable without an internal auth header.
+- Protect `/runs/*`; run history can include payloads, model activity, logs, and errors.
+- Workflows do not resume from checkpoints after Cloudflare Durable Object interruptions. Treat retries and external side effects as application-owned and idempotent.
+- Scope temporary R2 diff/context data by run ID or head SHA. Do not key mutable in-flight context only by PR number, or concurrent reviews can mix state.
+- Store durable review state separately from temporary run context. PR/head-scoped review JSON is okay; per-run patch manifests should be run-scoped.
+- Prefer `log.info`, `log.warn`, and `log.error` from `FlueContext` for workflow facts that should appear in run history. Use `console.log` only for low-value runtime debugging.
+- Keep model output structured with Valibot when trusted code consumes it. Skill instructions must match the schema exactly; do not ask for Markdown when the workflow expects JSON-like structured data.
+- Keep side-effecting operations (GitHub labels, comments, close/update actions) in trusted TypeScript code, not in model tools.
+
 ## Review Rule Policy
 
-Do not add agent review rules for issues that are already reliably caught by CI, including build failures, type checking, linting, link validation, redirect validation, and schema validation. Agent review rules should focus on style, clarity, maintainability, and conventions that CI cannot enforce.
+Do not add agent review rules for issues that are already reliably caught by CI, including build failures, type checking, linting, link validation, and schema validation. Agent review rules should focus on style, clarity, maintainability, and conventions that CI cannot enforce.
+
+Redirect file formatting is validated by CI, but missing redirects for renamed or deleted docs pages are not currently enforced by CI.
 
 Before adding a rule, verify whether the repository already catches the issue in CI. If it does, do not duplicate it in agent review output. For MDX/code structure checks, prefer AST-aware checks; avoid raw line pattern matching unless the rule explicitly ignores fenced code blocks and JSX component syntax.

--- a/.flue/app.ts
+++ b/.flue/app.ts
@@ -2,8 +2,11 @@ import { env as workerEnv } from "cloudflare:workers";
 import { registerProvider } from "@flue/runtime";
 import { flue } from "@flue/runtime/routing";
 import { Hono, type Hono as HonoApp, type MiddlewareHandler } from "hono";
-
-const INTERNAL_AUTH_HEADER = "x-flue-internal-token";
+import {
+	INTERNAL_AUTH_HEADER,
+	hasValidInternalToken,
+	normalizePathname,
+} from "./lib/internal-auth";
 
 const bindings = workerEnv as unknown as {
 	AI: Ai;
@@ -21,11 +24,12 @@ registerProvider("cloudflare", {
 });
 
 const requireInternalToken: MiddlewareHandler = async (c, next) => {
-	const expected = (c.env as Record<string, string | undefined>)
-		.DOCS_FLUE_INTERNAL_TOKEN;
-	const provided = c.req.header(INTERNAL_AUTH_HEADER);
-
-	if (!expected || provided !== expected) {
+	if (
+		!hasValidInternalToken(
+			c.env as Record<string, string | undefined>,
+			c.req.header(INTERNAL_AUTH_HEADER),
+		)
+	) {
 		return c.text("Unauthorized", 401);
 	}
 
@@ -39,7 +43,9 @@ app.get("/health", (c) => c.json({ ok: true }));
 app.use("/runs/*", requireInternalToken);
 app.use("/workflows/*", async (c, next) => {
 	// GitHub calls orchestrate directly; it verifies the webhook signature before acting.
-	if (new URL(c.req.url).pathname === "/workflows/orchestrate") {
+	if (
+		normalizePathname(new URL(c.req.url).pathname) === "/workflows/orchestrate"
+	) {
 		await next();
 		return;
 	}

--- a/.flue/app.ts
+++ b/.flue/app.ts
@@ -1,6 +1,9 @@
 import { env as workerEnv } from "cloudflare:workers";
 import { registerProvider } from "@flue/runtime";
 import { flue } from "@flue/runtime/routing";
+import { Hono, type Hono as HonoApp, type MiddlewareHandler } from "hono";
+
+const INTERNAL_AUTH_HEADER = "x-flue-internal-token";
 
 const bindings = workerEnv as unknown as {
 	AI: Ai;
@@ -17,8 +20,35 @@ registerProvider("cloudflare", {
 	},
 });
 
-export default {
-	fetch(req: Request, env: Record<string, string>, ctx: ExecutionContext) {
-		return flue().fetch(req, env, ctx);
-	},
+const requireInternalToken: MiddlewareHandler = async (c, next) => {
+	const expected = (c.env as Record<string, string | undefined>)
+		.DOCS_FLUE_INTERNAL_TOKEN;
+	const provided = c.req.header(INTERNAL_AUTH_HEADER);
+
+	if (!expected || provided !== expected) {
+		return c.text("Unauthorized", 401);
+	}
+
+	await next();
 };
+
+const app = new Hono();
+
+app.get("/health", (c) => c.json({ ok: true }));
+
+app.use("/runs/*", requireInternalToken);
+app.use("/workflows/*", async (c, next) => {
+	// GitHub calls orchestrate directly; it verifies the webhook signature before acting.
+	if (new URL(c.req.url).pathname === "/workflows/orchestrate") {
+		await next();
+		return;
+	}
+	return requireInternalToken(c, next);
+});
+
+// flue() and this app can resolve through separate Hono instances in pnpm's
+// dependency graph. They are runtime-compatible; the cast avoids duplicate type
+// identities leaking through the mount boundary.
+app.route("/", flue() as unknown as HonoApp);
+
+export default app;

--- a/.flue/lib/github-repo-tools.ts
+++ b/.flue/lib/github-repo-tools.ts
@@ -102,7 +102,9 @@ export function makeReadRepoFileTool(token: string): ToolDefinition {
 				Type.String({ description: `Git ref. Defaults to "${DEFAULT_REF}".` }),
 			),
 		}),
-		async execute({ path, ref = DEFAULT_REF }: { path: string; ref?: string }) {
+		async execute(args) {
+			const path = String(args.path ?? "");
+			const ref = String(args.ref ?? DEFAULT_REF);
 			const res = await fetch(
 				`https://api.github.com/repos/${REPO}/contents/${path}?ref=${encodeURIComponent(ref)}`,
 				{ headers: apiHeaders(token) },
@@ -150,7 +152,9 @@ export function makeSearchRepoTool(token: string): ToolDefinition {
 				}),
 			),
 		}),
-		async execute({ query, path }: { query: string; path?: string }) {
+		async execute(args) {
+			const query = String(args.query ?? "");
+			const path = typeof args.path === "string" ? args.path : undefined;
 			const q = `${query} repo:${REPO}${path ? ` path:${path}` : ""}`;
 			const res = await fetch(
 				`https://api.github.com/search/code?q=${encodeURIComponent(q)}&per_page=20`,
@@ -206,13 +210,10 @@ export function makeGetNpmPackageInfoTool(): ToolDefinition {
 				}),
 			),
 		}),
-		async execute({
-			packageName,
-			version,
-		}: {
-			packageName: string;
-			version?: string;
-		}) {
+		async execute(args) {
+			const packageName = String(args.packageName ?? "");
+			const version =
+				typeof args.version === "string" ? args.version : undefined;
 			const encoded = encodeURIComponent(packageName);
 			const url = version
 				? `https://registry.npmjs.org/${encoded}/${encodeURIComponent(version)}`
@@ -254,7 +255,8 @@ export function makeTraceDependencyTool(token: string): ToolDefinition {
 					"npm package name, e.g. 'algoliasearch' or '@astrojs/react'",
 			}),
 		}),
-		async execute({ packageName }: { packageName: string }) {
+		async execute(args) {
+			const packageName = String(args.packageName ?? "");
 			// 1. Check package.json for direct dep
 			const pkgRes = await fetch(
 				`https://api.github.com/repos/${REPO}/contents/package.json?ref=${DEFAULT_REF}`,

--- a/.flue/lib/internal-auth.ts
+++ b/.flue/lib/internal-auth.ts
@@ -1,0 +1,26 @@
+export const INTERNAL_AUTH_HEADER = "x-flue-internal-token";
+
+export function getInternalHeaders(env: Record<string, string>) {
+	const token = env.DOCS_FLUE_INTERNAL_TOKEN;
+	if (!token) {
+		throw new Error(
+			"DOCS_FLUE_INTERNAL_TOKEN is required for internal workflow dispatch.",
+		);
+	}
+	return {
+		"content-type": "application/json",
+		[INTERNAL_AUTH_HEADER]: token,
+	};
+}
+
+export function hasValidInternalToken(
+	env: Record<string, string | undefined>,
+	provided: string | undefined,
+) {
+	const expected = env.DOCS_FLUE_INTERNAL_TOKEN;
+	return expected !== undefined && provided === expected;
+}
+
+export function normalizePathname(pathname: string) {
+	return pathname.replace(/\/+$/, "") || "/";
+}

--- a/.flue/package.json
+++ b/.flue/package.json
@@ -16,6 +16,7 @@
 		"@flue/cli": "0.11.0",
 		"@flue/runtime": "0.11.0",
 		"agents": "0.14.1",
+		"hono": "4.12.25",
 		"valibot": "1.4.1",
 		"wrangler": "4.97.0"
 	}

--- a/.flue/pnpm-lock.yaml
+++ b/.flue/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       agents:
         specifier: 0.14.1
         version: 0.14.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.3.8(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.195(zod@4.4.3))(zod@4.4.3))(@cloudflare/workers-types@4.20260526.1)(ai@6.0.195(zod@4.4.3))(just-bash@3.0.1)(react@19.2.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.3)(yaml@2.9.0))(zod@4.4.3)
+      hono:
+        specifier: 4.12.25
+        version: 4.12.25
       valibot:
         specifier: 1.4.1
         version: 1.4.1
@@ -1598,6 +1601,10 @@ packages:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+    engines: {node: '>=16.9.0'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -3109,7 +3116,7 @@ snapshots:
       '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(valibot@1.4.1)(zod@4.4.3)
       '@valibot/to-json-schema': 1.7.0(valibot@1.4.1)
       hono: 4.12.23
-      hono-openapi: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.23))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(valibot@1.4.1)(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.23)(openapi-types@12.1.3)
+      hono-openapi: 1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.25))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(valibot@1.4.1)(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.23)(openapi-types@12.1.3)
       js-yaml: 4.2.0
       just-bash: 3.0.1
       openapi-types: 12.1.3
@@ -3162,6 +3169,12 @@ snapshots:
     dependencies:
       '@standard-schema/spec': 1.1.0
       hono: 4.12.23
+
+  '@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.25)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      hono: 4.12.25
+    optional: true
 
   '@img/colour@1.1.0': {}
 
@@ -4059,17 +4072,19 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono-openapi@1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.23))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(valibot@1.4.1)(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.23)(openapi-types@12.1.3):
+  hono-openapi@1.3.0(@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.25))(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(valibot@1.4.1)(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.23)(openapi-types@12.1.3):
     dependencies:
       '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(@valibot/to-json-schema@1.7.0(valibot@1.4.1))(quansync@0.2.11)(typebox@1.1.38)(valibot@1.4.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(valibot@1.4.1)(zod@4.4.3)
       '@types/json-schema': 7.0.15
       openapi-types: 12.1.3
     optionalDependencies:
-      '@hono/standard-validator': 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.23)
+      '@hono/standard-validator': 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.25)
       hono: 4.12.23
 
   hono@4.12.23: {}
+
+  hono@4.12.25: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/.flue/workflows/code-review-orchestrator.ts
+++ b/.flue/workflows/code-review-orchestrator.ts
@@ -33,6 +33,8 @@ import {
 } from "../lib/github";
 import type { StyleGuideFinding, StyleGuideResult } from "./style-guide-review";
 
+const INTERNAL_AUTH_HEADER = "x-flue-internal-token";
+
 export const route: WorkflowRouteHandler = async (_c, next) => next();
 
 // Only review docs/partials/changelog MDX, capped before specialist fan-out.
@@ -46,10 +48,17 @@ const BOT_COMMENT_MARKER = "<!-- cloudflare-docs-flue-code-review -->";
 
 // Regex to extract the previously reviewed head SHA from the bot comment
 const REVIEWED_HEAD_SHA_RE = /<!-- reviewed-head-sha: ([0-9a-f]{40}) -->/;
+const REVIEWED_AT_RE = /<!-- reviewed-at: ([^\n]+) -->/;
 
 function extractReviewedHeadSha(body: string | null): string | null {
 	if (!body) return null;
 	const m = body.match(REVIEWED_HEAD_SHA_RE);
+	return m?.[1] ?? null;
+}
+
+function extractReviewedAt(body: string | null): string | null {
+	if (!body) return null;
+	const m = body.match(REVIEWED_AT_RE);
 	return m?.[1] ?? null;
 }
 
@@ -103,14 +112,14 @@ interface CodeReviewOrchestratorPayload {
 	triggerEyesReactionId?: number | null;
 }
 
-export async function run({ id, init, payload, env, runId, req }: FlueContext) {
+export async function run({ id: runId, init, payload, env, req }: FlueContext) {
 	const input = parsePayload(payload);
 	const typedEnv = env as Record<string, string & unknown>;
 
 	const reviewMode =
 		(typedEnv.DOCS_FLUE_REVIEW_MODE as string | undefined) ?? "log";
 	const bucket = typedEnv.DOCS_FLUE_BUCKET as unknown as R2Bucket;
-	const loader = typedEnv.LOADER as Parameters<
+	const loader = typedEnv.LOADER as unknown as Parameters<
 		typeof getShellSandbox
 	>[0]["loader"];
 	const workspace = getDefaultWorkspace();
@@ -321,12 +330,13 @@ export async function run({ id, init, payload, env, runId, req }: FlueContext) {
 	// 	action: "context_fetched",
 	// });
 
-	// PR-scoped context directory in R2 — keyed by PR number so each new commit
-	// overwrites the previous state rather than accumulating stale data.
+	// Run-scoped context directory in R2 so concurrent reviews for the same PR
+	// cannot overwrite each other's manifest, patches, or comments.
 	// Written to R2 (not the local workspace) so specialist Durable Objects,
 	// which run in separate isolates, can read the files into their own workspace.
-	const diffDir = `diffs/pr-${input.number}`;
-	const commentsPath = `diffs/pr-${input.number}/comments.json`;
+	const prDir = `diffs/pr-${input.number}`;
+	const diffDir = `${prDir}/runs/${runId}`;
+	const commentsPath = `${diffDir}/comments.json`;
 
 	// ── 2. Write diff and comments to R2, and post placeholder comment ────────
 	await Promise.all([
@@ -362,6 +372,9 @@ export async function run({ id, init, payload, env, runId, req }: FlueContext) {
 	let styleGuideResult: StyleGuideResult;
 	try {
 		const styleGuideFiles = selectStyleGuideFiles(allFiles);
+		const internalHeaders = getInternalHeaders(
+			typedEnv as Record<string, string>,
+		);
 		// console.log({
 		// 	message: `Style-guide review fan-out: PR #${input.number} — ${styleGuideFiles.length} file(s), concurrency ${STYLE_GUIDE_CONCURRENCY}`,
 		// 	event: "code_review_orchestrator",
@@ -376,11 +389,12 @@ export async function run({ id, init, payload, env, runId, req }: FlueContext) {
 			styleGuideFiles.map(
 				(file, index) => async () =>
 					dispatchStyleGuideReview(
-						`${id}:style-guide:${index}`,
+						`${runId}:style-guide:${index}`,
 						input.number,
 						diffDir,
 						commentsPath,
 						req,
+						internalHeaders,
 						file.filename,
 					),
 			),
@@ -488,7 +502,7 @@ export async function run({ id, init, payload, env, runId, req }: FlueContext) {
 	// ── 4. Reconcile findings with review history and human comments ───────────
 	// Load previous findings from R2 (structured) rather than parsing the comment.
 	const previousReviewKey = previousReviewedSha
-		? `${diffDir}/review-${previousReviewedSha}.json`
+		? `${prDir}/review-${previousReviewedSha}.json`
 		: null;
 	let previousFindings: StyleGuideFinding[] = [];
 	if (previousReviewKey) {
@@ -564,7 +578,7 @@ export async function run({ id, init, payload, env, runId, req }: FlueContext) {
 	}
 
 	// ── 5. Persist findings to R2 for future reconciliation ───────────────────
-	const currentReviewKey = `${diffDir}/review-${currentHeadSha}.json`;
+	const currentReviewKey = `${prDir}/review-${currentHeadSha}.json`;
 	await bucket.put(currentReviewKey, JSON.stringify(reconciled.active));
 
 	// ── 6. Render the review comment ───────────────────────────────────────────
@@ -677,7 +691,10 @@ function partitionComments(comments: GitHubIssueComment[]): {
 
 	// Human comments after the last bot review — exclude automated bots
 	// (GitHub Actions, Dependabot, etc.) since they never address review findings.
-	const botTimestamp = botComment?.created_at ?? null;
+	const botTimestamp =
+		extractReviewedAt(botComment?.body ?? null) ??
+		botComment?.created_at ??
+		null;
 	const humanCommentsAfterBot = comments.filter(
 		(c) =>
 			!c.body?.includes(BOT_COMMENT_MARKER) &&
@@ -825,6 +842,7 @@ async function dispatchStyleGuideReview(
 	diffDir: string,
 	commentsPath: string,
 	req: Request | undefined,
+	internalHeaders: HeadersInit,
 	filename?: string,
 ): Promise<StyleGuideResult> {
 	// Derive the base URL from the incoming request so this works on any port
@@ -835,7 +853,7 @@ async function dispatchStyleGuideReview(
 
 	const response = await fetch(url, {
 		method: "POST",
-		headers: { "content-type": "application/json" },
+		headers: internalHeaders,
 		body: JSON.stringify({ number: prNumber, diffDir, commentsPath, filename }),
 	});
 
@@ -936,6 +954,7 @@ function renderComment(
 	forceFullReview?: boolean,
 ): string {
 	const shortSha = reviewedHeadSha.slice(0, 7);
+	const reviewedAt = new Date().toISOString();
 	// Exclude anything acknowledged by the reviewer from active sections
 	const ignoredPaths = new Set(
 		reconciled.ignored_by_reviewer.map((f) => `${f.path}:${f.line}:${f.rule}`),
@@ -961,6 +980,7 @@ function renderComment(
 	const lines: string[] = [
 		BOT_COMMENT_MARKER,
 		`<!-- reviewed-head-sha: ${reviewedHeadSha} -->`,
+		`<!-- reviewed-at: ${reviewedAt} -->`,
 		`<!-- updated-at: ${new Date().toISOString()} -->`,
 		"",
 		"## Review",
@@ -1120,4 +1140,17 @@ async function incrementAutoReviewCount(
 ): Promise<void> {
 	const key = `diffs/pr-${prNumber}/auto-review-count.json`;
 	await bucket.put(key, JSON.stringify({ count: current + 1 }));
+}
+
+function getInternalHeaders(env: Record<string, string>) {
+	const token = env.DOCS_FLUE_INTERNAL_TOKEN;
+	if (!token) {
+		throw new Error(
+			"DOCS_FLUE_INTERNAL_TOKEN is required for internal workflow dispatch.",
+		);
+	}
+	return {
+		"content-type": "application/json",
+		[INTERNAL_AUTH_HEADER]: token,
+	};
 }

--- a/.flue/workflows/code-review-orchestrator.ts
+++ b/.flue/workflows/code-review-orchestrator.ts
@@ -31,9 +31,8 @@ import {
 	updateIssueComment,
 	type GitHubIssueComment,
 } from "../lib/github";
+import { getInternalHeaders } from "../lib/internal-auth";
 import type { StyleGuideFinding, StyleGuideResult } from "./style-guide-review";
-
-const INTERNAL_AUTH_HEADER = "x-flue-internal-token";
 
 export const route: WorkflowRouteHandler = async (_c, next) => next();
 
@@ -1140,17 +1139,4 @@ async function incrementAutoReviewCount(
 ): Promise<void> {
 	const key = `diffs/pr-${prNumber}/auto-review-count.json`;
 	await bucket.put(key, JSON.stringify({ count: current + 1 }));
-}
-
-function getInternalHeaders(env: Record<string, string>) {
-	const token = env.DOCS_FLUE_INTERNAL_TOKEN;
-	if (!token) {
-		throw new Error(
-			"DOCS_FLUE_INTERNAL_TOKEN is required for internal workflow dispatch.",
-		);
-	}
-	return {
-		"content-type": "application/json",
-		[INTERNAL_AUTH_HEADER]: token,
-	};
 }

--- a/.flue/workflows/dependabot-review.ts
+++ b/.flue/workflows/dependabot-review.ts
@@ -228,7 +228,7 @@ async function postOrUpdateComment(
 
 // ── run() ─────────────────────────────────────────────────────────────────────
 
-export async function run({ init, payload, env, runId }: FlueContext) {
+export async function run({ id: runId, init, payload, env }: FlueContext) {
 	const input = parsePayload(payload);
 	const typedEnv = env as Record<string, unknown>;
 	const reviewMode =

--- a/.flue/workflows/orchestrate.ts
+++ b/.flue/workflows/orchestrate.ts
@@ -20,6 +20,8 @@ import {
 	verifyGitHubSignature,
 } from "../lib/github";
 
+const INTERNAL_AUTH_HEADER = "x-flue-internal-token";
+
 export const route: WorkflowRouteHandler = async (_c, next) => next();
 
 export async function run({ payload, env, req }: FlueContext) {
@@ -137,13 +139,14 @@ export async function run({ payload, env, req }: FlueContext) {
 
 	// ── 3a. Handle Dependabot PR events ─────────────────────────────────────
 	if (isDependabotReviewEvent) {
+		const internalHeaders = getInternalHeaders(env as Record<string, string>);
 		const baseUrl = new URL(req.url);
 		const dependabotUrl = new URL(baseUrl);
 		dependabotUrl.pathname = `/workflows/dependabot-review`;
 		dependabotUrl.searchParams.set("wait", "result");
 		const dependabotResponse = await fetch(dependabotUrl, {
 			method: "POST",
-			headers: { "content-type": "application/json" },
+			headers: internalHeaders,
 			body: JSON.stringify({ eventType: "pull_request", number }),
 		});
 		if (!dependabotResponse.ok) {
@@ -192,6 +195,7 @@ export async function run({ payload, env, req }: FlueContext) {
 
 		// Check if the PR is from Dependabot — if so route to dependabot-review
 		const prForSlash = await getPullRequest(token, number).catch(() => null);
+		const internalHeaders = getInternalHeaders(typedEnv);
 		const baseUrl = new URL(req.url);
 		const reviewUrl = new URL(baseUrl);
 		if (prForSlash?.user?.login === "dependabot[bot]") {
@@ -199,7 +203,7 @@ export async function run({ payload, env, req }: FlueContext) {
 			reviewUrl.searchParams.set("wait", "result");
 			const _reviewResponse = await fetch(reviewUrl, {
 				method: "POST",
-				headers: { "content-type": "application/json" },
+				headers: internalHeaders,
 				body: JSON.stringify({
 					eventType: "pull_request",
 					number,
@@ -212,7 +216,7 @@ export async function run({ payload, env, req }: FlueContext) {
 			reviewUrl.searchParams.set("wait", "result");
 			const _reviewResponse = await fetch(reviewUrl, {
 				method: "POST",
-				headers: { "content-type": "application/json" },
+				headers: internalHeaders,
 				body: JSON.stringify({
 					eventType: "pull_request",
 					number,
@@ -269,6 +273,7 @@ export async function run({ payload, env, req }: FlueContext) {
 
 		// Check if the PR is from Dependabot — if so route to dependabot-review
 		const prForReview = await getPullRequest(token, number).catch(() => null);
+		const internalHeaders = getInternalHeaders(typedEnv);
 		const baseUrl = new URL(req.url);
 		const reviewUrl = new URL(baseUrl);
 		if (prForReview?.user?.login === "dependabot[bot]") {
@@ -276,7 +281,7 @@ export async function run({ payload, env, req }: FlueContext) {
 			reviewUrl.searchParams.set("wait", "result");
 			const _reviewResponse = await fetch(reviewUrl, {
 				method: "POST",
-				headers: { "content-type": "application/json" },
+				headers: internalHeaders,
 				body: JSON.stringify({
 					eventType: "pull_request",
 					number,
@@ -289,7 +294,7 @@ export async function run({ payload, env, req }: FlueContext) {
 			reviewUrl.searchParams.set("wait", "result");
 			const _reviewResponse = await fetch(reviewUrl, {
 				method: "POST",
-				headers: { "content-type": "application/json" },
+				headers: internalHeaders,
 				body: JSON.stringify({
 					eventType: "pull_request",
 					number,
@@ -313,6 +318,7 @@ export async function run({ payload, env, req }: FlueContext) {
 	}
 
 	const baseUrl = new URL(req.url);
+	const internalHeaders = getInternalHeaders(env as Record<string, string>);
 	const results: Record<string, unknown> = {};
 
 	// ── 5. Dispatch spam-and-off-topic-filter (issues + PRs on open/reopen) ─
@@ -345,7 +351,7 @@ export async function run({ payload, env, req }: FlueContext) {
 			filterUrl.searchParams.set("wait", "result");
 			const filterResponse = await fetch(filterUrl, {
 				method: "POST",
-				headers: { "content-type": "application/json" },
+				headers: internalHeaders,
 				body: JSON.stringify({ eventType, number }),
 			});
 
@@ -410,7 +416,7 @@ export async function run({ payload, env, req }: FlueContext) {
 			reviewUrl.searchParams.set("wait", "result");
 			const reviewResponse = await fetch(reviewUrl, {
 				method: "POST",
-				headers: { "content-type": "application/json" },
+				headers: internalHeaders,
 				body: JSON.stringify({ eventType: "pull_request", number }),
 			});
 
@@ -516,4 +522,17 @@ function getIssueOrPullRequestTitle(
 
 function truncateLogValue(value: string) {
 	return value.length > 100 ? `${value.slice(0, 97)}...` : value;
+}
+
+function getInternalHeaders(env: Record<string, string>) {
+	const token = env.DOCS_FLUE_INTERNAL_TOKEN;
+	if (!token) {
+		throw new Error(
+			"DOCS_FLUE_INTERNAL_TOKEN is required for internal workflow dispatch.",
+		);
+	}
+	return {
+		"content-type": "application/json",
+		[INTERNAL_AUTH_HEADER]: token,
+	};
 }

--- a/.flue/workflows/orchestrate.ts
+++ b/.flue/workflows/orchestrate.ts
@@ -19,8 +19,7 @@ import {
 	isCodeOwner,
 	verifyGitHubSignature,
 } from "../lib/github";
-
-const INTERNAL_AUTH_HEADER = "x-flue-internal-token";
+import { getInternalHeaders } from "../lib/internal-auth";
 
 export const route: WorkflowRouteHandler = async (_c, next) => next();
 
@@ -522,17 +521,4 @@ function getIssueOrPullRequestTitle(
 
 function truncateLogValue(value: string) {
 	return value.length > 100 ? `${value.slice(0, 97)}...` : value;
-}
-
-function getInternalHeaders(env: Record<string, string>) {
-	const token = env.DOCS_FLUE_INTERNAL_TOKEN;
-	if (!token) {
-		throw new Error(
-			"DOCS_FLUE_INTERNAL_TOKEN is required for internal workflow dispatch.",
-		);
-	}
-	return {
-		"content-type": "application/json",
-		[INTERNAL_AUTH_HEADER]: token,
-	};
 }

--- a/.flue/workflows/spam-and-off-topic-filter.ts
+++ b/.flue/workflows/spam-and-off-topic-filter.ts
@@ -70,7 +70,7 @@ interface SpamAndOffTopicFilterPayload {
 	number: number;
 }
 
-export async function run({ init, payload, env, runId }: FlueContext) {
+export async function run({ id: runId, init, payload, env }: FlueContext) {
 	const input = parsePayload(payload);
 	const typedEnv = env as Record<string, unknown>;
 	const bucket = typedEnv.DOCS_FLUE_BUCKET as R2Bucket;

--- a/.flue/workflows/style-guide-review.ts
+++ b/.flue/workflows/style-guide-review.ts
@@ -93,7 +93,7 @@ interface PullRequestMetadata {
 	head: string;
 }
 
-export async function run({ init, payload, env, runId }: FlueContext) {
+export async function run({ id: runId, init, payload, env }: FlueContext) {
 	const input = parsePayload(payload);
 	const typedEnv = env as Record<string, unknown>;
 	const bucket = typedEnv.DOCS_FLUE_BUCKET as R2Bucket;


### PR DESCRIPTION
### Summary

Updates the Flue docs bot to match current Flue 0.11 routing and workflow patterns. This protects run/subworkflow routes with an internal token, scopes temporary review context by run to avoid concurrent PR review collisions, and aligns Dependabot/tooling instructions with structured workflow outputs.

Validation run locally:

- `pnpm exec tsc -p .flue/tsconfig.json --noEmit`
- `pnpm run flue:build`
