### PR TITLE
Add Origin Analytics cross-references to HTTP error articles and slow website guide

### DIFF
--- a/src/content/dash-routes/core-manually-defined.json
+++ b/src/content/dash-routes/core-manually-defined.json
@@ -2,36 +2,58 @@
 	{
 		"deeplink": "/?to=/:account/tunnels",
 		"name": "Tunnels",
-		"parent": ["Networking"]
+		"parent": [
+			"Networking"
+		]
 	},
 	{
 		"deeplink": "/?to=/:account/data-catalog/overview",
 		"name": "R2 Data Catalog",
-		"parent": ["Storage & databases", "R2 object storage"]
+		"parent": [
+			"Storage & databases",
+			"R2 object storage"
+		]
 	},
 	{
 		"name": "Browser Run",
 		"deeplink": "/?to=/:account/workers/browser-run",
-		"parent": ["Compute & AI"]
+		"parent": [
+			"Compute & AI"
+		]
 	},
 	{
 		"deeplink": "/?to=/:account/workers/browser-run/logs",
 		"name": "Browser Run Logs",
-		"parent": ["Compute & AI"]
+		"parent": [
+			"Compute & AI"
+		]
 	},
 	{
 		"deeplink": "/?to=/:account/workers/browser-run/runs",
 		"name": "Browser Run Runs",
-		"parent": ["Compute & AI"]
+		"parent": [
+			"Compute & AI"
+		]
 	},
 	{
 		"deeplink": "/?to=/:account/mesh",
 		"name": "Mesh",
-		"parent": ["Networking"]
+		"parent": [
+			"Networking"
+		]
 	},
 	{
 		"deeplink": "/?to=/:account/domains/registrations",
 		"name": "Registrations",
-		"parent": ["Domain registration"]
+		"parent": [
+			"Domain registration"
+		]
+	},
+	{
+		"deeplink": "/?to=/:account/:zone/speed/origin-analytics",
+		"name": "Origin Analytics",
+		"parent": [
+			"Speed"
+		]
 	}
 ]

--- a/src/content/dash-routes/core-manually-defined.json
+++ b/src/content/dash-routes/core-manually-defined.json
@@ -2,58 +2,41 @@
 	{
 		"deeplink": "/?to=/:account/tunnels",
 		"name": "Tunnels",
-		"parent": [
-			"Networking"
-		]
+		"parent": ["Networking"]
 	},
 	{
 		"deeplink": "/?to=/:account/data-catalog/overview",
 		"name": "R2 Data Catalog",
-		"parent": [
-			"Storage & databases",
-			"R2 object storage"
-		]
+		"parent": ["Storage & databases", "R2 object storage"]
 	},
 	{
 		"name": "Browser Run",
 		"deeplink": "/?to=/:account/workers/browser-run",
-		"parent": [
-			"Compute & AI"
-		]
+		"parent": ["Compute & AI"]
 	},
 	{
 		"deeplink": "/?to=/:account/workers/browser-run/logs",
 		"name": "Browser Run Logs",
-		"parent": [
-			"Compute & AI"
-		]
+		"parent": ["Compute & AI"]
 	},
 	{
 		"deeplink": "/?to=/:account/workers/browser-run/runs",
 		"name": "Browser Run Runs",
-		"parent": [
-			"Compute & AI"
-		]
+		"parent": ["Compute & AI"]
 	},
 	{
 		"deeplink": "/?to=/:account/mesh",
 		"name": "Mesh",
-		"parent": [
-			"Networking"
-		]
+		"parent": ["Networking"]
 	},
 	{
 		"deeplink": "/?to=/:account/domains/registrations",
 		"name": "Registrations",
-		"parent": [
-			"Domain registration"
-		]
+		"parent": ["Domain registration"]
 	},
 	{
 		"deeplink": "/?to=/:account/:zone/speed/origin-analytics",
 		"name": "Origin Analytics",
-		"parent": [
-			"Speed"
-		]
+		"parent": ["Speed"]
 	}
 ]

--- a/src/content/docs/speed/troubleshooting/slow-website.mdx
+++ b/src/content/docs/speed/troubleshooting/slow-website.mdx
@@ -149,6 +149,8 @@ If your website is slow, the issue may be at your origin server. Use Origin Anal
 In the Cloudflare dashboard:
 
 1. Go to **Speed** > **Origin Analytics**.
+
+   <DashButton url="/?to=/:account/:zone/speed/origin-analytics" />
 2. Review the **Origin Response Time** metrics.
 3. Look for patterns in slow responses (specific paths, times of day, or geographic regions).
 
@@ -156,6 +158,8 @@ High origin response times indicate your origin server is struggling. Consider:
 - Upgrading your hosting plan
 - Optimizing database queries
 - Implementing server-side caching
+
+For a full guide on available metrics, diagnostic flows, and how to interpret origin status codes, refer to [Origin Analytics](/speed/origin-analytics/).
 
 ### Check for slow Workers
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-499.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-499.mdx
@@ -36,3 +36,7 @@ Depending on the client-side timeout settings, the following scenarios can occur
 - **Shorter client timeout (less than 38 seconds)**: If the client has a shorter timeout, it will abandon the connection before Cloudflare completes processing, and a `499` response code will be logged.
 - **Successful connection (more than 38 seconds)**: If the client has a longer timeout and the TCP connection is successfully established, the HTTP transaction proceeds normally, and Cloudflare returns a standard status code (`HTTP 200`).
 - **Handshake failure**: If the client has a longer timeout but Cloudflare cannot establish the TCP handshake with the origin server, Cloudflare will return an `HTTP 522` status code.
