### PR TITLE
Clarify Logpush job output_options update behavior

### DIFF
--- a/src/content/docs/logs/logpush/logpush-job/log-output-options.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/log-output-options.mdx
@@ -43,6 +43,11 @@ We have replaced this with **output_options** as it is used for both Logpull and
   "destination_conf": "s3://<BUCKET_PATH>?region=us-west-2"
 }
 ```
+:::caution[Updates replace output_options in full]
+
+When you update a Logpush job via `PUT /accounts/{account_id}/logpush/jobs/{job_id}` or `PUT /zones/{zone_id}/logpush/jobs/{job_id}`, the **output_options** object is replaced entirely. Any field that was previously set but omitted from the update payload is reset to its default value.
+For example, if the existing job sets `timestamp_format: "rfc3339"` and your update only includes `field_names`, the job will revert to the default `timestamp_format` (`unixnano` for API-created jobs).
+Always include the complete **output_options** object you want applied when updating a job.
 
 ## Output types
 


### PR DESCRIPTION
### Summary

Added caution note about updating Logpush job output options: output_options is fully replaced on PUT updates, so omitting previously set fields resets them to defaults.

Context: SFSC case 02150792