### PR TITLE
[Cloudflare One] Clarify MCP portal DLP / TLS decryption behavior

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -652,9 +652,13 @@ Gateway routing only applies to real-time tool calls made by users through the p
 
 ### TLS decryption
 
-You do not need to turn on [Gateway TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) for DLP to inspect portal traffic. The portal terminates the connection from the MCP client and re-originates the request through Gateway, so Gateway inspects the payload inline regardless of your account's TLS decryption setting.
+DLP inspection requires Gateway to decrypt TLS traffic. For portal traffic, Gateway decrypts and inspects the payload automatically — you do not need to turn on the account-level [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) setting. Because the portal terminates the connection from the MCP client and re-originates the request through Gateway, Gateway decrypts portal traffic regardless of whether the global TLS decryption setting is on.
 
-This applies only to traffic that flows through the portal. To inspect MCP traffic that does not pass through the portal — for example, an agent on a [device running the WARP client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) connecting directly to an upstream MCP server — you must turn on [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) as you would for any other [HTTP policy](/cloudflare-one/traffic-policies/http-policies/).
+This automatic decryption applies only to traffic that flows through the portal. To inspect MCP traffic that does not pass through the portal — for example, an agent on a [device running the WARP client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) connecting directly to an upstream MCP server — you must turn on [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) as you would for any other [HTTP policy](/cloudflare-one/traffic-policies/http-policies/).
+
+:::note
+Portal traffic ignores the global TLS decryption setting, but it still respects [Do Not Inspect](/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) HTTP policies. If a Do Not Inspect policy matches portal traffic, Gateway does not decrypt it and DLP cannot scan it. Check that your Do Not Inspect policies do not unintentionally exempt your upstream MCP servers from inspection.
+:::
 
 ### Supported transports
 

--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -650,6 +650,12 @@ Because portal traffic routes through Gateway, it also respects [Gateway egress 
 Gateway routing only applies to real-time tool calls made by users through the portal. Background operations such as [admin credential synchronization](#synchronize-the-mcp-server) do not route through Gateway and will not use your egress policy IPs.
 :::
 
+### TLS decryption
+
+You do not need to turn on [Gateway TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) for DLP to inspect portal traffic. The portal terminates the connection from the MCP client and re-originates the request through Gateway, so Gateway inspects the payload inline regardless of your account's TLS decryption setting.
+
+This applies only to traffic that flows through the portal. To inspect MCP traffic that does not pass through the portal — for example, an agent on a [device running the WARP client](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/) connecting directly to an upstream MCP server — you must turn on [TLS decryption](/cloudflare-one/traffic-policies/http-policies/tls-decryption/) as you would for any other [HTTP policy](/cloudflare-one/traffic-policies/http-policies/).
+
 ### Supported transports
 
 Gateway routing supports [Streamable HTTP](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/#streamable-http) connections only. If an upstream MCP server is configured with a Server-Sent Events (SSE) endpoint (a URL ending in `/sse`), the portal will automatically attempt to connect using Streamable HTTP instead. If the upstream server does not support Streamable HTTP, the connection will fail when Gateway routing is turned on.
@@ -677,6 +683,15 @@ For example, the following policy blocks traffic that contains [credentials and 
 | ----------- | -------- | -------------------------------------------------- | ----- | ------ |
 | Host        | in       | `example-mcp-server.example.workers.dev`           | And   | Block  |
 | DLP Profile | in       | _Credentials and Secrets_, _Financial Information_ |       |        |
+
+### What happens when a request is blocked
+
+When a tool call matches a Block DLP policy, Gateway blocks it and the portal surfaces the block to the MCP client as an error rather than completing the tool call. This applies in both directions:
+
+- **Tool call requests**: If the data the agent sends to a tool matches a DLP profile, Gateway blocks the outbound request and the agent receives an error indicating the request was blocked.
+- **Tool call responses**: If the data the upstream server returns matches a DLP profile, Gateway blocks the response and the portal returns an error instead of the matched content.
+
+The agent can retry the request, but it will continue to be blocked until the content no longer matches the policy.
 
 ### Limitations
 


### PR DESCRIPTION
## Summary

Clarifies how DLP and TLS decryption behave for [MCP server portal](https://developers.cloudflare.com/cloudflare-one/access-controls/ai-controls/mcp-portals/) traffic routed through Gateway.

DLP inspection requires Gateway to decrypt TLS. For portal traffic, Gateway does this automatically and **supersedes the account-level TLS decryption setting** — so admins don't need to turn that setting on for portal DLP to work. This is a useful property (TLS decryption is a hot-button setting for some orgs), but the original framing of "TLS decryption not required" was misleading: decryption still happens, the portal just forces it on for its own traffic.

The portal does **not** ignore everything, though: it still respects **Do Not Inspect** HTTP policies. If a Do Not Inspect policy matches portal traffic, Gateway won't decrypt it and DLP can't scan it. This PR calls that out so admins don't accidentally exempt their upstream MCP servers from inspection.

## Changes

- Add a `TLS decryption` subsection under **Route portal traffic through Gateway** > **How Gateway routing works**, explaining that portal traffic is decrypted automatically and supersedes the global setting, and that direct (non-portal) MCP traffic still needs decryption.
- Add a note that portal traffic still respects [Do Not Inspect](https://developers.cloudflare.com/cloudflare-one/traffic-policies/http-policies/#do-not-inspect) policies.
- Add a **What happens when a request is blocked** subsection after the example Gateway policy.

All internal links verified against existing pages. No new components or code blocks.
