### PR TITLE
[Flagship] Add Go SDK docs

### DIFF
--- a/src/content/docs/flagship/index.mdx
+++ b/src/content/docs/flagship/index.mdx
@@ -27,7 +27,7 @@ Ship features safely with feature flags.
 
 Flagship is Cloudflare's feature flag service. It lets you control feature visibility in your applications without redeploying code. Define flags with targeting rules and percentage-based rollouts, then evaluate them directly inside your Workers through a [native binding](/flagship/binding/) or from server and browser applications with [OpenFeature SDKs](/flagship/sdk/).
 
-[OpenFeature](https://openfeature.dev/) is the CNCF open standard for feature flag management. Flagship is compatible with OpenFeature, so you can use the official TypeScript and Python SDKs and swap providers without changing evaluation code.
+[OpenFeature](https://openfeature.dev/) is the CNCF open standard for feature flag management. Flagship is compatible with OpenFeature, so you can use the official TypeScript SDK from Workers, Node.js, or the browser, and the official Go SDK from Go server applications. You can swap providers without changing evaluation code.
 
 Check out the [Get started guide](/flagship/get-started/) to create your first feature flag.
 
@@ -41,7 +41,7 @@ Evaluate flags with a native Workers binding. Type-safe methods with automatic f
 
 <Feature header="OpenFeature SDK" href="/flagship/sdk/" cta="View SDK docs">
 
-Use the official OpenFeature SDKs to evaluate flags from Workers, Node.js, browsers, and Python server applications. Switch from another flag provider by changing provider configuration.
+Use the official OpenFeature SDKs to evaluate flags from Workers, Node.js, browsers, and Go server applications. Switch from another flag provider by changing one line of configuration.
 
 </Feature>
 

--- a/src/content/docs/flagship/index.mdx
+++ b/src/content/docs/flagship/index.mdx
@@ -27,7 +27,7 @@ Ship features safely with feature flags.
 
 Flagship is Cloudflare's feature flag service. It lets you control feature visibility in your applications without redeploying code. Define flags with targeting rules and percentage-based rollouts, then evaluate them directly inside your Workers through a [native binding](/flagship/binding/) or from server and browser applications with [OpenFeature SDKs](/flagship/sdk/).
 
-[OpenFeature](https://openfeature.dev/) is the CNCF open standard for feature flag management. Flagship is compatible with OpenFeature, so you can use the official TypeScript SDK from Workers, Node.js, or the browser, and the official Go SDK from Go server applications. You can swap providers without changing evaluation code.
+[OpenFeature](https://openfeature.dev/) is the CNCF open standard for feature flag management. Flagship ships official SDKs for TypeScript (Workers, Node.js, and browsers), Python, and Go. You can swap providers without changing evaluation code.
 
 Check out the [Get started guide](/flagship/get-started/) to create your first feature flag.
 
@@ -41,7 +41,7 @@ Evaluate flags with a native Workers binding. Type-safe methods with automatic f
 
 <Feature header="OpenFeature SDK" href="/flagship/sdk/" cta="View SDK docs">
 
-Use the official OpenFeature SDKs to evaluate flags from Workers, Node.js, browsers, and Go server applications. Switch from another flag provider by changing one line of configuration.
+Use the official OpenFeature SDKs to evaluate flags from Workers, Node.js, browsers, Python, and Go server applications. Switch from another flag provider by changing one line of configuration.
 
 </Feature>
 

--- a/src/content/docs/flagship/sdk/go.mdx
+++ b/src/content/docs/flagship/sdk/go.mdx
@@ -1,0 +1,98 @@
+---
+pcx_content_type: how-to
+title: Go SDK
+description: Set up the Flagship OpenFeature provider to evaluate Flagship feature flags from Go server applications.
+sidebar:
+  order: 3
+products:
+  - flagship
+---
+
+The Go SDK provides an OpenFeature-compatible server provider for Go applications. It evaluates flags over HTTP and does not support the Cloudflare Workers binding.
+
+## Installation
+
+Install with `go get`:
+
+```sh
+go get github.com/cloudflare/flagship/sdks/go
+```
+
+## Setup
+
+Configure the provider with your Flagship app ID, Cloudflare account ID, and an API token with Flagship Evaluate permission.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	flagship "github.com/cloudflare/flagship/sdks/go"
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+func main() {
+	ctx := context.Background()
+
+	provider, err := flagship.NewProvider(flagship.Options{
+		AppID:     "<APP_ID>",
+		AccountID: "<ACCOUNT_ID>",
+		AuthToken: "<API_TOKEN>",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := openfeature.SetProviderAndWait(provider); err != nil {
+		log.Fatal(err)
+	}
+	defer openfeature.Shutdown()
+
+	client := openfeature.NewDefaultClient()
+	evalCtx := openfeature.NewEvaluationContext("user-42", map[string]any{
+		"plan": "enterprise",
+	})
+
+	enabled, err := client.BooleanValue(ctx, "new-checkout", false, evalCtx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("new-checkout:", enabled)
+}
+```
+
+## Flag types
+
+The Go SDK supports all OpenFeature server-side flag types.
+
+```go
+enabled, _ := client.BooleanValue(ctx, "new-checkout", false, evalCtx)
+variant, _ := client.StringValue(ctx, "homepage-hero", "control", evalCtx)
+rate, _ := client.FloatValue(ctx, "sample-rate", 0.1, evalCtx)
+limit, _ := client.IntValue(ctx, "upload-limit", 10, evalCtx)
+config, _ := client.ObjectValue(ctx, "ui-config", map[string]any{"theme": "light"}, evalCtx)
+```
+
+Use the `*ValueDetails` methods when you need reason, variant, metadata, or error codes.
+
+## Configuration options
+
+| Option           | Description                                                              |
+| ---------------- | ------------------------------------------------------------------------ |
+| `AppID`          | Flagship app ID.                                                         |
+| `AccountID`      | Required with `AppID`.                                                   |
+| `AuthToken`      | Adds `Authorization: Bearer <token>` to each request.                    |
+| `Headers`        | Static headers. Explicit `Authorization` overrides `AuthToken`.          |
+| `HeadersFactory` | Dynamic per-request headers. Values override `Headers` and `AuthToken`.  |
+| `HTTPClient`     | Custom HTTP client.                                                      |
+| `Timeout`        | Per-attempt timeout. Defaults to 5 seconds.                              |
+| `Retries`        | Retry attempts on transient errors. Defaults to 1 and is capped at 10.   |
+| `DisableRetries` | Disables retries when set to true.                                       |
+| `RetryDelay`     | Delay between retries. Defaults to 1 second and is capped at 30 seconds. |
+
+## Evaluation context
+
+Context attributes are sent as URL query parameters. Supported values are strings, numeric types, booleans, and `time.Time`. Maps, slices, structs, and other complex values return `INVALID_CONTEXT` through OpenFeature and do not trigger an HTTP request.

--- a/src/content/docs/flagship/sdk/go.mdx
+++ b/src/content/docs/flagship/sdk/go.mdx
@@ -78,21 +78,47 @@ config, _ := client.ObjectValue(ctx, "ui-config", map[string]any{"theme": "light
 
 Use the `*ValueDetails` methods when you need reason, variant, metadata, or error codes.
 
+## Response caching
+
+The provider can cache evaluations to avoid a network round-trip for repeated flag/context pairs. Caching is off by default and enabled by setting `CacheTTL`:
+
+```go
+provider, err := flagship.NewProvider(flagship.Options{
+	AppID:        "<APP_ID>",
+	AccountID:    "<ACCOUNT_ID>",
+	AuthToken:    "<API_TOKEN>",
+	CacheTTL:     30 * time.Second, // values may be up to this stale
+	CacheMaxSize: 1000,             // LRU-evicted beyond this many entries
+})
+```
+
+Each cache entry is keyed by flag key, flag type, and the full evaluation context, so distinct contexts never share a cached value. Cache hits resolve with `reason == openfeature.CachedReason`.
+
+Disabled flags, errors, and type mismatches are never cached. Because freshness is TTL-based, a flag change in Flagship takes effect after the entry expires.
+
+The cache is per-provider instance, guarded by a mutex for concurrent use, and cleared on `Shutdown`.
+
 ## Configuration options
 
-| Option           | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| `AppID`          | Flagship app ID.                                                         |
-| `AccountID`      | Required with `AppID`.                                                   |
-| `AuthToken`      | Adds `Authorization: Bearer <token>` to each request.                    |
-| `Headers`        | Static headers. Explicit `Authorization` overrides `AuthToken`.          |
-| `HeadersFactory` | Dynamic per-request headers. Values override `Headers` and `AuthToken`.  |
-| `HTTPClient`     | Custom HTTP client.                                                      |
-| `Timeout`        | Per-attempt timeout. Defaults to 5 seconds.                              |
-| `Retries`        | Retry attempts on transient errors. Defaults to 1 and is capped at 10.   |
-| `DisableRetries` | Disables retries when set to true.                                       |
-| `RetryDelay`     | Delay between retries. Defaults to 1 second and is capped at 30 seconds. |
+| Option           | Description                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------- |
+| `AppID`          | Flagship app ID.                                                                                          |
+| `AccountID`      | Required with `AppID`.                                                                                    |
+| `BaseURL`        | Base URL override. Defaults to `https://api.cloudflare.com`.                                              |
+| `AuthToken`      | Adds `Authorization: Bearer <token>` to each request.                                                     |
+| `Headers`        | Static headers. Explicit `Authorization` overrides `AuthToken`.                                           |
+| `HeadersFactory` | Dynamic per-request headers. Values override `Headers` and `AuthToken`.                                   |
+| `HTTPClient`     | Custom HTTP client.                                                                                       |
+| `Timeout`        | Per-attempt timeout. Defaults to 5 seconds.                                                               |
+| `Retries`        | Retry attempts on transient errors. Defaults to 1 and is capped at 10.                                    |
+| `DisableRetries` | Disables retries when set to `true`.                                                                      |
+| `RetryDelay`     | Delay between retries. Defaults to 1 second and is capped at 30 seconds.                                  |
+| `CacheTTL`       | Enables in-memory response caching when greater than 0. Cached values may be up to this duration stale.   |
+| `CacheMaxSize`   | Maximum number of cached entries. LRU-evicted beyond this limit. Defaults to 1000 when `CacheTTL` is set. |
+| `Logging`        | Enables debug and error logging. Off by default.                                                          |
+| `Logger`         | Optional `slog`-compatible logger. Uses the default `slog` logger when unset.                             |
+| `Hooks`          | Provider-level OpenFeature hooks.                                                                         |
 
 ## Evaluation context
 
-Context attributes are sent as URL query parameters. Supported values are strings, numeric types, booleans, and `time.Time`. Maps, slices, structs, and other complex values return `INVALID_CONTEXT` through OpenFeature and do not trigger an HTTP request.
+Context attributes are sent as URL query parameters. Supported values are strings, numeric types, booleans, and `time.Time`. `nil` values are skipped. Maps, slices, structs, and other complex values return `INVALID_CONTEXT` through OpenFeature and do not trigger an HTTP request.

--- a/src/content/docs/flagship/sdk/index.mdx
+++ b/src/content/docs/flagship/sdk/index.mdx
@@ -18,11 +18,12 @@ Evaluate Flagship feature flags using OpenFeature.
 
 [OpenFeature](https://openfeature.dev/) is the CNCF standard for feature flag interfaces. It provides a vendor-neutral API so you can switch between flag providers without changing evaluation code.
 
-Flagship provides official OpenFeature-compatible SDKs for TypeScript and Go. The source code is available on [GitHub](https://github.com/cloudflare/flagship).
+Flagship provides official OpenFeature-compatible SDKs for TypeScript, Python, and Go. The source code is available on [GitHub](https://github.com/cloudflare/flagship).
 
 | SDK        | Package                                                                                               | Runtime                    | Evaluation modes                              |
 | ---------- | ----------------------------------------------------------------------------------------------------- | -------------------------- | --------------------------------------------- |
 | TypeScript | [`@cloudflare/flagship`](https://www.npmjs.com/package/@cloudflare/flagship)                          | Workers, Node.js, browsers | Workers binding, HTTP, browser prefetch cache |
+| Python     | [`cloudflare-flagship`](https://pypi.org/project/cloudflare-flagship/)                                | Python server applications | HTTP                                          |
 | Go         | [`github.com/cloudflare/flagship/sdks/go`](https://pkg.go.dev/github.com/cloudflare/flagship/sdks/go) | Go server applications     | HTTP                                          |
 
 The TypeScript SDK includes two providers:
@@ -67,4 +68,5 @@ go get github.com/cloudflare/flagship/sdks/go
 
 - Set up the [server provider](/flagship/sdk/server-provider/) for Workers, Node.js, or other server-side runtimes.
 - Set up the [client provider](/flagship/sdk/client-provider/) for browser applications.
+- Set up the [Python SDK](/flagship/sdk/python/) for Python server applications.
 - Set up the [Go SDK](/flagship/sdk/go/) for Go server applications.

--- a/src/content/docs/flagship/sdk/index.mdx
+++ b/src/content/docs/flagship/sdk/index.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: overview
 title: OpenFeature SDK
-description: Use the official Flagship OpenFeature SDKs to evaluate feature flags from Workers, Node.js, browsers, and Go applications.
+description: Use the official Flagship OpenFeature SDKs to evaluate feature flags from Workers, Node.js, browsers, Python, and Go applications.
 sidebar:
   order: 6
 products:
@@ -26,8 +26,6 @@ Flagship provides official OpenFeature-compatible SDKs for TypeScript, Python, a
 | Python     | [`cloudflare-flagship`](https://pypi.org/project/cloudflare-flagship/)                                | Python server applications | HTTP                                          |
 | Go         | [`github.com/cloudflare/flagship/sdks/go`](https://pkg.go.dev/github.com/cloudflare/flagship/sdks/go) | Go server applications     | HTTP                                          |
 
-The TypeScript SDK includes two providers:
-
 ## SDKs
 
 Flagship SDKs are organized by language. The TypeScript SDK has separate setup guides for server-side and browser usage because they use different OpenFeature packages and runtime behavior.
@@ -35,14 +33,15 @@ Flagship SDKs are organized by language. The TypeScript SDK has separate setup g
 - [TypeScript Server SDK](/flagship/sdk/server-provider/) — For Workers, Node.js, and other server-side JavaScript runtimes.
 - [TypeScript Client SDK](/flagship/sdk/client-provider/) — For browser applications that need synchronous OpenFeature web SDK evaluation.
 - [Python SDK](/flagship/sdk/python/) — For Python server applications.
+- [Go SDK](/flagship/sdk/go/) — For Go server applications.
 
 :::note
 If you are running inside a Cloudflare Worker, the [binding](/flagship/binding/) is the recommended approach because it avoids HTTP overhead. You can also [pass the binding to the OpenFeature SDK](/flagship/sdk/server-provider/) to get the best of both. Use the SDK without a binding when running in non-Worker runtimes like Node.js or the browser.
 :::
 
-## TypeScript installation
+## Installation
 
-For server-side usage:
+For TypeScript server-side usage:
 
 <PackageManagers
 	type="add"
@@ -50,7 +49,7 @@ For server-side usage:
 	pkg="@cloudflare/flagship @openfeature/server-sdk"
 />
 
-For browser usage:
+For TypeScript browser usage:
 
 <PackageManagers
 	type="add"
@@ -58,7 +57,13 @@ For browser usage:
 	pkg="@cloudflare/flagship @openfeature/web-sdk"
 />
 
-For Go server applications:
+For Python:
+
+```sh
+uv add cloudflare-flagship
+```
+
+For Go:
 
 ```sh
 go get github.com/cloudflare/flagship/sdks/go

--- a/src/content/docs/flagship/sdk/index.mdx
+++ b/src/content/docs/flagship/sdk/index.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: overview
-title: OpenFeature SDKs
-description: Use the official Flagship OpenFeature SDKs to evaluate feature flags from Workers, Node.js, browsers, and Python applications.
+title: OpenFeature SDK
+description: Use the official Flagship OpenFeature SDKs to evaluate feature flags from Workers, Node.js, browsers, and Go applications.
 sidebar:
   order: 6
 products:
@@ -18,14 +18,14 @@ Evaluate Flagship feature flags using OpenFeature.
 
 [OpenFeature](https://openfeature.dev/) is the CNCF standard for feature flag interfaces. It provides a vendor-neutral API so you can switch between flag providers without changing evaluation code.
 
-Flagship provides official OpenFeature-compatible SDKs for TypeScript and Python. The source code is available on [GitHub](https://github.com/cloudflare/flagship).
+Flagship provides official OpenFeature-compatible SDKs for TypeScript and Go. The source code is available on [GitHub](https://github.com/cloudflare/flagship).
 
-For Cloudflare Workers, use the Workers binding when possible. Use an SDK when you need OpenFeature compatibility, are running outside Workers, or need browser-side flag evaluation.
+| SDK        | Package                                                                                               | Runtime                    | Evaluation modes                              |
+| ---------- | ----------------------------------------------------------------------------------------------------- | -------------------------- | --------------------------------------------- |
+| TypeScript | [`@cloudflare/flagship`](https://www.npmjs.com/package/@cloudflare/flagship)                          | Workers, Node.js, browsers | Workers binding, HTTP, browser prefetch cache |
+| Go         | [`github.com/cloudflare/flagship/sdks/go`](https://pkg.go.dev/github.com/cloudflare/flagship/sdks/go) | Go server applications     | HTTP                                          |
 
-| SDK        | Package                                                                      | Runtime                    | Evaluation modes                              |
-| ---------- | ---------------------------------------------------------------------------- | -------------------------- | --------------------------------------------- |
-| TypeScript | [`@cloudflare/flagship`](https://www.npmjs.com/package/@cloudflare/flagship) | Workers, Node.js, browsers | Workers binding, HTTP, browser prefetch cache |
-| Python     | [`cloudflare-flagship`](https://pypi.org/project/cloudflare-flagship/)       | Python server applications | HTTP                                          |
+The TypeScript SDK includes two providers:
 
 ## SDKs
 
@@ -57,22 +57,14 @@ For browser usage:
 	pkg="@cloudflare/flagship @openfeature/web-sdk"
 />
 
-## Python installation
-
-Install the Python SDK with `uv` or `pip`:
+For Go server applications:
 
 ```sh
-uv add cloudflare-flagship
+go get github.com/cloudflare/flagship/sdks/go
 ```
-
-```sh
-pip install cloudflare-flagship
-```
-
-The Python SDK provides `FlagshipServerProvider` for server-side applications. It supports HTTP evaluation, sync and async APIs, all OpenFeature flag types, retries, timeouts, and optional response caching.
 
 ## Next steps
 
-- Set up the [TypeScript Server SDK](/flagship/sdk/server-provider/) for Workers, Node.js, or other server-side runtimes.
-- Set up the [TypeScript Client SDK](/flagship/sdk/client-provider/) for browser applications.
-- Set up the [Python SDK](/flagship/sdk/python/) for Python server applications.
+- Set up the [server provider](/flagship/sdk/server-provider/) for Workers, Node.js, or other server-side runtimes.
+- Set up the [client provider](/flagship/sdk/client-provider/) for browser applications.
+- Set up the [Go SDK](/flagship/sdk/go/) for Go server applications.


### PR DESCRIPTION
## Summary

- Add Go SDK setup docs for Flagship OpenFeature evaluation.
- Add Go SDK package information to the Flagship SDK overview.
- Mention Go server applications in the Flagship overview SDK description.