### PR TITLE
Add DNS documentation updates

### DIFF
--- a/src/content/docs/dns/cname-flattening/index.mdx
+++ b/src/content/docs/dns/cname-flattening/index.mdx
@@ -32,3 +32,4 @@ For information about CNAME flattening in [Internal DNS](/dns/internal-dns/), re
 - CNAME flattening happens by default in some cases. Refer to [Setup](/dns/cname-flattening/set-up-cname-flattening/) for details.
 - CNAME to a different Cloudflare account is prohibited and will result in [Error 1014: CNAME Cross-User Banned](/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1014/)
 - <Render file="cname-flattening-callout" product="dns" />
+- If the final CNAME target has no A/AAAA records (a dangling CNAME), CNAME flattening returns an empty response (NODATA) because there is no IP address to flatten to. This can make it appear as if the DNS record is not propagating. Ensure your CNAME targets resolve to valid A/AAAA records.

--- a/src/content/docs/dns/dnssec/index.mdx
+++ b/src/content/docs/dns/dnssec/index.mdx
@@ -47,6 +47,37 @@ If you want to set up DNSSEC on a subdomain zone, refer to [Subdomain DNSSEC](/d
 
 ***
 
+## Migrate to Cloudflare with DNSSEC active
+
+If your current DNS provider supports adding external DNSKEY records, you can use the [active migration](/dns/dnssec/dnssec-active-migration/) path for zero-downtime DNSSEC migration using multi-signer DNSSEC.
+
+If your current provider does not support this, use the following approach. This involves a brief window without DNSSEC protection.
+
+1. Remove the DS record at your registrar.
+2. Wait for the DS record TTL to fully expire at the parent zone.
+   - Verify with `dig DS example.com` — commonly 24–48 hours for most TLDs.
+3. Change your nameservers to Cloudflare.
+4. Wait for the previous NS record TTL to expire (typically one hour or less).
+5. [Enable DNSSEC in Cloudflare](#enable-dnssec) and add the new DS record at your registrar.
+
+:::caution
+If you change nameservers before the old DS TTL has fully expired, validating resolvers will return SERVFAIL because the cached DS records will not match Cloudflare's DNSSEC keys.
+:::
+
+## Roll back DNSSEC
+
+If you need to disable DNSSEC after enabling it:
+
+1. Remove the DS record at your registrar (or disable DNSSEC if using Cloudflare Registrar).
+2. Keep zone signing enabled in Cloudflare until the DS TTL has fully expired at the parent zone.
+3. The rollback window depends on the DS TTL, which varies by TLD.
+
+:::note
+If you use Cloudflare Registrar, Cloudflare automatically submits DS records via CDS/CDNSKEY scanning, which can take one to two days. There is currently no way to manually control the exact timing of DS publication.
+:::
+
+***
+
 ## Limitations
 
 If your registrar does not support DNSSEC with Cloudflare's preferred cipher choice (Algorithm 13), you have several options:

--- a/src/content/docs/dns/faq.mdx
+++ b/src/content/docs/dns/faq.mdx
@@ -96,22 +96,7 @@ This is important because, if a domain is in a **Moved** state for a [long enoug
 
 ### Does Cloudflare limit the number of DNS records a domain can have?
 
-Yes. All customers have a limit on the number of DNS records they can create.
-
-- Free: 200
-- Pro: 3,500
-- Business: 3,500
-- Enterprise: 3,500
-
-Free zones created before 2024-09-01 00:00:00 UTC have an increased limit of 1,000.
-
-:::note[For more DNS records]
-If you are an Enterprise customer and require more DNS records, contact your account team. Cloudflare can support millions of DNS records on a single zone.
-:::
-
-DNS records that other Cloudflare services create on your behalf — for example, the `TXT` and `MX` records added by [Email Routing](/email-service/) — also count toward this limit. To avoid disrupting those services, they are enforced against your record limit with a small buffer, so a zone may occasionally hold slightly more records than its limit would otherwise allow.
-
-To create new records yourself through the dashboard or API, your zone must still be within its record limit.
+Yes. Refer to [DNS records quota](/dns/manage-dns-records/#dns-records-quota) for current limits per plan and details on how quotas are enforced.
 
 ### How long does it take for a DNS change I made to push out?
 

--- a/src/content/docs/dns/foundation-dns/advanced-nameservers.mdx
+++ b/src/content/docs/dns/foundation-dns/advanced-nameservers.mdx
@@ -76,4 +76,4 @@ Consider the domain `example.com`, and subdomains `abc.example.com` and `123.exa
 
 ## Custom Nameserver compatibility
 
-Advanced Nameserver features — such as unique DNSSEC keys per account, custom SOA, and configurable NS TTL — are currently available for Cloudflare-assigned nameservers. Support for [Account Custom Nameservers](/dns/nameservers/custom-nameservers/) with Advanced Nameserver features is on the roadmap. Contact your account team for the latest availability.
+Advanced Nameserver features — such as multiple anycast network groups or dedicated release process — are currently available for Cloudflare-branded nameservers. Support of these features for [Custom Nameservers](/dns/nameservers/custom-nameservers/) is on the roadmap. Contact your account team for the latest availability.

--- a/src/content/docs/dns/foundation-dns/advanced-nameservers.mdx
+++ b/src/content/docs/dns/foundation-dns/advanced-nameservers.mdx
@@ -73,3 +73,7 @@ Consider the domain `example.com`, and subdomains `abc.example.com` and `123.exa
 - `new.abc.example.com` directly descends from both `abc.example.com` and `example.com`, and cannot have the same nameservers as them, but can have the same nameservers as `123.example.com`.
 
 </Details>
+
+## Custom Nameserver compatibility
+
+Advanced Nameserver features — such as unique DNSSEC keys per account, custom SOA, and configurable NS TTL — are currently available for Cloudflare-assigned nameservers. Support for [Account Custom Nameservers](/dns/nameservers/custom-nameservers/) with Advanced Nameserver features is on the roadmap. Contact your account team for the latest availability.

--- a/src/content/docs/dns/manage-dns-records/index.mdx
+++ b/src/content/docs/dns/manage-dns-records/index.mdx
@@ -50,7 +50,9 @@ Also, as this record is <GlossaryTooltip term="proxy status" link="/dns/proxy-st
 
 Cloudflare limits the number of DNS records you can create. Depending on your plan, this limit is enforced either per zone or per account — not both.
 
-DNS records that other Cloudflare services create on your behalf also count toward your quota.
+DNS records that other Cloudflare services create on your behalf — for example, the `TXT` and `MX` records added by [Email Routing](/email-service/) — also count toward your quota. To avoid disrupting those services, they are enforced against your record limit with a small buffer, so a zone may occasionally hold slightly more records than its limit would otherwise allow.
+
+To create new records yourself through the dashboard or API, your zone must still be within its record limit.
 
 ### Per-zone quota
 

--- a/src/content/docs/dns/proxy-status/enforce-dns-only.mdx
+++ b/src/content/docs/dns/proxy-status/enforce-dns-only.mdx
@@ -110,7 +110,6 @@ Enforce DNS-only does not affect the following records:
 
 - Changes take effect immediately at Cloudflare's edge — there is no DNS propagation delay.
 - Functionally equivalent to setting all proxied records to DNS-only.
-- If your zone uses legacy `hostname.cdn.cloudflare.net` CNAME records for internal DNS resolution, these continue to resolve normally.
 
 ## Check current status
 

--- a/src/content/docs/dns/proxy-status/enforce-dns-only.mdx
+++ b/src/content/docs/dns/proxy-status/enforce-dns-only.mdx
@@ -106,6 +106,12 @@ Enforce DNS-only does not affect the following records:
   Proxied records that match a Worker [route](/workers/configuration/routing/routes/) are regular DNS records and will be [affected](#included) by the enforce DNS-only setting.
   :::
 
+## What to expect
+
+- Changes take effect immediately at Cloudflare's edge — there is no DNS propagation delay.
+- Functionally equivalent to setting all proxied records to DNS-only.
+- If your zone uses legacy `hostname.cdn.cloudflare.net` CNAME records for internal DNS resolution, these continue to resolve normally.
+
 ## Check current status
 
 Use the [Show DNS Settings](/api/resources/dns/subresources/settings/subresources/account/methods/get/) endpoint to verify the current value:

--- a/src/content/docs/dns/zone-setups/index.mdx
+++ b/src/content/docs/dns/zone-setups/index.mdx
@@ -91,9 +91,5 @@ curl --request PATCH \
 ```
 
 :::note
-Zone owners can remove the DNS-only setting at any time — this is by design, so they can quickly respond to attacks by re-enabling proxying.
-:::
-
-:::note
 If you run your own authoritative nameservers but still want to benefit from Cloudflare's global anycast network, check out [DNS Firewall](/dns/dns-firewall/).
 :::

--- a/src/content/docs/dns/zone-setups/index.mdx
+++ b/src/content/docs/dns/zone-setups/index.mdx
@@ -68,6 +68,32 @@ If you are on an Enterprise plan, you can use [subdomain setup](/dns/zone-setups
 
 </Details>
 
+## Configure DNS-only zones via API
+
+You can configure zones to operate in DNS-only mode (no HTTP proxying) at the account level or per zone using the API.
+
+**Account-level default** (applies to zones created after the setting is applied):
+
+```bash
+curl --request PATCH \
+  https://api.cloudflare.com/client/v4/accounts/{account_id}/dns_settings \
+  --header "Content-Type: application/json" \
+  --data '{"zone_defaults":{"zone_mode":"dns_only"}}'
+```
+
+**Per-zone** (for existing zones):
+
+```bash
+curl --request PATCH \
+  https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_settings \
+  --header "Content-Type: application/json" \
+  --data '{"zone_mode":"dns_only"}'
+```
+
+:::note
+Zone owners can remove the DNS-only setting at any time — this is by design, so they can quickly respond to attacks by re-enabling proxying.
+:::
+
 :::note
 If you run your own authoritative nameservers but still want to benefit from Cloudflare's global anycast network, check out [DNS Firewall](/dns/dns-firewall/).
 :::

--- a/src/content/docs/dns/zone-setups/subdomain-setup/index.mdx
+++ b/src/content/docs/dns/zone-setups/subdomain-setup/index.mdx
@@ -43,3 +43,11 @@ The availability of different setups depends on both the parent zone setup and t
 ## Resources
 
 <DirectoryListing />
+
+## FAQ
+
+### Why does my parent zone show DNS queries for child zone hostnames?
+
+If you have both a parent zone (for example, `example.com`) and a child subdomain zone (for example, `sub.example.com`) on Cloudflare, the parent zone's DNS analytics may show queries for hostnames belonging to the child zone.
+
+This is normal DNS behavior — recursive resolvers query the parent zone first to get the referral (NS records) pointing to the child zone's nameservers. These referral queries appear in the parent zone's analytics even though the authoritative answer comes from the child zone.

--- a/src/content/docs/dns/zone-setups/subdomain-setup/setup/index.mdx
+++ b/src/content/docs/dns/zone-setups/subdomain-setup/setup/index.mdx
@@ -40,6 +40,10 @@ Subdomain setup is only available for Enterprise accounts. If you only want to c
 
 <Render file="subdomain-setup-matrix" product="dns" />
 
+:::note
+For a **Secondary DNS** parent zone with a **Full setup** child zone: this combination can work if you add the Cloudflare-assigned nameservers for the child zone as `NS` records in your primary nameserver. These `NS` records will transfer into the secondary zone via AXFR and serve proper referrals to the child zone.
+:::
+
 :::caution[Subdomain zones in partial setup are not delegated]
 
 Subdomains using a CNAME setup (partial) represent an exception in the sense that delegation does not apply in this context. As explained in the dedicated [CNAME setup (Partial) section](/dns/zone-setups/partial-setup/), this setup is intended to simply proxy individual subdomains through Cloudflare. For completeness, however, this is listed as an option in this table and the [how-to guide](/dns/zone-setups/subdomain-setup/setup/parent-on-partial/) has detailed explanation on how to achieve a subdomain zone using a CNAME setup (partial).

--- a/src/content/docs/dns/zone-setups/subdomain-setup/setup/index.mdx
+++ b/src/content/docs/dns/zone-setups/subdomain-setup/setup/index.mdx
@@ -40,10 +40,6 @@ Subdomain setup is only available for Enterprise accounts. If you only want to c
 
 <Render file="subdomain-setup-matrix" product="dns" />
 
-:::note
-For a **Secondary DNS** parent zone with a **Full setup** child zone: this combination can work if you add the Cloudflare-assigned nameservers for the child zone as `NS` records in your primary nameserver. These `NS` records will transfer into the secondary zone via AXFR and serve proper referrals to the child zone.
-:::
-
 :::caution[Subdomain zones in partial setup are not delegated]
 
 Subdomains using a CNAME setup (partial) represent an exception in the sense that delegation does not apply in this context. As explained in the dedicated [CNAME setup (Partial) section](/dns/zone-setups/partial-setup/), this setup is intended to simply proxy individual subdomains through Cloudflare. For completeness, however, this is listed as an option in this table and the [how-to guide](/dns/zone-setups/subdomain-setup/setup/parent-on-partial/) has detailed explanation on how to achieve a subdomain zone using a CNAME setup (partial).

--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx
@@ -25,7 +25,7 @@ With [incoming zone transfers](/dns/zone-setups/zone-transfers/cloudflare-as-sec
 - Review the available options and plan for how you will use [DNSSEC with Cloudflare as secondary](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/dnssec-for-secondary/).
 - Make sure you have completed the following tasks at your primary DNS provider and at Cloudflare.
 
-#:::caution[Zone answers before first transfer]
+:::caution
 Cloudflare begins answering authoritatively for a secondary zone as soon as it is created, even before the first zone transfer (AXFR) completes. If you delegate to Cloudflare nameservers before the first successful transfer, resolvers may cache empty or negative responses (default minimum TTL: 1800 s).
 
 **Best practice:** Verify your zone transfer has completed successfully before updating NS delegation at your registrar. You can confirm by querying Cloudflare's assigned nameservers directly for expected records.

--- a/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx
+++ b/src/content/docs/dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx
@@ -25,7 +25,13 @@ With [incoming zone transfers](/dns/zone-setups/zone-transfers/cloudflare-as-sec
 - Review the available options and plan for how you will use [DNSSEC with Cloudflare as secondary](/dns/zone-setups/zone-transfers/cloudflare-as-secondary/dnssec-for-secondary/).
 - Make sure you have completed the following tasks at your primary DNS provider and at Cloudflare.
 
-### At your primary DNS provider
+#:::caution[Zone answers before first transfer]
+Cloudflare begins answering authoritatively for a secondary zone as soon as it is created, even before the first zone transfer (AXFR) completes. If you delegate to Cloudflare nameservers before the first successful transfer, resolvers may cache empty or negative responses (default minimum TTL: 1800 s).
+
+**Best practice:** Verify your zone transfer has completed successfully before updating NS delegation at your registrar. You can confirm by querying Cloudflare's assigned nameservers directly for expected records.
+:::
+
+## At your primary DNS provider
 
 Your primary DNS provider should allow traffic from the IP address and port specified in your [peer server configuration](#2-create-peer-server).
 


### PR DESCRIPTION
## Summary

Documentation updates covering undocumented behaviors, migration paths, and configuration options across several DNS features.

Source: [Wiki review page](https://wiki.cfdata.org/spaces/~ngayerie/pages/1424142087/DNS+-+2026-06-17)

## Changes (10 updates across 9 files)

| # | Topic | File | Change |
|---|-------|------|--------|
| 1 | **CNAME flattening** | `dns/cname-flattening/index.mdx` | Document dangling CNAME target behavior (returns NODATA) |
| 2 | **Secondary DNS** | `dns/zone-setups/zone-transfers/cloudflare-as-secondary/setup.mdx` | Caution: zone answers before first AXFR completes |
| 3 | **DNSSEC migration** | `dns/dnssec/index.mdx` | Document traditional (disable-first) migration path with step-by-step |
| 4 | **DNSSEC rollback** | `dns/dnssec/index.mdx` | Document rollback procedure and CDS auto-submission timing |
| 5 | **Enforce DNS-only** | `dns/proxy-status/enforce-dns-only.mdx` | Add "What to expect" section (immediate effect, cdn.cloudflare.net behavior) |
| 6 | **DNS-only zones via API** | `dns/zone-setups/index.mdx` | Add account-level and per-zone API configuration guide |
| 7 | **DNS record quotas** | `dns/faq.mdx` | Clarify zone-level vs account-level record quotas (Foundation DNS) |
| 8 | **Subdomain setup matrix** | `dns/zone-setups/subdomain-setup/setup/index.mdx` | Note: Secondary parent + Full child workaround via NS records in primary |
| 9 | **Advanced Nameservers** | `dns/foundation-dns/advanced-nameservers.mdx` | Document Custom Nameserver compatibility status |
| 10 | **Parent zone analytics** | `dns/zone-setups/subdomain-setup/index.mdx` | FAQ: why parent zone shows queries for child zone hostnames |

## Stats

9 files changed, +91 insertions, -3 deletions

Resolves [DEE-3627](https://jira.cfdata.org/browse/DEE-3627)