### PR TITLE
[Access] Raise documented domains-per-application limit to 50

### DIFF
--- a/src/content/docs/cloudflare-one/account-limits.mdx
+++ b/src/content/docs/cloudflare-one/account-limits.mdx
@@ -27,7 +27,7 @@ This page lists the default account limits for rules, applications, fields, and 
 | Identity providers       | 50    |
 | Reusable policies        | 500   |
 | Rules per application    | 1,000 |
-| Domains per application  | 5     |
+| Domains per application  | 50    |
 | Infrastructure targets   | 5,000 |
 | MCP portals              | 20    |
 | MCP servers per portal   | 20    |


### PR DESCRIPTION
## Summary

AUTH-8660 raised the default `DefaultMaxDestinationsPerApp` from 5 to 50 in edgeauth. This PR updates the documented limit on the Cloudflare One account limits page to match.

## Change

One value in the Access section of `account-limits.mdx`:

- `Domains per application`: 5 → 50

## Related

- AUTH-8660: https://jira.cfdata.org/browse/AUTH-8660
- edgeauth commit: 0929753