### PR TITLE
Update react-router docs for its new v8 version

### DIFF
--- a/src/content/docs/workers/development-testing/wrangler-vs-vite.mdx
+++ b/src/content/docs/workers/development-testing/wrangler-vs-vite.mdx
@@ -31,8 +31,8 @@ Use the [Vite plugin](/workers/vite-plugin/) for:
 - **Frontend-centric development:**
   If you already use Vite with modern frontend frameworks like React, Vue, Svelte, or Solid, the Vite plugin integrates into your development workflow.
 
-- **React Router v7:**
-  If you are using [React Router v7](https://reactrouter.com/) (the successor to Remix), it is officially supported by the Vite plugin as a full-stack SSR framework.
+- **React Router v8:**
+  If you are using [React Router v8](https://reactrouter.com/) (the successor to Remix), it is officially supported by the Vite plugin as a full-stack SSR framework.
 
 - **Rapid iteration (HMR):**
   If you need near-instant updates in the browser, the Vite plugin provides [Hot Module Replacement (HMR)](https://vite.dev/guide/features.html#hot-module-replacement) during local development.

--- a/src/content/docs/workers/framework-guides/web-apps/react-router.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/react-router.mdx
@@ -90,7 +90,7 @@ It combines with the [Cloudflare Vite plugin](/workers/vite-plugin/) to provide 
         	- wrangler.jsonc
         </FileTree>
 
-        `react-router.config.ts` is your [React Router config file](https://reactrouter.com/explanation/special-files#react-routerconfigts).
+        `react-router.config.ts` is your [React Router config file](https://reactrouter.com/api/framework-conventions/react-router.config.ts).
         In this file:
         	- `ssr` is set to `true`, meaning that your application will use server-side rendering.
 

--- a/src/content/docs/workers/framework-guides/web-apps/react-router.mdx
+++ b/src/content/docs/workers/framework-guides/web-apps/react-router.mdx
@@ -19,7 +19,7 @@ import {
 	WranglerConfig,
 } from "~/components";
 
-**Start from CLI**: Scaffold a full-stack app with [React Router v7](https://reactrouter.com/) and the [Cloudflare Vite plugin](/workers/vite-plugin/) for lightning-fast development.
+**Start from CLI**: Scaffold a full-stack app with [React Router v8](https://reactrouter.com/) and the [Cloudflare Vite plugin](/workers/vite-plugin/) for lightning-fast development.
 
 <PackageManagers
 	type="create"
@@ -27,7 +27,7 @@ import {
 	args="my-react-router-app --framework=react-router"
 />
 
-**Or just deploy**: Create a full-stack app using React Router v7, with CI/CD and previews all set up for you.
+**Or just deploy**: Create a full-stack app using React Router v8, with CI/CD and previews all set up for you.
 
 [![Deploy to Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/react-router-starter-template)
 
@@ -56,7 +56,7 @@ Learn more about [automatic project configuration](/workers/framework-guides/aut
 
 ## What is React Router?
 
-[React Router v7](https://reactrouter.com/) is a full-stack React framework for building web applications.
+[React Router v8](https://reactrouter.com/) is a full-stack React framework for building web applications.
 It combines with the [Cloudflare Vite plugin](/workers/vite-plugin/) to provide a first-class experience for developing, building and deploying your apps on Cloudflare.
 
 ## Creating a full-stack React Router app
@@ -93,7 +93,6 @@ It combines with the [Cloudflare Vite plugin](/workers/vite-plugin/) to provide 
         `react-router.config.ts` is your [React Router config file](https://reactrouter.com/explanation/special-files#react-routerconfigts).
         In this file:
         	- `ssr` is set to `true`, meaning that your application will use server-side rendering.
-        	- `future.v8_viteEnvironmentApi` is set to `true` to enable compatibility with the [Cloudflare Vite plugin](/workers/vite-plugin/).
 
 
         `vite.config.ts` is your [Vite config file](https://vite.dev/config/).

--- a/src/content/docs/workers/vite-plugin/index.mdx
+++ b/src/content/docs/workers/vite-plugin/index.mdx
@@ -16,14 +16,14 @@ Your Worker code runs inside [workerd](https://github.com/cloudflare/workerd), m
 - Uses the Vite [Environment API](https://vite.dev/guide/api-environment) to integrate Vite with the Workers runtime
 - Provides direct access to [Workers runtime APIs](/workers/runtime-apis/) and [bindings](/workers/runtime-apis/bindings/)
 - Builds your front-end assets for deployment to Cloudflare, enabling you to build static sites, SPAs, and full-stack applications
-- Official support for [TanStack Start](https://tanstack.com/start/) and [React Router v7](https://reactrouter.com/) with server-side rendering
+- Official support for [TanStack Start](https://tanstack.com/start/) and [React Router v8](https://reactrouter.com/) with server-side rendering
 - Leverages Vite's hot module replacement for consistently fast updates
 - Supports `vite preview` for previewing your build output in the Workers runtime prior to deployment
 
 ## Use cases
 
 - [TanStack Start](https://tanstack.com/start/)
-- [React Router v7](https://reactrouter.com/)
+- [React Router v8](https://reactrouter.com/)
 - Static sites, such as single-page applications, with or without an integrated backend API
 - Standalone Workers
 - Multi-Worker applications

--- a/src/content/docs/workers/vite-plugin/reference/vite-environments.mdx
+++ b/src/content/docs/workers/vite-plugin/reference/vite-environments.mdx
@@ -67,7 +67,7 @@ The default behavior of using the Worker name as the environment name is appropr
 
 ## Full-stack frameworks
 
-If you are using the Cloudflare Vite plugin with [TanStack Start](https://tanstack.com/start/) or [React Router v7](https://reactrouter.com/), then your Worker is used for server-side rendering and tightly integrated with the framework.
+If you are using the Cloudflare Vite plugin with [TanStack Start](https://tanstack.com/start/) or [React Router v8](https://reactrouter.com/), then your Worker is used for server-side rendering and tightly integrated with the framework.
 To support this, you should assign it to the `ssr` environment by setting `viteEnvironment.name` in the plugin config.
 
 ```ts title="vite.config.ts"


### PR DESCRIPTION
React-router v8 has been released (https://remix.run/blog/react-router-v8), this PR is updating our docs accordingly