### PR TITLE
[Agents] Add Agents SDK changelog

### DIFF
--- a/src/content/changelog/agents/2026-06-16-agents-sdk-v0.16.1.mdx
+++ b/src/content/changelog/agents/2026-06-16-agents-sdk-v0.16.1.mdx
@@ -1,0 +1,122 @@
+---
+title: Build agents that safely browse, run code, and recover from interruptions
+description: "Agents SDK v0.16.1 adds the Codemode runtime and connector model, rebuilds browser automation on durable CDP sessions, improves Think orchestration, and adds Voice output-device selection."
+products:
+  - agents
+  - workers
+date: 2026-06-16
+---
+
+import { PackageManagers, TypeScriptExample } from "~/components";
+
+The latest release of the [Agents SDK](https://github.com/cloudflare/agents) makes it easier to build agents that can safely interact with real systems and keep working through interruptions.
+
+Agents can now browse websites through Browser Run, write code against external tools through Codemode, use client-provided tools when delegating to Think sub-agents, and recover more reliably from deploys, Durable Object evictions, and connection churn.
+
+## Safer browser automation
+
+Agents can now use [Browser Run](/browser-run/) through a single durable `browser_execute` tool. Instead of choosing from a fixed list of actions, the model writes code against the Chrome DevTools Protocol (CDP) and can inspect pages, capture screenshots, read rendered content, debug frontend behavior, and interact with live browser sessions.
+
+<TypeScriptExample>
+
+```ts
+const browserTools = createBrowserTools({
+	ctx: this.ctx,
+	browser: this.env.BROWSER,
+	loader: this.env.LOADER,
+	session: { mode: "dynamic" },
+});
+```
+
+</TypeScriptExample>
+
+Browser sessions can be one-time, reused, or promoted from one-time to persistent during a run. This is useful when an agent needs a human to log in, complete MFA, or approve a sensitive action. The run can pause, keep the same tabs and cookies, and resume after approval.
+
+The browser tools also add Live View URLs, optional session recording, and quick actions such as `browser_markdown`, `browser_extract`, `browser_links`, and `browser_scrape` for one-shot browsing tasks.
+
+## Resumable code execution with approvals
+
+Codemode now uses `createCodemodeRuntime`, connectors, and a durable execution log. This lets you give a model one `codemode` tool instead of a large prompt full of tool definitions. The model can discover the capabilities it needs, write code against typed globals, and reuse saved snippets.
+
+<TypeScriptExample>
+
+```ts
+const runtime = createCodemodeRuntime({
+	ctx: this.ctx,
+	executor: new DynamicWorkerExecutor({ loader: this.env.LOADER }),
+	connectors: [new GithubConnector(this.ctx, this.env, connection)],
+});
+
+const result = streamText({
+	model,
+	messages,
+	tools: { codemode: runtime.tool() },
+});
+```
+
+</TypeScriptExample>
+
+When the code reaches an approval-gated action, the runtime pauses execution and returns a pending approval. After approval, completed calls replay from the durable log, the approved action runs, and the same code continues. This makes it practical to build agents that create issues, update external systems, or perform other side effects without custom pause-and-resume logic for every tool.
+
+## Better Think delegation
+
+Think sub-agents can now use client-defined tools over the RPC `chat()` path. A parent agent can pass tool schemas with `clientTools` and resolve tool calls through `onClientToolCall`. This lets delegated agents use caller-provided capabilities without requiring a browser WebSocket.
+
+<TypeScriptExample>
+
+```ts
+await child.chat(message, callback, {
+	signal,
+	clientTools: [
+		{
+			name: "get_user_timezone",
+			description: "Get the caller's timezone",
+			parameters: { type: "object" },
+		},
+	],
+	onClientToolCall: async ({ toolName, input }) => {
+		return runClientTool(toolName, input);
+	},
+});
+```
+
+</TypeScriptExample>
+
+Think Workflows also improve `step.prompt()`. A prompt step now runs a full agentic turn before returning structured output, so the agent can call tools before producing the typed result. This makes Workflow steps more useful for durable triage, research, and approval flows.
+
+The unified Think execute tool can also include `cdp.*` browser capabilities alongside `state.*` and `tools.*` when Browser Run is bound.
+
+## Voice output device selection
+
+Voice clients can route assistant audio to a specific output device. Use `outputDeviceId` with `useVoiceAgent`, or call `client.setOutputDevice()` from the framework-agnostic client.
+
+<TypeScriptExample>
+
+```tsx
+const voice = useVoiceAgent({
+	agent: "MyVoiceAgent",
+	outputDeviceId: selectedSpeakerId,
+});
+```
+
+</TypeScriptExample>
+
+Browsers without speaker-selection support continue playing through the default output device and report a non-fatal `outputDeviceError`.
+
+## Reliability fixes
+
+This release includes several fixes for production agents:
+
+- `useAgent` and `AgentClient` handle WebSocket replacement more reliably during reconnects and configuration changes.
+- Chat stream replay is more reliable after reconnects, deploys, and provider errors.
+- Fiber recovery continues across multi-pass scans and backs off when recovery hooks keep failing.
+- Agent teardown continues even when the request that started teardown is canceled.
+- Large session histories use byte-budgeted reads to reduce memory pressure during startup.
+
+### Upgrade
+
+To update to the latest version:
+
+<PackageManagers pkg="agents@latest @cloudflare/think@latest @cloudflare/codemode@latest @cloudflare/ai-chat@latest @cloudflare/voice@latest" />
+
+Refer to the [Codemode documentation](/agents/model-context-protocol/protocol/codemode/), [Browser tools documentation](/agents/tools/browser/), [Think tools documentation](/agents/harnesses/think/tools/), and [Voice documentation](/agents/communication-channels/voice/) for more information.

--- a/src/content/changelog/agents/2026-06-16-agents-sdk-v0.16.1.mdx
+++ b/src/content/changelog/agents/2026-06-16-agents-sdk-v0.16.1.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build agents that safely browse, run code, and recover from interruptions
+title: Agents SDK improves browser automation, code execution, and recovery
 description: "Agents SDK v0.16.1 adds the Codemode runtime and connector model, rebuilds browser automation on durable CDP sessions, improves Think orchestration, and adds Voice output-device selection."
 products:
   - agents


### PR DESCRIPTION
### Summary

Adds an Agents SDK changelog entry for v0.16.1, covering durable browser automation, Codemode runtime updates, Think delegation improvements, Voice output device selection, and reliability fixes.

Follows up on https://github.com/cloudflare/cloudflare-docs/pull/31424.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
