### PR TITLE
[RealtimeKit] Add Android and iOS breakout rooms docs to UI Kit

### DIFF
--- a/src/content/docs/realtime/realtimekit/ui-kit/breakout-rooms.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/breakout-rooms.mdx
@@ -18,6 +18,8 @@ import RTKCodeSnippet from "~/components/realtimekit/RTKCodeSnippet/RTKCodeSnipp
 
 ### Start breakout room
 
+<RTKCodeSnippet id={["web-react", "web-web-components", "web-angular"]}>
+
 1. In your RealtimeKit meeting, click **Breakout Rooms**
 2. In the Create Breakout dialog, add the number of rooms you want and click **Create**
 
@@ -47,6 +49,74 @@ To assign participants manually:
 4. Click **Start Breakout**
 5. Click **Yes, start** in the confirmation dialog
 
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+1. In your RealtimeKit meeting, tap **Breakout Rooms**
+2. In the Create Breakout dialog, add the number of rooms you want and tap **Create**
+
+Once you have created breakout rooms, assign participants to the rooms. You can either:
+
+- **Assign participants automatically** - RealtimeKit splits participants evenly across rooms
+- **Assign participants manually** - Select which participants you want in each room
+
+#### Assign participants automatically
+
+To assign participants automatically:
+
+1. In the Assign Participants dialog, tap the shuffle button
+2. Participants are assigned to the rooms
+3. Edit room names by tapping the pencil icon beside the room name (optional)
+4. Move participants to different rooms if needed
+5. Tap **Start Breakout**
+6. Tap **Yes, start** in the confirmation dialog
+
+#### Assign participants manually
+
+To assign participants manually:
+
+1. In the Assign Participants dialog, select the participants you want to assign to a room
+2. In the Rooms section, tap **Assign**
+3. Repeat for all participants and rooms
+4. Tap **Start Breakout**
+5. Tap **Yes, start** in the confirmation dialog
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+1. In your RealtimeKit meeting, tap **Breakout Rooms**
+2. In the Create Breakout dialog, add the number of rooms you want and tap **Create**
+
+Once you have created breakout rooms, assign participants to the rooms. You can either:
+
+- **Assign participants automatically** - RealtimeKit splits participants evenly across rooms
+- **Assign participants manually** - Select which participants you want in each room
+
+#### Assign participants automatically
+
+To assign participants automatically:
+
+1. In the Assign Participants dialog, tap the shuffle button
+2. Participants are assigned to the rooms
+3. Edit room names by tapping the pencil icon beside the room name (optional)
+4. Move participants to different rooms if needed
+5. Tap **Start Breakout**
+6. Tap **Yes, start** in the confirmation dialog
+
+#### Assign participants manually
+
+To assign participants manually:
+
+1. In the Assign Participants dialog, select the participants you want to assign to a room
+2. In the Rooms section, tap **Assign**
+3. Repeat for all participants and rooms
+4. Tap **Start Breakout**
+5. Tap **Yes, start** in the confirmation dialog
+
+</RTKCodeSnippet>
+
 ## Integrate breakout rooms
 
 After setting up breakout rooms via the API, you need to integrate them into your application using the RealtimeKit SDK.
@@ -56,6 +126,7 @@ After setting up breakout rooms via the API, you need to integrate them into you
 ### Initialize the SDK with breakout rooms support
 
 Initialize the SDK and add an event handler for breakout rooms:
+
 
 <RTKCodeSnippet id="web-react">
 
