### PR TITLE
feat(WO-1441): document Workers Observability CMB support

### DIFF
--- a/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
+++ b/src/content/docs/workers/observability/exporting-opentelemetry-data/index.mdx
@@ -99,6 +99,8 @@ After setting up destinations in the dashboard, configure your Worker to export 
 
 :::note[`persist` and pricing]
 By default, `persist` is `true`, which means logs and traces are both exported to your destination and stored in the Cloudflare dashboard. Dashboard storage is billed [separately](/workers/observability/logs/workers-logs/#pricing). Set `persist` to `false` if you only need data in your external destination.
+
+If your account has [Customer Metadata Boundary](/data-localization/metadata-boundary/) configured, the copy stored by Cloudflare respects your configured region. Data exported to your OTLP destination is delivered to the endpoint you configure.
 :::
 
 Once you've configured your Wrangler configuration file, redeploy your Worker for new configurations to take effect. Note that it may take a few minutes for events to reach your destination.

--- a/src/content/docs/workers/observability/index.mdx
+++ b/src/content/docs/workers/observability/index.mdx
@@ -13,6 +13,8 @@ import { LinkCard, CardGrid } from "~/components";
 
 Cloudflare Workers provides comprehensive observability tools to help you understand how your applications are performing, diagnose issues, and gain insights into request flows. Whether you want to use Cloudflare's native observability platform or export telemetry data to your existing monitoring stack, Workers has you covered.
 
+Workers Observability supports [Customer Metadata Boundary](/data-localization/metadata-boundary/). If your account has a Customer Metadata Boundary configured, Workers Logs, traces, and queryable observability data stored by Cloudflare are processed and stored according to your configured region.
+
 ## Logs
 
 Logs are essential for troubleshooting and understanding your application's behavior. Cloudflare offers several ways to access and manage your Worker logs.

--- a/src/content/docs/workers/observability/logs/workers-logs.mdx
+++ b/src/content/docs/workers/observability/logs/workers-logs.mdx
@@ -26,6 +26,8 @@ Logs include [invocation logs](/workers/observability/logs/workers-logs/#invocat
 
 To send logs to a third party, use [Workers Logpush](/workers/observability/logs/logpush/) or [Tail Workers](/workers/observability/logs/tail-workers/).
 
+If your account has [Customer Metadata Boundary](/data-localization/metadata-boundary/) configured, Workers Logs stored by Cloudflare are processed and stored according to your configured region.
+
 ## Enable Workers Logs
 
 :::note[Wrangler version]

--- a/src/content/docs/workers/observability/query-builder.mdx
+++ b/src/content/docs/workers/observability/query-builder.mdx
@@ -20,7 +20,7 @@ import {
 	Steps,
 } from "~/components";
 
-The Query Builder helps you write structured queries to investigate and visualize your telemetry data. The Query Builder searches the Workers Observability dataset, which currently includes all logs stored by [Workers Logs](/workers/observability/logs/workers-logs/).
+The Query Builder helps you write structured queries to investigate and visualize your telemetry data. The Query Builder searches the Workers Observability dataset, which currently includes all logs stored by [Workers Logs](/workers/observability/logs/workers-logs/). If your account has [Customer Metadata Boundary](/data-localization/metadata-boundary/) configured, Query Builder reads Workers Observability data from your configured region.
 
 The Query Builder can be found in the **Observability** page of the Cloudflare dashboard:
 


### PR DESCRIPTION
## Why

Workers Observability now needs to clearly state how Cloudflare-stored logs, traces, and queryable telemetry behave when Customer Metadata Boundary is configured.

## What

- Add CMB support wording to the Workers Observability landing page.
- Clarify Workers Logs and Query Builder regional behavior.
- Clarify that OTLP `persist` stores the Cloudflare copy according to CMB, while exported data goes to the customer-configured endpoint.

Jira: WO-1441