### PR TITLE
[Workers] Clarify observability pricing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -193,6 +193,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/ @baubuchon-cf @irvinebroque @dinasaur404 @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
 /src/content/partials/cloudflare-for-platforms/ @baubuchon-cf @irvinebroque @dinasaur404 @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
 /src/content/docs/workers/observability/ @irvinebroque @mikenomitch @nevikashah @cloudflare/product-owners @vy-ton
+/src/content/partials/workers/workers_logs_pricing.mdx @irvinebroque @mikenomitch @nevikashah @cloudflare/product-owners @vy-ton
 /src/content/docs/workers/static-assets @irvinebroque @GregBrimble @WalshyDev @cloudflare/deploy-config @cloudflare/product-owners @MattieTK @vy-ton
 /src/content/docs/workers-vpc/ @nikitacano @elithrar @thomasgauvin @cloudflare/product-owners
 /src/content/partials/workers-vpc/ @nikitacano @elithrar @thomasgauvin @cloudflare/product-owners

--- a/src/content/docs/workers/platform/pricing.mdx
+++ b/src/content/docs/workers/platform/pricing.mdx
@@ -139,6 +139,8 @@ Existing Workers will not be impacted when changing the default usage model. You
 
 <Render file="workers_logs_pricing" product="workers" />
 
+You can use Workers Logs without exporting Workers Trace Events. On the Workers Paid plan, persisted log events are charged at $0.60 per million after included usage. Events exported with Workers Trace Events Logpush are charged separately at $0.05 per million after included usage. There is no combined price for these events. If an event is both persisted by Workers Logs and exported by Workers Trace Events Logpush, and both included allowances are exceeded, both overage charges apply: $0.60 per million for Workers Logs plus $0.05 per million for export.
+
 :::note[Workers Logs documentation]
 
 For more information and [examples of Workers Logs billing](/workers/observability/logs/workers-logs/#example-pricing), refer to the [Workers Logs documentation](/workers/observability/logs/workers-logs).

--- a/src/content/partials/workers/workers_logs_pricing.mdx
+++ b/src/content/partials/workers/workers_logs_pricing.mdx
@@ -5,9 +5,9 @@
 
 import { Markdown } from "~/components"
 
-Workers Logs is included in both the Free and Paid [Workers plans](/workers/platform/pricing/).
+Workers Logs is included in both the Free and Paid [Workers plans](/workers/platform/pricing/). Workers Logs pricing covers log events that Cloudflare persists and makes queryable in the Cloudflare dashboard.
 
-|                    | Log Events Written                                                 | Retention  |
+| Plan               | Persisted log events                                               | Retention  |
 | ------------------ | ------------------------------------------------------------------ | ---------- |
 | **Workers Free**   | 200,000 per day                                                    | 3 Days     |
 | **Workers Paid**   | 20 million included per month <br /> +$0.60 per additional million | 7 Days     |


### PR DESCRIPTION
## Summary

- Clarifies that Workers Logs pricing applies to persisted/queryable log events stored by Cloudflare.
- Clarifies that Workers Trace Events Logpush pricing applies to exported events.
- Documents that using both is additive where both overage rates apply.

## Validation

- `git diff --check origin/production...HEAD`
- Targeted pricing content assertions

Full docs validation was not run in this sandbox because it has Node 22 and no pnpm/corepack, while this repo requires Node 24.
