### PR TITLE
[Registrar] Add refunds/registration-errors pages and expand existing docs

### DIFF
--- a/src/content/docs/registrar/account-options/domain-management.mdx
+++ b/src/content/docs/registrar/account-options/domain-management.mdx
@@ -69,3 +69,13 @@ There may be instances where users may wish to delete a domain prior to expirati
 5. Once you click the Delete button, you will be presented with a confirmation window. If you proceed, an email will be sent to all users with the Super Admin role in the account. The email contains a deletion authorization token that must be entered into the window which appears to confirm and complete the deletion.
 
 Once all steps are completed, the domain will then be scheduled for deletion. To understand more about the timelines and potential reasons why a domain cannot be deleted, refer to the Registrar [FAQ](/registrar/faq/#domain-deletions).
+
+### Troubleshoot domain deletion
+
+If you are unable to delete a domain, check the following:
+
+* **`.uk` domains cannot be deleted through the dashboard.** This is a known limitation. Contact Cloudflare support to request manual deletion of a `.uk`, `.co.uk`, `.org.uk`, or `.me.uk` domain.
+* **Domain is in `redemptionPeriod` or `pendingDelete` status.** `redemptionPeriod` (approximately days 40 to 70 after expiration) still supports self-serve dashboard restoration with a restoration fee, while the zone is not yet deleted. `pendingDelete` (approximately days 71 to 75) is terminal — restoration is no longer available, and the registry releases the domain approximately 5 to 7 days after entering it. `.uk` does not use `redemptionPeriod`; for `.uk`, recovery is governed by zone state and the T+90 boundary instead.
+* **Delete button returns a 404 or error.** If the **Delete** button produces an error, the domain may be in an inconsistent state at the registry level. Contact Cloudflare support and include the domain name and the error message you received.
+* **Delete token email not received.** The deletion authorization token is only sent to **Super Admin** users on the account. If you are not a Super Admin, ask one of the account's Super Admins to provide the token. Also check your spam folder. The token expires after 30 minutes.
+* **Domain is administratively locked.** Domains locked due to legal disputes, court orders, or abuse investigations cannot be deleted until the lock is removed. Contact Cloudflare support for details on the lock reason.

--- a/src/content/docs/registrar/account-options/inter-account-transfer.mdx
+++ b/src/content/docs/registrar/account-options/inter-account-transfer.mdx
@@ -51,3 +51,36 @@ The gaining account must log into their account and go to **Manage Domains** (un
 Select **View Actions** to display the domains with a pending move along and choose to accept or reject the request. Action must be taken within five days of the request.
 
 If no action is taken within the five days, the request will be automatically canceled.
+
+## Troubleshoot inter-account transfers
+
+### "This domain cannot be moved" error
+
+If the dashboard displays this error when you attempt to start a move, verify the following:
+
+* The domain was registered more than 10 days ago. Newly registered domains cannot be moved until the 10-day hold period expires.
+* The domain is not in `pendingDelete`, `redemptionPeriod`, or `pendingTransfer` status. Check the domain status on the **Manage Domain** page.
+* There is no pending Change of Registrant (COR) request. If a COR is in progress, complete or cancel it before initiating the move.
+* The registrant email address has been verified.
+* DNSSEC is turned off. Disable it and wait for the DS record to clear (up to 24 hours) before retrying.
+* The domain is not administratively locked by Cloudflare (for example, due to a legal dispute or abuse investigation). Contact support if you believe this was applied in error.
+
+### Source account is inaccessible
+
+If the domain is registered under a Cloudflare account you no longer have access to (for example, a former employee's account or a lost email address):
+
+1. You cannot use the self-serve inter-account transfer flow, because both the source and target accounts must confirm the move.
+2. Contact Cloudflare support for account recovery and provide proof of domain ownership, such as a government-issued ID matching the registrant name, business registration documents, or previous invoices.
+3. Cloudflare will verify your identity and may be able to facilitate the transfer on your behalf.
+
+### Domain registered through a third-party platform
+
+If your domain was registered through Cloudflare by a third-party platform (such as GoHighLevel, or a web design agency), the registration may be tied to the platform's Cloudflare account rather than yours. In this case:
+
+1. Contact the platform and request that they initiate the inter-account transfer to your Cloudflare account.
+
+### Nameserver mismatch after transfer
+
+After a successful inter-account move, the target account may assign different Cloudflare nameservers than the ones the domain was previously using. The registrar-level nameserver delegation must be updated to match the new account's assigned nameservers.
+
+In most cases, Cloudflare updates this automatically. If the domain remains in **Pending** status in the new account for more than 24 hours, contact Cloudflare support to request a nameserver resync at the registry level.

--- a/src/content/docs/registrar/account-options/refunds-and-cancellations.mdx
+++ b/src/content/docs/registrar/account-options/refunds-and-cancellations.mdx
@@ -1,0 +1,61 @@
+---
+pcx_content_type: reference
+title: Refunds and cancellations
+sidebar:
+  order: 9
+products:
+  - registrar
+description: Understand the refund and cancellation policy for Cloudflare Registrar domain registrations.
+---
+
+import { DashButton } from "~/components";
+
+## Refund policy
+
+Domain registrations, renewals, transfers, and restorations through Cloudflare Registrar are **non-refundable**. When you register, renew, transfer, or restore a domain, Cloudflare pays the registry fee on your behalf, and that payment cannot be reversed.
+
+This applies to all of the following:
+
+- New domain registrations.
+- Manual and automatic renewals.
+- Domain transfers (which include a one-year registration extension).
+- Domain restorations during the Redemption Period.
+
+Cloudflare does not issue refunds for these charges, including registrations made in error (for example, a typo in the domain name).
+
+## Cancelling a domain
+
+You can delete a domain registration at any time, but deleting a domain does not generate a refund. Deletion starts an irreversible process — once complete, the domain becomes available for anyone to register.
+
+To delete a domain, refer to [Delete a domain registration](/registrar/account-options/domain-management/#delete-a-domain-registration).
+
+## Avoid unwanted renewal charges
+
+Because renewals are non-refundable, turn off auto-renew before the renewal window if you no longer want a domain.
+
+1. In the Cloudflare dashboard, go to the **Manage domains** page.
+
+   <DashButton url="/?to=/:account/registrar/domains" />
+
+2. Find the domain and turn off the **Auto-renew** toggle.
+
+:::caution
+
+Turn off auto-renew at least 30 days before the expiration date. Cloudflare begins auto-renewal attempts approximately 30 days prior to expiration.
+
+:::
+
+## Failed registrations and duplicate charges
+
+A non-refundable policy applies to completed registrations. The following cases are different, because no successful registration occurred:
+
+| Scenario | What happens |
+| --- | --- |
+| Registration failed but payment was captured | The charge is typically voided automatically within 5 to 7 business days. If it is not reversed after 7 business days, contact Cloudflare support. |
+| Duplicate charge for the same domain | A temporary preauthorization hold may appear as a second charge and is released automatically. If you see two settled charges for the same domain, contact Cloudflare support with both invoice numbers. |
+
+## Tips to avoid unwanted charges
+
+- **Double-check the domain name** before confirming your purchase. Typos in domain names cannot be corrected after registration, and registrations are non-refundable.
+- **Review auto-renew settings** periodically, especially for domains you no longer need.
+- **Set calendar reminders** for domains approaching their renewal date if you want to make a decision before auto-renew triggers.

--- a/src/content/docs/registrar/account-options/renew-domains.mdx
+++ b/src/content/docs/registrar/account-options/renew-domains.mdx
@@ -93,3 +93,45 @@ When renewing a domain, additional years are always added to the current expirat
 
 
 :::
+
+## Troubleshoot auto-renewal failures
+
+If you receive an email stating that your domain failed to auto-renew, check the following:
+
+### Authorization failed
+
+The most common auto-renewal failure is `authorization failed`, which means the payment method on file was declined. To resolve this:
+
+1. Go to **Billing** in the Cloudflare dashboard and verify your primary payment method is valid and not expired.
+2. If the card was recently replaced, update the payment method with the new card details.
+3. Contact your bank to confirm they are not blocking the Cloudflare charge.
+
+After updating your payment method, Cloudflare will retry the renewal automatically. You can also [manually renew](#renew-a-domain-manually) at any time.
+
+### Renewal link in email returns a 404
+
+Renewal notification emails contain a link to the domain management page. If that link returns a 404 error, go to the dashboard directly:
+
+1. Log in to the [Cloudflare dashboard](https://dash.cloudflare.com/login).
+2. Go to **Domain Registration** &gt; **Manage Domains**.
+3. Find the domain and select **Manage** &gt; **Renew/Extend Domain**.
+
+### What happens when auto-renewal fails repeatedly
+
+If all auto-renewal attempts fail, the domain follows this timeline after expiration on standard TLDs:
+
+* **Grace Period — Day 1 to 30**: Domain resolves normally. You can renew at the standard fee.
+* **Suspension Period — Day 31 to 40**: Domain may resolve to a suspension page. You can still renew at the standard fee.
+* **Redemption Period — Day 41 to 70**: Domain enters `redemptionPeriod`. Self-serve restoration through the dashboard is available while the zone is not yet deleted, with a restoration fee on top of the renewal fee.
+* **Pending Delete — Day 71 to 75**: Domain enters `pendingDelete` and cannot be recovered through Cloudflare. It is released for public registration about 5 to 7 days later.
+
+Some TLDs do not follow the standard timeline:
+
+* `.uk` does not use a Redemption Period. Recovery is governed by zone state and a T+90 boundary instead.
+* `.co` has an accelerated registry nameserver change around T+5 that can move the zone earlier than the standard timeline.
+
+For more details on restoration during the Redemption Period, refer to the [FAQ](/registrar/faq/#domain-restoration).
+
+### Billing page shows no unpaid invoices but renewal emails continue
+
+Renewal failure emails may continue for a few days after you update your payment method, because the retry schedule is based on when the failure originally occurred. If your billing page shows all invoices as paid and your payment method is current, the domain will renew on the next automatic retry. No action is needed.

--- a/src/content/docs/registrar/account-options/whois-redaction.mdx
+++ b/src/content/docs/registrar/account-options/whois-redaction.mdx
@@ -10,9 +10,23 @@ description: Protect personal data with WHOIS redaction.
 
 Cloudflare Registrar provides personal data redaction on WHOIS information, if permitted by the registry.
 
+:::note
+
+WHOIS redaction is **free and enabled by default** for all domains registered through Cloudflare Registrar. You do not need to purchase a separate privacy or ID protection add-on. There is no additional cost.
+
+:::
+
 WHOIS is a standard for publishing the contact and nameserver information for all registered domains. Each registrar maintains their own WHOIS service. Anyone can query the registrar’s WHOIS service to reveal the data behind a given domain.
 
 However, broadcasting the registrant contact information via the WHOIS service can cause spam mail to be delivered to your personal addresses. Cloudflare Registrar offers personal data redaction on WHOIS for free, that meets current ICANN guidelines.
+
+To verify that redaction is active for your domain, search for your domain at [rdap.cloudflare.com](https://rdap.cloudflare.com/). Personal fields should display as `Data Redacted`.
+
+:::note
+
+Some TLDs do not permit WHOIS redaction. For example, `.us` domains require public WHOIS records per the usTLD Nexus Policy. Refer to [.US domains](/registrar/top-level-domains/us-domains/) for details.
+
+:::
 
 Cloudflare’s WHOIS service can be found at [https://rdap.cloudflare.com/](https://rdap.cloudflare.com/). Select **WHOIS** as the search type.
 

--- a/src/content/docs/registrar/faq.mdx
+++ b/src/content/docs/registrar/faq.mdx
@@ -36,6 +36,14 @@ If you still need to use different nameservers, you will have to [move your doma
 
 You can update both your default contact information and any individual Registrant, Administrator, Technical or Billing contact for your domain registrations by following [Registrant contact updates](/registrar/account-options/domain-contact-updates/). Details that may be updated include name, email, address, organization and telephone number.
 
+### How do I get a domain ownership or verification letter?
+
+To generate a certificate, go to **Domains** > **Registrations**, select your domain, and select the button under **Contacts**.
+
+### I registered my domain through GoHighLevel or another platform. How do I manage it?
+
+Some third-party platforms register domains through Cloudflare on your behalf. The domain registration is tied to the platform's Cloudflare account, not yours. To manage the domain directly, contact the platform and ask them to transfer the domain registration to your own Cloudflare account using the [inter-account transfer](/registrar/account-options/inter-account-transfer/) process.
+
 ---
 
 ## Domain transfers
@@ -105,6 +113,10 @@ For example, say `example.com` expires on March 1. You renew it on March 10, ext
 To avoid this, wait at least 45 days after renewal before transferring.
 
 If this already happened, you have effectively paid twice for the same year. Per ICANN rules, you are entitled to request a refund from your previous registrar.
+
+### Can I change my domain name after registration?
+
+No. Domain names cannot be changed after registration. If you registered the wrong name (for example, due to a typo), you must register the correct domain separately. Refer to [Refunds and cancellations](/registrar/account-options/refunds-and-cancellations/) for details.
 
 ### What Happens When a Domain Expires?
 
@@ -223,3 +235,15 @@ You will be billed when you input your authorization code and initiate the trans
 ### Is there a fee to transfer a .UK domain?
 
 No, there is no fee to transfer a `.uk` domain. Also, an additional year is NOT added during the transfer process. However, if the domain is nearing the expiration date and is set to auto-renew, it may be automatically renewed shortly after the completion of the transfer.
+
+### I was charged but my registration failed. Where is my refund?
+
+If your payment was captured but the domain registration did not complete (you received a "registration unsuccessful" email), the charge will typically be voided automatically within 5 to 7 business days. Check your bank statement for a pending or voided transaction. If the charge has not been reversed after 7 business days, contact Cloudflare support with your account email and the domain name.
+
+### I was charged twice for the same domain transfer or registration
+
+When you initiate a domain transfer or registration, Cloudflare may place a temporary preauthorization hold on your payment method to verify funds. This hold appears as a pending charge and is released automatically, usually within a few business days. If you see two settled (not pending) charges for the same domain on the same date, contact Cloudflare support with both invoice numbers.
+
+### Why is my domain priced differently than I expected?
+
+Cloudflare Registrar charges at-cost pricing with no markup. However, the registry fee varies by TLD. A `.com` domain costs less than a `.io` or `.ai` domain because the underlying registry fees are different. The price shown during checkout reflects the current registry list price plus the ICANN fee.

--- a/src/content/docs/registrar/registration-errors.mdx
+++ b/src/content/docs/registrar/registration-errors.mdx
@@ -1,0 +1,112 @@
+---
+pcx_content_type: troubleshooting
+title: Troubleshoot domain registration errors
+sidebar:
+  order: 9
+products:
+  - registrar
+description: Fix common errors when registering a new domain through Cloudflare Registrar.
+---
+
+import { DashButton } from "~/components";
+
+If you encounter an error while registering a new domain through Cloudflare Registrar, use this guide to identify the cause and resolve the issue.
+
+## Registration temporarily blocked
+
+**Error message**: `This domain registration is temporarily blocked. Please wait a few minutes and try again.`
+
+This is the most common registration error. It can be caused by:
+
+- **Fraud prevention checks**: Cloudflare's automated systems flagged the transaction for review. This can happen with new accounts, new payment methods, or unusual purchase patterns.
+- **Recent payment failure**: If a previous payment attempt failed (card declined, PayPal error), the system may temporarily block further attempts on the same domain.
+- **Rate limiting**: Too many registration attempts in a short period.
+
+### How to resolve
+
+1. Wait 15 to 30 minutes, then try again.
+2. If the error persists, try a different payment method (switch between credit card and PayPal, or use a different card).
+3. Verify that your billing address matches the address on file with your payment provider.
+4. Clear your browser cache or try in an incognito/private window.
+5. If the error continues after multiple attempts over several hours, contact Cloudflare support.
+
+## Payment declined
+
+**Error message**: `We're sorry, there was a payment error. Your card was declined.`
+
+Your payment method was rejected during checkout. Common causes:
+
+- **Incorrect billing details**: The name, address, or ZIP code does not match what your bank has on file.
+- **Card issuer block**: Some banks block international transactions or online purchases by default. Contact your bank to authorize the Cloudflare charge.
+- **Insufficient funds or credit limit**: Verify your account balance.
+- **Expired card**: Check that the expiration date and CVV are correct.
+- **Previously declined card**: If you accidentally rejected a payment confirmation on your phone or banking app, the card may remain in a declined state for that merchant. Contact your bank to clear the block, or use a different card.
+
+### Address validation failures
+
+If the checkout form rejects your address with a message like `cannot find your address`, try the following:
+
+1. Use the exact format your bank has on file (including apartment numbers, suite numbers, and abbreviations).
+2. Omit special characters from the street name.
+3. Try a shorter version of your address (for example, `123 Main St` instead of `123 Main Street, Suite 200`).
+4. If you are outside the United States, verify that you selected the correct country.
+
+## Registration failed but payment was captured
+
+**Error message** (via email): `Registration of [domain] unsuccessful`
+
+In some cases, your payment is processed but the registration fails at the registry level. This can happen due to:
+
+- Temporary communication errors between Cloudflare and the domain registry (such as Verisign for `.com`).
+- Registry maintenance or technical difficulties.
+- The domain was registered by another party between the time you started checkout and the time the registration was submitted.
+
+### What happens to your payment
+
+- If the charge shows as **pending** on your bank statement, it will typically be voided automatically within 5 to 7 business days.
+- If the charge was fully captured, Cloudflare will issue a refund. Contact support if the refund does not appear within 7 business days.
+
+### What to do
+
+1. Wait 24 to 48 hours and try registering the domain again. Most registry failures are temporary.
+2. Check whether the domain appears in your **Domain Registration** page. If it shows with a `registrationFailed` status, the zone may need to be cleaned up before you can retry.
+3. If the domain still shows as unavailable in your account but is available at other registrars, contact support to clear the failed registration state.
+
+## Domain shows unavailable but is not registered
+
+If you search for a domain and Cloudflare says it is unavailable, but a WHOIS lookup shows the domain is not registered:
+
+- **Registry propagation delay**: The registry may take a few hours to update availability after a previous registration attempt or expiration. Wait and try again.
+- **Previous failed registration**: A failed registration attempt in your account may still be holding the domain in a reserved state. Contact support to release it.
+- **Premium domain**: Some domains are classified as premium by the registry and may not be available at standard pricing. Cloudflare does not currently support premium domain registration for all TLDs.
+
+## Registration failed with invalid nameservers
+
+After purchasing a domain, the dashboard shows **Invalid nameservers** and the domain is stuck in **Pending** status.
+
+This typically means the registration completed at the registry, but the nameserver delegation was not properly set. Since the domain is registered through Cloudflare, the nameservers should be configured automatically.
+
+### How to resolve
+
+1. Wait up to 24 hours. Nameserver propagation can take time, especially for newer TLDs.
+2. If the domain remains in **Pending** status after 24 hours, contact support. The Cloudflare Registrar team can re-sync the nameserver delegation at the registry level.
+
+## Domain shows as registered but not in your account
+
+If you paid for a domain and received a charge confirmation, but the domain does not appear in your **Domain Registration** page:
+
+1. Verify you are logged into the correct Cloudflare account. Check the account email in the top-right corner of the dashboard.
+2. Check your email for a registration confirmation or failure notification from Cloudflare.
+3. Go to **Billing** &gt; **Invoices** to verify the payment was processed.
+
+   <DashButton url="/?to=/:account/billing" />
+
+4. If payment was processed but the domain is missing, contact support with your invoice number.
+
+## Unsupported TLD
+
+**Error message**: `[domain] cannot be registered as Cloudflare does not yet support the "[extension]" extension.`
+
+Cloudflare Registrar supports over 400 TLDs, but not all extensions are available. If you need a TLD that Cloudflare does not support, you will need to register it through another registrar. You can still use Cloudflare for DNS, CDN, and security services by [adding the domain](/fundamentals/manage-domains/add-site/) and updating nameservers at your registrar.
+
+For a list of supported TLDs, refer to [Top Level Domains supported](/registrar/top-level-domains/).


### PR DESCRIPTION
## Summary

Consolidates and updates the Registrar documentation work from the April 2026 support case gap analysis (originally PRs #30579 and #30580), incorporating SME/PM review feedback. Tracked in [SPM-3500](https://jira.cfdata.org/browse/SPM-3500).

This supersedes the two prior PRs, which were based on an older state of the docs and contained content the SME/PM flagged as inaccurate or no longer relevant.

## New pages

| Page | Path |
| --- | --- |
| Refunds and cancellations | `/registrar/account-options/refunds-and-cancellations/` |
| Troubleshoot domain registration errors | `/registrar/registration-errors/` |

## Updated pages

| File | What was added |
| --- | --- |
| `renew-domains.mdx` | Auto-renewal failure troubleshooting + corrected expiration timeline (`.uk`/`.co` exceptions) |
| `domain-management.mdx` | Deletion troubleshooting with corrected `redemptionPeriod`/`pendingDelete` behavior |
| `inter-account-transfer.mdx` | Transfer edge cases (account recovery, third-party platforms, nameserver mismatch) |
| `whois-redaction.mdx` | Clarify redaction is free and default; `.us` public-WHOIS exception |
| `faq.mdx` | Failed-registration refunds, duplicate charges, pricing, domain ownership letter, third-party platform Q&As |

## Changes from the original PRs (per SME/PM review)

- **Dropped `email-verification.mdx`, `nameserver-changes.mdx`, and `ca-domains.mdx`** — the cc-TLD email verification process changed (no longer a separate verification step), so these pages are no longer needed.
- **Refunds page rewritten to a strict no-refund policy** (the original draft was built around Add Grace Period refund eligibility).
- **`renew-domains` / `domain-management`**: corrected the `redemptionPeriod`/`pendingDelete` lifecycle wording and removed the incorrect "registrar team can remove the domain manually" claim.
- **`inter-account-transfer`**: clarified "contact support for account recovery", removed the iCloud reference, and removed an incorrect bullet about proving ownership of platform-registered (GoHighLevel) domains.
- **`faq`**: removed an incorrect Add Grace Period reference, rewrote the domain ownership letter answer to use the dashboard certificate flow, and removed the iCloud reference.
- **Dropped the `transfer-domain-to-cloudflare.mdx` edit** — that page was rewritten upstream and already covers auth-code troubleshooting; the flagged "auth codes are case-sensitive" / "transfer conditions" content is now moot.
- **`troubleshooting.mdx` deferred** — pending SME review (it was rewritten upstream).

## Validation

- `pnpm run check` (astro) — 0 errors
- All internal links/anchors verified against existing targets
- No references to the dropped pages
