### PR TITLE
Updates Broken link to the McpAgent class definition from Agents SDK

### DIFF
--- a/src/content/docs/agents/model-context-protocol/apis/agent-api.mdx
+++ b/src/content/docs/agents/model-context-protocol/apis/agent-api.mdx
@@ -12,7 +12,7 @@ products:
 
 import { TypeScriptExample, LinkCard } from "~/components";
 
-When you build MCP Servers on Cloudflare, you extend the [`McpAgent` class](https://github.com/cloudflare/agents/blob/main/packages/agents/src/mcp.ts), from the Agents SDK:
+When you build MCP Servers on Cloudflare, you extend the [`McpAgent` class](https://github.com/cloudflare/agents/blob/main/packages/agents/src/mcp/index.ts#L32-L620), from the Agents SDK:
 
 <TypeScriptExample>
 


### PR DESCRIPTION
### Summary

Updates the broken link to the McpAgent class definition on the agents api documentation.

Previously pointed at a non-existing file on the Agents SDK repo. 
Now points to the class definition under `packages/agents/src/mcp/index.ts`

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).

