### PR TITLE
Fix R2 metrics markdown tables

### DIFF
--- a/src/content/docs/r2/platform/metrics-analytics.mdx
+++ b/src/content/docs/r2/platform/metrics-analytics.mdx
@@ -6,7 +6,7 @@ products:
   - r2
 ---
 
-import { DashButton } from "~/components"
+import { DashButton } from "~/components";
 
 R2 exposes analytics that allow you to inspect the requests and storage of the buckets in your account.
 
@@ -16,32 +16,32 @@ The metrics displayed for a bucket in the [Cloudflare dashboard](https://dash.cl
 
 R2 currently has two datasets:
 
-| <div style="width:100px">Dataset </div> | <div style="width:235px">GraphQL Dataset Name </div> | Description                                                          |
-| --------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
-| Operations                              | `r2OperationsAdaptiveGroups`                         | This dataset consists of the operations taken on a bucket within an account. |
-| Storage                                 | `r2StorageAdaptiveGroups`                            | This dataset consists of the storage of a bucket within an account.          |
+| Dataset    | GraphQL Dataset Name         | Description                                                                  |
+| ---------- | ---------------------------- | ---------------------------------------------------------------------------- |
+| Operations | `r2OperationsAdaptiveGroups` | This dataset consists of the operations taken on a bucket within an account. |
+| Storage    | `r2StorageAdaptiveGroups`    | This dataset consists of the storage of a bucket within an account.          |
 
 ### Operations Dataset
 
-| <div style="width:175px"> Field </div> | Description                                                                                                                                                                                                                 |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| actionType                             | The name of the operation performed.                                                                                                                                                                                        |
-| actionStatus                           | The status of the operation. Can be `success`, `userError`, or `internalError`.                                                                                                                                             |
-| bucketName                             | The bucket this operation was performed on if applicable. For buckets with a jurisdiction specified, you must include the jurisdiction followed by an underscore before the bucket name. For example: `eu_your-bucket-name` |
-| objectName                             | The object this operation was performed on if applicable.                                                                                                                                                                   |
-| responseStatusCode                     | The http status code returned by this operation.                                                                                                                                                                            |
-| datetime                               | The time of the request.                                                                                                                                                                                                    |
+| Field              | Description                                                                                                                                                                                                                 |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| actionType         | The name of the operation performed.                                                                                                                                                                                        |
+| actionStatus       | The status of the operation. Can be `success`, `userError`, or `internalError`.                                                                                                                                             |
+| bucketName         | The bucket this operation was performed on if applicable. For buckets with a jurisdiction specified, you must include the jurisdiction followed by an underscore before the bucket name. For example: `eu_your-bucket-name` |
+| objectName         | The object this operation was performed on if applicable.                                                                                                                                                                   |
+| responseStatusCode | The http status code returned by this operation.                                                                                                                                                                            |
+| datetime           | The time of the request.                                                                                                                                                                                                    |
 
 ### Storage Dataset
 
-| <div style="width:175px"> Field </div> | Description                                                                                                                                                                                                                                                                                          |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| bucketName                             | The bucket this storage value is for. For buckets with a jurisdiction specified, you must include the [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) followed by an underscore before the bucket name. For example: `eu_your-bucket-name` |
-| payloadSize                            | The size of the objects in the bucket.                                                                                                                                                                                                                                                               |
-| metadataSize                           | The size of the metadata of the objects in the bucket.                                                                                                                                                                                                                                               |
-| objectCount                            | The number of objects in the bucket.                                                                                                                                                                                                                                                                 |
-| uploadCount                            | The number of pending multipart uploads in the bucket.                                                                                                                                                                                                                                               |
-| datetime                               | The time that this storage value represents.                                                                                                                                                                                                                                                         |
+| Field        | Description                                                                                                                                                                                                                                                                                          |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| bucketName   | The bucket this storage value is for. For buckets with a jurisdiction specified, you must include the [jurisdiction](https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions) followed by an underscore before the bucket name. For example: `eu_your-bucket-name` |
+| payloadSize  | The size of the objects in the bucket.                                                                                                                                                                                                                                                               |
+| metadataSize | The size of the metadata of the objects in the bucket.                                                                                                                                                                                                                                               |
+| objectCount  | The number of objects in the bucket.                                                                                                                                                                                                                                                                 |
+| uploadCount  | The number of pending multipart uploads in the bucket.                                                                                                                                                                                                                                               |
+| datetime     | The time that this storage value represents.                                                                                                                                                                                                                                                         |
 
 Metrics can be queried (and are retained) for the past 31 days. These datasets require an `accountTag` filter with your Cloudflare account ID.
 
@@ -58,6 +58,7 @@ Per-bucket analytics for R2 are available in the Cloudflare dashboard. To view c
 1. In the Cloudflare dashboard, go to the **R2 object storage** page.
 
    <DashButton url="/?to=/:account/r2/overview" />
+
 2. Select your bucket.
 3. Select the **Metrics** tab.
 


### PR DESCRIPTION
## Summary
- remove inline HTML `div` wrappers from R2 metrics markdown table headers
- let Prettier normalize the affected MDX table formatting

Closes #31310.

## Verification
- `git diff --check`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm exec prettier --check src/content/docs/r2/platform/metrics-analytics.mdx`
- custom Node assertion: no `<div style=...>` table headers remain in the R2 metrics page
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm exec astro check` (0 errors; existing hints only)