### PR TITLE
deprecate: add Sunset for Zone Settings Batch API

### DIFF
--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -3,6 +3,27 @@ link: "/fundamentals/api/reference/deprecations/"
 productName: API deprecations
 productLink: "/fundamentals/"
 entries:
+  - publish_date: "2026-06-16"
+    title: "Zone Settings Batch API"
+    description: |-
+      Deprecation date: April 23, 2025
+
+      End of life date: September 15, 2026
+
+      The Zone Settings Batch API endpoints, which read and edit multiple zone settings in a single request, are deprecated and will reach their end of life on September 15, 2026. Use the per-setting endpoints to read and edit individual zone settings instead.
+
+      Deprecated APIs:
+
+      - `GET /zones/{zone_id}/settings`
+      - `PATCH /zones/{zone_id}/settings`
+
+      Replacements:
+
+      - [Get zone setting](/api/resources/zones/subresources/settings/methods/get/) — `GET /zones/{zone_id}/settings/{setting_id}`
+      - [Edit zone setting](/api/resources/zones/subresources/settings/methods/edit/) — `PATCH /zones/{zone_id}/settings/{setting_id}`
+
+      Integrations that read or edit multiple settings in a single call must migrate to per-setting requests before September 15, 2026 to ensure uninterrupted service. After this date, the batch endpoints will no longer be available.
+
   - publish_date: "2026-05-13"
     title: "Gateway Audit SSH rules"
     description: |-


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

Add Sunset date for the Zone Settings Batch API

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
