### PR TITLE
[AI Gateway] Add OpenAI Codex

### DIFF
--- a/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Coding agents
-description: Route coding agents such as Claude Code, GitHub Copilot CLI, and Pi through AI Gateway for observability, caching, rate limiting, and cost tracking.
+description: Route coding agents such as Claude Code, GitHub Copilot CLI, OpenAI Codex, and Pi through AI Gateway for observability, caching, rate limiting, and cost tracking.
 pcx_content_type: navigation
 sidebar:
   order: 5
@@ -28,6 +28,7 @@ Follow the setup guide for your coding agent:
 
 - [Claude Code](/ai-gateway/integrations/coding-agents/claude-code/)
 - [GitHub Copilot CLI](/ai-gateway/integrations/coding-agents/github-copilot-cli/)
+- [OpenAI Codex](/ai-gateway/integrations/coding-agents/openai-codex/)
 - [Pi](/ai-gateway/integrations/coding-agents/pi/)
 
 ## Protect sensitive code with DLP

--- a/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/openai-codex.mdx
@@ -1,0 +1,84 @@
+---
+title: OpenAI Codex
+description: Route OpenAI Codex through AI Gateway using a custom model provider that points at the OpenAI endpoint.
+pcx_content_type: configuration
+sidebar:
+  order: 3
+products:
+  - ai-gateway
+---
+
+import { Tabs, TabItem, Steps } from "~/components";
+
+[OpenAI Codex](https://developers.openai.com/codex/) is a coding agent you run in your terminal. It supports [custom model providers](https://developers.openai.com/codex/config-advanced#custom-model-providers) defined in `config.toml`. This configuration adds a provider that points at AI Gateway's [OpenAI endpoint](/ai-gateway/usage/providers/openai/), so Codex sends its requests through AI Gateway. AI Gateway authenticates the model provider for you through [Unified Billing](/ai-gateway/features/unified-billing/), so you pass a Cloudflare API token instead of an OpenAI API key.
+
+:::note
+Codex custom providers only support the OpenAI Responses API (`wire_api = "responses"`). This means you can only use OpenAI models that support the Responses API, such as `gpt-5.5`. Models from other providers (for example, Anthropic or Google) do not use the OpenAI Responses request format, so they do not work with Codex through this configuration.
+:::
+
+## Prerequisites
+
+Before you start, you need:
+
+- Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
+- An AI Gateway. You can use your account's `default` gateway or [create a gateway](/ai-gateway/get-started/) and use its slug.
+- A [Cloudflare API token](/fundamentals/api/get-started/create-token/) with `AI Gateway` permission.
+- [Credits loaded](/ai-gateway/features/unified-billing/#load-credits) on your account for third-party models.
+- [Codex](https://developers.openai.com/codex/cli/) installed and updated to the latest version.
+
+<Steps>
+
+1. Create a Codex [profile](https://developers.openai.com/codex/config-advanced#profiles) file at `~/.codex/cloudflare-aig.config.toml`. The profile defines a custom model provider that points at your gateway's OpenAI endpoint and reads your Cloudflare API token from an environment variable.
+
+   Replace `<ACCOUNT_ID>` and `<GATEWAY_ID>` with your values. You can use `default` for the gateway to route through your account's default gateway, or change it to another gateway slug.
+
+   ```toml title="~/.codex/cloudflare-aig.config.toml"
+   model_provider = "cloudflare-ai-gateway"
+   model = "gpt-5.5"
+   model_reasoning_effort = "medium"
+
+   [model_providers.cloudflare-ai-gateway]
+   name = "Cloudflare AI Gateway"
+   # Run `wrangler whoami` to get your account ID, then replace <ACCOUNT_ID>.
+   # Use `default` for <GATEWAY_ID> to route through your account's default gateway.
+   base_url = "https://gateway.ai.cloudflare.com/v1/<ACCOUNT_ID>/<GATEWAY_ID>/openai"
+   env_key = "CLOUDFLARE_API_KEY"
+   wire_api = "responses"
+   ```
+
+   :::note
+   Codex does not expand environment variables inside `base_url`, so the account ID and gateway slug must be literal values. Only `CLOUDFLARE_API_KEY` is read from the environment.
+   :::
+
+2. Set your Cloudflare API token as the `CLOUDFLARE_API_KEY` environment variable. The following commands set it for the current session. To persist it, add it to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
+
+   Replace `<CLOUDFLARE_API_KEY>` with your value.
+
+   <Tabs syncKey="os">
+   <TabItem label="macOS / Linux">
+
+   ```bash
+   # Run `wrangler auth token` to get an auth token.
+   export CLOUDFLARE_API_KEY="<CLOUDFLARE_API_KEY>"
+   ```
+
+   </TabItem>
+   <TabItem label="Windows (PowerShell)">
+
+   ```powershell
+   # Run `wrangler auth token` to get an auth token.
+   $env:CLOUDFLARE_API_KEY = "<CLOUDFLARE_API_KEY>"
+   ```
+
+   </TabItem>
+   </Tabs>
+
+3. Start Codex with the profile and send a prompt. Requests now route through AI Gateway.
+
+   ```bash
+   codex --profile cloudflare-aig
+   ```
+
+</Steps>
+
+To confirm traffic reaches AI Gateway, refer to [Verify it works](/ai-gateway/integrations/coding-agents/#verify-it-works).

--- a/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
@@ -3,7 +3,7 @@ title: Pi
 description: Route the Pi coding agent through AI Gateway using its built-in Cloudflare AI Gateway provider.
 pcx_content_type: configuration
 sidebar:
-  order: 3
+  order: 4
 products:
   - ai-gateway
 ---

--- a/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
@@ -16,7 +16,7 @@ import { Tabs, TabItem, Steps } from "~/components";
 
 Before you start, you need:
 
-- An [authenticated gateway](/ai-gateway/configuration/authentication/) and its gateway token. The gateway token must have `Run` permissions.
+- An [authenticated gateway](/ai-gateway/configuration/authentication/) and its [gateway token](/ai-gateway/configuration/authentication/#setting-up-authenticated-gateway-using-the-dashboard). The gateway token must have `Run` permissions.
 - Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
 - Pi installed and updated to the latest version.
 
@@ -28,24 +28,30 @@ The token you give Pi is your gateway token, not a model provider key. To pay fo
 
 1. Set your gateway token, account ID, and gateway slug as environment variables. The following commands set them for the current session. To persist them, add them to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
 
-   Replace `<CF_AIG_TOKEN>`, `<ACCOUNT_ID>`, and `<GATEWAY_ID>` with your values.
+   Replace `<CLOUDFLARE_API_KEY>` and `<CLOUDFLARE_ACCOUNT_ID>` with your values. You can leave `CLOUDFLARE_GATEWAY_ID` as `default` to route through your account's default gateway, or change it to another gateway slug.
 
    <Tabs syncKey="os">
    <TabItem label="macOS / Linux">
 
    ```bash
-   export CLOUDFLARE_API_KEY="<CF_AIG_TOKEN>"
-   export CLOUDFLARE_ACCOUNT_ID="<ACCOUNT_ID>"
-   export CLOUDFLARE_GATEWAY_ID="<GATEWAY_ID>"
+   # Run `wrangler auth token` to get an auth token.
+   export CLOUDFLARE_API_KEY="<CLOUDFLARE_API_KEY>"
+   # Run `wrangler whoami` to get your account ID.
+   export CLOUDFLARE_ACCOUNT_ID="<CLOUDFLARE_ACCOUNT_ID>"
+   # Use `default` to route through your account's default gateway.
+   export CLOUDFLARE_GATEWAY_ID="default"
    ```
 
    </TabItem>
    <TabItem label="Windows (PowerShell)">
 
    ```powershell
-   $env:CLOUDFLARE_API_KEY = "<CF_AIG_TOKEN>"
-   $env:CLOUDFLARE_ACCOUNT_ID = "<ACCOUNT_ID>"
-   $env:CLOUDFLARE_GATEWAY_ID = "<GATEWAY_ID>"
+   # Run `wrangler auth token` to get an auth token.
+   $env:CLOUDFLARE_API_KEY = "<CLOUDFLARE_API_KEY>"
+   # Run `wrangler whoami` to get your account ID.
+   $env:CLOUDFLARE_ACCOUNT_ID = "<CLOUDFLARE_ACCOUNT_ID>"
+   # Use `default` to route through your account's default gateway.
+   $env:CLOUDFLARE_GATEWAY_ID = "default"
    ```
 
    </TabItem>

--- a/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
@@ -3,7 +3,7 @@ title: Pi
 description: Route the Pi coding agent through AI Gateway using its built-in Cloudflare AI Gateway provider.
 pcx_content_type: configuration
 sidebar:
-  order: 2
+  order: 3
 products:
   - ai-gateway
 ---

--- a/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
@@ -16,9 +16,9 @@ import { Tabs, TabItem, Steps } from "~/components";
 
 Before you start, you need:
 
-1. An [authenticated gateway](/ai-gateway/configuration/authentication/) and its gateway token. The gateway token must have `Run` permissions.
-2. Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
-3. Pi installed and updated to the latest version.
+- An [authenticated gateway](/ai-gateway/configuration/authentication/) and its gateway token. The gateway token must have `Run` permissions.
+- Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
+- Pi installed and updated to the latest version.
 
 :::note
 The token you give Pi is your gateway token, not a model provider key. To pay for model usage, enable [unified billing](/ai-gateway/features/unified-billing/) or store provider keys in AI Gateway with [BYOK (Store Keys)](/ai-gateway/configuration/bring-your-own-keys/). Either way, AI Gateway handles the provider authentication for you.
@@ -26,7 +26,7 @@ The token you give Pi is your gateway token, not a model provider key. To pay fo
 
 <Steps>
 
-1. Set your gateway token, account ID, and gateway slug as environment variables. The commands below set them for the current session. To persist them, add them to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
+1. Set your gateway token, account ID, and gateway slug as environment variables. The following commands set them for the current session. To persist them, add them to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
 
    Replace `<CF_AIG_TOKEN>`, `<ACCOUNT_ID>`, and `<GATEWAY_ID>` with your values.
 

--- a/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
@@ -3,7 +3,7 @@ title: Pi
 description: Route the Pi coding agent through AI Gateway using its built-in Cloudflare AI Gateway provider.
 pcx_content_type: configuration
 sidebar:
-  order: 3
+  order: 2
 products:
   - ai-gateway
 ---
@@ -16,42 +16,36 @@ import { Tabs, TabItem, Steps } from "~/components";
 
 Before you start, you need:
 
-- An [authenticated gateway](/ai-gateway/configuration/authentication/) and its [gateway token](/ai-gateway/configuration/authentication/#setting-up-authenticated-gateway-using-the-dashboard). The gateway token must have `Run` permissions.
-- Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
-- Pi installed and updated to the latest version.
+1. An [authenticated gateway](/ai-gateway/configuration/authentication/) and its gateway token. The gateway token must have `Run` permissions.
+2. Your Cloudflare account ID. To find it, refer to [Find your account and zone IDs](/fundamentals/account/find-account-and-zone-ids/).
+3. Pi installed and updated to the latest version.
 
 :::note
-The token you give Pi is your gateway token, not a model provider key. To pay for model usage, enable [Unified Billing](/ai-gateway/features/unified-billing/) or store provider keys in AI Gateway with [BYOK (Store Keys)](/ai-gateway/configuration/bring-your-own-keys/). Either way, AI Gateway handles the provider authentication for you.
+The token you give Pi is your gateway token, not a model provider key. To pay for model usage, enable [unified billing](/ai-gateway/features/unified-billing/) or store provider keys in AI Gateway with [BYOK (Store Keys)](/ai-gateway/configuration/bring-your-own-keys/). Either way, AI Gateway handles the provider authentication for you.
 :::
 
 <Steps>
 
-1. Set your gateway token, account ID, and gateway slug as environment variables. The following commands set them for the current session. To persist them, add them to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
+1. Set your gateway token, account ID, and gateway slug as environment variables. The commands below set them for the current session. To persist them, add them to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
 
-   Replace `<CLOUDFLARE_API_KEY>` and `<CLOUDFLARE_ACCOUNT_ID>` with your values. You can leave `CLOUDFLARE_GATEWAY_ID` as `default` to route through your account's default gateway, or change it to another gateway slug.
+   Replace `<CF_AIG_TOKEN>`, `<ACCOUNT_ID>`, and `<GATEWAY_ID>` with your values.
 
    <Tabs syncKey="os">
    <TabItem label="macOS / Linux">
 
    ```bash
-   # Run `wrangler auth token` to get an auth token.
-   export CLOUDFLARE_API_KEY="<CLOUDFLARE_API_KEY>"
-   # Run `wrangler whoami` to get your account ID.
-   export CLOUDFLARE_ACCOUNT_ID="<CLOUDFLARE_ACCOUNT_ID>"
-   # Use `default` to route through your account's default gateway.
-   export CLOUDFLARE_GATEWAY_ID="default"
+   export CLOUDFLARE_API_KEY="<CF_AIG_TOKEN>"
+   export CLOUDFLARE_ACCOUNT_ID="<ACCOUNT_ID>"
+   export CLOUDFLARE_GATEWAY_ID="<GATEWAY_ID>"
    ```
 
    </TabItem>
    <TabItem label="Windows (PowerShell)">
 
    ```powershell
-   # Run `wrangler auth token` to get an auth token.
-   $env:CLOUDFLARE_API_KEY = "<CLOUDFLARE_API_KEY>"
-   # Run `wrangler whoami` to get your account ID.
-   $env:CLOUDFLARE_ACCOUNT_ID = "<CLOUDFLARE_ACCOUNT_ID>"
-   # Use `default` to route through your account's default gateway.
-   $env:CLOUDFLARE_GATEWAY_ID = "default"
+   $env:CLOUDFLARE_API_KEY = "<CF_AIG_TOKEN>"
+   $env:CLOUDFLARE_ACCOUNT_ID = "<ACCOUNT_ID>"
+   $env:CLOUDFLARE_GATEWAY_ID = "<GATEWAY_ID>"
    ```
 
    </TabItem>
@@ -62,7 +56,7 @@ The token you give Pi is your gateway token, not a model provider key. To pay fo
 2. Start a session against a model. Requests now route through AI Gateway.
 
    ```bash
-   pi --provider cloudflare-ai-gateway --model "claude-sonnet-4-6"
+   pi --provider cloudflare-ai-gateway --model "claude-sonnet-4.6"
    ```
 
 </Steps>

--- a/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
+++ b/src/content/docs/ai-gateway/integrations/coding-agents/pi.mdx
@@ -21,7 +21,7 @@ Before you start, you need:
 - Pi installed and updated to the latest version.
 
 :::note
-The token you give Pi is your gateway token, not a model provider key. To pay for model usage, enable [unified billing](/ai-gateway/features/unified-billing/) or store provider keys in AI Gateway with [BYOK (Store Keys)](/ai-gateway/configuration/bring-your-own-keys/). Either way, AI Gateway handles the provider authentication for you.
+The token you give Pi is your gateway token, not a model provider key. To pay for model usage, enable [Unified Billing](/ai-gateway/features/unified-billing/) or store provider keys in AI Gateway with [BYOK (Store Keys)](/ai-gateway/configuration/bring-your-own-keys/). Either way, AI Gateway handles the provider authentication for you.
 :::
 
 <Steps>
@@ -56,7 +56,7 @@ The token you give Pi is your gateway token, not a model provider key. To pay fo
 2. Start a session against a model. Requests now route through AI Gateway.
 
    ```bash
-   pi --provider cloudflare-ai-gateway --model "claude-sonnet-4.6"
+   pi --provider cloudflare-ai-gateway --model "claude-sonnet-4-6"
    ```
 
 </Steps>


### PR DESCRIPTION
### Summary

Adds an **OpenAI Codex** setup guide to the **Coding agents** integration group (AI Gateway → Integrations), matching the existing Claude Code, GitHub Copilot CLI, and Pi pages. Codex is configured as a custom model provider that routes through AI Gateway's provider-native OpenAI endpoint.

| File                                            | Change                                            |
| ----------------------------------------------- | ------------------------------------------------- |
| `integrations/coding-agents/openai-codex.mdx`   | New OpenAI Codex setup guide                       |
| `integrations/coding-agents/index.mdx`          | Add Codex to the overview description and list     |
| `integrations/coding-agents/pi.mdx`             | Bump `sidebar.order` so the nav matches the list   |

### What changed

- **OpenAI Codex** _(new)_ — routes Codex through a [custom model provider](https://developers.openai.com/codex/config-advanced#custom-model-providers) defined in `~/.codex/cloudflare-aig.config.toml` that points at AI Gateway's [OpenAI endpoint](https://developers.cloudflare.com/ai-gateway/usage/providers/openai/). Authenticates with `CLOUDFLARE_API_KEY` and Unified Billing, so no OpenAI API key is needed in the environment. Launches with `codex --profile cloudflare-aig`.
- Documents two Codex-specific constraints:
  - Custom providers only support the OpenAI Responses API (`wire_api = "responses"`), so only OpenAI models that support the Responses API (for example, `gpt-5.5`) work — models from other providers do not.
  - Codex does not expand environment variables inside `base_url`, so the account ID and gateway slug must be literal values.
- **Overview** (`index.mdx`) — adds OpenAI Codex to the page description and the setup-guide list.
- **Pi** — bumps `sidebar.order` so the sidebar order matches the overview list (Claude Code → GitHub Copilot CLI → OpenAI Codex → Pi).

#### Notes

- Codex configuration verified end-to-end against a live AI Gateway (logs confirmed in the dashboard) for `gpt-5.5` via Unified Billing.
- All cross-links resolve to existing AI Gateway / Fundamentals pages.
- No files were renamed or moved, so no redirects are required.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
