### PR TITLE
Turnstile: add forces-interaction (3x) sitekey to testing scenarios

### DIFF
--- a/src/content/docs/turnstile/troubleshooting/testing.mdx
+++ b/src/content/docs/turnstile/troubleshooting/testing.mdx
@@ -159,3 +159,4 @@ Production secret keys will reject the dummy token. You must also use a dummy se
 | `1x00000000000000000000AA` | `1x0000000000000000000000000000000AA` | This combination will always result in successful validation. |
 | `2x00000000000000000000AB` | `2x0000000000000000000000000000000AA` | This combination will always fail. |
 | `1x00000000000000000000AA` | `3x0000000000000000000000000000000AA` | This combination will always fail with "timeout-or-duplicate" error. |
+| `3x00000000000000000000FF` | `1x0000000000000000000000000000000AA` | This combination forces an interactive challenge. After the visitor solves it, server-side validation always succeeds. |


### PR DESCRIPTION
## Summary

Closes #31088.

On the [Turnstile testing page](https://developers.cloudflare.com/turnstile/troubleshooting/testing/#testing-scenarios), the **Testing scenarios** table only demonstrated the always-pass and always-fail sitekeys. The `3x00000000000000000000FF` "forces interactive challenge" sitekey — already documented in the **Test sitekeys** table on the same page — was missing from the scenarios, which is what the issue reporter flagged.

This adds a row pairing that sitekey with the always-pass test secret key (`1x0000000000000000000000000000000AA`), so the interactive-challenge flow is represented:

| Test sitekey | Test secret key | Test case |
| --- | --- | --- |
| `3x00000000000000000000FF` | `1x0000000000000000000000000000000AA` | This combination forces an interactive challenge. After the visitor solves it, server-side validation always succeeds. |

The three existing rows are correct and left unchanged; this is purely additive.
