### PR TITLE
Remove outdated "no public API" limitation and link Environments API

### DIFF
--- a/src/content/partials/version-management/product-limitations.mdx
+++ b/src/content/partials/version-management/product-limitations.mdx
@@ -50,8 +50,8 @@ Version Management does not currently support or have limited support for the fo
 
 <Details header="Cloudflare API">
 
-- Version Management does not currently expose a public [API](/api/).
-- Customers can only use Version Management through the [Cloudflare dashboard](https://dash.cloudflare.com/).
+- Version Management environments — including their routing expressions and version assignments — can be managed through the public [Environments API](/api/resources/zones/subresources/environments/).
+- Creating, cloning, and editing zone versions (the configuration snapshots themselves) is currently only available through the [Cloudflare dashboard ↗](https://dash.cloudflare.com/).
 
 </Details>
 


### PR DESCRIPTION
### Summary

The Version Management overview currently states that Version Management does not expose a public API. The Environments API (/zones/{zone_id}/environments) is publicly available and supports listing, creating, updating, deleting, and rolling back environments, as well as managing their routing expressions and version assignments.

This change updates the Limitations section to point to the Environments API and clarifies that only version content management (creating/cloning/editing versions) remains dashboard-only.

Context: SFSC case 02109410