### PR TITLE
Update Ai Crawl Control Docs

### DIFF
--- a/src/content/changelog/ai-crawl-control/2026-06-16-pay-per-crawl-advanced-configuration.mdx
+++ b/src/content/changelog/ai-crawl-control/2026-06-16-pay-per-crawl-advanced-configuration.mdx
@@ -1,0 +1,14 @@
+---
+title: Pay Per Crawl advanced configuration
+description: Configure dynamic pricing and URI pattern exclusions for Pay Per Crawl.
+date: 2026-06-16
+---
+
+You can now configure advanced Pay Per Crawl settings for your zone, including:
+
+- **Disable Pay Per Crawl by URI pattern** using [Configuration Rules](/rules/configuration-rules/) to offer free access to specific pages while charging for others.
+- **Dynamic pricing** by having your origin return a `crawler-price` response header, or by using a [Cloudflare Worker](/workers/) to set prices based on request properties.
+
+When dynamic pricing is enabled, Pay Per Crawl adds a `cf-pay-per-crawl` request header to origin requests so your origin or Worker can determine the appropriate price.
+
+Refer to the [Advanced configuration documentation](/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration/) for details.

--- a/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
+++ b/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
@@ -81,7 +81,7 @@ Note that you can configure the response that gets returned when blocking an AI 
 :::note[Pay per crawl beta]
 Pay per crawl is currently in closed beta.
 
-To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
+To find out how to join the beta program, reach out to us at [Pay per crawl signup](https://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::

--- a/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
+++ b/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
@@ -79,7 +79,9 @@ Note that you can configure the response that gets returned when blocking an AI 
 <TabItem label="With pay per crawl">
 
 :::note[Pay per crawl beta]
-Pay per crawl is currently in beta.
+Pay per crawl is currently in closed beta.
+
+To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::

--- a/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
+++ b/src/content/docs/ai-crawl-control/features/manage-ai-crawlers.mdx
@@ -19,7 +19,7 @@ To manage AI crawlers:
 
    <DashButton url="/?to=/:account/:zone/ai" />
 
-3. Go to the **Crawlers** tab.
+3. Go to the **Security** tab.
 
 ## Review AI crawler activity
 
@@ -78,10 +78,8 @@ Note that you can configure the response that gets returned when blocking an AI 
 </TabItem>
 <TabItem label="With pay per crawl">
 
-:::note[Pay per crawl closed beta]
-Pay per crawl is currently in closed beta.
-
-To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
+:::note[Pay per crawl beta]
+Pay per crawl is currently in beta.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/set-up-cloudflare-account.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/set-up-cloudflare-account.mdx
@@ -24,7 +24,9 @@ To begin using pay per crawl, set up your Cloudflare account.
 Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up).
 
 :::note[Pay per crawl beta]
-Pay per crawl is currently in beta.
+Pay per crawl is currently in closed beta.
+
+To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/set-up-cloudflare-account.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/set-up-cloudflare-account.mdx
@@ -26,7 +26,7 @@ Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up).
 :::note[Pay per crawl beta]
 Pay per crawl is currently in closed beta.
 