@@ -160,6 +231,82 @@ export class AppComponent implements AfterViewInit {
 ```
 
 The `meetingChanged` event is triggered when a participant switches between the main meeting and breakout rooms. Update the meeting object reference when this event fires.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+When using `RealtimeKitUI.startMeeting()`, the SDK automatically manages the `RtkConnectedMeetingsListener` — no extra setup is required for breakout room switching.
+
+If you are building a **custom meeting UI** (bypassing `MeetingViewController`), register the listener yourself:
+
+```swift
+import RealtimeKit
+import RealtimeKitUI
+
+let listener = RtkConnectedMeetingsListener(rtkClient: rtkClient)
+
+listener.onChangingMeeting = { meetingId in
+    // Show a loading overlay; the SDK is switching rooms
+    let isReturningToMain = meetingId == rtkClient.connectedMeetings.parentMeeting?.id
+    showLoadingOverlay(message: isReturningToMain ? "Returning to Main Room\u{2026}" : "Joining breakout room\u{2026}")
+}
+
+listener.onMeetingChanged = { error in
+    hideLoadingOverlay()
+    if let error {
+        showErrorAlert(message: error.message)
+    } else {
+        // Re-register all feature event listeners — the SDK clears them during the room switch
+        rtkClient.addSelfEventListener(selfEventListener: self)
+        rtkClient.addParticipantsEventListener(participantsEventListener: self)
+        // … other listeners
+    }
+}
+
+listener.onStateUpdate = { meetings, parentMeeting in
+    // Refresh your breakout-rooms UI list
+}
+```
+
+:::note
+
+Hold a strong reference to `RtkConnectedMeetingsListener`. It deregisters itself on `deinit`.
+
+:::
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+When using `RealtimeKitUIBuilder` + `startMeeting()`, the SDK automatically registers and manages `RtkConnectedMeetingsEventListener` — no extra setup is required for breakout room switching.
+
+If you are building a **custom meeting UI**, register the listener yourself:
+
+```kotlin
+import com.cloudflare.realtimekit.ui.RtkConnectedMeetingsEventListener
+import com.cloudflare.realtimekit.models.MeetingError
+
+val connectedMeetingsListener = object : RtkConnectedMeetingsEventListener {
+    override fun onChangingMeeting(meetingId: String) {
+        // Show a transition screen; the SDK is switching rooms
+        val isReturningToMain = meetingId == meeting.connectedMeetings.parentMeeting?.id
+        showLoadingOverlay(isReturningToMain)
+    }
+
+    override fun onMeetingChanged(error: MeetingError?) {
+        hideLoadingOverlay()
+        if (error != null) {
+            showErrorMessage(error.message)
+        }
+        // No need to re-register listeners — the SDK handles this automatically
+    }
+}
+
+meeting.addConnectedMeetingsEventListener(connectedMeetingsListener)
+```
+
+The `onChangingMeeting` callback fires when the SDK starts leaving the current room. The `onMeetingChanged` callback fires when the switch completes (or fails).
 
 </RTKCodeSnippet>
 
@@ -297,6 +444,58 @@ The Default Meeting UI (`rtk-meeting` component) automatically joins the session
 :::
 
 The `showSetupScreen` property controls whether the setup screen is displayed, allowing participants to preview their audio and video before joining the session.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-ios">
+
+```swift
+import RealtimeKit
+import RealtimeKitUI
+
+let meetingInfo = RtkMeetingInfo(authToken: "<participant_auth_token>")
+let rtkUI = RealtimeKitUI(meetingInfo: meetingInfo)
+
+let setupVC = rtkUI.startMeeting {
+    // Called when the participant leaves or ends the meeting
+    self.dismiss(animated: true)
+}
+present(setupVC, animated: true)
+```
+
+:::note
+
+Like the web UI Kit, `MeetingViewController` **automatically joins the session** — you do not need to call `meeting.join()` manually.
+
+:::
+
+The setup screen (audio/video preview) is shown by default. Built-in breakout room support — including the room-switching overlay and room title updates — is handled automatically by `MeetingViewController`.
+
+</RTKCodeSnippet>
+
+<RTKCodeSnippet id="mobile-android">
+
+```kotlin
+import com.cloudflare.realtimekit.models.RtkMeetingInfo
+import com.cloudflare.realtimekit.ui.RealtimeKitUIBuilder
+import com.cloudflare.realtimekit.ui.RealtimeKitUIInfo
+
+val meetingInfo = RtkMeetingInfo(authToken = "<participant_auth_token>")
+val uiKitInfo = RealtimeKitUIInfo(
+    activity = this,
+    rtkMeetingInfo = meetingInfo,
+)
+val rtkUIKit = RealtimeKitUIBuilder.build(uiKitInfo)
+rtkUIKit.startMeeting()
+```
+
+:::note
+
+`RtkMeetingActivity` **automatically joins the session** — you do not need to call `meeting.join()` manually.
+
+:::
+
+Built-in breakout room support is handled automatically by `RtkMeetingActivity`. When participants are moved between rooms, a transition overlay is displayed with a localized message. The host can manage breakout rooms via the `RtkBreakoutRoomsBottomSheet`, which is shown automatically when the Breakout Rooms control bar button is tapped.
 
 </RTKCodeSnippet>
 

--- a/src/content/docs/realtime/realtimekit/ui-kit/breakout-rooms.mdx
+++ b/src/content/docs/realtime/realtimekit/ui-kit/breakout-rooms.mdx
@@ -56,17 +56,14 @@ To assign participants manually:
 1. In your RealtimeKit meeting, tap **Breakout Rooms**
 2. In the Create Breakout dialog, add the number of rooms you want and tap **Create**
 
-Once you have created breakout rooms, assign participants to the rooms. You can either:
-
-- **Assign participants automatically** - RealtimeKit splits participants evenly across rooms
-- **Assign participants manually** - Select which participants you want in each room
+Once you have created breakout rooms, assign participants to the rooms. You can assign participants automatically (RealtimeKit splits them evenly) or manually (you choose who goes where).
 
 #### Assign participants automatically
 
 To assign participants automatically:
 
 1. In the Assign Participants dialog, tap the shuffle button
-2. Participants are assigned to the rooms
+2. RealtimeKit assigns participants to the rooms
 3. Edit room names by tapping the pencil icon beside the room name (optional)
 4. Move participants to different rooms if needed
 5. Tap **Start Breakout**
@@ -89,17 +86,14 @@ To assign participants manually:
 1. In your RealtimeKit meeting, tap **Breakout Rooms**
 2. In the Create Breakout dialog, add the number of rooms you want and tap **Create**
 
-Once you have created breakout rooms, assign participants to the rooms. You can either:
-
-- **Assign participants automatically** - RealtimeKit splits participants evenly across rooms
-- **Assign participants manually** - Select which participants you want in each room
+Once you have created breakout rooms, assign participants to the rooms. You can assign participants automatically (RealtimeKit splits them evenly) or manually (you choose who goes where).
 
 #### Assign participants automatically
 
 To assign participants automatically:
 
 1. In the Assign Participants dialog, tap the shuffle button
-2. Participants are assigned to the rooms
+2. RealtimeKit assigns participants to the rooms
 3. Edit room names by tapping the pencil icon beside the room name (optional)
 4. Move participants to different rooms if needed
 5. Tap **Start Breakout**
@@ -258,9 +252,9 @@ listener.onMeetingChanged = { error in
         showErrorAlert(message: error.message)
     } else {
         // Re-register all feature event listeners — the SDK clears them during the room switch
-        rtkClient.addSelfEventListener(selfEventListener: self)
-        rtkClient.addParticipantsEventListener(participantsEventListener: self)
-        // … other listeners
+        // Re-register your listener instances, for example:
+        // rtkClient.addSelfEventListener(selfEventListener: mySelfListener)
+        // rtkClient.addParticipantsEventListener(participantsEventListener: myParticipantsListener)
     }
 }
 
@@ -456,9 +450,9 @@ import RealtimeKitUI
 let meetingInfo = RtkMeetingInfo(authToken: "<participant_auth_token>")
 let rtkUI = RealtimeKitUI(meetingInfo: meetingInfo)
 
-let setupVC = rtkUI.startMeeting {
+let setupVC = rtkUI.startMeeting { [weak self] in
     // Called when the participant leaves or ends the meeting
-    self.dismiss(animated: true)
+    self?.dismiss(animated: true)
 }
 present(setupVC, animated: true)
 ```
@@ -495,7 +489,7 @@ rtkUIKit.startMeeting()
 
 :::
 
-Built-in breakout room support is handled automatically by `RtkMeetingActivity`. When participants are moved between rooms, a transition overlay is displayed with a localized message. The host can manage breakout rooms via the `RtkBreakoutRoomsBottomSheet`, which is shown automatically when the Breakout Rooms control bar button is tapped.
+Built-in breakout room support is handled automatically by `RtkMeetingActivity`. When the SDK moves participants between rooms, it displays a transition overlay with a localized message. The host can manage breakout rooms via the `RtkBreakoutRoomsBottomSheet`, which is shown automatically when the Breakout Rooms control bar button is tapped.
 
 </RTKCodeSnippet>
 


### PR DESCRIPTION
Flesh out the breakout-rooms UI Kit page with mobile platform
coverage derived from the Android and iOS source summaries.

Added for both mobile platforms:
- UX walkthrough steps using tap-based phrasing
- SDK initialisation section covering the default UI (auto-managed)
  and the custom-UI listener pattern
- Render the meeting UI section with platform-specific snippets
  and notes that RtkMeetingActivity / MeetingViewController
  auto-join without a manual meeting.join() call

Android-specific details include RtkConnectedMeetingsEventListener
(onChangingMeeting / onMeetingChanged), the automatic transition
overlay shown by RtkMeetingActivity, and the RtkBreakoutRoomsBottomSheet
host management UI.

iOS-specific details include RtkConnectedMeetingsListener closure
callbacks (onChangingMeeting / onMeetingChanged / onStateUpdate),
the strong-reference lifecycle requirement, and the built-in support
in MeetingViewController.
