### PR TITLE
[AI Gateway] Document account-scoped API token limitation

### DIFF
--- a/src/content/docs/ai-gateway/configuration/authentication.mdx
+++ b/src/content/docs/ai-gateway/configuration/authentication.mdx
@@ -26,6 +26,14 @@ The `cf-aig-authorization` header is used with the `gateway.ai.cloudflare.com` e
    - If using [provider-native endpoints](/ai-gateway/usage/providers/) at `gateway.ai.cloudflare.com`, use the `cf-aig-authorization` header.
 4. Return to the settings page and toggle on Authenticated Gateway.
 
+:::caution[AI Gateway API tokens are account-scoped]
+The `AI Gateway Read`, `Run`, and `Write` permissions cannot be restricted to a single gateway — unlike R2, which supports per-bucket scoping. Any token with `AI Gateway Run` can call every gateway in the account and spend through any [BYOK](/ai-gateway/configuration/bring-your-own-keys/) budget.
+
+For isolation between gateways or tenants, use separate Cloudflare accounts or a Worker-side [AI Gateway binding](/ai-gateway/integrations/aig-workers-ai-binding/) rather than relying on token scope.
+
+Per-gateway token scoping is tracked as a [feature request](https://community.cloudflare.com/t/scope-api-tokens-to-a-specific-ai-gateway-matching-the-per-bucket-scoping-r2-alrea/930329).
+:::
+
 ## Example requests
 
 ```bash

--- a/src/content/docs/ai-gateway/configuration/authentication.mdx
+++ b/src/content/docs/ai-gateway/configuration/authentication.mdx
@@ -27,7 +27,7 @@ The `cf-aig-authorization` header is used with the `gateway.ai.cloudflare.com` e
 4. Return to the settings page and toggle on Authenticated Gateway.
 
 :::caution[AI Gateway API tokens are account-scoped]
-The `AI Gateway Read`, `Run`, and `Write` permissions cannot be restricted to a single gateway — unlike R2, which supports per-bucket scoping. Any token with `AI Gateway Run` can call every gateway in the account and spend through any [BYOK](/ai-gateway/configuration/bring-your-own-keys/) budget.
+The `AI Gateway Read`, `Run`, and `Edit` permissions cannot be restricted to a single gateway — unlike R2, which supports per-bucket scoping. Any token with `AI Gateway Run` can send requests through every gateway in the account, including any configured with stored provider keys through [Bring Your Own Keys (BYOK)](/ai-gateway/configuration/bring-your-own-keys/), consuming those credentials.
 
 For isolation between gateways or tenants, use separate Cloudflare accounts or a Worker-side [AI Gateway binding](/ai-gateway/integrations/aig-workers-ai-binding/) rather than relying on token scope.
 

--- a/src/content/docs/ai-gateway/configuration/authentication.mdx
+++ b/src/content/docs/ai-gateway/configuration/authentication.mdx
@@ -30,8 +30,6 @@ The `cf-aig-authorization` header is used with the `gateway.ai.cloudflare.com` e
 The `AI Gateway Read`, `Run`, and `Edit` permissions cannot be restricted to a single gateway — unlike R2, which supports per-bucket scoping. Any token with `AI Gateway Run` can send requests through every gateway in the account, including any configured with stored provider keys through [Bring Your Own Keys (BYOK)](/ai-gateway/configuration/bring-your-own-keys/), consuming those credentials.
 
 For isolation between gateways or tenants, use separate Cloudflare accounts or a Worker-side [AI Gateway binding](/ai-gateway/integrations/aig-workers-ai-binding/) rather than relying on token scope.
-
-Per-gateway token scoping is tracked as a [feature request](https://community.cloudflare.com/t/scope-api-tokens-to-a-specific-ai-gateway-matching-the-per-bucket-scoping-r2-alrea/930329).
 :::
 
 ## Example requests

--- a/src/content/docs/fundamentals/api/reference/permissions.mdx
+++ b/src/content/docs/fundamentals/api/reference/permissions.mdx
@@ -48,7 +48,7 @@ The applicable scope of user permissions is `com.cloudflare.api.user`.
 The applicable scope of account permissions is `com.cloudflare.api.account`.
 
 :::note
-The `AI Gateway Read`, `Run`, and `Write` permissions are account-scoped only — they cannot be restricted to a single gateway. For details, refer to [Authenticated Gateway](/ai-gateway/configuration/authentication/).
+The `AI Gateway Read`, `Run`, and `Edit` permissions are account-scoped only — they cannot be restricted to a single gateway. For details, refer to [Authenticated Gateway](/ai-gateway/configuration/authentication/).
 :::
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">

--- a/src/content/docs/fundamentals/api/reference/permissions.mdx
+++ b/src/content/docs/fundamentals/api/reference/permissions.mdx
@@ -47,6 +47,10 @@ The applicable scope of user permissions is `com.cloudflare.api.user`.
 
 The applicable scope of account permissions is `com.cloudflare.api.account`.
 
+:::note
+The `AI Gateway Read`, `Run`, and `Write` permissions are account-scoped only — they cannot be restricted to a single gateway. For details, refer to [Authenticated Gateway](/ai-gateway/configuration/authentication/).
+:::
+
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
 <Render


### PR DESCRIPTION
## Summary

Documents that AI Gateway API token permissions (`AI Gateway Read`, `Run`, `Write`) are **account-scoped only** — they cannot be restricted to a single gateway, unlike R2's per-bucket scoping. This means any token with `AI Gateway Run` can call every gateway in the account and spend through any BYOK budget.

Verified against the live IAM permission catalog: all three AI Gateway permission groups are scoped to `com.cloudflare.api.account`, with no per-gateway resource type, whereas R2 exposes `com.cloudflare.edge.r2.bucket`.

## Changes

- **AI Gateway → Authenticated Gateway**: adds a `:::caution` aside after the token-creation steps explaining the account-scope limitation, the BYOK blast-radius consequence, and isolation alternatives (separate accounts or a Worker-side AI Gateway binding).
- **Fundamentals → API token permissions**: adds a short `:::note` in the Account permissions section pointing to the Authenticated Gateway page for details.

Both call-outs link the tracked [feature request](https://community.cloudflare.com/t/scope-api-tokens-to-a-specific-ai-gateway-matching-the-per-bucket-scoping-r2-alrea/930329) for per-gateway scoping.

Closes #31339