### PR TITLE
[Workers AI] Map "pruna" author to Pruna AI in model catalog

### DIFF
--- a/src/components/models/data.ts
+++ b/src/components/models/data.ts
@@ -190,7 +190,7 @@ export const authorData: Record<string, { name: string; logo: string }> = {
 		logo: prunaai.src,
 	},
 	prunaai: {
-		name: "PrunaAI",
+		name: "Pruna AI",
 		logo: prunaai.src,
 	},
 	qwen: {

--- a/src/components/models/data.ts
+++ b/src/components/models/data.ts
@@ -185,6 +185,10 @@ export const authorData: Record<string, { name: string; logo: string }> = {
 		name: "PixVerse",
 		logo: pixverse.src,
 	},
+	pruna: {
+		name: "Pruna AI",
+		logo: prunaai.src,
+	},
 	prunaai: {
 		name: "PrunaAI",
 		logo: prunaai.src,


### PR DESCRIPTION
### Summary

Fixes the Pruna AI model pages on the Workers AI model catalog so they render the Pruna logo and display name instead of falling back to a lowercase "p" letter placeholder.

**Before:**
- Pages render a `p` letter avatar (gray box) and subtitle "Text-to-Video • pruna"
- Affected pages:
  - https://developers.cloudflare.com/ai/models/pruna/p-image/
  - https://developers.cloudflare.com/ai/models/pruna/p-image-edit/
  - https://developers.cloudflare.com/ai/models/pruna/p-image-try-on/
  - https://developers.cloudflare.com/ai/models/pruna/p-image-upscale/
  - https://developers.cloudflare.com/ai/models/pruna/p-video/
  - https://developers.cloudflare.com/ai/models/pruna/p-video-animate/
  - https://developers.cloudflare.com/ai/models/pruna/p-video-avatar/
  - https://developers.cloudflare.com/ai/models/pruna/p-video-replace/
- The catalog grid on https://developers.cloudflare.com/ai/models/ shows the same fallback for each Pruna card.

**Cause:**
- Every `pruna/p-*.json` catalog file in `src/content/catalog-models/` declares `model_id: "pruna/…"`.
- `getModelAuthor()` in `src/util/model-helpers.ts` extracts the first path segment → `"pruna"`.
- `authorData` in `src/components/models/data.ts` had a `prunaai` key but no `pruna` key, so the lookup misses and both `ModelDetailPage.astro` and `ModelCatalog.tsx` hit their letter-fallback branches.

**Fix:** Two changes to `authorData` in `src/components/models/data.ts`:

1. **Add a new `pruna` entry** with display name `"Pruna AI"`, reusing the existing `prunaai.svg` asset (same dual-key shape as `meta`/`meta-llama` and `mistral`/`mistralai`).
2. **Normalize the pre-existing `prunaai` entry** display name from `"PrunaAI"` (no space) to `"Pruna AI"` (with space) so both sibling keys share the same display name. Addresses unanimous reviewer feedback (Copilot inline at line 192-194, ask-bonk LLM review). Aligns with the in-file convention: `meta`/`meta-llama` both `"Meta"`, `mistral`/`mistralai` both `"MistralAI"`, `zai`/`zai-org` both `"Zhipu AI"`.

No new SVG or import added — reuses the existing `prunaai.svg` at `src/assets/images/workers-ai/prunaai.svg`.

Display name `"Pruna AI"` matches Pruna's own branding on https://www.pruna.ai/ and the in-file convention for other space-separated AI brands (`Kling AI`, `Moonshot AI`, `Resemble AI`, `Zhipu AI`).

The `prunaai` normalization has zero user-visible impact today: no current catalog or workers-ai model declares `model_id` starting with `prunaai/` or `@cf/prunaai/`, so `authorData["prunaai"]` is never consulted at runtime. The change is defensive future-proofing aligned with the existing dual-key precedent.

### Verification

- `pnpm exec astro check` → 0 errors, 0 warnings (the 4 hints are pre-existing in unrelated files).
- `pnpm exec prettier --check` → clean.
- `pnpm exec eslint` → clean.
- `pnpm exec vitest --project=Node` → 45 tests pass.
- Live preview deploy renders correctly on all 8 Pruna pages + catalog grid + author filter; zero remaining `PrunaAI` (no-space) substrings in served HTML.

### Documentation checklist

- [ ] N/A — code change in `src/components/`; no docs content, renames, or redirects touched.