### PR TITLE
docs: fix Python RPC example TabError and add compatibility_date

### DIFF
--- a/src/content/partials/workers/service-binding-rpc-example.mdx
+++ b/src/content/partials/workers/service-binding-rpc-example.mdx
@@ -11,6 +11,7 @@ For example, if Worker B implements the public method `add(a, b)`:
 ```jsonc
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
+	"compatibility_date": "2025-02-04",
 	"name": "worker_b",
 	"main": "./src/workerB.js"
 }
@@ -62,6 +63,7 @@ Worker A can declare a [binding](/workers/runtime-apis/bindings) to Worker B:
 ```jsonc
 {
 	"$schema": "./node_modules/wrangler/config-schema.json",
+	"compatibility_date": "2025-02-04",
 	"name": "worker_a",
 	"main": "./src/workerA.js",
 	"services": [
@@ -102,7 +104,7 @@ from workers import WorkerEntrypoint, Response
 class Default(WorkerEntrypoint):
     async def fetch(self, request):
         result = await self.env.WORKER_B.add(1, 2)
-		return Response(f"Result: {result}")
+        return Response(f"Result: {result}")
 ```
 
 </TabItem>


### PR DESCRIPTION
Fixes two issues from #31154 in the service-bindings RPC example:

1. The Python example mixed tabs and spaces — the `return` line was indented with two literal tabs inside an otherwise 4-space-indented function body, which raises `TabError: inconsistent use of tabs and spaces in indentation` when pasted into Python 3. Replaced the tabs with spaces.
2. Both `wrangler.jsonc` blocks were missing `compatibility_date`, without which `wrangler types` does not generate correctly for RPC. Added a recent `compatibility_date` to both.

Closes #31154.