-To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
+To find out how to join the beta program, reach out to us at [Pay per crawl signup](https://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/set-up-cloudflare-account.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/set-up-cloudflare-account.mdx
@@ -23,10 +23,8 @@ To begin using pay per crawl, set up your Cloudflare account.
 
 Sign up for a [Cloudflare account](https://dash.cloudflare.com/sign-up).
 
-:::note[Pay per crawl closed beta]
-Pay per crawl is currently in closed beta.
-
-To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
+:::note[Pay per crawl beta]
+Pay per crawl is currently in beta.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration.mdx
@@ -73,7 +73,7 @@ Currently, the only possible value for the `protocol` indicator is `cloudflare`.
 - **`in-band`**: When the zone has dynamic pricing enabled.
 - **`bypass`**: When the request is not subject to payment (for example, not a bot).
 
-### Using Workers for dynamic pricing
+### Use Workers for dynamic pricing
 
 If you prefer to maintain your origin as is, you can use a Worker to include the `crawler-price` header in responses. From a Worker you can, for example, select the price based on the incoming request's properties (including information added by the Cloudflare global network) or the content itself.
 

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration.mdx
@@ -45,6 +45,83 @@ To get started, use [Configuration Rules](/rules/configuration-rules/) to exclud
 Some paths are always free to crawl. These paths are: `/robots.txt`, `/sitemap.xml`, `/security.txt`, `/.well-known/security.txt`, `/crawlers.json`
 :::
 
+## Dynamic pricing
+
+The price you specify in Pay Per Crawl settings applies to the entire zone by default, but you can implement a differentiated pricing policy by selecting **Enable dynamic pricing** and having your origin HTTP responses include a `crawler-price` header. For example:
+
+```http
+crawler-price: USD 3.14
+```
+
+When the `crawler-price` header is present in a response, the price it specifies will be used instead of the default price specified in the Pay Per Crawl settings for the zone.
+
+:::note
+When Pay Per Crawl is enabled for a zone, the `crawler-price` response header is only forwarded to the client when the client is being asked to pay for the content (HTTP 402).
+:::
+
+### Request header for dynamic pricing
+
+Pay Per Crawl adds a `cf-pay-per-crawl` header to every origin request. This header indicates the pricing mode in effect, and can be used by the origin to decide whether or not to include a `crawler-price` header with the response.
+
+```http
+cf-pay-per-crawl: protocol=cloudflare, pricing=in-band
+```
+
+For the moment, the only possible value for the `protocol` indicator is `cloudflare`. For the `pricing` indicator the value can be one of the following:
+
+- **`zone-default`**: When the zone does not have in-band pricing enabled.
+- **`in-band`**: When the zone has dynamic pricing enabled.
+- **`bypass`**: When the request is not subject to payment (for example, not a bot).
+
+### Using Workers for dynamic pricing
+
+If you prefer to maintain your origin as is, you can use a Worker to include the `crawler-price` header in responses. From a Worker you can, for example, select the price based on the incoming request's properties (including information added by the Cloudflare global network) or the content itself.
+
+:::note[Snippets limitations]
+The `cf-pay-per-crawl` request header is also visible to Snippets, allowing for simple transformations without the full power of Workers. However, Snippets cannot be used to select a `crawler-price`, as response transformations at that later stage of request processing are no longer actionable by Pay Per Crawl.
+:::
+
+The following Worker script implements a simple example policy that selects the price based on the requested URL path, while still taking advantage of Cloudflare Cache:
+
+```typescript
+function getContentPriceUSD(request, response) {
+  const requestPath = new URL(request.url).pathname;
+
+  if (requestPath.startsWith("/premium-content/")) {
+    return 3.14;
+  }
+
+  if (requestPath.startsWith("/free-content/")) {
+    return 0.00;
+  }
+
+  return null; // Use the default price set in the zone configuration.
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    // Obtain the response first (and allow it to be cached if possible).
+    let response = await fetch(request, {cf: {cacheEverything: true}});
+
+    // Indicates the pricing mode in effect ("bypass", "zone-default", "in-band").
+    const cfPayPerCrawl = request.headers.get("CF-Pay-Per-Crawl") || "";
+
+    // If in-band pricing is enabled, use the request/response to select a price.
+    if (cfPayPerCrawl.match(/\bpricing=in-band\b/)) {
+      const contentPrice = getContentPriceUSD(request, response);
+
+      if (contentPrice !== null) {
+        // Make the response mutable, to allow setting the price header.
+        response = new Response(response.body, response);
+        response.headers.set("Crawler-Price", `USD ${contentPrice.toFixed(2)}`);
+      }
+    }
+    return response;
+  }
+};
+```
+
 ## Additional resources
 
 - [Configuration Rules documentation](/rules/configuration-rules/)
+- [Workers documentation](/workers/)

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration.mdx
@@ -67,7 +67,7 @@ Pay Per Crawl adds a `cf-pay-per-crawl` header to every origin request. This hea
 cf-pay-per-crawl: protocol=cloudflare, pricing=in-band
 ```
 
-For the moment, the only possible value for the `protocol` indicator is `cloudflare`. For the `pricing` indicator the value can be one of the following:
+Currently, the only possible value for the `protocol` indicator is `cloudflare`. For the `pricing` indicator the value can be one of the following:
 
 - **`zone-default`**: When the zone does not have in-band pricing enabled.
 - **`in-band`**: When the zone has dynamic pricing enabled.
@@ -85,39 +85,39 @@ The following Worker script implements a simple example policy that selects the 
 
 ```typescript
 function getContentPriceUSD(request, response) {
-  const requestPath = new URL(request.url).pathname;
+	const requestPath = new URL(request.url).pathname;
 
-  if (requestPath.startsWith("/premium-content/")) {
-    return 3.14;
-  }
+	if (requestPath.startsWith("/premium-content/")) {
+		return 3.14;
+	}
 
-  if (requestPath.startsWith("/free-content/")) {
-    return 0.00;
-  }
+	if (requestPath.startsWith("/free-content/")) {
+		return 0.0;
+	}
 
-  return null; // Use the default price set in the zone configuration.
+	return null; // Use the default price set in the zone configuration.
 }
 
 export default {
-  async fetch(request, env, ctx) {
-    // Obtain the response first (and allow it to be cached if possible).
-    let response = await fetch(request, {cf: {cacheEverything: true}});
+	async fetch(request, env, ctx) {
+		// Obtain the response first (and allow it to be cached if possible).
+		let response = await fetch(request, { cf: { cacheEverything: true } });
 
-    // Indicates the pricing mode in effect ("bypass", "zone-default", "in-band").
-    const cfPayPerCrawl = request.headers.get("CF-Pay-Per-Crawl") || "";
+		// Indicates the pricing mode in effect ("bypass", "zone-default", "in-band").
+		const cfPayPerCrawl = request.headers.get("CF-Pay-Per-Crawl") || "";
 
-    // If in-band pricing is enabled, use the request/response to select a price.
-    if (cfPayPerCrawl.match(/\bpricing=in-band\b/)) {
-      const contentPrice = getContentPriceUSD(request, response);
+		// If in-band pricing is enabled, use the request/response to select a price.
+		if (cfPayPerCrawl.match(/\bpricing=in-band\b/)) {
+			const contentPrice = getContentPriceUSD(request, response);
 
-      if (contentPrice !== null) {
-        // Make the response mutable, to allow setting the price header.
-        response = new Response(response.body, response);
-        response.headers.set("Crawler-Price", `USD ${contentPrice.toFixed(2)}`);
-      }
-    }
-    return response;
-  }
+			if (contentPrice !== null) {
+				// Make the response mutable, to allow setting the price header.
+				response = new Response(response.body, response);
+				response.headers.set("Crawler-Price", `USD ${contentPrice.toFixed(2)}`);
+			}
+		}
+		return response;
+	}
 };
 ```
 

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/select-crawlers-to-charge.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/select-crawlers-to-charge.mdx
@@ -31,7 +31,7 @@ Once you have enabled pay per crawl and set a price, you can specify which AI cr
 
    <DashButton url="/?to=/:account/:zone/ai" />
 
-2. Go to the **Crawlers** tab.
+2. Go to the **Security** tab.
 3. For each crawler, choose an action from the **Actions** column:
    - **Charge**: Charge the set price for successful content access
    - **Allow**: Allow free access without charging

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/set-a-pay-per-crawl-price.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/set-a-pay-per-crawl-price.mdx
@@ -30,15 +30,15 @@ Once your domain's visibility is set to **Visible** in Account Settings, you can
 	1. Go to **AI Crawl Control**.
 
 		<DashButton url="/?to=/:account/:zone/ai" />
-	2. Go to the **Settings** tab.
+	2. Go to the **Payments** tab.
 	3. In the **Pay Per Crawl** card, select **Enable**.
 	4. Set your default per crawl price. This is the amount charged for each successful content retrieval (HTTP 200 response) by an AI crawler.
-		- (Optional) To set different prices for different content, select **Enable custom pricing**. Refer to [Advanced configuration](/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration/) for details.
+		- (Optional) To set different prices for different content, select **Enable dynamic pricing**. Refer to [Advanced configuration](/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-site-owner/advanced-configuration/) for details.
 	5. Select **Save**.
 </Steps>
 
 After enabling and setting a price, the domain's status in Account Settings will change to **Enabled**.
 
 :::note[Pricing considerations]
-The minimum price is $0.01 USD per crawl. Consider your content value and expected crawler volume when setting your price.
+The minimum price is $0.001 USD per crawl. Consider your content value and expected crawler volume when setting your price.
 :::

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl.mdx
@@ -11,7 +11,9 @@ products:
 import { Steps, GlossaryTooltip } from "~/components";
 
 :::note[Pay per crawl beta]
-Pay per crawl is currently in beta.
+Pay per crawl is currently in closed beta.
+
+To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl.mdx
@@ -13,7 +13,7 @@ import { Steps, GlossaryTooltip } from "~/components";
 :::note[Pay per crawl beta]
 Pay per crawl is currently in closed beta.
 
-To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
+To find out how to join the beta program, reach out to us at [Pay per crawl signup](https://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::

--- a/src/content/docs/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl.mdx
+++ b/src/content/docs/ai-crawl-control/features/pay-per-crawl/what-is-pay-per-crawl.mdx
@@ -10,10 +10,8 @@ products:
 
 import { Steps, GlossaryTooltip } from "~/components";
 
-:::note[Pay per crawl closed beta]
-Pay per crawl is currently in closed beta.
-
-To find out how to join the beta program, reach out to us at [Pay per crawl signup](http://www.cloudflare.com/paypercrawl-signup/), or contact your account executive if you are an existing Enterprise customer.
+:::note[Pay per crawl beta]
+Pay per crawl is currently in beta.
 
 To learn more about pay per crawl, refer to Cloudflare blog: [Introducing pay per crawl: enabling content owners to charge AI crawlers for access](https://blog.cloudflare.com/introducing-pay-per-crawl/).
 :::


### PR DESCRIPTION
### Summary
In this MR we have updated Ai Crawl Control Docs.
Adds a new **Advanced configuration** reference page for Pay Per Crawl, documenting two new capabilities:
 
- **Disable Pay Per Crawl by URI pattern** — use Configuration Rules to offer free access to specific pages (homepages, public sections, functional endpoints) while charging for others.
- **Dynamic pricing** — have your origin or a Worker return a `crawler-price` response header to set per-request prices, with the `cf-pay-per-crawl` request header indicating the pricing mode in effect.
 

### Documentation checklist

- [X] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
