### PR TITLE
[Artifacts] Correct binding types and improve Wrangler cross-links

### DIFF
--- a/src/content/changelog/artifacts/2026-04-16-artifacts-now-in-beta.mdx
+++ b/src/content/changelog/artifacts/2026-04-16-artifacts-now-in-beta.mdx
@@ -21,13 +21,13 @@ As an example: you can use the Workers binding to create a repo and read back it
 ```ts
 # Create a thousand, a million or ten million repos: one for every agent, for every upstream branch, or every user.
 const created = await env.PROD_ARTIFACTS.create("agent-007");
-const remote = (await created.repo.info())?.remote;
+const remote = created.remote;
 ```
 
 Or, use the REST API to create a repo inside a namespace from your agent(s) running on any platform:
 
 ```bash
-curl --request POST "https://artifacts.cloudflare.net/v1/api/namespaces/some-namespace/repos" --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" --header "Content-Type: application/json" --data '{"name":"agent-007"}'
+curl --request POST "https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/artifacts/namespaces/some-namespace/repos" --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" --header "Content-Type: application/json" --data '{"name":"agent-007"}'
 ```
 
 Any Git client that speaks smart HTTP can use the returned remote URL:
@@ -35,7 +35,7 @@ Any Git client that speaks smart HTTP can use the returned remote URL:
 ```bash
 # Agents know git.
 # Every repository can act as a git repo, allowing agents to interact with Artifacts the way they know best: using the git CLI.
-git clone https://x:${REPO_TOKEN}@artifacts.cloudflare.net/some-namespace/agent-007.git
+git clone https://x:${REPO_TOKEN}@<ACCOUNT_ID>.artifacts.cloudflare.net/git/some-namespace/agent-007.git
 ```
 
 To learn more, refer to [Get started](/artifacts/get-started/), [Workers binding](/artifacts/api/workers-binding/), and [Git protocol](/artifacts/api/git-protocol/).

--- a/src/content/docs/artifacts/api/errors.mdx
+++ b/src/content/docs/artifacts/api/errors.mdx
@@ -13,19 +13,21 @@ products:
 
 This is a list of Artifacts errors.
 
+The Workers binding throws `ArtifactsError` for failures. Use the string `code` to match errors programmatically, or use `numericCode` to correlate with the REST API `errors[].code` values.
+
 ## Error codes
 
-| Name | Code | Description |
-|------|------|-------------|
-| `ALREADY_EXISTS` | 10201 | The target repository already exists in the namespace. |
-| `NOT_FOUND` | 10200 | The repository or remote resource does not exist. |
-| `IMPORT_IN_PROGRESS` | 10302 | The repository is still being imported and is not yet available. |
-| `FORK_IN_PROGRESS` | 10303 | The repository is still being forked and is not yet available. |
-| `INVALID_INPUT` | 10100 | A request parameter is missing, malformed, or outside the accepted range. |
-| `INVALID_REPO_NAME` | 10101 | The repository name does not meet naming requirements. |
-| `INVALID_TTL` | 10103 | The token TTL is outside the allowed range (60–31,536,000 seconds). |
-| `INVALID_URL` | 10104 | The source URL does not point to a valid git repository. |
-| `REMOTE_AUTH_REQUIRED` | 10106 | The remote repository requires authentication. |
-| `UPSTREAM_UNAVAILABLE` | 10401 | The remote git server could not be reached. |
-| `MEMORY_LIMIT` | 10402 | The operation exceeds service memory limits. |
-| `INTERNAL_ERROR` | 10400 | An unexpected internal error occurred. |
+| Name                   | Code  | Description                                                               |
+| ---------------------- | ----- | ------------------------------------------------------------------------- |
+| `ALREADY_EXISTS`       | 10201 | The target repository already exists in the namespace.                    |
+| `NOT_FOUND`            | 10200 | The repository or remote resource does not exist.                         |
+| `IMPORT_IN_PROGRESS`   | 10302 | The repository is still being imported and is not yet available.          |
+| `FORK_IN_PROGRESS`     | 10303 | The repository is still being forked and is not yet available.            |
+| `INVALID_INPUT`        | 10100 | A request parameter is missing, malformed, or outside the accepted range. |
+| `INVALID_REPO_NAME`    | 10101 | The repository name does not meet naming requirements.                    |
+| `INVALID_TTL`          | 10103 | The token TTL is outside the allowed range (60–31,536,000 seconds).       |
+| `INVALID_URL`          | 10104 | The source URL does not point to a valid git repository.                  |
+| `REMOTE_AUTH_REQUIRED` | 10106 | The remote repository requires authentication.                            |
+| `UPSTREAM_UNAVAILABLE` | 10401 | The remote git server could not be reached.                               |
+| `MEMORY_LIMIT`         | 10402 | The operation exceeds service memory limits.                              |
+| `INTERNAL_ERROR`       | 10400 | An unexpected internal error occurred.                                    |

