### PR TITLE
[Cloudflare One] Document Cloudflare IdP as default for new accounts

### DIFF
--- a/src/content/changelog/cloudflare-one/2026-06-18-cloudflare-idp-default.mdx
+++ b/src/content/changelog/cloudflare-one/2026-06-18-cloudflare-idp-default.mdx
@@ -1,0 +1,14 @@
+---
+title: Cloudflare identity provider is now the default for new accounts
+description: New Zero Trust organizations get the Cloudflare identity provider as their default login method instead of one-time PIN.
+date: 2026-06-18
+products:
+  - cloudflare-one
+  - access
+---
+
+When you create a new Zero Trust organization, Cloudflare now adds the [Cloudflare identity provider](/cloudflare-one/integrations/identity-providers/cloudflare/) as your default login method. Previously, new organizations started with [one-time PIN (OTP)](/cloudflare-one/integrations/identity-providers/one-time-pin/).
+
+With the Cloudflare identity provider, your users authenticate using their existing Cloudflare account credentials, and authentication is restricted to members of your account. You can still add OTP or connect any [third-party identity provider](/cloudflare-one/integrations/identity-providers/) whenever you need to.
+
+This change only applies to newly created accounts. Existing organizations keep the login methods they already have configured.

--- a/src/content/changelog/cloudflare-one/2026-06-18-cloudflare-idp-default.mdx
+++ b/src/content/changelog/cloudflare-one/2026-06-18-cloudflare-idp-default.mdx
@@ -11,4 +11,4 @@ When you create a new Zero Trust organization, Cloudflare now adds the [Cloudfla
 
 With the Cloudflare identity provider, your users authenticate using their existing Cloudflare account credentials, and authentication is restricted to members of your account. You can still add OTP or connect any [third-party identity provider](/cloudflare-one/integrations/identity-providers/) whenever you need to.
 
-This change only applies to newly created accounts. Existing organizations keep the login methods they already have configured.
+This change only applies to newly created accounts. Existing organizations keep the login methods they already have configured. If you would like to use the Cloudflare Identity Provider in an existing account, you must enable it.

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/cloudflare.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/cloudflare.mdx
@@ -16,6 +16,8 @@ Cloudflare Access can use Cloudflare itself as an identity provider, allowing yo
 
 When a user authenticates through the Cloudflare identity provider, Access verifies their Cloudflare account membership and grants or denies access based on your policy configuration.
 
+For newly created Zero Trust organizations, Cloudflare adds this identity provider automatically as the default login method, with **Restrict to account members** enabled. You do not need to set it up manually. The steps below describe how to add or reconfigure it.
+
 ## Set up Cloudflare as an identity provider
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">
@@ -49,6 +51,8 @@ Make a `POST` request to the [Identity Providers](/api/resources/zero_trust/subr
 | Option | Description | Default |
 | --- | --- | --- |
 | **Restrict to account members** | When enabled, only users who are members of your Cloudflare account can authenticate. When disabled, any Cloudflare user can authenticate (subject to your Access policies). | Disabled |
+
+The **Default** column reflects the value when you add this identity provider manually. When Cloudflare configures it automatically for a new organization, **Restrict to account members** is enabled.
 
 ## Use Cloudflare account membership in policies
 

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/cloudflare.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/cloudflare.mdx
@@ -16,7 +16,7 @@ Cloudflare Access can use Cloudflare itself as an identity provider, allowing yo
 
 When a user authenticates through the Cloudflare identity provider, Access verifies their Cloudflare account membership and grants or denies access based on your policy configuration.
 
-For newly created Zero Trust organizations, Cloudflare adds this identity provider automatically as the default login method, with **Restrict to account members** enabled. You do not need to set it up manually. The steps below describe how to add or reconfigure it.
+For newly created Zero Trust organizations, Cloudflare adds this identity provider automatically as the default login method, with **Restrict to account members** enabled. You do not need to set it up manually. The following steps describe how to add or reconfigure it.
 
 ## Set up Cloudflare as an identity provider
 

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/index.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/index.mdx
@@ -13,7 +13,9 @@ import { Render } from "~/components";
 
 Cloudflare One integrates with your organization's identity provider to apply Cloudflare One and Secure Web Gateway policies. If you work with partners, contractors, or other organizations, you can integrate multiple identity providers simultaneously.
 
-As an alternative to configuring an identity provider, Cloudflare One can send a [one-time PIN (OTP)](/cloudflare-one/integrations/identity-providers/one-time-pin/) to approved email addresses. No configuration needed — simply add a user's email address to an [Access policy](/cloudflare-one/access-controls/policies/) and to the group that allows your team to reach the application. You can simultaneously configure an OTP and an identity provider to allow users to use their own authentication method.
+When you create a new Zero Trust organization, Cloudflare automatically configures the [Cloudflare identity provider](/cloudflare-one/integrations/identity-providers/cloudflare/) as your default login method. Your users can authenticate with their existing Cloudflare account credentials without any additional setup, and you can add more identity providers at any time.
+
+You can also send a [one-time PIN (OTP)](/cloudflare-one/integrations/identity-providers/one-time-pin/) to approved email addresses. No configuration needed — simply add a user's email address to an [Access policy](/cloudflare-one/access-controls/policies/) and to the group that allows your team to reach the application. You can configure OTP and an identity provider at the same time to let users choose their own authentication method.
 
 Adding an identity provider as a login method requires configuration both in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **Zero Trust** > **Integrations** > **Identity providers** and with the identity provider itself. Consult our IdP-specific documentation to learn more about what you need to set up.
 

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/one-time-pin.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/one-time-pin.mdx
@@ -14,6 +14,8 @@ import { Tabs, TabItem, Render, APIRequest } from "~/components";
 
 Cloudflare Access can send a one-time PIN (OTP) to approved email addresses as an alternative to integrating an identity provider. You can simultaneously configure OTP login and the identity provider of your choice to allow users to select their own authentication method.
 
+New Zero Trust organizations use the [Cloudflare identity provider](/cloudflare-one/integrations/identity-providers/cloudflare/) as their default login method. OTP is no longer added automatically, but you can set it up at any time using the steps below.
+
 For example, if your team uses Okta but you are collaborating with someone outside your organization, you can use OTP to grant access to guests.
 
 <Render file="access/one-time-pin-warning" product="cloudflare-one" />

--- a/src/content/docs/cloudflare-one/integrations/identity-providers/one-time-pin.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/one-time-pin.mdx
@@ -14,7 +14,7 @@ import { Tabs, TabItem, Render, APIRequest } from "~/components";
 
 Cloudflare Access can send a one-time PIN (OTP) to approved email addresses as an alternative to integrating an identity provider. You can simultaneously configure OTP login and the identity provider of your choice to allow users to select their own authentication method.
 
-New Zero Trust organizations use the [Cloudflare identity provider](/cloudflare-one/integrations/identity-providers/cloudflare/) as their default login method. OTP is no longer added automatically, but you can set it up at any time using the steps below.
+New Zero Trust organizations use the [Cloudflare identity provider](/cloudflare-one/integrations/identity-providers/cloudflare/) as their default login method. OTP is no longer added automatically, but you can set it up at any time using the following steps.
 
 For example, if your team uses Okta but you are collaborating with someone outside your organization, you can use OTP to grant access to guests.
 

--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/set-up.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/set-up.mdx
@@ -50,7 +50,7 @@ Choose one of the [different ways](/cloudflare-one/team-and-resources/devices/cl
 
 ### 6. Log in to your organization's Cloudflare Zero Trust instance from your devices.
 
-Once the Cloudflare One Client is installed on the device, [log in to your Zero Trust organization](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/manual-deployment/). If you have already set up an identity provider in Cloudflare Access, the user will be prompted to authenticate using this method. If you have not set up an identity provider, the user can authenticate with a [one-time pin](/cloudflare-one/integrations/identity-providers/one-time-pin/) which is enabled by default.
+Once the Cloudflare One Client is installed on the device, [log in to your Zero Trust organization](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/manual-deployment/). The user is prompted to authenticate with one of your configured login methods. New organizations include the [Cloudflare identity provider](/cloudflare-one/integrations/identity-providers/cloudflare/) as the default, so users can sign in with their Cloudflare account credentials. You can also connect a [third-party identity provider](/cloudflare-one/integrations/identity-providers/) or enable a [one-time PIN](/cloudflare-one/integrations/identity-providers/one-time-pin/).
 
 Next, build [Secure Web Gateway policies](/cloudflare-one/traffic-policies/) to filter DNS, HTTP, and Network traffic on your devices.
 

--- a/src/content/partials/cloudflare-one/choose-team-name.mdx
+++ b/src/content/partials/cloudflare-one/choose-team-name.mdx
@@ -8,3 +8,5 @@ import { GlossaryTooltip } from "~/components";
    You can find your team name in the [Cloudflare dashboard](https://dash.cloudflare.com/) by going to **Zero Trust** > **Settings**.
 
 3. Complete your onboarding by selecting a subscription plan and entering your payment details. If you chose the **Zero Trust Free plan**, this step is still needed but you will not be charged.
+
+When you create your organization, Cloudflare automatically adds the [Cloudflare identity provider](/cloudflare-one/integrations/identity-providers/cloudflare/) as your default login method, so your users can sign in with their Cloudflare account credentials right away. You can add a [one-time PIN](/cloudflare-one/integrations/identity-providers/one-time-pin/) or connect a [third-party identity provider](/cloudflare-one/integrations/identity-providers/) at any time.


### PR DESCRIPTION
## Summary

New Zero Trust organizations now get the **Cloudflare identity provider** as their default login method instead of one-time PIN (OTP), per ztx-frontend MR !10557 (AUTH-8768). This updates the docs to match and adds a changelog entry.

## Changes

- **New changelog**: announces the Cloudflare IdP as the default for new accounts; notes existing orgs are unaffected.
- **identity-providers/index.mdx**: states new orgs are provisioned with the Cloudflare IdP automatically; reframes OTP as an additional option.
- **identity-providers/cloudflare.mdx**: notes this IdP is auto-configured as the default for new orgs (with **Restrict to account members** enabled) and clarifies the config table's default applies to manual setup.
- **identity-providers/one-time-pin.mdx**: notes OTP is no longer added automatically but can still be set up.
- **cloudflare-one-client/set-up.mdx**: removed the inaccurate "one-time PIN enabled by default" claim.
- **partials/choose-team-name.mdx**: documents the default login method during onboarding.

## Notes

- The "Secure private apps" guided quick-start (`secure-private-apps-shared-steps.mdx`) was intentionally left unchanged. Its first-policy step uses email-based OTP and is a separate flow that this MR does not touch.

## Validation

- `pnpm run format:core:check` passes.
- Changelog frontmatter validated against the changelog schema; all internal links resolve to existing pages.
