### PR TITLE
chore: pin opencode version in bonk jobs

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -59,6 +59,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
+          opencode_version: "1.17.7"
           agent: docs # use our Docs agent by default in this repo
           mentions: "/bigbonk"
           permissions: CODEOWNERS

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -85,6 +85,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
+          opencode_version: "1.17.7"
           agent: docs
           mentions: "/bonk"
           permissions: write
@@ -140,6 +141,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
+          opencode_version: "1.17.7"
           agent: docs
           permissions: write
           token_permissions: NO_PUSH


### PR DESCRIPTION
### Summary

Pinning opencode version to previous release as current version is breaking bonk, investigation here: https://github.com/cloudflare/cloudflare-docs/pull/31548

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

