### PR TITLE
[Agents, Access, Workers] Correct Code Mode capitalization

### DIFF
--- a/src/content/changelog/access/2026-03-26-mcp-portal-code-mode.mdx
+++ b/src/content/changelog/access/2026-03-26-mcp-portal-code-mode.mdx
@@ -1,21 +1,21 @@
 ---
-title: Code mode for MCP server portals
-description: MCP server portals support code mode, which reduces context window usage by collapsing tools into a single code execution tool.
+title: Code Mode for MCP server portals
+description: MCP server portals support Code Mode, which reduces context window usage by collapsing tools into a single code execution tool.
 date: 2026-03-26
 products:
   - access
 ---
 
-[MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) support [code mode](/agents/model-context-protocol/protocol/codemode/), a technique that reduces context window usage by replacing individual tool definitions with a single code execution tool. Code mode is turned on by default on all portals.
+[MCP server portals](/cloudflare-one/access-controls/ai-controls/mcp-portals/) support [Code Mode](/agents/model-context-protocol/protocol/codemode/), a technique that reduces context window usage by replacing individual tool definitions with a single code execution tool. Code Mode is turned on by default on all portals.
 
-To turn it off, edit the portal in **Access controls** > **AI controls** and turn off **Code mode** under **Basic information**.
+To turn it off, edit the portal in **Access controls** > **AI controls** and turn off **Code Mode** under **Basic information**.
 
-When code mode is active, the portal exposes a single `code` tool instead of listing every tool from every upstream MCP server. The connected AI agent writes JavaScript that calls typed `codemode.*` methods for each upstream tool. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, keeping authentication credentials and environment variables out of the model context.
+When Code Mode is active, the portal exposes a single `code` tool instead of listing every tool from every upstream MCP server. The connected AI agent writes JavaScript that calls typed `codemode.*` methods for each upstream tool. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, keeping authentication credentials and environment variables out of the model context.
 
-To use code mode, append `?codemode=search_and_execute` to your portal URL when connecting from an MCP client:
+To use Code Mode, append `?codemode=search_and_execute` to your portal URL when connecting from an MCP client:
 
 ```txt
 https://<subdomain>.<domain>/mcp?codemode=search_and_execute
 ```
 
