### PR TITLE
[Cloudflare Tunnel] Remove winget as suggested installation method

### DIFF
--- a/src/content/partials/cloudflare-one/tunnel/downloads.mdx
+++ b/src/content/partials/cloudflare-one/tunnel/downloads.mdx
@@ -36,17 +36,12 @@ Alternatively, download the [latest Darwin arm64 release](https://github.com/clo
 
 ### Windows
 
-Download and install `cloudflared` via [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
-
-```bash
-winget install --id Cloudflare.cloudflared
-```
-
-Alternatively, download the latest release directly:
+Download the latest release from [GitHub](https://github.com/cloudflare/cloudflared/releases/latest):
 
 | Type       | 32-bit                                                                                                     | 64-bit                                                                                                       |
 | ---------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Executable | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-386.exe) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.exe) |
+| MSI        | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-386.msi) | [Download](https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-windows-amd64.msi) |
 
 :::note
 


### PR DESCRIPTION
### Summary

Winget repository is not maintained by us, therefore we shouldn't advertise it as the primary installation method.
