### PR TITLE
[Containers] Add Google Artifact Registry as a supported external registry

### DIFF
--- a/src/content/changelog/containers/2026-06-18-google-artifact-registry-images.mdx
+++ b/src/content/changelog/containers/2026-06-18-google-artifact-registry-images.mdx
@@ -1,0 +1,31 @@
+---
+title: Use Google Artifact Registry images with Containers
+description: Use private Google Artifact Registry images
+products:
+  - containers
+date: 2026-06-18
+---
+
+import { WranglerConfig } from "~/components";
+
+Containers now support [Google Artifact Registry](https://cloud.google.com/artifact-registry) images. After you configure credentials, you can use a fully qualified Google Artifact Registry image reference in your [Wrangler configuration](/workers/wrangler/configuration/#containers) instead of first pushing the image to Cloudflare Registry.
+
+Provide the service account email with `--gar-email` and pipe the service account JSON key through `stdin`:
+
+```bash
+cat <PATH_TO_KEY> | npx wrangler containers registries configure <REGION>-docker.pkg.dev --gar-email=<SERVICE_ACCOUNT_EMAIL> --secret-name=<SECRET_NAME>
+```
+
+<WranglerConfig>
+
+```toml
+# Example: us-central1-docker.pkg.dev/my-project/my-repo/my-image:latest
+[[containers]]
+image = "<REGION>-docker.pkg.dev/<PROJECT_ID>/<REPOSITORY>/<IMAGE>:<TAG>"
+```
+
+</WranglerConfig>
+
+Only `*-docker.pkg.dev` hosts are supported. To configure credentials, refer to [Use private Google Artifact Registry images](/containers/platform-details/image-management/#use-private-google-artifact-registry-images).
+
+For more information, refer to [Image management](/containers/platform-details/image-management/).

--- a/src/content/changelog/containers/2026-07-01-google-artifact-registry-images.mdx
+++ b/src/content/changelog/containers/2026-07-01-google-artifact-registry-images.mdx
@@ -3,7 +3,7 @@ title: Use Google Artifact Registry images with Containers
 description: Use private Google Artifact Registry images
 products:
   - containers
-date: 2026-06-18
+date: 2026-07-01
 ---
 
 import { WranglerConfig } from "~/components";

--- a/src/content/docs/containers/local-dev.mdx
+++ b/src/content/docs/containers/local-dev.mdx
@@ -16,14 +16,14 @@ Docker compatible CLI tool and Engine are installed. For instance, you could use
 When you start a dev session, your container image will be built or downloaded. If your
 [Wrangler configuration](/workers/wrangler/configuration/#containers) sets
 the `image` attribute to a local path, the image will be built using the local Dockerfile.
-If the `image` attribute is set to an image reference, the image will be pulled from the referenced registry, such as the Cloudflare Registry, Docker Hub, or Amazon ECR.
+If the `image` attribute is set to an image reference, the image will be pulled from the referenced registry, such as the Cloudflare Registry, Docker Hub, Amazon ECR, or Google Artifact Registry.
 
 :::note
-With `wrangler dev`, image references from the Cloudflare Registry, Docker Hub, and Amazon ECR are supported in local development.
+With `wrangler dev`, image references from the Cloudflare Registry, Docker Hub, Amazon ECR, and Google Artifact Registry are supported in local development.
 
-With `vite dev`, image references from external registries such as Docker Hub and Amazon ECR are supported, but `vite dev` cannot pull directly from the Cloudflare Registry.
+With `vite dev`, image references from external registries such as Docker Hub, Amazon ECR, and Google Artifact Registry are supported, but `vite dev` cannot pull directly from the Cloudflare Registry.
 
-If you use a private Docker Hub or ECR image with `vite dev`, authenticate to that registry locally, for example with `docker login`.
+If you use a private Docker Hub, Amazon ECR, or Google Artifact Registry image in local development, authenticate to that registry locally, for example with `docker login`.
 
 As a workaround for Cloudflare Registry images, point `vite dev` at a local Dockerfile that uses `FROM <IMAGE_REFERENCE>`. Docker then pulls the base image during the local build. Make sure to `EXPOSE` a port for local dev as well.
 :::

--- a/src/content/docs/containers/platform-details/image-management.mdx
+++ b/src/content/docs/containers/platform-details/image-management.mdx
@@ -10,7 +10,7 @@ products:
   - containers
 ---
 
-import { WranglerConfig, PackageManagers } from "~/components";
+import { WranglerConfig, PackageManagers, Steps } from "~/components";
 
 ## Push images during `wrangler deploy`
 
@@ -45,12 +45,12 @@ This is not necessary if you are using a pre-built image, as described below.
 
 ## Use pre-built container images
 
-Containers support images from the Cloudflare managed registry at `registry.cloudflare.com`, [Docker Hub](https://hub.docker.com/), and [Amazon ECR](https://aws.amazon.com/ecr/).
+Containers support images from the Cloudflare managed registry at `registry.cloudflare.com`, [Docker Hub](https://hub.docker.com/), [Amazon ECR](https://aws.amazon.com/ecr/), and [Google Artifact Registry](https://cloud.google.com/artifact-registry).
 
 :::note
-Cloudflare does not cache images pulled from Docker Hub or Amazon ECR.
+Cloudflare does not cache images pulled from Docker Hub, Amazon ECR, or Google Artifact Registry.
 
-Docker Hub pulls may be subject to Docker Hub pull limits or fair-use restrictions. Pulling images from Amazon ECR may incur AWS egress charges.
+Docker Hub pulls may be subject to Docker Hub pull limits or fair-use restrictions. Pulling images from Amazon ECR or Google Artifact Registry may incur cloud provider egress charges.
 :::
 
 ### Use public Docker Hub images
@@ -85,7 +85,7 @@ Official Docker Hub images use the `library` namespace. For example, use `docker
 
 ### Configure private registry credentials
 
-To use a private image from Docker Hub or Amazon ECR, run [`wrangler containers registries configure`](/workers/wrangler/commands/containers/#containers-registries-configure) for the registry domain.
+To use a private image from Docker Hub, Amazon ECR, or Google Artifact Registry, run [`wrangler containers registries configure`](/workers/wrangler/commands/containers/#containers-registries-configure) for the registry domain.
 
 Wrangler prompts for the secret and stores it in [Secrets Store](/secrets-store). If you do not already have a Secrets Store store, Wrangler prompts you to create one first.
 
@@ -101,10 +101,12 @@ Configure Docker Hub in Wrangler using these values:
 
 To create a Docker Hub personal access token:
 
+<Steps>
 1. Sign in to [Docker Home](https://app.docker.com/).
 2. Go to **Account settings** > **Personal access tokens**.
 3. Select **Generate new token**.
 4. Give the token **Read** access, then copy the token value.
+</Steps>
 
 Interactive:
 
@@ -191,6 +193,67 @@ After you configure the registry, use the fully qualified Amazon ECR image refer
 
 </WranglerConfig>
 
+### Use private Google Artifact Registry images
+
+Configure Google Artifact Registry in Wrangler using these values:
+
+- registry domain: `<REGION>-docker.pkg.dev`
+- Google service account email flag: `--gar-email=<SERVICE_ACCOUNT_EMAIL>`
+- secret: the service account JSON key
+
+The public credential is the service account email, supplied with `--gar-email`. It must match the `client_email` field in the service account key.
+
+The private credential is the service account JSON key.
+Provide it through `stdin` (a file path, raw JSON, or base64) or the interactive prompt (a file path or base64).
+Wrangler stores the key base64-encoded in Secrets Store.
+
+:::caution
+Only `*-docker.pkg.dev` hosts are supported. Container Registry hosts such as `gcr.io` and `*.gcr.io` are not supported, because Google has shut down Container Registry.
+:::
+
+To generate the required credentials, create a service account with the **Artifact Registry Reader** role and download its JSON key:
+
+<Steps>
+1. In the [Google Cloud console](https://console.cloud.google.com), go to **IAM & Admin** > **Service Accounts**.
+2. Select **Create service account**, then enter a name, ID, and optional description.
+3. Grant the service account the **Artifact Registry Reader** role, then select **Done**.
+4. Select the service account, then open the **Keys** tab.
+5. Select **Add key** > **Create new key**, choose **JSON**, then select **Create**. The key file downloads to your machine.
+</Steps>
+
+Interactive:
+Wrangler prompts for the key, where you enter a file path or base64-encoded JSON:
+
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="containers registries configure <REGION>-docker.pkg.dev --gar-email=<SERVICE_ACCOUNT_EMAIL>"
+/>
+
+CI or scripts:
+Pipe the key through `stdin` (the key contents as raw JSON or base64, or a path to the key file)
+
+```bash
+cat <PATH_TO_KEY> | npx wrangler containers registries configure <REGION>-docker.pkg.dev --gar-email=<SERVICE_ACCOUNT_EMAIL> --secret-name=<SECRET_NAME> --skip-confirmation
+```
+
+If you have already stored the key in Secrets Store, reference the existing secret and omit the key:
+
+```bash
+npx wrangler containers registries configure <REGION>-docker.pkg.dev --gar-email=<SERVICE_ACCOUNT_EMAIL> --secret-name=<EXISTING_SECRET_NAME> --skip-confirmation
+```
+
+After you configure the registry, use the fully qualified Google Artifact Registry image reference in your Wrangler configuration:
+
+<WranglerConfig>
+
+```toml
+[[containers]]
+image = "<REGION>-docker.pkg.dev/<PROJECT_ID>/<REPOSITORY>/<IMAGE>:<TAG>"
+```
+
+</WranglerConfig>
+
 ### Use images from other registries
 
 If you want to use a pre-built image from another registry provider, first make sure it exists locally, then push it to the Cloudflare Registry:
@@ -233,11 +296,11 @@ This will output an image registry URI that you can then use in your Wrangler co
 </WranglerConfig>
 
 :::note
-With `wrangler dev`, image references from the Cloudflare Registry, Docker Hub, and Amazon ECR are supported in local development.
+With `wrangler dev`, image references from the Cloudflare Registry, Docker Hub, Amazon ECR, and Google Artifact Registry are supported in local development.
 
-With `vite dev`, image references from external registries such as Docker Hub and Amazon ECR are supported, but `vite dev` cannot pull directly from the Cloudflare Registry.
+With `vite dev`, image references from external registries such as Docker Hub, Amazon ECR, and Google Artifact Registry are supported, but `vite dev` cannot pull directly from the Cloudflare Registry.
 
-If you use a private Docker Hub or ECR image with `vite dev`, authenticate to that registry locally, for example with `docker login`.
+If you use a private Docker Hub, Amazon ECR, or Google Artifact Registry image in local development, authenticate to that registry locally, for example with `docker login`.
 :::
 
 ## Push images with CI

--- a/src/content/docs/workers/wrangler/configuration.mdx
+++ b/src/content/docs/workers/wrangler/configuration.mdx
@@ -1295,7 +1295,7 @@ The following options are available:
 
 - `image` <Type text="string" /> <MetaInfo text="required" />
   - The image to use for the container. This can either be a local path to a `Dockerfile`, in which case `wrangler deploy` will
-    build and push the image, or it can be an image reference. Supported registries are the Cloudflare Registry, Docker Hub, and Amazon ECR. For more information, refer to [Image Management](/containers/platform-details/image-management/).
+    build and push the image, or it can be an image reference. Supported registries are the Cloudflare Registry, Docker Hub, Amazon ECR, and Google Artifact Registry. For more information, refer to [Image Management](/containers/platform-details/image-management/).
 
 - `class_name` <Type text="string" /> <MetaInfo text="required" />
   - The corresponding Durable Object class name. This will make this Durable Object a container-enabled Durable Object

--- a/src/content/partials/workers/wrangler-commands/containers.mdx
+++ b/src/content/partials/workers/wrangler-commands/containers.mdx
@@ -102,12 +102,18 @@ wrangler containers registries configure [DOMAIN] [OPTIONS]
 
 - `DOMAIN` <Type text="string" /> <MetaInfo text="required" />
   - Domain to configure for the registry.
-- `--public-credential` <Type text="string" /> <MetaInfo text="required" />
-  - The public part of the registry credentials, e.g. `AWS_ACCESS_KEY_ID` for ECR
+- `--dockerhub-username` <Type text="string" /> <MetaInfo text="optional" />
+  - The Docker Hub username to authenticate with. Use with the `docker.io` domain. The secret is a Docker Hub personal access token.
+- `--aws-access-key-id` <Type text="string" /> <MetaInfo text="optional" />
+  - The AWS access key ID to authenticate with. Use with an Amazon ECR domain. The secret is the matching AWS secret access key.
+- `--gar-email` <Type text="string" /> <MetaInfo text="optional" />
+  - The Google service account email to authenticate with. Use with a `*-docker.pkg.dev` domain.
 - `--secret-store-id` <Type text="string" /> <MetaInfo text="optional" />
   - The ID of the secret store to use to store the registry credentials
 - `--secret-name` <Type text="string" /> <MetaInfo text="optional" />
   - The name Wrangler should store the registry credentials under
+
+The credential flags are mutually exclusive. Use the one that matches the registry you are configuring.
 
 When run interactively, wrangler will prompt you for your secret and store it in Secrets Store.
 To run non-interactively, you can send your secret value to wrangler through stdin to have
@@ -202,14 +208,14 @@ wrangler containers instances 12345678-abcd-1234-abcd-123456789abc --json
 
 ```json output
 [
-  {
-    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "name": "worker-12",
-    "state": "running",
-    "location": "sfo06",
-    "version": 3,
-    "created": "2025-06-01T12:00:00Z"
-  }
+	{
+		"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		"name": "worker-12",
+		"state": "running",
+		"location": "sfo06",
+		"version": 3,
+		"created": "2025-06-01T12:00:00Z"
+	}
 ]
 ```
 


### PR DESCRIPTION
### Summary

Documents **Google Artifact Registry (GAR)** as a supported external registry for Containers, alongside Docker Hub and Amazon ECR. Wrangler and Cloudchamber now support pulling pre-built images from `*-docker.pkg.dev` registries, so this adds the configuration and usage documentation.

- Add "Use private Google Artifact Registry images" section to image management, covering the `--gar-email` flag, service-account setup, and CI flag/stdin paths
- Note that only `*-docker.pkg.dev` hosts are supported (gcr.io is not)
- List GAR in the supported-registry references and local dev notes
- Document `--dockerhub-username`, `--aws-access-key-id`, and `--gar-email` flags for `registries configure`
- Add changelog entry for GAR image support

Related Wrangler change: cloudflare/workers-sdk#14311

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
