### PR TITLE
containers: Add documentation for the newly added container.exec()

### DIFF
--- a/src/content/changelog/containers/2026-06-18-container-exec.mdx
+++ b/src/content/changelog/containers/2026-06-18-container-exec.mdx
@@ -1,0 +1,47 @@
+---
+title: exec() is now available for Containers
+description: Control additional processes from the associated Durable Object.
+products:
+  - containers
+date: 2026-06-18
+---
+
+import { TypeScriptExample } from "~/components";
+
+`exec()` is now available for [Containers](/containers/). Use `this.ctx.container.exec()` to start processes inside a running Container, stream standard input and output, inspect exit codes, and signal each process.
+
+Call `exec()` from a class extending `Container`, or from another Durable Object through `this.ctx.container`. The associated Container must already be running.
+
+This example starts the Container when needed, then reads its Node.js version:
+
+<TypeScriptExample filename="src/index.ts">
+
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async readVersion() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec(["node", "--version"]);
+		const output = await process.output();
+		const decoder = new TextDecoder();
+
+		return {
+			exitCode: output.exitCode,
+			stdout: decoder.decode(output.stdout),
+			stderr: decoder.decode(output.stderr),
+		};
+	}
+}
+```
+
+</TypeScriptExample>
+
+The command array starts an executable directly, without an implicit shell. Invoke a shell explicitly for pipes, redirects, or variable expansion.
+
+One RPC method can coordinate multiple `exec()` calls in one caller-to-Durable Object round trip. It can also pass byte-oriented `ReadableStream` input or return streamed output with flow control.
+
+For options and streaming examples, refer to [Execute commands](/containers/execute-commands/).

--- a/src/content/docs/containers/container-class.mdx
+++ b/src/content/docs/containers/container-class.mdx
@@ -46,16 +46,16 @@ export default {
 The `Container` class extends `DurableObject`, so all [Durable Object](/durable-objects/) functionality is available — including [SQLite storage](/durable-objects/api/sqlite-storage-api/), [alarms](/durable-objects/api/alarms/), and [RPC methods](/durable-objects/api/base/#rpc-methods). Container disk is ephemeral by default, but Durable Object storage persists across container restarts.
 
 <TypeScriptExample>
-```
+```ts
 import { Container } from "@cloudflare/containers";
 
 export class MyContainer extends Container {
 	defaultPort = 8080;
 
 	async runAndPersist() {
-		const res = await this.fetch("/run-task");
+		const res = await this.containerFetch("/run-task");
 		const body = await res.text();
-		await this.ctx.storage.sql.exec(
+		this.ctx.storage.sql.exec(
 			"INSERT OR REPLACE INTO results (value) VALUES (?)",
 			body,
 		);
@@ -64,6 +64,10 @@ export class MyContainer extends Container {
 }
 ```
 </TypeScriptExample>
+
+## Execute commands
+
+Use `this.ctx.container.exec()` to start another process inside a running Container. Refer to [Execute commands](/containers/execute-commands/) for startup, streaming, output, and process-control examples.
 
 ## Properties
 
@@ -114,7 +118,7 @@ Run Worker code after the container has started.
 
 ```ts
 onStart(): void | Promise<void>
-```
+````
 
 **Returns**: `void | Promise<void>`. Resolve after any startup logic finishes.
 

