### PR TITLE
feat: add page-entity JSON-LD schema to all docs pages

### DIFF
--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -307,8 +307,9 @@ const _dateModified = _modifiedDate
 	: undefined;
 
 // datePublished: changelog entries only, sourced from the entry's date field.
-const _changelogEntry = Astro.locals.starlightRoute
-	.originalEntry as CollectionEntry<"changelog"> | undefined;
+const _changelogEntry = Astro.locals.starlightRoute.originalEntry as
+	| CollectionEntry<"changelog">
+	| undefined;
 const _datePublished =
 	_isChangelog && _changelogEntry?.data.date
 		? _changelogEntry.data.date.toISOString().slice(0, 10)
@@ -319,9 +320,7 @@ const _jsonLd: Record<string, unknown> = {
 	"@type": schemaType,
 	"@id": `${_canonicalUrl}#page`,
 	headline: _headline,
-	...(frontmatter.description
-		? { description: frontmatter.description }
-		: {}),
+	...(frontmatter.description ? { description: frontmatter.description } : {}),
 	url: _canonicalUrl,
 	inLanguage: "en",
 	image: ogImageUrl,
@@ -347,7 +346,13 @@ const _jsonLd: Record<string, unknown> = {
 <script src="src/scripts/analytics.ts"></script>
 <script src="src/scripts/explain-code.ts"></script>
 <script src="src/scripts/webmcp.ts"></script>
-{!shouldNoIndex && (
-	<script is:inline type="application/ld+json" set:html={JSON.stringify(_jsonLd)} />
-)}
+{
+	!shouldNoIndex && (
+		<script
+			is:inline
+			type="application/ld+json"
+			set:html={JSON.stringify(_jsonLd)}
+		/>
+	)
+}
 <Default><slot /></Default>

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -270,6 +270,76 @@ metaTags.map((attrs) => {
 		attrs,
 	});
 });
+
+// --- Page-entity JSON-LD ---
+// Map pcx_content_type to schema.org @type.
+// changelog / changelog-entry → BlogPosting
+// navigation / overview / reference-architecture-diagram → WebPage
+// everything else (including unset) → TechArticle
+const _contentType = frontmatter.pcx_content_type ?? "";
+const _isChangelog =
+	_contentType === "changelog" ||
+	_contentType === "changelog-entry" ||
+	currentSection === "changelog";
+const _isWebPage =
+	_contentType === "navigation" ||
+	_contentType === "overview" ||
+	_contentType === "reference-architecture-diagram";
+const schemaType = _isChangelog
+	? "BlogPosting"
+	: _isWebPage
+		? "WebPage"
+		: "TechArticle";
+
+// Canonical URL for the page entity.
+const _canonicalUrl = frontmatter.canonical
+	? new URL(frontmatter.canonical, Astro.site).toString()
+	: new URL(Astro.url.pathname, Astro.site).toString();
+
+// Prefer the enriched title already computed for the <title> tag.
+const _titleTag = head.find((x) => x.tag === "title");
+const _headline = _titleTag?.content ?? frontmatter.title;
+
+// dateModified: prefer git last-updated, fall back to manually reviewed date.
+const _modifiedDate = lastUpdated ?? frontmatter.reviewed;
+const _dateModified = _modifiedDate
+	? _modifiedDate.toISOString().slice(0, 10)
+	: undefined;
+
+// datePublished: changelog entries only, sourced from the entry's date field.
+const _changelogEntry = Astro.locals.starlightRoute
+	.originalEntry as CollectionEntry<"changelog"> | undefined;
+const _datePublished =
+	_isChangelog && _changelogEntry?.data.date
+		? _changelogEntry.data.date.toISOString().slice(0, 10)
+		: undefined;
+
+const _jsonLd: Record<string, unknown> = {
+	"@context": "https://schema.org",
+	"@type": schemaType,
+	"@id": `${_canonicalUrl}#page`,
+	headline: _headline,
+	...(frontmatter.description
+		? { description: frontmatter.description }
+		: {}),
+	url: _canonicalUrl,
+	inLanguage: "en",
+	image: ogImageUrl,
+	...(_dateModified ? { dateModified: _dateModified } : {}),
+	...(_datePublished ? { datePublished: _datePublished } : {}),
+	publisher: {
+		"@type": "Organization",
+		name: "Cloudflare",
+		url: "https://www.cloudflare.com/",
+	},
+	isPartOf: {
+		"@type": "WebSite",
+		"@id": "https://developers.cloudflare.com/#website",
+		name: "Cloudflare Docs",
+		url: "https://developers.cloudflare.com/",
+	},
+	...(frontmatter.tags?.length ? { keywords: frontmatter.tags } : {}),
+};
 ---
 
 <script src="src/scripts/footnotes.ts"></script>
@@ -277,4 +347,7 @@ metaTags.map((attrs) => {
 <script src="src/scripts/analytics.ts"></script>
 <script src="src/scripts/explain-code.ts"></script>
 <script src="src/scripts/webmcp.ts"></script>
+{!shouldNoIndex && (
+	<script is:inline type="application/ld+json" set:html={JSON.stringify(_jsonLd)} />
+)}
 <Default><slot /></Default>

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -351,7 +351,10 @@ const _jsonLd: Record<string, unknown> = {
 		<script
 			is:inline
 			type="application/ld+json"
-			set:html={JSON.stringify(_jsonLd)}
+			set:html={
+				// Escape < to prevent </script> in user content from closing the tag.
+				JSON.stringify(_jsonLd).replace(/</g, "\\u003c")
+			}
 		/>
 	)
 }


### PR DESCRIPTION
### Summary

Adds a page-entity `<script type="application/ld+json">` block to `Head.astro` alongside the existing `BreadcrumbList` JSON-LD emitted by `astro-breadcrumbs`. Currently, structured data coverage on Cloudflare Docs is navigation-only — every page has a `BreadcrumbList` but zero pages have a page-entity schema. This means machines can locate pages in the docs hierarchy but cannot classify what a page is about.

The new schema block emits a `TechArticle`, `BlogPosting`, or `WebPage` entity (mapped from `pcx_content_type`) with the following fields sourced from data already available in `Head.astro`:

| Field | Source |
|---|---|
| `@type` | `pcx_content_type` → `TechArticle` / `BlogPosting` / `WebPage` |
| `headline` | Enriched `<title>` tag content (e.g. `"CLI · Cloudflare Workers docs"`) |
| `description` | `frontmatter.description` |
| `url` / `@id` | `Astro.site + Astro.url.pathname` (or `frontmatter.canonical`) |
| `inLanguage` | `"en"` (static) |
| `image` | OG image URL (already computed) |
| `dateModified` | `lastUpdated` (git) or `frontmatter.reviewed` as fallback |
| `datePublished` | Changelog `date` field only |
| `publisher` | Static Cloudflare organization |
| `isPartOf` | Static `WebSite` entity for `developers.cloudflare.com` |
| `keywords` | `frontmatter.tags` (when present) |

Noindexed pages are excluded. The existing `BreadcrumbList` is untouched.
