### PR TITLE
Revise low-latency HLS broadcast recommendations

### DIFF
--- a/src/content/docs/stream/stream-live/start-stream-live.mdx
+++ b/src/content/docs/stream/stream-live/start-stream-live.mdx
@@ -135,7 +135,7 @@ If you are experiencing buffering, freezing, experiencing latency, or having oth
 
 #### Low-Latency HLS broadcast recommendations <Badge text="Beta" variant="caution" size="small" />
 
-- B Frames must be turned off or set to 0. B Frames are incompaible with LL-HLS and will result in jitter and sporatic buffering delays.
+- B Frames must be turned off or set to 0. B Frames are incompatible with LL-HLS and will result in jitter and sporadic buffering delays.
 - For lowest latency, use a GOP size (keyframe interval) of 2 seconds.
 - Broadcast to the RTMP endpoint if possible.
 - If using OBS, select the "ultra low" latency profile.

--- a/src/content/docs/stream/stream-live/start-stream-live.mdx
+++ b/src/content/docs/stream/stream-live/start-stream-live.mdx
@@ -135,7 +135,8 @@ If you are experiencing buffering, freezing, experiencing latency, or having oth
 
 #### Low-Latency HLS broadcast recommendations <Badge text="Beta" variant="caution" size="small" />
 
-- For lowest latency, use a GOP size (keyframe interval) of 1 or 2 seconds.
+- B Frames must be turned off or set to 0. B Frames are incompaible with LL-HLS and will result in jitter and sporatic buffering delays.
+- For lowest latency, use a GOP size (keyframe interval) of 2 seconds.
 - Broadcast to the RTMP endpoint if possible.
 - If using OBS, select the "ultra low" latency profile.
 

--- a/src/content/docs/stream/stream-live/start-stream-live.mdx
+++ b/src/content/docs/stream/stream-live/start-stream-live.mdx
@@ -135,9 +135,9 @@ If you are experiencing buffering, freezing, experiencing latency, or having oth
 
 #### Low-Latency HLS broadcast recommendations <Badge text="Beta" variant="caution" size="small" />
 
-- B Frames must be turned off or set to 0. B Frames are incompatible with LL-HLS and will result in jitter and sporadic buffering delays.
-- For lowest latency, use a GOP size (keyframe interval) of 2 seconds.
-- Broadcast to the RTMP endpoint if possible.
+- Turn off B Frames or set them to 0. B Frames are incompatible with LL-HLS and will result in jitter and sporadic buffering delays.
+- For lowest latency, use a GOP size (or "keyframe interval") of 2 - 4 seconds.
+- Broadcast to the RTMP endpoint if possible, SRT otherwise.
 - If using OBS, select the "ultra low" latency profile.
 
 ### Requirements


### PR DESCRIPTION
Updated low-latency HLS broadcast recommendations to specify that B Frames must be turned off and adjusted GOP size to 2 seconds.
