### PR TITLE
[Logs] Update Logpush dataset field definitions (2026-06-22)

### DIFF
--- a/src/content/changelog/logs/2026-06-22-log-fields-updated.mdx
+++ b/src/content/changelog/logs/2026-06-22-log-fields-updated.mdx
@@ -1,0 +1,19 @@
+---
+title: New Logpush datasets and updated fields across multiple Logpush datasets in Cloudflare Logs
+description: New Logpush datasets are now available, and fields have been updated across multiple Logpush datasets in Cloudflare Logs.
+date: 2026-06-22
+---
+
+Cloudflare has updated [Logpush datasets](/logs/logpush/logpush-job/datasets/):
+
+### New datasets
+
+- **WebSocket Analytics**: A new dataset with fields including `BytesReceivedClient`, `BytesReceivedOrigin`, `BytesSentClient`, `BytesSentOrigin`, `ClientASN`, `ClientIP`, `ClientRequestHost`, `ClientRequestPath`, `ClientRequestUserAgent`, `ColoCode`, `ConnectionCloseReason`, `ConnectionCloseSource`, `ConnectionID`, `ConnectionTransportCloseCode`, `EdgeEndTimestamp`, `EdgeStartTimestamp`, and `RayID`.
+- **WebSocket Analytics**: A new dataset with fields including `BytesReceivedClient`, `BytesReceivedOrigin`, `BytesSentClient`, `BytesSentOrigin`, `ClientASN`, `ClientIP`, `ClientRequestHost`, `ClientRequestPath`, `ClientRequestUserAgent`, `ColoCode`, `ConnectionCloseReason`, `ConnectionCloseSource`, `ConnectionID`, `ConnectionTransportCloseCode`, `EdgeEndTimestamp`, `EdgeStartTimestamp`, and `RayID`.
+
+### Updated fields in existing datasets
+
+- **Email Security Alerts** (added): `BCC`, `DKIMResult`, `DMARCPolicy`, `DMARCResult`, and `SPFResult`.
+- **Firewall events** (added): `ZoneName`.
+
+For the complete field definitions for each dataset, refer to [Logpush datasets](/logs/logpush/logpush-job/datasets/).

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/email_security_alerts.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/email_security_alerts.md
@@ -27,6 +27,12 @@ Type: `array[object]`
 
 List of objects containing metadata of attachments contained in this message (for example, [{"Md5": "91f073bd208689ddbd248e8989ecae90", "Sha1": "62b77e14e2c43049c45b5725018e78d0f9986930", "Sha256": "3b57505305e7162141fd898ed87d08f92fc42579b5047495859e56b3275a6c06", "Ssdeep": "McAQ8tPlH25e85Q2OiYpD08NvHmjJ97UfPMO47sekO:uN9M553OiiN/OJ9MM+e3", "Name": "attachment.gif", "ContentTypeProvided": "image/gif", "ContentTypeComputed": "application/x-msi", "Encrypted": true, "Decrypted": true}, ...]).
 
+## BCC
+
+Type: `array[string]`
+
+Email address portions of the BCC header provided by the sender, if present (for example, 'firstlast@cloudflare.com').
+
 ## CC
 
 Type: `array[string]`
