### PR TITLE
clarify temporary anti-abuse restriction for Pages.mdx

### DIFF
--- a/src/content/docs/pages/platform/limits.mdx
+++ b/src/content/docs/pages/platform/limits.mdx
@@ -79,4 +79,4 @@ Your Pages site can be managed by an unlimited number of users via the Cloudflar
 
 Cloudflare Pages has a soft limit of 100 projects within your account in order to prevent abuse. If you need this limit raised, contact your Cloudflare account team or use the Limit Increase Request Form at the top of this page.
 
-In order to protect against abuse of the service, Cloudflare may temporarily disable your ability to create new Pages projects, if you are deploying a large number of applications in a short amount of time. Contact support if you need this limit increased.
+In order to protect against abuse of the service, Cloudflare limits the number of new Pages projects you can create within your first 48 hours of using the service. If you are temporarily blocked from creating new projects, this restriction will automatically lift once the initial 48-hour window has passed.


### PR DESCRIPTION
The documentation previously instructed users to contact Support to  increase the limit if they were blocked from creating new Pages projects. 

The temporary anti-abuse restriction  triggers when bulk-creating projects in the first 48 hours. Support does not have the tooling to  manually override this temporary cooldown.

This update clarifies that the restriction is an automated anti-abuse  measure that will lift on its own. This sets the correct expectation  for users and prevents unresolvable tickets from reaching Support.

