### PR TITLE
docs: add dynamic hyperdrive bindings documentation to hyperdrive section

### DIFF
--- a/src/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg
+++ b/src/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" fill="none">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    .title { font-size: 16px; font-weight: 700; fill: #1a1a1a; }
+    .label { font-size: 13px; font-weight: 600; fill: #1a1a1a; }
+    .sublabel { font-size: 11px; fill: #6b7280; }
+    .code { font-size: 11px; fill: #6b7280; font-family: 'SF Mono', 'Fira Code', monospace; }
+    .box { rx: 10; stroke-width: 1.5; }
+    .box-tenant { fill: #f9fafb; stroke: #d1d5db; }
+    .box-platform { fill: #fff7ed; stroke: #f6821f; }
+    .box-db { fill: #f0f9ff; stroke: #0ea5e9; }
+    .box-kv { fill: #f3f4f6; stroke: #9ca3af; }
+    .arrow { stroke: #9ca3af; stroke-width: 2; fill: none; marker-end: url(#arr); }
+    .arrow-orange { stroke: #f6821f; stroke-width: 2; fill: none; marker-end: url(#arr-orange); }
+    .arrow-blue { stroke: #0ea5e9; stroke-width: 2; fill: none; marker-end: url(#arr-blue); }
+    .dashed { stroke-dasharray: 6,4; }
+    .section-label { font-size: 12px; font-weight: 700; fill: #9ca3af; text-transform: uppercase; letter-spacing: 0.08em; }
+  </style>
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#9ca3af"/>
+    </marker>
+    <marker id="arr-orange" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#f6821f"/>
+    </marker>
+    <marker id="arr-blue" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#0ea5e9"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="450" y="28" text-anchor="middle" class="title">Dynamic Hyperdrive Binding Resolution</text>
+
+  <!-- ==================== -->
+  <!-- COLUMN LABELS        -->
+  <!-- ==================== -->
+  <text x="160" y="56" text-anchor="middle" class="section-label">Tenant Request</text>
+  <text x="450" y="56" text-anchor="middle" class="section-label">Cloudflare Edge</text>
+  <text x="740" y="56" text-anchor="middle" class="section-label">Origin Infrastructure</text>
+
+  <!-- ==================== -->
+  <!-- TENANT COLUMN        -->
+  <!-- ==================== -->
+
+  <!-- Tenant Request -->
+  <rect x="60" y="72" width="200" height="64" class="box box-tenant"/>
+  <text x="160" y="94" text-anchor="middle" class="label">Incoming Request</text>
+  <text x="160" y="110" text-anchor="middle" class="sublabel">Tenant ID in headers or path</text>
+  <text x="160" y="126" text-anchor="middle" class="code">GET /api/tenant-42/data</text>
+
+  <!-- Arrow: Tenant → Dispatch Worker -->
+  <line x1="260" y1="104" x2="300" y2="104" class="arrow-orange"/>
+
+  <!-- ==================== -->
+  <!-- PLATFORM COLUMN      -->
+  <!-- ==================== -->
+
+  <!-- Dispatch Worker -->
+  <rect x="300" y="72" width="200" height="64" class="box box-platform"/>
+  <text x="400" y="94" text-anchor="middle" class="label">Dynamic Dispatch Worker</text>
+  <text x="400" y="110" text-anchor="middle" class="sublabel">Resolves tenant from KV</text>
+  <text x="400" y="126" text-anchor="middle" class="code">env.KV.get("tenant-id")</text>
+
+  <!-- Arrow: Dispatch → KV (down) -->
+  <line x1="400" y1="136" x2="400" y2="156" class="arrow"/>
+
+  <!-- KV Store -->
+  <rect x="340" y="156" width="120" height="40" class="box box-kv"/>
+  <text x="400" y="174" text-anchor="middle" class="label">KV Store</text>
+  <text x="400" y="188" text-anchor="middle" class="sublabel">Tenant config lookup</text>
+
+  <!-- Arrow: KV → Worker Loader (down) -->
+  <line x1="400" y1="196" x2="400" y2="216" class="arrow"/>
+
+  <!-- Worker Loader -->
+  <rect x="300" y="216" width="200" height="64" class="box box-platform"/>
+  <text x="400" y="238" text-anchor="middle" class="label">Worker Loader</text>
+  <text x="400" y="254" text-anchor="middle" class="sublabel">Loads tenant-specific Worker</text>
+  <text x="400" y="270" text-anchor="middle" class="code">env.LOADER.load({ ... })</text>
+
+  <!-- Arrow: Worker Loader → User Worker (down) -->
+  <line x1="400" y1="280" x2="400" y2="300" class="arrow-orange"/>
+
+  <!-- User Worker -->
+  <rect x="300" y="300" width="200" height="64" class="box box-platform"/>
+  <text x="400" y="322" text-anchor="middle" class="label">Tenant User Worker</text>
+  <text x="400" y="338" text-anchor="middle" class="sublabel">Plain pg driver code</text>
+  <text x="400" y="354" text-anchor="middle" class="code">new Client({ connectionString })</text>
+
+  <!-- Arrow: User Worker → OutboundInterceptor (down) -->
+  <line x1="400" y1="364" x2="400" y2="384" class="arrow-orange"/>
+
+  <!-- OutboundInterceptor -->
+  <rect x="300" y="384" width="200" height="64" class="box box-platform"/>
+  <text x="400" y="406" text-anchor="middle" class="label">OutboundInterceptor</text>
+  <text x="400" y="422" text-anchor="middle" class="sublabel">Intercepts connect() calls</text>
+  <text x="400" y="438" text-anchor="middle" class="code">this.env.DYNAMIC_HYPERDRIVE.get()</text>
+
+  <!-- ==================== -->
+  <!-- ORIGIN COLUMN        -->
+  <!-- ==================== -->
+
+  <!-- Arrow: OutboundInterceptor → Hyperdrive (right) -->
+  <line x1="500" y1="416" x2="540" y2="416" class="arrow-blue"/>
+
+  <!-- Hyperdrive Pool -->
+  <rect x="540" y="384" width="200" height="64" class="box box-db"/>
+  <text x="640" y="406" text-anchor="middle" class="label">Hyperdrive Pool</text>
+  <text x="640" y="422" text-anchor="middle" class="sublabel">Request-scoped RpcTarget</text>
+  <text x="640" y="438" text-anchor="middle" class="code">Pooled TCP socket returned</text>
+
+  <!-- Arrow: Hyperdrive → Origin DB (right) -->
+  <line x1="740" y1="416" x2="780" y2="416" class="arrow-blue"/>
+
+  <!-- Origin Database -->
+  <rect x="780" y="384" width="120" height="64" class="box box-db"/>
+  <text x="840" y="406" text-anchor="middle" class="label">Origin Database</text>
+  <text x="840" y="422" text-anchor="middle" class="sublabel">Tenant-specific</text>
+  <text x="840" y="438" text-anchor="middle" class="code">PostgreSQL / MySQL</text>
+
+  <!-- ==================== -->
+  <!-- RETURN PATH          -->
+  <!-- ==================== -->
+
+  <!-- Return arrow: Hyperdrive → OutboundInterceptor (lower path, dashed) -->
+  <line x1="640" y1="448" x2="640" y2="472" class="arrow dashed"/>
+  <line x1="640" y1="472" x2="400" y2="472" class="arrow dashed"/>
+  <line x1="400" y1="472" x2="400" y2="448" class="arrow dashed"/>
+
+  <!-- Response label -->
+  <text x="520" y="466" text-anchor="middle" class="sublabel">Pooled socket returned to User Worker</text>
+
+  <!-- ==================== -->
+  /* RESPONSE FLOW BACK   */
+  <!-- ==================== -->
+
+  <!-- Return arrow: User Worker → Tenant (left) -->
+  <line x1="300" y1="332" x2="260" y2="332" class="arrow-orange"/>
+
+  <!-- Tenant Response -->
+  <rect x="60" y="300" width="200" height="64" class="box box-tenant"/>
+  <text x="160" y="322" text-anchor="middle" class="label">Tenant Response</text>
+  <text x="160" y="338" text-anchor="middle" class="sublabel">Query results returned</text>
+  <text x="160" y="354" text-anchor="middle" class="code">Response.json({ result })</text>
+
+  <!-- ==================== -->
+  <!-- LEGEND               -->
+  <!-- ==================== -->
+  <rect x="60" y="484" width="200" height="28" rx="4" fill="#fff7ed" stroke="#f6821f" stroke-width="1"/>
+  <text x="160" y="502" text-anchor="middle" class="sublabel" style="fill: #c2410c; font-weight: 600;">Platform-managed components</text>
+
+  <rect x="300" y="484" width="200" height="28" rx="4" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="1"/>
+  <text x="400" y="502" text-anchor="middle" class="sublabel" style="fill: #0369a1; font-weight: 600;">Request-scoped, auto-disposed</text>
+</svg>

--- a/src/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg
+++ b/src/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 340" fill="none">
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     .title { font-size: 16px; font-weight: 700; fill: #1a1a1a; }
@@ -6,15 +6,16 @@
     .sublabel { font-size: 11px; fill: #6b7280; }
     .code { font-size: 11px; fill: #6b7280; font-family: 'SF Mono', 'Fira Code', monospace; }
     .box { rx: 10; stroke-width: 1.5; }
-    .box-tenant { fill: #f9fafb; stroke: #d1d5db; }
-    .box-platform { fill: #fff7ed; stroke: #f6821f; }
+    .box-client { fill: #f9fafb; stroke: #d1d5db; }
+    .box-host { fill: #fff7ed; stroke: #f6821f; }
+    .box-loader { fill: #fef3c7; stroke: #d97706; }
+    .box-dynamic { fill: #fce7f3; stroke: #db2777; }
     .box-db { fill: #f0f9ff; stroke: #0ea5e9; }
-    .box-kv { fill: #f3f4f6; stroke: #9ca3af; }
     .arrow { stroke: #9ca3af; stroke-width: 2; fill: none; marker-end: url(#arr); }
     .arrow-orange { stroke: #f6821f; stroke-width: 2; fill: none; marker-end: url(#arr-orange); }
     .arrow-blue { stroke: #0ea5e9; stroke-width: 2; fill: none; marker-end: url(#arr-blue); }
+    .arrow-pink { stroke: #db2777; stroke-width: 2; fill: none; marker-end: url(#arr-pink); }
     .dashed { stroke-dasharray: 6,4; }
-    .section-label { font-size: 12px; font-weight: 700; fill: #9ca3af; text-transform: uppercase; letter-spacing: 0.08em; }
   </style>
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
@@ -26,129 +27,109 @@
     <marker id="arr-blue" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
       <polygon points="0 0, 8 3, 0 6" fill="#0ea5e9"/>
     </marker>
+    <marker id="arr-pink" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#db2777"/>
+    </marker>
+    <marker id="arr-return" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#9ca3af"/>
+    </marker>
   </defs>
 
   <!-- Title -->
-  <text x="450" y="28" text-anchor="middle" class="title">Dynamic Hyperdrive Binding Resolution</text>
+  <text x="450" y="28" text-anchor="middle" class="title">Dynamic Hyperdrive with Dynamic Workers</text>
 
   <!-- ==================== -->
-  <!-- COLUMN LABELS        -->
-  <!-- ==================== -->
-  <text x="160" y="56" text-anchor="middle" class="section-label">Tenant Request</text>
-  <text x="450" y="56" text-anchor="middle" class="section-label">Cloudflare Edge</text>
-  <text x="740" y="56" text-anchor="middle" class="section-label">Origin Infrastructure</text>
-
-  <!-- ==================== -->
-  <!-- TENANT COLUMN        -->
+  <!-- ROW 1: Main flow     -->
   <!-- ==================== -->
 
-  <!-- Tenant Request -->
-  <rect x="60" y="72" width="200" height="64" class="box box-tenant"/>
-  <text x="160" y="94" text-anchor="middle" class="label">Incoming Request</text>
-  <text x="160" y="110" text-anchor="middle" class="sublabel">Tenant ID in headers or path</text>
-  <text x="160" y="126" text-anchor="middle" class="code">GET /api/tenant-42/data</text>
+  <!-- Client Request -->
+  <rect x="20" y="60" width="140" height="70" class="box box-client"/>
+  <text x="90" y="86" text-anchor="middle" class="label">Client</text>
+  <text x="90" y="102" text-anchor="middle" class="sublabel">HTTP request with</text>
+  <text x="90" y="116" text-anchor="middle" class="sublabel">tenant identifier</text>
 
-  <!-- Arrow: Tenant → Dispatch Worker -->
-  <line x1="260" y1="104" x2="300" y2="104" class="arrow-orange"/>
+  <!-- Arrow: Client to Host Worker -->
+  <line x1="160" y1="95" x2="195" y2="95" class="arrow-orange"/>
+
+  <!-- Host Worker -->
+  <rect x="195" y="60" width="160" height="70" class="box box-host"/>
+  <text x="275" y="82" text-anchor="middle" class="label">Host Worker</text>
+  <text x="275" y="98" text-anchor="middle" class="sublabel">Resolves tenant config</text>
+  <text x="275" y="112" text-anchor="middle" class="code">env.KV.get("tenant-id")</text>
+
+  <!-- Arrow: Host Worker to Worker Loader -->
+  <line x1="355" y1="95" x2="390" y2="95" class="arrow-orange"/>
+  <text x="373" y="87" text-anchor="middle" class="sublabel" style="font-size:9px">code as</text>
+  <text x="373" y="96" text-anchor="middle" class="sublabel" style="font-size:9px">payload</text>
+
+  <!-- Worker Loader API -->
+  <rect x="390" y="60" width="150" height="70" class="box box-loader"/>
+  <text x="465" y="82" text-anchor="middle" class="label">Worker Loader API</text>
+  <text x="465" y="98" text-anchor="middle" class="sublabel">Compiles and loads</text>
+  <text x="465" y="112" text-anchor="middle" class="code">env.LOADER.load()</text>
+
+  <!-- Arrow: Worker Loader to Dynamic Worker -->
+  <line x1="540" y1="95" x2="575" y2="95" class="arrow-pink"/>
+
+  <!-- Dynamic Worker -->
+  <rect x="575" y="60" width="150" height="70" class="box box-dynamic"/>
+  <text x="650" y="82" text-anchor="middle" class="label">Dynamic Worker</text>
+  <text x="650" y="98" text-anchor="middle" class="sublabel">Executes tenant code</text>
+  <text x="650" y="112" text-anchor="middle" class="sublabel">Temporary sandbox</text>
 
   <!-- ==================== -->
-  <!-- PLATFORM COLUMN      -->
+  <!-- ROW 2: DB connection -->
   <!-- ==================== -->
 
-  <!-- Dispatch Worker -->
-  <rect x="300" y="72" width="200" height="64" class="box box-platform"/>
-  <text x="400" y="94" text-anchor="middle" class="label">Dynamic Dispatch Worker</text>
-  <text x="400" y="110" text-anchor="middle" class="sublabel">Resolves tenant from KV</text>
-  <text x="400" y="126" text-anchor="middle" class="code">env.KV.get("tenant-id")</text>
-
-  <!-- Arrow: Dispatch → KV (down) -->
-  <line x1="400" y1="136" x2="400" y2="156" class="arrow"/>
-
-  <!-- KV Store -->
-  <rect x="340" y="156" width="120" height="40" class="box box-kv"/>
-  <text x="400" y="174" text-anchor="middle" class="label">KV Store</text>
-  <text x="400" y="188" text-anchor="middle" class="sublabel">Tenant config lookup</text>
-
-  <!-- Arrow: KV → Worker Loader (down) -->
-  <line x1="400" y1="196" x2="400" y2="216" class="arrow"/>
-
-  <!-- Worker Loader -->
-  <rect x="300" y="216" width="200" height="64" class="box box-platform"/>
-  <text x="400" y="238" text-anchor="middle" class="label">Worker Loader</text>
-  <text x="400" y="254" text-anchor="middle" class="sublabel">Loads tenant-specific Worker</text>
-  <text x="400" y="270" text-anchor="middle" class="code">env.LOADER.load({ ... })</text>
-
-  <!-- Arrow: Worker Loader → User Worker (down) -->
-  <line x1="400" y1="280" x2="400" y2="300" class="arrow-orange"/>
-
-  <!-- User Worker -->
-  <rect x="300" y="300" width="200" height="64" class="box box-platform"/>
-  <text x="400" y="322" text-anchor="middle" class="label">Tenant User Worker</text>
-  <text x="400" y="338" text-anchor="middle" class="sublabel">Plain pg driver code</text>
-  <text x="400" y="354" text-anchor="middle" class="code">new Client({ connectionString })</text>
-
-  <!-- Arrow: User Worker → OutboundInterceptor (down) -->
-  <line x1="400" y1="364" x2="400" y2="384" class="arrow-orange"/>
+  <!-- Arrow: Dynamic Worker down to Interceptor -->
+  <line x1="650" y1="130" x2="650" y2="165" class="arrow-pink"/>
+  <text x="690" y="150" class="sublabel" style="font-size:9px">connect()</text>
 
   <!-- OutboundInterceptor -->
-  <rect x="300" y="384" width="200" height="64" class="box box-platform"/>
-  <text x="400" y="406" text-anchor="middle" class="label">OutboundInterceptor</text>
-  <text x="400" y="422" text-anchor="middle" class="sublabel">Intercepts connect() calls</text>
-  <text x="400" y="438" text-anchor="middle" class="code">this.env.DYNAMIC_HYPERDRIVE.get()</text>
+  <rect x="390" y="165" width="175" height="65" class="box box-host"/>
+  <text x="478" y="187" text-anchor="middle" class="label">OutboundInterceptor</text>
+  <text x="478" y="203" text-anchor="middle" class="sublabel">Intercepts connect() calls</text>
+  <text x="478" y="217" text-anchor="middle" class="code">DYNAMIC_HYPERDRIVE.get()</text>
 
-  <!-- ==================== -->
-  <!-- ORIGIN COLUMN        -->
-  <!-- ==================== -->
+  <!-- Arrow: Dynamic Worker left to Interceptor -->
+  <line x1="650" y1="197" x2="565" y2="197" class="arrow-pink"/>
 
-  <!-- Arrow: OutboundInterceptor → Hyperdrive (right) -->
-  <line x1="500" y1="416" x2="540" y2="416" class="arrow-blue"/>
+  <!-- Arrow: Interceptor to Hyperdrive -->
+  <line x1="478" y1="230" x2="478" y2="260" class="arrow-blue"/>
 
   <!-- Hyperdrive Pool -->
-  <rect x="540" y="384" width="200" height="64" class="box box-db"/>
-  <text x="640" y="406" text-anchor="middle" class="label">Hyperdrive Pool</text>
-  <text x="640" y="422" text-anchor="middle" class="sublabel">Request-scoped RpcTarget</text>
-  <text x="640" y="438" text-anchor="middle" class="code">Pooled TCP socket returned</text>
+  <rect x="390" y="260" width="175" height="55" class="box box-db"/>
+  <text x="478" y="282" text-anchor="middle" class="label">Hyperdrive Pool</text>
+  <text x="478" y="298" text-anchor="middle" class="sublabel">Request-scoped connection</text>
 
-  <!-- Arrow: Hyperdrive → Origin DB (right) -->
-  <line x1="740" y1="416" x2="780" y2="416" class="arrow-blue"/>
+  <!-- Arrow: Hyperdrive to Database -->
+  <line x1="565" y1="287" x2="630" y2="287" class="arrow-blue"/>
 
   <!-- Origin Database -->
-  <rect x="780" y="384" width="120" height="64" class="box box-db"/>
-  <text x="840" y="406" text-anchor="middle" class="label">Origin Database</text>
-  <text x="840" y="422" text-anchor="middle" class="sublabel">Tenant-specific</text>
-  <text x="840" y="438" text-anchor="middle" class="code">PostgreSQL / MySQL</text>
+  <rect x="630" y="260" width="140" height="55" class="box box-db"/>
+  <text x="700" y="282" text-anchor="middle" class="label">Origin Database</text>
+  <text x="700" y="298" text-anchor="middle" class="sublabel">Tenant-specific</text>
 
   <!-- ==================== -->
   <!-- RETURN PATH          -->
   <!-- ==================== -->
 
-  <!-- Return arrow: Hyperdrive → OutboundInterceptor (lower path, dashed) -->
-  <line x1="640" y1="448" x2="640" y2="472" class="arrow dashed"/>
-  <line x1="640" y1="472" x2="400" y2="472" class="arrow dashed"/>
-  <line x1="400" y1="472" x2="400" y2="448" class="arrow dashed"/>
-
-  <!-- Response label -->
-  <text x="520" y="466" text-anchor="middle" class="sublabel">Pooled socket returned to User Worker</text>
-
-  <!-- ==================== -->
-  /* RESPONSE FLOW BACK   */
-  <!-- ==================== -->
-
-  <!-- Return arrow: User Worker → Tenant (left) -->
-  <line x1="300" y1="332" x2="260" y2="332" class="arrow-orange"/>
-
-  <!-- Tenant Response -->
-  <rect x="60" y="300" width="200" height="64" class="box box-tenant"/>
-  <text x="160" y="322" text-anchor="middle" class="label">Tenant Response</text>
-  <text x="160" y="338" text-anchor="middle" class="sublabel">Query results returned</text>
-  <text x="160" y="354" text-anchor="middle" class="code">Response.json({ result })</text>
+  <!-- Return arrow: Host Worker back to Client -->
+  <line x1="195" y1="105" x2="160" y2="105" class="arrow dashed"/>
+  <text x="178" y="120" text-anchor="middle" class="sublabel" style="font-size:9px">response</text>
 
   <!-- ==================== -->
   <!-- LEGEND               -->
   <!-- ==================== -->
-  <rect x="60" y="484" width="200" height="28" rx="4" fill="#fff7ed" stroke="#f6821f" stroke-width="1"/>
-  <text x="160" y="502" text-anchor="middle" class="sublabel" style="fill: #c2410c; font-weight: 600;">Platform-managed components</text>
+  <rect x="195" y="330" width="12" height="6" rx="2" fill="#fff7ed" stroke="#f6821f" stroke-width="1"/>
+  <text x="213" y="337" class="sublabel" style="font-size:10px; fill: #c2410c;">Host Worker</text>
 
-  <rect x="300" y="484" width="200" height="28" rx="4" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="1"/>
-  <text x="400" y="502" text-anchor="middle" class="sublabel" style="fill: #0369a1; font-weight: 600;">Request-scoped, auto-disposed</text>
+  <rect x="310" y="330" width="12" height="6" rx="2" fill="#fef3c7" stroke="#d97706" stroke-width="1"/>
+  <text x="328" y="337" class="sublabel" style="font-size:10px; fill: #92400e;">Worker Loader</text>
+
+  <rect x="440" y="330" width="12" height="6" rx="2" fill="#fce7f3" stroke="#db2777" stroke-width="1"/>
+  <text x="458" y="337" class="sublabel" style="font-size:10px; fill: #9d174d;">Dynamic Worker (temporary)</text>
+
+  <rect x="620" y="330" width="12" height="6" rx="2" fill="#f0f9ff" stroke="#0ea5e9" stroke-width="1"/>
+  <text x="638" y="337" class="sublabel" style="font-size:10px; fill: #0369a1;">Hyperdrive / Database</text>
 </svg>

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -23,14 +23,7 @@ interface Env {
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    const tenantId = request.headers.get("x-tenant-id") || "default";
-    
-    const tenantData = await env.KV.get(tenantId);
-    if (!tenantData) {
-      return new Response("Tenant configuration not found", { status: 404 });
-    }
-    
-    const tenant = JSON.parse(tenantData);
+    let tenant = JSON.parse(await env.KV.get("tenant-id"));
 
     return new Response(`Configured dynamic connection`, {
       headers: { "x-connection-string": tenant.connectionString }
@@ -46,30 +39,30 @@ export default {
 
 ### FAQ
 
-### How does the dynamic design work under the hood?
+### Dynamic design under the hood
 
 Hyperdrive automatically spins up its connection pools in the data center closest to your origin database using your runtime `targetRegion` parameter. When a user makes a request, the `OutboundInterceptor` handles it at the edge; if the query is cached, it is served instantly from the global node closest to that user, bypassing your database entirely. If it misses the cache, it travels over Cloudflare's backbone via pre-warmed, persistent TCP sockets, eliminating long-distance handshake penalties.
 
-### Are host URLs unique or reused?
+### Host URL uniqueness
 
 Host URLs are unique. Single hosts are not reused across different database names. Every individual tenant database receives its own unique Hyperdrive ID under the hood, completely decoupled from your front-end preview URLs or custom domains. Your infrastructure maps incoming app requests to the tenant's connection string, and `DYNAMIC_HYPERDRIVE.get()` fetches the correct pool instantly at runtime with zero configuration cold starts.
 
-### Will multiple pools spin up for a single connection string globally, and how does that affect our database connection limits?
+### Pool allocation per connection string
 
 Each individual connection string has its own pool. Any multi-pool routing under the hood is an internal implementation detail. To ensure reliability, Hyperdrive currently shards your available connections across multiple pools for redundancy. This sharding mechanism may evolve in the future as routing is optimized, but protecting your database limits remains a core priority.
 
-### How does `maxConnections` actually apply across these instances?
+### `maxConnections` behavior across instances
 
 The `maxConnections` parameter does not restrict the number of inbound client requests hitting the edge. Instead, it defines the hard ceiling of outbound database sockets that one single dynamic Hyperdrive instance maintains directly to your origin database. Hyperdrive multiplexes thousands of incoming edge hits down into a highly optimized number of persistent connections up to that configured maximum, protecting your multi-tenant databases from connection exhaustion during sudden traffic spikes. This is a soft limit, and Hyperdrive may occasionally exceed it in unusual traffic situations.
 
-### What is the inactivity timeout for a pool?
+### Pool inactivity timeout
 
 When the last active connection closes, the pool stays alive for an additional 15 minutes before shutting down to ensure subsequent traffic does not hit a cold start. This 15-minute window is an internal implementation detail and may change in the future as platform performance is optimized.
 
-### Are there account-level configuration limits on the total number of unique dynamic Hyperdrive pools as we scale from 5M to 50M apps?
+### Account-level configuration limits at scale
 
 Utilizing Dynamic Hyperdrive to generate parameters via code at runtime completely bypasses static configuration limitations. For this dynamic execution plane, configuration capacities are a soft limit.
 
-### How do we pull per-tenant metrics for our users?
+### Per-tenant metrics retrieval
 
 You can programmatically query the GraphQL Analytics API by `hyperdriveId` to pull live data on connection counts, query latency, error rates, and cache hit ratios. You can pipe this data straight into your own customer-facing dashboards.

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -1,82 +1,43 @@
 ---
 title: Dynamic Hyperdrive Bindings
-pcx_content_type: how-to
-description: Learn how to dynamically provision and resolve database connections at runtime using Dynamic Hyperdrive bindings and Workers for Platforms.
+pcx_content_type: configuration
 sidebar:
-  order: 3
-products:
-  - hyperdrive
-  - workers
+  order: 5
 ---
 
-import { Details } from "~/components";
+import { TypeScriptExample } from "~/components";
 
 Dynamic Hyperdrive bindings allow SaaS platforms to provision and resolve database connections at runtime for thousands of unique tenant databases, eliminating the static configuration limits inherent to traditional bindings.
 
-Unlike static bindings, which require a pre-declared resource ID at deploy time, a Dynamic Hyperdrive binding is explicitly created as part of a [Binding Group](/cloudflare-for-platforms/workers-for-platforms/configuration/binding-groups/) and must be configured dynamically before use. Your platform provisions the binding during customer onboarding via `.create()`, and resolves it per-request at runtime via `.get()`. This model decouples your tenant database infrastructure from static Workers configuration, enabling true multi-tenant database connectivity at scale.
-
-## How it works
-
-Dynamic Hyperdrive bindings behave as explicitly created resources that require upstream configuration before they can be consumed.
-
-1. **Dynamic instantiation** — During tenant onboarding, your platform calls `.create()` with the tenant-specific database parameters (connection string, target region, caching settings, connection limits, and optional mTLS certificates). This generates a binding scoped to that tenant.
-2. **Request-scoped resolution** — At runtime, the platform's dynamic dispatch Worker calls `.get()` with the tenant's parameters. The returned object is an `RpcTarget` that exists only for the duration of the current request. It is not a persistent Worker entrypoint and requires no explicit cleanup or revocation.
-3. **Request isolation** — Each invocation receives its own resolved binding instance. Hyperdrive manages connection pooling and query routing independently per tenant, ensuring that one tenant's traffic does not interfere with another's.
+Unlike static bindings, which require a pre-declared resource ID at deploy time, a Dynamic Hyperdrive binding can be resolved dynamically per-request at runtime. This model decouples your tenant database infrastructure from static Workers configuration, enabling true multi-tenant database connectivity at scale.
 
 Because the binding is resolved dynamically, there are no static limits on the total number of unique Hyperdrive configurations your platform can create. Configuration capacity is a soft limit for this dynamic execution plane.
 
-![Dynamic Hyperdrive bindings architecture showing a tenant request flowing through a dynamic dispatch Worker, which loads a tenant-specific user Worker and intercepts outbound database connections via an OutboundInterceptor that resolves a request-scoped Hyperdrive pool.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
+The following example demonstrates an outbound interception pattern that intercepts database connections, resolves tenant-specific parameters from KV, and dynamically configures the Hyperdrive binding for each request.
 
-## Implementation
-
-The following example demonstrates an `OutboundInterceptor` that intercepts database connections, resolves tenant-specific parameters from KV, and dynamically fetches the correct Hyperdrive binding for each request.
-
-```typescript
-export class OutboundInterceptor extends WorkerEntrypoint {
-  async connect(host) {
-    if (host === this.ctx.props.connectionString) {
-      // .get() returns an RpcTarget that lives for this request only,
-      // not a stored WorkerEntrypoint. Nothing to persist or revoke.
-      let hyperdriveStub = this.env.DYNAMIC_HYPERDRIVE.get({
-        connectionString: this.ctx.props.tenant.connectionString,
-        targetRegion: this.ctx.props.tenant.cloudRegion,
-        cachingEnabled: this.ctx.props.tenant.cachingEnabled,
-        maxConnections: this.ctx.props.tenant.maxConnections,
-        mtlsCertificateId: this.ctx.props.tenant.customCertId
-      });
-      return hyperdriveStub.connect(host); // calls hyperdrive connect
-    }
-    return connect(host); // general tcp connect
-  }
+<TypeScriptExample>
+```ts
+interface Env {
+  KV: KVNamespace;
 }
 
 export default {
-  async fetch(request, env, ctx) {
-    let tenant = await env.KV.get("tenant-id");
-    const worker = env.LOADER.load({
-      compatibilityDate: "2026-06-04",
-      mainModule: "src/index.js",
-      modules: { // what a real user writes
-        "src/index.js": `
-import { Client } from "pg";
-export default {
-  async fetch(request, env) {
-    const client = new Client({ connectionString: env.CONNECTION_STRING });
-    await client.connect();
-    const result = await client.query("SELECT * FROM pg_tables");
-    return Response.json({ success: true, result: result.rows });
-  },
-};`,
-      },
-      env: { CONNECTION_STRING: connectionString },
-      globalOutbound: ctx.exports.OutboundInterceptor({
-        props: { tenant },
-      }),
-    });
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const tenantId = request.headers.get("x-tenant-id") || "default";
+    
+    const tenantData = await env.KV.get(tenantId);
+    if (!tenantData) {
+      return new Response("Tenant configuration not found", { status: 404 });
+    }
+    
+    const tenant = JSON.parse(tenantData);
 
-    return worker.getEntrypoint().fetch(request);
+    return new Response(`Configured dynamic connection`, {
+      headers: { "x-connection-string": tenant.connectionString }
+    });
   },
 };
+
 ```
 
 ## FAQ

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -1,0 +1,110 @@
+---
+title: Dynamic Hyperdrive Bindings
+pcx_content_type: how-to
+description: Learn how to dynamically provision and resolve database connections at runtime using Dynamic Hyperdrive bindings and Workers for Platforms.
+sidebar:
+  order: 3
+products:
+  - hyperdrive
+  - workers
+---
+
+import { Details } from "~/components";
+
+Dynamic Hyperdrive bindings allow SaaS platforms to provision and resolve database connections at runtime for thousands of unique tenant databases, eliminating the static configuration limits inherent to traditional bindings.
+
+Unlike static bindings, which require a pre-declared resource ID at deploy time, a Dynamic Hyperdrive binding is explicitly created as part of a [Binding Group](/cloudflare-for-platforms/workers-for-platforms/configuration/binding-groups/) and must be configured dynamically before use. Your platform provisions the binding during customer onboarding via `.create()`, and resolves it per-request at runtime via `.get()`. This model decouples your tenant database infrastructure from static Workers configuration, enabling true multi-tenant database connectivity at scale.
+
+## How it works
+
+Dynamic Hyperdrive bindings behave as explicitly created resources that require upstream configuration before they can be consumed.
+
+1. **Dynamic instantiation** — During tenant onboarding, your platform calls `.create()` with the tenant-specific database parameters (connection string, target region, caching settings, connection limits, and optional mTLS certificates). This generates a binding scoped to that tenant.
+2. **Request-scoped resolution** — At runtime, the platform's dynamic dispatch Worker calls `.get()` with the tenant's parameters. The returned object is an `RpcTarget` that exists only for the duration of the current request. It is not a persistent Worker entrypoint and requires no explicit cleanup or revocation.
+3. **Request isolation** — Each invocation receives its own resolved binding instance. Hyperdrive manages connection pooling and query routing independently per tenant, ensuring that one tenant's traffic does not interfere with another's.
+
+Because the binding is resolved dynamically, there are no static limits on the total number of unique Hyperdrive configurations your platform can create. Configuration capacity is a soft limit for this dynamic execution plane.
+
+![Dynamic Hyperdrive bindings architecture showing a tenant request flowing through a dynamic dispatch Worker, which loads a tenant-specific user Worker and intercepts outbound database connections via an OutboundInterceptor that resolves a request-scoped Hyperdrive pool.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
+
+## Implementation
+
+The following example demonstrates an `OutboundInterceptor` that intercepts database connections, resolves tenant-specific parameters from KV, and dynamically fetches the correct Hyperdrive binding for each request.
+
+```typescript
+export class OutboundInterceptor extends WorkerEntrypoint {
+  async connect(host) {
+    if (host === this.ctx.props.connectionString) {
+      // .get() returns an RpcTarget that lives for this request only,
+      // not a stored WorkerEntrypoint. Nothing to persist or revoke.
+      let hyperdriveStub = this.env.DYNAMIC_HYPERDRIVE.get({
+        connectionString: this.ctx.props.tenant.connectionString,
+        targetRegion: this.ctx.props.tenant.cloudRegion,
+        cachingEnabled: this.ctx.props.tenant.cachingEnabled,
+        maxConnections: this.ctx.props.tenant.maxConnections,
+        mtlsCertificateId: this.ctx.props.tenant.customCertId
+      });
+      return hyperdriveStub.connect(host); // calls hyperdrive connect
+    }
+    return connect(host); // general tcp connect
+  }
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    let tenant = await env.KV.get("tenant-id");
+    const worker = env.LOADER.load({
+      compatibilityDate: "2026-06-04",
+      mainModule: "src/index.js",
+      modules: { // what a real user writes
+        "src/index.js": `
+import { Client } from "pg";
+export default {
+  async fetch(request, env) {
+    const client = new Client({ connectionString: env.CONNECTION_STRING });
+    await client.connect();
+    const result = await client.query("SELECT * FROM pg_tables");
+    return Response.json({ success: true, result: result.rows });
+  },
+};`,
+      },
+      env: { CONNECTION_STRING: connectionString },
+      globalOutbound: ctx.exports.OutboundInterceptor({
+        props: { tenant },
+      }),
+    });
+
+    return worker.getEntrypoint().fetch(request);
+  },
+};
+```
+
+## FAQ
+
+### How does the dynamic design work under the hood?
+
+Hyperdrive automatically spins up its connection pools in the data center closest to your origin database using your runtime `targetRegion` parameter. When a user makes a request, the `OutboundInterceptor` handles it at the edge; if the query is cached, it is served instantly from the global node closest to that user, bypassing your database entirely. If it misses the cache, it travels over Cloudflare's backbone via pre-warmed, persistent TCP sockets, eliminating long-distance handshake penalties.
+
+### Are host URLs unique or reused?
+
+Host URLs are unique. Single hosts are not reused across different database names. Every individual tenant database receives its own unique Hyperdrive ID under the hood, completely decoupled from your front-end preview URLs or custom domains. Your infrastructure maps incoming app requests to the tenant's connection string, and `DYNAMIC_HYPERDRIVE.get()` fetches the correct pool instantly at runtime with zero configuration cold starts.
+
+### Will multiple pools spin up for a single connection string globally, and how does that affect our database connection limits?
+
+Each individual connection string has its own pool. Any multi-pool routing under the hood is an internal implementation detail. To ensure reliability, Hyperdrive currently shards your available connections across multiple pools for redundancy. This sharding mechanism may evolve in the future as routing is optimized, but protecting your database limits remains a core priority.
+
+### How does `maxConnections` actually apply across these instances?
+
+The `maxConnections` parameter does not restrict the number of inbound client requests hitting the edge. Instead, it defines the hard ceiling of outbound database sockets that one single dynamic Hyperdrive instance maintains directly to your origin database. Hyperdrive multiplexes thousands of incoming edge hits down into a highly optimized number of persistent connections up to that configured maximum, protecting your multi-tenant databases from connection exhaustion during sudden traffic spikes. This is a soft limit, and Hyperdrive may occasionally exceed it in unusual traffic situations.
+
+### What is the inactivity timeout for a pool?
+
+When the last active connection closes, the pool stays alive for an additional 15 minutes before shutting down to ensure subsequent traffic does not hit a cold start. This 15-minute window is an internal implementation detail and may change in the future as platform performance is optimized.
+
+### Are there account-level configuration limits on the total number of unique dynamic Hyperdrive pools as we scale from 5M to 50M apps?
+
+Utilizing Dynamic Hyperdrive to generate parameters via code at runtime completely bypasses static configuration limitations. For this dynamic execution plane, configuration capacities are a soft limit.
+
+### How do we pull per-tenant metrics for our users?
+
+You can programmatically query the GraphQL Analytics API by `hyperdriveId` to pull live data on connection counts, query latency, error rates, and cache hit ratios. You can pipe this data straight into your own customer-facing dashboards.

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -39,8 +39,12 @@ export default {
 };
 
 ```
+<figure>
+  ![Dynamic Hyperdrive bindings architecture showing a tenant request flowing through an OutboundInterceptor resolving a request-scoped Hyperdrive pool.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
+  <figcaption>Architecture overview: How runtime platform bindings dynamically resolve connection pooling configurations per request.</figcaption>
+</figure>
 
-## FAQ
+### FAQ
 
 ### How does the dynamic design work under the hood?
 

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -18,28 +18,28 @@ This model decouples your tenant database infrastructure from deploy-time config
 
 ## How it works
 
-Dynamic Hyperdrive bindings run on [Dynamic Workers](/dynamic-workers/). A Dynamic Worker is a temporary, sandboxed Worker that executes code on demand. A host Worker passes raw code as a payload to the Worker Loader API, which spins up a Dynamic Worker to execute it. After the Dynamic Worker returns a result, it dissolves. The host Worker returns the response to the client.
+Dynamic Hyperdrive bindings run on [Dynamic Workers](/dynamic-workers/). A Dynamic Worker is a sandboxed Worker that executes code on demand. A loader Worker passes raw code as a payload to the Worker Loader API, which spins up a Dynamic Worker to execute it.
 
 The dynamic Hyperdrive flow works as follows:
 
-1. A tenant request arrives at the host Worker.
-2. The host Worker resolves tenant configuration from [KV](/kv/) (connection string, region, caching preferences).
-3. The host Worker calls `env.LOADER.load()` to spin up a Dynamic Worker loaded with the tenant's database code.
-4. The host Worker attaches an `OutboundInterceptor` to the Dynamic Worker through the `globalOutbound` option.
+1. A tenant request arrives at the loader Worker.
+2. The loader Worker resolves tenant configuration (connection string, region, caching preferences).
+3. The loader Worker calls `env.LOADER.load()` to spin up a Dynamic Worker loaded with the tenant's database code.
+4. The loader Worker attaches an `OutboundInterceptor` to the Dynamic Worker through the `globalOutbound` option.
 5. When the Dynamic Worker opens a database connection, the `OutboundInterceptor` intercepts the `connect()` call and calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters.
-6. Hyperdrive creates a temporary, request-scoped connection pool in the data center closest to the origin database. If a cached result exists for the query, Hyperdrive returns it from the edge without contacting the database.
-7. The Dynamic Worker receives a standard database response. After the request completes, the Dynamic Worker dissolves.
+6. Hyperdrive creates a request-scoped connection pool in the data center closest to the origin database. If a cached result exists for the query, Hyperdrive returns it from the edge without contacting the database.
+7. The Dynamic Worker receives a standard database response.
 
 <figure>
-	![Dynamic Hyperdrive bindings architecture showing a host Worker passing
+	![Dynamic Hyperdrive bindings architecture showing a loader Worker passing
 	tenant code to the Worker Loader API, which spins up a Dynamic Worker that
 	connects through Hyperdrive to the origin
 	database.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
 	<figcaption>
-		A tenant request arrives at the host Worker, which passes code to the Worker
+		A tenant request arrives at the loader Worker, which passes code to the Worker
 		Loader API. The Dynamic Worker executes the code, and the
 		OutboundInterceptor intercepts database connections to route them through
-		Hyperdrive. After the response, the Dynamic Worker dissolves.
+		Hyperdrive.
 	</figcaption>
 </figure>
 
@@ -52,11 +52,10 @@ This section walks through the prerequisites, configuration, and code required t
 Before you begin, ensure you have the following:
 
 1. A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) with access to [Dynamic Workers](/dynamic-workers/).
-2. A [KV namespace](/kv/) (or another data store) containing tenant configuration. Each tenant record should include the database connection string, target region, and any optional parameters (caching, max connections, mTLS certificate ID).
-3. A publicly accessible PostgreSQL (or PostgreSQL-compatible) database for each tenant. Hyperdrive supports PostgreSQL-compatible databases such as CockroachDB, Neon, and Supabase. For the full list, refer to [Supported databases and features](/hyperdrive/reference/supported-databases-and-features/).
-4. A `DYNAMIC_HYPERDRIVE` binding configured on your host Worker. This is the dynamic Hyperdrive namespace binding that exposes the `.get()` method.
-5. A `LOADER` binding for the [Worker Loader](/dynamic-workers/getting-started/#configure-worker-loader) that loads Dynamic Workers.
-6. [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) version 16.17.0 or later, and [Wrangler](/workers/wrangler/install-and-update/) installed.
+2. A publicly accessible PostgreSQL, MySQL, or compatible database for each tenant. Hyperdrive supports PostgreSQL-compatible databases such as CockroachDB, Neon, and Supabase. For the full list, refer to [Supported databases and features](/hyperdrive/reference/supported-databases-and-features/).
+3. A `DYNAMIC_HYPERDRIVE` binding configured on your loader Worker. This is the dynamic Hyperdrive namespace binding that exposes the `.get()` method.
+4. A `LOADER` binding for the [Worker Loader](/dynamic-workers/getting-started/#configure-worker-loader) that loads Dynamic Workers.
+5. [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) version 16.17.0 or later, and [Wrangler](/workers/wrangler/install-and-update/) installed.
 
 :::note
 
@@ -66,7 +65,7 @@ If your tenant databases require client certificate authentication (mTLS), uploa
 
 ### Define tenant configuration
 
-Store each tenant's database parameters in KV (or your preferred data store). At minimum, each tenant record needs a `connectionString` and a `cloudRegion`. Optional fields control caching, connection limits, and mTLS.
+Each tenant's database parameters are passed to `DYNAMIC_HYPERDRIVE.get()` at runtime. The following table describes the available parameters.
 
 | Parameter          | Required | Description                                                                                                                                                                                                |
 | ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,9 +75,9 @@ Store each tenant's database parameters in KV (or your preferred data store). At
 | `maxConnections`   | No       | Maximum number of outbound database sockets for this tenant. Defaults to the platform-level limit.                                                                                                         |
 | `customCertId`     | No       | mTLS certificate ID for databases that require client certificate authentication. Refer to [SSL/TLS certificates](/hyperdrive/configuration/tls-ssl-certificates-for-hyperdrive/) for upload instructions. |
 
-### Write the host Worker
+### Write the loader Worker
 
-The host Worker has two parts: an `OutboundInterceptor` that intercepts database connections, and a `fetch` handler that resolves tenant configuration and loads the tenant's Dynamic Worker.
+The loader Worker has two parts: an `OutboundInterceptor` that intercepts database connections, and a `fetch` handler that resolves tenant configuration and loads the tenant's Dynamic Worker.
 
 ```js
 // OutboundInterceptor — intercepts all outbound connect() calls
@@ -109,9 +108,9 @@ export class OutboundInterceptor extends WorkerEntrypoint {
 	}
 }
 
-// Host Worker entrypoint — handles incoming requests, resolves
-// tenant config from KV, and uses the Worker Loader API to spin
-// up a Dynamic Worker with the tenant's database code.
+// Loader Worker entrypoint — handles incoming requests, resolves
+// tenant config, and uses the Worker Loader API to spin up a
+// Dynamic Worker with the tenant's database code.
 export default {
 	async fetch(request, env, ctx) {
 		let tenant = await env.KV.get("tenant-id");
@@ -122,8 +121,8 @@ export default {
 			mainModule: "src/index.js",
 			modules: {
 				// This string is the Dynamic Worker's code.
-				// It executes inside a temporary sandbox, not on
-				// the host Worker. It uses a standard pg driver
+				// It executes inside a sandboxed environment, not
+				// on the loader Worker. It uses a standard pg driver
 				// with no Hyperdrive-specific code.
 				"src/index.js": `
 import { Client } from "pg";
@@ -151,11 +150,11 @@ The key parts of this code:
 
 - **`OutboundInterceptor`** — Extends `WorkerEntrypoint` and overrides `connect()`. When the Dynamic Worker opens a database connection, this interceptor checks if the host matches the tenant's connection string. If it does, it calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters to create a request-scoped Hyperdrive pool. If the required `connectionString` prop is missing, the interceptor throws an error. All other outbound connections pass through unchanged.
 - **`DYNAMIC_HYPERDRIVE.get()`** — Accepts an object with the tenant's connection string, region, caching preferences, connection limit, and optional mTLS certificate ID. It returns an `RpcTarget` scoped to the current request. There is nothing to persist, revoke, or clean up after the request ends.
-- **`env.LOADER.load()`** — Creates a [Dynamic Worker](/dynamic-workers/) from the code defined in `modules`. The Dynamic Worker is temporary — it executes the tenant's code in an isolated sandbox and dissolves after the request completes. The tenant code uses a standard `pg` driver and has no awareness of Hyperdrive. The `globalOutbound` option wires the `OutboundInterceptor` so that all outbound `connect()` calls from the Dynamic Worker pass through it.
+- **`env.LOADER.load()`** — Creates a [Dynamic Worker](/dynamic-workers/) from the code defined in `modules`. The Dynamic Worker executes the tenant's code in an isolated sandbox. The tenant code uses a standard `pg` driver and has no awareness of Hyperdrive. The `globalOutbound` option wires the `OutboundInterceptor` so that all outbound `connect()` calls from the Dynamic Worker pass through it.
 
 ### Verify the connection
 
-Deploy your host Worker and send a request with a valid tenant identifier. If the tenant configuration in KV contains a valid connection string and the origin database is reachable, the response contains the query results from the tenant's database.
+Deploy your loader Worker and send a request with a valid tenant identifier. If the tenant configuration contains a valid connection string and the origin database is reachable, the response contains the query results from the tenant's database.
 
 You can confirm that Hyperdrive is active by checking the `cf-hyperdrive` response header, or by querying the [GraphQL Analytics API](/analytics/graphql-api/) filtered by `hyperdriveId` to verify connection counts and cache hit ratios for the tenant.
 
@@ -203,13 +202,5 @@ curl https://api.cloudflare.com/client/v4/graphql \
 ```
 
 You can pipe this data into your own customer-facing dashboards.
-
-</Details>
-
-<Details header="Can I use databases in a private network?">
-
-Dynamic Hyperdrive bindings require a publicly accessible database. If your databases are in a private network, you must expose them through a secure tunnel or gateway before using them with dynamic Hyperdrive.
-
-For static Hyperdrive configurations, refer to [Connect to a private database using Workers VPC](/hyperdrive/configuration/connect-to-private-database-vpc/).
 
 </Details>

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -3,103 +3,128 @@ title: Dynamic Hyperdrive bindings
 pcx_content_type: configuration
 sidebar:
   order: 5
-description: Provision and resolve database connections at runtime for multi-tenant platforms.
+description: Provision database connections at runtime for multi-tenant platforms using Dynamic Workers.
 products:
   - hyperdrive
 ---
 
 import { Details } from "~/components";
 
-Dynamic Hyperdrive bindings let SaaS platforms provision and resolve database connections at runtime for thousands of unique tenant databases. Unlike [static Hyperdrive bindings](/hyperdrive/get-started/), which require a pre-declared resource ID at deploy time, a dynamic binding resolves per-request at runtime.
+Dynamic Hyperdrive bindings let multi-tenant platforms provision and resolve database connections at runtime for thousands of unique tenant databases. Unlike [static Hyperdrive bindings](/hyperdrive/get-started/), which require a pre-declared resource ID at deploy time, a dynamic binding resolves per-request at runtime.
 
-This model decouples your tenant database infrastructure from static Workers configuration. There are no static limits on the total number of unique Hyperdrive configurations your platform can create.
+In this context, **static** means a decision made ahead of time — when you deploy a traditional Worker, its code and configuration are locked in. **Dynamic** means a decision made on the fly, while the program runs.
+
+This model decouples your tenant database infrastructure from deploy-time configuration. There are no static limits on the total number of unique Hyperdrive configurations your platform can create.
 
 ## How it works
 
-With a standard database connection, every query from the edge must travel all the way to the origin database and back, including the TCP handshake, TLS negotiation, and authentication on each new connection. Static Hyperdrive improves this by maintaining pre-configured connection pools near the origin and caching read queries at the edge.
+Dynamic Hyperdrive bindings run on [Dynamic Workers](/dynamic-workers/). A Dynamic Worker is a temporary, sandboxed Worker that executes code on demand. A host Worker passes raw code as a payload to the Worker Loader API, which spins up a Dynamic Worker to execute it. After the Dynamic Worker returns a result, it dissolves. The host Worker returns the response to the client.
 
-Dynamic Hyperdrive extends this pattern for multi-tenant platforms. Instead of pre-registering each tenant database, the platform resolves database credentials at runtime and creates a request-scoped Hyperdrive pool on demand. The request flow works as follows:
+The dynamic Hyperdrive flow works as follows:
 
-1. A tenant request arrives at the platform's dispatch Worker.
-2. The dispatch Worker resolves tenant configuration from [KV](/kv/) (connection string, region, caching preferences).
-3. A [Worker Loader](/cloudflare-for-platforms/workers-for-platforms/configuration/dynamic-dispatch/) loads the tenant's user Worker and wires up the `OutboundInterceptor`.
-4. When the user Worker opens a database connection, the `OutboundInterceptor` intercepts the `connect()` call and calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters.
-5. Hyperdrive creates a temporary, request-scoped connection pool in the data center closest to the origin database. If a cached result exists for the query, Hyperdrive returns it from the edge without contacting the database at all.
-6. The pooled connection (or cached result) is returned through the interceptor to the user Worker, which receives a standard database response.
-
-The temporary pool remains warm for 15 minutes after the last active connection closes, so subsequent requests from the same tenant reuse it without a cold start.
+1. A tenant request arrives at the host Worker.
+2. The host Worker resolves tenant configuration from [KV](/kv/) (connection string, region, caching preferences).
+3. The host Worker calls `env.LOADER.load()` to spin up a Dynamic Worker loaded with the tenant's database code.
+4. The host Worker attaches an `OutboundInterceptor` to the Dynamic Worker through the `globalOutbound` option.
+5. When the Dynamic Worker opens a database connection, the `OutboundInterceptor` intercepts the `connect()` call and calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters.
+6. Hyperdrive creates a temporary, request-scoped connection pool in the data center closest to the origin database. If a cached result exists for the query, Hyperdrive returns it from the edge without contacting the database.
+7. The Dynamic Worker receives a standard database response. After the request completes, the Dynamic Worker dissolves.
 
 <figure>
-	![Dynamic Hyperdrive bindings architecture showing a tenant request flowing
-	through an OutboundInterceptor that resolves a request-scoped Hyperdrive
-	pool.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
+	![Dynamic Hyperdrive bindings architecture showing a host Worker passing
+	tenant code to the Worker Loader API, which spins up a Dynamic Worker that
+	connects through Hyperdrive to the origin
+	database.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
 	<figcaption>
-		A tenant request flows from left to right. The OutboundInterceptor traps the
-		database connect call, resolves a dynamic Hyperdrive pool, and returns
-		either a cached edge result or a pooled origin connection — without the
-		tenant code knowing Hyperdrive exists.
+		A tenant request arrives at the host Worker, which passes code to the Worker
+		Loader API. The Dynamic Worker executes the code, and the
+		OutboundInterceptor intercepts database connections to route them through
+		Hyperdrive. After the response, the Dynamic Worker dissolves.
 	</figcaption>
 </figure>
 
 ## Get started
 
-This section walks through the prerequisites, configuration, and code required to set up dynamic Hyperdrive bindings on a multi-tenant platform.
+This section walks through the prerequisites, configuration, and code required to set up dynamic Hyperdrive bindings with [Dynamic Workers](/dynamic-workers/).
 
 ### Prerequisites
 
 Before you begin, ensure you have the following:
 
-1. A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) with [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/) enabled.
+1. A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) with access to [Dynamic Workers](/dynamic-workers/).
 2. A [KV namespace](/kv/) (or another data store) containing tenant configuration. Each tenant record should include the database connection string, target region, and any optional parameters (caching, max connections, mTLS certificate ID).
-3. A publicly accessible PostgreSQL (or compatible) database for each tenant. If your databases are in a private network, refer to [Connect to a private database using Workers VPC](/hyperdrive/configuration/connect-to-private-database-vpc/).
-4. A `DYNAMIC_HYPERDRIVE` binding configured on your platform Worker. This is the dynamic Hyperdrive namespace binding that exposes the `.get()` method.
-5. A `LOADER` binding for the [Worker Loader](/cloudflare-for-platforms/workers-for-platforms/configuration/dynamic-dispatch/) that loads tenant user Workers.
+3. A publicly accessible PostgreSQL (or PostgreSQL-compatible) database for each tenant. Hyperdrive supports PostgreSQL-compatible databases such as CockroachDB, Neon, and Supabase. For the full list, refer to [Supported databases and features](/hyperdrive/reference/supported-databases-and-features/).
+4. A `DYNAMIC_HYPERDRIVE` binding configured on your host Worker. This is the dynamic Hyperdrive namespace binding that exposes the `.get()` method.
+5. A `LOADER` binding for the [Worker Loader](/dynamic-workers/getting-started/#configure-worker-loader) that loads Dynamic Workers.
 6. [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) version 16.17.0 or later, and [Wrangler](/workers/wrangler/install-and-update/) installed.
+
+:::note
+
+If your tenant databases require client certificate authentication (mTLS), upload the certificates before configuring dynamic Hyperdrive bindings. Refer to [Upload mTLS certificates](/hyperdrive/configuration/tls-ssl-certificates-for-hyperdrive/#step-1-upload-your-client-certificates-mtls-certificates) for instructions. Use the certificate ID returned by the upload command as the `customCertId` value in your tenant configuration.
+
+:::
 
 ### Define tenant configuration
 
 Store each tenant's database parameters in KV (or your preferred data store). At minimum, each tenant record needs a `connectionString` and a `cloudRegion`. Optional fields control caching, connection limits, and mTLS.
 
-| Parameter          | Required | Description                                                                                                                                                    |
-| ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `connectionString` | Yes      | Full database connection string (for example, `postgres://user:password@host:5432/dbname`).                                                                    |
-| `cloudRegion`      | Yes      | Cloud provider region where the origin database runs (for example, `us-east-1`). Hyperdrive uses this to place the connection pool in the nearest data center. |
-| `cachingEnabled`   | No       | Set to `true` to enable query caching at the edge. Defaults to `true`.                                                                                         |
-| `maxConnections`   | No       | Maximum number of outbound database sockets for this tenant. Defaults to the platform-level limit.                                                             |
-| `customCertId`     | No       | mTLS certificate ID for databases that require client certificate authentication.                                                                              |
+| Parameter          | Required | Description                                                                                                                                                                                                |
+| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `connectionString` | Yes      | Full database connection string (for example, `postgres://user:password@host:5432/dbname`).                                                                                                                |
+| `cloudRegion`      | Yes      | Cloud provider region where the origin database runs (for example, `us-east-1`). Hyperdrive uses this to place the connection pool in the nearest data center.                                             |
+| `cachingEnabled`   | No       | Set to `true` to turn on query caching at the edge. Defaults to `true`.                                                                                                                                    |
+| `maxConnections`   | No       | Maximum number of outbound database sockets for this tenant. Defaults to the platform-level limit.                                                                                                         |
+| `customCertId`     | No       | mTLS certificate ID for databases that require client certificate authentication. Refer to [SSL/TLS certificates](/hyperdrive/configuration/tls-ssl-certificates-for-hyperdrive/) for upload instructions. |
 
-### Write the platform Worker
+### Write the host Worker
 
-The platform Worker has two parts: an `OutboundInterceptor` that traps database connections, and a `fetch` handler that resolves tenant configuration and loads the tenant's user Worker.
+The host Worker has two parts: an `OutboundInterceptor` that intercepts database connections, and a `fetch` handler that resolves tenant configuration and loads the tenant's Dynamic Worker.
 
 ```js
+// OutboundInterceptor — intercepts all outbound connect() calls
+// from the Dynamic Worker. When the Dynamic Worker tries to open
+// a database connection, this class catches it and routes traffic
+// through a dynamic Hyperdrive pool.
 export class OutboundInterceptor extends WorkerEntrypoint {
 	async connect(host) {
-		if (host === this.ctx.props.connectionString) {
-			// .get() returns an RpcTarget that lives for this request only,
-			// not a stored WorkerEntrypoint. Nothing to persist or revoke.
-			let hyperdriveStub = env.DYNAMIC_HYPERDRIVE.get({
+		// Validate that the required tenant configuration is present.
+		if (!this.ctx.props.tenant?.connectionString) {
+			throw new Error("Missing required tenant connectionString in props");
+		}
+
+		if (host === this.ctx.props.tenant.connectionString) {
+			// .get() returns an RpcTarget scoped to this request only.
+			// Nothing to persist or revoke after the request ends.
+			let hyperdriveStub = this.env.DYNAMIC_HYPERDRIVE.get({
 				connectionString: this.ctx.props.tenant.connectionString,
 				targetRegion: this.ctx.props.tenant.cloudRegion,
 				cachingEnabled: this.ctx.props.tenant.cachingEnabled,
 				maxConnections: this.ctx.props.tenant.maxConnections,
 				mtlsCertificateId: this.ctx.props.tenant.customCertId,
 			});
-			return hyperdriveStub.connect(host); // calls Hyperdrive connect
+			return hyperdriveStub.connect(host); // routes through Hyperdrive
 		}
-		return connect(host); // general TCP connect
+
+		return connect(host); // general TCP connect for non-database traffic
 	}
 }
 
+// Host Worker entrypoint — handles incoming requests, resolves
+// tenant config from KV, and uses the Worker Loader API to spin
+// up a Dynamic Worker with the tenant's database code.
 export default {
 	async fetch(request, env, ctx) {
 		let tenant = await env.KV.get("tenant-id");
+		// Worker Loader API — compiles and loads a Dynamic Worker
+		// from the code defined in the modules object.
 		const worker = env.LOADER.load({
 			compatibilityDate: "2026-06-04",
 			mainModule: "src/index.js",
 			modules: {
-				// This is what a tenant's user Worker looks like.
-				// It uses a standard pg driver with no Hyperdrive-specific code.
+				// This string is the Dynamic Worker's code.
+				// It executes inside a temporary sandbox, not on
+				// the host Worker. It uses a standard pg driver
+				// with no Hyperdrive-specific code.
 				"src/index.js": `
 import { Client } from "pg";
 export default {
@@ -111,7 +136,7 @@ export default {
   },
 };`,
 			},
-			env: { CONNECTION_STRING: connectionString },
+			env: { CONNECTION_STRING: tenant.connectionString },
 			globalOutbound: ctx.exports.OutboundInterceptor({
 				props: { tenant },
 			}),
@@ -124,13 +149,13 @@ export default {
 
 The key parts of this code:
 
-- **`OutboundInterceptor`** — Extends `WorkerEntrypoint` and overrides `connect()`. When the tenant's user Worker opens a database connection, this interceptor checks if the host matches the tenant's connection string. If it does, it calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters to create a request-scoped Hyperdrive pool. All other outbound connections pass through unchanged.
+- **`OutboundInterceptor`** — Extends `WorkerEntrypoint` and overrides `connect()`. When the Dynamic Worker opens a database connection, this interceptor checks if the host matches the tenant's connection string. If it does, it calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters to create a request-scoped Hyperdrive pool. If the required `connectionString` prop is missing, the interceptor throws an error. All other outbound connections pass through unchanged.
 - **`DYNAMIC_HYPERDRIVE.get()`** — Accepts an object with the tenant's connection string, region, caching preferences, connection limit, and optional mTLS certificate ID. It returns an `RpcTarget` scoped to the current request. There is nothing to persist, revoke, or clean up after the request ends.
-- **`env.LOADER.load()`** — Loads a tenant-specific user Worker using the [Worker Loader](/cloudflare-for-platforms/workers-for-platforms/configuration/dynamic-dispatch/). The tenant code uses a standard `pg` driver and has no awareness of Hyperdrive. The `globalOutbound` option wires the `OutboundInterceptor` so that all outbound `connect()` calls from the user Worker pass through it.
+- **`env.LOADER.load()`** — Creates a [Dynamic Worker](/dynamic-workers/) from the code defined in `modules`. The Dynamic Worker is temporary — it executes the tenant's code in an isolated sandbox and dissolves after the request completes. The tenant code uses a standard `pg` driver and has no awareness of Hyperdrive. The `globalOutbound` option wires the `OutboundInterceptor` so that all outbound `connect()` calls from the Dynamic Worker pass through it.
 
 ### Verify the connection
 
-Deploy your platform Worker and send a request with a valid tenant identifier. If the tenant configuration in KV contains a valid connection string and the origin database is reachable, the response contains the query results from the tenant's database.
+Deploy your host Worker and send a request with a valid tenant identifier. If the tenant configuration in KV contains a valid connection string and the origin database is reachable, the response contains the query results from the tenant's database.
 
 You can confirm that Hyperdrive is active by checking the `cf-hyperdrive` response header, or by querying the [GraphQL Analytics API](/analytics/graphql-api/) filtered by `hyperdriveId` to verify connection counts and cache hit ratios for the tenant.
 
@@ -158,20 +183,33 @@ Hyperdrive multiplexes thousands of incoming edge requests into a small number o
 
 </Details>
 
-<Details header="How long does an idle pool stay alive?">
-
-When the last active connection closes, the pool stays alive for an additional 15 minutes. This ensures subsequent traffic does not hit a cold start. The 15-minute window is an internal implementation detail and may change as platform performance is optimized.
-
-</Details>
-
-<Details header="Are there account-level configuration limits?">
-
-Dynamic Hyperdrive generates parameters via code at runtime, which bypasses static configuration limitations entirely. For this dynamic execution plane, configuration capacities are a soft limit.
-
-</Details>
-
 <Details header="How do I retrieve per-tenant metrics?">
 
-You can query the [GraphQL Analytics API](/analytics/graphql-api/) by `hyperdriveId` to pull data on connection counts, query latency, error rates, and cache hit ratios. You can pipe this data into your own customer-facing dashboards.
+Each tenant database receives a unique `hyperdriveId`. You can query the [GraphQL Analytics API](/analytics/graphql-api/) to pull per-tenant data on connection counts, query latency, error rates, and cache hit ratios.
+
+The following example queries connection and cache metrics for a specific tenant's Hyperdrive ID:
+
+```bash
+curl https://api.cloudflare.com/client/v4/graphql \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: $accountTag }) { hyperdriveAdaptiveGroups(filter: { hyperdriveId: $hyperdriveId }, limit: 10, orderBy: [datetime_ASC]) { dimensions { hyperdriveId datetime } sum { connectionCount cacheHits cacheMisses } avg { queryDurationMs } } } } }",
+    "variables": {
+      "accountTag": "<YOUR_ACCOUNT_ID>",
+      "hyperdriveId": "<TENANT_HYPERDRIVE_ID>"
+    }
+  }'
+```
+
+You can pipe this data into your own customer-facing dashboards.
+
+</Details>
+
+<Details header="Can I use databases in a private network?">
+
+Dynamic Hyperdrive bindings require a publicly accessible database. If your databases are in a private network, you must expose them through a secure tunnel or gateway before using them with dynamic Hyperdrive.
+
+For static Hyperdrive configurations, refer to [Connect to a private database using Workers VPC](/hyperdrive/configuration/connect-to-private-database-vpc/).
 
 </Details>

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -1,69 +1,177 @@
 ---
-title: Dynamic Hyperdrive Bindings
+title: Dynamic Hyperdrive bindings
 pcx_content_type: configuration
 sidebar:
   order: 5
+description: Provision and resolve database connections at runtime for multi-tenant platforms.
+products:
+  - hyperdrive
 ---
 
-import { TypeScriptExample } from "~/components";
+import { Details } from "~/components";
 
-Dynamic Hyperdrive bindings allow SaaS platforms to provision and resolve database connections at runtime for thousands of unique tenant databases, eliminating the static configuration limits inherent to traditional bindings.
+Dynamic Hyperdrive bindings let SaaS platforms provision and resolve database connections at runtime for thousands of unique tenant databases. Unlike [static Hyperdrive bindings](/hyperdrive/get-started/), which require a pre-declared resource ID at deploy time, a dynamic binding resolves per-request at runtime.
 
-Unlike static bindings, which require a pre-declared resource ID at deploy time, a Dynamic Hyperdrive binding can be resolved dynamically per-request at runtime. This model decouples your tenant database infrastructure from static Workers configuration, enabling true multi-tenant database connectivity at scale.
+This model decouples your tenant database infrastructure from static Workers configuration. There are no static limits on the total number of unique Hyperdrive configurations your platform can create.
 
-Because the binding is resolved dynamically, there are no static limits on the total number of unique Hyperdrive configurations your platform can create. Configuration capacity is a soft limit for this dynamic execution plane.
+## How it works
 
-The following example demonstrates an outbound interception pattern that intercepts database connections, resolves tenant-specific parameters from KV, and dynamically configures the Hyperdrive binding for each request.
+With a standard database connection, every query from the edge must travel all the way to the origin database and back, including the TCP handshake, TLS negotiation, and authentication on each new connection. Static Hyperdrive improves this by maintaining pre-configured connection pools near the origin and caching read queries at the edge.
 
-<TypeScriptExample>
-```ts
-interface Env {
-  KV: KVNamespace;
+Dynamic Hyperdrive extends this pattern for multi-tenant platforms. Instead of pre-registering each tenant database, the platform resolves database credentials at runtime and creates a request-scoped Hyperdrive pool on demand. The request flow works as follows:
+
+1. A tenant request arrives at the platform's dispatch Worker.
+2. The dispatch Worker resolves tenant configuration from [KV](/kv/) (connection string, region, caching preferences).
+3. A [Worker Loader](/cloudflare-for-platforms/workers-for-platforms/configuration/dynamic-dispatch/) loads the tenant's user Worker and wires up the `OutboundInterceptor`.
+4. When the user Worker opens a database connection, the `OutboundInterceptor` intercepts the `connect()` call and calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters.
+5. Hyperdrive creates a temporary, request-scoped connection pool in the data center closest to the origin database. If a cached result exists for the query, Hyperdrive returns it from the edge without contacting the database at all.
+6. The pooled connection (or cached result) is returned through the interceptor to the user Worker, which receives a standard database response.
+
+The temporary pool remains warm for 15 minutes after the last active connection closes, so subsequent requests from the same tenant reuse it without a cold start.
+
+<figure>
+	![Dynamic Hyperdrive bindings architecture showing a tenant request flowing
+	through an OutboundInterceptor that resolves a request-scoped Hyperdrive
+	pool.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
+	<figcaption>
+		A tenant request flows from left to right. The OutboundInterceptor traps the
+		database connect call, resolves a dynamic Hyperdrive pool, and returns
+		either a cached edge result or a pooled origin connection — without the
+		tenant code knowing Hyperdrive exists.
+	</figcaption>
+</figure>
+
+## Get started
+
+This section walks through the prerequisites, configuration, and code required to set up dynamic Hyperdrive bindings on a multi-tenant platform.
+
+### Prerequisites
+
+Before you begin, ensure you have the following:
+
+1. A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) with [Workers for Platforms](/cloudflare-for-platforms/workers-for-platforms/) enabled.
+2. A [KV namespace](/kv/) (or another data store) containing tenant configuration. Each tenant record should include the database connection string, target region, and any optional parameters (caching, max connections, mTLS certificate ID).
+3. A publicly accessible PostgreSQL (or compatible) database for each tenant. If your databases are in a private network, refer to [Connect to a private database using Workers VPC](/hyperdrive/configuration/connect-to-private-database-vpc/).
+4. A `DYNAMIC_HYPERDRIVE` binding configured on your platform Worker. This is the dynamic Hyperdrive namespace binding that exposes the `.get()` method.
+5. A `LOADER` binding for the [Worker Loader](/cloudflare-for-platforms/workers-for-platforms/configuration/dynamic-dispatch/) that loads tenant user Workers.
+6. [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) version 16.17.0 or later, and [Wrangler](/workers/wrangler/install-and-update/) installed.
+
+### Define tenant configuration
+
+Store each tenant's database parameters in KV (or your preferred data store). At minimum, each tenant record needs a `connectionString` and a `cloudRegion`. Optional fields control caching, connection limits, and mTLS.
+
+| Parameter          | Required | Description                                                                                                                                                    |
+| ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `connectionString` | Yes      | Full database connection string (for example, `postgres://user:password@host:5432/dbname`).                                                                    |
+| `cloudRegion`      | Yes      | Cloud provider region where the origin database runs (for example, `us-east-1`). Hyperdrive uses this to place the connection pool in the nearest data center. |
+| `cachingEnabled`   | No       | Set to `true` to enable query caching at the edge. Defaults to `true`.                                                                                         |
+| `maxConnections`   | No       | Maximum number of outbound database sockets for this tenant. Defaults to the platform-level limit.                                                             |
+| `customCertId`     | No       | mTLS certificate ID for databases that require client certificate authentication.                                                                              |
+
+### Write the platform Worker
+
+The platform Worker has two parts: an `OutboundInterceptor` that traps database connections, and a `fetch` handler that resolves tenant configuration and loads the tenant's user Worker.
+
+```js
+export class OutboundInterceptor extends WorkerEntrypoint {
+	async connect(host) {
+		if (host === this.ctx.props.connectionString) {
+			// .get() returns an RpcTarget that lives for this request only,
+			// not a stored WorkerEntrypoint. Nothing to persist or revoke.
+			let hyperdriveStub = env.DYNAMIC_HYPERDRIVE.get({
+				connectionString: this.ctx.props.tenant.connectionString,
+				targetRegion: this.ctx.props.tenant.cloudRegion,
+				cachingEnabled: this.ctx.props.tenant.cachingEnabled,
+				maxConnections: this.ctx.props.tenant.maxConnections,
+				mtlsCertificateId: this.ctx.props.tenant.customCertId,
+			});
+			return hyperdriveStub.connect(host); // calls Hyperdrive connect
+		}
+		return connect(host); // general TCP connect
+	}
 }
 
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    let tenant = JSON.parse(await env.KV.get("tenant-id"));
-
-    return new Response(`Configured dynamic connection`, {
-      headers: { "x-connection-string": tenant.connectionString }
-    });
+	async fetch(request, env, ctx) {
+		let tenant = await env.KV.get("tenant-id");
+		const worker = env.LOADER.load({
+			compatibilityDate: "2026-06-04",
+			mainModule: "src/index.js",
+			modules: {
+				// This is what a tenant's user Worker looks like.
+				// It uses a standard pg driver with no Hyperdrive-specific code.
+				"src/index.js": `
+import { Client } from "pg";
+export default {
+  async fetch(request, env) {
+    const client = new Client({ connectionString: env.CONNECTION_STRING });
+    await client.connect();
+    const result = await client.query("SELECT * FROM pg_tables");
+    return Response.json({ success: true, result: result.rows });
   },
+};`,
+			},
+			env: { CONNECTION_STRING: connectionString },
+			globalOutbound: ctx.exports.OutboundInterceptor({
+				props: { tenant },
+			}),
+		});
+
+		return worker.getEntrypoint().fetch(request);
+	},
 };
 ```
-</TypeScriptExample>
 
-<figure>
-  ![Dynamic Hyperdrive bindings architecture showing a tenant request flowing through an OutboundInterceptor resolving a request-scoped Hyperdrive pool.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
-  <figcaption>Architecture overview: How runtime platform bindings dynamically resolve connection pooling configurations per request.</figcaption>
-</figure>
+The key parts of this code:
 
-### FAQ
+- **`OutboundInterceptor`** — Extends `WorkerEntrypoint` and overrides `connect()`. When the tenant's user Worker opens a database connection, this interceptor checks if the host matches the tenant's connection string. If it does, it calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters to create a request-scoped Hyperdrive pool. All other outbound connections pass through unchanged.
+- **`DYNAMIC_HYPERDRIVE.get()`** — Accepts an object with the tenant's connection string, region, caching preferences, connection limit, and optional mTLS certificate ID. It returns an `RpcTarget` scoped to the current request. There is nothing to persist, revoke, or clean up after the request ends.
+- **`env.LOADER.load()`** — Loads a tenant-specific user Worker using the [Worker Loader](/cloudflare-for-platforms/workers-for-platforms/configuration/dynamic-dispatch/). The tenant code uses a standard `pg` driver and has no awareness of Hyperdrive. The `globalOutbound` option wires the `OutboundInterceptor` so that all outbound `connect()` calls from the user Worker pass through it.
 
-### Dynamic design under the hood
+### Verify the connection
 
-Hyperdrive automatically spins up its connection pools in the data center closest to your origin database using your runtime `targetRegion` parameter. When a user makes a request, the `OutboundInterceptor` handles it at the edge; if the query is cached, it is served instantly from the global node closest to that user, bypassing your database entirely. If it misses the cache, it travels over Cloudflare's backbone via pre-warmed, persistent TCP sockets, eliminating long-distance handshake penalties.
+Deploy your platform Worker and send a request with a valid tenant identifier. If the tenant configuration in KV contains a valid connection string and the origin database is reachable, the response contains the query results from the tenant's database.
 
-### Host URL uniqueness
+You can confirm that Hyperdrive is active by checking the `cf-hyperdrive` response header, or by querying the [GraphQL Analytics API](/analytics/graphql-api/) filtered by `hyperdriveId` to verify connection counts and cache hit ratios for the tenant.
 
-Host URLs are unique. Single hosts are not reused across different database names. Every individual tenant database receives its own unique Hyperdrive ID under the hood, completely decoupled from your front-end preview URLs or custom domains. Your infrastructure maps incoming app requests to the tenant's connection string, and `DYNAMIC_HYPERDRIVE.get()` fetches the correct pool instantly at runtime with zero configuration cold starts.
+## Frequently asked questions
 
-### Pool allocation per connection string
+<Details header="How does host URL uniqueness work?">
 
-Each individual connection string has its own pool. Any multi-pool routing under the hood is an internal implementation detail. To ensure reliability, Hyperdrive currently shards your available connections across multiple pools for redundancy. This sharding mechanism may evolve in the future as routing is optimized, but protecting your database limits remains a core priority.
+Host URLs are unique. Single hosts are not reused across different database names. Every individual tenant database receives its own unique Hyperdrive ID under the hood, completely decoupled from your front-end preview URLs or custom domains.
 
-### `maxConnections` behavior across instances
+Your infrastructure maps incoming app requests to the tenant's connection string, and `DYNAMIC_HYPERDRIVE.get()` fetches the correct pool at runtime with zero configuration cold starts.
 
-The `maxConnections` parameter does not restrict the number of inbound client requests hitting the edge. Instead, it defines the hard ceiling of outbound database sockets that one single dynamic Hyperdrive instance maintains directly to your origin database. Hyperdrive multiplexes thousands of incoming edge hits down into a highly optimized number of persistent connections up to that configured maximum, protecting your multi-tenant databases from connection exhaustion during sudden traffic spikes. This is a soft limit, and Hyperdrive may occasionally exceed it in unusual traffic situations.
+</Details>
 
-### Pool inactivity timeout
+<Details header="How are pools allocated per connection string?">
 
-When the last active connection closes, the pool stays alive for an additional 15 minutes before shutting down to ensure subsequent traffic does not hit a cold start. This 15-minute window is an internal implementation detail and may change in the future as platform performance is optimized.
+Each individual connection string has its own pool. To ensure reliability, Hyperdrive shards your available connections across multiple pools for redundancy. This sharding mechanism may evolve as routing is optimized, but protecting your database limits remains a core priority.
 
-### Account-level configuration limits at scale
+</Details>
 
-Utilizing Dynamic Hyperdrive to generate parameters via code at runtime completely bypasses static configuration limitations. For this dynamic execution plane, configuration capacities are a soft limit.
+<Details header="What does maxConnections control?">
 
-### Per-tenant metrics retrieval
+The `maxConnections` parameter does not restrict the number of inbound client requests hitting the edge. It defines the hard ceiling of outbound database sockets that one dynamic Hyperdrive instance maintains to your origin database.
 
-You can programmatically query the GraphQL Analytics API by `hyperdriveId` to pull live data on connection counts, query latency, error rates, and cache hit ratios. You can pipe this data straight into your own customer-facing dashboards.
+Hyperdrive multiplexes thousands of incoming edge requests into a small number of persistent connections up to that configured maximum. This protects your multi-tenant databases from connection exhaustion during traffic spikes. This is a soft limit, and Hyperdrive may occasionally exceed it under unusual traffic conditions.
+
+</Details>
+
+<Details header="How long does an idle pool stay alive?">
+
+When the last active connection closes, the pool stays alive for an additional 15 minutes. This ensures subsequent traffic does not hit a cold start. The 15-minute window is an internal implementation detail and may change as platform performance is optimized.
+
+</Details>
+
+<Details header="Are there account-level configuration limits?">
+
+Dynamic Hyperdrive generates parameters via code at runtime, which bypasses static configuration limitations entirely. For this dynamic execution plane, configuration capacities are a soft limit.
+
+</Details>
+
+<Details header="How do I retrieve per-tenant metrics?">
+
+You can query the [GraphQL Analytics API](/analytics/graphql-api/) by `hyperdriveId` to pull data on connection counts, query latency, error rates, and cache hit ratios. You can pipe this data into your own customer-facing dashboards.
+
+</Details>

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -10,36 +10,34 @@ products:
 
 import { Details } from "~/components";
 
-Dynamic Hyperdrive bindings let multi-tenant platforms provision and resolve database connections at runtime for thousands of unique tenant databases. Unlike [static Hyperdrive bindings](/hyperdrive/get-started/), which require a pre-declared resource ID at deploy time, a dynamic binding resolves per-request at runtime.
+Dynamic Hyperdrive bindings let multi-tenant platforms provision database connections at runtime for thousands of unique tenant databases. Unlike [static Hyperdrive bindings](/hyperdrive/get-started/), which require a pre-declared resource ID at deploy time, a dynamic binding resolves per-request at runtime.
 
-In this context, **static** means a decision made ahead of time — when you deploy a traditional Worker, its code and configuration are locked in. **Dynamic** means a decision made on the fly, while the program runs.
+In this context, **static** means a decision made ahead of time — when you deploy a Worker, its code and configuration are locked in. **Dynamic** means a decision made on the fly, while the program runs.
 
 This model decouples your tenant database infrastructure from deploy-time configuration. There are no static limits on the total number of unique Hyperdrive configurations your platform can create.
 
 ## How it works
 
-Dynamic Hyperdrive bindings run on [Dynamic Workers](/dynamic-workers/). A Dynamic Worker is a sandboxed Worker that executes code on demand. A loader Worker passes raw code as a payload to the Worker Loader API, which spins up a Dynamic Worker to execute it.
+Dynamic Hyperdrive bindings build on [Dynamic Workers](/dynamic-workers/). You create a Worker that spins up other Workers, called [Dynamic Workers](/dynamic-workers/), at runtime to execute code on-demand in a secure, sandboxed environment. You provide the code, choose which bindings the Dynamic Worker can access, and control whether the Dynamic Worker can reach the network. In order for a Worker to create Dynamic Workers, it needs a [Worker Loader](/dynamic-workers/getting-started/#configure-worker-loader) binding.
 
-The dynamic Hyperdrive flow works as follows:
+The following steps describe the full request lifecycle:
 
-1. A tenant request arrives at the loader Worker.
-2. The loader Worker resolves tenant configuration (connection string, region, caching preferences).
-3. The loader Worker calls `env.LOADER.load()` to spin up a Dynamic Worker loaded with the tenant's database code.
-4. The loader Worker attaches an `OutboundInterceptor` to the Dynamic Worker through the `globalOutbound` option.
-5. When the Dynamic Worker opens a database connection, the `OutboundInterceptor` intercepts the `connect()` call and calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters.
-6. Hyperdrive creates a request-scoped connection pool in the data center closest to the origin database. If a cached result exists for the query, Hyperdrive returns it from the edge without contacting the database.
-7. The Dynamic Worker receives a standard database response.
+1. **The request arrives.** A user makes an HTTP request that hits the Worker.
+2. **The Worker resolves the tenant configuration.** The Worker looks up the tenant's database connection string and parameters, such as the target region and connection limits.
+3. **The Worker spins up a Dynamic Worker.** The Worker calls the Worker Loader (`env.LOADER.load()`). The Worker Loader takes a raw text string of database code and compiles it into an isolated Dynamic Worker. At the same time, the Worker attaches an outbound network interceptor (`OutboundInterceptor`) to the Dynamic Worker through the [`globalOutbound`](/dynamic-workers/usage/egress-control/) option.
+4. **The interceptor catches the database call.** Inside its sandbox, the Dynamic Worker runs its code and tries to open a standard database connection. The `OutboundInterceptor` catches that outbound `connect()` call before it can leave the server.
+5. **The interceptor provisions a dynamic Hyperdrive connection.** The `OutboundInterceptor` passes the tenant's connection string and parameters to the dynamic Hyperdrive binding (`env.DYNAMIC_HYPERDRIVE.get()`). The binding hashes the connection credentials to generate a unique Hyperdrive ID on the spot. It returns a short-lived `RpcTarget` that provisions a connection pool in the data center closest to the origin database — without requiring the database to be registered with Cloudflare ahead of time.
+6. **The Dynamic Worker executes and dissolves.** The pooled connection socket passes through the `OutboundInterceptor` into the Dynamic Worker. The database query executes. `worker.getEntrypoint().fetch(request)` sends the incoming request to the Dynamic Worker's `fetch()` handler, which processes it and returns a response. The Dynamic Worker and its short-lived Hyperdrive connection then dissolve from memory.
 
 <figure>
-	![Dynamic Hyperdrive bindings architecture showing a loader Worker passing
-	tenant code to the Worker Loader API, which spins up a Dynamic Worker that
-	connects through Hyperdrive to the origin
+	![Dynamic Hyperdrive bindings architecture showing a Worker passing tenant
+	code to the Worker Loader, which spins up a Dynamic Worker that connects
+	through Hyperdrive to the origin
 	database.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
 	<figcaption>
-		A tenant request arrives at the loader Worker, which passes code to the Worker
-		Loader API. The Dynamic Worker executes the code, and the
-		OutboundInterceptor intercepts database connections to route them through
-		Hyperdrive.
+		A tenant request arrives at the Worker, which passes code to the Worker
+		Loader. The Dynamic Worker executes the code, and the OutboundInterceptor
+		intercepts database connections to route them through Hyperdrive.
 	</figcaption>
 </figure>
 
@@ -53,8 +51,8 @@ Before you begin, ensure you have the following:
 
 1. A [Cloudflare account](https://dash.cloudflare.com/sign-up/workers-and-pages) with access to [Dynamic Workers](/dynamic-workers/).
 2. A publicly accessible PostgreSQL, MySQL, or compatible database for each tenant. Hyperdrive supports PostgreSQL-compatible databases such as CockroachDB, Neon, and Supabase. For the full list, refer to [Supported databases and features](/hyperdrive/reference/supported-databases-and-features/).
-3. A `DYNAMIC_HYPERDRIVE` binding configured on your loader Worker. This is the dynamic Hyperdrive namespace binding that exposes the `.get()` method.
-4. A `LOADER` binding for the [Worker Loader](/dynamic-workers/getting-started/#configure-worker-loader) that loads Dynamic Workers.
+3. A `DYNAMIC_HYPERDRIVE` binding configured on your Worker. This is the dynamic Hyperdrive namespace binding that exposes the `.get()` method.
+4. A `LOADER` binding for the [Worker Loader](/dynamic-workers/getting-started/#configure-worker-loader) that creates Dynamic Workers.
 5. [Node.js](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) version 16.17.0 or later, and [Wrangler](/workers/wrangler/install-and-update/) installed.
 
 :::note
@@ -75,15 +73,15 @@ Each tenant's database parameters are passed to `DYNAMIC_HYPERDRIVE.get()` at ru
 | `maxConnections`   | No       | Maximum number of outbound database sockets for this tenant. Defaults to the platform-level limit.                                                                                                         |
 | `customCertId`     | No       | mTLS certificate ID for databases that require client certificate authentication. Refer to [SSL/TLS certificates](/hyperdrive/configuration/tls-ssl-certificates-for-hyperdrive/) for upload instructions. |
 
-### Write the loader Worker
+### Write the Worker
 
-The loader Worker has two parts: an `OutboundInterceptor` that intercepts database connections, and a `fetch` handler that resolves tenant configuration and loads the tenant's Dynamic Worker.
+The Worker has two parts: an `OutboundInterceptor` that intercepts database connections from the Dynamic Worker, and a `fetch` handler that resolves tenant configuration and uses the Worker Loader to spin up a Dynamic Worker.
 
 ```js
 // OutboundInterceptor — intercepts all outbound connect() calls
 // from the Dynamic Worker. When the Dynamic Worker tries to open
-// a database connection, this class catches it and routes traffic
-// through a dynamic Hyperdrive pool.
+// a database connection, this class catches it and routes the
+// traffic through a dynamic Hyperdrive pool.
 export class OutboundInterceptor extends WorkerEntrypoint {
 	async connect(host) {
 		// Validate that the required tenant configuration is present.
@@ -108,13 +106,13 @@ export class OutboundInterceptor extends WorkerEntrypoint {
 	}
 }
 
-// Loader Worker entrypoint — handles incoming requests, resolves
-// tenant config, and uses the Worker Loader API to spin up a
-// Dynamic Worker with the tenant's database code.
+// Worker entrypoint — handles incoming requests, resolves tenant
+// config, and uses the Worker Loader to spin up a Dynamic Worker
+// with the tenant's database code.
 export default {
 	async fetch(request, env, ctx) {
 		let tenant = await env.KV.get("tenant-id");
-		// Worker Loader API — compiles and loads a Dynamic Worker
+		// Worker Loader — compiles and loads a Dynamic Worker
 		// from the code defined in the modules object.
 		const worker = env.LOADER.load({
 			compatibilityDate: "2026-06-04",
@@ -122,7 +120,7 @@ export default {
 			modules: {
 				// This string is the Dynamic Worker's code.
 				// It executes inside a sandboxed environment, not
-				// on the loader Worker. It uses a standard pg driver
+				// on the Worker. It uses a standard pg driver
 				// with no Hyperdrive-specific code.
 				"src/index.js": `
 import { Client } from "pg";
@@ -150,11 +148,11 @@ The key parts of this code:
 
 - **`OutboundInterceptor`** — Extends `WorkerEntrypoint` and overrides `connect()`. When the Dynamic Worker opens a database connection, this interceptor checks if the host matches the tenant's connection string. If it does, it calls `DYNAMIC_HYPERDRIVE.get()` with the tenant's parameters to create a request-scoped Hyperdrive pool. If the required `connectionString` prop is missing, the interceptor throws an error. All other outbound connections pass through unchanged.
 - **`DYNAMIC_HYPERDRIVE.get()`** — Accepts an object with the tenant's connection string, region, caching preferences, connection limit, and optional mTLS certificate ID. It returns an `RpcTarget` scoped to the current request. There is nothing to persist, revoke, or clean up after the request ends.
-- **`env.LOADER.load()`** — Creates a [Dynamic Worker](/dynamic-workers/) from the code defined in `modules`. The Dynamic Worker executes the tenant's code in an isolated sandbox. The tenant code uses a standard `pg` driver and has no awareness of Hyperdrive. The `globalOutbound` option wires the `OutboundInterceptor` so that all outbound `connect()` calls from the Dynamic Worker pass through it.
+- **`env.LOADER.load()`** — Uses the [Worker Loader](/dynamic-workers/getting-started/#configure-worker-loader) to create a [Dynamic Worker](/dynamic-workers/) from the code defined in `modules`. The Dynamic Worker executes the tenant's code in an isolated sandbox. The tenant code uses a standard `pg` driver and has no awareness of Hyperdrive. The `globalOutbound` option wires the `OutboundInterceptor` so that all outbound `connect()` calls from the Dynamic Worker pass through it.
 
 ### Verify the connection
 
-Deploy your loader Worker and send a request with a valid tenant identifier. If the tenant configuration contains a valid connection string and the origin database is reachable, the response contains the query results from the tenant's database.
+Deploy your Worker and send a request with a valid tenant identifier. If the tenant configuration contains a valid connection string and the origin database is reachable, the response contains the query results from the tenant's database.
 
 You can confirm that Hyperdrive is active by checking the `cf-hyperdrive` response header, or by querying the [GraphQL Analytics API](/analytics/graphql-api/) filtered by `hyperdriveId` to verify connection counts and cache hit ratios for the tenant.
 

--- a/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
+++ b/src/content/docs/hyperdrive/configuration/dynamic-hyperdrive-bindings.mdx
@@ -30,8 +30,9 @@ export default {
     });
   },
 };
-
 ```
+</TypeScriptExample>
+
 <figure>
   ![Dynamic Hyperdrive bindings architecture showing a tenant request flowing through an OutboundInterceptor resolving a request-scoped Hyperdrive pool.](~/assets/images/hyperdrive/configuration/dynamic-hyperdrive-bindings.svg)
   <figcaption>Architecture overview: How runtime platform bindings dynamically resolve connection pooling configurations per request.</figcaption>


### PR DESCRIPTION
### Summary

This PR adds the official documentation for **Dynamic Hyperdrive Bindings**. It introduces the configuration guidelines and usage requirements for dynamically connecting Workers for Platforms architectures to Hyperdrive configurations at runtime. 

To ensure a clean deployment and bypass unrelated upstream framework build blockers, this documentation has been placed directly within the core Hyperdrive directory layout (`src/content/docs/hyperdrive/configuration/`).
