### PR TITLE
[Flagship] Improve SDK docs and navigation

### DIFF
--- a/src/content/docs/flagship/best-practices.mdx
+++ b/src/content/docs/flagship/best-practices.mdx
@@ -1,0 +1,84 @@
+---
+pcx_content_type: concept
+title: Best practices
+description: Best practices for using Flagship in applications, including evaluation paths, rollout workflows, and safe flag cleanup.
+sidebar:
+  order: 5
+products:
+  - flagship
+---
+
+Use these patterns to keep Flagship evaluations predictable, fast, and easy to maintain.
+
+## Choose the right evaluation path
+
+Use the [Workers binding](/flagship/binding/) inside Cloudflare Workers. The binding handles authentication automatically and avoids application-managed API tokens.
+
+Use the [OpenFeature SDK](/flagship/sdk/) when you run outside Workers or need a vendor-neutral OpenFeature interface. In Workers, you can still pass the binding to the OpenFeature server provider to keep binding performance while using OpenFeature APIs.
+
+## Evaluate once per request
+
+Avoid evaluating the same flag repeatedly in a loop. Evaluate the flag once, store the result in a local variable, and reuse it for the rest of the request.
+
+```ts
+const enabled = await env.FLAGS.getBooleanValue("show-related-items", false, {
+	userId,
+});
+
+for (const item of items) {
+	if (enabled) {
+		item.related = await loadRelatedItems(item.id);
+	}
+}
+```
+
+## Pass context consistently
+
+Targeting and percentage rollouts depend on the evaluation context you pass from your application. Use stable identifiers and the same attribute names everywhere.
+
+```ts
+const context = {
+	userId: session.user.id,
+	plan: session.user.plan,
+	country: request.cf?.country ?? "unknown",
+};
+
+const enabled = await env.FLAGS.getBooleanValue("new-checkout", false, context);
+```
+
+For OpenFeature SDKs, use `targetingKey` as the stable identifier. For the Workers binding, use the attribute configured for your rollout, such as `userId`.
+
+## Choose safe defaults
+
+Every evaluation method requires a default value. Choose a default that keeps your application safe if the flag does not exist, cannot be evaluated, or has a type mismatch.
+
+For release flags, this is usually the existing experience. For configuration flags, choose conservative limits or behavior that your application can handle without extra dependencies.
+
+## Use details for debugging and observability
+
+Use `*Details` methods when you need to understand why a value was returned. Details include the resolved value, variant, reason, and error metadata.
+
+```ts
+const details = await env.FLAGS.getBooleanDetails("new-checkout", false, {
+	userId: "user-42",
+});
+
+console.log(details.value);
+console.log(details.variant);
+console.log(details.reason);
+console.log(details.errorCode);
+```
+
+## Roll out progressively
+
+Start with a small percentage rollout, monitor application metrics, then increase the percentage over time.
+
+1. Create the flag with a small rollout, such as 5%.
+2. Monitor errors, latency, business metrics, and user feedback.
+3. Increase to 25%, then 50%, then 100% as confidence grows.
+4. After the rollout reaches 100%, make the winning variant the default and remove temporary targeting rules.
+5. After the feature is fully shipped, remove the old code path and delete the flag.
+
+## Clean up stale flags
+
+Flags that are disabled or fully rolled out still add maintenance cost. Before deleting a flag, disable it first, monitor for unexpected behavior, remove the evaluation code, deploy the code change, then delete the flag from Flagship.

--- a/src/content/docs/flagship/binding/methods.mdx
+++ b/src/content/docs/flagship/binding/methods.mdx
@@ -8,13 +8,15 @@ products:
   - flagship
 ---
 
-The Flagship binding provides the following methods for evaluating feature flags. All methods are asynchronous and return a `Promise`. Evaluation methods never throw — they always return a value, falling back to the `defaultValue` you provide on errors.
+The Flagship binding provides the following methods for evaluating feature flags. All methods are asynchronous and return a `Promise`. For known evaluation failures, typed methods return the `defaultValue` you provide.
 
 Refer to the [types reference](/flagship/binding/types/) for the definitions of `FlagshipEvaluationContext` and `FlagshipEvaluationDetails`.
 
 ## `get()`
 
 Returns the raw flag value without type checking. Use this method when the flag type is not known at compile time.
+
+If you provide `defaultValue`, `get()` returns that value for known evaluation failures, such as a missing flag. If you omit `defaultValue`, known evaluation failures are thrown.
 
 ```ts
 get(flagKey: string, defaultValue?: unknown, context?: FlagshipEvaluationContext): Promise<unknown>
@@ -218,11 +220,11 @@ console.log(details.variant); // "brand-refresh"
 
 ## Error handling
 
-Evaluation methods never throw. They always return a value. When an error occurs, the method returns the `defaultValue` you provided. Use the `*Details` variants to inspect what went wrong.
+Typed evaluation methods return the `defaultValue` you provided for known evaluation failures, such as a missing flag or type mismatch. Unexpected runtime failures can still throw. Use the `*Details` methods to inspect known evaluation failures.
 
 ### Type mismatch
 
-If you call a typed method on a flag with a different type (for example, `getBooleanValue` on a string flag), the method returns the default value. The `*Details` variants set `errorCode` to `"TYPE_MISMATCH"`.
+If you call a typed method on a flag with a different type (for example, `getBooleanValue` on a string flag), the method returns the default value. The `*Details` methods set `errorCode` to `"TYPE_MISMATCH"`.
 
 ```ts
 // Flag "checkout-flow" is a string flag, but you call getBooleanDetails.
@@ -233,7 +235,7 @@ console.log(details.errorCode); // "TYPE_MISMATCH"
 
 ### Evaluation failure
 
-If evaluation fails for any other reason (for example, a network error or missing flag), the method returns the default value. The `*Details` variants set `errorCode` to `"GENERAL"`.
+If evaluation fails for another reason, the method returns the default value. The `*Details` methods include an `errorCode` such as `"FLAG_NOT_FOUND"`, `"INVALID_CONTEXT"`, `"PARSE_ERROR"`, or `"GENERAL"`.
 
 ```ts
 const details = await env.FLAGS.getStringDetails(
@@ -241,7 +243,7 @@ const details = await env.FLAGS.getStringDetails(
 	"fallback",
 );
 console.log(details.value); // "fallback"
-console.log(details.errorCode); // "GENERAL"
+console.log(details.errorCode); // "FLAG_NOT_FOUND"
 ```
 
 ## Parameters reference

