### PR TITLE
More Python Workers examples in docs (email, rpc, handlers, streams)

### DIFF
--- a/src/content/docs/durable-objects/api/base.mdx
+++ b/src/content/docs/durable-objects/api/base.mdx
@@ -78,7 +78,9 @@ class MyDurableObject(DurableObject):
 
 #### Example
 
-<TypeScriptExample>
+<Tabs>
+
+<TypeScriptExample omitTabs={true}>
 ```ts
 export class MyDurableObject extends DurableObject<Env> {
 	async fetch(request: Request): Promise<Response> {
@@ -91,6 +93,22 @@ export class MyDurableObject extends DurableObject<Env> {
 }
 ```
 </TypeScriptExample>
+
+<TabItem label="Python" icon="seti:python">
+
+```python
+from workers import DurableObject, Response
+from urllib.parse import urlparse
+
+class MyDurableObject(DurableObject):
+    async def fetch(self, request):
+        path = urlparse(request.url).path
+        if path == "/hello":
+            return Response("Hello, World!")
+        return Response("Not found", status=404)
+```
+
+</TabItem> </Tabs>
 
 ### `alarm`
 
@@ -113,7 +131,9 @@ export class MyDurableObject extends DurableObject<Env> {
 
 #### Example
 
-<TypeScriptExample>
+<Tabs>
+
+<TypeScriptExample omitTabs={true}>
 ```ts
 export class MyDurableObject extends DurableObject<Env> {
 	async alarm(alarmInfo?: AlarmInvocationInfo): Promise<void> {
@@ -125,6 +145,20 @@ export class MyDurableObject extends DurableObject<Env> {
 }
 ```
 </TypeScriptExample>
+
+<TabItem label="Python" icon="seti:python">
+
+```python
+from workers import DurableObject
+
+class MyDurableObject(DurableObject):
+    async def alarm(self, alarm_info=None):
+        if alarm_info and alarm_info.isRetry:
+            print(f"Alarm retry attempt {alarm_info.retryCount}")
+        await self.process_scheduled_task()
+```
+
+</TabItem> </Tabs>
 
 ### `webSocketMessage`
 
@@ -147,7 +181,9 @@ export class MyDurableObject extends DurableObject<Env> {
 
 #### Example
 
-<TypeScriptExample>
+<Tabs>
+
+<TypeScriptExample omitTabs={true}>
 ```ts
 export class MyDurableObject extends DurableObject<Env> {
 	async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer) {
@@ -160,6 +196,21 @@ export class MyDurableObject extends DurableObject<Env> {
 }
 ```
 </TypeScriptExample>
+
+<TabItem label="Python" icon="seti:python">
+
+```python
+from workers import DurableObject
+
+class MyDurableObject(DurableObject):
+    async def webSocketMessage(self, ws, message):
+        if isinstance(message, str):
+            ws.send(f"Received: {message}")
+        else:
+            ws.send(f"Received {len(message)} bytes")
+```
+
+</TabItem> </Tabs>
 
 ### `webSocketClose`
 
@@ -183,7 +234,9 @@ export class MyDurableObject extends DurableObject<Env> {
 
 #### Example
 
-<TypeScriptExample>
+<Tabs>
+
+<TypeScriptExample omitTabs={true}>
 ```ts
 export class MyDurableObject extends DurableObject<Env> {
 	async webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean) {
@@ -196,6 +249,19 @@ export class MyDurableObject extends DurableObject<Env> {
 }
 ```
 </TypeScriptExample>
+
+<TabItem label="Python" icon="seti:python">
+
+```python
+from workers import DurableObject
+
+class MyDurableObject(DurableObject):
+    async def webSocketClose(self, ws, code, reason, was_clean):
+        ws.close(code, reason)
+        print(f"WebSocket closed: code={code}, reason={reason}")
+```
+
+</TabItem> </Tabs>
 
 ### `webSocketError`
 
@@ -215,7 +281,9 @@ export class MyDurableObject extends DurableObject<Env> {
 
 #### Example
 
-<TypeScriptExample>
+<Tabs>
+
+<TypeScriptExample omitTabs={true}>
 ```ts
 export class MyDurableObject extends DurableObject<Env> {
 	async webSocketError(ws: WebSocket, error: unknown) {
@@ -225,6 +293,18 @@ export class MyDurableObject extends DurableObject<Env> {
 }
 ```
 </TypeScriptExample>
+
+<TabItem label="Python" icon="seti:python">
+
+```python
+from workers import DurableObject
+
+class MyDurableObject(DurableObject):
+    async def webSocketError(self, ws, error):
+        print(f"WebSocket error: {error}")
+```
+
+</TabItem> </Tabs>
 
 ## Properties
 

--- a/src/content/docs/email-service/api/route-emails/email-handler.mdx
+++ b/src/content/docs/email-service/api/route-emails/email-handler.mdx
@@ -19,6 +19,8 @@ Process incoming emails using the `email()` handler in your Cloudflare Workers. 
 
 Add the `email` handler function to your Worker's exported handlers:
 
+<Tabs> <TabItem label="TypeScript" icon="seti:typescript">
+
 ```ts
 export default {
 	async email(message, env, ctx): Promise<void> {
@@ -27,6 +29,18 @@ export default {
 	},
 } satisfies ExportedHandler<Env>;
 ```
+
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint
+
+class Default(WorkerEntrypoint):
+    async def email(self, message, env, ctx):
+        await message.forward("destination@example.com")
+```
+
+</TabItem> </Tabs>
 
 ### Parameters
 

--- a/src/content/docs/workers/runtime-apis/bindings/service-bindings/rpc.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/service-bindings/rpc.mdx
@@ -12,7 +12,7 @@ products:
   - workers
 ---
 
-import { DirectoryListing, Render, TypeScriptExample, WranglerConfig } from "~/components"
+import { DirectoryListing, Render, Tabs, TabItem, TypeScriptExample, WranglerConfig } from "~/components"
 
 [Service bindings](/workers/runtime-apis/bindings/service-bindings) allow one Worker to call into another, without going through a publicly-accessible URL.
 
@@ -37,6 +37,8 @@ You do not need to learn, implement, or think about special protocols to use the
 
 To provide RPC methods from your Worker, you must extend the `WorkerEntrypoint` class, as shown in the example below:
 
+<Tabs> <TabItem label="JavaScript" icon="seti:javascript">
+
 ```js
 import { WorkerEntrypoint } from "cloudflare:workers";
 
@@ -44,6 +46,18 @@ export default class extends WorkerEntrypoint {
   async add(a, b) { return a + b; }
 }
 ```
+
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint
+
+class Default(WorkerEntrypoint):
+    async def add(self, a, b):
+        return a + b
+```
+
+</TabItem> </Tabs>
 
 A new instance of the class is created every time the Worker is called. Note that even though the Worker is implemented as a class, it is still stateless — the class instance only lasts for the duration of the invocation. If you need to persist or coordinate state in Workers, you should use [Durable Objects](/durable-objects).
 
@@ -69,6 +83,8 @@ For example, a Worker that declares a binding to the [environment variable](/wor
 
 Can access it by calling `this.env.GREETING`:
 
+<Tabs> <TabItem label="JavaScript" icon="seti:javascript">
+
 ```js
 import { WorkerEntrypoint } from "cloudflare:workers";
 
@@ -81,6 +97,21 @@ export default class extends WorkerEntrypoint {
 }
 ```
 
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint, Response
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        return Response("Hello from my-worker")
+
+    async def greet(self, name):
+        return self.env.GREETING + name
+```
+
+</TabItem> </Tabs>
+
 You can use any type of [binding](/workers/runtime-apis/bindings) this way.
 
 ### Lifecycle methods (`ctx`)
@@ -88,6 +119,8 @@ You can use any type of [binding](/workers/runtime-apis/bindings) this way.
 The [`ctx`](/workers/runtime-apis/context) object is exposed as a class property of the `WorkerEntrypoint` class.
 
 For example, you can extend the lifetime of the invocation context by calling the `waitUntil()` method:
+
+<Tabs> <TabItem label="JavaScript" icon="seti:javascript">
 
 ```js
 import { WorkerEntrypoint } from "cloudflare:workers";
@@ -107,6 +140,28 @@ export default class extends WorkerEntrypoint {
   }
 }
 ```
+
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint, Response
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        return Response("Hello from my-worker")
+
+    async def signup(self, email, name):
+        # _send_event() will continue running, even after this method returns a value to the caller
+        self.ctx.waitUntil(self._send_event("signup", email))
+        # Perform any other work
+        return "Success"
+
+    async def _send_event(self, event_name, email):
+        # ...
+        pass
+```
+
+</TabItem> </Tabs>
 
 ### Fetching static assets
 
@@ -168,6 +223,8 @@ You can use this to group multiple pieces of compute together. For example, you 
 
 </WranglerConfig>
 
+<Tabs> <TabItem label="JavaScript" icon="seti:javascript">
+
 ```js
 import { WorkerEntrypoint } from "cloudflare:workers";
 
@@ -210,6 +267,32 @@ export default class extends WorkerEntrypoint {
 }
 ```
 
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint, Response
+
+class AdminEntrypoint(WorkerEntrypoint):
+    async def create_user(self, username):
+        await self.env.D1.prepare("INSERT INTO users (username) VALUES (?)").bind(username).run()
+
+    async def delete_user(self, username):
+        await self.env.D1.prepare("DELETE FROM users WHERE username = ?").bind(username).run()
+
+class UserEntrypoint(WorkerEntrypoint):
+    async def get_tasks(self, user_id):
+        return await self.env.D1.prepare("SELECT title FROM tasks WHERE user_id = ?").bind(user_id).run()
+
+    async def create_task(self, user_id, title):
+        await self.env.D1.prepare("INSERT INTO tasks (user_id, title) VALUES (?, ?)").bind(user_id, title).run()
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        return Response("Hello from my to do app")
+```
+
+</TabItem> </Tabs>
+
 You can then declare a Service binding directly to `AdminEntrypoint` in another Worker:
 
 
@@ -232,6 +315,8 @@ You can then declare a Service binding directly to `AdminEntrypoint` in another 
 
 </WranglerConfig>
 
+<Tabs> <TabItem label="JavaScript" icon="seti:javascript">
+
 ```js
 export default {
   async fetch(request, env) {
@@ -240,6 +325,19 @@ export default {
   },
 };
 ```
+
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint, Response
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        await self.env.ADMIN.create_user("aNewUser")
+        return Response("Hello from admin app")
+```
+
+</TabItem> </Tabs>
 
 You can learn more about how to configure D1 in the [D1 documentation](/d1/get-started/#3-bind-your-worker-to-your-d1-database).
 

--- a/src/content/docs/workers/runtime-apis/handlers/scheduled.mdx
+++ b/src/content/docs/workers/runtime-apis/handlers/scheduled.mdx
@@ -134,6 +134,20 @@ export default {
 } satisfies ExportedHandler<Env>;
 ```
 
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint, fetch
+from datetime import datetime, timezone
+
+class Default(WorkerEntrypoint):
+    async def scheduled(self, controller, env, ctx):
+        if controller.cron == "*/5 * * * *":
+            await fetch("https://example.com/api/sync")
+        elif controller.cron == "0 0 * * *":
+            await env.MY_KV.put("last-cleanup", datetime.now(timezone.utc).isoformat())
+```
+
 </TabItem> </Tabs>
 
 The value of `controller.cron` is the exact cron expression string from your configuration. It must match character-for-character, including spacing.

--- a/src/content/docs/workers/runtime-apis/handlers/tail.mdx
+++ b/src/content/docs/workers/runtime-apis/handlers/tail.mdx
@@ -6,6 +6,8 @@ products:
   - workers
 ---
 
+import { Tabs, TabItem } from "~/components";
+
 ## Background
 
 The `tail()` handler is the handler you implement when writing a [Tail Worker](/workers/observability/logs/tail-workers/). Tail Workers can be used to process logs in real-time and send them to a logging or analytics service.
@@ -15,6 +17,8 @@ The `tail()` handler is called once each time the connected producer Worker is i
 To configure a Tail Worker, refer to [Tail Workers documentation](/workers/observability/logs/tail-workers/).
 
 ## Syntax
+
+<Tabs> <TabItem label="JavaScript" icon="seti:javascript">
 
 ```js
 export default {
@@ -26,6 +30,19 @@ export default {
   }
 }
 ```
+
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint, fetch
+import json
+
+class Default(WorkerEntrypoint):
+    async def tail(self, events, env, ctx):
+        await fetch("<YOUR_ENDPOINT>", method="POST", body=json.dumps(events))
+```
+
+</TabItem> </Tabs>
 
 ### Parameters
 

--- a/src/content/docs/workers/runtime-apis/streams/index.mdx
+++ b/src/content/docs/workers/runtime-apis/streams/index.mdx
@@ -67,6 +67,20 @@ async function fetchAndStream(request) {
 }
 ```
 
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint, Response, fetch
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        # Fetch from origin server.
+        response = await fetch(request)
+
+        # Stream the response body to the client.
+        return Response(response.body, headers=response.headers)
+```
+
 </TabItem> </Tabs>
 
 A [`TransformStream`](/workers/runtime-apis/streams/transformstream/) and the [`ReadableStream.pipeTo()`](/workers/runtime-apis/streams/readablestream/#methods) method can be used to modify the response body as it is being streamed:
@@ -123,6 +137,30 @@ async function fetchAndStream(request) {
 	// ... and deliver our Response while that’s running.
 	return new Response(readable, response);
 }
+```
+
+</TabItem> <TabItem label="Python" icon="seti:python">
+
+```python
+from workers import WorkerEntrypoint, Response
+from js import ReadableStream, TextEncoder
+from pyodide.ffi import create_proxy, to_js
+import asyncio
+
+class Default(WorkerEntrypoint):
+    async def fetch(self, request):
+        enc = TextEncoder.new()
+
+        async def start(controller):
+            for i in range(5):
+                controller.enqueue(enc.encode(f"chunk {i}\n"))
+                await asyncio.sleep(0.1)
+            controller.close()
+
+        stream = ReadableStream.new(
+            to_js({"start": create_proxy(start)})
+        )
+        return Response(stream, headers={"Content-Type": "text/plain"})
 ```
 
 </TabItem> </Tabs>


### PR DESCRIPTION
### Summary

Add more Python tabs across various docs pages. In particular email, rpc, handlers and streams.