-For more information, refer to [code mode](/cloudflare-one/access-controls/ai-controls/mcp-portals/#code-mode).
+For more information, refer to [Code Mode](/cloudflare-one/access-controls/ai-controls/mcp-portals/#code-mode).

--- a/src/content/changelog/agents/2026-03-17-codemode-sdk-v0.2.1.mdx
+++ b/src/content/changelog/agents/2026-03-17-codemode-sdk-v0.2.1.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@cloudflare/codemode v0.2.1: MCP barrel export, zero-dependency main entry point, and custom sandbox modules"
-description: "Codemode v0.2.0–v0.2.1 adds a new @cloudflare/codemode/mcp export with codeMcpServer and openApiMcpServer, makes the main entry point dependency-free, and lets you inject custom modules into the sandbox."
+description: "Code Mode v0.2.0–v0.2.1 adds a new @cloudflare/codemode/mcp export with codeMcpServer and openApiMcpServer, makes the main entry point dependency-free, and lets you inject custom modules into the sandbox."
 products:
   - agents
   - workers

--- a/src/content/changelog/agents/2026-06-16-agents-sdk-v0.16.1.mdx
+++ b/src/content/changelog/agents/2026-06-16-agents-sdk-v0.16.1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agents SDK improves browser automation, code execution, and recovery
-description: "Agents SDK v0.16.1 adds the Codemode runtime and connector model, rebuilds browser automation on durable CDP sessions, improves Think orchestration, and adds Voice output-device selection."
+description: "Agents SDK v0.16.1 adds the Code Mode runtime and connector model, rebuilds browser automation on durable CDP sessions, improves Think orchestration, and adds Voice output-device selection."
 products:
   - agents
   - workers
@@ -11,7 +11,7 @@ import { PackageManagers, TypeScriptExample } from "~/components";
 
 The latest release of the [Agents SDK](https://github.com/cloudflare/agents) makes it easier to build agents that can safely interact with real systems and keep working through interruptions.
 
-Agents can now browse websites through Browser Run, write code against external tools through Codemode, use client-provided tools when delegating to Think sub-agents, and recover more reliably from deploys, Durable Object evictions, and connection churn.
+Agents can now browse websites through Browser Run, write code against external tools through Code Mode, use client-provided tools when delegating to Think sub-agents, and recover more reliably from deploys, Durable Object evictions, and connection churn.
 
 ## Safer browser automation
 
@@ -36,7 +36,7 @@ The browser tools also add Live View URLs, optional session recording, and quick
 
 ## Resumable code execution with approvals
 
-Codemode now uses `createCodemodeRuntime`, connectors, and a durable execution log. This lets you give a model one `codemode` tool instead of a large prompt full of tool definitions. The model can discover the capabilities it needs, write code against typed globals, and reuse saved snippets.
+Code Mode now uses `createCodemodeRuntime`, connectors, and a durable execution log. This lets you give a model one `codemode` tool instead of a large prompt full of tool definitions. The model can discover the capabilities it needs, write code against typed globals, and reuse saved snippets.
 
 <TypeScriptExample>
 
@@ -119,4 +119,4 @@ To update to the latest version:
 
 <PackageManagers pkg="agents@latest @cloudflare/think@latest @cloudflare/codemode@latest @cloudflare/ai-chat@latest @cloudflare/voice@latest" />
 
-Refer to the [Codemode documentation](/agents/model-context-protocol/protocol/codemode/), [Browser tools documentation](/agents/tools/browser/), [Think tools documentation](/agents/harnesses/think/tools/), and [Voice documentation](/agents/communication-channels/voice/) for more information.
+Refer to the [Code Mode documentation](/agents/model-context-protocol/protocol/codemode/), [Browser tools documentation](/agents/tools/browser/), [Think tools documentation](/agents/harnesses/think/tools/), and [Voice documentation](/agents/communication-channels/voice/) for more information.

--- a/src/content/docs/agents/harnesses/think/configuration.mdx
+++ b/src/content/docs/agents/harnesses/think/configuration.mdx
@@ -128,7 +128,7 @@ For the full Session API — context blocks, compaction, search, skills, and mul
 | `@cloudflare/think/messengers/telegram` | Telegram messenger provider and delivery helpers              |
 | `@cloudflare/think/workflows`           | `ThinkWorkflow`, `step.prompt()` — Workflow prompts           |
 | `@cloudflare/think/tools/workspace`     | `createWorkspaceTools()` — for custom storage backends        |
-| `@cloudflare/think/tools/execute`       | `createExecuteTool()` — sandboxed code execution via codemode |
+| `@cloudflare/think/tools/execute`       | `createExecuteTool()` — sandboxed code execution via Code Mode |
 | `@cloudflare/think/tools/browser`       | `createBrowserTools()` — Chrome DevTools Protocol tools       |
 | `@cloudflare/think/tools/extensions`    | `createExtensionTools()` — LLM-driven extension loading       |
 | `@cloudflare/think/extensions`          | `ExtensionManager`, `HostBridgeLoopback` — extension runtime  |

--- a/src/content/docs/agents/harnesses/think/tools.mdx
+++ b/src/content/docs/agents/harnesses/think/tools.mdx
@@ -161,7 +161,7 @@ getTools(): ToolSet {
 When `needsApproval` returns `true`, the tool call is sent to the client for approval. The conversation pauses until the client responds with `CF_AGENT_TOOL_APPROVAL`.
 
 :::note
-Inside the [code execution tool](#code-execution-tool)'s sandbox, `needsApproval` behaves differently: it maps to the codemode runtime's durable pause/approve/resume flow, and a function-valued `needsApproval` always requires approval. Refer to [Approvals (human-in-the-loop)](#approvals-human-in-the-loop).
+Inside the [code execution tool](#code-execution-tool)'s sandbox, `needsApproval` behaves differently: it maps to the Code Mode runtime's durable pause/approve/resume flow, and a function-valued `needsApproval` always requires approval. Refer to [Approvals (human-in-the-loop)](#approvals-human-in-the-loop).
 :::
 
 ## Per-turn tool overrides
@@ -228,7 +228,7 @@ export class MyAgent extends Think<Env> {
 
 ## Code execution tool
 
-Let the LLM write and run JavaScript in a sandboxed Worker, recorded on a durable codemode runtime (abort-and-replay, human approvals, audit trail, reusable snippets). Requires `@cloudflare/codemode` and a `worker_loaders` binding.
+Let the LLM write and run JavaScript in a sandboxed Worker, recorded on a durable Code Mode runtime (abort-and-replay, human approvals, audit trail, reusable snippets). Requires `@cloudflare/codemode` and a `worker_loaders` binding.
 
 ```sh
 npm install @cloudflare/codemode
@@ -403,7 +403,7 @@ This adds the durable CDP tool plus stateless [Quick Action](/agents/tools/brows
 
 Pass `quickActions: false` to keep only `browser_execute`, or pass `quickActions: { actions, maxChars, options }` to configure the stateless tools. The Quick Action tools share the `browser` binding, need no Worker Loader, and resolve `ctx` from the current Agent automatically. To use only the stateless tools, import `createQuickActionTools` from `@cloudflare/think/tools/browser`.
 
-The tool is backed by a codemode runtime with the `cdp` connector: the model writes async arrow functions that run in a sandboxed Worker isolate, with `cdp.send()`, `cdp.attachToTarget()`, `cdp.spec()` (the live, normalized protocol description), session helpers (`cdp.startSession()`, `cdp.sessionInfo()`, `cdp.closeSession()`), and debug-log helpers. Executions are recorded for abort-and-replay, so browser sessions survive approval pauses.
+The tool is backed by a Code Mode runtime with the `cdp` connector: the model writes async arrow functions that run in a sandboxed Worker isolate, with `cdp.send()`, `cdp.attachToTarget()`, `cdp.spec()` (the live, normalized protocol description), session helpers (`cdp.startSession()`, `cdp.sessionInfo()`, `cdp.closeSession()`), and debug-log helpers. Executions are recorded for abort-and-replay, so browser sessions survive approval pauses.
 
 By default each execution gets a fresh browser session (`one-shot`), torn down when the run ends. Pass `session: { mode: "dynamic" }` to let the model promote a session with `cdp.startSession()` so later executions continue in the same browser, or `session: { mode: "reuse", key }` for a named long-lived session. Stale sessions are reclaimed by the connector's `sweep()` — call it from a scheduled task.
 

--- a/src/content/docs/agents/model-context-protocol/cloudflare/servers-for-cloudflare/index.mdx
+++ b/src/content/docs/agents/model-context-protocol/cloudflare/servers-for-cloudflare/index.mdx
@@ -18,7 +18,7 @@ These MCP servers allow your MCP client to read configurations from your account
 
 The [Cloudflare API MCP server](https://github.com/cloudflare/mcp) provides access to the entire [Cloudflare API](/api/) — over 2,500 endpoints across DNS, Workers, R2, Zero Trust, and every other product — through just two tools: `search()` and `execute()`.
 
-It uses [Codemode](/agents/model-context-protocol/protocol/codemode/), a technique where the model writes JavaScript against a typed representation of the OpenAPI spec and the Cloudflare API client, rather than loading individual tool definitions for each endpoint. The generated code runs inside an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) sandbox.
+It uses [Code Mode](/agents/model-context-protocol/protocol/codemode/), a technique where the model writes JavaScript against a typed representation of the OpenAPI spec and the Cloudflare API client, rather than loading individual tool definitions for each endpoint. The generated code runs inside an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) sandbox.
 
 This approach uses approximately 1,000 tokens regardless of how many API endpoints exist. An equivalent MCP server that exposed every endpoint as a native tool would consume over 1 million tokens — more than the entire context window of most foundation models.
 
@@ -26,7 +26,7 @@ This approach uses approximately 1,000 tokens regardless of how many API endpoin
 | --------------------------------- | ----- | ---------- |
 | Native MCP (full schemas)         | 2,594 | ~1,170,000 |
 | Native MCP (required params only) | 2,594 | ~244,000   |
-| Codemode                          | 2     | ~1,000     |
+| Code Mode                         | 2     | ~1,000     |
 
 ### Connect to the Cloudflare API MCP server
 

--- a/src/content/docs/agents/model-context-protocol/protocol/codemode.mdx
+++ b/src/content/docs/agents/model-context-protocol/protocol/codemode.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: reference
-title: Codemode
+title: Code Mode
 description: Let LLMs use external systems by writing TypeScript in a secure sandbox, backed by a durable runtime with discovery, approvals, and reusable snippets.
 tags:
   - AI
@@ -19,7 +19,7 @@ import {
 
 <InlineBadge preset="beta" />
 
-Codemode lets a model use external systems by **writing TypeScript** instead of making individual tool calls. The model gets one tool — `codemode({ code })` — that executes its code in a sandboxed Worker. Inside the sandbox, every integration you configure is available as a typed global, and a four-method platform SDK handles discovery, side effects, and reuse.
+Code Mode lets a model use external systems by **writing TypeScript** instead of making individual tool calls. The model gets one tool — `codemode({ code })` — that executes its code in a sandboxed Worker. Inside the sandbox, every integration you configure is available as a typed global, and a four-method platform SDK handles discovery, side effects, and reuse.
 
 ```ts
 // The developer configures one tool:
@@ -36,12 +36,12 @@ const prs = await github.list_pull_requests({
 ```
 
 :::caution
-Codemode is experimental and may have breaking changes in future releases. Use with caution in production.
+Code Mode is experimental and may have breaking changes in future releases. Use with caution in production.
 :::
 
-## Why use Codemode
+## Why use Code Mode
 
-- **Tool descriptions do not scale.** The classic approach generates types for every tool and puts them all in the tool description. Ten tools is fine; a GitHub MCP server plus a Stripe spec plus an internal API is thousands of prompt tokens the model pays for on every request, mostly for tools it will not call. Codemode moves discovery _inside the sandbox_: `codemode.search` and `codemode.describe` return results into the running code, not into the context window. The model pulls exactly the type information it needs, when it needs it.
+- **Tool descriptions do not scale.** The classic approach generates types for every tool and puts them all in the tool description. Ten tools is fine; a GitHub MCP server plus a Stripe spec plus an internal API is thousands of prompt tokens the model pays for on every request, mostly for tools it will not call. Code Mode moves discovery _inside the sandbox_: `codemode.search` and `codemode.describe` return results into the running code, not into the context window. The model pulls exactly the type information it needs, when it needs it.
 - **Models are better at code than at tool protocols.** Filtering, joining, retrying, and looping over pages each cost a round trip through the model in tool-call style. In code it is just code: one sandbox run can do what would otherwise take a dozen tool calls.
 - **Real work needs durable state.** Creating issues, sending messages, and merging pull requests need human approval, an audit trail, and sometimes an undo. Those concerns have one home — the runtime — instead of being rebuilt per app. The model's code pauses at an approval-required call and continues after approval as if nothing happened.
 
@@ -61,7 +61,7 @@ The sandbox has **no network access**. Model code cannot `fetch`; every effect g
 npm install @cloudflare/codemode
 ```
 
-## Configure Codemode
+## Configure Code Mode
 
 ### 1. Add the Vite plugin
 
@@ -517,7 +517,7 @@ For import attributes to work, your `tsconfig.json` needs `"module": "esnext"` (
 ## Related resources
 
 <LinkCard
-	title="Codemode connectors example"
+	title="Code Mode connectors example"
 	href="https://github.com/cloudflare/agents/tree/main/examples/codemode-connectors"
 	description="The connector playground — MCP, OpenAPI, and custom connectors with in-sandbox approvals."
 />
@@ -531,5 +531,5 @@ For import attributes to work, your `tsconfig.json` needs `"module": "esnext"` (
 <LinkCard
 	title="MCP client"
 	href="/agents/model-context-protocol/apis/client-api/"
-	description="Connect to MCP servers and expose their tools as codemode connectors."
+	description="Connect to MCP servers and expose their tools as Code Mode connectors."
 />

--- a/src/content/docs/agents/tools/browser.mdx
+++ b/src/content/docs/agents/tools/browser.mdx
@@ -17,7 +17,7 @@ import {
 
 Agents can use [Browser Run](/browser-run/) to inspect and interact with web pages through the [Chrome DevTools Protocol (CDP)](/browser-run/cdp/). <InlineBadge preset="beta" /> Browser tools are useful when an agent needs to understand rendered pages, capture screenshots, debug frontend behavior, or extract information that is only available after JavaScript runs.
 
-Instead of a fixed set of browser actions (click, screenshot, navigate), the model writes code that runs CDP commands against a live browser session through the `cdp` connector — accessing all domains, commands, events, and types in the protocol. Executions are recorded on a durable codemode runtime (abort-and-replay), so a run can pause for approval and resume with its browser session intact.
+Instead of a fixed set of browser actions (click, screenshot, navigate), the model writes code that runs CDP commands against a live browser session through the `cdp` connector — accessing all domains, commands, events, and types in the protocol. Executions are recorded on a durable Code Mode runtime (abort-and-replay), so a run can pause for approval and resume with its browser session intact.
 
 Use browser tools when you want an agent to:
 
@@ -113,7 +113,7 @@ export { CodemodeRuntime } from "agents/browser";
 
 </TypeScriptExample>
 
-`agents/browser` re-exports the codemode runtime for browser tool setups. Codemode-specific examples can also import `CodemodeRuntime` from `@cloudflare/codemode`.
+`agents/browser` re-exports the Code Mode runtime for browser tool setups. Code Mode-specific examples can also import `CodemodeRuntime` from `@cloudflare/codemode`.
 
 ## Session lifecycle
 
@@ -179,7 +179,7 @@ Quick Actions require a Worker `compatibility_date` of `2026-03-24` or later and
 
 [Live View](/browser-run/features/live-view/) lets a human watch or control a running browser session in real time. Use it for human-in-the-loop steps such as login, MFA, CAPTCHA, or sensitive input.
 
-Because the codemode runtime can pause a run with the browser session intact, a handoff follows this pattern:
+Because the Code Mode runtime can pause a run with the browser session intact, a handoff follows this pattern:
 
 1. The model calls `cdp.getLiveViewUrl()` to get a link to the current tab.
 2. The agent surfaces the link to the user.

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -33,7 +33,7 @@ MCP server portals provide the following capabilities:
 
 - **Non-browser client support**: MCP clients authenticate to the portal using a standard OAuth 2.0 authorization code flow via [managed OAuth](/cloudflare-one/access-controls/applications/http-apps/managed-oauth/). Non-browser clients receive a `401` response with a `WWW-Authenticate` header pointing to Access's OAuth discovery endpoints, rather than a browser redirect. You can also connect using [Access service tokens](#connect-with-a-service-token) for machine-to-machine access.
 
-- **Code mode**: Code mode is available by default on all portals. It collapses all upstream tools into a single `code` tool. The AI agent writes JavaScript that calls typed methods for each tool, and the code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment. This keeps context window usage fixed regardless of how many tools are available. Refer to [code mode](#code-mode) for connection instructions.
+- **Code Mode**: Code Mode is available by default on all portals. It collapses all upstream tools into a single `code` tool. The AI agent writes JavaScript that calls typed methods for each tool, and the code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment. This keeps context window usage fixed regardless of how many tools are available. Refer to [Code Mode](#code-mode) for connection instructions.
 
 - **Observability**: Once the user's AI agent is connected to the portal, Cloudflare Access logs the individual requests made using the tools in the portal. You can optionally route portal traffic through [Cloudflare Gateway](#route-portal-traffic-through-gateway) for richer HTTP logging and data loss prevention (DLP) scanning.
 
@@ -403,11 +403,11 @@ If you [rename a tool with an alias](#rename-tools-and-prompts-with-aliases), th
 
 For example, if you alias the tool `list_issues` to `issues` on a server with ID `github`, the namespaced name becomes `github_issues`.
 
-#### Namespacing in code mode
+#### Namespacing in Code Mode
 
-When [code mode](#code-mode) is active, the portal applies an additional transformation to make namespaced tool names safe for use as JavaScript identifiers. Hyphens and dots in the namespaced name are replaced with underscores, names that start with a digit get a `_` prefix, and JavaScript reserved words get a `_` suffix. For example, a server with ID `my-server` and a tool named `get-data` would appear as `my_server_get_data` in the code mode sandbox.
+When [Code Mode](#code-mode) is active, the portal applies an additional transformation to make namespaced tool names safe for use as JavaScript identifiers. Hyphens and dots in the namespaced name are replaced with underscores, names that start with a digit get a `_` prefix, and JavaScript reserved words get a `_` suffix. For example, a server with ID `my-server` and a tool named `get-data` would appear as `my_server_get_data` in the Code Mode sandbox.
 
-This sanitization happens automatically. You do not need to call any helper functions when using code mode as an end user.
+This sanitization happens automatically. You do not need to call any helper functions when using Code Mode as an end user.
 
 #### Helper functions in the Agents SDK
 
@@ -415,7 +415,7 @@ If you are building an MCP client with the [Agents SDK](/agents/model-context-pr
 
 - **`normalizeServerId`** (exported from `agents/mcp/client`) normalizes a caller-supplied server ID into a safe string. For example, `"GitHub MCP!"` becomes `"github-mcp"`. The SDK calls this automatically when you pass an `id` option to `addMcpServer()`.
 
-- **`sanitizeToolName`** (exported from `@cloudflare/codemode`) converts a tool name into a valid JavaScript identifier by replacing hyphens and dots with underscores. This is called automatically in code mode contexts. Refer to the [code mode SDK reference](/agents/model-context-protocol/protocol/codemode/#sanitizetoolnamename) for details.
+- **`sanitizeToolName`** (exported from `@cloudflare/codemode`) converts a tool name into a valid JavaScript identifier by replacing hyphens and dots with underscores. This is called automatically in Code Mode contexts. Refer to the [Code Mode SDK reference](/agents/model-context-protocol/protocol/codemode/#sanitizetoolnamename) for details.
 
 :::note
 The Agents SDK uses a `tool_{server_id}_{tool_name}` format (with a `tool_` prefix) when returning tools from `getAITools()`. This differs from the portal format, which uses `{server_id}_{tool_name}` without the prefix.
@@ -446,16 +446,16 @@ When you connect with the [`optimize_context`](#optimize-context) query paramete
 | `portal_query_tools` | `minimize_tools`, `search_and_execute` | Searches upstream tools by name, description, or schema using a regex pattern. Returns full tool definitions so the agent can call them. Required in `minimize_tools` mode because upstream tool schemas are stripped to reduce context size. |
 | `portal_execute` | `search_and_execute` | Calls an upstream tool by name with the provided arguments. In `search_and_execute` mode, upstream tools are hidden from the tool list entirely, so agents must use `portal_query_tools` to discover them and `portal_execute` to call them. |
 
-#### Code mode tools
+#### Code Mode tools
 
-When you connect with [code mode](#code-mode) enabled, the portal replaces all upstream tools with two code execution tools:
+When you connect with [Code Mode](#code-mode) enabled, the portal replaces all upstream tools with two code execution tools:
 
 | Tool | Description |
 | --- | --- |
 | `portal_codemode_search` | Searches available tools by running JavaScript in a sandboxed Worker. The sandbox provides a `codemode.tools()` function that returns all upstream tool definitions with sanitized names. |
 | `portal_codemode_execute` | Calls upstream tools by running JavaScript in a sandboxed Worker. The sandbox provides a `codemode` proxy object where each property maps to an upstream tool. Supports `Promise.all()` for parallel tool calls. |
 
-Refer to the [code mode SDK reference](/agents/model-context-protocol/protocol/codemode/) for details on writing code for these tools.
+Refer to the [Code Mode SDK reference](/agents/model-context-protocol/protocol/codemode/) for details on writing code for these tools.
 
 ## Manage portals via API
 
@@ -564,17 +564,17 @@ resource "cloudflare_dns_record" "mcp_portal" {
 
 For the full list of supported resource arguments, refer to the [Terraform provider documentation](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs).
 
-## Code mode
+## Code Mode
 
-[Code mode](/agents/model-context-protocol/protocol/codemode/) is turned on by default on all MCP server portals. It reduces context window usage by collapsing all tools in the portal into a single `code` tool. Instead of loading a separate tool definition for each upstream MCP server tool, the connected AI agent writes JavaScript that calls typed `codemode.*` methods. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, which keeps authentication credentials and environment variables out of the model context.
+[Code Mode](/agents/model-context-protocol/protocol/codemode/) is turned on by default on all MCP server portals. It reduces context window usage by collapsing all tools in the portal into a single `code` tool. Instead of loading a separate tool definition for each upstream MCP server tool, the connected AI agent writes JavaScript that calls typed `codemode.*` methods. The generated code runs in an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) environment, which keeps authentication credentials and environment variables out of the model context.
 
-To use code mode, the MCP client must request it when connecting to the portal URL. Refer to [Connect with code mode](#connect-with-code-mode) for the required query parameter.
+To use Code Mode, the MCP client must request it when connecting to the portal URL. Refer to [Connect with Code Mode](#connect-with-code-mode) for the required query parameter.
 
-Code mode is useful for portals that aggregate many MCP servers or servers that expose a large number of tools. Context window usage stays fixed regardless of how many tools are available through the portal.
+Code Mode is useful for portals that aggregate many MCP servers or servers that expose a large number of tools. Context window usage stays fixed regardless of how many tools are available through the portal.
 
-### Connect with code mode
+### Connect with Code Mode
 
-To use code mode, append the `?codemode=search_and_execute` query string parameter to your portal URL when [connecting](#connect-to-a-portal) from an MCP client.
+To use Code Mode, append the `?codemode=search_and_execute` query string parameter to your portal URL when [connecting](#connect-to-a-portal) from an MCP client.
 
 For example, if your portal URL is `https://<subdomain>.<domain>/mcp`, connect to:
 
@@ -584,7 +584,7 @@ https://<subdomain>.<domain>/mcp?codemode=search_and_execute
 
 For MCP clients with server configuration files, use the portal URL with the query string parameter:
 
-```json title="MCP client configuration with code mode"
+```json title="MCP client configuration with Code Mode"
 {
 	"mcpServers": {
 		"example-portal": {
@@ -599,19 +599,19 @@ For MCP clients with server configuration files, use the portal URL with the que
 }
 ```
 
-When code mode is active, the portal advertises a single `code` tool to connected MCP clients. The AI agent discovers available tools by inspecting the typed method signatures in the Dynamic Worker environment and composes multiple tool calls into a single code execution.
+When Code Mode is active, the portal advertises a single `code` tool to connected MCP clients. The AI agent discovers available tools by inspecting the typed method signatures in the Dynamic Worker environment and composes multiple tool calls into a single code execution.
 
-For more information on building with code mode, refer to the [code mode SDK reference](/agents/model-context-protocol/protocol/codemode/).
+For more information on building with Code Mode, refer to the [Code Mode SDK reference](/agents/model-context-protocol/protocol/codemode/).
 
-### Turn off code mode
+### Turn off Code Mode
 
-To turn off code mode for a portal:
+To turn off Code Mode for a portal:
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
 
 1. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Zero Trust** > **Access controls** > **AI controls**.
 2. Find the portal you want to configure, then select the three dots > **Edit**.
-3. Under **Basic information**, turn off **Code mode**.
+3. Under **Basic information**, turn off **Code Mode**.
 
 </TabItem> <TabItem label="API">
 
@@ -826,7 +826,7 @@ For MCP clients with server configuration files:
 }
 ```
 
-For more information on the code mode pattern behind `search_and_execute`, refer to the [Code mode SDK reference](/agents/model-context-protocol/protocol/codemode/).
+For more information on the Code Mode pattern behind `search_and_execute`, refer to the [Code Mode SDK reference](/agents/model-context-protocol/protocol/codemode/).
 
 ## Manage portal sessions
 

--- a/src/content/docs/dynamic-workers/getting-started.mdx
+++ b/src/content/docs/dynamic-workers/getting-started.mdx
@@ -17,7 +17,7 @@ Dynamic Workers support two loading modes:
 - `load(code)` creates a fresh Dynamic Worker for one-time execution.
 - `get(id, callback)` caches a Dynamic Worker by ID so it can stay warm across requests.
 
-`load()` is best for one-time code execution, for example when using [Codemode](/agents/model-context-protocol/protocol/codemode/). `get(id, callback)` is better when the same code will receive subsequent requests, for example when you are building applications.
+`load()` is best for one-time code execution, for example when using [Code Mode](/agents/model-context-protocol/protocol/codemode/). `get(id, callback)` is better when the same code will receive subsequent requests, for example when you are building applications.
 
 ### Try it out
 

--- a/src/content/docs/workers/runtime-apis/bindings/worker-loader.mdx
+++ b/src/content/docs/workers/runtime-apis/bindings/worker-loader.mdx
@@ -28,11 +28,11 @@ Worker Loaders also enable **sandboxing** of code, meaning that you can strictly
 
 With proper sandboxing configured, you can safely run code you do not trust in a dynamic isolate.
 
-## Codemode
+## Code Mode
 
-A primary use case for Dynamic Worker Loaders is [Codemode](/agents/model-context-protocol/protocol/codemode/) in the [Agents SDK](/agents/). Codemode converts your tools into typed TypeScript APIs and gives the LLM a single "write code" tool. The generated code runs in an isolated Worker sandbox, which lets AI agents chain multiple tool calls in one execution and reduces round-trips through the model.
+A primary use case for Dynamic Worker Loaders is [Code Mode](/agents/model-context-protocol/protocol/codemode/) in the [Agents SDK](/agents/). Code Mode converts your tools into typed TypeScript APIs and gives the LLM a single "write code" tool. The generated code runs in an isolated Worker sandbox, which lets AI agents chain multiple tool calls in one execution and reduces round-trips through the model.
 
-Codemode works with both standard AI SDK tools and [MCP](/agents/model-context-protocol/) tools.
+Code Mode works with both standard AI SDK tools and [MCP](/agents/model-context-protocol/) tools.
 
 ## Basic usage
 


### PR DESCRIPTION
### Summary

Corrects the Code Mode proper noun capitalization across docs pages, changelog entries, and related reference pages. Leaves package names, API symbols, URL slugs, anchors, and query parameters such as `@cloudflare/codemode`, `CodemodeRuntime`, `codemode.*`, `/codemode/`, and `?codemode=` unchanged.

| URL | Instances fixed |
| --- | ---: |
| https://developers.cloudflare.com/agents/harnesses/think/configuration/ | 1 |
| https://developers.cloudflare.com/agents/harnesses/think/tools/ | 3 |
| https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/ | 2 |
| https://developers.cloudflare.com/agents/model-context-protocol/protocol/codemode/ | 8 |
| https://developers.cloudflare.com/agents/tools/browser/ | 4 |
| https://developers.cloudflare.com/changelog/post/2026-03-17-codemode-sdk-v0.2.1/ | 1 |
| https://developers.cloudflare.com/changelog/post/2026-03-26-mcp-portal-code-mode/ | 8 |
| https://developers.cloudflare.com/changelog/post/2026-06-16-agents-sdk-v0.16.1/ | 4 |
| https://developers.cloudflare.com/cloudflare-one/access-controls/ai-controls/mcp-portals/ | 28 |
| https://developers.cloudflare.com/dynamic-workers/getting-started/ | 1 |
| https://developers.cloudflare.com/workers/runtime-apis/bindings/worker-loader/ | 4 |

Total: 64 instances fixed.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