@@ -38,6 +44,24 @@ Email address portions of the CC header provided by the sender (for example, 'fi
 Type: `array[string]`
 
 Email address portions of the CC header provided by the sender (for example, 'First Last').
+
+## DKIMResult
+
+Type: `string`
+
+Summary DKIM authentication result for the message. <br />Possible values are <em>pass</em> \| <em>neutral</em> \| <em>fail</em> \| <em>error</em> \| <em>permerror</em> \| <em>temperror</em> \| <em>none</em>.
+
+## DMARCPolicy
+
+Type: `string`
+
+Effective DMARC policy for the sending domain. <br />Possible values are <em>none</em> \| <em>quarantine</em> \| <em>reject</em> \| <em>undefined</em>.
+
+## DMARCResult
+
+Type: `string`
+
+Overall DMARC authentication result for the message. <br />Possible values are <em>pass</em> \| <em>fail</em> \| <em>none</em>.
 
 ## FinalDisposition
 
@@ -140,6 +164,12 @@ SMTP HELO server geolocation info (for example, 'US/NV/Las Vegas').
 Type: `string`
 
 Hostname provided by the SMTP HELO server.
+
+## SPFResult
+
+Type: `string`
+
+Summary SPF authentication result for the message. <br />Possible values are <em>pass</em> \| <em>neutral</em> \| <em>fail</em> \| <em>softfail</em> \| <em>permerror</em> \| <em>temperror</em> \| <em>none</em>.
 
 ## Subject
 

--- a/src/content/docs/logs/logpush/logpush-job/datasets/account/websocket_analytics.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/account/websocket_analytics.md
@@ -1,0 +1,112 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: WebSocket Analytics
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `websocket_analytics`.
+
+## BytesReceivedClient
+
+Type: `int`
+
+Number of bytes received from the client.
+
+## BytesReceivedOrigin
+
+Type: `int`
+
+Number of bytes received from the origin.
+
+## BytesSentClient
+
+Type: `int`
+
+Number of bytes sent to the client.
+
+## BytesSentOrigin
+
+Type: `int`
+
+Number of bytes sent to the origin.
+
+## ClientASN
+
+Type: `int`
+
+The client's autonomous system number (ASN).
+
+## ClientIP
+
+Type: `string`
+
+The client IP address.
+
+## ClientRequestHost
+
+Type: `string`
+
+The host requested by the client in the WebSocket upgrade request.
+
+## ClientRequestPath
+
+Type: `string`
+
+The path requested by the client in the WebSocket upgrade request.
+
+## ClientRequestUserAgent
+
+Type: `string`
+
+The user agent reported by the client.
+
+## ColoCode
+
+Type: `string`
+
+IATA airport code of the data center that handled the connection.
+
+## ConnectionCloseReason
+
+Type: `string`
+
+The reason the WebSocket connection ended. Possible values are <em>none</em> \| <em>unspecifiedError</em> \| <em>timedOut</em> \| <em>peerReset</em> \| <em>upstreamReset</em> \| <em>protocolViolation</em> \| <em>peerNoError</em>.
+
+## ConnectionCloseSource
+
+Type: `string`
+
+Which side initiated the connection close; <em>upstream</em> \| <em>downstream</em> \| <em>me</em> \| <em>both</em>, or the raw internal value if unrecognized.
+
+## ConnectionID
+
+Type: `string`
+
+Unique identifier of the WebSocket connection, hex-encoded.
+
+## ConnectionTransportCloseCode
+
+Type: `int`
+
+The first transport-level close code observed. For TLS connections this is the TLS alert code; for plain TCP connections (no TLS) it is always 0. The most significant bit indicates the source: 0 = proxy-initiated, 1 = eyeball-initiated.
+
+## EdgeEndTimestamp
+
+Type: `int or string`
+
+Timestamp at which the WebSocket connection closed.
+
+## EdgeStartTimestamp
+
+Type: `int or string`
+
+Timestamp at which the WebSocket connection was established.
+
+## RayID
+
+Type: `string`
+
+The Ray ID of the WebSocket upgrade request.

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/firewall_events.md
@@ -266,3 +266,9 @@ The Cloudflare security product-specific RuleID triggered by this request.
 Type: `string`
 
 The Cloudflare security product triggered by this request. <br />Possible sources are <em>unknown</em> \| <em>asn</em> \| <em>country</em> \| <em>ip</em> \| <em>iprange</em> \| <em>securitylevel</em> \| <em>zonelockdown</em> \| <em>waf</em> \| <em>firewallrules</em> \| <em>uablock</em> \| <em>ratelimit</em> \| <em>bic</em> \| <em>hot</em> \| <em>l7ddos</em> \| <em>validation</em> \| <em>botfight</em> \| <em>apishield</em> \| <em>botmanagement</em> \| <em>dlp</em> \| <em>firewallmanaged</em> \| <em>firewallcustom</em> \| <em>apishieldschemavalidation</em> \| <em>apishieldtokenvalidation</em> \| <em>apishieldsequencemitigation</em>.
+
+## ZoneName
+
+Type: `string`
+
+The human-readable name of the zone (for example, 'cloudflare.com').

--- a/src/content/docs/logs/logpush/logpush-job/datasets/zone/websocket_analytics.md
+++ b/src/content/docs/logs/logpush/logpush-job/datasets/zone/websocket_analytics.md
@@ -1,0 +1,112 @@
+---
+# Code generator. DO NOT EDIT.
+
+title: WebSocket Analytics
+pcx_content_type: configuration
+sidebar:
+  order: 21
+---
+
+The descriptions below detail the fields available for `websocket_analytics`.
+
+## BytesReceivedClient
+
+Type: `int`
+
+Number of bytes received from the client.
+
+## BytesReceivedOrigin
+
+Type: `int`
+
+Number of bytes received from the origin.
+
+## BytesSentClient
+
+Type: `int`
+
+Number of bytes sent to the client.
+
+## BytesSentOrigin
+
+Type: `int`
+
+Number of bytes sent to the origin.
+
+## ClientASN
+
+Type: `int`
+
+The client's autonomous system number (ASN).
+
+## ClientIP
+
+Type: `string`
+
+The client IP address.
+
+## ClientRequestHost
+
+Type: `string`
+
+The host requested by the client in the WebSocket upgrade request.
+
+## ClientRequestPath
+
+Type: `string`
+
+The path requested by the client in the WebSocket upgrade request.
+
+## ClientRequestUserAgent
+
+Type: `string`
+
+The user agent reported by the client.
+
+## ColoCode
+
+Type: `string`
+
+IATA airport code of the data center that handled the connection.
+
+## ConnectionCloseReason
+
+Type: `string`
+
+The reason the WebSocket connection ended. Possible values are <em>none</em> \| <em>unspecifiedError</em> \| <em>timedOut</em> \| <em>peerReset</em> \| <em>upstreamReset</em> \| <em>protocolViolation</em> \| <em>peerNoError</em>.
+
+## ConnectionCloseSource
+
+Type: `string`
+
+Which side initiated the connection close; <em>upstream</em> \| <em>downstream</em> \| <em>me</em> \| <em>both</em>, or the raw internal value if unrecognized.
+
+## ConnectionID
+
+Type: `string`
+
+Unique identifier of the WebSocket connection, hex-encoded.
+
+## ConnectionTransportCloseCode
+
+Type: `int`
+
+The first transport-level close code observed. For TLS connections this is the TLS alert code; for plain TCP connections (no TLS) it is always 0. The most significant bit indicates the source: 0 = proxy-initiated, 1 = eyeball-initiated.
+
+## EdgeEndTimestamp
+
+Type: `int or string`
+
+Timestamp at which the WebSocket connection closed.
+
+## EdgeStartTimestamp
+
+Type: `int or string`
+
+Timestamp at which the WebSocket connection was established.
+
+## RayID
+
+Type: `string`
+
+The Ray ID of the WebSocket upgrade request.


### PR DESCRIPTION
## Summary

Automated sync of Logpush dataset field definitions from [data/entities](https://gitlab.cfdata.org/cloudflare/data/entities).

### New datasets

- **WebSocket Analytics**: A new dataset with fields including `BytesReceivedClient`, `BytesReceivedOrigin`, `BytesSentClient`, `BytesSentOrigin`, `ClientASN`, `ClientIP`, `ClientRequestHost`, `ClientRequestPath`, `ClientRequestUserAgent`, `ColoCode`, `ConnectionCloseReason`, `ConnectionCloseSource`, `ConnectionID`, `ConnectionTransportCloseCode`, `EdgeEndTimestamp`, `EdgeStartTimestamp`, and `RayID`.
- **WebSocket Analytics**: A new dataset with fields including `BytesReceivedClient`, `BytesReceivedOrigin`, `BytesSentClient`, `BytesSentOrigin`, `ClientASN`, `ClientIP`, `ClientRequestHost`, `ClientRequestPath`, `ClientRequestUserAgent`, `ColoCode`, `ConnectionCloseReason`, `ConnectionCloseSource`, `ConnectionID`, `ConnectionTransportCloseCode`, `EdgeEndTimestamp`, `EdgeStartTimestamp`, and `RayID`.

### Updated fields in existing datasets

- **Email Security Alerts** (added): `BCC`, `DKIMResult`, `DMARCPolicy`, `DMARCResult`, and `SPFResult`.
- **Firewall events** (added): `ZoneName`.

### Files changed
- `src/content/docs/logs/logpush/logpush-job/datasets/account/` — dataset pages
- `src/content/docs/logs/logpush/logpush-job/datasets/zone/` — dataset pages
- `src/content/changelog/logs/2026-06-22-log-fields-updated.mdx` — changelog

### Documentation checklist
- [x] Changelog entry added
- [x] Content generated by code generator (DO NOT EDIT manually)
