### PR TITLE
Document Node.js compatibility stubs

### DIFF
--- a/src/content/compatibility-flags/nodejs-compat.md
+++ b/src/content/compatibility-flags/nodejs-compat.md
@@ -23,7 +23,7 @@ Note that some Node.js APIs are only enabled when your Worker's compatibility da
 
 Some Node.js modules are available in Workers only as non-functional stubs. These modules can be imported or required, but do not provide working implementations of the corresponding Node.js APIs. Stubs exist for compatibility with packages that check whether a module exists, and should not be used directly in application code.
 
-The following stubs require `nodejs_compat`. They are enabled automatically when your Worker has a compatibility date on or after the date shown:
+The following stubs are enabled automatically only when `nodejs_compat` is enabled and your Worker's compatibility date is on or after the date shown:
 
 | Stub module           | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
 | --------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |

--- a/src/content/compatibility-flags/nodejs-compat.md
+++ b/src/content/compatibility-flags/nodejs-compat.md
@@ -25,24 +25,24 @@ Some Node.js modules are available in Workers only as non-functional stubs. Thes
 
 The following stubs are enabled automatically only when `nodejs_compat` is enabled and your Worker's compatibility date is on or after the date shown:
 
-| Stub module           | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
-| --------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |
-| `node:http2`          | `2025-09-01`                             | `enable_nodejs_http2_module`          | `disable_nodejs_http2_module`          |
-| `node:vm`             | `2025-10-01`                             | `enable_nodejs_vm_module`             | `disable_nodejs_vm_module`             |
-| `node:cluster`        | `2025-12-04`                             | `enable_nodejs_cluster_module`        | `disable_nodejs_cluster_module`        |
-| `node:domain`         | `2025-12-04`                             | `enable_nodejs_domain_module`         | `disable_nodejs_domain_module`         |
-| `node:trace_events`   | `2025-12-04`                             | `enable_nodejs_trace_events_module`   | `disable_nodejs_trace_events_module`   |
-| `node:wasi`           | `2025-12-04`                             | `enable_nodejs_wasi_module`           | `disable_nodejs_wasi_module`           |
-| `node:_stream_wrap`   | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
-| `node:dgram`          | `2026-01-29`                             | `enable_nodejs_dgram_module`          | `disable_nodejs_dgram_module`          |
-| `node:inspector`      | `2026-01-29`                             | `enable_nodejs_inspector_module`      | `disable_nodejs_inspector_module`      |
-| `node:sqlite`         | `2026-01-29`                             | `enable_nodejs_sqlite_module`         | `disable_nodejs_sqlite_module`         |
-| `node:child_process`  | `2026-03-17`                             | `enable_nodejs_child_process_module`  | `disable_nodejs_child_process_module`  |
-| `node:readline`       | `2026-03-17`                             | `enable_nodejs_readline_module`       | `disable_nodejs_readline_module`       |
-| `node:repl`           | `2026-03-17`                             | `enable_nodejs_repl_module`           | `disable_nodejs_repl_module`           |
-| `node:tty`            | `2026-03-17`                             | `enable_nodejs_tty_module`            | `disable_nodejs_tty_module`            |
-| `node:v8`             | `2026-03-17`                             | `enable_nodejs_v8_module`             | `disable_nodejs_v8_module`             |
-| `node:worker_threads` | `2026-03-17`                             | `enable_nodejs_worker_threads_module` | `disable_nodejs_worker_threads_module` |
+| Stub module                                                                     | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
+| ------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |
+| [`node:http2`](https://nodejs.org/docs/latest/api/http2.html)                   | `2025-09-01`                             | `enable_nodejs_http2_module`          | `disable_nodejs_http2_module`          |
+| [`node:vm`](https://nodejs.org/docs/latest/api/vm.html)                         | `2025-10-01`                             | `enable_nodejs_vm_module`             | `disable_nodejs_vm_module`             |
+| [`node:cluster`](https://nodejs.org/docs/latest/api/cluster.html)               | `2025-12-04`                             | `enable_nodejs_cluster_module`        | `disable_nodejs_cluster_module`        |
+| [`node:domain`](https://nodejs.org/docs/latest/api/domain.html)                 | `2025-12-04`                             | `enable_nodejs_domain_module`         | `disable_nodejs_domain_module`         |
+| [`node:trace_events`](https://nodejs.org/docs/latest/api/tracing.html)          | `2025-12-04`                             | `enable_nodejs_trace_events_module`   | `disable_nodejs_trace_events_module`   |
+| [`node:wasi`](https://nodejs.org/docs/latest/api/wasi.html)                     | `2025-12-04`                             | `enable_nodejs_wasi_module`           | `disable_nodejs_wasi_module`           |
+| [`node:_stream_wrap`](https://nodejs.org/docs/latest/api/stream.html)           | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
+| [`node:dgram`](https://nodejs.org/docs/latest/api/dgram.html)                   | `2026-01-29`                             | `enable_nodejs_dgram_module`          | `disable_nodejs_dgram_module`          |
+| [`node:inspector`](https://nodejs.org/docs/latest/api/inspector.html)           | `2026-01-29`                             | `enable_nodejs_inspector_module`      | `disable_nodejs_inspector_module`      |
+| [`node:sqlite`](https://nodejs.org/docs/latest/api/sqlite.html)                 | `2026-01-29`                             | `enable_nodejs_sqlite_module`         | `disable_nodejs_sqlite_module`         |
+| [`node:child_process`](https://nodejs.org/docs/latest/api/child_process.html)   | `2026-03-17`                             | `enable_nodejs_child_process_module`  | `disable_nodejs_child_process_module`  |
+| [`node:readline`](https://nodejs.org/docs/latest/api/readline.html)             | `2026-03-17`                             | `enable_nodejs_readline_module`       | `disable_nodejs_readline_module`       |
+| [`node:repl`](https://nodejs.org/docs/latest/api/repl.html)                     | `2026-03-17`                             | `enable_nodejs_repl_module`           | `disable_nodejs_repl_module`           |
+| [`node:tty`](https://nodejs.org/docs/latest/api/tty.html)                       | `2026-03-17`                             | `enable_nodejs_tty_module`            | `disable_nodejs_tty_module`            |
+| [`node:v8`](https://nodejs.org/docs/latest/api/v8.html)                         | `2026-03-17`                             | `enable_nodejs_v8_module`             | `disable_nodejs_v8_module`             |
+| [`node:worker_threads`](https://nodejs.org/docs/latest/api/worker_threads.html) | `2026-03-17`                             | `enable_nodejs_worker_threads_module` | `disable_nodejs_worker_threads_module` |
 
 When enabling `nodejs_compat`, we recommend using the latest version of [Wrangler CLI](/workers/wrangler/), and the latest compatibility date, in order to maximize compatibility. Some older versions of Wrangler inject additional polyfills that are no longer necessary when your Worker uses a more recent compatibility date, because they are provided by the Workers runtime.
 

--- a/src/content/compatibility-flags/nodejs-compat.md
+++ b/src/content/compatibility-flags/nodejs-compat.md
@@ -12,15 +12,38 @@ disable_flag: "no_nodejs_compat"
 
 Enables [Node.js APIs](/workers/runtime-apis/nodejs/) in the Workers Runtime.
 
-Note that some Node.js APIs are only enabled if your Worker's compatibility date is set to on or after the following dates:
+Note that some Node.js APIs are only enabled when your Worker's compatibility date is on or after the following dates:
 
-| Node.js API | Enabled after  |
-|---|---|
-| [`http.server`](/workers/configuration/compatibility-flags/#enable-nodejs-http-server-modules)  | `2025-09-01`  |
-| [`node:http`, `node:https`](/workers/configuration/compatibility-flags/#enable-availability-of-nodehttp-and-nodehttps-modules)  | `2025-08-15`  |
-| [`process.env`](/workers/configuration/compatibility-flags/#enable-auto-populating-processenv)  | `2025-04-01`  |
-| [Disable Top-level Await in `require()`](/workers/configuration/compatibility-flags/#disable-top-level-await-in-require)  | `2024-12-02`  |
+| Node.js API                                                                                                                    | Enabled with `nodejs_compat` on or after |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| [Disable Top-level Await in `require()`](/workers/configuration/compatibility-flags/#disable-top-level-await-in-require)       | `2024-12-02`                             |
+| [`process.env`](/workers/configuration/compatibility-flags/#enable-auto-populating-processenv)                                 | `2025-04-01`                             |
+| [`node:http`, `node:https`](/workers/configuration/compatibility-flags/#enable-availability-of-nodehttp-and-nodehttps-modules) | `2025-08-15`                             |
+| [`http.server`](/workers/configuration/compatibility-flags/#enable-nodejs-http-server-modules)                                 | `2025-09-01`                             |
 
-When enabling `nodejs_compat`, we recommend using the latest version of [Wrangler CLI](/workers/wrangler/), and the latest compatiblity date, in order to maximize compatibility. Some older versions of Wrangler inject additional polyfills that are no longer neccessary, as they are provided by the Workers runtime, if your Worker is using a more recent compatibility date.
+Some Node.js modules are available in Workers only as non-functional stubs. These modules can be imported or required, but do not provide working implementations of the corresponding Node.js APIs. Stubs exist for compatibility with packages that check whether a module exists, and should not be used directly in application code.
 
-If you see errors using a particular NPM package on Workers, you should first try updating your compatibility date and use the latest version of [Wrangler CLI](/workers/wrangler/) or the [Cloudflare Vite Plugin](/workers/vite-plugin/). If you still encounter issues, please report them by [opening a GitHub issue](https://github.com/cloudflare/workers-sdk/issues/new?template=bug-template.yaml).
+The following stubs require `nodejs_compat`. They are enabled automatically when your Worker has a compatibility date on or after the date shown:
+
+| Stub module           | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
+| --------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |
+| `node:http2`          | `2025-09-01`                             | `enable_nodejs_http2_module`          | `disable_nodejs_http2_module`          |
+| `node:vm`             | `2025-10-01`                             | `enable_nodejs_vm_module`             | `disable_nodejs_vm_module`             |
+| `node:cluster`        | `2025-12-04`                             | `enable_nodejs_cluster_module`        | `disable_nodejs_cluster_module`        |
+| `node:domain`         | `2025-12-04`                             | `enable_nodejs_domain_module`         | `disable_nodejs_domain_module`         |
+| `node:trace_events`   | `2025-12-04`                             | `enable_nodejs_trace_events_module`   | `disable_nodejs_trace_events_module`   |
+| `node:wasi`           | `2025-12-04`                             | `enable_nodejs_wasi_module`           | `disable_nodejs_wasi_module`           |
+| `node:_stream_wrap`   | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
+| `node:dgram`          | `2026-01-29`                             | `enable_nodejs_dgram_module`          | `disable_nodejs_dgram_module`          |
+| `node:inspector`      | `2026-01-29`                             | `enable_nodejs_inspector_module`      | `disable_nodejs_inspector_module`      |
+| `node:sqlite`         | `2026-01-29`                             | `enable_nodejs_sqlite_module`         | `disable_nodejs_sqlite_module`         |
+| `node:child_process`  | `2026-03-17`                             | `enable_nodejs_child_process_module`  | `disable_nodejs_child_process_module`  |
+| `node:readline`       | `2026-03-17`                             | `enable_nodejs_readline_module`       | `disable_nodejs_readline_module`       |
+| `node:repl`           | `2026-03-17`                             | `enable_nodejs_repl_module`           | `disable_nodejs_repl_module`           |
+| `node:tty`            | `2026-03-17`                             | `enable_nodejs_tty_module`            | `disable_nodejs_tty_module`            |
+| `node:v8`             | `2026-03-17`                             | `enable_nodejs_v8_module`             | `disable_nodejs_v8_module`             |
+| `node:worker_threads` | `2026-03-17`                             | `enable_nodejs_worker_threads_module` | `disable_nodejs_worker_threads_module` |
+
+When enabling `nodejs_compat`, we recommend using the latest version of [Wrangler CLI](/workers/wrangler/), and the latest compatibility date, in order to maximize compatibility. Some older versions of Wrangler inject additional polyfills that are no longer necessary when your Worker uses a more recent compatibility date, because they are provided by the Workers runtime.
+
+If you see errors using a particular npm package on Workers, you should first try updating your compatibility date and use the latest version of [Wrangler CLI](/workers/wrangler/) or the [Cloudflare Vite Plugin](/workers/vite-plugin/). If you still encounter issues, please report them by [opening a GitHub issue](https://github.com/cloudflare/workers-sdk/issues/new?template=bug-template.yaml).

--- a/src/content/compatibility-flags/nodejs-compat.mdx
+++ b/src/content/compatibility-flags/nodejs-compat.mdx
@@ -1,0 +1,34 @@
+---
+_build:
+  publishResources: false
+  render: never
+  list: never
+
+name: "Node.js compatibility"
+sort_date: "2023-01-15"
+enable_flag: "nodejs_compat"
+disable_flag: "no_nodejs_compat"
+---
+
+import { Render } from "~/components";
+
+Enables [Node.js APIs](/workers/runtime-apis/nodejs/) in the Workers Runtime.
+
+Note that some Node.js APIs are only enabled when your Worker's compatibility date is on or after the following dates:
+
+| Node.js API                                                                                                                    | Enabled with `nodejs_compat` on or after |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| [Disable Top-level Await in `require()`](/workers/configuration/compatibility-flags/#disable-top-level-await-in-require)       | `2024-12-02`                             |
+| [`process.env`](/workers/configuration/compatibility-flags/#enable-auto-populating-processenv)                                 | `2025-04-01`                             |
+| [`node:http`, `node:https`](/workers/configuration/compatibility-flags/#enable-availability-of-nodehttp-and-nodehttps-modules) | `2025-08-15`                             |
+| [`http.server`](/workers/configuration/compatibility-flags/#enable-nodejs-http-server-modules)                                 | `2025-09-01`                             |
+
+Some Node.js modules are available in Workers only as non-functional stubs. These modules can be imported or required, but do not provide working implementations of the corresponding Node.js APIs. Stubs exist for compatibility with packages that check whether a module exists, and should not be used directly in application code.
+
+The following stubs are enabled automatically only when `nodejs_compat` is enabled and your Worker's compatibility date is on or after the date shown:
+
+<Render file="nodejs-compat-stub-modules" product="workers" />
+
+When enabling `nodejs_compat`, we recommend using the latest version of [Wrangler CLI](/workers/wrangler/), and the latest compatibility date, in order to maximize compatibility. Some older versions of Wrangler inject additional polyfills that are no longer necessary when your Worker uses a more recent compatibility date, because they are provided by the Workers runtime.
+
+If you see errors using a particular npm package on Workers, you should first try updating your compatibility date and use the latest version of [Wrangler CLI](/workers/wrangler/) or the [Cloudflare Vite Plugin](/workers/vite-plugin/). If you still encounter issues, please report them by [opening a GitHub issue](https://github.com/cloudflare/workers-sdk/issues/new?template=bug-template.yaml).

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -35,9 +35,9 @@ To enable built-in Node.js APIs and add polyfills, add the `nodejs_compat` compa
 
 ## Supported Node.js APIs
 
-The runtime APIs from Node.js listed below as "🟢 supported" are currently natively supported in the Workers Runtime. Items listed as "🟡 partially supported" include usable APIs, but do not implement the complete Node.js API surface.
+The runtime APIs from Node.js listed in this section with the status "🟢 supported" are currently natively supported in the Workers Runtime. Items listed as "🟡 partially supported" include usable APIs, but do not implement the complete Node.js API surface.
 
-[Deprecated or experimental APIs from Node.js](https://nodejs.org/docs/latest/api/documentation.html#stability-index), and APIs that do not fit in a serverless context, are not included as part of the supported API list below. Some import-only stubs for these APIs are listed separately in [Non-functional stub modules](#non-functional-stub-modules).
+[Deprecated or experimental APIs from Node.js](https://nodejs.org/docs/latest/api/documentation.html#stability-index), and APIs that do not fit in a serverless context, are not included in the supported API list in this section. Some import-only stubs for these APIs are listed separately in [Non-functional stub modules](#non-functional-stub-modules).
 
 | API Name                                                                         | Natively supported by the Workers Runtime                                         |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
@@ -63,7 +63,7 @@ The runtime APIs from Node.js listed below as "🟢 supported" are currently nat
 | [Process](/workers/runtime-apis/nodejs/process/)                                 | 🟢 supported                                                                      |
 | [Punycode](https://nodejs.org/docs/latest/api/punycode.html) (deprecated)        | 🟢 supported                                                                      |
 | [Query strings](https://nodejs.org/docs/latest/api/querystring.html)             | 🟢 supported                                                                      |
-| [Stream](/workers/runtime-apis/nodejs/streams)                                   | 🟢 supported                                                                      |
+| [Stream](/workers/runtime-apis/nodejs/streams/)                                   | 🟢 supported                                                                      |
 | [String decoder](/workers/runtime-apis/nodejs/string-decoder/)                   | 🟢 supported                                                                      |
 | [Test runner](/workers/runtime-apis/nodejs/test/)                                | 🟡 partially supported                                                            |
 | [Timers](/workers/runtime-apis/nodejs/timers/)                                   | 🟢 supported                                                                      |

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -7,7 +7,7 @@ products:
   - workers
 ---
 
-import { DirectoryListing, WranglerConfig } from "~/components";
+import { WranglerConfig } from "~/components";
 
 When you write a Worker, you may need to import packages from [npm](https://www.npmjs.com/). Many npm packages rely on APIs from the [Node.js runtime](https://nodejs.org/en/about), and will not work unless these Node.js APIs are available.
 
@@ -15,8 +15,7 @@ Cloudflare Workers provides a subset of Node.js APIs in two forms:
 
 1. As built-in APIs provided by the Workers Runtime. Most of these APIs are
    full implementations of the corresponding Node.js APIs, while a few are
-   partially supported or non-functional stubs intended for the APIs to be
-   available for import only but not for actual use.
+   partially supported.
 2. As polyfill shim implementations that [Wrangler](/workers/wrangler/) adds to your Worker's code, allowing it to import the module, but calling API methods will throw errors.
 
 ## Get Started
@@ -27,10 +26,8 @@ To enable built-in Node.js APIs and add polyfills, add the `nodejs_compat` compa
 
 ```jsonc
 {
-	"compatibility_flags": [
-		"nodejs_compat"
-	],
-	"compatibility_date": "$today"
+	"compatibility_flags": ["nodejs_compat"],
+	"compatibility_date": "$today",
 }
 ```
 
@@ -38,60 +35,74 @@ To enable built-in Node.js APIs and add polyfills, add the `nodejs_compat` compa
 
 ## Supported Node.js APIs
 
-The runtime APIs from Node.js listed below as "🟢 supported" are currently natively supported in the Workers Runtime. Item listed as "🟡 partially supported" are either only partially implemented or are implemented as non-functional stubs.
+The runtime APIs from Node.js listed below as "🟢 supported" are currently natively supported in the Workers Runtime. Items listed as "🟡 partially supported" include usable APIs, but do not implement the complete Node.js API surface.
 
-[Deprecated or experimental APIs from Node.js](https://nodejs.org/docs/latest/api/documentation.html#stability-index), and APIs that do not fit in a serverless context, are not included as part of the list below:
+[Deprecated or experimental APIs from Node.js](https://nodejs.org/docs/latest/api/documentation.html#stability-index), and APIs that do not fit in a serverless context, are not included as part of the supported API list below. Some import-only stubs for these APIs are listed separately in [Non-functional stub modules](#non-functional-stub-modules).
 
-| API Name                                                                         | Natively supported by the Workers Runtime                                                    |
-| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [Assertion testing](/workers/runtime-apis/nodejs/assert/)                        | 🟢 supported                                                                                 |
-| [Asynchronous context tracking](/workers/runtime-apis/nodejs/asynclocalstorage/) | 🟢 supported                                                                                 |
-| [Async hooks](https://nodejs.org/docs/latest/api/async_hooks.html)               | 🟡 partially supported (non-functional)                                                      |
-| [Buffer](/workers/runtime-apis/nodejs/buffer/)                                   | 🟢 supported                                                                                 |
-| [Child processes](https://nodejs.org/docs/latest/api/child_process.html)         | 🟡 partially supported (non-functional)                                                      |
-| [Cluster](https://nodejs.org/docs/latest/api/cluster.html)                       | 🟡 partially supported (non-functional)                                                      |
-| [Console](https://nodejs.org/docs/latest/api/console.html)                       | 🟡 partially supported                                                                       |
-| [Crypto](/workers/runtime-apis/nodejs/crypto/)                                   | 🟢 supported                                                                                 |
-| [Debugger](/workers/observability/dev-tools/)                                    | 🟢 supported via [Chrome Dev Tools integration](/workers/observability/dev-tools/)           |
-| [Diagnostics Channel](/workers/runtime-apis/nodejs/diagnostics-channel/)         | 🟢 supported                                                                                 |
-| [DNS](/workers/runtime-apis/nodejs/dns/)                                         | 🟢 supported                                                                                 |
-| Errors                                                                           | 🟢 supported                                                                                 |
-| [Events](/workers/runtime-apis/nodejs/eventemitter/)                             | 🟢 supported                                                                                 |
-| [File system](/workers/runtime-apis/nodejs/fs/)                                  | 🟢 supported                                                                                 |
-| Globals                                                                          | 🟢 supported                                                                                 |
-| [HTTP](/workers/runtime-apis/nodejs/http/)                                       | 🟢 supported                                                                                 |
-| [HTTP/2](https://nodejs.org/docs/latest/api/http2.html)                          | 🟡 partially supported (non-functional)                                                      |
-| [HTTPS](/workers/runtime-apis/nodejs/https/)                                     | 🟢 supported                                                                                 |
-| [Inspector](https://nodejs.org/docs/latest/api/inspector.html)                   | 🟡 partially supported via [Chrome Dev Tools integration](/workers/observability/dev-tools/) |
-| [Module](https://nodejs.org/docs/latest/api/module.html)                         | 🟡 partially supported                                                                       |
-| [Net](/workers/runtime-apis/nodejs/net/)                                         | 🟢 supported                                                                                 |
-| [OS](https://nodejs.org/docs/latest/api/os.html)                                 | 🟡 partially supported                                                                       |
-| [Path](/workers/runtime-apis/nodejs/path/)                                       | 🟢 supported                                                                                 |
-| [Performance hooks](https://nodejs.org/docs/latest/api/perf_hooks.html)          | 🟡 partially supported                                                                       |
-| [Process](/workers/runtime-apis/nodejs/process/)                                 | 🟢 supported                                                                                 |
-| [Punycode](https://nodejs.org/docs/latest/api/punycode.html) (deprecated)        | 🟢 supported                                                                                 |
-| [Readline](https://nodejs.org/docs/latest/api/readline.html)                     | 🟡 partially supported (non-functional)                                                      |
-| [REPL](https://nodejs.org/docs/latest/api/repl.html)                             | 🟡 partially supported (non-functional)                                                      |
-| [Query strings](https://nodejs.org/docs/latest/api/querystring.html)             | 🟢 supported                                                                                 |
-| [SQLite](https://nodejs.org/docs/latest/api/sqlite.html)                         | ⚪ not yet supported                                                                         |
-| [Stream](/workers/runtime-apis/nodejs/streams)                                   | 🟢 supported                                                                                 |
-| [String decoder](/workers/runtime-apis/nodejs/string-decoder/)                   | 🟢 supported                                                                                 |
-| [Test runner](https://nodejs.org/docs/latest/api/test.html)                      | ⚪ not supported                                                                             |
-| [Timers](/workers/runtime-apis/nodejs/timers/)                                   | 🟢 supported                                                                                 |
-| [TLS/SSL](/workers/runtime-apis/nodejs/tls/)                                     | 🟡 partially supported                                                                       |
-| [UDP/datagram](https://nodejs.org/docs/latest/api/dgram.html)                    | 🟡 partially supported (non-functional)                                                      |
-| [URL](/workers/runtime-apis/nodejs/url/)                                         | 🟢 supported                                                                                 |
-| [Utilities](/workers/runtime-apis/nodejs/util/)                                  | 🟢 supported                                                                                 |
-| [V8](https://nodejs.org/docs/latest/api/v8.html)                                 | 🟡 partially supported (non-functional)                                                      |
-| [VM](https://nodejs.org/docs/latest/api/vm.html)                                 | 🟡 partially supported (non-functional)                                                      |
-| [Web Crypto API](/workers/runtime-apis/web-crypto/)                              | 🟢 supported                                                                                 |
-| [Web Streams API](/workers/runtime-apis/streams/)                                | 🟢 supported                                                                                 |
-| [Zlib](/workers/runtime-apis/nodejs/zlib/)                                       | 🟢 supported                                                                                 |
+| API Name                                                                         | Natively supported by the Workers Runtime                                         |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [Assertion testing](/workers/runtime-apis/nodejs/assert/)                        | 🟢 supported                                                                      |
+| [Asynchronous context tracking](/workers/runtime-apis/nodejs/asynclocalstorage/) | 🟢 supported                                                                      |
+| [Buffer](/workers/runtime-apis/nodejs/buffer/)                                   | 🟢 supported                                                                      |
+| [Console](https://nodejs.org/docs/latest/api/console.html)                       | 🟡 partially supported                                                            |
+| [Crypto](/workers/runtime-apis/nodejs/crypto/)                                   | 🟢 supported                                                                      |
+| [Debugger](/workers/observability/dev-tools/)                                    | 🟢 supported via [Chrome DevTools integration](/workers/observability/dev-tools/) |
+| [Diagnostics Channel](/workers/runtime-apis/nodejs/diagnostics-channel/)         | 🟢 supported                                                                      |
+| [DNS](/workers/runtime-apis/nodejs/dns/)                                         | 🟡 partially supported                                                            |
+| Errors                                                                           | 🟢 supported                                                                      |
+| [Events](/workers/runtime-apis/nodejs/eventemitter/)                             | 🟢 supported                                                                      |
+| [File system](/workers/runtime-apis/nodejs/fs/)                                  | 🟢 supported                                                                      |
+| Globals                                                                          | 🟢 supported                                                                      |
+| [HTTP](/workers/runtime-apis/nodejs/http/)                                       | 🟢 supported                                                                      |
+| [HTTPS](/workers/runtime-apis/nodejs/https/)                                     | 🟢 supported                                                                      |
+| [Module](https://nodejs.org/docs/latest/api/module.html)                         | 🟡 partially supported                                                            |
+| [Net](/workers/runtime-apis/nodejs/net/)                                         | 🟢 supported                                                                      |
+| [OS](https://nodejs.org/docs/latest/api/os.html)                                 | 🟡 partially supported                                                            |
+| [Path](/workers/runtime-apis/nodejs/path/)                                       | 🟢 supported                                                                      |
+| [Performance hooks](https://nodejs.org/docs/latest/api/perf_hooks.html)          | 🟡 partially supported                                                            |
+| [Process](/workers/runtime-apis/nodejs/process/)                                 | 🟢 supported                                                                      |
+| [Punycode](https://nodejs.org/docs/latest/api/punycode.html) (deprecated)        | 🟢 supported                                                                      |
+| [Query strings](https://nodejs.org/docs/latest/api/querystring.html)             | 🟢 supported                                                                      |
+| [Stream](/workers/runtime-apis/nodejs/streams)                                   | 🟢 supported                                                                      |
+| [String decoder](/workers/runtime-apis/nodejs/string-decoder/)                   | 🟢 supported                                                                      |
+| [Test runner](/workers/runtime-apis/nodejs/test/)                                | 🟡 partially supported                                                            |
+| [Timers](/workers/runtime-apis/nodejs/timers/)                                   | 🟢 supported                                                                      |
+| [TLS/SSL](/workers/runtime-apis/nodejs/tls/)                                     | 🟡 partially supported                                                            |
+| [URL](/workers/runtime-apis/nodejs/url/)                                         | 🟢 supported                                                                      |
+| [Utilities](/workers/runtime-apis/nodejs/util/)                                  | 🟢 supported                                                                      |
+| [Web Crypto API](/workers/runtime-apis/web-crypto/)                              | 🟢 supported                                                                      |
+| [Web Streams API](/workers/runtime-apis/streams/)                                | 🟢 supported                                                                      |
+| [Zlib](/workers/runtime-apis/nodejs/zlib/)                                       | 🟢 supported                                                                      |
 
 Unless otherwise specified, native implementations of Node.js APIs in Workers are intended to match the implementation in the [Current release of Node.js](https://github.com/nodejs/release#release-schedule).
 
 If an API you wish to use is missing and you want to suggest that Workers support it, please add a post or comment in the
 [Node.js APIs discussions category](https://github.com/cloudflare/workerd/discussions/categories/node-js-apis) on GitHub.
+
+### Non-functional stub modules
+
+Some Node.js modules are available as non-functional stubs. A stub can be imported or required, but does not provide a working implementation of the underlying Node.js API. These stubs exist so packages that check for the presence of a module can load in Workers, but they are not suitable for direct use in application code.
+
+The following stubs require the `nodejs_compat` compatibility flag. They are enabled automatically when your Worker has a compatibility date on or after the date shown. To enable one earlier, add the corresponding enable flag. To keep one unavailable after that date, add the corresponding disable flag.
+
+| Stub module           | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
+| --------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |
+| `node:http2`          | `2025-09-01`                             | `enable_nodejs_http2_module`          | `disable_nodejs_http2_module`          |
+| `node:vm`             | `2025-10-01`                             | `enable_nodejs_vm_module`             | `disable_nodejs_vm_module`             |
+| `node:cluster`        | `2025-12-04`                             | `enable_nodejs_cluster_module`        | `disable_nodejs_cluster_module`        |
+| `node:domain`         | `2025-12-04`                             | `enable_nodejs_domain_module`         | `disable_nodejs_domain_module`         |
+| `node:trace_events`   | `2025-12-04`                             | `enable_nodejs_trace_events_module`   | `disable_nodejs_trace_events_module`   |
+| `node:wasi`           | `2025-12-04`                             | `enable_nodejs_wasi_module`           | `disable_nodejs_wasi_module`           |
+| `node:_stream_wrap`   | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
+| `node:dgram`          | `2026-01-29`                             | `enable_nodejs_dgram_module`          | `disable_nodejs_dgram_module`          |
+| `node:inspector`      | `2026-01-29`                             | `enable_nodejs_inspector_module`      | `disable_nodejs_inspector_module`      |
+| `node:sqlite`         | `2026-01-29`                             | `enable_nodejs_sqlite_module`         | `disable_nodejs_sqlite_module`         |
+| `node:child_process`  | `2026-03-17`                             | `enable_nodejs_child_process_module`  | `disable_nodejs_child_process_module`  |
+| `node:readline`       | `2026-03-17`                             | `enable_nodejs_readline_module`       | `disable_nodejs_readline_module`       |
+| `node:repl`           | `2026-03-17`                             | `enable_nodejs_repl_module`           | `disable_nodejs_repl_module`           |
+| `node:tty`            | `2026-03-17`                             | `enable_nodejs_tty_module`            | `disable_nodejs_tty_module`            |
+| `node:v8`             | `2026-03-17`                             | `enable_nodejs_v8_module`             | `disable_nodejs_v8_module`             |
+| `node:worker_threads` | `2026-03-17`                             | `enable_nodejs_worker_threads_module` | `disable_nodejs_worker_threads_module` |
 
 ### Node.js API Polyfills
 
@@ -113,9 +124,7 @@ If you need to enable only the Node.js `AsyncLocalStorage` API, you can enable t
 
 ```jsonc
 {
-	"compatibility_flags": [
-		"nodejs_als"
-	]
+	"compatibility_flags": ["nodejs_als"],
 }
 ```
 

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -83,7 +83,7 @@ If an API you wish to use is missing and you want to suggest that Workers suppor
 
 Some Node.js modules are available as non-functional stubs. A stub can be imported or required, but does not provide a working implementation of the underlying Node.js API. These stubs exist so packages that check for the presence of a module can load in Workers, but they are not suitable for direct use in application code.
 
-The following stubs require the `nodejs_compat` compatibility flag. They are enabled automatically when your Worker has a compatibility date on or after the date shown. To enable one earlier, add the corresponding enable flag. To keep one unavailable after that date, add the corresponding disable flag.
+The following stubs are enabled automatically only when the `nodejs_compat` compatibility flag is enabled and your Worker's compatibility date is on or after the date shown. To enable one earlier, add the corresponding enable flag. To keep one unavailable after that date, add the corresponding disable flag.
 
 | Stub module           | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
 | --------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -7,7 +7,7 @@ products:
   - workers
 ---
 
-import { WranglerConfig } from "~/components";
+import { Render, WranglerConfig } from "~/components";
 
 When you write a Worker, you may need to import packages from [npm](https://www.npmjs.com/). Many npm packages rely on APIs from the [Node.js runtime](https://nodejs.org/en/about), and will not work unless these Node.js APIs are available.
 
@@ -85,24 +85,7 @@ Some Node.js modules are available as non-functional stubs. A stub can be import
 
 The following stubs are enabled automatically only when the `nodejs_compat` compatibility flag is enabled and your Worker's compatibility date is on or after the date shown. To enable one earlier, add the corresponding enable flag. To keep one unavailable after that date, add the corresponding disable flag.
 
-| Stub module                                                                     | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
-| ------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |
-| [`node:http2`](https://nodejs.org/docs/latest/api/http2.html)                   | `2025-09-01`                             | `enable_nodejs_http2_module`          | `disable_nodejs_http2_module`          |
-| [`node:vm`](https://nodejs.org/docs/latest/api/vm.html)                         | `2025-10-01`                             | `enable_nodejs_vm_module`             | `disable_nodejs_vm_module`             |
-| [`node:cluster`](https://nodejs.org/docs/latest/api/cluster.html)               | `2025-12-04`                             | `enable_nodejs_cluster_module`        | `disable_nodejs_cluster_module`        |
-| [`node:domain`](https://nodejs.org/docs/latest/api/domain.html)                 | `2025-12-04`                             | `enable_nodejs_domain_module`         | `disable_nodejs_domain_module`         |
-| [`node:trace_events`](https://nodejs.org/docs/latest/api/tracing.html)          | `2025-12-04`                             | `enable_nodejs_trace_events_module`   | `disable_nodejs_trace_events_module`   |
-| [`node:wasi`](https://nodejs.org/docs/latest/api/wasi.html)                     | `2025-12-04`                             | `enable_nodejs_wasi_module`           | `disable_nodejs_wasi_module`           |
-| [`node:_stream_wrap`](https://nodejs.org/docs/latest/api/stream.html)           | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
-| [`node:dgram`](https://nodejs.org/docs/latest/api/dgram.html)                   | `2026-01-29`                             | `enable_nodejs_dgram_module`          | `disable_nodejs_dgram_module`          |
-| [`node:inspector`](https://nodejs.org/docs/latest/api/inspector.html)           | `2026-01-29`                             | `enable_nodejs_inspector_module`      | `disable_nodejs_inspector_module`      |
-| [`node:sqlite`](https://nodejs.org/docs/latest/api/sqlite.html)                 | `2026-01-29`                             | `enable_nodejs_sqlite_module`         | `disable_nodejs_sqlite_module`         |
-| [`node:child_process`](https://nodejs.org/docs/latest/api/child_process.html)   | `2026-03-17`                             | `enable_nodejs_child_process_module`  | `disable_nodejs_child_process_module`  |
-| [`node:readline`](https://nodejs.org/docs/latest/api/readline.html)             | `2026-03-17`                             | `enable_nodejs_readline_module`       | `disable_nodejs_readline_module`       |
-| [`node:repl`](https://nodejs.org/docs/latest/api/repl.html)                     | `2026-03-17`                             | `enable_nodejs_repl_module`           | `disable_nodejs_repl_module`           |
-| [`node:tty`](https://nodejs.org/docs/latest/api/tty.html)                       | `2026-03-17`                             | `enable_nodejs_tty_module`            | `disable_nodejs_tty_module`            |
-| [`node:v8`](https://nodejs.org/docs/latest/api/v8.html)                         | `2026-03-17`                             | `enable_nodejs_v8_module`             | `disable_nodejs_v8_module`             |
-| [`node:worker_threads`](https://nodejs.org/docs/latest/api/worker_threads.html) | `2026-03-17`                             | `enable_nodejs_worker_threads_module` | `disable_nodejs_worker_threads_module` |
+<Render file="nodejs-compat-stub-modules" product="workers" />
 
 ### Node.js API Polyfills
 

--- a/src/content/docs/workers/runtime-apis/nodejs/index.mdx
+++ b/src/content/docs/workers/runtime-apis/nodejs/index.mdx
@@ -85,24 +85,24 @@ Some Node.js modules are available as non-functional stubs. A stub can be import
 
 The following stubs are enabled automatically only when the `nodejs_compat` compatibility flag is enabled and your Worker's compatibility date is on or after the date shown. To enable one earlier, add the corresponding enable flag. To keep one unavailable after that date, add the corresponding disable flag.
 
-| Stub module           | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
-| --------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |
-| `node:http2`          | `2025-09-01`                             | `enable_nodejs_http2_module`          | `disable_nodejs_http2_module`          |
-| `node:vm`             | `2025-10-01`                             | `enable_nodejs_vm_module`             | `disable_nodejs_vm_module`             |
-| `node:cluster`        | `2025-12-04`                             | `enable_nodejs_cluster_module`        | `disable_nodejs_cluster_module`        |
-| `node:domain`         | `2025-12-04`                             | `enable_nodejs_domain_module`         | `disable_nodejs_domain_module`         |
-| `node:trace_events`   | `2025-12-04`                             | `enable_nodejs_trace_events_module`   | `disable_nodejs_trace_events_module`   |
-| `node:wasi`           | `2025-12-04`                             | `enable_nodejs_wasi_module`           | `disable_nodejs_wasi_module`           |
-| `node:_stream_wrap`   | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
-| `node:dgram`          | `2026-01-29`                             | `enable_nodejs_dgram_module`          | `disable_nodejs_dgram_module`          |
-| `node:inspector`      | `2026-01-29`                             | `enable_nodejs_inspector_module`      | `disable_nodejs_inspector_module`      |
-| `node:sqlite`         | `2026-01-29`                             | `enable_nodejs_sqlite_module`         | `disable_nodejs_sqlite_module`         |
-| `node:child_process`  | `2026-03-17`                             | `enable_nodejs_child_process_module`  | `disable_nodejs_child_process_module`  |
-| `node:readline`       | `2026-03-17`                             | `enable_nodejs_readline_module`       | `disable_nodejs_readline_module`       |
-| `node:repl`           | `2026-03-17`                             | `enable_nodejs_repl_module`           | `disable_nodejs_repl_module`           |
-| `node:tty`            | `2026-03-17`                             | `enable_nodejs_tty_module`            | `disable_nodejs_tty_module`            |
-| `node:v8`             | `2026-03-17`                             | `enable_nodejs_v8_module`             | `disable_nodejs_v8_module`             |
-| `node:worker_threads` | `2026-03-17`                             | `enable_nodejs_worker_threads_module` | `disable_nodejs_worker_threads_module` |
+| Stub module                                                                     | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
+| ------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |
+| [`node:http2`](https://nodejs.org/docs/latest/api/http2.html)                   | `2025-09-01`                             | `enable_nodejs_http2_module`          | `disable_nodejs_http2_module`          |
+| [`node:vm`](https://nodejs.org/docs/latest/api/vm.html)                         | `2025-10-01`                             | `enable_nodejs_vm_module`             | `disable_nodejs_vm_module`             |
+| [`node:cluster`](https://nodejs.org/docs/latest/api/cluster.html)               | `2025-12-04`                             | `enable_nodejs_cluster_module`        | `disable_nodejs_cluster_module`        |
+| [`node:domain`](https://nodejs.org/docs/latest/api/domain.html)                 | `2025-12-04`                             | `enable_nodejs_domain_module`         | `disable_nodejs_domain_module`         |
+| [`node:trace_events`](https://nodejs.org/docs/latest/api/tracing.html)          | `2025-12-04`                             | `enable_nodejs_trace_events_module`   | `disable_nodejs_trace_events_module`   |
+| [`node:wasi`](https://nodejs.org/docs/latest/api/wasi.html)                     | `2025-12-04`                             | `enable_nodejs_wasi_module`           | `disable_nodejs_wasi_module`           |
+| [`node:_stream_wrap`](https://nodejs.org/docs/latest/api/stream.html)           | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
+| [`node:dgram`](https://nodejs.org/docs/latest/api/dgram.html)                   | `2026-01-29`                             | `enable_nodejs_dgram_module`          | `disable_nodejs_dgram_module`          |
+| [`node:inspector`](https://nodejs.org/docs/latest/api/inspector.html)           | `2026-01-29`                             | `enable_nodejs_inspector_module`      | `disable_nodejs_inspector_module`      |
+| [`node:sqlite`](https://nodejs.org/docs/latest/api/sqlite.html)                 | `2026-01-29`                             | `enable_nodejs_sqlite_module`         | `disable_nodejs_sqlite_module`         |
+| [`node:child_process`](https://nodejs.org/docs/latest/api/child_process.html)   | `2026-03-17`                             | `enable_nodejs_child_process_module`  | `disable_nodejs_child_process_module`  |
+| [`node:readline`](https://nodejs.org/docs/latest/api/readline.html)             | `2026-03-17`                             | `enable_nodejs_readline_module`       | `disable_nodejs_readline_module`       |
+| [`node:repl`](https://nodejs.org/docs/latest/api/repl.html)                     | `2026-03-17`                             | `enable_nodejs_repl_module`           | `disable_nodejs_repl_module`           |
+| [`node:tty`](https://nodejs.org/docs/latest/api/tty.html)                       | `2026-03-17`                             | `enable_nodejs_tty_module`            | `disable_nodejs_tty_module`            |
+| [`node:v8`](https://nodejs.org/docs/latest/api/v8.html)                         | `2026-03-17`                             | `enable_nodejs_v8_module`             | `disable_nodejs_v8_module`             |
+| [`node:worker_threads`](https://nodejs.org/docs/latest/api/worker_threads.html) | `2026-03-17`                             | `enable_nodejs_worker_threads_module` | `disable_nodejs_worker_threads_module` |
 
 ### Node.js API Polyfills
 

--- a/src/content/partials/workers/nodejs-compat-stub-modules.mdx
+++ b/src/content/partials/workers/nodejs-compat-stub-modules.mdx
@@ -10,7 +10,7 @@
 | [`node:domain`](https://nodejs.org/docs/latest/api/domain.html)                 | `2025-12-04`                             | `enable_nodejs_domain_module`         | `disable_nodejs_domain_module`         |
 | [`node:trace_events`](https://nodejs.org/docs/latest/api/tracing.html)          | `2025-12-04`                             | `enable_nodejs_trace_events_module`   | `disable_nodejs_trace_events_module`   |
 | [`node:wasi`](https://nodejs.org/docs/latest/api/wasi.html)                     | `2025-12-04`                             | `enable_nodejs_wasi_module`           | `disable_nodejs_wasi_module`           |
-| [`node:_stream_wrap`](https://nodejs.org/docs/latest/api/stream.html)           | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
+| `node:_stream_wrap`                                                             | `2026-01-29`                             | `enable_nodejs_stream_wrap_module`    | `disable_nodejs_stream_wrap_module`    |
 | [`node:dgram`](https://nodejs.org/docs/latest/api/dgram.html)                   | `2026-01-29`                             | `enable_nodejs_dgram_module`          | `disable_nodejs_dgram_module`          |
 | [`node:inspector`](https://nodejs.org/docs/latest/api/inspector.html)           | `2026-01-29`                             | `enable_nodejs_inspector_module`      | `disable_nodejs_inspector_module`      |
 | [`node:sqlite`](https://nodejs.org/docs/latest/api/sqlite.html)                 | `2026-01-29`                             | `enable_nodejs_sqlite_module`         | `disable_nodejs_sqlite_module`         |

--- a/src/content/partials/workers/nodejs-compat-stub-modules.mdx
+++ b/src/content/partials/workers/nodejs-compat-stub-modules.mdx
@@ -1,29 +1,6 @@
 ---
-_build:
-  publishResources: false
-  render: never
-  list: never
-
-name: "Node.js compatibility"
-sort_date: "2023-01-15"
-enable_flag: "nodejs_compat"
-disable_flag: "no_nodejs_compat"
+{}
 ---
-
-Enables [Node.js APIs](/workers/runtime-apis/nodejs/) in the Workers Runtime.
-
-Note that some Node.js APIs are only enabled when your Worker's compatibility date is on or after the following dates:
-
-| Node.js API                                                                                                                    | Enabled with `nodejs_compat` on or after |
-| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
-| [Disable Top-level Await in `require()`](/workers/configuration/compatibility-flags/#disable-top-level-await-in-require)       | `2024-12-02`                             |
-| [`process.env`](/workers/configuration/compatibility-flags/#enable-auto-populating-processenv)                                 | `2025-04-01`                             |
-| [`node:http`, `node:https`](/workers/configuration/compatibility-flags/#enable-availability-of-nodehttp-and-nodehttps-modules) | `2025-08-15`                             |
-| [`http.server`](/workers/configuration/compatibility-flags/#enable-nodejs-http-server-modules)                                 | `2025-09-01`                             |
-
-Some Node.js modules are available in Workers only as non-functional stubs. These modules can be imported or required, but do not provide working implementations of the corresponding Node.js APIs. Stubs exist for compatibility with packages that check whether a module exists, and should not be used directly in application code.
-
-The following stubs are enabled automatically only when `nodejs_compat` is enabled and your Worker's compatibility date is on or after the date shown:
 
 | Stub module                                                                     | Enabled with `nodejs_compat` on or after | Enable flag                           | Disable flag                           |
 | ------------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------- | -------------------------------------- |
@@ -43,7 +20,3 @@ The following stubs are enabled automatically only when `nodejs_compat` is enabl
 | [`node:tty`](https://nodejs.org/docs/latest/api/tty.html)                       | `2026-03-17`                             | `enable_nodejs_tty_module`            | `disable_nodejs_tty_module`            |
 | [`node:v8`](https://nodejs.org/docs/latest/api/v8.html)                         | `2026-03-17`                             | `enable_nodejs_v8_module`             | `disable_nodejs_v8_module`             |
 | [`node:worker_threads`](https://nodejs.org/docs/latest/api/worker_threads.html) | `2026-03-17`                             | `enable_nodejs_worker_threads_module` | `disable_nodejs_worker_threads_module` |
-
-When enabling `nodejs_compat`, we recommend using the latest version of [Wrangler CLI](/workers/wrangler/), and the latest compatibility date, in order to maximize compatibility. Some older versions of Wrangler inject additional polyfills that are no longer necessary when your Worker uses a more recent compatibility date, because they are provided by the Workers runtime.
-
-If you see errors using a particular npm package on Workers, you should first try updating your compatibility date and use the latest version of [Wrangler CLI](/workers/wrangler/) or the [Cloudflare Vite Plugin](/workers/vite-plugin/). If you still encounter issues, please report them by [opening a GitHub issue](https://github.com/cloudflare/workers-sdk/issues/new?template=bug-template.yaml).


### PR DESCRIPTION
## Summary

- Adds a distinct non-functional stub modules section to the Workers Node.js compatibility page, separate from the supported Node.js API table.
- Documents the compatibility-date conditions, enable flags, and disable flags for Node.js stub modules such as `node:tty`, `node:child_process`, `node:vm`, and related modules.
- Adds the same stub module information to the `nodejs_compat` compatibility flag entry so readers can find the date-gated behavior from either docs path.
- Links each stub module name to the relevant Node.js API documentation.
- Extracts the stub modules table into a shared Workers partial so the runtime API page and compatibility flag entry use one source of truth.