### PR TITLE
Add docs note about limitation on OTLP format.

### DIFF
--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
@@ -47,6 +47,9 @@ Most providers require authentication headers. Refer to your provider's document
 To start sending data to your destination, you'll need to create a destination in the Cloudflare dashboard.
 
 ### Creating a destination
+:::note[Protocol]
+Cloudflare does not support the [Binary format](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding) for OTLP ingest.
+:::
 
 ![Observability Destinations dashboard showing configured destinations for Grafana and Honeycomb with their respective endpoints and status](~/assets/images/workers-observability/destinations.png)
 

--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
@@ -48,7 +48,7 @@ To start sending data to your destination, you'll need to create a destination i
 
 ### Creating a destination
 :::note[Protocol]
-Cloudflare does not support the [Binary format](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding) for OTLP ingest.
+Cloudflare does not support the [Binary format](https://opentelemetry.io/docs/specs/otlp/#binary-protobuf-encoding) for OTLP ingest.
 :::
 
 ![Observability Destinations dashboard showing configured destinations for Grafana and Honeycomb with their respective endpoints and status](~/assets/images/workers-observability/destinations.png)


### PR DESCRIPTION
### Summary

Cloudflare does not currently support the binary protobuf format for OTLP destinations, this is not well documented, and took a bit of figuring out when attempting to connect Worker traces to Dynatrace.

The only location that this is somewhat documented is here: https://developers.cloudflare.com/ai-gateway/observability/otel-integration/#common-otel-backends where it lists that the AI gateway supports the JSON or protobuf destination, but this doesn't highlight explicitly that the binary version of the protocol is not supported.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).