### PR TITLE
Billing: correct location of invoice email preferences (Subscriptions tab)

### DIFF
--- a/src/content/docs/billing/manage/invoices.mdx
+++ b/src/content/docs/billing/manage/invoices.mdx
@@ -33,8 +33,8 @@ To receive invoice emails when you add or remove subscriptions from your account
 
    <DashButton url="/?to=/:account/billing" />
 
-2. Select **Invoices and documents**.
-3. From **Billing email preferences**, turn on invoice emails.
+2. Select **Subscriptions**.
+3. From the **Billing Email** card, turn on invoice emails.
 
 </Steps>
 


### PR DESCRIPTION
Fixes #31128.

The "Receive invoice emails" steps pointed to the **Invoices and documents** tab, but the billing email preferences aren't there. Per the issue reporter, they live in a **Billing Email** card on the **Subscriptions** tab (Manage Account > Billing).

Updated steps 2–3 of that section to point to the correct location. The **Download invoice** section below is left unchanged, since downloading invoices *is* on the Invoices and documents tab.
