### PR TITLE
[AI Gateway] Remove account-level spend limit mentions

### DIFF
--- a/src/content/docs/ai-gateway/features/spend-limits.mdx
+++ b/src/content/docs/ai-gateway/features/spend-limits.mdx
@@ -15,10 +15,6 @@ Unlike [rate limiting](/ai-gateway/features/rate-limiting/), which caps the numb
 
 Spend limits apply to both [Unified Billing](/ai-gateway/features/unified-billing/) requests and [BYOK](/ai-gateway/configuration/bring-your-own-keys/) requests for models with known pricing.
 
-:::note
-Unified Billing also has an account-level [spend limit](/ai-gateway/features/unified-billing/#spend-limits) on your loaded credits that applies across all gateways, but only to Unified Billing requests. Both limits are enforced independently — whichever one is reached first will block requests.
-:::
-
 ![Spend limits rules configured on a gateway](~/assets/images/ai-gateway/spend-limits-rules.png)
 
 ## How it works

--- a/src/content/docs/ai-gateway/features/unified-billing.mdx
+++ b/src/content/docs/ai-gateway/features/unified-billing.mdx
@@ -114,12 +114,7 @@ The HTTP API supports the following providers:
 
 ### Spend limits
 
-You can set spend limits at two levels:
-
-- **Account-level** — Set a spend limit on your loaded credits on this page to cap total Unified Billing spend across all gateways.
-- **Per-gateway** — Set [granular spend limit rules](/ai-gateway/features/spend-limits/) on individual gateways, scoped by model, provider, or custom metadata dimensions like user or team.
-
-Both limits are enforced independently. Whichever one is reached first will block requests.
+Set [spend limit rules](/ai-gateway/features/spend-limits/) on individual gateways to cap spend, scoped by model, provider, or custom metadata dimensions like user or team.
 
 ### Zero Data Retention (ZDR)
 

--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -271,6 +271,6 @@ For more details on these options, refer to [Request handling](/ai-gateway/confi
 
 ## Related resources
 
-- [Unified Billing](/ai-gateway/features/unified-billing/) — load credits and manage spend limits.
+- [Unified Billing](/ai-gateway/features/unified-billing/) — load credits and pay for inference requests with a single Cloudflare bill.
 - [Workers AI binding](/ai-gateway/usage/worker-binding-methods/) — call models from within a Cloudflare Worker using `env.AI.run()`.
 - [Model catalog](/ai/models/) — browse models supported by the REST API.


### PR DESCRIPTION
Deprecate account-level spend limits on Unified Billing credits in favor of more granular per-gateway spend limit rules remain the only spend limit mechanism.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