+
+### Diagnose with Origin Analytics
+
+Use [Origin Analytics](/speed/origin-analytics/) to check whether slow origin response times are causing clients to close connections prematurely. If P95 origin response times are high, identify the slow endpoints in the **Top endpoints** table and optimize them to reduce `499` errors.

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520.mdx
@@ -69,3 +69,6 @@ Do not conclude your origin returned a 5xx error solely because `OriginResponseS
 
 :::
 
+## Diagnose with Origin Analytics
+
+Use [Origin Analytics](/speed/origin-analytics/) to compare what your origin returned (`originResponseStatus`) with what Cloudflare served to the end user (`edgeResponseStatus`). If your origin returned a `200` but Cloudflare served a `520`, the response was likely malformed — for example, oversized headers or an early connection close. The **Top endpoints** table can help you identify which paths are producing `520` errors.

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522.mdx
@@ -38,3 +38,7 @@ Two different timeouts cause HTTP error `522` depending on when they occur betwe
 
   - An [MTR or traceroute](/support/troubleshooting/general-troubleshooting/gathering-information-for-troubleshooting-sites/#perform-a-traceroute) from your origin web server to a [Cloudflare IP address](http://www.cloudflare.com/ips) that most commonly connected to your origin web server before the issue occurred. Identify a connecting Cloudflare IP recorded in the origin web server logs.
   - Details from the hosting provider's investigation, such as pertinent logs or conversations with the hosting provider.
+
+### Diagnose with Origin Analytics
+
+Use [Origin Analytics](/speed/origin-analytics/) to check for TCP connection failures to your origin. If the **Top endpoints** table shows a high TCP failure rate for specific paths, the issue may be path-specific rather than a general origin problem. Origin Analytics can also help confirm whether your origin is reachable from Cloudflare's edge.

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-524.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-524.mdx
@@ -49,3 +49,7 @@ Here are some other actions you can take on the Cloudflare side:
 Note that you may observe a 1 second difference between the timeout you have set and the actual time at which the Error `524` is returned. This is expected, it is due to the current work on implementing our proxy - [Pingora](https://blog.cloudflare.com/how-we-built-pingora-the-proxy-that-connects-cloudflare-to-the-internet/).
 As a workaround, you can simply set the timeout to one second more (121 seconds instead of 120 seconds, for example).
 :::
+
+### Diagnose with Origin Analytics
+
+Use [Origin Analytics](/speed/origin-analytics/) to monitor origin response times and catch requests approaching your timeout threshold before they result in `524` errors. If P95 response times are near the [Proxy Read Timeout](/fundamentals/reference/connection-limits/), identify the slow paths in the **Top endpoints** table and optimize them — or increase the timeout for Enterprise zones.

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-525.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-525.mdx
@@ -44,3 +44,7 @@ If `525` errors occur intermittently, review the origin web server error logs to
 - [Review the cipher suites](/ssl/edge-certificates/additional-options/cipher-suites/) used by your server to ensure they are compatible with Cloudflare.
 
 - Check your server's error logs from the timestamps when `525` errors occur to identify any issues causing the connection to be reset during the SSL handshake.
+
+### Diagnose with Origin Analytics
+
+Use [Origin Analytics](/speed/origin-analytics/) to check whether SSL handshake failures are affecting specific endpoints. The **Origin status codes** chart shows when Cloudflare received no HTTP response from your origin (`originResponseStatus` of `0`), which can indicate TLS negotiation failures. Cross-reference these timestamps with your origin SSL error logs to pinpoint the cause.


### PR DESCRIPTION
## Summary

Cross-reference the [Origin Analytics](/speed/origin-analytics/) article in all HTTP error articles where it's relevant, and in the slow website troubleshooting guide.

The Origin Analytics article already links *to* these error pages — these changes create the reverse links so users troubleshooting errors are guided toward Origin Analytics as a diagnostic tool.

## Changes

### HTTP Error pages — new `### Diagnose with Origin Analytics` section in each:

| Error | What Origin Analytics helps with |
|-------|--------------------------------|
| **499** | Slow origin response times causing clients to close connections prematurely |
| **520** | Compare `originResponseStatus` vs `edgeResponseStatus` to spot malformed responses |
| **522** | TCP connection failure rate in the Top endpoints table |
| **524** | P95 response times approaching the Proxy Read Timeout threshold |
| **525** | `originResponseStatus=0` correlating with TLS negotiation failures |

### Slow website guide (`/speed/troubleshooting/slow-website/`):
- Added a link to the Origin Analytics article at the end of Step 3's "Check origin response times" subsection, which already referenced Origin Analytics by name and dashboard path but never linked to the dedicated article.

## Files changed (6)
- `src/content/docs/support/troubleshooting/http-status-codes/4xx-client-error/error-499.mdx`
- `src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-520.mdx`
- `src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522.mdx`
- `src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-524.mdx`
- `src/content/docs/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-525.mdx`
- `src/content/docs/speed/troubleshooting/slow-website.mdx`

Resolves [DEE-3602](https://jira.cfdata.org/browse/DEE-3602)