--- a/src/content/docs/flagship/binding/types.mdx
+++ b/src/content/docs/flagship/binding/types.mdx
@@ -41,17 +41,15 @@ interface FlagshipEvaluationDetails<T> {
 	variant?: string;
 	reason?: string;
 	errorCode?: string;
-	errorMessage?: string;
 }
 ```
 
-| Property       | Type     | Description                                                                            |
-| -------------- | -------- | -------------------------------------------------------------------------------------- |
-| `flagKey`      | `string` | The key of the evaluated flag.                                                         |
-| `value`        | `T`      | The resolved flag value.                                                               |
-| `variant`      | `string` | The name of the matched variation, if any.                                             |
-| `reason`       | `string` | Why the flag resolved to this value (for example, `"TARGETING_MATCH"` or `"DEFAULT"`). |
-| `errorCode`    | `string` | An error code if evaluation failed (for example, `"TYPE_MISMATCH"` or `"GENERAL"`).    |
-| `errorMessage` | `string` | A human-readable description of the error.                                             |
+| Property    | Type     | Description                                                                            |
+| ----------- | -------- | -------------------------------------------------------------------------------------- |
+| `flagKey`   | `string` | The key of the evaluated flag.                                                         |
+| `value`     | `T`      | The resolved flag value.                                                               |
+| `variant`   | `string` | The name of the matched variant, if any.                                               |
+| `reason`    | `string` | Why the flag resolved to this value (for example, `"TARGETING_MATCH"` or `"DEFAULT"`). |
+| `errorCode` | `string` | An error code if evaluation failed (for example, `"TYPE_MISMATCH"` or `"GENERAL"`).    |
 
 Refer to [evaluation reasons and error codes](/flagship/reference/evaluation-reasons/) for the full list of possible values.

--- a/src/content/docs/flagship/concepts.mdx
+++ b/src/content/docs/flagship/concepts.mdx
@@ -1,20 +1,20 @@
 ---
 pcx_content_type: concept
 title: Concepts
-description: Understand Flagship core concepts including apps, flags, variations, targeting rules, evaluation context, and flag propagation.
+description: Understand Flagship core concepts including apps, flags, variants, targeting rules, evaluation context, and flag propagation.
 sidebar:
   order: 3
 products:
   - flagship
 ---
 
-Flagship organizes feature flags into apps. You define flags with variations and targeting rules, then evaluate them within Cloudflare's global network.
+Flagship organizes feature flags into apps. You define flags with variants and targeting rules, then evaluate them within Cloudflare's global network.
 
 ## Overview
 
 Flagship feature flags go through three stages from creation to evaluation:
 
-1. **Configure** — Create flags and targeting rules in the [Cloudflare dashboard](https://dash.cloudflare.com/) or through the API.
+1. **Configure** — Create flags and targeting rules in the [Cloudflare dashboard](https://dash.cloudflare.com/) or through the [API](/api/resources/flagship).
 2. **Propagate** — Flagship automatically distributes your flag configuration across Cloudflare's global network within seconds.
 3. **Evaluate** — Your Worker (or SDK) evaluates flags locally using the propagated configuration. There is no round-trip to a central server.
 
@@ -28,36 +28,36 @@ An app typically maps to a single project, service, or product surface. Each Clo
 
 ## Flags
 
-A flag is a named feature toggle. Each flag has a key, a set of [variations](#variations), [targeting rules](#targeting-rules), and an enabled/disabled state.
+A flag is a named feature toggle. Each flag has a key, a set of [variants](#variants), [targeting rules](#targeting-rules), and an enabled/disabled state.
 
 Flag keys must be unique within an app. Keys can contain letters, numbers, hyphens, and underscores.
 
-When a flag is disabled, it always returns the default variation regardless of any targeting rules.
+When a flag is disabled, it always returns the default variant regardless of any targeting rules. Choose a default variant that is safe for your application if Flagship cannot evaluate the flag.
 
-## Variations
+## Variants
 
-Variations are the possible values a flag can return. Each flag must have at least one variation, and one variation is designated as the default.
+Variants are the possible values a flag can return. Each flag must have at least one variant, and one variant is designated as the default.
 
-Flagship supports four variation types:
+Flagship supports four variant types:
 
-| Type        | Example                                                               |
-| ----------- | --------------------------------------------------------------------- |
-| Boolean     | `on: true`, `off: false`                                              |
-| String      | `v1: "old-checkout"`, `v2: "new-checkout"`                            |
-| Number      | `low: 100`, `high: 1000`                                              |
-| JSON object | `premium: { "tier": "premium", "features": ["analytics", "export"] }` |
+| Type    | Example                                                               |
+| ------- | --------------------------------------------------------------------- |
+| Boolean | `on: true`, `off: false`                                              |
+| String  | `v1: "old-checkout"`, `v2: "new-checkout"`                            |
+| Number  | `low: 100`, `high: 1000`                                              |
+| JSON    | `premium: { "tier": "premium", "features": ["analytics", "export"] }` |
 
-Use boolean flags for simple on/off toggles. Use string, number, or JSON object flags when you need to deliver configuration values or structured data.
+Use boolean flags for simple on/off toggles. Use string, number, or JSON flags when you need to deliver configuration values or structured data. JSON variants can contain objects or arrays.
 
 ## Targeting rules
 
-Targeting rules control which variation a flag returns for a given request. Rules are evaluated in sequential order, and the first matching rule wins. If no rule matches, the default variation is returned.
+Targeting rules control which variant a flag returns for a given request. Rules are evaluated in sequential order, and the first matching rule wins. If no rule matches, the default variant is returned.
 
 Each rule contains:
 
 - **Conditions** that compare an attribute from the [evaluation context](#evaluation-context) against a value using an operator.
-- An optional **percentage rollout** that splits traffic across variations.
-- A **variation** to serve when the rule matches.
+- An optional **percentage rollout** that splits traffic across variants.
+- A **variant** to serve when the rule matches.
 
 Conditions within a rule can be grouped with `AND`/`OR` operators.
 
@@ -80,6 +80,8 @@ When using the [OpenFeature SDK](/flagship/sdk/), you pass context through the O
 
 Flagship uses context attributes to match targeting rules and to determine percentage rollout bucketing. A consistent context (for example, the same `userId`) produces the same rollout result on every evaluation.
 
+Avoid sending sensitive data in evaluation context. Only include attributes needed by targeting rules or rollout bucketing.
+
 ## Flag propagation
 
-During the brief propagation window after a flag change, some regions may still serve the previous flag value. After propagation completes, all subsequent evaluations return the updated value.
+After you change a flag, it can take up to 30 seconds for the updated value to reflect globally. During this propagation window, some evaluations may still return the previous flag value.

--- a/src/content/docs/flagship/configuration.mdx
+++ b/src/content/docs/flagship/configuration.mdx
@@ -90,3 +90,7 @@ export default {
 </TypeScriptExample>
 
 Refer to the [binding API reference](/flagship/binding/) for the full list of methods.
+
+## Local development
+
+Flagship bindings work with `wrangler dev`. Local Workers use the live Flagship app configured by `app_id`. There is no local flag store. Make sure your local Wrangler configuration points to a valid Flagship app before testing evaluations.

--- a/src/content/docs/flagship/get-started.mdx
+++ b/src/content/docs/flagship/get-started.mdx
@@ -115,13 +115,13 @@ Evaluate flags using the OpenFeature client:
 
 <Tabs> <TabItem label="With binding">
 
-Pass the Flagship binding directly to the provider. This avoids additional HTTP requests and is the recommended approach inside a Worker. Authentication is handled automatically through the binding.
+Pass the Flagship binding directly to the provider. This avoids additional HTTP overhead and is the recommended approach inside a Worker. The binding handles authentication automatically.
 
 <TypeScriptExample>
 
 ```ts
 import { OpenFeature } from "@openfeature/server-sdk";
