### PR TITLE
[Agents] Publish MCP skill artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ distllms/
 # Astro build cache
 .astro-cache/
 
-# skills/ is fetched from middlecache via bin/fetch-skills.ts
-skills/
+# /skills/ is fetched from middlecache via bin/fetch-skills.ts
+/skills/
 !.agents/skills/
 !.agents/commands/
 !.agents/agents/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -252,7 +252,14 @@ export default defineConfig({
 			serialize: createSitemapLastmodSerializer(),
 		}),
 		react(),
-		skills(),
+		skills({
+			mcp: {
+				prefix: "/.well-known/mcp/skills",
+				resourceBase: "skill://",
+				directoryManifest: true,
+				archives: true,
+			},
+		}),
 	],
 	vite: {
 		resolve: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,7 @@ export default [
 			".flue/.wrangler/",
 			"dist/",
 			".github/",
+			"skills/",
 		],
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"astro-breadcrumbs": "3.4.0",
 		"astro-expressive-code": "0.43.1",
 		"astro-icon": "1.1.5",
-		"astro-skills": "0.1.0",
+		"astro-skills": "github:irvinebroque/astro-skills#codex/sep-2640-mcp-skills",
 		"cidr-tools": "12.0.3",
 		"codeowners-utils": "1.0.2",
 		"date-fns": "4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: 1.1.5
         version: 1.1.5
       astro-skills:
-        specifier: 0.1.0
-        version: 0.1.0(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
+        specifier: github:irvinebroque/astro-skills#codex/sep-2640-mcp-skills
+        version: https://codeload.github.com/irvinebroque/astro-skills/tar.gz/04e47a6d9eed19f2243bf0f857ebdacd98e6de6d(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
       cidr-tools:
         specifier: 12.0.3
         version: 12.0.3
@@ -2805,8 +2805,9 @@ packages:
   astro-icon@1.1.5:
     resolution: {integrity: sha512-CJYS5nWOw9jz4RpGWmzNQY7D0y2ZZacH7atL2K9DeJXJVaz7/5WrxeyIxO8KASk1jCM96Q4LjRx/F3R+InjJrw==}
 
-  astro-skills@0.1.0:
-    resolution: {integrity: sha512-Xa+sltSMMZEoJB4L3kn8fqRbQMogApQOIMq+P9Fi2lX/CTvComvplFgm/O+zPbIpdrCz3KGs9bdiZkHfzxApqQ==}
+  astro-skills@https://codeload.github.com/irvinebroque/astro-skills/tar.gz/04e47a6d9eed19f2243bf0f857ebdacd98e6de6d:
+    resolution: {gitHosted: true, integrity: sha512-ZToEc2KlJTi5SnN4bKZhg9M5KqPOGkNTuP8F0M70jXjn5egu5vW2CIKq2pC6FQlurF2qC1fUJtPUhnXg90sbtg==, tarball: https://codeload.github.com/irvinebroque/astro-skills/tar.gz/04e47a6d9eed19f2243bf0f857ebdacd98e6de6d}
+    version: 0.1.0
     peerDependencies:
       astro: '*'
       typescript: ^5.9.3
@@ -9069,7 +9070,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro-skills@0.1.0(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3):
+  astro-skills@https://codeload.github.com/irvinebroque/astro-skills/tar.gz/04e47a6d9eed19f2243bf0f857ebdacd98e6de6d(astro@6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3):
     dependencies:
       astro: 6.4.7(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(tsx@4.22.4)(yaml@2.9.0)
       gray-matter: 4.0.3

--- a/public/_headers
+++ b/public/_headers
@@ -19,5 +19,17 @@
 /.well-known/agent-skills/index.json
   Content-Type: application/json; charset=utf-8
 
+/.well-known/mcp/skills/index.json
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/mcp/skills/.tree.json
+  Content-Type: application/json; charset=utf-8
+
+/.well-known/mcp/skills/*/SKILL.md
+  Content-Type: text/markdown; charset=utf-8
+
+/.well-known/mcp/skills/*.tar.gz
+  Content-Type: application/gzip
+
 /.well-known/mcp/server-card.json
   Content-Type: application/json; charset=utf-8

--- a/src/content/docs/agents/model-context-protocol/cloudflare/servers-for-cloudflare/index.mdx
+++ b/src/content/docs/agents/model-context-protocol/cloudflare/servers-for-cloudflare/index.mdx
@@ -18,6 +18,8 @@ These MCP servers allow your MCP client to read configurations from your account
 
 The [Cloudflare API MCP server](https://github.com/cloudflare/mcp) provides access to the entire [Cloudflare API](/api/) — over 2,500 endpoints across DNS, Workers, R2, Zero Trust, and every other product — through just two tools: `search()` and `execute()`.
 
+For most Cloudflare automation and account-management tasks, use the Cloudflare API MCP server. It can reach the full Cloudflare API from one connection, so you usually do not need to configure product-specific MCP servers.
+
 It uses [Code Mode](/agents/model-context-protocol/protocol/codemode/), a technique where the model writes JavaScript against a typed representation of the OpenAPI spec and the Cloudflare API client, rather than loading individual tool definitions for each endpoint. The generated code runs inside an isolated [Dynamic Worker](/workers/runtime-apis/bindings/worker-loader/) sandbox.
 
 This approach uses approximately 1,000 tokens regardless of how many API endpoints exist. An equivalent MCP server that exposed every endpoint as a native tool would consume over 1 million tokens — more than the entire context window of most foundation models.
@@ -86,7 +88,11 @@ Clone the [cloudflare/skills](https://github.com/cloudflare/skills) repository a
 
 ## Product-specific MCP servers
 
-In addition to the Cloudflare API MCP server, Cloudflare provides product-specific MCP servers for targeted use cases:
+Cloudflare also provides product-specific MCP servers for targeted use cases:
+
+:::note[Use the Cloudflare API MCP server by default]
+For most use cases, connect to the [Cloudflare API MCP server](#cloudflare-api-mcp-server). Use the product-specific MCP servers below only when you need a specialized workflow, non-API data source, or server-specific behavior.
+:::
 
 | Server Name                                                                                                             | Description                                                                                     | Server URL                                     |
 | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
 		"jsxImportSource": "react"
 	},
 	"include": [".astro/types.d.ts", "**/*"],
-	"exclude": ["dist", "worker", ".flue"]
+	"exclude": ["dist", "worker", ".flue", "skills"]
 }


### PR DESCRIPTION
### Summary

Uses the experimental MCP publication mode from [FredKSchott/astro-skills#4](https://github.com/FredKSchott/astro-skills/pull/4) to publish Cloudflare Skills artifacts under `/.well-known/mcp/skills/`, including an SEP-style skill index, tree manifest, direct file resources, and archive resources backed by the generated Cloudflare Skills bundle.

This follows [SEP-2640: Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) in the Model Context Protocol repository.

Companion implementation PRs:

- [cloudflare/mcp#165](https://github.com/cloudflare/mcp/pull/165)
- [irvinebroque/astro-skills#1](https://github.com/irvinebroque/astro-skills/pull/1)

Dependency note: this branch validates when the linked `astro-skills` PR is built locally, but a fresh GitHub dependency install currently needs that PR to include consumable package output, such as built `dist/` files or an equivalent package/prepare flow.

Also updates the Cloudflare MCP servers docs to recommend the Cloudflare API MCP server by default, while positioning product-specific MCP servers as specialized options.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