--- a/src/content/docs/artifacts/api/workers-binding.mdx
+++ b/src/content/docs/artifacts/api/workers-binding.mdx
@@ -64,7 +64,7 @@ Use namespace methods on `env.ARTIFACTS` to create, list, inspect, import, or de
 - `opts.setDefaultBranch` <Type text="string" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
 
-`create()` returns repo metadata including `name`, `remote`, `defaultBranch`, and an initial token. Save these values if you need them later.
+`create()` returns repo metadata including `name`, `remote`, `defaultBranch`, an initial `token`, and a parsed `tokenExpiresAt` timestamp. Save these values if you need them later.
 
 <TypeScriptExample>
 
@@ -81,6 +81,7 @@ async function createRepo(artifacts: Artifacts) {
 		name: created.name,
 		remote: created.remote,
 		initialToken: created.token,
+		tokenExpiresAt: created.tokenExpiresAt,
 	};
 }
 ```
@@ -113,6 +114,8 @@ async function getRepoHandle(artifacts: Artifacts) {
 - `opts.cursor` <Type text="Cursor" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsRepoListResult>" />
 
+The result includes the page of repos, a `total` count for the namespace, and an optional `cursor` for the next page.
+
 <TypeScriptExample>
 
 ```ts
@@ -120,6 +123,7 @@ async function listRepos(artifacts: Artifacts) {
 	const page = await artifacts.list({ limit: 10 });
 
 	return {
+		total: page.total,
 		repos: page.repos.map((repo) => ({
 			name: repo.name,
 			status: repo.status,
@@ -145,7 +149,7 @@ Import a repository from an external git remote.
 - `params.target.opts.readOnly` <Type text="boolean" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
 
-`import()` returns repo metadata including `name`, `remote`, `defaultBranch`, and an initial token. Save the `remote` and `name` values if you need them later.
+`import()` returns repo metadata including `name`, `remote`, `defaultBranch`, an initial `token`, and a parsed `tokenExpiresAt` timestamp. Save the `remote` and `name` values if you need them later.
 
 <TypeScriptExample>
 
@@ -165,6 +169,7 @@ async function importFromGitHub(artifacts: Artifacts) {
 		name: imported.name,
 		remote: imported.remote,
 		token: imported.token,
+		tokenExpiresAt: imported.tokenExpiresAt,
 	};
 }
 ```
@@ -271,56 +276,29 @@ async function forkRepo(artifacts: Artifacts) {
 
 </TypeScriptExample>
 
-### `log(opts?)`
+## Read repo content
 
-- `opts.ref` <Type text="string" /> <MetaInfo text="optional" /> — Branch, tag, or commit hash.
-- `opts.limit` <Type text="number" /> <MetaInfo text="optional" />
-- `opts.offset` <Type text="number" /> <MetaInfo text="optional" />
-- Returns <Type text="Promise<ArtifactsLogResult>" />
+The Workers binding creates and manages repos. To read commit history, commits, trees, or file contents, use the [REST API](/artifacts/api/rest-api/#repo-content) endpoints or a Git client.
 
-<TypeScriptExample>
+## Errors
 
-```ts
-async function readCommitHistory(artifacts: Artifacts) {
-	const repo = await artifacts.get("starter-repo");
-	const history = await repo.log({ ref: "main", limit: 10 });
-	return history;
-}
-```
-
-</TypeScriptExample>
-
-### `readCommit(hash)`
-
-- `hash` <Type text="string" /> <MetaInfo text="required" /> — Commit SHA-1 hash.
-- Returns <Type text="Promise<ArtifactsCommit>" />
-
-<TypeScriptExample>
+Binding methods throw `ArtifactsError` when an operation fails. The error has a string `code` matching the values in the [REST API error reference](/artifacts/api/errors/) and a `numericCode` that matches the REST API `errors[].code` value.
 
 ```ts
-async function readCommit(artifacts: Artifacts, hash: string) {
-	const repo = await artifacts.get("starter-repo");
-	return repo.readCommit(hash);
+async function safeCreate(artifacts: Artifacts, name: string) {
+	try {
+		return await artifacts.create(name);
+	} catch (error) {
+		if (error instanceof ArtifactsError) {
+			// Handle known errors by code.
+			if (error.code === "ALREADY_EXISTS") {
+				return artifacts.get(name);
+			}
+		}
+		throw error;
+	}
 }
 ```
-
-</TypeScriptExample>
-
-### `readTree(hash)`
-
-- `hash` <Type text="string" /> <MetaInfo text="required" /> — Tree SHA-1 hash.
-- Returns <Type text="Promise<ArtifactsTree>" />
-
-<TypeScriptExample>
-
-```ts
-async function readTree(artifacts: Artifacts, hash: string) {
-	const repo = await artifacts.get("starter-repo");
-	return repo.readTree(hash);
-}
-```
-
-</TypeScriptExample>
 
 ## Worker example
 
@@ -342,6 +320,7 @@ export default {
 			return Response.json({
 				name: created.name,
 				remote: created.remote,
+				tokenExpiresAt: created.tokenExpiresAt,
 			});
 		}
 

--- a/src/content/docs/artifacts/api/workers-binding.mdx
+++ b/src/content/docs/artifacts/api/workers-binding.mdx
@@ -64,7 +64,7 @@ Use namespace methods on `env.ARTIFACTS` to create, list, inspect, import, or de
 - `opts.setDefaultBranch` <Type text="string" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
 
-`create()` returns repo metadata including `name`, `remote`, `defaultBranch`, an initial `token`, and a parsed `tokenExpiresAt` timestamp. Save these values if you need them later.
+`create()` returns repo metadata including `name`, `remote`, `defaultBranch`, an initial `token`, and a `tokenExpiresAt` timestamp as an ISO 8601 string. Save these values if you need them later.
 
 <TypeScriptExample>
 
@@ -149,7 +149,7 @@ Import a repository from an external git remote.
 - `params.target.opts.readOnly` <Type text="boolean" /> <MetaInfo text="optional" />
 - Returns <Type text="Promise<ArtifactsCreateRepoResult>" />
 
-`import()` returns repo metadata including `name`, `remote`, `defaultBranch`, an initial `token`, and a parsed `tokenExpiresAt` timestamp. Save the `remote` and `name` values if you need them later.
+`import()` returns repo metadata including `name`, `remote`, `defaultBranch`, an initial `token`, and a `tokenExpiresAt` timestamp as an ISO 8601 string. Save the `remote` and `name` values if you need them later.
 
 <TypeScriptExample>
 
@@ -282,7 +282,7 @@ The Workers binding creates and manages repos. To read commit history, commits, 
 
 ## Errors
 
-Binding methods throw `ArtifactsError` when an operation fails. The error has a string `code` matching the values in the [REST API error reference](/artifacts/api/errors/) and a `numericCode` that matches the REST API `errors[].code` value.
+Binding methods throw `ArtifactsError` when an operation fails. The error class is generated as a global alongside the `Artifacts` type by `npx wrangler types`. The error has a string `code` matching the values in the [REST API error reference](/artifacts/api/errors/) and a `numericCode` that matches the REST API `errors[].code` value.
 
 ```ts
 async function safeCreate(artifacts: Artifacts, name: string) {

--- a/src/content/docs/artifacts/get-started/workers.mdx
+++ b/src/content/docs/artifacts/get-started/workers.mdx
@@ -121,6 +121,7 @@ export default {
 				name: created.name,
 				remote: created.remote,
 				token: created.token,
+				tokenExpiresAt: created.tokenExpiresAt,
 			});
 		}
 
@@ -161,19 +162,21 @@ curl http://localhost:8787/repos \
   }'
 ```
 
-Your Worker will call `env.ARTIFACTS.create()` and return three values you will need for Git operations:
+Your Worker will call `env.ARTIFACTS.create()` and return the repo metadata and initial token:
 
 
 ```json
 {
 	"name": "starter-repo",
 	"remote": "https://<ACCOUNT_ID>.artifacts.cloudflare.net/git/default/starter-repo.git",
-	"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000"
+	"token": "art_v1_0123456789abcdef0123456789abcdef01234567?expires=1760000000",
+	"tokenExpiresAt": "2025-10-09T05:33:20.000Z"
 }
 ```
 - `name`: the repo name. Must be unique within the namespace.
 - `remote`: the Git remote URL for this repo. `<ACCOUNT_ID>` will be your actual Cloudflare account ID.
 - `token`: a short-lived credential for Git operations. The token encodes its expiry directly in the `?expires=` suffix as a Unix timestamp.
+- `tokenExpiresAt`: the token expiry as an ISO 8601 timestamp. This is returned by the binding in addition to the `token` string.
 
 Copy the `remote` and `token` values into local shell variables:
 
@@ -201,7 +204,6 @@ export ARTIFACTS_TOKEN=$(printf '%s' "$RESPONSE" | jq -r '.token')
 ## 5. Push your first commit with git
 
 In the previous step, your Worker created an empty Artifacts repo. Now you will create a local Git repo, add a file, and push it to Artifacts — the same way you would push to any Git remote.
-
 
 ```sh
 mkdir artifacts-demo
@@ -244,7 +246,8 @@ git clone "$ARTIFACTS_AUTH_REMOTE" artifacts-clone
 
 ## 7. Deploy your Worker
 
-Switch back to your Worker project directory: 
+Switch back to your Worker project directory:
+
 ```sh
 cd artifacts-worker
 ```

--- a/src/content/docs/artifacts/platform/limits.mdx
+++ b/src/content/docs/artifacts/platform/limits.mdx
@@ -15,9 +15,9 @@ These limits cover naming rules, storage, and request rates for control-plane an
 | Feature                        | Limit                                                                                              |
 | ------------------------------ | -------------------------------------------------------------------------------------------------- |
 | Control-plane request rate     | 2,000 requests per 10 seconds per Artifacts namespace                                              |
-| Git request rate, per artifact     | 2,000 requests per 10 seconds per artifact                                                             |
+| Git request rate, per repo     | 2,000 requests per 10 seconds per repo                                                             |
 | Maximum storage per repository | 10 GB                                                                                              |
 | Maximum storage per account    | 1 TB (can be raised on request)                                                                    |
-| Maximum number of repositories | Unlimited                                 |
+| Maximum number of repositories | Unlimited                                                                                          |
 | Maximum number of namespaces   | Unlimited                                                                                          |
 | Namespace and repo names       | Start with a letter or digit. Remaining characters may include letters, digits, `.`, `_`, and `-`. |

--- a/src/content/docs/workers/wrangler/commands/artifacts.mdx
+++ b/src/content/docs/workers/wrangler/commands/artifacts.mdx
@@ -10,4 +10,6 @@ import { WranglerNamespace, InlineBadge } from "~/components";
 
 Manage [Artifacts](/artifacts/) namespaces, repositories, and repo-scoped tokens using Wrangler. <InlineBadge text="Private beta" variant="caution" />
 
+Use `wrangler artifacts namespaces` to list or inspect namespaces, and `wrangler artifacts repos` to create, list, get, delete, or issue tokens for repositories. For a higher-level guide, refer to [Artifacts Wrangler commands](/artifacts/api/wrangler/).
+
 <WranglerNamespace namespace="artifacts" />


### PR DESCRIPTION
Corrects several inaccuracies in the Artifacts docs after validating against the latest `workers-sdk` (`@cloudflare/workers-types@4.20260613.1`) and `wrangler generate-types` output.

- Removes `log()`, `readCommit()`, and `readTree()` from the Workers binding reference. These methods do not exist on the `ArtifactsRepo` type in the latest runtime types; repo content reads are available through the REST API or a Git client.
- Documents the `tokenExpiresAt` field returned by `create()` and `import()`, and the `total` field returned by `list()`.
- Adds an `ArtifactsError` section explaining how binding errors correlate with REST API error codes.
- Fixes table formatting in the limits page and adds a cross-link from the Wrangler commands reference to the dedicated Artifacts Wrangler commands guide.

No visual changes.

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