-import { FlagshipServerProvider } from "@cloudflare/flagship";
+import { FlagshipServerProvider } from "@cloudflare/flagship/server";
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
@@ -148,13 +148,13 @@ export default {
 
 </TabItem> <TabItem label="With app ID">
 
-Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). The provider makes HTTP requests to the Flagship evaluation endpoint. Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship Evaluate permission.
+Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship Evaluate permission.
 
 <TypeScriptExample>
 
 ```ts
 import { OpenFeature } from "@openfeature/server-sdk";
-import { FlagshipServerProvider } from "@cloudflare/flagship";
+import { FlagshipServerProvider } from "@cloudflare/flagship/server";
 
 await OpenFeature.setProviderAndWait(
 	new FlagshipServerProvider({
@@ -182,3 +182,4 @@ Refer to the [SDK documentation](/flagship/sdk/) for detailed setup instructions
 - Learn about [targeting rules](/flagship/targeting/) to serve different values based on user attributes.
 - Explore the full [binding API reference](/flagship/binding/) for all evaluation methods.
 - Read about [percentage rollouts](/flagship/targeting/percentage-rollouts/) for gradual feature releases.
+- Refer to the [Flagship API reference](/flagship/reference/api-reference/) to manage Flagship programmatically.

--- a/src/content/docs/flagship/index.mdx
+++ b/src/content/docs/flagship/index.mdx
@@ -25,9 +25,9 @@ Ship features safely with feature flags.
 
 </Description>
 
-Flagship is Cloudflare's feature flag service. It lets you control feature visibility in your applications without redeploying code. Define flags with targeting rules and percentage-based rollouts, then evaluate them directly inside your Workers through a [native binding](/flagship/binding/).
+Flagship is Cloudflare's feature flag service. It lets you control feature visibility in your applications without redeploying code. Define flags with targeting rules and percentage-based rollouts, then evaluate them directly inside your Workers through a [native binding](/flagship/binding/) or from server and browser applications with [OpenFeature SDKs](/flagship/sdk/).
 
-[OpenFeature](https://openfeature.dev/) is the CNCF open standard for feature flag management. Flagship is compatible with OpenFeature, so you can use the [`@cloudflare/flagship`](https://www.npmjs.com/package/@cloudflare/flagship) SDK from any JavaScript runtime — Workers, Node.js, or the browser — and swap providers without changing evaluation code.
+[OpenFeature](https://openfeature.dev/) is the CNCF open standard for feature flag management. Flagship is compatible with OpenFeature, so you can use the official TypeScript and Python SDKs and swap providers without changing evaluation code.
 
 Check out the [Get started guide](/flagship/get-started/) to create your first feature flag.
 
@@ -41,7 +41,7 @@ Evaluate flags with a native Workers binding. Type-safe methods with automatic f
 
 <Feature header="OpenFeature SDK" href="/flagship/sdk/" cta="View SDK docs">
 
-Use the [`@cloudflare/flagship`](https://www.npmjs.com/package/@cloudflare/flagship) OpenFeature provider to evaluate flags from Workers, Node.js, or browsers. Switch from another flag provider by changing one line of configuration.
+Use the official OpenFeature SDKs to evaluate flags from Workers, Node.js, browsers, and Python server applications. Switch from another flag provider by changing provider configuration.
 
 </Feature>
 
@@ -57,9 +57,9 @@ Gradually release features to a percentage of users. Consistent hashing ensures 
 
 </Feature>
 
-<Feature header="Multi-type variations" href="/flagship/concepts/">
+<Feature header="Multi-type variants" href="/flagship/concepts/">
 
-Flag variations can be booleans, strings, numbers, or structured JSON objects. Use object variations to deliver entire configuration blocks as a single flag.
+Flag variants can be booleans, strings, numbers, or structured JSON values. Use JSON variants to deliver entire configuration blocks as a single flag.
 
 </Feature>
 

--- a/src/content/docs/flagship/reference/api-reference.mdx
+++ b/src/content/docs/flagship/reference/api-reference.mdx
@@ -1,0 +1,10 @@
+---
+pcx_content_type: navigation
+title: API reference
+description: API endpoints for managing Flagship apps, flags, and targeting rules.
+products:
+  - flagship
+external_link: /api/resources/flagship/
+sidebar:
+  order: 3
+---

--- a/src/content/docs/flagship/reference/evaluation-reasons.mdx
+++ b/src/content/docs/flagship/reference/evaluation-reasons.mdx
@@ -14,22 +14,26 @@ When you evaluate a flag using the binding's `*Details` methods or the OpenFeatu
 
 ## Evaluation reasons
 
-| Reason            | Description                                                                                                                        |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `TARGETING_MATCH` | A targeting rule's conditions matched the evaluation context, and the rule's variation was returned.                               |
-| `SPLIT`           | A targeting rule with a percentage rollout matched. The user fell within the rollout percentage and received the rule's variation. |
-| `DEFAULT`         | No targeting rule matched the evaluation context. The flag's default variation was returned.                                       |
-| `DISABLED`        | The flag is disabled. The default variation was returned regardless of targeting rules.                                            |
+| Reason            | Description                                                                                                                      |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `TARGETING_MATCH` | A targeting rule's conditions matched the evaluation context, and the rule's variant was returned.                               |
+| `SPLIT`           | A targeting rule with a percentage rollout matched. The user fell within the rollout percentage and received the rule's variant. |
+| `DEFAULT`         | No targeting rule matched the evaluation context. The flag's default variant was returned.                                       |
+| `DISABLED`        | The flag is disabled. The default variant was returned regardless of targeting rules.                                            |
+| `CACHED`          | The SDK returned a cached evaluation result.                                                                                     |
+| `ERROR`           | Evaluation failed and the default value was returned.                                                                            |
 
 ## Error codes
 
 When an evaluation error occurs, the method returns the default value you provided. The `*Details` methods include additional metadata about the error.
 
-| Error code       | Description                                                                                                                                                               |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TYPE_MISMATCH`  | The flag's variation type does not match the requested type. For example, calling `getBooleanValue` on a flag whose variation is a string. The default value is returned. |
-| `GENERAL`        | An unexpected error occurred during evaluation (for example, a network failure). The default value is returned.                                                           |
-| `FLAG_NOT_FOUND` | The specified flag key does not exist in the app. The default value is returned.                                                                                          |
+| Error code        | Description                                                                                                                                                           |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TYPE_MISMATCH`   | The flag's variant type does not match the requested type. For example, calling `getBooleanValue` on a flag whose variant is a string. The default value is returned. |
+| `FLAG_NOT_FOUND`  | The specified flag key does not exist in the app. The default value is returned.                                                                                      |
+| `INVALID_CONTEXT` | The evaluation context contains unsupported values, such as objects or arrays in HTTP evaluation. The default value is returned.                                      |
+| `PARSE_ERROR`     | The SDK received an invalid evaluation response. The default value is returned.                                                                                       |
+| `GENERAL`         | An unexpected error occurred during evaluation, such as a timeout or network failure. The default value is returned.                                                  |
 
 ## Example
 
@@ -50,7 +54,7 @@ switch (details.reason) {
 		console.log(`Included in rollout, variant: ${details.variant}`);
 		break;
 	case "DEFAULT":
-		console.log("No rule matched, using default variation");
+		console.log("No rule matched, using default variant");
 		break;
 	case "DISABLED":
 		console.log("Flag is disabled");
@@ -58,9 +62,7 @@ switch (details.reason) {
 }
 
 if (details.errorCode) {
-	console.error(
-		`Evaluation error: ${details.errorCode} - ${details.errorMessage}`,
-	);
+	console.error(`Evaluation error: ${details.errorCode}`);
 }
 ```
 

