### PR TITLE
Pages: clarify SPA fallback behavior is for unmatched paths

### DIFF
--- a/src/content/docs/pages/configuration/serving-pages.mdx
+++ b/src/content/docs/pages/configuration/serving-pages.mdx
@@ -18,7 +18,7 @@ You can define a custom page to be displayed when Pages cannot find a requested 
 
 ## Single-page application (SPA) rendering
 
-If your project does not include a top-level `404.html` file, Pages assumes that you are deploying a single-page application. This includes frameworks like React, Vue, and Angular. Pages' default single-page application behavior matches all incoming paths to the root (`/`), allowing you to capture URLs like `/about` or `/help` and respond to them from within your SPA.
+If your project does not include a top-level `404.html` file, Pages assumes that you are deploying a single-page application. This includes frameworks like React, Vue, and Angular. Pages' default single-page application behavior serves the root (`/`) for any incoming path that does not correspond to a static asset, allowing your application to handle routes like `/about` or `/help` client-side from within your SPA.
 
 ## Caching and performance
 


### PR DESCRIPTION
Fixes #31288.

The SPA-rendering section said Pages "matches all incoming paths to the root (`/`)", which reads as though *every* path is served the root. It's actually a **fallback**: a request for `/about` is served `about.html` if that asset exists, and only paths with no matching static asset fall back to `/`.

Reworded to make the fallback behavior explicit (using the wording suggested by the issue reporter):

> Pages' default single-page application behavior serves the root (`/`) for any incoming path that does not correspond to a static asset, allowing your application to handle routes like `/about` or `/help` client-side from within your SPA.
