### PR TITLE
[Durable Objects] Add apac-ne and apac-se location hints changelog

### DIFF
--- a/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
+++ b/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
@@ -15,7 +15,7 @@ Use the new hints the same way as any other `locationHint`:
 const stubNE = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-ne" });
 
 // Southeast Asia-Pacific (Singapore, Indonesia, etc.)
-const stub = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-se" });
+const stubSE = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-se" });
 ```
 
 If your users are spread across all of Asia-Pacific, the existing `apac` hint remains the right choice. Only reach for `apac-ne` or `apac-se` when your traffic is clearly concentrated in one sub-region and you want to minimize round-trip time to that audience.

--- a/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
+++ b/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
@@ -3,6 +3,7 @@ title: New Asia-Pacific location hints: apac-ne and apac-se
 description: Durable Objects now supports two new location hints for Northeast and Southeast Asia-Pacific, giving you finer-grained control within the `apac` region.
 products:
   - durable-objects
+  - workers
 date: 2026-06-19
 ---
 
@@ -18,7 +19,7 @@ const stubNE = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-ne" });
 const stubSE = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-se" });
 ```
 
-If your users are spread across all of Asia-Pacific, the existing `apac` hint remains the right choice. Only reach for `apac-ne` or `apac-se` when your traffic is clearly concentrated in one sub-region and you want to minimize round-trip time to that audience.
+If your users are spread across all of Asia-Pacific, the existing `apac` hint remains the right choice. Only reach for `apac-ne` or `apac-se` when your traffic is clearly concentrated in one sub-region and you want to minimize round-trip time to that audience. The default behavior and what we generally recommended is not adding a location hint unless absolutely needed, this will create the Durable Object as close to the initializing request as possible to reduce latency. 
 
 As with all location hints, these are best-effort suggestions. Cloudflare will place the Durable Object in a nearby data center, not necessarily the exact hinted location.
 

--- a/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
+++ b/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
@@ -1,0 +1,25 @@
+---
+title: New Asia-Pacific location hints: apac-ne and apac-se
+description: Durable Objects now supports two new location hints for Northeast and Southeast Asia-Pacific, giving you finer-grained placement control within the apac region.
+products:
+  - durable-objects
+date: 2026-06-19
+---
+
+Durable Objects now supports two new location hints for Asia-Pacific: `apac-ne` (Northeast Asia-Pacific) and `apac-se` (Southeast Asia-Pacific). Use `apac-ne` or `apac-se` when you want finer-grained placement within Asia-Pacific rather than the broader `apac` hint.
+
+Use the new hints the same way as any other `locationHint`:
+
+```js
+// Northeast Asia-Pacific (Japan, Korea, etc.)
+const stub = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-ne" });
+
+// Southeast Asia-Pacific (Singapore, Indonesia, etc.)
+const stub = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-se" });
+```
+
+If your users are spread across all of Asia-Pacific, the existing `apac` hint remains the right choice. Only reach for `apac-ne` or `apac-se` when your traffic is clearly concentrated in one sub-region and you want to minimize round-trip time to that audience.
+
+As with all location hints, these are best-effort suggestions. Cloudflare will place the Durable Object in a nearby data center, not necessarily the exact hinted location.
+
+For the full list of supported hints, refer to [Data location — Provide a location hint](/durable-objects/reference/data-location/#provide-a-location-hint).

--- a/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
+++ b/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
@@ -12,7 +12,7 @@ Use the new hints the same way as any other `locationHint`:
 
 ```js
 // Northeast Asia-Pacific (Japan, Korea, etc.)
-const stub = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-ne" });
+const stubNE = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-ne" });
 
 // Southeast Asia-Pacific (Singapore, Indonesia, etc.)
 const stub = env.MY_DURABLE_OBJECT.get(id, { locationHint: "apac-se" });

--- a/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
+++ b/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
@@ -1,5 +1,5 @@
 ---
-title: New Asia-Pacific location hints: apac-ne and apac-se
+title: "New Asia-Pacific location hints: apac-ne and apac-se"
 description: Durable Objects now supports two new location hints for Northeast and Southeast Asia-Pacific, giving you finer-grained control within the `apac` region.
 products:
   - durable-objects

--- a/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
+++ b/src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx
@@ -1,6 +1,6 @@
 ---
 title: New Asia-Pacific location hints: apac-ne and apac-se
-description: Durable Objects now supports two new location hints for Northeast and Southeast Asia-Pacific, giving you finer-grained placement control within the apac region.
+description: Durable Objects now supports two new location hints for Northeast and Southeast Asia-Pacific, giving you finer-grained control within the `apac` region.
 products:
   - durable-objects
 date: 2026-06-19


### PR DESCRIPTION
Adds a changelog entry for the two new Asia-Pacific location hints (`apac-ne` and `apac-se`) introduced in #31443.

## Summary

- New changelog file: `src/content/changelog/durable-objects/2026-06-19-apac-ne-apac-se-location-hints.mdx`

## Notes

- Date is set to today (2026-06-19) and should be updated to the actual merge date of #31443 before this merges.
- This PR should be merged alongside or after #31443.