### PR TITLE
[Stream] Add warning about caching manifests

### DIFF
--- a/src/content/docs/stream/viewing-videos/using-own-player/index.mdx
+++ b/src/content/docs/stream/viewing-videos/using-own-player/index.mdx
@@ -18,7 +18,13 @@ Platform-specific guides:
 - [iOS (AVPlayer)](/stream/viewing-videos/using-own-player/ios/)
 - [Android (ExoPlayer)](/stream/viewing-videos/using-own-player/android/)
 
-## Fetch HLS and Dash manifests
+## Use HLS and Dash manifests
+
+:::warning
+
+Manifests are dynamic assets that may be updated at any time. Do not cache, proxy, or store manifests; always read them directly from Stream. Outdated manifests may be missing features or refer to assets which have been moved.
+
+:::
 
 ### URL
 

--- a/src/content/docs/stream/viewing-videos/using-own-player/index.mdx
+++ b/src/content/docs/stream/viewing-videos/using-own-player/index.mdx
@@ -20,7 +20,7 @@ Platform-specific guides:
 
 ## Use HLS and Dash manifests
 
-:::warning
+:::caution
 
 Manifests are dynamic assets that may be updated at any time. Do not cache, proxy, or store manifests; always read them directly from Stream. Outdated manifests may be missing features or refer to assets which have been moved.
 


### PR DESCRIPTION
Updated section title and added warning about dynamic manifests.

### Summary

Notice to customers using custom players that manifests are living assets and should always be fetched fresh.

### Documentation checklist

<!-- Remove items that do not apply -->
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
