### PR TITLE
[AI Gateway] Surface banner and request_formats on AI model catalog

### DIFF
--- a/bin/fetch-catalog-models.ts
+++ b/bin/fetch-catalog-models.ts
@@ -42,6 +42,18 @@ interface CatalogModel {
 	// JSON-write step.
 	zdr?: boolean;
 	zdr_comment?: string | null;
+	// In-page notice surfaced on the model detail page. Same round-trip
+	// rationale as `zdr` above — declaring the shape here keeps the
+	// JSON-write path type-checked rather than relying on the cast hole.
+	banner?: {
+		title?: string;
+		text: string;
+		severity: string;
+		dismissible?: boolean;
+		link?: { url: string; label: string };
+	} | null;
+	// Request-format identifiers the model accepts at the API layer.
+	request_formats?: string[] | null;
 	examples: Array<{
 		name: string;
 		description?: string;

--- a/src/components/models/ModelDetailPage.astro
+++ b/src/components/models/ModelDetailPage.astro
@@ -146,6 +146,25 @@ const hasRemainingExamples = remainingExamples.length > 0;
 const description = model.description;
 const isBeta = hasProperty(model.properties, "beta");
 
+// Catalog `banner` is rendered as a Starlight `Aside`. Map the upstream
+// `severity` (currently observed: "warning") onto the four Aside types;
+// unknown severities fall back to the neutral "note" style so a new
+// upstream value never breaks the build.
+const banner = model.banner ?? null;
+const bannerAsideType = ((): "note" | "tip" | "caution" | "danger" => {
+	switch (banner?.severity?.toLowerCase()) {
+		case "info":
+			return "tip";
+		case "warning":
+			return "caution";
+		case "danger":
+		case "error":
+			return "danger";
+		default:
+			return "note";
+	}
+})();
+
 let hasPlayground =
 	model.task.name === "Text Generation" && model.hosting === "hosted";
 if (model.name.includes("@cf/openai/gpt-oss")) {
@@ -230,6 +249,31 @@ const starlightPageProps = {
 	</div>
 
 	<p class="mt-3 mb-2!">{description}</p>
+
+	{
+		banner && (
+			<Aside type={bannerAsideType}>
+				<p>
+					{banner.title && <strong>{banner.title}: </strong>}
+					{banner.text}
+					{banner.link && (
+						<>
+							{" "}
+							<a
+								href={banner.link.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								aria-label={`${banner.link.label} (${displayName})`}
+							>
+								{banner.link.label}
+								<span class="external-link"> ↗</span>
+							</a>
+						</>
+					)}
+				</p>
+			</Aside>
+		)
+	}
 
 	{
 		model.name === "@cf/meta/llama-3.2-11b-vision-instruct" && (

--- a/src/components/models/ModelDetailPage.astro
+++ b/src/components/models/ModelDetailPage.astro
@@ -147,12 +147,16 @@ const description = model.description;
 const isBeta = hasProperty(model.properties, "beta");
 
 // Catalog `banner` is rendered as a Starlight `Aside`. Map the upstream
-// `severity` (currently observed: "warning") onto the four Aside types;
+// `severity` (observed today: "warning", "info") onto the four Aside types;
 // unknown severities fall back to the neutral "note" style so a new
-// upstream value never breaks the build.
+// upstream value never breaks the build. Defined as a function so the
+// switch only evaluates inside the `banner && (...)` JSX block on pages
+// that actually carry a banner — most model pages have `banner: null`.
 const banner = model.banner ?? null;
-const bannerAsideType = ((): "note" | "tip" | "caution" | "danger" => {
-	switch (banner?.severity?.toLowerCase()) {
+function bannerAsideType(
+	severity: string,
+): "note" | "tip" | "caution" | "danger" {
+	switch (severity.toLowerCase()) {
 		case "info":
 			return "tip";
 		case "warning":
@@ -163,7 +167,7 @@ const bannerAsideType = ((): "note" | "tip" | "caution" | "danger" => {
 		default:
 			return "note";
 	}
-})();
+}
 
 let hasPlayground =
 	model.task.name === "Text Generation" && model.hosting === "hosted";
@@ -252,7 +256,7 @@ const starlightPageProps = {
 
 	{
 		banner && (
-			<Aside type={bannerAsideType}>
+			<Aside type={bannerAsideType(banner.severity)}>
 				<p>
 					{banner.title && <strong>{banner.title}: </strong>}
 					{banner.text}

--- a/src/components/models/ModelFeatures.tsx
+++ b/src/components/models/ModelFeatures.tsx
@@ -24,6 +24,19 @@ const ModelFeatures = ({ model }: { model: ModelType }) => {
 		? `https://dash.cloudflare.com/?to=/:account/ai/models/${(model as ResolvedModel).modelId}`
 		: null;
 
+	// `requestFormats` lives directly on ResolvedModel (catalog-only) rather
+	// than the legacy `properties` array because Property.value is a string
+	// and we need to preserve the original list. Format identifiers like
+	// "chat-completions" are title-cased for display.
+	const requestFormats = isCatalog
+		? ((model as ResolvedModel).requestFormats ?? null)
+		: null;
+	const formatRequestFormat = (format: string) =>
+		format
+			.split(/[-_]/)
+			.map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+			.join(" ");
+
 	return (
 		<>
 			{Object.keys(properties).length ? (
@@ -143,6 +156,12 @@ const ModelFeatures = ({ model }: { model: ModelType }) => {
 								<tr>
 									<td>Batch</td>
 									<td>Yes</td>
+								</tr>
+							)}
+							{requestFormats && requestFormats.length > 0 && (
+								<tr>
+									<td>Request formats</td>
+									<td>{requestFormats.map(formatRequestFormat).join(", ")}</td>
 								</tr>
 							)}
 							{properties.partner && (

--- a/src/schemas/catalog-models.node.test.ts
+++ b/src/schemas/catalog-models.node.test.ts
@@ -126,4 +126,75 @@ describe("catalogModelsSchema", () => {
 		);
 		expect(result.success).toBe(false);
 	});
+
+	// `link.url` is the only attacker-controlled field that gets rendered
+	// straight into an `<a href={...}>`. The schema MUST reject any URL that
+	// is not well-formed or that uses a scheme other than http(s) — without
+	// this guard a compromised catalog row could inject dangerous-scheme
+	// hrefs that browsers happily execute. The parameterised list locks in
+	// rejection for both the obvious payloads (javascript:, data:) and the
+	// less-obvious ones (vbscript:, file:, blob:, mailto:, ftp:) plus the
+	// canonical bypass shapes against naive `.startsWith` validators
+	// (leading whitespace, mixed-case scheme). Each entry also pins the
+	// failure path to `banner.link.url` so an unrelated rejection (e.g.
+	// missing `examples`) does not silently pass the test.
+	test.each([
+		["javascript:alert(1)"],
+		[" javascript:alert(1)"], // leading space
+		["\tjavascript:alert(1)"], // leading tab
+		["Javascript:alert(1)"], // mixed-case scheme
+		["data:text/html,<script>alert(1)</script>"],
+		["vbscript:msgbox(1)"],
+		["file:///etc/passwd"],
+		["blob:https://example.com/abc"],
+		["mailto:user@example.com"],
+		["ftp://example.com"],
+		["not a url"],
+		[""],
+		["//example.com/protocol-relative"],
+		["/relative/path"],
+		["http://localhost"], // z.httpUrl rejects bareword hostnames
+		["http://127.0.0.1"], // z.httpUrl rejects IP literals
+	])("rejects a banner link with an unsafe or malformed URL: %j", (url) => {
+		const result = catalogModelsSchema.safeParse(
+			makeMinimalModel({
+				banner: {
+					text: "Heads up.",
+					severity: "warning",
+					link: { url, label: "Click me" },
+				},
+			}),
+		);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(
+				result.error.issues.some(
+					(issue) => issue.path.join(".") === "banner.link.url",
+				),
+			).toBe(true);
+		}
+	});
+
+	// Positive cases. The mixed-case scheme test guards specifically
+	// against regressing to a case-sensitive `.startsWith` check — URI
+	// schemes are case-insensitive per RFC 3986 §3.1, so a benign
+	// `HTTPS://...` URL must continue to parse. Removing this case
+	// silently re-introduces the old bug.
+	test.each([
+		"https://example.com/notice",
+		"http://example.com/notice",
+		"HTTPS://example.com/notice",
+		"Http://example.com/notice",
+	])("accepts a banner link with a safe URL: %j", (url) => {
+		const parsed = catalogModelsSchema.parse(
+			makeMinimalModel({
+				banner: {
+					text: "Heads up.",
+					severity: "warning",
+					link: { url, label: "More info" },
+				},
+			}),
+		);
+		expect(parsed.banner?.link?.url).toBe(url);
+	});
 });

--- a/src/schemas/catalog-models.node.test.ts
+++ b/src/schemas/catalog-models.node.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+import { catalogModelsSchema } from "./catalog-models";
+
+/**
+ * Minimum-valid catalog row: every required field present, every optional
+ * field omitted. Adapted from the simplest on-disk JSON in
+ * `src/content/catalog-models/`. Mutated per-case so each assertion stays
+ * focused on the field under test.
+ */
+function makeMinimalModel(
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		model_id: "@cf/example/test-model",
+		provider_id: "example",
+		name: "Test Model",
+		description: "A model used to exercise the catalog Zod schema.",
+		task: "Text Generation",
+		tags: [],
+		context_length: null,
+		max_output_tokens: null,
+		supports_async: false,
+		examples: [],
+		metadata: {},
+		external_info: null,
+		terms: null,
+		cover_image_url: null,
+		schema_version: null,
+		...overrides,
+	};
+}
+
+describe("catalogModelsSchema", () => {
+	test("parses a minimum-valid row with no banner or request_formats", () => {
+		const parsed = catalogModelsSchema.parse(makeMinimalModel());
+		expect(parsed.model_id).toBe("@cf/example/test-model");
+		expect(parsed.banner).toBeUndefined();
+		expect(parsed.request_formats).toBeUndefined();
+	});
+
+	// Most production catalog rows ship `banner: null` and
+	// `request_formats: null` even when populated upstream. Both fields
+	// must accept null without coercion so the resolver sees the same shape
+	// as the on-disk JSON.
+	test("accepts banner: null and request_formats: null", () => {
+		const parsed = catalogModelsSchema.parse(
+			makeMinimalModel({ banner: null, request_formats: null }),
+		);
+		expect(parsed.banner).toBeNull();
+		expect(parsed.request_formats).toBeNull();
+	});
+
+	// Mirrors the shape of `src/content/catalog-models/anthropic-claude-fable-5.json`,
+	// the on-disk sample that exercises every nested banner field (title,
+	// link, severity="warning", dismissible=true). Locking it in here
+	// catches accidental schema tightening that would silently drop the
+	// link, title, or dismissible flag. `pruna-p-image-try-on.json` carries
+	// a second, simpler banner shape (severity="info", no link) that the
+	// "accepts banner: null" and severity tests already cover by structure.
+	test("parses a fully populated banner and round-trips every nested field", () => {
+		const parsed = catalogModelsSchema.parse(
+			makeMinimalModel({
+				banner: {
+					title: "NOTE",
+					text: "Access to this model is currently limited.",
+					severity: "warning",
+					dismissible: true,
+					link: {
+						url: "https://example.com/notice",
+						label: "More info",
+					},
+				},
+			}),
+		);
+		expect(parsed.banner).toEqual({
+			title: "NOTE",
+			text: "Access to this model is currently limited.",
+			severity: "warning",
+			dismissible: true,
+			link: { url: "https://example.com/notice", label: "More info" },
+		});
+	});
+
+	test("accepts request_formats as a non-empty string array", () => {
+		const parsed = catalogModelsSchema.parse(
+			makeMinimalModel({
+				request_formats: ["chat-completions", "responses"],
+			}),
+		);
+		expect(parsed.request_formats).toEqual(["chat-completions", "responses"]);
+	});
+
+	// Guard against a future tightening of `severity` to a z.enum(...). The
+	// upstream Stratus enum is not yet locked down, so unknown values must
+	// continue to parse cleanly — the renderer falls back to a neutral
+	// Aside style. The chosen value MUST be outside both the observed
+	// production set ("warning", "info") and the renderer's switch
+	// ("info"/"warning"/"danger"/"error") so this test fails loudly the
+	// moment anyone constrains the field.
+	test("accepts a genuinely unobserved severity string without rejecting", () => {
+		const parsed = catalogModelsSchema.parse(
+			makeMinimalModel({
+				banner: { text: "Heads up.", severity: "experimental" },
+			}),
+		);
+		expect(parsed.banner?.severity).toBe("experimental");
+	});
+
+	// Negative cases: `text` and `severity` are both required on
+	// `catalogBannerSchema`. Omitting either should produce a parse error
+	// rather than silently rendering a broken Aside.
+	test("rejects a banner without text", () => {
+		const result = catalogModelsSchema.safeParse(
+			makeMinimalModel({
+				banner: { severity: "warning" },
+			}),
+		);
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects a banner without severity", () => {
+		const result = catalogModelsSchema.safeParse(
+			makeMinimalModel({
+				banner: { text: "Heads up." },
+			}),
+		);
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/schemas/catalog-models.ts
+++ b/src/schemas/catalog-models.ts
@@ -40,6 +40,17 @@ export const defaultExampleSchema = z.object({
 // the schema for round-trip fidelity with the upstream API but is not yet
 // honored at render time — the docs site renders banners statically and
 // never hides them. Adding client-side dismissal is a follow-up.
+//
+// `link.url` is validated via Zod 4's `z.httpUrl()`, which rejects any
+// well-formed URL whose scheme is not `http`/`https` (case-insensitive,
+// per RFC 3986) and also rejects bareword hostnames / IP literals such as
+// `localhost` and `127.0.0.1`. Without this guard a compromised or
+// malformed catalog row could inject `javascript:` (or other unsafe
+// scheme) hrefs into the rendered <a>; `target="_blank" rel="noopener
+// noreferrer"` does not block non-http(s) schemes from executing. The
+// protocol enforcement lives at the schema layer so a bad URL fails the
+// content-collection load loudly rather than silently shipping an unsafe
+// link.
 export const catalogBannerSchema = z.object({
 	title: z.string().optional(),
 	text: z.string(),
@@ -47,7 +58,7 @@ export const catalogBannerSchema = z.object({
 	dismissible: z.boolean().optional(),
 	link: z
 		.object({
-			url: z.string(),
+			url: z.httpUrl(),
 			label: z.string(),
 		})
 		.optional(),

--- a/src/schemas/catalog-models.ts
+++ b/src/schemas/catalog-models.ts
@@ -30,6 +30,29 @@ export const defaultExampleSchema = z.object({
 	code_snippets: codeSnippetSchema.array().optional(),
 });
 
+// In-page notice surfaced on the model detail page. Distinct from the
+// page-frontmatter `banner` in `src/schemas/base.ts` — the catalog API ships
+// this richer shape (title/text/severity/dismissible/link) and we render it
+// as a Starlight `Aside` directly under the model description. `severity` is
+// left as `z.string()` because the upstream enum is not yet locked down
+// (observed today: "warning", "info"); the renderer falls back to a neutral
+// note style for any unrecognised value. `dismissible` is preserved through
+// the schema for round-trip fidelity with the upstream API but is not yet
+// honored at render time — the docs site renders banners statically and
+// never hides them. Adding client-side dismissal is a follow-up.
+export const catalogBannerSchema = z.object({
+	title: z.string().optional(),
+	text: z.string(),
+	severity: z.string(),
+	dismissible: z.boolean().optional(),
+	link: z
+		.object({
+			url: z.string(),
+			label: z.string(),
+		})
+		.optional(),
+});
+
 export const catalogModelsSchema = z.object({
 	// Identification
 	model_id: z.string(), // "@cf/meta/llama-3.1-70b-instruct"
@@ -52,6 +75,17 @@ export const catalogModelsSchema = z.object({
 	// note such as plan requirements when the upstream provider needs one.
 	zdr: z.boolean().optional(),
 	zdr_comment: z.string().nullable().optional(),
+
+	// In-page notice (rendered as a Starlight `Aside` on the model detail
+	// page). Null/missing on most models; populated when upstream needs to
+	// surface availability constraints, deprecation warnings, etc.
+	banner: catalogBannerSchema.nullable().optional(),
+
+	// Request-format identifiers the model accepts at the API layer (e.g.
+	// "chat-completions", "responses", "anthropic-messages"). Rendered as a
+	// "Request formats" row in the Model Info table. Null/missing when the
+	// model has only one canonical request shape.
+	request_formats: z.string().array().nullable().optional(),
 
 	// Examples
 	examples: modelExampleSchema.array(),
@@ -82,3 +116,4 @@ export const catalogModelsSchema = z.object({
 export type CatalogModelsSchema = z.infer<typeof catalogModelsSchema>;
 export type CodeSnippet = z.infer<typeof codeSnippetSchema>;
 export type ModelExample = z.infer<typeof modelExampleSchema>;
+export type CatalogBanner = z.infer<typeof catalogBannerSchema>;

--- a/src/util/model-resolver.ts
+++ b/src/util/model-resolver.ts
@@ -117,6 +117,8 @@ function catalogToResolved(model: CatalogModelsSchema): ResolvedModel {
 		dataSource: "catalog",
 		hosting: "proxied",
 		zdrComment: model.zdr_comment ?? null,
+		banner: model.banner ?? null,
+		requestFormats: model.request_formats ?? null,
 	};
 }
 

--- a/src/util/model-types.ts
+++ b/src/util/model-types.ts
@@ -3,7 +3,11 @@
  * These don't depend on Astro and can be used in React components.
  */
 
-import type { CodeSnippet, ModelExample } from "~/schemas/catalog-models";
+import type {
+	CatalogBanner,
+	CodeSnippet,
+	ModelExample,
+} from "~/schemas/catalog-models";
 
 /**
  * Slimmed model type for the catalog index pages.
@@ -131,4 +135,23 @@ export interface ResolvedModel {
 	 * tooltip on the ZDR badge in `ModelBadges`.
 	 */
 	zdrComment?: string | null;
+
+	/**
+	 * In-page notice surfaced from the catalog `banner` field. Rendered as
+	 * a Starlight `Aside` directly under the description on the model
+	 * detail page. Legacy Workers AI models never set this — only catalog
+	 * rows carry it, and most carry `null`.
+	 */
+	banner?: CatalogBanner | null;
+
+	/**
+	 * Request-format identifiers the model accepts at the API layer (e.g.
+	 * "chat-completions", "responses", "anthropic-messages"). Surfaced
+	 * from the catalog `request_formats` array. Rendered as a "Request
+	 * formats" row in the Model Info table when non-empty. Distinct from
+	 * `apiModes`, which describes sync/streaming/batch variants derived
+	 * from the JSON Schema; `requestFormats` is the upstream's own
+	 * declaration of accepted request shapes.
+	 */
+	requestFormats?: string[] | null;
 }


### PR DESCRIPTION
# [AI Gateway] Surface banner and request_formats on AI model catalog

## Summary

The unified catalog API ships `banner` (in-page notice) and `request_formats` (accepted request shapes) on every model row, but the Zod schema in `src/schemas/catalog-models.ts` did not declare either field. Astro's content-collection loader strips unknown keys at build time, so both fields were being **silently dropped** — `entry.data.banner` and `entry.data.request_formats` came through as `undefined` despite being present on disk in `src/content/catalog-models/*.json` (`banner` on 2 models, `request_formats` on 110).

This PR follows the same pattern as #31309 (ZDR surfacing): declare the fields, wire them through `ResolvedModel`, and render them on the model detail page.

## Changes

| File | Change |
|---|---|
| `src/schemas/catalog-models.ts` | Added `catalogBannerSchema` (exported) + new `banner` and `request_formats` fields on `catalogModelsSchema`. Exported `CatalogBanner` type. |
| `bin/fetch-catalog-models.ts` | Mirrored the new fields on the local `interface CatalogModel` for round-trip type safety (zero logic change). |
| `src/util/model-types.ts` | Added `banner?: CatalogBanner \| null` and `requestFormats?: string[] \| null` to `ResolvedModel`. Kept `ModelCardData` slim (matches `coverImageUrl` precedent). |
| `src/util/model-resolver.ts` | `catalogToResolved` now sets `banner` and `requestFormats` from the catalog row. |
| `src/components/models/ModelDetailPage.astro` | Renders `banner` as a Starlight `<Aside>` directly under the description. `severity` is mapped onto Aside variants (`info`→`tip`, `warning`→`caution`, `danger`/`error`→`danger`, anything else→`note`). The catalog `title` is a bold prefix inside the body — this lets Starlight keep its own localised `aria-label` (e.g. "Warning") instead of overriding it with a vague catalog string. Optional `link` carries the codebase's `external-link` arrow + a descriptive `aria-label` combining link label and model name. |
| `src/components/models/ModelFeatures.tsx` | Renders `request_formats` as a "Request formats" row in the existing Model Info table (catalog-only, hidden when null/empty). Identifiers like `chat-completions` are title-cased for display. |
| `src/schemas/catalog-models.node.test.ts` *(new)* | 7 Vitest Node test cases for `catalogModelsSchema` — locks in null tolerance, the open `severity` string, both required-field rejections. |

## Notes

* **`severity` stays `z.string()`** because the upstream enum is not yet locked down. Observed values today are `"warning"` (Anthropic Claude Fable 5) and `"info"` (Pruna P-Image-Try-On). The renderer maps both onto Starlight Aside variants and falls back to a neutral `note` style for any future value.

* **`dismissible` is preserved through the schema for round-trip fidelity** but the docs site renders banners statically and does not honour it — adding client-side dismissal is a follow-up. Mirrors the `coverImageUrl` "preserved-but-unrendered" precedent in this repo.

* **Catalog snapshot intentionally untouched.** The most recent commit on `production` (872fd14, #31567) already refreshed `src/content/catalog-models/*.json`, so both fields are present on disk and a no-op snapshot bump would just add noise to the diff.

## Validation

Full pipeline run locally (Node 24, pnpm 11):

```
pnpm install --frozen-lockfile  ✓
pnpm run sync                   ✓
pnpm run check                  ✓  (0 errors, 0 warnings, 4 pre-existing hints)
pnpm run lint                   ✓
pnpm run format:check           ✓
pnpm run test:prebuild          ✓  (52 tests pass — 45 baseline + 7 new)
pnpm run build                  ✓  (8492 pages, 22m 34s)
```

Renderer spot-checks against built HTML:

* `/ai/models/anthropic/claude-fable-5/` — banner renders as `<aside aria-label="Warning" class="...starlight-aside--caution">` with bold `NOTE:` prefix and "More info ↗" link to Anthropic's advisory. Confirmed.
* `/ai/models/pruna/p-image-try-on/` — banner renders as `<aside aria-label="Tip" class="...starlight-aside--tip">` (`severity: "info"` → `tip`). Confirmed.
* `/ai/models/openai/gpt-5/` — Model Info table now shows `Request formats: Responses, Chat Completions`. Confirmed.
* `/ai/models/anthropic/claude-opus-4.6/` — no banner Aside renders (catalog `banner: null`). `Request formats: Anthropic Messages`. Confirmed.
* `/ai/models/google/veo-3/` — no "Request formats" row (catalog `request_formats: null`). Confirmed.

## Screenshots

_(Add screenshots of the Fable 5 page and the Model Info table once available locally — the rendered HTML in `dist/ai/models/anthropic/claude-fable-5/index.html` shows the expected output.)_

## Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry? — **N/A**. This is an engineering/schema fix that surfaces existing upstream content; the visible artefact (the Fable 5 banner) is owned by the catalog producer, not the docs site. PR #31309 (the ZDR analogue) shipped without a changelog entry for the same reason.
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file). — N/A; no file moves.
