### PR TITLE
Add SSL and Cloudflare for SaaS documentation updates

### DIFF
--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/index.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/index.mdx
@@ -35,6 +35,19 @@ For production traffic, the hostname should have `status: active`, `ssl.status: 
 
 Custom hostnames using another CDN are not compatible with Cloudflare for SaaS. Since Cloudflare must be able to validate your customer's ownership of the hostname you add, if their usage of another CDN obfuscates their DNS records, hostname validation will fail.
 
+## Migrate a hostname from another SaaS provider
+
+If you are onboarding a hostname that is currently active on another Cloudflare for SaaS provider, follow these steps to minimize downtime:
+
+1. Create the custom hostname on your zone and complete [pre-validation](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/pre-validation/) so it reaches `status: active` before the DNS change.
+2. Issue and validate the certificate (using [TXT](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt/) or [Delegated DCV](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv/)) so `ssl.status` reaches `active`.
+3. Ask your customer to update their DNS CNAME to point to your SaaS target.
+4. Confirm traffic has switched to your zone. The previous provider can then delete their custom hostname.
+
+:::note
+Multiple SaaS providers can hold an active custom hostname for the same domain simultaneously. Cloudflare routes traffic based on where the DNS CNAME points — the target determines which SaaS zone receives the traffic.
+:::
+
 ## Related resources
 
 <DirectoryListing />

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/pre-validation.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/domain-support/hostname-validation/pre-validation.mdx
@@ -114,3 +114,18 @@ To get and use the `ownership_verification` record:
 4. After a few minutes, you will see the hostname status become **Active** in the UI.
 
 5. Once the hostname is active, your customer can remove the token from their origin server.
+
+## Zero-downtime migration with HTTP DCV
+
+When onboarding a customer whose hostname is already live with another provider, you can use pre-validation combined with manual HTTP DCV to achieve zero-downtime migration:
+
+1. Create the custom hostname with `"ssl": {"method": "http", "type": "dv"}`.
+2. Complete [hostname ownership pre-validation](#pre-validate-with-a-txt-record) using a TXT record so the hostname reaches `status: active`.
+3. Wait for the `ssl.validation_records` to populate with the HTTP DCV token (an `http_url` and `http_body` pair).
+4. Ask your customer to serve the DCV token at the `http_url` path on their current live origin. The certificate authority will validate it against the current DNS target.
+5. Once `ssl.status` reaches `active`, the hostname and certificate are both ready.
+6. Your customer can now update their DNS CNAME to point to your SaaS target with no interruption — the certificate is already issued.
+
+:::note
+The HTTP DCV token is single-use and must be served before it expires. Refer to [DCV tokens validity](/ssl/edge-certificates/changing-dcv-method/validation-backoff-schedule/#dcv-tokens-validity) for expiration periods by certificate authority.
+:::

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting.mdx
@@ -132,7 +132,9 @@ Consider the following solutions:
 ## Custom hostname fails to verify because the zone is held
 
 The [zone hold feature](/fundamentals/account/account-security/zone-holds/) is a toggle that will prevent their zone from being activated on other Cloudflare account. When enabled, Cloudflare is not able to issue an SSL/TLS certificate on behalf of that domain name for either a zone or custom hostname.
-When the option `Also prevent subdomains` is enabled, this prevents the verification of custom hostnames for this domain. The custom hostname will remain in the `Blocked` status, with the following error message: `The hostname is associated with a held zone. Please contact the owner of this domain to have the hold removed.` In this case, the owner of the zone needs to [release the hold](/fundamentals/account/account-security/zone-holds/#release-zone-holds) before the custom hostname can become activated. After the hostname has been validated, the zone hold can be enabled again.
+When the option `Also prevent subdomains` is enabled, this prevents the verification of custom hostnames for this domain. The custom hostname will remain in the `Blocked` status, with the following error message: `The hostname is associated with a held zone. Please contact the owner of this domain to have the hold removed.` In this case, the owner of the zone needs to [release the hold](/fundamentals/account/account-security/zone-holds/#release-zone-holds) before the custom hostname can become activated.
+
+The `Blocked` status is terminal — the custom hostname will not retry validation automatically. After the zone hold is released, select **Refresh** on the custom hostname in the Cloudflare dashboard, or send a [PATCH request](/api/resources/custom_hostnames/methods/edit/) to the custom hostname, to restart the validation process. After the hostname has been validated, the zone hold can be enabled again.
 
 ## Hostnames over 64 characters
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works.mdx
@@ -61,6 +61,12 @@ B --> C
 C --> D
 ```
 
