### PR TITLE
docs: fix typo

### DIFF
--- a/src/content/docs/workers/runtime-apis/fetch.mdx
+++ b/src/content/docs/workers/runtime-apis/fetch.mdx
@@ -87,7 +87,7 @@ class Default(WorkerEntrypoint):
       _ For all requests this forwards the `Pragma: no-cache` and `Cache-Control: no-cache` headers to the origin.
       _ For `no-store`, requests to origins not hosted by Cloudflare bypass the use of Cloudflare's caches.
       \_ For `no-cache`, requests to origins not hosted by Cloudflare are forced to revalidate with
-      the origin before resonding.
+      the origin before responding.
   - An object that defines the content and behavior of the request.
 
 ---


### PR DESCRIPTION
### Summary

The word responding is misspelled.

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
