### PR TITLE
[Access] Document MCP portal 40-server-per-portal limit

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -919,6 +919,8 @@ MCP server portals have the following known limitations:
 
 - **Admin OAuth tokens can expire silently.** The admin credential used to [authenticate an MCP server](#reauthenticate-the-mcp-server) is subject to the upstream provider's token expiration policy. When the token expires, the server status changes to **Error** or **Sync Required** and the server will not appear in the portal for end users. Admins are not notified when this happens. Periodically check the [server status](#server-status) and [reauthenticate](#reauthenticate-the-mcp-server) servers that show an error.
 
+- **Each portal supports up to 40 MCP servers.** If you need to aggregate more than 40 servers into a single portal, contact your Cloudflare account team to request a higher limit. The dashboard displays a warning as you approach the limit.
+
 ## Policy limitations
 
 MCP server portals use a dedicated Access application type that does not support the following Access policy features:

--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -30,7 +30,7 @@ This page lists the default account limits for rules, applications, fields, and 
 | Domains per application  | 5     |
 | Infrastructure targets   | 5,000 |
 | MCP portals              | 20    |
-| MCP servers per portal   | 20    |
+| MCP servers per portal   | 40    |
 | Custom domains per MCP portal | 5 |
 | MCP portal session inactivity timeout | 24 hours |
 


### PR DESCRIPTION
## Summary

Document the per-portal MCP server limit (40) in the MCP Portals known limitations section. SHIP-15229 raised the default from 20 to 40 and added entitlement-based per-account overrides; this doc change makes the limit discoverable.

## What's added

One new bullet under **Known limitations**:

- States the default of 40 MCP servers per portal.
- Notes that customers can request a higher limit via their account team.
- Mentions the in-dashboard warning as the limit is approached.

## Related

- SHIP-15229: https://jira.cfdata.org/browse/SHIP-15229
- MCP-127: https://jira.cfdata.org/browse/MCP-127