### PR TITLE
perf: speed up changelog RSS feed generation

### DIFF
--- a/src/util/changelog.ts
+++ b/src/util/changelog.ts
@@ -96,9 +96,17 @@ export type GetChangelogsOptions = {
 	filter?: (entry: CollectionEntry<"changelog">) => boolean;
 };
 
-export async function getChangelogs({
-	filter,
-}: GetChangelogsOptions): Promise<Array<CollectionEntry<"changelog">>> {
+// The normalized + sorted set of changelog entries is identical across every
+// feed; only the caller-supplied `filter` differs. Building it involves a full
+// `getCollection` scan plus a `getEntry` validation per entry plus loading the
+// WARP releases, so we compute it once and reuse it. Without this, the ~190
+// changelog feeds (global, per-product, per-area) each re-ran the entire scan.
+let changelogBasePromise: Promise<Array<CollectionEntry<"changelog">>> | null =
+	null;
+
+async function getChangelogBase(): Promise<
+	Array<CollectionEntry<"changelog">>
+> {
 	let entries = await getCollection("changelog");
 
 	entries = await Promise.all(
@@ -128,10 +136,6 @@ export async function getChangelogs({
 
 	entries = entries.concat(await getWARPReleases());
 
-	if (filter) {
-		entries = entries.filter((e) => filter(e));
-	}
-
 	// Exclude entries with a date in the future so that changelog posts
 	// merged ahead of time do not appear until their publish date.
 	const now = new Date();
@@ -142,6 +146,19 @@ export async function getChangelogs({
 	);
 
 	return entries.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+}
+
+export async function getChangelogs({
+	filter,
+}: GetChangelogsOptions): Promise<Array<CollectionEntry<"changelog">>> {
+	if (!changelogBasePromise) {
+		changelogBasePromise = getChangelogBase();
+	}
+
+	const entries = await changelogBasePromise;
+
+	// Always return a new array so callers can't mutate the cached base.
+	return filter ? entries.filter((e) => filter(e)) : [...entries];
 }
 
 // Pre-computed set of all product IDs that have at least one visible changelog

--- a/src/util/container.ts
+++ b/src/util/container.ts
@@ -4,6 +4,38 @@ import mdxRenderer from "@astrojs/mdx/server.js";
 import { render, type CollectionEntry } from "astro:content";
 import type { AstroComponentFactory } from "astro/runtime/server/index.js";
 
+// Creating an Astro container (and registering its renderers) is expensive, so
+// we build a single shared instance lazily and reuse it across every call.
+// Previously a fresh container was created per entry, which dominated the cost
+// of rendering changelog RSS feeds (hundreds of feeds × hundreds of entries).
+let containerPromise: Promise<
+	Awaited<ReturnType<typeof experimental_AstroContainer.create>>
+> | null = null;
+
+function getContainer() {
+	if (!containerPromise) {
+		containerPromise = (async () => {
+			const container = await experimental_AstroContainer.create({});
+			container.addServerRenderer({
+				name: "astro:jsx",
+				renderer: mdxRenderer,
+			});
+			container.addServerRenderer({
+				name: "@astrojs/react",
+				renderer: reactRenderer,
+			});
+			return container;
+		})();
+	}
+
+	return containerPromise;
+}
+
+// Cache of rendered entry HTML, keyed by collection + id. The same changelog
+// entry is rendered for the global feed, the per-product feed, every area feed
+// it belongs to, etc.; memoizing avoids re-rendering identical content.
+const entryHtmlCache = new Map<string, Promise<string>>();
+
 export async function entryToString(
 	entry: CollectionEntry<"docs" | "changelog">,
 	locals: any,
@@ -12,24 +44,28 @@ export async function entryToString(
 		return entry.rendered.html;
 	}
 
-	const container = await experimental_AstroContainer.create({});
-	container.addServerRenderer({
-		name: "astro:jsx",
-		renderer: mdxRenderer,
-	});
-	container.addServerRenderer({
-		name: "@astrojs/react",
-		renderer: reactRenderer,
-	});
+	// `getChangelogs` rewrites `entry.id` to a folder-stripped slug, so prefer
+	// the unique source `filePath` to avoid collisions between same-named files
+	// in different product folders. Fall back to collection + id otherwise.
+	const cacheKey = entry.filePath ?? `${entry.collection}:${entry.id}`;
+	const cached = entryHtmlCache.get(cacheKey);
+	if (cached) {
+		return cached;
+	}
 
-	const { Content } = await render(entry);
+	const renderPromise = (async () => {
+		const container = await getContainer();
+		const { Content } = await render(entry);
 
-	const html = await container.renderToString(Content, {
-		params: { slug: entry.id },
-		locals,
-	});
+		return container.renderToString(Content, {
+			params: { slug: entry.id },
+			locals,
+		});
+	})();
 
-	return html;
+	entryHtmlCache.set(cacheKey, renderPromise);
+
+	return renderPromise;
 }
 
 export async function componentToString(


### PR DESCRIPTION
AI-generated - Testing

Reuse a single Astro container and memoize rendered entry HTML in entryToString, and cache the normalized getChangelogs() base set so the ~190 changelog feeds no longer re-create a container per entry, re-render identical entries, or re-scan the full collection each time.
