### PR TITLE
[Registrar] Add domain ownership certificate page

### DIFF
--- a/src/content/dash-routes/core-manually-defined.json
+++ b/src/content/dash-routes/core-manually-defined.json
@@ -28,5 +28,10 @@
 		"deeplink": "/?to=/:account/mesh",
 		"name": "Mesh",
 		"parent": ["Networking"]
+	},
+	{
+		"deeplink": "/?to=/:account/domains/registrations",
+		"name": "Registrations",
+		"parent": ["Domains"]
 	}
 ]

--- a/src/content/dash-routes/core-manually-defined.json
+++ b/src/content/dash-routes/core-manually-defined.json
@@ -32,6 +32,6 @@
 	{
 		"deeplink": "/?to=/:account/domains/registrations",
 		"name": "Registrations",
-		"parent": ["Domains"]
+		"parent": ["Domain registration"]
 	}
 ]

--- a/src/content/docs/registrar/account-options/domain-ownership-certificate.mdx
+++ b/src/content/docs/registrar/account-options/domain-ownership-certificate.mdx
@@ -10,7 +10,7 @@ description: Generate a domain ownership certificate (WHOIS ownership letter) fo
 
 import { Steps, DashButton } from "~/components";
 
-A domain ownership certificate is a PDF letter that certifies Cloudflare is the registrar of record for your domain and lists the domain's current registration data. You can use it as proof of ownership when a third party — such as a bank, marketplace, or legal entity — requires written confirmation that you control the domain.
+A domain ownership certificate is a PDF letter that certifies Cloudflare is the registrar of record for your domain and lists the domain's current registration data. You can use it as proof of ownership when a third party (such as a bank, marketplace, or legal entity) requires written confirmation that you control the domain.
 
 The certificate is generated on demand and is automatically populated with your domain's current WHOIS information and the date it was generated. It includes:
 
@@ -27,9 +27,9 @@ The contact details shown on the certificate reflect the authoritative contact i
 To download a domain ownership certificate:
 
 <Steps>
-1. In the Cloudflare dashboard, go to the **Manage domains** page.
+1. In the Cloudflare dashboard, go to the **Registrations** page.
 
-   <DashButton url="/?to=/:account/registrar/domains" />
+   <DashButton url="/?to=/:account/domains/registrations" />
 
 2. Find the domain you want a certificate for, and select **Manage**.
 3. Select the **Contacts** tab.
@@ -38,7 +38,7 @@ To download a domain ownership certificate:
 
 Your browser downloads a PDF named `<domain>_ownership_letter.pdf`.
 
-## Requirements
+## Prerequisites and restrictions
 
 You can only generate a certificate when:
 
@@ -46,4 +46,8 @@ You can only generate a certificate when:
 - You have permission to view the domain's contact information.
 - The domain has registrant contact information on file.
 
-If any of these conditions are not met, the certificate cannot be generated. Domains that are pending transfer or have not yet completed registration with Cloudflare Registrar are not eligible until the registration is finalized.
+If any of these conditions are not met, the certificate cannot be generated.
+
+:::note
+Domains that are pending transfer or have not yet completed registration with Cloudflare Registrar are not eligible until the registration is finalized.
+:::

--- a/src/content/docs/registrar/account-options/domain-ownership-certificate.mdx
+++ b/src/content/docs/registrar/account-options/domain-ownership-certificate.mdx
@@ -1,0 +1,49 @@
+---
+pcx_content_type: how-to
+title: Domain ownership certificate
+sidebar:
+  order: 5
+products:
+  - registrar
+description: Generate a domain ownership certificate (WHOIS ownership letter) for a domain registered with Cloudflare Registrar.
+---
+
+import { Steps, DashButton } from "~/components";
+
+A domain ownership certificate is a PDF letter that certifies Cloudflare is the registrar of record for your domain and lists the domain's current registration data. You can use it as proof of ownership when a third party — such as a bank, marketplace, or legal entity — requires written confirmation that you control the domain.
+
+The certificate is generated on demand and is automatically populated with your domain's current WHOIS information and the date it was generated. It includes:
+
+- A certification statement confirming that Cloudflare, an ICANN-accredited registrar, is the registrar for the domain.
+- **Exhibit A**, containing the domain's registration data:
+  - Creation date and registry expiry date.
+  - Registrant, administrative, technical, and billing contacts.
+  - Name servers.
+
+The contact details shown on the certificate reflect the authoritative contact information Cloudflare has on file, not the redacted values published in public WHOIS. To review or update this information, refer to [Registrant contact updates](/registrar/account-options/domain-contact-updates/).
+
+## Generate a certificate
+
+To download a domain ownership certificate:
+
+<Steps>
+1. In the Cloudflare dashboard, go to the **Manage domains** page.
+
+   <DashButton url="/?to=/:account/registrar/domains" />
+
+2. Find the domain you want a certificate for, and select **Manage**.
+3. Select the **Contacts** tab.
+4. Select **Download ownership certificate**.
+</Steps>
+
+Your browser downloads a PDF named `<domain>_ownership_letter.pdf`.
+
+## Requirements
+
+You can only generate a certificate when:
+
+- The domain is registered with (sponsored by) Cloudflare Registrar.
+- You have permission to view the domain's contact information.
+- The domain has registrant contact information on file.
+
+If any of these conditions are not met, the certificate cannot be generated. Domains that are pending transfer or have not yet completed registration with Cloudflare Registrar are not eligible until the registration is finalized.


### PR DESCRIPTION
### Summary

Adds a new how-to page documenting the **domain ownership certificate** (WHOIS ownership letter) for Cloudflare Registrar.

The certificate is a PDF that certifies Cloudflare is the registrar of record for a domain and lists the domain's current registration data (creation/expiry dates, registrant/administrative/technical/billing contacts, and name servers). It is generated on demand from the dashboard and auto-populated with the domain's current WHOIS information and the generation date.

The page covers:

- What the certificate is and when to use it (proof of ownership for third parties).
- What the certificate contains, including Exhibit A.
- The dashboard steps to generate and download it (**Manage domains** > domain > **Contacts**).
- Requirements for generating a certificate (Cloudflare Registrar–sponsored domain, contact-view permission, contacts on file).

New page: `registrar/account-options/domain-ownership-certificate/`, added to the **Registration options** section.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] No files changed name or location, so no redirects are required.
