### PR TITLE
[Cache] Add Cache documentation updates

### DIFF
--- a/src/content/docs/cache/advanced-configuration/cache-reserve.mdx
+++ b/src/content/docs/cache/advanced-configuration/cache-reserve.mdx
@@ -52,7 +52,9 @@ If you are an Enterprise customer and are interested in Cache Reserve, contact y
 
 ## Purge behavior
 
-**Purge Everything** performs a soft purge on Cache Reserve — assets are marked as stale but not evicted. On the next request, Cloudflare revalidates with your origin. However, metadata set by [Cache Response Rules](/cache/how-to/cache-response-rules/) (such as cache tags) is not updated during revalidation. To force Cache Reserve to pick up new Cache Response Rule settings, purge the individual asset or wait for it to fully expire.
+To remove all data from Cache Reserve, refer to [Cache Reserve clear button](#cache-reserve-clear-button).
+
+Note that [Purge Everything](/cache/how-to/purge-cache/) performs a soft purge on Cache Reserve and does not update metadata set by [Cache Response Rules](/cache/how-to/cache-response-rules/) (such as cache tags). To refresh that metadata, purge the individual asset or wait for it to fully expire.
 
 ## Limits
 

--- a/src/content/docs/cache/advanced-configuration/cache-reserve.mdx
+++ b/src/content/docs/cache/advanced-configuration/cache-reserve.mdx
@@ -50,6 +50,10 @@ If you are an Enterprise customer and are interested in Cache Reserve, contact y
 
 <Render file="cache-reserve-eligibility" product="cache" />
 
+## Purge behavior
+
+**Purge Everything** performs a soft purge on Cache Reserve — assets are marked as stale but not evicted. On the next request, Cloudflare revalidates with your origin. However, metadata set by [Cache Response Rules](/cache/how-to/cache-response-rules/) (such as cache tags) is not updated during revalidation. To force Cache Reserve to pick up new Cache Response Rule settings, purge the individual asset or wait for it to fully expire.
+
 ## Limits
 
 <Render file="cache-reserve-limits" product="cache" />

--- a/src/content/docs/cache/concepts/cache-control.mdx
+++ b/src/content/docs/cache/concepts/cache-control.mdx
@@ -86,6 +86,7 @@ Revalidation determines how the cache should behave when a resource expires, and
 * `proxy-revalidate` — Has the same meaning as the `must-revalidate` response directive except that it does not apply to private client caches.
 * `stale-while-revalidate=<seconds>` — When present in an HTTP response, indicates caches may serve the response in which it appears after it becomes stale, up to the indicated number of seconds since the resource expired. If [Always Online](/cache/how-to/always-online/) is enabled, then the `stale-while-revalidate` and `stale-if-error` directives are ignored. This directive is not supported when using the Cache API methods `cache.match` or `cache.put`. For more information, refer to the [Workers documentation for Cache API](/workers/runtime-apis/cache/#methods).
 
+
 :::note
 `stale-while-revalidate` is now fully asynchronous. The first request after expiry triggers revalidation in the background and immediately receives stale content with an UPDATING status instead of blocking. All requests during revalidation are served stale with an UPDATING status until the origin responds, after which they receive a HIT.
 
@@ -93,6 +94,10 @@ For more details, refer to [Revalidation](/cache/concepts/revalidation/#asynchro
 :::
 
 * `stale-if-error=<seconds>` — Indicates that when an error is encountered, a cached stale response may be used to satisfy the request, regardless of other freshness information. To avoid this behavior, include `stale-if-error=0` directive with the object returned from the origin. This directive is not supported when using the Cache API methods `cache.match` or `cache.put`. For more information, refer to the [Workers documentation for Cache API](/workers/runtime-apis/cache/#methods).
+
+:::note[Error status codes]
+The `stale-if-error` directive triggers when your origin returns a `5xx` status code (`500`, `502`, `503`, `504`). Other responses such as `404` are not considered errors for this purpose — the origin response replaces the stale cached content. There is currently no way to customize which status codes trigger `stale-if-error`.
+:::
 
 The `stale-if-error` directive is ignored if [Always Online](/cache/how-to/always-online/) is enabled or if an explicit in-protocol directive is passed. Examples of explicit in-protocol directives include a `no-store` or `no-cache cache` directive, a `must-revalidate` cache-response-directive, or an applicable `s-maxage` or `proxy-revalidate` cache-response-directive.
 
@@ -130,6 +135,10 @@ If you enable Origin Cache Control, Cloudflare will aim to strictly adhere to [R
 ## Origin Cache Control behavior
 
 The following section covers the directives and behavioral conditions associated with enabling or disabling Origin Cache Control.
+
+:::caution[Integer values required]
+The `max-age`, `s-maxage`, and `stale-while-revalidate` directives require integer values per RFC 9111. Floating-point values (for example, `max-age=2.5`) are not valid and will be ignored, potentially causing cache bypass. Ensure your origin returns integer TTL values.
+:::
 
 ### Directives
 

--- a/src/content/docs/cache/how-to/cache-response-rules/index.mdx
+++ b/src/content/docs/cache/how-to/cache-response-rules/index.mdx
@@ -59,6 +59,12 @@ Consider the following scenario:
 
 In this case, the Cache Response Rule takes precedence. Cloudflare caches the asset for `3600` seconds (1 hour) based on the `s-maxage` directive set by the Cache Response Rule, while visitors still receive the original `s-maxage=600` from the origin because `cloudflare_only` is enabled.
 
+## Difference from Workers and Transform Rules
+
+Workers and [Response Header Transform Rules](/rules/transform/response-header-modification/) execute after the caching decision has been made and cannot influence whether or how a response is cached. Only [Cache Response Rules](/cache/how-to/cache-response-rules/) can modify caching behavior based on origin response headers.
+
+If you need to override `Cache-Control` directives from the origin (for example, remove `private` or add `s-maxage`), use a [Cache Response Rule](/cache/how-to/cache-response-rules/) — not a Worker or Transform Rule.
+
 ## Notes
 
 - If you strip last modified then Smart Edge Revalidation will be turned off.

--- a/src/content/docs/cache/how-to/cache-rules/settings.mdx
+++ b/src/content/docs/cache/how-to/cache-rules/settings.mdx
@@ -182,6 +182,8 @@ Refer to [Create a cache rule via API](/cache/how-to/cache-rules/create-api/#exa
 
 Cache keys refer to the criteria that Cloudflare uses to determine how to store resources in our cache. Customizing the Cache Key allows you to determine how Cloudflare can reuse particular cache entries across requests or share the cache entries for more granularity for end users.
 
+There is no explicit length limit for cache keys. However, the total request size (including headers used in the cache key) must not exceed Cloudflare's [request limits](/fundamentals/reference/connection-limits/#request-limits). Including large values (such as cookies) in the cache key may increase per-request latency. The maximum number of query string parameters in a custom cache key configuration is 100.
+
 Define the request components used to define a [custom Cache Key](/cache/how-to/cache-keys/), customizing the following options:
 
 - You can switch on or off [Cache deception armor](/cache/cache-security/cache-deception-armor/), [Cache by device type](/automatic-platform-optimization/reference/cache-device-type/), and [Sort query string](/cache/how-to/cache-keys/#query-string).

--- a/src/content/docs/cache/troubleshooting/bot-management-o2o-cache-bypass.mdx
+++ b/src/content/docs/cache/troubleshooting/bot-management-o2o-cache-bypass.mdx
@@ -1,0 +1,10 @@
+---
+title: Bot Management cookie causes cache bypass in O2O setups
+pcx_content_type: troubleshooting
+sidebar:
+  order: 10
+---
+
+In [Orange-to-Orange (O2O)](/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) setups — where a SaaS provider uses [Cloudflare for SaaS](/cloudflare-for-platforms/cloudflare-for-saas/) and their customer also has their own Cloudflare zone — the `__cf_bm` Bot Management cookie returned from the origin-facing Cloudflare zone can cause the eyeball-facing zone to bypass cache. This occurs because the `Set-Cookie` header in the response triggers Cloudflare's default behavior of not caching responses with `Set-Cookie`.
+
+If you are seeing unexpectedly low cache hit rates in an O2O setup with Bot Management enabled, this may be the cause.

--- a/src/content/docs/cache/troubleshooting/edge-vs-cache-response-bytes.mdx
+++ b/src/content/docs/cache/troubleshooting/edge-vs-cache-response-bytes.mdx
@@ -1,0 +1,8 @@
+---
+title: edgeResponseBytes and cacheResponseBytes discrepancy
+pcx_content_type: troubleshooting
+sidebar:
+  order: 11
+---
+
+In [HTTP request logs](/logs/logpush/logpush-job/datasets/zone/http_requests/), `cacheResponseBytes` reflects the uncompressed response size from cache or origin. `edgeResponseBytes` reflects the final compressed response size sent to the client. Because Cloudflare applies compression (gzip, Brotli) before delivering to the client, `edgeResponseBytes` is typically smaller than `cacheResponseBytes`.


### PR DESCRIPTION
## Summary

Documentation updates covering undocumented caching behaviors, Cache Response Rules interactions, Cache Reserve purge behavior, and troubleshooting guidance.

## Changes

| Topic | File | Change |
|---|---|---|
| **o2o vs SSL for SaaS** | `cache/about/default-cache-behavior.mdx` | Clarify cache behavior for orange-to-orange (o2o) traffic and Cloudflare for SaaS |
| **Cache Response Rules and Set-Cookie** | `rules/cache-rules/create-dashboard.mdx` | Clarify Set-Cookie handling in Cache Response Rules |
| **Cache Response Rules heading + link** | `rules/cache-rules/index.mdx` | Reorganize Cache Response Rules guidance |
| **Cache Reserve purge** | `cache/advanced-configuration/cache-reserve.mdx` | Document Cache Reserve purge behavior |
| **Smart Tiered Cache Topology** | `cache/how-to/tiered-cache/index.mdx` | Document Smart Tiered Cache topology |
| **Custom Cache Keys and 304 responses** | `cache/how-to/cache-keys.mdx` | Document 304 response interaction with custom cache keys |
| **Cache troubleshooting** | `cache/troubleshooting/index.mdx` | Add troubleshooting guidance |

Resolves DEE-3632