### PR TITLE
[Access] Document MCP portal dashboard error details surface

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -129,7 +129,7 @@ The MCP server status indicates the synchronization status of the MCP server to 
 
 #### Error details
 
-When an MCP server is in the **Error** state, the API returns an `error_details` object with structured information to help you diagnose the issue:
+When an MCP server is in the **Error** or **Sync Required** state, Cloudflare Access surfaces structured information to help you diagnose the issue. In the dashboard, hover over the server's status to view the error message, the error category (upstream or connection), the HTTP status code, and the MCP protocol error code (if applicable). The same details are returned by the API as an `error_details` object:
 
 | Field | Description |
 | --- | --- |


### PR DESCRIPTION
## Summary

The `error_details` API surface is already documented for MCP server status. SHIP-14800 (MCP-32 frontend) now surfaces the same structured error info in the dashboard as a hover tooltip on the server status. This PR updates the Error details section to call out the dashboard surface alongside the existing API documentation.

## Why

SHIP-14800 blocks SHIP-15209 (MCP Server Portals GA). Admins should be able to find docs for the in-dashboard diagnostics they will rely on at GA.

## Change

One-sentence update to the **Error details** subsection of the MCP server status docs to mention that hovering over the server status in the dashboard reveals the same structured error info that the API returns.

## Related

- SHIP-14800: https://jira.cfdata.org/browse/SHIP-14800
- SHIP-15209 (GA): https://jira.cfdata.org/browse/SHIP-15209
- ztx-frontend MCP-32 commit: 38774c8d72