### PR TITLE
chore: add style guide rules for numbered headings and raw HTML in MDX

### DIFF
--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -181,6 +181,7 @@ Do not use: "Learn more about...", "To read more...", "refer the [Page] page/doc
 - Do not use gerund phrases for page titles or section headings: "Install Wrangler" not "Installing Wrangler".
 - Subtitles/subheadings must be verb or noun phrases — never a question ("How do I install Wrangler?") or a call to action.
 - Do not use emojis in `title` or `sidebar.label`.
+- Do not start headings with a number or step label (`## 1. Do this`, `## Step 2 — Configure`). Sequential steps belong in a numbered list or a `Steps` component, not in headings.
 
 ---
 
@@ -286,6 +287,8 @@ All components are imported from `~/components`. Imports must appear after the f
 - Package install/exec commands → `PackageManagers`
 - Multi-step procedures → `Steps`
 - Dashboard navigation steps → `DashButton` (not bare links)
+
+**No raw HTML elements for layout or styling.** Do not write `<div>`, `<span>`, `<table>`, `<br>`, `<style>`, or any other raw HTML element directly in MDX to achieve layout, overflow, scrolling, borders, or visual effects. Use a Cloudflare docs component instead, or restructure the content. The only permitted raw HTML is inline void elements like `<br/>` for line breaks inside code annotations where no component applies.
 
 | Component                             | Purpose                                                                             |
 | ------------------------------------- | ----------------------------------------------------------------------------------- |

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -288,7 +288,7 @@ All components are imported from `~/components`. Imports must appear after the f
 - Multi-step procedures → `Steps`
 - Dashboard navigation steps → `DashButton` (not bare links)
 
-**No raw HTML elements for layout or styling.** Do not write `<div>`, `<span>`, `<table>`, `<br>`, `<style>`, or any other raw HTML element directly in MDX to achieve layout, overflow, scrolling, borders, or visual effects. Use a Cloudflare docs component instead, or restructure the content. The only permitted raw HTML is inline void elements like `<br/>` for line breaks inside code annotations where no component applies.
+**No raw HTML elements for layout or styling.** Do not write `<div>`, `<span>`, `<table>`, `<br>`, `<style>`, or any other raw HTML element directly in MDX to achieve layout, overflow, scrolling, borders, or visual effects. Use a Cloudflare docs component instead, or restructure the content.
 
 | Component                             | Purpose                                                                             |
 | ------------------------------------- | ----------------------------------------------------------------------------------- |

--- a/.agents/skills/docs-review/SKILL.md
+++ b/.agents/skills/docs-review/SKILL.md
@@ -154,6 +154,8 @@ See `.agents/references/style-guide.md` for the full rules. Quick reference:
 | ------------------------ | ---------------------------------------------------------------------------------------------------- |
 | Unescaped MDX characters | `{`, `}`, `<`, `>` in prose must be escaped or in backticks                                          |
 | Component imports        | Every component used must be imported from `~/components`                                            |
+| Numbered headings        | Headings must not start with a number or step label (`## 1. Do this`) — use `Steps` or a numbered list instead |
+| Raw HTML in MDX          | `<div>`, `<span>`, `<table>`, `<br>`, `<style>` etc. for layout/styling are not permitted — use a component or restructure the content |
 | Workers code             | Must use `TypeScriptExample`, not bare `js`/`ts` fences                                              |
 | Config blocks            | Must use `WranglerConfig` with TOML input; use `$today` for `compatibility_date`                     |
 | Package install commands | Must use `PackageManagers`, not bare `sh` fences                                                     |

--- a/.agents/skills/docs-review/SKILL.md
+++ b/.agents/skills/docs-review/SKILL.md
@@ -150,21 +150,21 @@ Read full files for context — code that looks wrong in a diff may be correct i
 
 See `.agents/references/style-guide.md` for the full rules. Quick reference:
 
