### PR TITLE
[Billing] Add Super Administrators link and update Plan Extensions to Active Subscriptions

### DIFF
--- a/src/content/docs/billing/manage/change-plan.mdx
+++ b/src/content/docs/billing/manage/change-plan.mdx
@@ -14,7 +14,7 @@ Occasionally, you may want to upgrade or downgrade the plan associated with a sp
 
 ## Limitations
 
-Only Super Administrators can manage changes to domain plans.
+Only [Super Administrators](/fundamentals/manage-members/roles/#account-scoped-roles) can manage changes to domain plans.
 
 If you decide to downgrade or remove a domain, Cloudflare does not issue refunds. Refer to our [billing policy](/billing/understand/billing-policy/) for more information.
 
@@ -39,7 +39,7 @@ To change the Cloudflare plan for a domain in the dashboard:
 
 2. Go to **Overview**.
 
-3. For Plan Extensions, select **Change**.
+3. For Active Subscriptions, select **Change**.
 
    ![Screenshot of the Overview page with the Plan extension section highlighted](~/assets/images/fundamentals/get-started/change-plan.png)
 
@@ -76,7 +76,7 @@ To change the duration of your Cloudflare plan in the dashboard:
 
 2. Go to **Overview**.
 
-3. For Plan Extensions, select **Change**.
+3. For Active Subscriptions, select **Change**.
 
    ![Screenshot of the Overview page with the Plan extension section highlighted](~/assets/images/fundamentals/get-started/change-plan.png)
 


### PR DESCRIPTION
### Summary

Combines two small billing doc fixes from stale PRs into a single PR:

1. **Link "Super Administrators"** to the roles documentation page so users can understand the permission requirement (ref [#30884](https://github.com/cloudflare/cloudflare-docs/pull/30884))
2. **Replace "Plan Extensions" with "Active Subscriptions"** to match the current dashboard UI (ref [#30866](https://github.com/cloudflare/cloudflare-docs/pull/30866))

DEE-3598

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