--- a/src/content/docs/flagship/reference/limits.mdx
+++ b/src/content/docs/flagship/reference/limits.mdx
@@ -12,12 +12,17 @@ Flagship enforces the following limits.
 
 ## Platform limits
 
-| Feature                         | Limit    |
-| ------------------------------- | -------- |
-| Apps per account                | 10,000   |
-| Flags per app                   | 5,000    |
-| Condition nesting depth         | 6 levels |
-| Flag configuration size per app | 25 MB    |
+| Feature                         | Limit     |
+| ------------------------------- | --------- |
+| Apps per account                | 10,000    |
+| Flags per app                   | 5,000     |
+| Flag, app, and variant keys     | 64 chars  |
+| Condition attribute names       | 64 chars  |
+| Condition string values         | 256 chars |
+| Variant value size              | 10 KB     |
+| Condition nesting depth         | 5 levels  |
+| Flag description                | 512 chars |
+| Flag configuration size per app | 25 MB     |
 
 :::note
 The apps-per-account and flags-per-app limits are soft limits. If your use case requires higher limits, contact Cloudflare support.
@@ -26,4 +31,6 @@ The apps-per-account and flags-per-app limits are soft limits. If your use case 
 ## Notes
 
 - Condition nesting depth counts from the top-level condition group. A flat list of conditions (no nesting) has a depth of 1.
-- Flag configuration size refers to the total serialized size of all flags within a single app, including their variations and rules.
+- Flag keys, app names, condition set names, and variant keys can contain letters, numbers, hyphens, and underscores.
+- All variants on a flag must use the same value type: boolean, string, number, or JSON.
+- Flag configuration size refers to the total serialized size of all flags within a single app, including their variants and rules.

--- a/src/content/docs/flagship/sdk/client-provider.mdx
+++ b/src/content/docs/flagship/sdk/client-provider.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: how-to
-title: Client provider
+title: TypeScript Client SDK
 description: Set up the FlagshipClientProvider to evaluate feature flags synchronously in browser applications using the OpenFeature web SDK.
 sidebar:
   order: 2
@@ -15,7 +15,7 @@ The `FlagshipClientProvider` implements the OpenFeature web provider interface f
 This makes the provider suitable for client-side rendering where synchronous access to flag values is required.
 
 :::caution
-We do not recommend using the client provider in public-facing apps right now. It requires a Cloudflare API token, which would be exposed in client-side code and visible to anyone who inspects your application. We are working on a safer solution for client-side flag evaluation — in the meantime, use the [Worker binding](/flagship/binding/) or the [server provider](/flagship/sdk/server-provider/).
+We do not recommend using the client provider in public-facing apps right now. It requires a Cloudflare API token, which would be exposed in client-side code and visible to anyone who inspects your application. We are working on a safer solution for client-side flag evaluation — in the meantime, use the [Worker binding](/flagship/binding/) or the [TypeScript server SDK](/flagship/sdk/server-provider/).
 :::
 
 ## prefetchFlags
