### PR TITLE
[Access] Document MCP portal server/portal description precedence

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/ai-controls/mcp-portals.mdx
@@ -293,6 +293,8 @@ When multiple names exist, the portal resolves them in this order: `portal_alias
 
 If no alias is set, the portal uses the original name and description from the upstream server.
 
+Custom descriptions follow the same precedence. Set a description by including the `description` field on an entry in `updated_tools` or `updated_prompts`. In API responses, server-level descriptions are returned as `server_description` and portal-level descriptions are returned as `portal_description`. Portal-level descriptions take precedence over server-level descriptions when both are set.
+
 #### Set aliases in the dashboard
 
 <Tabs syncKey="aliasLevel"> <TabItem label="Portal-level alias">


### PR DESCRIPTION
## Summary

MCP-36 split the portal `updated_tools` response so descriptions are returned as `server_description` and `portal_description`, mirroring the existing `server_alias` / `portal_alias` split. MCP-69 then removed the deprecated single `description` field from API responses.

Net effect for API consumers: parsing `description` on the response no longer works. The narrative docs already describe alias precedence; this PR adds the parallel guidance for descriptions so the response shape is discoverable from the page.

## Change

One new paragraph appended to the **Alias precedence** subsection:

- Notes that `description` is the input field on `updated_tools` / `updated_prompts`.
- Notes that responses return `server_description` and `portal_description`.
- States that portal-level descriptions take precedence over server-level descriptions, matching alias behavior.

## Related

- MCP-36: https://jira.cfdata.org/browse/MCP-36
- MCP-69: https://jira.cfdata.org/browse/MCP-69
- agw-config-api commits: 40cefb5 (add split), c067d68 (remove deprecated field)