### PR TITLE
Add Browser Run crawler to Cloudflare crawlers page

### DIFF
--- a/src/content/docs/fundamentals/reference/cloudflare-site-crawling.mdx
+++ b/src/content/docs/fundamentals/reference/cloudflare-site-crawling.mdx
@@ -46,7 +46,7 @@ Cloudflare will also crawl your site in other, specific situations:
 
 ## Developer product crawlers
 
-[Browser Run](/browser-run/) is a Cloudflare developer product that can crawl third-party websites on behalf of Cloudflare customers. Unlike the crawlers listed above, it does not crawl your site as part of a Cloudflare service you have enabled. It is used by developers building applications with Cloudflare's platform.
+[Browser Run](/browser-run/) is a Cloudflare developer product that can crawl third-party websites on behalf of Cloudflare customers. Unlike the crawlers in the Crawling situations section, it does not crawl your site as part of a Cloudflare service you have enabled. It is used by developers building applications with Cloudflare's platform.
 
 - [**Browser Run /crawl endpoint**](/browser-run/quick-actions/crawl-endpoint/)
   - _User-Agent_: `CloudflareBrowserRenderingCrawler/1.0`

--- a/src/content/docs/fundamentals/reference/cloudflare-site-crawling.mdx
+++ b/src/content/docs/fundamentals/reference/cloudflare-site-crawling.mdx
@@ -48,6 +48,4 @@ Cloudflare will also crawl your site in other, specific situations:
 
 [Browser Run](/browser-run/) is a Cloudflare developer product that can crawl third-party websites on behalf of Cloudflare customers. Unlike the crawlers in the Crawling situations section, it does not crawl your site as part of a Cloudflare service you have enabled. It is used by developers building applications with Cloudflare's platform.
 
-- [**Browser Run /crawl endpoint**](/browser-run/quick-actions/crawl-endpoint/)
-  - _User-Agent_: `CloudflareBrowserRenderingCrawler/1.0`
-  - Refer to [Automatic request headers](/browser-run/reference/automatic-request-headers/) for non-configurable headers, bot detection IDs, and cryptographic verification methods you can use to identify or block Browser Run traffic.
+The [**Browser Run /crawl endpoint**](/browser-run/quick-actions/crawl-endpoint/) uses a _User-Agent_ of `CloudflareBrowserRenderingCrawler/1.0`. For non-configurable headers, bot detection IDs, and cryptographic verification methods you can use to identify or block Browser Run traffic, refer to [Automatic request headers](/browser-run/reference/automatic-request-headers/).

--- a/src/content/docs/fundamentals/reference/cloudflare-site-crawling.mdx
+++ b/src/content/docs/fundamentals/reference/cloudflare-site-crawling.mdx
@@ -43,3 +43,11 @@ Cloudflare will also crawl your site in other, specific situations:
 - **Custom Hostname validation**:
   - _User-Agent_: `Cloudflare Custom Hostname Verification`
   - _Triggered when_: You choose to validate a custom hostname with an [HTTP ownership token](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/pre-validation/#http-tokens).
+
+## Developer product crawlers
+
+[Browser Run](/browser-run/) is a Cloudflare developer product that can crawl third-party websites on behalf of Cloudflare customers. Unlike the crawlers listed above, it does not crawl your site as part of a Cloudflare service you have enabled. It is used by developers building applications with Cloudflare's platform.
+
+- [**Browser Run /crawl endpoint**](/browser-run/quick-actions/crawl-endpoint/)
+  - _User-Agent_: `CloudflareBrowserRenderingCrawler/1.0`
+  - Refer to [Automatic request headers](/browser-run/reference/automatic-request-headers/) for non-configurable headers, bot detection IDs, and cryptographic verification methods you can use to identify or block Browser Run traffic.


### PR DESCRIPTION
Objective: include Browser Run in list of Cloudflare Crawlers. while distinguishing that it's used by developers, not CF
- Add Developer product crawlers section to distinguish from Cloudflare-on-your-behalf crawlers
- List Browser Run /crawl endpoint with User-Agent string
- Link to crawl endpoint docs and automatic request headers for verification/blocking

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
