### PR TITLE
[Zaraz] Fix debug mode settings page URL.mdx

### DIFF
--- a/src/content/docs/zaraz/web-api/debug-mode.mdx
+++ b/src/content/docs/zaraz/web-api/debug-mode.mdx
@@ -16,7 +16,7 @@ You can set this cookie manually or via the `zaraz.debug` helper function availa
 
 1. In the Cloudflare dashboard, go to the **Settings** page.
 
-	<DashButton url="/?to=/:account/tag-management/settings" />
+	<DashButton url="/?to=/:account/tag-management/zaraz/:zone/tools-config/settings" />
 2. Copy your **Debug Key**.
 3. Open a web browser and access its Developer Tools. For example, to access Developer Tools in Google Chrome, select **View** > **Developer** > **Developer Tools**.
 4. Select the **Console** pane and enter the following command to create a debug cookie:


### PR DESCRIPTION
The debug mode documentation linked to the wrong settings page. The debug key is located under Web tag management > Tag setup > Domain > Settings tab, not the generic tag-management/settings page. Update the DashButton URL from:
  /:account/tag-management/settings
to:
  /:account/tag-management/zaraz/:zone/tools-config/settings

