### PR TITLE
Update documentation on custom rulesets limit

### DIFF
--- a/src/content/docs/waf/custom-rules/index.mdx
+++ b/src/content/docs/waf/custom-rules/index.mdx
@@ -35,6 +35,7 @@ The maximum number of custom rules applies to all rules in the `http_request_fir
 - Zone: All custom rules plus all the rules across custom rulesets defined at the zone level.
 - Account: All the rules across custom rulesets defined at the account level.
 
+The **number of custom rulesets** limit counts only [custom rulesets](/waf/custom-rules/custom-rulesets/) (`kind: "custom"`) created at the zone level. Custom rules added directly to the zone (which are stored in the zone's entry point ruleset) do not count toward this limit. Each custom ruleset must be [deployed](/waf/custom-rules/custom-rulesets/#deploy-a-custom-ruleset-via-api) via an `execute` rule in the entry point ruleset to take effect.
 ---
 
 ## Next steps


### PR DESCRIPTION
Clarified the limit on custom rulesets and deployment requirements.

### Summary

<!-- Add context such as the type of documentation being updated or added -->

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
