### PR TITLE
flue: add /ignore-review-limit command for codeowners

### DIFF
--- a/.flue/lib/code-review-render.ts
+++ b/.flue/lib/code-review-render.ts
@@ -248,6 +248,9 @@ export function renderComment(
 	lines.push(
 		"| `/full-review` | Re-reviews the entire PR diff from scratch, ignoring incremental history. Useful after a rebase, when you want a fresh review, or if the bot gets out of sync and reports issues that no longer exist. |",
 	);
+	lines.push(
+		"| `/ignore-review-limit` | Permanently lifts the 2-review automatic limit for this PR. Future pushes will trigger reviews as normal. |",
+	);
 	lines.push("");
 	lines.push("</details>");
 
@@ -279,7 +282,7 @@ export function renderReviewLimitComment(existingBody?: string): string {
 		"",
 		"⏸️ Automatic reviews for this PR are paused.",
 		"",
-		"This PR has already received 2 automatic reviews. To run another review, a codeowner can comment `/review` or `/full-review`.",
+		"This PR has already received 2 automatic reviews. To run another review, a codeowner can comment `/review` or `/full-review`. To permanently lift the limit for this PR, a codeowner can comment `/ignore-review-limit`.",
 		"",
 		"> **Tip:** Keep PRs in draft mode until they are ready for review — the bot skips draft PRs automatically.",
 	];

--- a/.flue/lib/code-review-state.ts
+++ b/.flue/lib/code-review-state.ts
@@ -105,3 +105,34 @@ export async function incrementAutoReviewCount(
 	const key = `diffs/pr-${prNumber}/auto-review-count.json`;
 	await bucket.put(key, JSON.stringify({ count: current + 1 }));
 }
+
+/**
+ * Check whether the review limit has been permanently ignored for a PR.
+ * Returns false if no ignore flag exists.
+ */
+export async function isReviewLimitIgnored(
+	bucket: R2Bucket,
+	prNumber: number,
+): Promise<boolean> {
+	const key = `diffs/pr-${prNumber}/ignore-review-limit.json`;
+	const obj = await bucket.get(key);
+	if (!obj) return false;
+	const data = (await obj.json()) as { ignored?: boolean };
+	return data.ignored === true;
+}
+
+/**
+ * Permanently ignore the review limit for a PR in R2.
+ * Records the actor who set the flag for auditability.
+ */
+export async function setReviewLimitIgnored(
+	bucket: R2Bucket,
+	prNumber: number,
+	actor: string,
+): Promise<void> {
+	const key = `diffs/pr-${prNumber}/ignore-review-limit.json`;
+	await bucket.put(
+		key,
+		JSON.stringify({ ignored: true, actor, setAt: new Date().toISOString() }),
+	);
+}

--- a/.flue/workflows/code-review-orchestrator.ts
+++ b/.flue/workflows/code-review-orchestrator.ts
@@ -47,6 +47,7 @@ import {
 	extractReviewedHeadSha,
 	getAutoReviewCount,
 	incrementAutoReviewCount,
+	isReviewLimitIgnored,
 	partitionComments,
 } from "../lib/code-review-state";
 import {
@@ -86,10 +87,14 @@ export async function run({ id: runId, init, payload, env }: FlueContext) {
 	const workspace = getDefaultWorkspace();
 
 	// ── Auto-review limit check ────────────────────────────────────────────────
-	// Automatic reviews are capped at 2 per PR. Codeowner commands bypass this.
+	// Automatic reviews are capped at 2 per PR. Codeowner commands bypass this,
+	// and the /ignore-review-limit command permanently lifts the cap for the PR.
 	if (!input.bypassReviewLimit) {
-		const autoReviewCount = await getAutoReviewCount(bucket, input.number);
-		if (autoReviewCount >= 2) {
+		const [autoReviewCount, limitIgnored] = await Promise.all([
+			getAutoReviewCount(bucket, input.number),
+			isReviewLimitIgnored(bucket, input.number),
+		]);
+		if (autoReviewCount >= 2 && !limitIgnored) {
 			console.log({
 				message: `Auto-review limit reached: PR #${input.number} — ${autoReviewCount} reviews already run`,
 				event: "code_review_orchestrator",

--- a/.flue/workflows/orchestrate.ts
+++ b/.flue/workflows/orchestrate.ts
@@ -21,6 +21,7 @@ import {
 } from "../lib/github";
 import { getInternalHeaders } from "../lib/internal-auth";
 import { admitWorkflow, pollRun } from "../lib/poll-run";
+import { setReviewLimitIgnored } from "../lib/code-review-state";
 import {
 	getIssueOrPullRequestLabel,
 	getIssueOrPullRequestNumber,
@@ -128,6 +129,8 @@ export async function run({ payload, env, req }: FlueContext) {
 	const isFullReviewCommand =
 		isOnPullRequest && trimmedComment === "/full-review";
 	const isReviewCommand = isOnPullRequest && trimmedComment === "/review";
+	const isIgnoreReviewLimitCommand =
+		isOnPullRequest && trimmedComment === "/ignore-review-limit";
 
 	if (
 		!req ||
@@ -135,7 +138,8 @@ export async function run({ payload, env, req }: FlueContext) {
 			!isCodeReviewEvent &&
 			!isDependabotReviewEvent &&
 			!isFullReviewCommand &&
-			!isReviewCommand)
+			!isReviewCommand &&
+			!isIgnoreReviewLimitCommand)
 	) {
 		return { acted: false, summary: "No action needed." };
 	}
@@ -347,11 +351,56 @@ export async function run({ payload, env, req }: FlueContext) {
 		}
 	}
 
+	// ── 5. Handle /ignore-review-limit command ──────────────────────────────
+	if (isIgnoreReviewLimitCommand) {
+		const commentId = (body.comment as Record<string, unknown> | undefined)
+			?.id as number | undefined;
+
+		if (!commentId || !senderLogin) {
+			return { acted: false, summary: "Missing comment id or sender." };
+		}
+
+		const typedEnv = env as Record<string, string>;
+		const token = await getInstallationToken(typedEnv);
+		const orgToken = typedEnv.GITHUB_ORG_TOKEN ?? "";
+		const codeowner = await isCodeOwner(token, orgToken, senderLogin as string);
+
+		if (!codeowner) {
+			console.log({
+				message: `Ignore review limit command ignored — ${senderLogin} is not a codeowner`,
+				event: "github_webhook_orchestrator",
+				delivery,
+				number,
+				action: "ignore_review_limit_ignored_not_codeowner",
+			});
+			return { acted: false, summary: "Commenter is not a codeowner." };
+		}
+
+		const bucket = typedEnv.DOCS_FLUE_BUCKET as unknown as R2Bucket;
+		await setReviewLimitIgnored(bucket, number, senderLogin as string);
+
+		// Acknowledge with 👍
+		await addReactionToComment(token, commentId, "+1");
+
+		console.log({
+			message: `Review limit permanently ignored by ${senderLogin}: PR #${number}`,
+			event: "github_webhook_orchestrator",
+			delivery,
+			number,
+			action: "ignore_review_limit_set",
+		});
+
+		return {
+			acted: true,
+			summary: `Review limit permanently ignored by @${senderLogin}.`,
+		};
+	}
+
 	const baseUrl = new URL(req.url).origin;
 	const internalHeaders = getInternalHeaders(env as Record<string, string>);
 	const results: Record<string, unknown> = {};
 
-	// ── 5. Dispatch spam-and-off-topic-filter (issues + PRs on open/reopen) ─
+	// ── 6. Dispatch spam-and-off-topic-filter (issues + PRs on open/reopen) ─
 	if (isSpamFilterEvent) {
 		// Skip spam filter for codeowners — their issues and PRs are never spam.
 		let skipSpamFilter = false;
@@ -477,7 +526,7 @@ export async function run({ payload, env, req }: FlueContext) {
 		} // end else (not skipSpamFilter)
 	}
 
-	// ── 6. Dispatch code-review-orchestrator (PRs only) ─────────────────────
+	// ── 7. Dispatch code-review-orchestrator (PRs only) ─────────────────────
 	// The code review orchestrator posts its own GitHub comment when done, so
 	// we don't need to wait for the result here — fire-and-forget.
 	if (isCodeReviewEvent) {


### PR DESCRIPTION
## Summary

Adds a `/ignore-review-limit` slash command that permanently lifts the 2-review automatic cap for a PR.

## Changes

**`.flue/lib/code-review-state.ts`**
- `isReviewLimitIgnored(bucket, prNumber)` — reads `diffs/pr-{N}/ignore-review-limit.json` from R2
- `setReviewLimitIgnored(bucket, prNumber, actor)` — writes the flag with actor + timestamp

**`.flue/workflows/code-review-orchestrator.ts`**
- Limit check now reads ignore flag in parallel with the count; only blocks if `count >= 2 && !limitIgnored`

**`.flue/workflows/orchestrate.ts`**
- Detects `/ignore-review-limit` comments on PRs
- Verifies codeowner, writes R2 flag, acknowledges with 👍

**`.flue/lib/code-review-render.ts`**
- Added `/ignore-review-limit` to the Commands table in completed review comments
- Updated the paused-review message to mention the command alongside `/review` / `/full-review`