### PR TITLE
Add Hypernode Hosting SSL certificate installation link

### DIFF
--- a/src/content/docs/ssl/origin-configuration/origin-ca/index.mdx
+++ b/src/content/docs/ssl/origin-configuration/origin-ca/index.mdx
@@ -88,6 +88,7 @@ To add an Origin CA certificate to your origin web server
 - [Amazon Web Services](https://knowledge.digicert.com/tutorials/amazon-aws-create-csr-install-ssl-certificate)
 - [Apache cPanel](https://www.digicert.com/kb/ssl-certificate-installation-apache-cpanel.htm)
 - [Ubuntu Server with Apache2](https://www.digicert.com/kb/csr-ssl-installation/ubuntu-server-with-apache2-openssl.htm#ssl_certificate_install)
+- [Hypernode Hosting](https://docs.hypernode.com/hypernode-platform/ssl/how-to-use-ssl-certificates-on-your-hypernode-when-ordered-via-hypernode-com.html#add-a-third-party-ssl-certificate-to-your-account)
 
 :::note
 If you do not see your server in the list above, search the [DigiCert documentation](https://www.digicert.com/search-results) or contact your hosting provider, web admin, or server vendor.


### PR DESCRIPTION
### Summary

Our users are frequently using Cloudflare and could use a nudge into the right direction for setting up Cloudflare Origin CA.

Not sure where Cloudflare draws the line for adding vendors, but thought it was worth trying since AWS and GoDaddy are on the list as well. 

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
