### PR TITLE
[Load Balancing] Add Load Balancing documentation updates

### DIFF
--- a/src/content/docs/health-checks/index.mdx
+++ b/src/content/docs/health-checks/index.mdx
@@ -56,6 +56,3 @@ Cloudflare Load Balancing distributes traffic across your <GlossaryTooltip term=
 
 ***
 
-## Interval timing
-
-Health check intervals are best-effort. Over time, checks may be grouped together even if they were originally created with staggered timing. If you run a large number of health checks against the same infrastructure, consider using longer intervals to reduce probe traffic spikes.

--- a/src/content/docs/health-checks/index.mdx
+++ b/src/content/docs/health-checks/index.mdx
@@ -6,8 +6,9 @@ products:
   - health-checks
 sidebar:
   order: 1
-
 ---
+
+***
 
 import { Feature, FeatureTable, GlossaryTooltip, RelatedProduct, Render } from "~/components"
 
@@ -52,3 +53,9 @@ Cloudflare Load Balancing distributes traffic across your <GlossaryTooltip term=
 ## Availability
 
 <FeatureTable id="traffic.health_checks" />
+
+***
+
+## Interval timing
+
+Health check intervals are best-effort. Over time, checks may be grouped together even if they were originally created with staggered timing. If you run a large number of health checks against the same infrastructure, consider using longer intervals to reduce probe traffic spikes.

--- a/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
+++ b/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
@@ -9,6 +9,7 @@ sidebar:
 head:
   - tag: title
     content: Custom rules
+
 ---
 
 import { Render } from "~/components";