-| Rule                     | Detail                                                                                               |
-| ------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Unescaped MDX characters | `{`, `}`, `<`, `>` in prose must be escaped or in backticks                                          |
-| Component imports        | Every component used must be imported from `~/components`                                            |
-| Numbered headings        | Headings must not start with a number or step label (`## 1. Do this`) — use `Steps` or a numbered list instead |
+| Rule                     | Detail                                                                                                                                 |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Unescaped MDX characters | `{`, `}`, `<`, `>` in prose must be escaped or in backticks                                                                            |
+| Component imports        | Every component used must be imported from `~/components`                                                                              |
+| Numbered headings        | Headings must not start with a number or step label (`## 1. Do this`) — use `Steps` or a numbered list instead                         |
 | Raw HTML in MDX          | `<div>`, `<span>`, `<table>`, `<br>`, `<style>` etc. for layout/styling are not permitted — use a component or restructure the content |
-| Workers code             | Must use `TypeScriptExample`, not bare `js`/`ts` fences                                              |
-| Config blocks            | Must use `WranglerConfig` with TOML input; use `$today` for `compatibility_date`                     |
-| Package install commands | Must use `PackageManagers`, not bare `sh` fences                                                     |
-| Code block languages     | Lowercase, from the supported set — see `.agents/references/style-guide.md`                          |
-| Internal links           | Root-relative paths, trailing slash, no file extensions, no full `developers.cloudflare.com` URLs    |
-| Frontmatter              | `title` and `description` required; `pcx_content_type` must be a valid value                         |
-| Writing style            | See `.agents/references/style-guide.md` — covers voice, contractions, terminology, headings, etc.    |
-| Code correctness         | For type checking, API usage, and binding patterns, load the `code-review` skill                     |
-| Accuracy                 | Claims must be substantiated — link to sources of truth, do not re-explain what other pages cover    |
+| Workers code             | Must use `TypeScriptExample`, not bare `js`/`ts` fences                                                                                |
+| Config blocks            | Must use `WranglerConfig` with TOML input; use `$today` for `compatibility_date`                                                       |
+| Package install commands | Must use `PackageManagers`, not bare `sh` fences                                                                                       |
+| Code block languages     | Lowercase, from the supported set — see `.agents/references/style-guide.md`                                                            |
+| Internal links           | Root-relative paths, trailing slash, no file extensions, no full `developers.cloudflare.com` URLs                                      |
+| Frontmatter              | `title` and `description` required; `pcx_content_type` must be a valid value                                                           |
+| Writing style            | See `.agents/references/style-guide.md` — covers voice, contractions, terminology, headings, etc.                                      |
+| Code correctness         | For type checking, API usage, and binding patterns, load the `code-review` skill                                                       |
+| Accuracy                 | Claims must be substantiated — link to sources of truth, do not re-explain what other pages cover                                      |
 
 ### 3. Assess What to Flag
 

--- a/.agents/skills/docs-review/SKILL.md
+++ b/.agents/skills/docs-review/SKILL.md
@@ -150,21 +150,19 @@ Read full files for context — code that looks wrong in a diff may be correct i
 
 See `.agents/references/style-guide.md` for the full rules. Quick reference:
 
