### PR TITLE
[Billing] Document default budget alerts and clarify usage-based scope

### DIFF
--- a/src/content/docs/billing/manage/budget-alerts.mdx
+++ b/src/content/docs/billing/manage/budget-alerts.mdx
@@ -20,7 +20,7 @@ Budget alerts are available to Pay-as-you-go accounts only. Enterprise contract 
 
 Cloudflare creates a default budget alert for every eligible Pay-as-you-go account that does not already have one. The default uses a $10 account-level threshold and activates at the turn of your next billing cycle, so it does not fire based on usage you have already incurred.
 
-The default alert behaves exactly like an alert you create yourself. When projected monthly usage-based spend reaches $10, Cloudflare sends an email notification to your account contacts. The alert is informational only. It does not cap your usage or impact your account in any way.
+The default alert behaves exactly like an alert you create yourself. When your cumulative usage-based spend this cycle reaches $10, Cloudflare sends an email notification to your account contacts. The alert is informational only. It does not cap your usage or impact your account in any way.
 
 The threshold only counts spend on usage-based products. Recurring subscription fees, such as the Workers Paid plan fee or other monthly plan charges, are not included in the calculation.
 

--- a/src/content/docs/billing/manage/budget-alerts.mdx
+++ b/src/content/docs/billing/manage/budget-alerts.mdx
@@ -16,6 +16,16 @@ Budget alerts notify you by email when your account-wide usage-based spend cross
 Budget alerts are available to Pay-as-you-go accounts only. Enterprise contract accounts are not supported.
 :::
 
+## Default budget alert
+
+Cloudflare creates a default budget alert for every eligible Pay-as-you-go account that does not already have one. The default uses a $10 account-level threshold and activates at the turn of your next billing cycle, so it does not fire based on usage you have already incurred.
+
+The default alert behaves exactly like an alert you create yourself. When projected monthly usage-based spend reaches $10, Cloudflare sends an email notification to your account contacts. The alert is informational only. It does not cap your usage or impact your account in any way.
+
+The threshold only counts spend on usage-based products. Recurring subscription fees, such as the Workers Paid plan fee or other monthly plan charges, are not included in the calculation.
+
+You can change the threshold, add additional alerts, or delete the default alert at any time using the steps in [View and manage budget alerts](#view-and-manage-budget-alerts). If you already configured your own budget alert, nothing changes.
+
 ## Create a budget alert
 
 <Steps>
@@ -49,9 +59,11 @@ From there you can edit or delete existing alerts.
 ## How budget alerts work
 
 - Budget alerts evaluate your cumulative usage-based spend for the current billing period.
+- Only spend on usage-based products counts toward the threshold. Recurring subscription fees, such as the Workers Paid plan fee or other monthly plan charges, are excluded.
 - When spend crosses the threshold, Cloudflare sends a single email notification to all configured recipients.
 - The alert resets at the start of each new billing period.
 - Budget alerts are informational only. They do not pause or cap usage. Your monthly invoice remains the authoritative source for billing.
+- Default alerts created automatically by Cloudflare behave the same as alerts you create yourself. They can be edited or deleted at any time.
 
 ## Budget alerts compared to usage notifications
 

--- a/src/content/docs/billing/understand/usage-based-billing.mdx
+++ b/src/content/docs/billing/understand/usage-based-billing.mdx
@@ -45,7 +45,7 @@ For a detailed walkthrough of how a single request generates charges across mult
 
 The [billable usage dashboard](/billing/manage/billable-usage/) gives Pay-as-you-go customers daily visibility into usage-based costs. The dashboard shows a daily cost breakdown chart and a per-product usage table with free-tier allowances, so you can see exactly what you are being charged for.
 
-You can also set up [budget alerts](/billing/manage/budget-alerts/) to get notified by email when your account-wide spend crosses a dollar threshold you define.
+Eligible Pay-as-you-go accounts also receive a default [budget alert](/billing/manage/budget-alerts/) automatically. The default uses a $10 account-level threshold and activates at the turn of your next billing cycle. You can change the threshold, add additional alerts, or delete the default alert at any time.
 
 ## Usage-based billing notifications
 


### PR DESCRIPTION
## Summary

Updates the Billing developer docs to cover the default-on Budget alerts release. Adds a "Default budget alert" section to the Budget alerts page, clarifies that alerts only count usage-based spend (not recurring subscription fees like the Workers Paid plan fee), and updates the Usage-based billing page to mention default alerts.

## Companion changelog PR

This is the docs counterpart to the changelog post in PR #31467.

## Changes

### `src/content/docs/billing/manage/budget-alerts.mdx`

- **New section `## Default budget alert`** between the intro and "Create a budget alert." Explains the $10 default threshold, cycle-start activation, that the alert is informational only, and that existing user-set alerts are untouched.
- **Clarifies scope** in the new section and in "How budget alerts work": only spend on usage-based products counts toward the threshold; recurring subscription fees (Workers Paid plan fee, monthly plan charges) are excluded.
- **New bullet** in "How budget alerts work" confirming default alerts behave the same as user-created alerts.

### `src/content/docs/billing/understand/usage-based-billing.mdx`

- **One sentence updated** in "Monitor your usage" to note that eligible accounts now receive a default budget alert automatically, with the $10 threshold and cycle-start activation.

## Validation

- `astro check`: 0 errors, 0 warnings on changed files
- Local preview verified at `/billing/manage/budget-alerts/` and `/billing/understand/usage-based-billing/`

## Review

Per the [docs review process](https://wiki.cfdata.org/spaces/RE/pages/1099945559/Contributing+to+the+changelog), will route for PM review.