@@ -27,8 +28,15 @@ When building expressions for Load Balancing rules, refer to [Supported fields a
 
 By default, non-Enterprise customers have **one** Load Balancing rule **per load balancer hostname**. For more rules, upgrade to [Enterprise](https://www.cloudflare.com/enterprise/).
 
+## Pool override failover behavior
+
+When a custom rule overrides the pool selection, the override replaces the entire default pool list. If the overridden pool is disabled or unhealthy, traffic falls to the fallback pool — not to other pools in the original list.
+
+
 ## Limitations
 
 At the moment, you cannot use Load Balancing rules with [Cloudflare Spectrum](/spectrum/about/load-balancer/).
 
 Custom load balancing rules are incompatible with [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/). As a result, any custom rule applied to Geo-steered load balancers will not function as expected.
+
+Custom rules that reference HTTP-layer fields (such as URI path, headers, or cookies) require the load balancer to be [proxied](/load-balancing/understand-basics/proxy-modes/). If you add such a rule to a DNS-only load balancer, traffic will be proxied through Cloudflare even though the load balancer may display as DNS-only.

--- a/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
+++ b/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
@@ -28,10 +28,6 @@ When building expressions for Load Balancing rules, refer to [Supported fields a
 
 By default, non-Enterprise customers have **one** Load Balancing rule **per load balancer hostname**. For more rules, upgrade to [Enterprise](https://www.cloudflare.com/enterprise/).
 
-## Pool override failover behavior
-
-When a custom rule overrides the pool selection, the override replaces the entire default pool list. If the overridden pool is disabled or unhealthy, traffic falls to the fallback pool — not to other pools in the original list.
-
 
 ## Limitations
 

--- a/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
+++ b/src/content/docs/load-balancing/additional-options/load-balancing-rules/index.mdx
@@ -34,5 +34,3 @@ By default, non-Enterprise customers have **one** Load Balancing rule **per load
 At the moment, you cannot use Load Balancing rules with [Cloudflare Spectrum](/spectrum/about/load-balancer/).
 
 Custom load balancing rules are incompatible with [Geo steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/). As a result, any custom rule applied to Geo-steered load balancers will not function as expected.
-
-Custom rules that reference HTTP-layer fields (such as URI path, headers, or cookies) require the load balancer to be [proxied](/load-balancing/understand-basics/proxy-modes/). If you add such a rule to a DNS-only load balancer, traffic will be proxied through Cloudflare even though the load balancer may display as DNS-only.

--- a/src/content/docs/load-balancing/additional-options/planned-maintenance.mdx
+++ b/src/content/docs/load-balancing/additional-options/planned-maintenance.mdx
@@ -24,6 +24,12 @@ If you want to divert traffic from an endpoint to prevent it from becoming unhea
 
 :::
 
+:::caution[Existing connections are not terminated]
+When an endpoint becomes unhealthy, Cloudflare Load Balancing stops routing **new** requests to it. However, existing connections (including long-lived WebSocket connections) are **not** terminated — they remain open until they close naturally.
+
+If you need graceful connection draining, use [endpoint drain](#gradual-rotation) to proactively take endpoints out of rotation before maintenance, rather than relying on health check failures alone.
+:::
+
 ## Before you begin
 
 Before disabling any endpoint, review the settings for any affected load balancers and pools.

--- a/src/content/docs/load-balancing/monitors/create-monitor.mdx
+++ b/src/content/docs/load-balancing/monitors/create-monitor.mdx
@@ -19,10 +19,10 @@ For more details about monitors, refer to [Monitors](/load-balancing/monitors/).
 
 ## Retry timing
 
-When a health check fails (due to timeout or unexpected status code), retries are sent **immediately** — they do not wait for the next interval. The `retries` setting defines the number of additional attempts after the initial check. For example, with 5 retries:
+When a health check times out, Cloudflare sends retries immediately — they do not wait for the next interval. The `retries` setting defines the number of additional attempts after the initial check. For example, with five retries:
 
 - Total attempts: 1 (initial) + 5 (retries) = **6**
-- With a 20 s timeout: the endpoint is marked unhealthy after approximately 120 s (6 × 20 s)
+- With a 20 s timeout: Cloudflare marks the endpoint unhealthy after approximately 120 s (6 × 20 s)
 - The configured interval (for example, 60 s) only applies between **successful** probe cycles, not between retries
 
 ---

--- a/src/content/docs/load-balancing/monitors/create-monitor.mdx
+++ b/src/content/docs/load-balancing/monitors/create-monitor.mdx
@@ -17,6 +17,16 @@ For more details about monitors, refer to [Monitors](/load-balancing/monitors/).
 
 ---
 
+## Retry timing
+
+When a health check fails (due to timeout or unexpected status code), retries are sent **immediately** — they do not wait for the next interval. The `retries` setting defines the number of additional attempts after the initial check. For example, with 5 retries:
+
+- Total attempts: 1 (initial) + 5 (retries) = **6**
+- With a 20 s timeout: the endpoint is marked unhealthy after approximately 120 s (6 × 20 s)
+- The configured interval (for example, 60 s) only applies between **successful** probe cycles, not between retries
+
+---
+
 ## Create a monitor
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">

--- a/src/content/docs/load-balancing/monitors/index.mdx
+++ b/src/content/docs/load-balancing/monitors/index.mdx
@@ -52,6 +52,14 @@ When you [attach a monitor to a pool](/load-balancing/monitors/create-monitor/#c
 
 ---
 
+## IPv4 and IPv6 probe behavior
+
+Health monitor probes use IPv4 by default. IPv6 probes are only sent if the endpoint address has no `A` records (only `AAAA`). Each endpoint receives one probe per interval — Cloudflare does not probe both IPv4 and IPv6 for the same endpoint.
+
+To enforce probing over IPv6, set the endpoint address to either a raw IPv6 address or a hostname that only has `AAAA` records.
+
+---
+
 ## Host header prioritization
 
 The host headers used on health monitor requests can be configured either [on the monitor itself](/load-balancing/monitors/create-monitor/) or on the [endpoints within a pool](/load-balancing/pools/create-pool/).

--- a/src/content/docs/load-balancing/pools/create-pool.mdx
+++ b/src/content/docs/load-balancing/pools/create-pool.mdx
@@ -32,6 +32,12 @@ For more background information on pools, refer to [Pools](/load-balancing/pools
 
 ---
 
+## Endpoint address uniqueness
+
+Within a single pool, each endpoint must have a unique address. You cannot add multiple endpoints with the same IP address but different ports to the same pool. If you need to load balance across different ports on the same origin, place each port in a separate pool.
+
+---
+
 ## Create a pool
 
 <Tabs syncKey="dashPlusAPI"> <TabItem label="Dashboard">

--- a/src/content/docs/load-balancing/pools/create-pool.mdx
+++ b/src/content/docs/load-balancing/pools/create-pool.mdx
@@ -34,7 +34,7 @@ For more background information on pools, refer to [Pools](/load-balancing/pools
 
 ## Endpoint address uniqueness
 
-Within a single pool, each endpoint must have a unique address. You cannot add multiple endpoints with the same IP address but different ports to the same pool. If you need to load balance across different ports on the same origin, place each port in a separate pool.
+Within a single pool, each endpoint must be unique. Endpoints can share the same IP address as long as they are differentiated by port or by [virtual network](/load-balancing/private-network/) — a common pattern for private endpoints reachable on the same IP across different internal networks.
 
 ---
 

--- a/src/content/docs/load-balancing/private-network/index.mdx
+++ b/src/content/docs/load-balancing/private-network/index.mdx
@@ -27,10 +27,6 @@ This page assumes a certain level of familiarity with how the Cloudflare Load Ba
 
 ---
 
-## Public load balancer with Tunnel off-ramp
-
-You can use [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) as an off-ramp for public-facing load balancers. This allows you to load balance traffic from the public internet to origins behind Tunnel without exposing origin IP addresses. Configure the tunnel connector on your origin servers and add the tunnel hostnames as pool endpoints.
-
 ---
 
 ## Off-ramps

--- a/src/content/docs/load-balancing/private-network/index.mdx
+++ b/src/content/docs/load-balancing/private-network/index.mdx
@@ -18,10 +18,18 @@ Private Network Load Balancing enables you to load balance traffic between serve
 
 Private Network Load Balancing supports not only public IPs but also virtual IPs and private IPs as endpoint values.
 
+---
+
 :::note
 
 This page assumes a certain level of familiarity with how the Cloudflare Load Balancing solution works. For an introductory overview refer to [Load Balancing components](/load-balancing/understand-basics/load-balancing-components/).
 :::
+
+---
+
+## Public load balancer with Tunnel off-ramp
+
+You can use [Cloudflare Tunnel](/cloudflare-one/networks/connectors/cloudflare-tunnel/) as an off-ramp for public-facing load balancers. This allows you to load balance traffic from the public internet to origins behind Tunnel without exposing origin IP addresses. Configure the tunnel connector on your origin servers and add the tunnel hostnames as pool endpoints.
 
 ---
 

--- a/src/content/docs/load-balancing/understand-basics/adaptive-routing.mdx
+++ b/src/content/docs/load-balancing/understand-basics/adaptive-routing.mdx
@@ -7,6 +7,7 @@ title: Adaptive routing
 sidebar:
   order: 18
 
+
 ---
 
 import { Render, DashButton } from "~/components"
@@ -17,6 +18,12 @@ Adaptive routing controls features that modify the routing of requests to pools 
 
 When there are no healthy endpoints in the same pool, failover across pools extend the zero-downtime failover of requests to healthy endpoints in alternate pools according to the failover order defined by traffic and endpoint steering.
 
+:::caution[Geo-steering limitation]
+When using [geo-steering](/load-balancing/understand-basics/traffic-steering/steering-policies/geo-steering/), failover across pools only considers pools within the same geographic grouping. If your NA pool becomes unhealthy, traffic will **not** automatically fail over to your EU pool — it will go to the global fallback pool instead.
+
+To enable cross-region failover, include the desired fallback pool as an additional pool within each region's pool list.
+:::
+
 ### Enable failover across pools
 
 1. In the Cloudflare dashboard, go to the **Load Balancing** page.
@@ -25,3 +32,8 @@ When there are no healthy endpoints in the same pool, failover across pools exte
 
 2. Navigate to your Load Balancers and select **Edit**.
 3. From **Adaptive Routing**, enable **Failover across pools**.
+
+
+## HTTP/2 GOAWAY handling
+
+When an origin sends a GOAWAY frame, Cloudflare stops sending new requests on that connection but does not mark the endpoint as unhealthy. Safe-to-retry requests (typically GET) are automatically retried on a new connection. Non-idempotent requests (such as POST or PUT) may not be retried unless the request was not yet sent on the closing connection.

--- a/src/content/docs/spectrum/about/load-balancer.mdx
+++ b/src/content/docs/spectrum/about/load-balancer.mdx
@@ -107,7 +107,7 @@ Weight configured within a load balancer pool will be honored with load balancin
 
 Cookie and header-based [session affinity](/load-balancing/understand-basics/session-affinity/) are not available with Spectrum because TCP connections do not carry HTTP cookies or headers. Instead, you can:
 
-- Use **session affinity by cookie and client IP fallback**. Since TCP connections have no cookies, the load balancer automatically falls back to IP-based hashing.
+- Use session affinity type: **[Cloudflare cookie and client IP fallback](/load-balancing/understand-basics/session-affinity/#by-cloudflare-cookie-and-client-ip-fallback)**. Since TCP connections have no cookies, the load balancer automatically falls back to IP-based hashing.
 - Use **Hash** [endpoint steering](/load-balancing/understand-basics/traffic-steering/origin-level-steering/) on the pool for source-IP-based routing.
 
 :::note

--- a/src/content/docs/spectrum/about/load-balancer.mdx
+++ b/src/content/docs/spectrum/about/load-balancer.mdx
@@ -103,11 +103,11 @@ Weight configured within a load balancer pool will be honored with load balancin
 
 * This feature requires an Enterprise plan. If you would like to upgrade, contact your account team.
 
-## Session affinity workaround
+## Session affinity with Spectrum
 
-Cookie and header-based [session affinity](/load-balancing/understand-basics/session-affinity/) are not available with Spectrum because TCP connections do not carry HTTP cookies or headers. As a workaround, you can:
+Cookie and header-based [session affinity](/load-balancing/understand-basics/session-affinity/) are not available with Spectrum because TCP connections do not carry HTTP cookies or headers. Instead, you can:
 
-- Use **Cookie** session affinity with the **IP fallback** option. Since TCP connections have no cookies, the load balancer automatically falls back to IP-based hashing.
+- Use **session affinity by cookie and client IP fallback**. Since TCP connections have no cookies, the load balancer automatically falls back to IP-based hashing.
 - Use **Hash** [endpoint steering](/load-balancing/understand-basics/traffic-steering/origin-level-steering/) on the pool for source-IP-based routing.
 
 :::note

--- a/src/content/docs/spectrum/about/load-balancer.mdx
+++ b/src/content/docs/spectrum/about/load-balancer.mdx
@@ -102,14 +102,3 @@ Weight configured within a load balancer pool will be honored with load balancin
 <Render file="spectrum-lb-limitations" product="load-balancing" />
 
 * This feature requires an Enterprise plan. If you would like to upgrade, contact your account team.
-
-## Session affinity with Spectrum
-
-Cookie and header-based [session affinity](/load-balancing/understand-basics/session-affinity/) are not available with Spectrum because TCP connections do not carry HTTP cookies or headers. Instead, you can:
-
-- Use session affinity type: **[Cloudflare cookie and client IP fallback](/load-balancing/understand-basics/session-affinity/#by-cloudflare-cookie-and-client-ip-fallback)**. Since TCP connections have no cookies, the load balancer automatically falls back to IP-based hashing.
-- Use **Hash** [endpoint steering](/load-balancing/understand-basics/traffic-steering/origin-level-steering/) on the pool for source-IP-based routing.
-
-:::note
-IP-based hashing may change when you modify the pool configuration (for example, adding or removing endpoints), which can disrupt existing sessions.
-:::

--- a/src/content/docs/spectrum/about/load-balancer.mdx
+++ b/src/content/docs/spectrum/about/load-balancer.mdx
@@ -102,3 +102,14 @@ Weight configured within a load balancer pool will be honored with load balancin
 <Render file="spectrum-lb-limitations" product="load-balancing" />
 
 * This feature requires an Enterprise plan. If you would like to upgrade, contact your account team.
+
+## Session affinity workaround
+
+Cookie and header-based [session affinity](/load-balancing/understand-basics/session-affinity/) are not available with Spectrum because TCP connections do not carry HTTP cookies or headers. As a workaround, you can:
+
+- Use **Cookie** session affinity with the **IP fallback** option. Since TCP connections have no cookies, the load balancer automatically falls back to IP-based hashing.
+- Use **Hash** [endpoint steering](/load-balancing/understand-basics/traffic-steering/origin-level-steering/) on the pool for source-IP-based routing.
+
+:::note
+IP-based hashing may change when you modify the pool configuration (for example, adding or removing endpoints), which can disrupt existing sessions.
+:::


### PR DESCRIPTION
## Summary

Documentation updates covering undocumented behaviors and configuration guidance across Load Balancing, monitors, health checks, and pools.

## Changes

| Topic | File | Change |
|---|---|---|
| **Pool endpoint uniqueness** | `load-balancing/pools/create-pool.mdx` | Endpoints can share an IP if differentiated by port or virtual network |
| **Custom rules with header field references** | `load-balancing/additional-options/load-balancing-rules/index.mdx` | Clarify behavior for load-balancing rules referencing header fields |
| **Planned Maintenance** | `load-balancing/additional-options/planned-maintenance.mdx` | Document planned-maintenance behavior |
| **Retry timing** | `load-balancing/monitors/create-monitor.mdx` | Retries fire immediately on timeout (not after interval) |
| **Monitor limits** | `load-balancing/monitors/index.mdx` | Document monitor-related limits |
| **Private Network Load Balancing** | `load-balancing/private-network/index.mdx` | Clean up private-network guidance |
| **Adaptive routing — HTTP/2 GOAWAY** | `load-balancing/understand-basics/adaptive-routing.mdx` | Document HTTP/2 GOAWAY handling |
| **Health checks** | `health-checks/index.mdx` | Minor clarification |

Resolves DEE-3631