### PR TITLE
Spectrum: proxy protocol unsupported for all Private Network LB off-ramps (not just WAN)

### DIFF
--- a/src/content/docs/spectrum/reference/limitations.mdx
+++ b/src/content/docs/spectrum/reference/limitations.mdx
@@ -29,7 +29,7 @@ Minecraft Java Edition is supported but Minecraft Bedrock Edition is not support
 
 ## Private Network Load Balancing
 
-When using [Spectrum](/load-balancing/private-network/#on-ramps) as an on-ramp and [Cloudflare WAN](/load-balancing/private-network/#cloudflare-wan) as an off-ramp the [proxy protocol](/spectrum/how-to/enable-proxy-protocol/) setting in Spectrum is not supported.
+When using [Spectrum](/load-balancing/private-network/#on-ramps) as an on-ramp into Private Network Load Balancing, the [proxy protocol](/spectrum/how-to/enable-proxy-protocol/) setting in Spectrum is not supported. This applies regardless of the [off-ramp](/load-balancing/private-network/) used to reach your private origin, including Cloudflare WAN and Cloudflare Tunnel.
 
 ## Cloudflare Tunnel
 


### PR DESCRIPTION
## Summary

The [Spectrum Limitations](https://developers.cloudflare.com/spectrum/reference/limitations/#private-network-load-balancing) page states that the Spectrum proxy protocol setting is unsupported when using Spectrum as an on-ramp and **Cloudflare WAN** as an off-ramp. This is also the case when the off-ramp is **Cloudflare Tunnel**: the proxy protocol header (v1 and v2) is not delivered to the private origin, so the origin does not receive the original client IP.

This PR generalizes the note so it applies regardless of the off-ramp and explicitly includes Cloudflare Tunnel.

## Change

Before:
> When using Spectrum as an on-ramp and Cloudflare WAN as an off-ramp the proxy protocol setting in Spectrum is not supported.

After:
> When using Spectrum as an on-ramp into Private Network Load Balancing, the proxy protocol setting in Spectrum is not supported. This applies regardless of the off-ramp used to reach your private origin, including Cloudflare WAN and Cloudflare Tunnel.

## Verification

Verified empirically with a public Spectrum TCP application whose origin is a Load Balancer using Private Network Load Balancing (LTM) with a private-IP origin routed over Cloudflare Tunnel. With proxy protocol set to v1, v2, and off, the origin received the raw client bytes with no proxy protocol header in all cases.