### PR TITLE
chore: update ci formatting

### DIFF
--- a/.github/workflows/auto-format-apply.yml
+++ b/.github/workflows/auto-format-apply.yml
@@ -107,7 +107,7 @@ jobs:
           PATCH="${{ steps.meta.outputs.patch_path }}"
 
           # File extensions prettier is allowed to format.
-          ALLOWED_EXT='\.(js|jsx|ts|tsx|mjs|css|json|yaml|yml|md|astro)$'
+          ALLOWED_EXT='\.(js|jsx|ts|tsx|mjs|css|json|yaml|yml|astro)$'
 
           # Paths the bot must NEVER modify regardless of extension. The
           # blocklist is the security boundary; the allowlist is a sanity
@@ -277,7 +277,7 @@ jobs:
           # Re-validate the staged diff against the same path rules. This
           # guards against any drift between artifact contents and what
           # actually applied (renames, partial application, etc.).
-          ALLOWED_EXT='\.(js|jsx|ts|tsx|mjs|css|json|yaml|yml|md|astro)$'
+          ALLOWED_EXT='\.(js|jsx|ts|tsx|mjs|css|json|yaml|yml|astro)$'
           BLOCKED='^(\.github/|package\.json$|package-lock\.json$|pnpm-lock\.yaml$|\.npmrc$|patches/|\.husky/)'
           staged=$(git diff --staged --name-only)
           fail=0

--- a/.github/workflows/auto-format-build.yml
+++ b/.github/workflows/auto-format-build.yml
@@ -16,7 +16,6 @@ on:
       - "**/*.json"
       - "**/*.yaml"
       - "**/*.yml"
-      - "**/*.md"
       - "**/*.astro"
 
 permissions:
@@ -70,7 +69,7 @@ jobs:
           git fetch --depth=1 origin "$BASE_SHA"
           mapfile -t files < <(
             git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD \
-            | grep -E '\.(js|jsx|ts|tsx|mjs|css|json|yaml|yml|md|astro)$' \
+            | grep -E '\.(js|jsx|ts|tsx|mjs|css|json|yaml|yml|astro)$' \
             | while IFS= read -r f; do [[ -L "$f" ]] || echo "$f"; done \
             || true
           )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           git fetch --depth=1 origin "$BASE_SHA"
           mapfile -t files < <(
             git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD \
-            | grep -E '\.(js|jsx|ts|tsx|mjs|css)$' || true
+            | grep -E '\.(js|jsx|ts|tsx|mjs|css|json|yaml|yml|astro)$' || true
           )
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No prettier-scoped files changed."


### PR DESCRIPTION
### Summary

The auto-format bot, the local pnpm run format command, and the CI "Check formatting" safety net each operated on different file-extension sets. This caused two issues:

1. The bot formatted .md files that neither the local command nor CI touched — producing surprise style: format commits on contributor branches.
2. The CI safety net only checked js,jsx,ts,tsx,mjs,css, so misformatted .json/.yaml/.yml/.astro files could merge unformatted when the bot couldn't push (e.g. forks with "allow edits by maintainers" disabled).
Changes:
- Removed .md from the bot (auto-format-build.yml trigger paths + grep allowlist; auto-format-apply.yml both ALLOWED_EXT validation regexes).
- Widened the CI check (ci.yml) to js,jsx,ts,tsx,mjs,css,json,yaml,yml,astro.
All three now share the same set: js,jsx,ts,tsx,mjs,css,json,yaml,yml,astro. .mdx remains excluded everywhere by design (bulk-format churn).
### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
