### PR TITLE
[AI Search] Document wrangler ai-search jobs commands

### DIFF
--- a/src/content/docs/ai-search/how-to/manage-indexing-jobs.mdx
+++ b/src/content/docs/ai-search/how-to/manage-indexing-jobs.mdx
@@ -1,0 +1,62 @@
+---
+pcx_content_type: how-to
+title: Manage indexing jobs
+description: List, trigger, inspect, cancel, and view logs for AI Search indexing jobs using Wrangler.
+sidebar:
+  order: 7
+products:
+  - ai-search
+---
+
+Indexing jobs scan an AI Search instance's data source and reindex new, modified, or deleted content. For how scheduled jobs run, refer to [Syncing](/ai-search/configuration/indexing/syncing/).
+
+Use the [Wrangler](/workers/wrangler/) `ai-search jobs` commands to manage these jobs from the command line. These commands wrap the AI Search [Jobs API](/ai-search/api/instances/rest-api/#jobs); for the full flags of each command, refer to [Wrangler commands](/ai-search/wrangler-commands/).
+
+:::note
+All `wrangler ai-search jobs` commands accept `-n, --namespace` (defaults to `default`) to target a [namespace](/ai-search/concepts/namespaces/), and `--json` to return machine-readable output.
+:::
+
+## List jobs
+
+List the indexing jobs for an instance. Use `--page` and `--per-page` to page through results.
+
+```sh
+# List indexing jobs for an instance
+npx wrangler ai-search jobs list my-instance
+```
+
+## Trigger a job
+
+Trigger a new indexing job. Use `--description` to label the job.
+
+```sh
+# Trigger a new indexing job (optionally describe it)
+npx wrangler ai-search jobs create my-instance --description "manual reindex"
+```
+
+## Get job details
+
+Show the details of a single job by its ID.
+
+```sh
+# Inspect a specific job
+npx wrangler ai-search jobs get my-instance <job-id>
+```
+
+## Cancel a job
+
+Cancel a running job. Add `-y, --force` to skip the confirmation prompt.
+
+```sh
+# Cancel a running job (skip the prompt with -y)
+npx wrangler ai-search jobs cancel my-instance <job-id>
+```
+
+## View job logs
+
+List the log entries for a job. Use `--page` and `--per-page` to page through entries.
+
+```sh
+# View a job's logs
+npx wrangler ai-search jobs logs my-instance <job-id>
+```


### PR DESCRIPTION
### Summary

Adds a how-to page documenting the new `wrangler ai-search jobs` commands added to Wrangler in [cloudflare/workers-sdk#14367](https://github.com/cloudflare/workers-sdk/pull/14367). The page lives at `/ai-search/how-to/manage-indexing-jobs/` and covers managing AI Search indexing jobs from the command line:

```sh
npx wrangler ai-search jobs list <instance>
npx wrangler ai-search jobs create <instance>
npx wrangler ai-search jobs get <instance> <job-id>
npx wrangler ai-search jobs cancel <instance> <job-id>
npx wrangler ai-search jobs logs <instance> <job-id>
```

- One short section per command with a runnable `sh` example and a one-line explanation.
- Documents the shared `-n, --namespace` (default `default`) and `--json` flags, plus the per-command `--description`, `-y, --force`, and `--page`/`--per-page` flags. No flags or behavior beyond #14367 were invented.
- Links to the existing [Syncing](https://developers.cloudflare.com/ai-search/configuration/indexing/syncing/) concept, the Jobs section of the [Instances REST API](https://developers.cloudflare.com/ai-search/api/instances/rest-api/#jobs), and the auto-generated [Wrangler commands](https://developers.cloudflare.com/ai-search/wrangler-commands/) reference.
- `sidebar.order: 7` places it after the existing AI Search "How to" pages. The sidebar is built from the folder structure and frontmatter, so no nav config was hand-edited.

The per-command reference on `/ai-search/wrangler-commands/` is auto-generated from Wrangler's own command metadata via `<WranglerNamespace namespace="ai-search" />`, so it is intentionally not hand-written. Those entries will surface automatically once this repo's `wrangler` dependency is bumped to the release containing #14367. This PR does not bump that dependency.

### Screenshots

<!-- TODO: add a screenshot of the rendered page / "How to" sidebar entry before requesting review -->

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
