### PR TITLE
[Cloudflare One] Update IP geolocation providers list with additional public sources

### DIFF
--- a/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
+++ b/src/content/docs/cloudflare-one/traffic-policies/egress-policies/dedicated-egress-ips.mdx
@@ -122,6 +122,8 @@ To verify that the IP geolocation has updated, check your dedicated egress IP in
 - [ipgeolocation.io](https://ipgeolocation.io/)
 - [ipify](https://www.ipify.org/)
 - [Ipstack](https://ipstack.com/)
+- [IPwhois.io](https://ipwhois.io/)
+- [Bigdatacloud](https://www.bigdatacloud.com/)
 
 </Details>
 


### PR DESCRIPTION
This PR expands the list of publicly available IP geolocation providers referenced in the Dedicated egress IPs documentation.

The additions are intended to improve the completeness of the list and provide customers with additional options for validating IP geolocation data.

This is a documentation-only change.