### PR TITLE
[Workers] Add Durable Objects to claim deployments

### DIFF
--- a/src/content/changelog/workers/2026-06-19-temporary-accounts-for-agents.mdx
+++ b/src/content/changelog/workers/2026-06-19-temporary-accounts-for-agents.mdx
@@ -18,6 +18,6 @@ wrangler deploy --temporary
 
 The temporary deployment stays live for 60 minutes. During that window, the agent can verify the Worker, redeploy changes, and return both the live Worker URL and claim URL. Opening the claim URL lets you sign in to or create a Cloudflare account and make the temporary account permanent.
 
-Temporary preview accounts currently support a limited set of products, including Workers, Workers Static Assets, Workers KV, D1, Hyperdrive, Queues, and SSL/TLS certificates. For supported products, limits, and claim behavior, refer to [Claim deployments (temporary accounts)](/workers/platform/claim-deployments/).
+Temporary preview accounts currently support a limited set of products, including Workers, Workers Static Assets, Workers KV, D1, Durable Objects, Hyperdrive, Queues, and SSL/TLS certificates. For supported products, limits, and claim behavior, refer to [Claim deployments (temporary accounts)](/workers/platform/claim-deployments/).
 
 For more context, refer to [Temporary Cloudflare Accounts for Agents](https://blog.cloudflare.com/temporary-accounts/).

--- a/src/content/docs/workers/platform/claim-deployments.mdx
+++ b/src/content/docs/workers/platform/claim-deployments.mdx
@@ -97,6 +97,7 @@ Temporary preview accounts currently support the following Cloudflare products a
 | [Workers Static Assets](/workers/static-assets/) | Up to 1,000 files, with each asset up to 5 MiB                |
 | [Workers KV](/kv/)                               | Commands that use temporary credentials                       |
 | [D1](/d1/)                                       | One database, with up to 100 MB per database and 100 MB total |
+| [Durable Objects](/durable-objects/)             | Commands that use temporary credentials                       |
 | [Hyperdrive](/hyperdrive/)                       | Up to two database configurations and 10 connections          |
 | [Queues](/queues/)                               | Up to 10 queues                                               |
 | [SSL/TLS certificates](/ssl/)                    | Commands that use temporary credentials                       |


### PR DESCRIPTION
### Summary

Updates the Workers claim deployments page to list Durable Objects as a supported temporary preview account product. Also updates the related Workers changelog sentence so the product list stays consistent.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
