### PR TITLE
[Spectrum] Add @steve-cloudflare as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -263,7 +263,8 @@ package.json @cloudflare/content-engineering
 /src/content/docs/smart-shield/configuration/cache-reserve/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare @ack-cf @zaidoon1
 /src/content/docs/smart-shield/configuration/regional-tiered-cache.mdx @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare @ack-cf @zaidoon1
 /src/content/docs/smart-shield/configuration/smart-tiered-cache.mdx @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @ncrouch-cflare @ack-cf @zaidoon1
-/src/content/docs/spectrum/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @cansu
+/src/content/docs/spectrum/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @cansu @steve-cloudflare
+/src/content/partials/spectrum/ @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners @cansu @steve-cloudflare
 /src/content/docs/speed/ @cloudflare/product-owners @ack-cf
 /src/content/partials/speed/ @cloudflare/product-owners @ack-cf
 /src/content/changelog/speed/ @cloudflare/pm-changelogs @cloudflare/product-owners @ack-cf


### PR DESCRIPTION
### Summary

Adds `@steve-cloudflare` to CODEOWNERS for the Spectrum product area so I can review and approve PRs touching Spectrum docs and partials.

Also adds an entry for `/src/content/partials/spectrum/`, which was not previously covered.

### Documentation checklist

<!-- CODEOWNERS-only change; content checklist items do not apply -->
