### PR TITLE
harden fetch-ai-models against transient upstream failures

### DIFF
--- a/bin/fetch-ai-models.js
+++ b/bin/fetch-ai-models.js
@@ -56,9 +56,7 @@ try {
 	// JSON files in place so docs continue to render the last known good
 	// catalog; the next successful run will sync new/removed models.
 	const message = err.message.endsWith(".") ? err.message : `${err.message}.`;
-	console.error(
-		`fetch-ai-models: ${message} Keeping existing model files.`,
-	);
+	console.error(`fetch-ai-models: ${message} Keeping existing model files.`);
 	process.exit(0);
 }
 

--- a/bin/fetch-ai-models.js
+++ b/bin/fetch-ai-models.js
@@ -4,14 +4,63 @@ import path from "node:path";
 const OUTPUT_DIR = path.join(process.cwd(), "src/content/workers-ai-models");
 const API_URL = "https://ai-cloudflare-com.pages.dev/api/models";
 
-const response = await fetch(API_URL);
-if (!response.ok) {
-	throw new Error(
-		`fetch-ai-models: API returned HTTP ${response.status} ${response.statusText}.`,
-	);
+// The upstream API fans out per-model schema fetches on cache miss and can
+// return a transient 502 if any of those flake. Retry the whole request a
+// handful of times before giving up so a momentary blip doesn't fail the
+// whole sync.
+const MAX_ATTEMPTS = 4;
+const BASE_DELAY_MS = 500;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Marker so the loop can tell "upstream returned 4xx we can't recover from"
+// apart from a transient network error.
+class NonRetryableHttpError extends Error {}
+
+async function fetchModels() {
+	let lastError;
+	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+		try {
+			const response = await fetch(API_URL, {
+				signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+			});
+			if (response.ok) return await response.json();
+			const message = `API returned HTTP ${response.status} ${response.statusText}.`;
+			// 429 + 5xx are worth retrying; other 4xx (auth, not found) won't get better.
+			const retryable = response.status === 429 || response.status >= 500;
+			if (!retryable) throw new NonRetryableHttpError(message);
+			lastError = new Error(message);
+		} catch (err) {
+			if (err instanceof NonRetryableHttpError) throw err;
+			lastError = err;
+		}
+		if (attempt === MAX_ATTEMPTS) throw lastError;
+		// Exponential backoff with ±25% jitter so retries don't pile up.
+		const base = BASE_DELAY_MS * 2 ** (attempt - 1);
+		const jitter = base * (Math.random() * 0.5 - 0.25);
+		const wait = Math.round(base + jitter);
+		console.warn(
+			`fetch-ai-models: attempt ${attempt} failed (${lastError.message}); retrying in ${wait}ms`,
+		);
+		await sleep(wait);
+	}
+	throw lastError;
 }
 
-const data = await response.json();
+let data;
+try {
+	data = await fetchModels();
+} catch (err) {
+	// Don't fail the build over a transient upstream blip. Leave existing
+	// JSON files in place so docs continue to render the last known good
+	// catalog; the next successful run will sync new/removed models.
+	const message = err.message.endsWith(".") ? err.message : `${err.message}.`;
+	console.error(
+		`fetch-ai-models: ${message} Keeping existing model files.`,
+	);
+	process.exit(0);
+}
 
 const existingFiles = new Set(
 	fs.readdirSync(OUTPUT_DIR).filter((file) => file.endsWith(".json")),

--- a/bin/fetch-ai-models.js
+++ b/bin/fetch-ai-models.js
@@ -16,7 +16,12 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Marker so the loop can tell "upstream returned 4xx we can't recover from"
 // apart from a transient network error.
-class NonRetryableHttpError extends Error {}
+class NonRetryableHttpError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = "NonRetryableHttpError";
+	}
+}
 
 async function fetchModels() {
 	let lastError;

--- a/bin/fetch-ai-models.js
+++ b/bin/fetch-ai-models.js
@@ -45,7 +45,6 @@ async function fetchModels() {
 		);
 		await sleep(wait);
 	}
-	throw lastError;
 }
 
 let data;


### PR DESCRIPTION
### Summary

Makes `bin/fetch-ai-models.js` resilient to transient upstream failures.

The upstream API at `ai-cloudflare-com.pages.dev/api/models` fans out per-model schema fetches on cache miss and occasionally returns a 502 if any of those flake, which fails the whole sync (and any build that depends on it).

- Retries the request up to 4 times with exponential backoff + jitter
- Only retries on 429 and 5xx; other 4xx fail fast
- Adds a 30s per-request timeout via `AbortSignal.timeout`
- If all retries fail, logs and exits 0 so existing model JSON files stay in place rather than failing the build — the next successful run picks up any drift
