### PR TITLE
Update CODEOWNERS for Turnstile Team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -302,6 +302,7 @@ package.json @cloudflare/content-engineering
 # Turnstile
 
 /src/content/docs/turnstile/ @migueldemoura @punkeel @marinaelmore @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
+/public/turnstile/ @migueldemoura @punkeel @marinaelmore @cloudflare/appsec-reviewers @elithrar @cloudflare/product-owners
 
 # Waiting Room
 


### PR DESCRIPTION
Need to add additional path for Turnstile documentation

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