--- a/src/content/docs/containers/execute-commands.mdx
+++ b/src/content/docs/containers/execute-commands.mdx
@@ -1,0 +1,493 @@
+---
+title: Execute commands
+description: Run additional processes inside an active Container.
+pcx_content_type: how-to
+sidebar:
+  order: 2.6
+products:
+  - containers
+reviewed: 2026-06-18
+---
+
+import { TypeScriptExample } from "~/components";
+
+Use `exec()` to start another process inside a running [Container](/containers/container-class/). The examples call `this.ctx.container.exec()` inside a class extending `Container` from `@cloudflare/containers`.
+
+`exec()` does not start a stopped Container. In remote procedure call (RPC) methods, check `this.ctx.container.running` and call `await this.start()` when needed. You can also use the `onStart()` hook to run any series of commands whenever the Container starts.
+
+## Run a process after startup
+
+The following hook runs a preparation command whenever the Container starts. You can execute any series of startup commands from this hook. `output()` buffers standard output and standard error as separate `ArrayBuffer` values.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	override async onStart() {
+		const process = await this.ctx.container.exec([
+			"node",
+			"scripts/prepare.js",
+		]);
+		const output = await process.output();
+		const decoder = new TextDecoder();
+
+	if (output.exitCode !== 0) {
+		throw new Error(
+			`Container preparation failed: ${decoder.decode(output.stderr)}`,
+		);
+	}
+
+	console.log(decoder.decode(output.stdout));
+    }
+
+}
+
+```
+</TypeScriptExample>
+
+In an RPC method, ensure the Container is running before calling `exec()`. Standard output uses a readable stream by default.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async readVersion() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec(["node", "--version"]);
+		const stdout = process.stdout
+			? await new Response(process.stdout).text()
+			: "";
+		const exitCode = await process.exitCode;
+
+		return { pid: process.pid, stdout, exitCode };
+	}
+}
+```
+</TypeScriptExample>
+
+The returned `pid` identifies the new process. The `exitCode` promise resolves when that process exits.
+
+## Pass arguments directly
+
+The `exec()` operation starts the executable directly with the provided argument array. It does not start a shell first.
+
+Each array item becomes one argument. Shell features such as pipes, redirects, globbing, and variable expansion do not run implicitly.
+
+Invoke a shell when your command needs those features. Use `["bash", "-lc", "<COMMAND>"]` if Bash exists in your image. Use `["sh", "-c", "<COMMAND>"]` if the image only provides a Portable Operating System Interface (POSIX) shell. Pass untrusted values as separate arguments instead of interpolating them into a shell command string.
+
+## Send standard input
+
+Pass a `ReadableStream` to send existing data. Setting `stdout` to `"ignore"` discards standard output.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async importData(data: string) {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const stdin = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(data));
+				controller.close();
+			},
+		});
+		const process = await this.ctx.container.exec(["cat"], {
+			stdin,
+			stdout: "ignore",
+		});
+		const output = await process.output();
+
+		return {
+			stdoutBytes: output.stdout.byteLength,
+			exitCode: output.exitCode,
+		};
+	}
+}
+```
+</TypeScriptExample>
+
+Ignored standard output produces an empty buffer from `output()`. Set `stdin` to `"pipe"` to write data over time.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async concatenateInput() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec(["cat"], {
+			stdin: "pipe",
+		});
+		const writer = process.stdin?.getWriter();
+
+		if (!writer) {
+			throw new Error("Standard input is unavailable");
+		}
+
+		const encoder = new TextEncoder();
+		await writer.write(encoder.encode("first\n"));
+		await writer.write(encoder.encode("second\n"));
+		await writer.close();
+
+		const output = await process.output();
+		return new TextDecoder().decode(output.stdout);
+	}
+}
+```
+</TypeScriptExample>
+
+Close the writer to send end-of-file (EOF). If you omit `stdin`, `exec()` closes standard input and sends EOF immediately.
+
+### Pass an RPC stream to standard input
+
+RPC methods can accept byte-oriented `ReadableStream` values whose underlying source uses `type: "bytes"`. A `Request` body meets this requirement. You can pass the received stream directly to `exec()` without buffering the entire stream in the Durable Object. For more information, refer to [Streams over RPC](/workers/runtime-apis/rpc/#readablestream-writeablestream-request-and-response).
+
+<TypeScriptExample>
+```ts
+import { Container, getContainer } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async writeFile(input: ReadableStream<Uint8Array>) {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+	const process = await this.ctx.container.exec(
+		["tee", "/tmp/upload.bin"],
+		{
+			stdin: input,
+			stdout: "ignore",
+		},
+	);
+
+	return process.exitCode;
+    }
+
+}
+
+export default {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		if (!request.body) {
+			return new Response("Request body required", { status: 400 });
+		}
+
+	const container = getContainer(env.MY_CONTAINER, "upload-worker");
+	const exitCode = await container.writeFile(request.body);
+
+	return Response.json({ exitCode });
+    },
+
+};
+
+```
+</TypeScriptExample>
+
+RPC transfers ownership of the stream to the Durable Object. The calling Worker cannot read it after passing it to `writeFile()`.
+
+The following `cat` process exits because standard input is omitted:
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async verifyEndOfFile() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec(["cat"]);
+		const output = await process.output();
+
+		return {
+			stdoutBytes: output.stdout.byteLength,
+			exitCode: output.exitCode,
+		};
+	}
+}
+```
+</TypeScriptExample>
+
+## Set the process context
+
+Use `cwd`, `env`, and `user` to set the process context. The process inherits the Container environment set by `envVars`. Per-execution `env` values add variables or override matching keys.
+
+This example uses `sh` because it needs expansion and redirection. It also captures standard output and standard error separately.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	envVars = {
+		BASE_VALUE: "inherited",
+		MODE: "default",
+	};
+
+	async inspectWorkspace() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec(
+			[
+				"sh",
+				"-c",
+				'printf "%s:%s:%s:%s" "$PWD" "$BASE_VALUE" "$MODE" "$EXTRA_VALUE"; printf "diagnostic" >&2',
+			],
+			{
+				cwd: "/workspace",
+				env: {
+					MODE: "inspection",
+					EXTRA_VALUE: "added",
+				},
+			},
+		);
+		const output = await process.output();
+		const decoder = new TextDecoder();
+
+		return {
+			stdout: decoder.decode(output.stdout),
+			stderr: decoder.decode(output.stderr),
+		};
+	}
+}
+```
+</TypeScriptExample>
+
+The `user` option sets the user name or numeric user ID (UID) for the process. The Container runtime resolves user names from the container image.
+
+## Combine standard error
+
+Set `stderr` to `"combined"` to merge standard error into standard output. Combined output requires `stdout: "pipe"`.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async readCombinedOutput() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec(
+			[
+				"bash",
+				"-lc",
+				'printf "standard output\n"; printf "standard error\n" >&2',
+			],
+			{
+				stdout: "pipe",
+				stderr: "combined",
+			},
+		);
+		const output = await process.output();
+
+		return new TextDecoder().decode(output.stdout);
+	}
+}
+```
+</TypeScriptExample>
+
+The merged stream does not guarantee ordering between source streams. In this mode, `process.stderr` is `null`, and `output.stderr` is an empty `ArrayBuffer`. This example assumes Bash exists in the image.
+
+## Handle nonzero exits
+
+A nonzero exit code resolves `exitCode` normally. It does not reject the promise.
+
+This example preserves standard error while ignoring standard output:
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async runCheck() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+	const process = await this.ctx.container.exec(
+		[
+			"sh",
+			"-c",
+			'printf "not captured"; printf "check failed\n" >&2; exit 7',
+		],
+		{ stdout: "ignore" },
+	);
+	const output = await process.output();
+
+	return {
+		exitCode: output.exitCode,
+		stdoutBytes: output.stdout.byteLength,
+		stderr: new TextDecoder().decode(output.stderr),
+	};
+    }
+
+}
+
+```
+</TypeScriptExample>
+
+The result contains exit code `7` and the standard error text. Its ignored standard output buffer has zero bytes.
+
+## Stream large output
+
+`output()` buffers both streams in memory. For large output, drain `stdout` and `stderr` concurrently instead.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+async function countBytes(stream: ReadableStream<Uint8Array> | null) {
+	if (!stream) {
+		return 0;
+	}
+
+	let bytes = 0;
+	for await (const chunk of stream) {
+		bytes += chunk.byteLength;
+	}
+	return bytes;
+}
+
+export class MyContainer extends Container {
+	async generateLargeOutput() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec([
+			"sh",
+			"-c",
+			'i=0; while [ "$i" -lt 100000 ]; do printf "output %s\n" "$i"; printf "error %s\n" "$i" >&2; i=$((i + 1)); done',
+		]);
+
+		const [stdoutBytes, stderrBytes, exitCode] = await Promise.all([
+			countBytes(process.stdout),
+			countBytes(process.stderr),
+			process.exitCode,
+		]);
+
+		return { stdoutBytes, stderrBytes, exitCode };
+	}
+}
+```
+</TypeScriptExample>
+
+Streaming and `output()` are alternative consumption methods. `output()` throws a `TypeError` if either stream has started being consumed. A second call to `output()` also throws a `TypeError`.
+
+### Return standard output over RPC
+
+Return a `ReadableStream` from an RPC method to stream output to the calling Worker. Combining standard error provides one stream for both output channels.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async streamCommandOutput(): Promise<ReadableStream<Uint8Array>> {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+	const process = await this.ctx.container.exec(
+		["sh", "-c", 'printf "starting\n"; run-report'],
+		{ stderr: "combined" },
+	);
+
+	return process.stdout!;
+    }
+
+}
+
+```
+</TypeScriptExample>
+
+RPC transfers ownership of the stream to the caller and preserves flow control. The caller must consume or cancel the stream. If the caller stops reading, backpressure can pause a process that continues writing.
+
+This method transfers output, not the `ExecProcess` handle. Define a separate application protocol when the caller needs completion metadata or process control.
+
+## Stop a process
+
+`exec()` has no built-in timeout. You can request termination after a delay with `kill()` and then await `exitCode`.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async runWithTimeout() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec(["sleep", "120"]);
+		const timer = setTimeout(() => process.kill(), 30_000);
+
+		try {
+			return await process.exitCode;
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+}
+```
+</TypeScriptExample>
+
+Calling `kill()` without an argument queues a `SIGTERM`, signal `15`. You can pass another signal when the process requires it. A process can handle or ignore a signal, so this is not a hard execution deadline. Observe completion through `exitCode`, and do not infer a specific exit code from a signal.
+
+## Coordinate operations
+
+Place `exec()` calls in the Durable Object that controls the Container. The Durable Object can coordinate process state and Container lifecycle.
+
+One application RPC method can perform multiple `exec()` operations. Each command remains a separate exec operation, but the caller makes one Durable Object RPC call. This reduces caller-to-Durable Object round trips while keeping lifecycle decisions together.
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async runDiagnostics() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const commands = [
+			["uname", "-a"],
+			["node", "--version"],
+		];
+		const decoder = new TextDecoder();
+		const results = [];
+
+		for (const command of commands) {
+			const process = await this.ctx.container.exec(command);
+			const output = await process.output();
+			results.push({
+				command,
+				exitCode: output.exitCode,
+				stdout: decoder.decode(output.stdout),
+				stderr: decoder.decode(output.stderr),
+			});
+		}
+
+		return results;
+	}
+}
+```
+</TypeScriptExample>
+
+For all fields and return types, refer to the [`exec()` API contract](/durable-objects/api/container/#exec).

--- a/src/content/docs/durable-objects/api/container.mdx
+++ b/src/content/docs/durable-objects/api/container.mdx
@@ -82,6 +82,87 @@ this.ctx.container.start({
 
 - None.
 
+### `exec`
+
+`exec` starts another process inside an already-running Container. It does not start a stopped Container.
+
+The following example calls `this.ctx.container.exec()` inside a class extending `Container` from `@cloudflare/containers`. In RPC methods, check `this.ctx.container.running` and call `await this.start()` when needed. You can also use the `onStart()` hook to run any series of commands whenever the Container starts.
+
+```ts
+exec(
+  cmd: string[],
+  options?: ContainerExecOptions,
+): Promise<ExecProcess>
+```
+
+The `exec` operation starts the executable directly with the provided arguments. It does not start a shell or interpret pipes, redirects, expansion, or other shell syntax. Invoke Bash explicitly with `["bash", "-lc", "<COMMAND>"]` when Bash exists in the image. Use `["sh", "-c", "<COMMAND>"]` for images with only a Portable Operating System Interface (POSIX) shell.
+
+The following RPC method starts the Container before executing a command:
+
+<TypeScriptExample>
+```ts
+import { Container } from "@cloudflare/containers";
+
+export class MyContainer extends Container {
+	async runCommand() {
+		if (!this.ctx.container.running) {
+			await this.start();
+		}
+
+		const process = await this.ctx.container.exec(["node", "--version"]);
+		const output = await process.output();
+
+		return {
+			pid: process.pid,
+			exitCode: output.exitCode,
+			stdout: new TextDecoder().decode(output.stdout),
+		};
+	}
+}
+```
+</TypeScriptExample>
+
+#### Parameters
+
+- `cmd` (`string[]`) — executable followed by its arguments.
+- `options` (`ContainerExecOptions`, optional) — process configuration:
+  - `stdin` (`ReadableStream | "pipe"`) — source for standard input. Use `"pipe"` to write through the returned `stdin` stream. When omitted, standard input closes and sends end-of-file (EOF).
+  - `stdout` (`"pipe" | "ignore"`, default `"pipe"`) — captures or discards standard output.
+  - `stderr` (`"pipe" | "ignore" | "combined"`, default `"pipe"`) — captures, discards, or merges standard error into standard output. The `"combined"` value requires `stdout: "pipe"`. Combined output does not guarantee ordering between its source streams.
+  - `cwd` (`string`) — working directory for the process.
+  - `env` (`Record<string, string>`) — environment additions and overrides. The process inherits existing Container variables. Matching keys use the per-execution value.
+  - `user` (`string`) — image user for the process.
+
+#### Return values
+
+Returns `Promise<ExecProcess>`.
+
+An `ExecProcess` has these fields and methods:
+
+- `stdin` (`WritableStream | null`) — writable standard input when `stdin` is `"pipe"`.
+- `stdout` (`ReadableStream | null`) — readable standard output when piped.
+- `stderr` (`ReadableStream | null`) — readable standard error when piped separately.
+- `pid` (`number`) — process identifier.
+- `exitCode` (`Promise<number>`) — resolves when the process exits. Nonzero codes resolve normally instead of rejecting.
+- `output()` (`Promise<ExecOutput>`) — reads buffered output once. `ExecOutput` contains `stdout` (`ArrayBuffer`), `stderr` (`ArrayBuffer`), and `exitCode` (`number`). Ignored streams produce empty buffers. Use `TextDecoder` to decode text.
+- `kill(signal?: number)` (`void`) — queues a signal for the process. The default is `SIGTERM`, signal `15`. The signal must be from `1` through `64`.
+
+With `stderr: "combined"`, `stderr` is `null` on `ExecProcess` and an empty `ArrayBuffer` on `ExecOutput`. Read both output channels from `stdout`.
+
+`output()` throws a `TypeError` when called more than once or after either readable stream starts being consumed. For large output, consume both readable streams concurrently instead of buffering them with `output()`.
+
+`exec` has no built-in timeout. Use `kill()` to request termination, then observe completion through `exitCode`. A process can handle or ignore a signal, so this does not enforce a hard deadline. Do not infer a specific exit code from the signal.
+
+#### Exceptions
+
+- `exec()` throws when the Container is not running.
+- `exec()` throws a `TypeError` when `cmd` is empty, an option mode is invalid, or `stderr: "combined"` is used with `stdout: "ignore"`.
+- `exec()` rejects if the runtime cannot create or start the process.
+- Environment variable names cannot contain `=` or null characters. Environment values, `cwd`, and `user` cannot contain null characters.
+- `kill()` throws a `RangeError` when the signal is outside the supported range.
+
+For task-oriented examples, refer to [Execute commands](/containers/execute-commands/).
+
 ### `destroy`
 
 `destroy` stops the container and optionally returns a custom error message to the `monitor()` error callback.


### PR DESCRIPTION
### Summary

We are adding a new set of docs for the newly added container.exec() method under the Durable Object Containers umbrella.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
