### PR TITLE
[Workflows] Document rollback step options

### DIFF
--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -10,7 +10,6 @@ date: 2026-06-16 15:00:00 UTC
 
 The [step configuration](/workflows/build/workers-api/#workflowstepconfig) contains the resolved retry and timeout configurations, so you can customize your compensating logic according to any of these fields.
 
-This is useful when a Workflow coordinates external side effects, such as payments, inventory reservations, user provisioning, or infrastructure changes, and needs to undo earlier work safely after a later step fails.
 
 
 

--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -12,7 +12,6 @@ The [step configuration](/workflows/build/workers-api/#workflowstepconfig) conta
 
 This is useful when a Workflow coordinates external side effects, such as payments, inventory reservations, user provisioning, or infrastructure changes, and needs to undo earlier work safely after a later step fails.
 
-The `rollback` handler now receives a `ctx` object with the original step context, including `ctx.step.name`, `ctx.step.count`, `ctx.attempt`, and the resolved step `config`.
 
 `rollbackConfig` is now limited to retry and timeout settings, matching the behavior supported by rollback handlers.
 

--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -19,14 +19,15 @@ await step.do(
 	},
 	{
 		rollback: async ({ ctx, output, error }) => {
-			// Use the original step output to undo work in the external system.
+			// `output` is the value returned by the step being rolled back.
 			const { chargeId } = output as { chargeId: string };
 			await refundCharge(chargeId, {
-				// Add the source step to logs or audit records for this recovery action.
+				// `ctx` is the original step context, including step name, count, attempt, and config.
 				reason: `${ctx.step.name}: ${error.message}`,
 			});
 		},
 		rollbackConfig: {
+			// `rollbackConfig` controls retries and timeout for the rollback handler.
 			retries: { limit: 3, delay: "30 seconds", backoff: "linear" },
 			timeout: "5 minutes",
 		},

--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -19,8 +19,10 @@ await step.do(
 	},
 	{
 		rollback: async ({ ctx, output, error }) => {
+			// Use the original step output to undo work in the external system.
 			const { chargeId } = output as { chargeId: string };
 			await refundCharge(chargeId, {
+				// Add the source step to logs or audit records for this recovery action.
 				reason: `${ctx.step.name}: ${error.message}`,
 			});
 		},

--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -3,7 +3,7 @@ title: Workflows rollback handlers now include step context
 description: Workflows rollback handlers now receive the original step context, and rollbackConfig is limited to retry and timeout settings.
 products:
   - workflows
-date: 2026-06-16 15:00:00 UTC
+date: 2026-06-23 12:00:00 UTC
 ---
 
 [Workflows](/workflows/) makes it easier to build reliable multi-step applications that can recover when downstream systems fail. Rollback handlers now receive the original [step context](/workflows/build/step-context/) via a `ctx` object for the step being rolled back. This includes `ctx.step.name`, `ctx.step.count`, `ctx.attempt`, and the step `config` with defaults applied.

--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -13,7 +13,6 @@ The [step configuration](/workflows/build/workers-api/#workflowstepconfig) conta
 This is useful when a Workflow coordinates external side effects, such as payments, inventory reservations, user provisioning, or infrastructure changes, and needs to undo earlier work safely after a later step fails.
 
 
-`rollbackConfig` is now limited to retry and timeout settings, matching the behavior supported by rollback handlers.
 
 ```ts
 await step.do(

--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -6,12 +6,9 @@ products:
 date: 2026-06-16 15:00:00 UTC
 ---
 
-[Workflows](/workflows/) makes it easier to build reliable multi-step applications that can recover when downstream systems fail. Rollback handlers now receive the original [step context](/workflows/build/step-context/) via a `ctx` object for the step being rolled back. This includes `ctx.step.name`, `ctx.step.count`, `ctx.attempt`, and the resolved step `config`. 
+[Workflows](/workflows/) makes it easier to build reliable multi-step applications that can recover when downstream systems fail. Rollback handlers now receive the original [step context](/workflows/build/step-context/) via a `ctx` object for the step being rolled back. This includes `ctx.step.name`, `ctx.step.count`, `ctx.attempt`, and the step `config` with defaults applied.
 
-The [step configuration](/workflows/build/workers-api/#workflowstepconfig) contains the resolved retry and timeout configurations, so you can customize your compensating logic according to any of these fields.
-
-
-
+The [step configuration](/workflows/build/workers-api/#workflowstepconfig) includes the retry and timeout settings used for that step, so you can customize your step recovery logic according to those fields.
 
 ```ts
 await step.do(

--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -1,0 +1,39 @@
+---
+title: Workflows rollback handlers now include step context
+description: Workflows rollback handlers now receive the original step context, and rollbackConfig is limited to retry and timeout settings.
+products:
+  - workflows
+date: 2026-06-16 15:00:00 UTC
+---
+
+[Workflows](/workflows/) makes it easier to build reliable multi-step applications that can recover when downstream systems fail. Rollback handlers now receive the original step context for the step being rolled back, so you can write compensating logic that knows which step failed, which attempt ran, and which retry or timeout configuration applied.
+
+This is useful when a Workflow coordinates external side effects, such as payments, inventory reservations, user provisioning, or infrastructure changes, and needs to undo earlier work safely after a later step fails.
+
+The `rollback` handler now receives a `ctx` object with the original step context, including `ctx.step.name`, `ctx.step.count`, `ctx.attempt`, and the resolved step `config`.
+
+`rollbackConfig` is now limited to retry and timeout settings, matching the behavior supported by rollback handlers.
+
+```ts
+await step.do(
+	"create charge",
+	async () => {
+		const charge = await createCharge();
+		return { chargeId: charge.id };
+	},
+	{
+		rollback: async ({ ctx, output, error }) => {
+			const { chargeId } = output as { chargeId: string };
+			await refundCharge(chargeId, {
+				reason: `${ctx.step.name}: ${error.message}`,
+			});
+		},
+		rollbackConfig: {
+			retries: { limit: 3, delay: "30 seconds", backoff: "linear" },
+			timeout: "5 minutes",
+		},
+	},
+);
+```
+
+Refer to [rollback options](/workflows/build/workers-api/#rollback-options) to learn more.

--- a/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
+++ b/src/content/changelog/workflows/2026-06-16-rollback-options.mdx
@@ -6,7 +6,9 @@ products:
 date: 2026-06-16 15:00:00 UTC
 ---
 
-[Workflows](/workflows/) makes it easier to build reliable multi-step applications that can recover when downstream systems fail. Rollback handlers now receive the original step context for the step being rolled back, so you can write compensating logic that knows which step failed, which attempt ran, and which retry or timeout configuration applied.
+[Workflows](/workflows/) makes it easier to build reliable multi-step applications that can recover when downstream systems fail. Rollback handlers now receive the original [step context](/workflows/build/step-context/) via a `ctx` object for the step being rolled back. This includes `ctx.step.name`, `ctx.step.count`, `ctx.attempt`, and the resolved step `config`. 
+
+The [step configuration](/workflows/build/workers-api/#workflowstepconfig) contains the resolved retry and timeout configurations, so you can customize your compensating logic according to any of these fields.
 
 This is useful when a Workflow coordinates external side effects, such as payments, inventory reservations, user provisioning, or infrastructure changes, and needs to undo earlier work safely after a later step fails.
 

--- a/src/content/docs/workflows/build/workers-api.mdx
+++ b/src/content/docs/workflows/build/workers-api.mdx
@@ -90,18 +90,18 @@ Refer to the [events and parameters](/workflows/build/events-and-parameters/) do
 
 {/* prettier-ignore */}
 - <code>step.do(name: string, callback: (ctx: WorkflowStepContext): RpcSerializable): Promise&lt;T&gt;</code>
-- <code>step.do(name: string, callback: (ctx: WorkflowStepContext): RpcSerializable, options?: RollbackOptions): Promise&lt;T&gt;</code>
+- <code>step.do(name: string, callback: (ctx: WorkflowStepContext): RpcSerializable, rollbackOptions?: WorkflowStepRollbackOptions&lt;T&gt;): Promise&lt;T&gt;</code>
 - <code>step.do(name: string, config?: WorkflowStepConfig, callback: (ctx: WorkflowStepContext):
 	RpcSerializable): Promise&lt;T&gt;</code>
 	- `name` - the name of the step, up to 256 characters.
 	- `config` (optional) - an optional `WorkflowStepConfig` for configuring [step specific retry behaviour](/workflows/build/sleeping-and-retrying/).
 	- `callback` - an asynchronous function that receives a [`WorkflowStepContext`](/workflows/build/step-context/) and optionally returns serializable state for the Workflow to persist. In JavaScript Workflows, this includes a fresh, unlocked `ReadableStream<Uint8Array>` for large binary output.
 - <code>step.do(name: string, config?: WorkflowStepConfig, callback: (ctx: WorkflowStepContext):
-	RpcSerializable, options?: RollbackOptions): Promise&lt;T&gt;</code>
+	RpcSerializable, rollbackOptions?: WorkflowStepRollbackOptions&lt;T&gt;): Promise&lt;T&gt;</code>
 	- `name` - the name of the step, up to 256 characters.
 	- `config` (optional) - an optional `WorkflowStepConfig` for configuring [step specific retry behaviour](/workflows/build/sleeping-and-retrying/).
 	- `callback` - an asynchronous function that receives a [`WorkflowStepContext`](/workflows/build/step-context/) and optionally returns serializable state for the Workflow to persist. In JavaScript Workflows, this includes a fresh, unlocked `ReadableStream<Uint8Array>` for large binary output.
-	- `options` (optional) - register rollback logic for the step. If the Workflow later fails, registered rollbacks run in reverse completion order.
+	- `rollbackOptions` (optional) - register rollback logic for the step. If the Workflow later fails, registered rollbacks run in reverse step-start order.
 
 :::note[Returning state]
 
@@ -214,21 +214,29 @@ Refer to the [documentation on sleeping and retrying](/workflows/build/sleeping-
 ## Rollback options
 
 ```ts
-type RollbackContext = {
+type WorkflowRollbackContext<T = unknown> = {
+	ctx: WorkflowStepContext;
 	error: Error;
-	output: unknown | undefined;
+	output: T | undefined;
 };
 
-type RollbackFn = (ctx: RollbackContext) => Promise<void>;
+type WorkflowRollbackHandler<T = unknown> = (
+	ctx: WorkflowRollbackContext<T>,
+) => Promise<void>;
 
-type RollbackOptions = {
-	rollback: RollbackFn;
-	rollbackConfig?: WorkflowStepConfig;
+type WorkflowStepRollbackConfig = Pick<
+	WorkflowStepConfig,
+	"retries" | "timeout"
+>;
+
+type WorkflowStepRollbackOptions<T = unknown> = {
+	rollback: WorkflowRollbackHandler<T>;
+	rollbackConfig?: WorkflowStepRollbackConfig;
 };
 ```
 
-- Pass this `RollbackOptions` object as the final argument to `step.do()` to register a compensating action for a successful step.
-- `rollback` receives the error that caused the Workflow to fail and the step output returned by the forward step.
+- Pass this `WorkflowStepRollbackOptions` object as the final argument to `step.do()` to register a compensating action for a successful step.
+- `rollback` receives the original step context, the error that caused the Workflow to fail, and the step output returned by the forward step.
 - `rollbackConfig` applies retry and timeout settings to the rollback handler itself.
 
 <TypeScriptExample>
@@ -243,9 +251,11 @@ export class BillingWorkflow extends WorkflowEntrypoint<Env> {
 				return { chargeId: charge.id };
 			},
 			{
-				rollback: async ({ output, error }) => {
+				rollback: async ({ ctx, output, error }) => {
 					const { chargeId } = output as { chargeId: string };
-					await refundCharge(chargeId, { reason: error.message });
+					await refundCharge(chargeId, {
+						reason: `${ctx.step.name}: ${error.message}`,
+					});
 				},
 				rollbackConfig: {
 					retries: {


### PR DESCRIPTION
### Summary

Updates the Workflows Workers API reference for `step.do()` rollback options.

This clarifies that rollback options are passed as the final `step.do()` argument, that the options object must include a `rollback` handler, that rollback handlers receive the original step context and that `rollbackConfig` only supports retry and timeout configuration.

Also adds a Workflows changelog entry for the rollback context and `rollbackConfig` update.

### Screenshots (optional)

N/A

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).