### PR TITLE
Clarify that robots.txt is advisory and User-Agent is spoofable

### DIFF
--- a/src/content/docs/browser-run/reference/automatic-request-headers.mdx
+++ b/src/content/docs/browser-run/reference/automatic-request-headers.mdx
@@ -21,7 +21,7 @@ The default User-Agent depends on how you access Browser Run:
 | [CDP](/browser-run/cdp/) ([Puppeteer](/browser-run/puppeteer/), [Playwright](/browser-run/playwright/)) | The default User-Agent of the underlying Chrome version                                                           | Yes, via Puppeteer/Playwright configuration |
 
 :::note
-Because the User-Agent is configurable for most methods and the Chrome version may change as Browser Run updates its underlying browser engine, destination servers should use the non-configurable headers below to identify Browser Run requests rather than relying on the User-Agent string.
+The User-Agent header is not a reliable way to identify Browser Run requests. It is configurable for most Browser Run methods, changes when the underlying Chrome version updates, and any HTTP client can send any User-Agent string. Destination servers should use the [non-configurable headers](#non-configurable-headers) and [Web Bot Auth](#about-web-bot-auth) signatures below, which provide cryptographic proof that a request originated from Cloudflare Browser Run.
 :::
 
 ## Non-configurable headers

--- a/src/content/docs/browser-run/reference/robots-txt.mdx
+++ b/src/content/docs/browser-run/reference/robots-txt.mdx
@@ -10,13 +10,19 @@ products:
 
 This page provides general guidance on configuring `robots.txt` and sitemaps for websites you plan to access with Browser Run.
 
+:::note[robots.txt is advisory, not enforceable]
+The `robots.txt` standard is a voluntary protocol. Only well-behaved bots choose to follow it. Any client can send any User-Agent string, so `robots.txt` rules that target a specific User-Agent cannot prevent a spoofed or malicious client from accessing your site. To enforce access restrictions, use server-side controls such as a web application firewall (WAF), request header validation, or authentication.
+
+To verify that a request originated from Cloudflare Browser Run specifically, use the cryptographic [Web Bot Auth](/browser-run/reference/automatic-request-headers/#about-web-bot-auth) signatures or the [non-configurable headers](/browser-run/reference/automatic-request-headers/#non-configurable-headers) that Cloudflare attaches to every Browser Run request. You can also create [WAF rules](/browser-run/faq/#can-i-allowlist-browser-run-on-my-own-website) using the [bot detection IDs](/browser-run/reference/automatic-request-headers/#bot-detection) to allow or block Browser Run traffic.
+:::
+
 ## Identifying Browser Run requests
 
 Requests can be identified by the [automatic headers](/browser-run/reference/automatic-request-headers/) that Cloudflare attaches:
 
-- [User-Agent](/browser-run/reference/automatic-request-headers/#user-agent) — Each Browser Run method has a different default User-Agent, which you can use to write targeted `robots.txt` rules
-- `cf-brapi-request-id` — Unique identifier for Quick Actions requests
-- `Signature-agent` — Pointer to Cloudflare's bot verification keys
+- [User-Agent](/browser-run/reference/automatic-request-headers/#user-agent): Each Browser Run method has a different default User-Agent, which you can use to write targeted `robots.txt` rules.
+- `cf-brapi-request-id`: Unique identifier for Quick Actions requests.
+- `Signature-agent`: Pointer to Cloudflare's bot verification keys.
 
 To allow or block Browser Run traffic using WAF rules instead of `robots.txt`, use the [bot detection IDs](/browser-run/reference/automatic-request-headers/#bot-detection) on the automatic request headers page.
 

--- a/src/content/docs/browser-run/reference/robots-txt.mdx
+++ b/src/content/docs/browser-run/reference/robots-txt.mdx
@@ -20,9 +20,9 @@ To verify that a request originated from Cloudflare Browser Run specifically, us
 
 Requests can be identified by the [automatic headers](/browser-run/reference/automatic-request-headers/) that Cloudflare attaches:
 
-- [User-Agent](/browser-run/reference/automatic-request-headers/#user-agent): Each Browser Run method has a different default User-Agent, which you can use to write targeted `robots.txt` rules.
-- `cf-brapi-request-id`: Unique identifier for Quick Actions requests.
-- `Signature-agent`: Pointer to Cloudflare's bot verification keys.
+- [User-Agent](/browser-run/reference/automatic-request-headers/#user-agent): Each Browser Run method has a different default User-Agent, which you can use to write targeted `robots.txt` rules
+- `cf-brapi-request-id`: Unique identifier for Quick Actions requests
+- `Signature-agent`: Pointer to Cloudflare's bot verification keys
 
 To allow or block Browser Run traffic using WAF rules instead of `robots.txt`, use the [bot detection IDs](/browser-run/reference/automatic-request-headers/#bot-detection) on the automatic request headers page.
 


### PR DESCRIPTION
- Add note to robots-txt.mdx explaining robots.txt is voluntary and User-Agent is spoofable, with generic enforcement advice (WAF, header validation, auth) and Browser Run-specific verification options
- Strengthen User-Agent note in automatic-request-headers.mdx to explicitly state User-Agent is unreliable and point to Web Bot Auth for cryptographic verification
- Fix em dashes to colons in robots-txt.mdx bullet list

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
