### PR TITLE
[Web Analytics/RUM] Updated beacon changelog with latest release

### DIFF
--- a/src/content/release-notes/beacon-min-js.yaml
+++ b/src/content/release-notes/beacon-min-js.yaml
@@ -3,6 +3,9 @@ link: "/web-analytics/changelog/"
 productName: beacon.min.js
 productLink: "/web-analytics/"
 entries:
+  - publish_date: "2026-06-16"
+    description: Updated Google's web-vitals library to version 5.3.0. JavaScript build output target updated to ES2015.
+
   - publish_date: "2026-05-15"
     description: Updated Google's web-vitals library to version 4.2.4 and captured Interaction to Next Paint (INP) sub-part metrics (Input Delay, Processing Duration, Presentation Delay)
 

--- a/src/content/release-notes/beacon-min-js.yaml
+++ b/src/content/release-notes/beacon-min-js.yaml
@@ -4,7 +4,7 @@ productName: beacon.min.js
 productLink: "/web-analytics/"
 entries:
   - publish_date: "2026-06-16"
-    description: Updated Google's web-vitals library to version 5.3.0. JavaScript build output target updated to ES2015.
+    description: Updated Google's web-vitals library to version 5.3.0 and updated the JavaScript build output target to ES2015.
 
   - publish_date: "2026-05-15"
     description: Updated Google's web-vitals library to version 4.2.4 and captured Interaction to Next Paint (INP) sub-part metrics (Input Delay, Processing Duration, Presentation Delay)


### PR DESCRIPTION
Adds an entry to the Web Analytics beacon changelog covering that we updated a JavaScript dependency version and updated our build output target to ES2015.