-| Rule                     | Detail                                                                                                                                 |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Unescaped MDX characters | `{`, `}`, `<`, `>` in prose must be escaped or in backticks                                                                            |
-| Component imports        | Every component used must be imported from `~/components`                                                                              |
-| Numbered headings        | Headings must not start with a number or step label (`## 1. Do this`) — use `Steps` or a numbered list instead                         |
-| Raw HTML in MDX          | `<div>`, `<span>`, `<table>`, `<br>`, `<style>` etc. for layout/styling are not permitted — use a component or restructure the content |
-| Workers code             | Must use `TypeScriptExample`, not bare `js`/`ts` fences                                                                                |
-| Config blocks            | Must use `WranglerConfig` with TOML input; use `$today` for `compatibility_date`                                                       |
-| Package install commands | Must use `PackageManagers`, not bare `sh` fences                                                                                       |
-| Code block languages     | Lowercase, from the supported set — see `.agents/references/style-guide.md`                                                            |
-| Internal links           | Root-relative paths, trailing slash, no file extensions, no full `developers.cloudflare.com` URLs                                      |
-| Frontmatter              | `title` and `description` required; `pcx_content_type` must be a valid value                                                           |
-| Writing style            | See `.agents/references/style-guide.md` — covers voice, contractions, terminology, headings, etc.                                      |
-| Code correctness         | For type checking, API usage, and binding patterns, load the `code-review` skill                                                       |
-| Accuracy                 | Claims must be substantiated — link to sources of truth, do not re-explain what other pages cover                                      |
+| Rule                     | Detail                                                                                               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Unescaped MDX characters | `{`, `}`, `<`, `>` in prose must be escaped or in backticks                                          |
+| Component imports        | Every component used must be imported from `~/components`                                            |
+| Workers code             | Must use `TypeScriptExample`, not bare `js`/`ts` fences                                              |
+| Config blocks            | Must use `WranglerConfig` with TOML input; use `$today` for `compatibility_date`                     |
+| Package install commands | Must use `PackageManagers`, not bare `sh` fences                                                     |
+| Code block languages     | Lowercase, from the supported set — see `.agents/references/style-guide.md`                          |
+| Internal links           | Root-relative paths, trailing slash, no file extensions, no full `developers.cloudflare.com` URLs    |
+| Frontmatter              | `title` and `description` required; `pcx_content_type` must be a valid value                         |
+| Writing style            | See `.agents/references/style-guide.md` — covers voice, contractions, terminology, headings, etc.    |
+| Code correctness         | For type checking, API usage, and binding patterns, load the `code-review` skill                     |
+| Accuracy                 | Claims must be substantiated — link to sources of truth, do not re-explain what other pages cover    |
 
 ### 3. Assess What to Flag
 

--- a/.flue/.agents/reference/style-guide/always/core-content.md
+++ b/.flue/.agents/reference/style-guide/always/core-content.md
@@ -69,6 +69,7 @@ description: Always load for any MDX file with added content lines.
 - If a heading ends with `.`, `?`, `!`, or `:` → **warning**: remove trailing punctuation.
 - If a heading begins with a verb ending in `-ing` (`Installing`, `Configuring`, `Setting up`) → **warning**: use imperative form instead (`Install`, `Configure`, `Set up`).
 - If frontmatter `title:` or `sidebar.label:` contains an emoji → **warning**: remove it.
+- If a heading starts with a number or step label (`## 1. Do this`, `## Step 2 —`, `## 3:`) → **warning**: do not use numbered or step-labelled headings. Use a `Steps` component or a numbered list instead.
 
 ---
 
@@ -96,6 +97,10 @@ description: Always load for any MDX file with added content lines.
 - Valid types: `:::note`, `:::caution`, `:::tip`.
 - If a patch adds more than one admonition of the same type in the same section → **suggestion**: consolidate or integrate the content into prose.
 - If an admonition content could be integrated into surrounding prose → **suggestion**: do so rather than using an admonition.
+
+**Raw HTML**
+
+- If an added line contains a raw HTML element used for layout or styling (`<div`, `<span`, `<style`, `<table`, `<tr`, `<td`, `<th`) → **warning**: do not use raw HTML for layout or styling in MDX. Use a Cloudflare docs component or restructure the content instead.
 
 **Numbers**
 


### PR DESCRIPTION
### Summary

Adds two missing style guide rules caught during review of PR #31396:

1. **No numbered headings** — headings must not start with a number or step label (`## 1. Do this`, `## Step 2 — Configure`). Sequential steps belong in a `Steps` component or numbered list, not in headings.
2. **No raw HTML for layout/styling** — `<div>`, `<span>`, `<table>`, `<style>`, etc. are not permitted in MDX for layout or visual effects. Use a component or restructure the content.

Updated in:
- `.agents/references/style-guide.md` — human/agent reference
- `.flue/.agents/reference/style-guide/always/core-content.md` — rule definitions for the automated PR review bot
