### PR TITLE
[DO] Address review feedback on metrics filter changelog

### DIFF
--- a/src/content/changelog/durable-objects/2026-06-12-durable-objects-metrics-filter-by-id-name.mdx
+++ b/src/content/changelog/durable-objects/2026-06-12-durable-objects-metrics-filter-by-id-name.mdx
@@ -15,7 +15,7 @@ You can now filter the **Metrics** tab for a Durable Objects namespace by an ind
 
 ![The Durable Objects Metrics tab filtered to a single object by ID, showing per-object requests and errors by invocation status.](~/assets/images/changelog/durable-objects/durable-objects-metrics-dashboard.png)
 
-Start typing an ID or name into the filter and select a match from the autocomplete dropdown. The autocomplete only shows objects with invocations during the selected time range, so an object that does not appear has not been invoked in that window — it has not necessarily been deleted. Every chart on the page updates to reflect only the selected object. This makes it easier to identify and investigate a single Durable Object when debugging a high-traffic object, an error spike, or unexpected storage usage. Clear the filter to return to namespace-level metrics.
+Start typing an ID or name into the filter and select a match from the autocomplete dropdown. The autocomplete only shows objects with invocations during the selected time range, so an object that does not appear has not been invoked in that window. This does not necessarily mean the object has been deleted. Every chart on the page updates to reflect only the selected object. This makes it easier to identify and investigate a single Durable Object when debugging a high-traffic object, an error spike, or unexpected storage usage. Clear the filter to return to namespace-level metrics.
 
 Metrics are powered by the [GraphQL Analytics API](/analytics/graphql-api/), so standard analytics behavior such as ingestion delay and [sampling](/analytics/faq/graphql-api-inconsistent-results/) applies.
 

--- a/src/content/changelog/durable-objects/2026-06-12-durable-objects-metrics-filter-by-id-name.mdx
+++ b/src/content/changelog/durable-objects/2026-06-12-durable-objects-metrics-filter-by-id-name.mdx
@@ -13,10 +13,10 @@ You can now filter the **Metrics** tab for a Durable Objects namespace by an ind
 
 <DashButton url="/?to=/:account/workers/durable-objects" />
 
-Start typing an ID or name into the filter and select a match from the autocomplete dropdown. Every chart on the page updates to reflect only the selected object. This makes it easier to identify and investigate a single Durable Object when debugging a high-traffic object, an error spike, or unexpected storage usage. Clear the filter to return to namespace-level metrics.
+![The Durable Objects Metrics tab filtered to a single object by ID, showing per-object requests and errors by invocation status.](~/assets/images/changelog/durable-objects/durable-objects-metrics-dashboard.png)
+
+Start typing an ID or name into the filter and select a match from the autocomplete dropdown. The autocomplete only shows objects with invocations during the selected time range, so an object that does not appear has not been invoked in that window — it has not necessarily been deleted. Every chart on the page updates to reflect only the selected object. This makes it easier to identify and investigate a single Durable Object when debugging a high-traffic object, an error spike, or unexpected storage usage. Clear the filter to return to namespace-level metrics.
 
 Metrics are powered by the [GraphQL Analytics API](/analytics/graphql-api/), so standard analytics behavior such as ingestion delay and [sampling](/analytics/faq/graphql-api-inconsistent-results/) applies.
 
 For more information, refer to [Metrics and analytics](/durable-objects/observability/metrics-and-analytics/).
-
-![The Durable Objects Metrics tab filtered to a single object by ID, showing per-object requests and errors by invocation status.](~/assets/images/changelog/durable-objects/durable-objects-metrics-dashboard.png)


### PR DESCRIPTION
### Summary

Follow-up to #31316 (merged) addressing post-merge review comments from @vy-ton on the Durable Objects metrics filter changelog entry:

- Move the dashboard screenshot to immediately after the `DashButton` so readers see the UI before reading how to use it.
- Clarify that the autocomplete only lists objects with invocations during the selected time range — a missing object means no recent invocations, not that the object has been deleted (confirmed by @apeacock1991 in the original PR thread).

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
