### PR TITLE
[Workers] Fix tracing changelog config key (tracing → traces)

### DIFF
--- a/src/content/changelog/workers/2025-11-07-automatic-tracing.mdx
+++ b/src/content/changelog/workers/2025-11-07-automatic-tracing.mdx
@@ -29,7 +29,7 @@ Tracing helps you identify performance bottlenecks, resolve errors, and understa
 ```jsonc
 {
 	"observability": {
-		"tracing": {
+		"traces": {
 			"enabled": true,
 		},
 	},


### PR DESCRIPTION
The "Workers automatic tracing, now in open beta" changelog (2025-11-07) showed the config key as `observability.tracing`, but the correct key is `observability.traces` — the same key used in the Traces docs (/workers/observability/traces/).

With the wrong key, `wrangler` only prints an easy-to-miss warning ("Unexpected fields found in observability field: tracing") and ignores the field, so tracing is never enabled — misleading for anyone copying the snippet.

This corrects the snippet to `traces`.

Internal tracking: WO-1397

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
