### PR TITLE
Clarify health check options for regions

### DIFF
--- a/src/content/partials/load-balancing/monitor-health-check-regions-options.mdx
+++ b/src/content/partials/load-balancing/monitor-health-check-regions-options.mdx
@@ -7,7 +7,7 @@
 
 Health monitor probes are sent from every single data center in Cloudflare’s network to the endpoints within the associated pool. This allows probes to hit each endpoint during intervals set by the customer.
 
-**All Regions**
+**All Regions (Enterprise only)**
 
 Three health monitor probes per region are sent to each endpoint in the associated pool. There are a total of 13 regions, resulting in 39 probes.
 


### PR DESCRIPTION
Both "All Data Centers" and "All Regions" are Ent only. 
For reference:
https://wiki.cfdata.org/spaces/LB/pages/269067936/Load+Balancing+Self+Serve+vs.+Enterprise

"Health Monitor Locations"
Self Serve -> "Default to 1 region. Ability to purchase up to 8 regions out of the total 13." Enterprise -> "Ability to select All Regions or All Datacenters. See below why this is massively important."