@@ -36,7 +36,7 @@ The following example initializes the provider with a set of pre-fetched flags a
 
 ```ts
 import { OpenFeature } from "@openfeature/web-sdk";
-import { FlagshipClientProvider } from "@cloudflare/flagship";
+import { FlagshipClientProvider } from "@cloudflare/flagship/web";
 
 await OpenFeature.setProviderAndWait(
 	new FlagshipClientProvider({
@@ -64,17 +64,21 @@ if (showBanner) {
 </TypeScriptExample>
 
 :::note
-`getBooleanValue` on the client provider is synchronous and does not require `await`, unlike the [server provider](/flagship/sdk/server-provider/).
+`getBooleanValue` on the client provider is synchronous and does not require `await`, unlike the [TypeScript server SDK](/flagship/sdk/server-provider/).
 :::
 
 ## Configuration options
 
-| Option          | Type       | Required | Description                                                                                                                          |
-| --------------- | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `appId`         | `string`   | Yes      | The Flagship app ID from the Cloudflare dashboard.                                                                                   |
-| `accountId`     | `string`   | Yes      | Your Cloudflare account ID.                                                                                                          |
-| `authToken`     | `string`   | Yes      | A Cloudflare [API token](/fundamentals/api/get-started/create-token/) with Flagship read permissions.                                |
-| `prefetchFlags` | `string[]` | Yes      | Flag keys to fetch on initialization and on every context change. Flags not in this list return `FLAG_NOT_FOUND` at evaluation time. |
+| Option          | Type          | Required | Description                                                                                                                          |
+| --------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `appId`         | `string`      | Yes      | The Flagship app ID from the Cloudflare dashboard.                                                                                   |
+| `accountId`     | `string`      | Yes      | Your Cloudflare account ID.                                                                                                          |
+| `authToken`     | `string`      | Yes      | A Cloudflare [API token](/fundamentals/api/get-started/create-token/) with Flagship read permissions.                                |
+| `fetchOptions`  | `RequestInit` | No       | Custom fetch options applied to HTTP requests.                                                                                       |
+| `timeout`       | `number`      | No       | Request timeout in milliseconds. Defaults to `5000`.                                                                                 |
+| `retries`       | `number`      | No       | Retry attempts on transient errors. Defaults to `1` and is capped at `10`.                                                           |
+| `retryDelay`    | `number`      | No       | Delay between retries in milliseconds. Defaults to `1000` and is capped at `30000`.                                                  |
+| `prefetchFlags` | `string[]`    | Yes      | Flag keys to fetch on initialization and on every context change. Flags not in this list return `FLAG_NOT_FOUND` at evaluation time. |
 
 ## When to use the client provider
 

--- a/src/content/docs/flagship/sdk/index.mdx
+++ b/src/content/docs/flagship/sdk/index.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: overview
-title: OpenFeature SDK
-description: Use the @cloudflare/flagship OpenFeature SDK to evaluate Flagship feature flags from Workers, Node.js, or the browser.
+title: OpenFeature SDKs
+description: Use the official Flagship OpenFeature SDKs to evaluate feature flags from Workers, Node.js, browsers, and Python applications.
 sidebar:
   order: 6
 products:
@@ -12,24 +12,34 @@ import { Description, PackageManagers } from "~/components";
 
 <Description>
 
-Evaluate Flagship feature flags from any JavaScript runtime using OpenFeature.
+Evaluate Flagship feature flags using OpenFeature.
 
 </Description>
 
 [OpenFeature](https://openfeature.dev/) is the CNCF standard for feature flag interfaces. It provides a vendor-neutral API so you can switch between flag providers without changing evaluation code.
 
-The [`@cloudflare/flagship`](https://www.npmjs.com/package/@cloudflare/flagship) package is an OpenFeature-compatible SDK for evaluating Flagship feature flags. The source code is available on [GitHub](https://github.com/cloudflare/flagship).
+Flagship provides official OpenFeature-compatible SDKs for TypeScript and Python. The source code is available on [GitHub](https://github.com/cloudflare/flagship).
 
-The SDK includes two providers:
+For Cloudflare Workers, use the Workers binding when possible. Use an SDK when you need OpenFeature compatibility, are running outside Workers, or need browser-side flag evaluation.
 
-- **FlagshipServerProvider** — For server-side runtimes such as [Cloudflare Workers](/workers/), Node.js, and other server-side JavaScript environments. Each evaluation call makes an asynchronous request to the Flagship evaluation endpoint.
-- **FlagshipClientProvider** — For browser applications. Pre-fetches all flag values on initialization and evaluates synchronously from an in-memory cache.
+| SDK        | Package                                                                      | Runtime                    | Evaluation modes                              |
+| ---------- | ---------------------------------------------------------------------------- | -------------------------- | --------------------------------------------- |
+| TypeScript | [`@cloudflare/flagship`](https://www.npmjs.com/package/@cloudflare/flagship) | Workers, Node.js, browsers | Workers binding, HTTP, browser prefetch cache |
+| Python     | [`cloudflare-flagship`](https://pypi.org/project/cloudflare-flagship/)       | Python server applications | HTTP                                          |
+
+## SDKs
+
+Flagship SDKs are organized by language. The TypeScript SDK has separate setup guides for server-side and browser usage because they use different OpenFeature packages and runtime behavior.
+
+- [TypeScript Server SDK](/flagship/sdk/server-provider/) — For Workers, Node.js, and other server-side JavaScript runtimes.
+- [TypeScript Client SDK](/flagship/sdk/client-provider/) — For browser applications that need synchronous OpenFeature web SDK evaluation.
+- [Python SDK](/flagship/sdk/python/) — For Python server applications.
 
 :::note
 If you are running inside a Cloudflare Worker, the [binding](/flagship/binding/) is the recommended approach because it avoids HTTP overhead. You can also [pass the binding to the OpenFeature SDK](/flagship/sdk/server-provider/) to get the best of both. Use the SDK without a binding when running in non-Worker runtimes like Node.js or the browser.
 :::
 
-## Installation
+## TypeScript installation
 
 For server-side usage:
 
@@ -47,7 +57,22 @@ For browser usage:
 	pkg="@cloudflare/flagship @openfeature/web-sdk"
 />
 
+## Python installation
+
+Install the Python SDK with `uv` or `pip`:
+
+```sh
+uv add cloudflare-flagship
+```
+
+```sh
+pip install cloudflare-flagship
+```
+
+The Python SDK provides `FlagshipServerProvider` for server-side applications. It supports HTTP evaluation, sync and async APIs, all OpenFeature flag types, retries, timeouts, and optional response caching.
+
 ## Next steps
 
-- Set up the [server provider](/flagship/sdk/server-provider/) for Workers, Node.js, or other server-side runtimes.
-- Set up the [client provider](/flagship/sdk/client-provider/) for browser applications.
+- Set up the [TypeScript Server SDK](/flagship/sdk/server-provider/) for Workers, Node.js, or other server-side runtimes.
+- Set up the [TypeScript Client SDK](/flagship/sdk/client-provider/) for browser applications.
+- Set up the [Python SDK](/flagship/sdk/python/) for Python server applications.

--- a/src/content/docs/flagship/sdk/python.mdx
+++ b/src/content/docs/flagship/sdk/python.mdx
@@ -1,0 +1,112 @@
+---
+pcx_content_type: how-to
+title: Python SDK
+description: Set up the FlagshipServerProvider to evaluate Flagship feature flags from Python server applications using OpenFeature.
+sidebar:
+  order: 3
+products:
+  - flagship
+---
+
+The Python SDK provides an OpenFeature-compatible `FlagshipServerProvider` for server-side Python applications. It evaluates flags over HTTP and does not support the Cloudflare Workers binding.
+
+## Installation
+
+Install with `uv` or `pip`:
+
+```sh
+uv add cloudflare-flagship
+```
+
+```sh
+pip install cloudflare-flagship
+```
+
+## Setup
+
+Configure the provider with your Flagship app ID, Cloudflare account ID, and an API token with Flagship Evaluate permission.
+
+```python
+from openfeature import api
+from openfeature.evaluation_context import EvaluationContext
+from flagship import FlagshipServerProvider
+
+api.set_provider(
+    FlagshipServerProvider(
+        app_id="<APP_ID>",
+        account_id="<ACCOUNT_ID>",
+        auth_token="<API_TOKEN>",
+    )
+)
+
+client = api.get_client()
+enabled = client.get_boolean_value(
+    "new-checkout",
+    False,
+    EvaluationContext(targeting_key="user-42", attributes={"plan": "enterprise"}),
+)
+```
+
+## Flag types
+
+The Python SDK supports all OpenFeature flag types. Python's OpenFeature SDK separates numeric values into integer and float methods.
+
+```python
+enabled = client.get_boolean_value("new-checkout", False, context)
+variant = client.get_string_value("homepage-hero", "control", context)
+limit = client.get_integer_value("upload-limit", 10, context)
+rate = client.get_float_value("sample-rate", 0.1, context)
+config = client.get_object_value("ui-config", {"theme": "light"}, context)
+```
+
+Use the `*_details` methods when you need the resolved value, reason, variant, or error code.
+
+## Configuration options
+
+| Option            | Type                           | Default | Description                                                 |
+| ----------------- | ------------------------------ | ------- | ----------------------------------------------------------- |
+| `app_id`          | `str`                          | None    | Flagship app ID.                                            |
+| `account_id`      | `str`                          | None    | Required with `app_id`.                                     |
+| `auth_token`      | `str`                          | None    | Bearer token added to every request.                        |
+| `headers_factory` | `Callable[[], dict[str, str]]` | None    | Dynamic per-request headers.                                |
+| `timeout`         | `float`                        | `5.0`   | Request timeout in seconds.                                 |
+| `retries`         | `int`                          | `1`     | Retry attempts on transient errors, capped at `10`.         |
+| `retry_delay`     | `float`                        | `1.0`   | Delay between retries in seconds, capped at `30.0`.         |
+| `logging`         | `bool`                         | `False` | Enable SDK-level debug output through the SDK logger.       |
+| `cache_ttl`       | `float`                        | None    | Cache TTL in seconds. Enables caching when set.             |
+| `cache_max_size`  | `int`                          | `1000`  | Maximum cached entries before least-recently-used eviction. |
+
+## Response caching
+
+Server-side response caching is off by default. Enable it with `cache_ttl` when you want repeated evaluations for the same flag, type, and evaluation context to reuse a recent result.
+
+```python
+FlagshipServerProvider(
+    app_id="<APP_ID>",
+    account_id="<ACCOUNT_ID>",
+    auth_token="<API_TOKEN>",
+    cache_ttl=30.0,
+    cache_max_size=1000,
+)
+```
+
+Cached values may be stale until the TTL expires. Keep the TTL short for flags that you expect to change during active rollouts. The provider does not cache disabled flags or errors.
+
+## Evaluation context
+
+Context attributes are sent as URL query parameters. Supported values are strings, integers, floats, booleans, and `datetime` values. Dictionaries, lists, tuples, and other complex values raise `InvalidContextError`.
+
+## Async evaluation
+
+The async API mirrors the sync API:
+
+```python
+enabled = await client.get_boolean_value_async("new-checkout", False, context)
+details = await client.get_boolean_details_async("new-checkout", False, context)
+```
+
+When shutting down in an async context, use `shutdown_async()`:
+
+```python
+await api.shutdown_async()
+```

--- a/src/content/docs/flagship/sdk/server-provider.mdx
+++ b/src/content/docs/flagship/sdk/server-provider.mdx
@@ -1,6 +1,6 @@
 ---
 pcx_content_type: how-to
-title: Server provider
+title: TypeScript Server SDK
 description: Set up the FlagshipServerProvider to evaluate feature flags from Workers, Node.js, or other server-side JavaScript runtimes using OpenFeature.
 sidebar:
   order: 1
@@ -12,7 +12,7 @@ import { Tabs, TabItem, TypeScriptExample } from "~/components";
 
 The `FlagshipServerProvider` implements the OpenFeature server provider interface. The provider works in [Cloudflare Workers](/workers/), Node.js, and any server-side JavaScript runtime that supports the Fetch API.
 
-Inside a Cloudflare Worker, you can pass the Flagship [binding](/flagship/binding/) directly to the provider. This avoids HTTP overhead and is the recommended approach. Outside of Workers, initialize the provider with an app ID and account ID — each evaluation call makes an HTTP request to the Flagship evaluation endpoint.
+Inside a Cloudflare Worker, you can pass the Flagship [binding](/flagship/binding/) directly to the provider. This avoids HTTP overhead and is the recommended approach. Outside of Workers, initialize the provider with an app ID and account ID.
 
 ## Setup
 
@@ -24,7 +24,7 @@ Pass the Flagship binding directly to the provider. This is the recommended appr
 
 ```ts
 import { OpenFeature } from "@openfeature/server-sdk";
