### PR TITLE
[DNS] Document child zone delegation behavior for subdomain setup decommissioning

### DIFF
--- a/src/content/docs/dns/zone-setups/subdomain-setup/setup/index.mdx
+++ b/src/content/docs/dns/zone-setups/subdomain-setup/setup/index.mdx
@@ -11,7 +11,7 @@ head:
     content: Subdomain delegation and available setups
 ---
 
-import { DirectoryListing, GlossaryTooltip, Render } from "~/components";
+import { DirectoryListing, GlossaryTooltip, Render, Steps } from "~/components";
 
 :::note[Availability]
 Subdomain setup is only available for Enterprise accounts. If you only want to create a subdomain for your site in Cloudflare, refer to [Create a subdomain record](/dns/manage-dns-records/how-to/create-subdomain/).
@@ -68,3 +68,18 @@ If a certificate is already active on the child zone for a specific hostname (`s
 ## Access applications
 
 <Render file="subdomain-setup-access-apps" product="dns" />
+
+## Decommission a subdomain setup
+
+To stop delegating a subdomain to Cloudflare, you must delete the child zone from your Cloudflare account. Removing the `NS` records from the parent zone does not stop the delegation.
+
+This is because Cloudflare automatically serves `NS` delegation for active child zones based on the zone's status, not based on `NS` records configured in the parent zone.
+
+To decommission a subdomain setup:
+
+<Steps>
+1. Go to the child zone in the Cloudflare dashboard.
+2. Delete the zone entirely.
+3. Remove the `NS` records from the parent zone to clean up your DNS configuration.
+4. (Optional) Configure the subdomain as a hostname with an `A` or `CNAME` record in the parent zone.
+</Steps>


### PR DESCRIPTION
## Summary

When a subdomain is set up as a child zone on Cloudflare, NS delegation is served automatically based on the child zone's active status — not based on NS records stored in the parent zone. Customers may expect that deleting NS records from the parent zone stops the delegation, but it doesn't. The child zone must be deleted to stop serving delegation.

This PR adds a **"Decommission a subdomain setup"** section to the [subdomain setup page](/dns/zone-setups/subdomain-setup/setup/) with clear steps.

## Changes

| File | Change |
|------|--------|
| `dns/zone-setups/subdomain-setup/setup/index.mdx` | New section: "Decommission a subdomain setup" with explanation and 4-step procedure |

## Stats

1 file changed, +13 insertions

Resolves [DEE-3626](https://jira.cfdata.org/browse/DEE-3626)