### PR TITLE
fix: encode @ as %40 in canonical URLs and sitemap to match Workers Static Assets behavior

### DIFF
--- a/sitemap.serializer.ts
+++ b/sitemap.serializer.ts
@@ -121,6 +121,7 @@ export function createSitemapLastmodSerializer() {
 		} else {
 			item.lastmod = currentDateString;
 		}
+		item.url = item.url.replace(/@/g, "%40");
 		return item;
 	};
 }

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -264,9 +264,9 @@ if (frontmatter.canonical) {
 	}
 }
 
-// Cloudflare's edge encodes `@` → `%40` in URL paths and 307-redirects the
-// decoded form, so `/@cf/...` is always served as `/%40cf/...`. Ensure the
-// canonical href matches by encoding any bare `@` in the path.
+// The Workers Static Assets binding 307-redirects URLs with bare `@` in the
+// path to their percent-encoded form (e.g. `/@cf/...` → `/%40cf/...`). Ensure
+// the canonical href matches by encoding any bare `@` in the path.
 const canonicalIdx = head.findIndex(
 	({ tag, attrs }) => tag === "link" && attrs?.rel === "canonical",
 );

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -264,6 +264,19 @@ if (frontmatter.canonical) {
 	}
 }
 
+// Cloudflare's edge encodes `@` → `%40` in URL paths and 307-redirects the
+// decoded form, so `/@cf/...` is always served as `/%40cf/...`. Ensure the
+// canonical href matches by encoding any bare `@` in the path.
+const canonicalIdx = head.findIndex(
+	({ tag, attrs }) => tag === "link" && attrs?.rel === "canonical",
+);
+if (canonicalIdx !== -1) {
+	const href = head[canonicalIdx].attrs!.href;
+	if (typeof href === "string") {
+		head[canonicalIdx].attrs!.href = href.replace(/@/g, "%40");
+	}
+}
+
 metaTags.map((attrs) => {
 	head.push({
 		tag: "meta",
@@ -292,9 +305,11 @@ const schemaType = _isChangelog
 		: "TechArticle";
 
 // Canonical URL for the page entity.
-const _canonicalUrl = frontmatter.canonical
-	? new URL(frontmatter.canonical, Astro.site).toString()
-	: new URL(Astro.url.pathname, Astro.site).toString();
+const _canonicalUrl = (
+	frontmatter.canonical
+		? new URL(frontmatter.canonical, Astro.site).toString()
+		: new URL(Astro.url.pathname, Astro.site).toString()
+).replace(/@/g, "%40");
 
 // Prefer the enriched title already computed for the <title> tag.
 const _titleTag = head.find((x) => x.tag === "title");

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -264,9 +264,7 @@ if (frontmatter.canonical) {
 	}
 }
 
-// The Workers Static Assets binding 307-redirects URLs with bare `@` in the
-// path to their percent-encoded form (e.g. `/@cf/...` → `/%40cf/...`). Ensure
-// the canonical href matches by encoding any bare `@` in the path.
+// `@` in URL paths (e.g. AI model pages) must be encoded as `%40`.
 const canonicalIdx = head.findIndex(
 	({ tag, attrs }) => tag === "link" && attrs?.rel === "canonical",
 );


### PR DESCRIPTION
## Problem

Cloudflare's Workers Static Assets binding 307-redirects URLs containing bare `@` in the path to their percent-encoded form (e.g. `/@cf/...` → `/%40cf/...`). This caused a mismatch between the canonical link tag (`/@cf/...`) and the actual served URL (`/%40cf/...`).

Algolia's crawler treats these as distinct URLs and marks the page as non-canonical, dropping it from the search index. This was affecting all Workers AI model pages (e.g. `/ai/models/@cf/...` and `/ai/models/@hf/...`).

## Root cause

Per RFC 3986 §2.2, `@` is a reserved character (gen-delim). When used as data in a path segment (not as a delimiter), it should be percent-encoded as `%40`. The Workers Static Assets binding enforces this with a 307 redirect.

Starlight generates the canonical from `Astro.url.pathname`, which gives the decoded `@` form — so the canonical never matched the actual served URL.

## Fix

- `Head.astro`: after Starlight populates the `head` array, replace any bare `@` in the canonical `href` with `%40`. Same for the JSON-LD `canonicalUrl`.
- `sitemap.serializer.ts`: encode `@` as `%40` in sitemap URLs so they match the canonical and avoid the redirect hop during crawling.

## Images
<img width="903" height="488" alt="Screenshot 2026-06-17 at 3 35 28 PM" src="https://github.com/user-attachments/assets/9bf59480-ad9c-47a0-8674-043859018f0b" />
<img width="717" height="168" alt="Screenshot 2026-06-17 at 3 36 20 PM" src="https://github.com/user-attachments/assets/723c1a67-0e96-48b2-9987-90dfa22e6221" />