-import { FlagshipServerProvider } from "@cloudflare/flagship";
+import { FlagshipServerProvider } from "@cloudflare/flagship/server";
 
 export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
@@ -53,13 +53,13 @@ export default {
 
 </TabItem> <TabItem label="With app ID">
 
-Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). The provider makes HTTP requests to the Flagship evaluation endpoint. Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship read permissions.
+Use an app ID, account ID, and an API token when running outside of a Worker (for example, in Node.js). Generate an [API token](/fundamentals/api/get-started/create-token/) from your Cloudflare account with Flagship read permissions.
 
 <TypeScriptExample>
 
 ```ts
 import { OpenFeature } from "@openfeature/server-sdk";
-import { FlagshipServerProvider } from "@cloudflare/flagship";
+import { FlagshipServerProvider } from "@cloudflare/flagship/server";
 
 await OpenFeature.setProviderAndWait(
 	new FlagshipServerProvider({
@@ -83,20 +83,44 @@ const showNewCheckout = await client.getBooleanValue("new-checkout", false, {
 
 ## Configuration options
 
-| Option      | Type       | Required | Description                                                                                                                                        |
-| ----------- | ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `binding`   | `Flagship` | No       | The Flagship binding from `env.FLAGS`. Use this inside a Worker for best performance. Authentication is handled automatically through the binding. |
-| `appId`     | `string`   | No       | The Flagship app ID from the Cloudflare dashboard. Required when not using a binding.                                                              |
-| `accountId` | `string`   | No       | Your Cloudflare account ID. Required when not using a binding.                                                                                     |
-| `authToken` | `string`   | No       | A Cloudflare [API token](/fundamentals/api/get-started/create-token/) with Flagship read permissions. Required when not using a binding.           |
+| Option         | Type          | Required | Description                                                                                                                              |
+| -------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `binding`      | `Flagship`    | No       | The Flagship binding from `env.FLAGS`. Use this inside a Worker for best performance. The binding handles authentication automatically.  |
+| `appId`        | `string`      | No       | The Flagship app ID from the Cloudflare dashboard. Required when not using a binding.                                                    |
+| `accountId`    | `string`      | No       | Your Cloudflare account ID. Required when using `appId`.                                                                                 |
+| `authToken`    | `string`      | No       | A Cloudflare [API token](/fundamentals/api/get-started/create-token/) with Flagship read permissions. Required when not using a binding. |
+| `fetchOptions` | `RequestInit` | No       | Custom fetch options applied to HTTP requests.                                                                                           |
+| `timeout`      | `number`      | No       | Request timeout in milliseconds. Defaults to `5000`.                                                                                     |
+| `retries`      | `number`      | No       | Retry attempts on transient errors. Defaults to `1` and is capped at `10`.                                                               |
+| `retryDelay`   | `number`      | No       | Delay between retries in milliseconds. Defaults to `1000` and is capped at `30000`.                                                      |
+| `cacheTtl`     | `number`      | No       | Cache TTL in milliseconds. Enables response caching when greater than `0`.                                                               |
+| `cacheMaxSize` | `number`      | No       | Maximum cached entries. Defaults to `1000` when `cacheTtl` is set.                                                                       |
 
 Provide either `binding` or `appId`, `accountId`, and `authToken`.
+
+## Response caching
+
+Server-side response caching is off by default. Enable it with `cacheTtl` when you want repeated evaluations for the same flag, type, and evaluation context to reuse a recent result.
+
+```ts
+new FlagshipServerProvider({
+	appId: "<APP_ID>",
+	accountId: "<ACCOUNT_ID>",
+	authToken: "<API_TOKEN>",
+	cacheTtl: 30_000,
+	cacheMaxSize: 1000,
+});
+```
+
+Use caching for high-traffic server applications that repeatedly evaluate the same flags for the same contexts. Cached values may be stale until the TTL expires, so keep the TTL short for flags that you expect to change during active rollouts. The provider does not cache disabled flags or errors.
 
 ## Evaluation context
 
 OpenFeature uses an evaluation context to pass user attributes to the flag provider. The `targetingKey` field is the primary user identifier.
 
 Pass additional attributes alongside `targetingKey` to match [targeting rules](/flagship/targeting/). For example, you can include `plan`, `country`, or any custom attribute your rules reference.
+
+Use primitive context values such as strings, numbers, booleans, and `Date` objects. The provider rejects objects and arrays as invalid context.
 
 <TypeScriptExample>
 
@@ -120,7 +144,7 @@ The SDK ships with two hooks that you can attach to the OpenFeature client.
 <TypeScriptExample>
 
 ```ts
