### PR TITLE
WARP: document webkit2gtk3 dependency limitation on newer Fedora

### DIFF
--- a/src/content/partials/cloudflare-one/warp/system-requirements/linux.mdx
+++ b/src/content/partials/cloudflare-one/warp/system-requirements/linux.mdx
@@ -5,7 +5,7 @@
 
 |                       |                                                                               |
 | --------------------- | ----------------------------------------------------------------------------- |
-| **OS version**        | CentOS 8, RHEL 8, RHEL 9 [^1], Debian 12, Debian 13, Fedora 34, Fedora 35, Ubuntu 22.04 LTS, Ubuntu 24.04 LTS |
+| **OS version**        | CentOS 8, RHEL 8, RHEL 9 [^1], Debian 12, Debian 13, Fedora 34, Fedora 35 [^3], Ubuntu 22.04 LTS, Ubuntu 24.04 LTS |
 | **Processor**         | AMD64 / x86-64 or ARM64 / AArch64                                   |
 | **HD space**          | 75 MB                                                                         |
 | **Memory**            | 35 MB                                                                         |
@@ -15,3 +15,5 @@
 [^1]: On RHEL 9 and later, enable the [Extra Packages for Enterprise Linux (EPEL)](https://docs.fedoraproject.org/en-US/epel/) repository (`sudo dnf install epel-release`) before installing `cloudflare-warp`. EPEL provides dependencies required by the client UI.
 
 [^2]: Minimum 1281 bytes with [Path MTU Discovery](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/path-mtu-discovery/)
+
+[^3]: The Linux client UI depends on the `webkit2gtk3` library. Fedora releases newer than those listed (Fedora 41 and later) ship `webkit2gtk4.x` instead of `webkit2gtk3` and do not provide a `webkit2gtk3` package, so the `cloudflare-warp` RPM cannot currently be installed on them.


### PR DESCRIPTION
Fixes #31057.

Users on newer Fedora releases (43/44) hit `nothing provides webkit2gtk3 needed by cloudflare-warp` when installing the RPM, with no explanation in the docs. The supported-versions table lists only Fedora 34/35; newer Fedora ships `webkit2gtk4.x` and no longer provides `webkit2gtk3`, which the `cloudflare-warp` RPM depends on — hence the failure.

Added a footnote on the Fedora entry (matching the existing `[^1]` RHEL/EPEL dependency footnote) documenting that the client UI requires `webkit2gtk3` and that Fedora 41+ does not provide it. This documents the limitation rather than recommending an unofficial workaround (the linked issue confirms there is no official fix yet).