+## Detect O2O traffic
+
+When traffic flows through an O2O configuration, Cloudflare sets the HTTP header `cf-connecting-o2o: 1` on requests entering the SaaS provider's zone. There is no API field or zone setting that indicates whether O2O is active — it is a per-request routing behavior determined by the customer's DNS configuration.
+
+You can check for this header in your origin server or in a [Cloudflare Worker](/workers/) to identify O2O traffic and apply specific logic.
+
 ## Without O2O
 
 If you do not have your own Cloudflare zone and have only onboarded one or more of your hostnames to a SaaS Provider, then O2O will not be enabled.

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/http.mdx
@@ -23,7 +23,7 @@ You choose one certificate validation method when you [create a custom hostname]
 
 ## Non-wildcard custom hostnames
 
-If your custom hostname does not include a wildcard, Cloudflare always attempts to complete DCV through [HTTP validation](#http-automatic) after the hostname points to your SaaS target, even if you have selected **TXT** for your validation method.
+If your custom hostname does not include a wildcard, Cloudflare attempts to complete DCV through [HTTP validation](#http-automatic) after the hostname points to your SaaS target, even if you have selected **TXT** for your validation method.
 
 This HTTP validation should succeed as long as your customer's hostname points to your SaaS target and they do not have any [CAA records](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/troubleshooting/#certificate-authority-authorization-caa-records) blocking your chosen certificate authority.
 
@@ -32,6 +32,10 @@ This HTTP validation should succeed as long as your customer's hostname points t
 HTTP DCV validation is not allowed for wildcard certificates. Use [TXT validation](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/txt/) instead. You can also configure [Delegated DCV](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/validate-certificates/delegated-dcv/) to automate TXT-based validation.
 
 ---
+
+:::note[DCV records are generated asynchronously]
+After you create a custom hostname, the `ssl.validation_records` array may be empty for a short period while Cloudflare requests DCV tokens from the certificate authority. If the array is empty, wait a few seconds and query the [custom hostname details endpoint](/api/resources/custom_hostnames/methods/get/) again.
+:::
 
 ## Validation methods
 

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin.mdx
@@ -28,6 +28,19 @@ To use a custom origin server, you need to meet the following requirements:
 
 To use a custom origin, select that option when [creating a new custom hostname](/cloudflare-for-platforms/cloudflare-for-saas/security/certificate-management/issue-and-validate/) in the dashboard or include the `"custom_origin_server": your_custom_origin_server` parameter when using the API [POST command](/api/resources/custom_hostnames/methods/create/).
 
+## Cloud provider origins (Azure, AWS, GCP)
+
+When using a cloud provider endpoint as a custom origin (for example, Azure App Service, AWS ALB, or GCP Cloud Run), the provider may reject requests with a `404` or `400` error if the `Host` header does not match a domain configured on that endpoint.
+
+By default, Cloudflare sends the original custom hostname as the `Host` header. If your cloud provider expects a different hostname:
+
+1. Configure the cloud provider to accept the custom hostname as a valid domain, or
+2. Use an [Origin Rule](/rules/origin-rules/) to override the `Host` header to match the hostname your cloud provider expects.
+
+:::note
+This is a common issue with Azure App Service, where the platform returns a default parking page (404) when the incoming `Host` header does not match any configured custom domain.
+:::
+
 ## SNI rewrites
 
 <Render

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin.mdx
@@ -69,6 +69,14 @@ You do not need to add individual Worker routes for each custom hostname. The wi
 
 :::
 
+## Interaction with custom origin server
+
+:::caution
+When a Worker route matches incoming traffic, the request is handled by the Worker. The [`custom_origin_server`](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/custom-origin/) setting on individual custom hostnames is bypassed because the Worker processes the request before origin resolution occurs.
+
+If you need per-hostname origin routing, implement it within your Worker using `request.headers.get("host")` or `request.cf.hostMetadata` (via [custom metadata](/cloudflare-for-platforms/cloudflare-for-saas/domain-support/custom-metadata/)).
+:::
+
 ## Related resources
 
 - [Hostname routing](/cloudflare-for-platforms/workers-for-platforms/configuration/hostname-routing/) - Learn about advanced routing patterns, including dispatch Workers and O2O behavior.

--- a/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started.mdx
+++ b/src/content/docs/cloudflare-for-platforms/cloudflare-for-saas/start/getting-started.mdx
@@ -33,6 +33,10 @@ import { Example, Render } from "~/components";
 
 <Render file="get-started-fallback-origin" product="cloudflare-for-platforms" />
 
+:::note
+Changing the fallback origin hostname is non-disruptive. Existing custom hostname traffic continues to flow while the fallback origin is updated, and the change propagates across Cloudflare's edge within seconds.
+:::
+
 ### 2. (Optional) Create CNAME target
 
 The CNAME target — optional, but highly encouraged — provides a friendly and more flexible place for customers to [route their traffic](#3-have-customer-create-cname-record). You may want to use a subdomain such as `customers.<SAAS_PROVIDER>.com`.

--- a/src/content/docs/ssl/edge-certificates/changing-dcv-method/troubleshooting.mdx
+++ b/src/content/docs/ssl/edge-certificates/changing-dcv-method/troubleshooting.mdx
@@ -37,6 +37,8 @@ If you have issues while HTTP DCV is in place, review the following settings:
 
 - **Anything affecting `/.well-known/*`**: Review [WAF custom rules](/waf/custom-rules/), [IP Access Rules](/waf/tools/ip-access-rules/), and other [configuration rules](/rules/configuration-rules/) to make sure that your rules _do not_ enable interactive challenge on the validation URL.
 
+- **Workers routes**: If you have [Workers routes](/workers/configuration/routing/routes/) matching `*/*` or paths that include `/.well-known/pki-validation/*` or `/.well-known/acme-challenge/*`, your Worker may intercept DCV requests from the certificate authority. Make sure your Worker either passes through requests to these paths or does not match them. This is especially relevant for [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) zones that use a [Worker as the fallback origin](/cloudflare-for-platforms/cloudflare-for-saas/start/advanced-settings/worker-as-origin/).
+
 - **Cloudflare Account Settings** and **Page Rules**: Review your [account settings](/fundamentals/reference/under-attack-mode/), [Configuration Rules](/rules/configuration-rules/), and [Page Rules](/rules/page-rules/) to ensure you have not enabled Under Attack mode on the validation URL.
 
   :::caution

--- a/src/content/docs/ssl/edge-certificates/changing-dcv-method/validation-backoff-schedule.mdx
+++ b/src/content/docs/ssl/edge-certificates/changing-dcv-method/validation-backoff-schedule.mdx
@@ -58,6 +58,10 @@ In manual processes, it is possible that you fall behind schedule when you place
 
 In automatic processes, most validations complete within the first five minutes, unless there is a setup misconfiguration.
 
+### Cloudflare for SaaS
+
+For [custom hostnames](/cloudflare-for-platforms/cloudflare-for-saas/), the same backoff schedule applies to automatic DCV retries. If you need to trigger an immediate recheck — for example, after your customer has placed the DCV token — send a [PATCH request](/api/resources/custom_hostnames/methods/edit/) to the custom hostname with the current `ssl` settings. This resets the backoff timer and triggers a new validation attempt immediately.
+
 | Retry Attempt | In Seconds | In Minutes | In Hours |
 | ------------- | ---------- | ---------- | -------- |
 | 0             | 60         | 1.000      | 0.016667 |


### PR DESCRIPTION
## Summary

Documentation updates covering undocumented behaviors, migration paths, and configuration guidance across SSL certificate validation and Cloudflare for SaaS.


## Changes (13 updates across 12 files)

| # | Gap | File | Change |
|---|-----|------|--------|
| 1 | **DCV troubleshooting** | `ssl/.../troubleshooting.mdx` | Workers routes can intercept `/.well-known/pki-validation/*` and `/.well-known/acme-challenge/*` |
| 2 | **Worker as origin** | `cloudflare-for-saas/.../worker-as-origin.mdx` | Caution: `custom_origin_server` is bypassed when Worker route matches |
| 3 | **HTTP DCV** | `cloudflare-for-saas/.../validate-certificates/http.mdx` | Async `validation_records` generation; wildcard parent prerequisite |
| 4 | **SaaS-to-SaaS migration** | `cloudflare-for-saas/.../hostname-validation/index.mdx` | Zero-downtime provider migration steps |
| 5 | **Fallback origin** | `cloudflare-for-saas/.../getting-started.mdx` | Changing fallback origin is non-disruptive |
| 6 | **Zone hold** | `cloudflare-for-saas/.../troubleshooting.mdx` | `Blocked` status is terminal; PATCH needed after hold release |
| 7 | **O2O detection** | `cloudflare-for-saas/.../how-it-works.mdx` | `cf-connecting-o2o: 1` header; no API field |
| 8 | **Custom origin** | `cloudflare-for-saas/.../custom-origin.mdx` | Azure/cloud provider Host header mismatch guidance |
| 9 | **Validation backoff** | `ssl/.../validation-backoff-schedule.mdx` | SaaS-specific PATCH to reset backoff timer |
| 10 | **Pre-validation** | `cloudflare-for-saas/.../pre-validation.mdx` | Zero-downtime migration with HTTP DCV |


Resolves DEE-3630