-import { LoggingHook, TelemetryHook } from "@cloudflare/flagship";
+import { LoggingHook, TelemetryHook } from "@cloudflare/flagship/server";
 
 OpenFeature.addHooks(new LoggingHook(), new TelemetryHook());
 ```

--- a/src/content/docs/flagship/targeting/index.mdx
+++ b/src/content/docs/flagship/targeting/index.mdx
@@ -12,17 +12,19 @@ import { DirectoryListing } from "~/components";
 
 Targeting rules let you serve different flag values to different users based on their attributes. Each flag can have zero or more rules.
 
-Rules are evaluated in sequential order, from top to bottom. The first rule whose conditions match is used, and its configured variation is returned. If no rule matches, Flagship returns the flag's default variation.
+Rules are evaluated in sequential order, from top to bottom. The first rule whose conditions match is used, and its configured variant is returned. If no rule matches, Flagship returns the flag's default variant.
 
-When a flag is disabled, the default variation is always returned regardless of rules.
+When a flag is disabled, the default variant is always returned regardless of rules.
+
+Place more specific rules before broader rules. A broad catch-all rule can prevent later rules from running.
 
 ## How rules work
 
 A rule consists of:
 
 - **Conditions** — One or more attribute comparisons that must be satisfied. For example, `country equals "US"` or `plan in ["enterprise", "business"]`.
-- **Serve variation** — The variation to return when the rule matches.
-- **Rollout** (optional) — A percentage-based gradual release. Only the specified percentage of matching users receive the rule's variation. The rest continue to the next rule.
+- **Serve variant** — The variant to return when the rule matches.
+- **Rollout** (optional) — A percentage-based gradual release. Only the specified percentage of matching users receive the rule's variant. The rest continue to the next rule.
 
 ## Condition structure
 
@@ -32,9 +34,11 @@ Each condition compares an attribute from the evaluation context against a value
 - **Operator** — The comparison to perform. Flagship supports [11 operators](/flagship/targeting/operators/).
 - **Value** — The value to compare against. Can be a string, number, or array depending on the operator.
 
+If the evaluation context does not include the attribute referenced by a condition, that condition does not match.
+
 ## Logical grouping
 
-Conditions within a rule can be grouped with `AND`/`OR` operators and nested up to six levels deep.
+Conditions within a rule can be grouped with `AND`/`OR` operators and nested up to five levels deep.
 
 For example, to target enterprise users in the US or Canada:
 
@@ -43,6 +47,8 @@ For example, to target enterprise users in the US or Canada:
   - `OR`:
     - `country equals "US"`
     - `country equals "CA"`
+
+Use the smallest set of context attributes necessary to express the rule. This keeps rule behavior easier to reason about and avoids sending unnecessary user data in evaluation context.
 
 ## Learn more
 

--- a/src/content/docs/flagship/targeting/percentage-rollouts.mdx
+++ b/src/content/docs/flagship/targeting/percentage-rollouts.mdx
@@ -10,9 +10,29 @@ products:
 
 Percentage rollouts let you gradually release a feature to a fraction of your users. Any [targeting rule](/flagship/targeting/) can include a rollout percentage between 0 and 100.
 
+Use percentage rollouts when you want to limit blast radius, run an experiment, or sample requests without deploying new code.
+
 ## How percentage rollouts work
 
-When a rule has a percentage rollout, Flagship evaluates the rule's conditions first. If the conditions match, only the specified percentage of users receive the rule's variation. Users who do not fall into the rollout percentage continue to the next rule or receive the default variation if no further rules match.
+When a rule has a percentage rollout, the rule only serves its variant when both the rule conditions and the rollout bucket match. Contexts that do not match the rule continue to the next rule or receive the default variant if no later rule matches.
+
+For example, a rule can target users on the `enterprise` plan, then serve the new experience to only 10% of those users. Users outside the 10% continue through the rest of the rule list.
+
+```json
+{
+	"priority": 1,
+	"conditions": [
+		{ "attribute": "plan", "operator": "equals", "value": "enterprise" }
+	],
+	"serve_variation": "on",
+	"rollout": {
+		"percentage": 10,
+		"attribute": "userId"
+	}
+}
+```
+
+The `reason` in evaluation details is `SPLIT` when a percentage rollout serves the variant.
 
 ## Sticky bucketing
 
@@ -20,19 +40,44 @@ Flagship uses consistent hashing on a configurable attribute to assign users to 
 
 By default, the bucketing attribute is `targetingKey`. You can configure which attribute to use for bucketing when you set up the rollout in the dashboard.
 
+Rollout buckets are independent across accounts and flags. The same identifier may fall into different buckets for different flags, which helps avoid correlated rollouts across unrelated features.
+
+Choose a bucketing attribute based on what should remain stable:
+
+| Use case               | Suggested attribute                     |
+| ---------------------- | --------------------------------------- |
+| User-facing release    | Stable user ID or `targetingKey`        |
+| Account-level rollout  | Account ID                              |
+| Organization rollout   | Organization or workspace ID            |
+| Request-level sampling | Request ID or another per-request value |
+
+For most feature releases and experiments, use a stable user or account identifier. Use request-level values only when changing between requests is acceptable, such as for traffic sampling.
+
 :::caution[Random assignment without targetingKey]
 If `targetingKey` is not present in the evaluation context and no alternative bucketing attribute is configured, Flagship cannot produce a stable hash. In this case the rollout bucket is assigned randomly on each evaluation, meaning the same user may receive different flag values across requests.
 
 Always provide a stable `targetingKey` (or configure a consistent bucketing attribute) to guarantee sticky bucketing.
 :::
 
-## Example
+## Common rollout patterns
+
+### Progressive rollout
+
+Start with a small rollout, monitor your application, then increase the percentage as confidence grows.
+
+1. Create a flag with a 5% rollout.
+2. Monitor errors, latency, product metrics, and user feedback.
+3. Increase to 25%, then 50%, then 100%.
+4. After the rollout reaches 100%, remove temporary targeting rules and make the winning variant the default.
+5. After the feature is fully shipped, remove the old code path and delete the flag.
+
+### Targeted rollout plus percentage rollout
 
 Consider a flag `new-checkout` with the following rules:
 
-1. **Rule 1**: `plan equals "enterprise"` — serve variation `on`.
-2. **Rule 2**: 25% rollout on `userId` — serve variation `on`.
-3. **Default variation**: `off`.
+1. **Rule 1**: `plan equals "enterprise"` — serve variant `on`.
+2. **Rule 2**: 25% rollout on `userId` — serve variant `on`.
+3. **Default variant**: `off`.
 
 In this configuration:
 
@@ -41,3 +86,119 @@ In this configuration:
 - The remaining 75% of non-enterprise users see the standard checkout.
 
 As you gain confidence, increase the rollout percentage until you reach 100%.
+
+### A/B/n testing
+
+For a plain A/B/n test with no audience conditions, configure each variant's traffic share in the Cloudflare dashboard. The dashboard calculates the cumulative thresholds for you.
+
+If you manage a plain A/B/n test directly through the API, create one rule per variant with cumulative rollout percentages. Flagship evaluates rules in priority order. If a context matches a rule but does not fall into that rule's rollout percentage, evaluation continues to the next rule.
+
+For a 30% / 40% / 30% split across variants A, B, and C:
+
+| Variant | Share | Cumulative threshold |
+| ------- | ----- | -------------------- |
+| A       | 30%   | 30                   |
+| B       | 40%   | 70                   |
+| C       | 30%   | 100                  |
+
+```json
+[
+	{
+		"priority": 1,
+		"conditions": [],
+		"serve_variation": "variant-a",
+		"rollout": { "percentage": 30, "attribute": "targetingKey" }
+	},
+	{
+		"priority": 2,
+		"conditions": [],
+		"serve_variation": "variant-b",
+		"rollout": { "percentage": 70, "attribute": "targetingKey" }
+	},
+	{
+		"priority": 3,
+		"conditions": [],
+		"serve_variation": "variant-c",
+		"rollout": { "percentage": 100, "attribute": "targetingKey" }
+	}
+]
+```
+
+In API-managed configurations, the first rule covers buckets 0-30. The second rule covers buckets 31-70. The final rule catches the remaining buckets through 100. Always set the final rule to 100 when every eligible context should receive a variant.
+
+Use the same bucketing attribute on every rule in the experiment. If each rule uses a different attribute, users may not stay in the intended split.
+
+### Targeted A/B/n testing
+
+You can combine audience targeting with a multi-variant rollout. For example, you might want only premium users to enter an experiment, then split those premium users across three variants.
+
+For targeted A/B/n tests, repeat the same audience condition on each variant rule and use cumulative rollout thresholds. When you use this targeted multi-rule pattern, configure the cumulative threshold for each rule explicitly, whether you are using the dashboard or the API.
+
+For a premium-only split where 20% receive variant A, 40% receive variant B, and the remaining 40% receive variant C, use thresholds of 20, 60, and 100:
+
+```json
+[
+	{
+		"priority": 1,
+		"conditions": [
+			{ "attribute": "plan", "operator": "equals", "value": "premium" }
+		],
+		"serve_variation": "variant-a",
+		"rollout": { "percentage": 20, "attribute": "targetingKey" }
+	},
+	{
+		"priority": 2,
+		"conditions": [
+			{ "attribute": "plan", "operator": "equals", "value": "premium" }
+		],
+		"serve_variation": "variant-b",
+		"rollout": { "percentage": 60, "attribute": "targetingKey" }
+	},
+	{
+		"priority": 3,
+		"conditions": [
+			{ "attribute": "plan", "operator": "equals", "value": "premium" }
+		],
+		"serve_variation": "variant-c",
+		"rollout": { "percentage": 100, "attribute": "targetingKey" }
+	}
+]
+```
+
+Users who do not match `plan equals "premium"` skip all three rules and receive the flag's default variant, unless a later rule matches them.
+
+### Request sampling
+
+You can use percentage rollouts for request-level sampling by choosing a per-request bucketing attribute. For example, a 1% rollout can enable extra logging or diagnostics for a small fraction of requests.
+
+Only use this pattern when it is acceptable for the same user to receive different results on different requests.
+
+## Troubleshooting
+
+### Rollout results change between requests
+
+If the same user receives different values across requests, the evaluation context is probably missing `targetingKey` or the configured bucketing attribute.
+
+Pass the same stable identifier on every evaluation:
+
+```ts
+const enabled = await env.FLAGS.getBooleanValue("gradual-rollout", false, {
+	userId: session.user.id,
+});
+```
+
+Then configure the rollout to bucket by `userId`.
+
+### Rollout never reaches some users
+
+Check rule order. A catch-all rule with a lower priority number can return a variant before later rollout rules run. Place broad catch-all rules after more specific rules.
+
+### A/B/n split does not match expected percentages
+
+For plain dashboard-managed A/B/n tests, enter each variant's traffic share and let the dashboard calculate thresholds.
+
+For API-managed A/B/n tests, or for targeted A/B/n tests configured as multiple rules, use cumulative thresholds. A 30% / 40% / 30% split should use thresholds of 30, 70, and 100, not 30, 40, and 30.
+
+### Default variant appears during a rollout
+
+This can happen when a context matches the rule conditions but falls outside the rollout percentage, and no later rule matches. Add a later rule or use a 100% final rule if every matching context should receive a non-default variant.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -75,6 +75,7 @@ const sidebar = [
 					{ label: "Durable Objects", link: "/durable-objects/" },
 					{ label: "Queues", link: "/queues/" },
 					{ label: "Workflows", link: "/workflows/" },
+					{ label: "Flagship", link: "/flagship/" },
 					{ label: "Browser Run", link: "/browser-run/" },
 					{ label: "Workers VPC", link: "/workers-vpc/" },
 					{


### PR DESCRIPTION
## Summary

- Add Flagship to the Compute sidebar.
- Expand and reorganize Flagship SDK docs for TypeScript, Python, and Go.
- Add Flagship best practices and clarify limits, error handling, caching, context, and local dev behavior, and more.