### PR TITLE
docs(cloudflare-challenges): clarify a 401 on a PAT request is expected

### DIFF
--- a/src/content/docs/cloudflare-challenges/reference/private-access-tokens.mdx
+++ b/src/content/docs/cloudflare-challenges/reference/private-access-tokens.mdx
@@ -16,7 +16,7 @@ While some challenges require interactivity, most challenges served are invisibl
 
 ## Expected 401 responses
 
-While loading a Challenge Page, the visitor's browser may attempt to retrieve a Private Access Token by issuing a request to a `/cdn-cgi/challenge-platform/.../pat/...` path. When the visitor's device, browser, or network environment cannot provide a token — for example on unsupported platforms, in some managed or enterprise environments, or when connected through certain VPNs — this request returns an HTTP `401` response.
+While loading a Challenge Page, the visitor's browser may attempt to retrieve a Private Access Token by issuing a request to a `/cdn-cgi/challenge-platform/.../pat/...` path. When the visitor's device, browser, or network environment cannot provide a token — for example, on unsupported platforms, in some managed or enterprise environments, or when connected through certain VPNs — this request returns an HTTP `401` response.
 
 This `401` is expected and does **not** mean the visitor is blocked. The Private Access Token flow is an optimization used to reduce challenge steps. When a token is unavailable, Cloudflare falls back to a standard challenge and the visitor continues through the Challenge Page as usual.
 

--- a/src/content/docs/cloudflare-challenges/reference/private-access-tokens.mdx
+++ b/src/content/docs/cloudflare-challenges/reference/private-access-tokens.mdx
@@ -13,3 +13,11 @@ When a visitor is presented with a Challenge Page, Cloudflare evaluates various 
 A PAT does not automatically solve a challenge or let a visitor bypass the Challenge Page. The visitor still encounters the Challenge Page regardless of whether they have a valid PAT.
 
 While some challenges require interactivity, most challenges served are invisible to the visitor.
+
+## Expected 401 responses
+
+While loading a Challenge Page, the visitor's browser may attempt to retrieve a Private Access Token by issuing a request to a `/cdn-cgi/challenge-platform/.../pat/...` path. When the visitor's device, browser, or network environment cannot provide a token — for example on unsupported platforms, in some managed or enterprise environments, or when connected through certain VPNs — this request returns an HTTP `401` response.
+
+This `401` is expected and does **not** mean the visitor is blocked. The Private Access Token flow is an optimization used to reduce challenge steps. When a token is unavailable, Cloudflare falls back to a standard challenge and the visitor continues through the Challenge Page as usual.
+
+If you are inspecting network requests in your browser's developer tools and notice a `401` on a `/cdn-cgi/challenge-platform/.../pat/...` request, you can safely disregard it. It is part of normal challenge processing and is not the cause of a block.

--- a/src/content/docs/cloudflare-challenges/troubleshooting/challenge-solve-issues.mdx
+++ b/src/content/docs/cloudflare-challenges/troubleshooting/challenge-solve-issues.mdx
@@ -35,7 +35,7 @@ Ensure your browser is updated to the latest version to maintain compatibility.
 
 When a Challenge Page loads, the browser may request a [Private Access Token (PAT)](/cloudflare-challenges/reference/private-access-tokens/) from a `/cdn-cgi/challenge-platform/.../pat/...` endpoint. On devices, browsers, or networks that cannot issue a token, this request returns an HTTP `401`.
 
-This response is **expected** and does not mean the visitor was blocked or that the widget failed. Cloudflare falls back to a standard challenge and the visitor proceeds as normal. A `401` on this request — for example one seen in browser developer tools or a HAR capture — is not, on its own, a sign of a misconfiguration, a false positive, or a block. For more details, see [Private Access Tokens](/cloudflare-challenges/reference/private-access-tokens/).
+This response is **expected** and does not mean the visitor was blocked or that the widget failed. Cloudflare falls back to a standard challenge and the visitor proceeds as normal. A `401` on this request — for example, one seen in browser developer tools or a HAR capture — is not, on its own, a sign of a misconfiguration, a false positive, or a block. For more details, refer to [Private Access Tokens](/cloudflare-challenges/reference/private-access-tokens/).
 
 ## Troubleshooting
 

--- a/src/content/docs/cloudflare-challenges/troubleshooting/challenge-solve-issues.mdx
+++ b/src/content/docs/cloudflare-challenges/troubleshooting/challenge-solve-issues.mdx
@@ -31,6 +31,12 @@ If the issue persists, try switching to a different network or device to rule ou
 Ensure your browser is updated to the latest version to maintain compatibility.
 :::
 
+## 401 response on a Private Access Token request
+
+When a Challenge Page loads, the browser may request a [Private Access Token (PAT)](/cloudflare-challenges/reference/private-access-tokens/) from a `/cdn-cgi/challenge-platform/.../pat/...` endpoint. On devices, browsers, or networks that cannot issue a token, this request returns an HTTP `401`.
+
+This response is **expected** and does not mean the visitor was blocked or that the widget failed. Cloudflare falls back to a standard challenge and the visitor proceeds as normal. A `401` on this request — for example one seen in browser developer tools or a HAR capture — is not, on its own, a sign of a misconfiguration, a false positive, or a block. For more details, see [Private Access Tokens](/cloudflare-challenges/reference/private-access-tokens/).
+
 ## Troubleshooting
 
 Follow the steps below to ensure that your environment is properly configured.


### PR DESCRIPTION
## Summary

Clarifies that an HTTP `401` on a Private Access Token (PAT) request (a request to a `/cdn-cgi/challenge-platform/.../pat/...` path) is **expected behavior and not a block**.

Visitors and site operators sometimes see this `401` in browser developer tools or a HAR capture and interpret it as being "blocked by Turnstile" or as a Challenge failure. In reality, when a device, browser, or network cannot issue a token, Cloudflare falls back to a standard challenge and the visitor proceeds through the Challenge Page normally.

## Changes

- **Private Access Tokens reference** (`cloudflare-challenges/reference/private-access-tokens`): add an _Expected 401 responses_ section explaining the behavior.
- **Challenge solve issues** (`cloudflare-challenges/troubleshooting/challenge-solve-issues`): add a _401 response on a Private Access Token request_ troubleshooting entry, cross-linked to the PAT reference. This page is also surfaced under Turnstile troubleshooting via its external link.

## Notes

Prose-only additions to two `.mdx` files under `cloudflare-challenges`. No code or component changes.