### PR TITLE
Add note about manual certificate cleanup when deleting Workers Custom Domains

### DIFF
--- a/src/content/docs/workers/configuration/routing/custom-domains.mdx
+++ b/src/content/docs/workers/configuration/routing/custom-domains.mdx
@@ -159,6 +159,10 @@ Creating a Custom Domain will also generate an [Advanced Certificate](/ssl/edge-
 
 These certificates are generated with default settings. To override these settings, delete the generated certificate and create your own certificate in the Cloudflare dashboard. Refer to [Manage advanced certificates](/ssl/edge-certificates/advanced-certificate-manager/manage-certificates/) for instructions.
 
+:::caution
+When you delete a Custom Domain, the associated Advanced Certificate is **not** automatically deleted. You must manually remove the certificate from the Cloudflare dashboard under **SSL/TLS** > **Edge Certificates**, or via the [API](/api/resources/ssl/subresources/certificate_packs/methods/delete/). Leaving unused certificates in place does not affect functionality but may cause confusion when auditing your certificate inventory.
+:::
+
 ## Redirect between www and root domain
 
 Because Custom Domains require an exact hostname match, a Worker attached to `example.com` will not receive requests sent to `www.example.com`, and vice versa. To make both versions of your domain work, set up a redirect rule:


### PR DESCRIPTION
## Summary

When a Workers Custom Domain is deleted, the associated Advanced Certificate is not automatically removed. This can cause confusion when users audit their certificate inventory and find orphaned certificates.

This PR adds a caution admonition to the existing **Certificates** section of the Custom Domains page, clarifying that the certificate must be manually deleted from the dashboard or API.

## Changes

| File | Change |
|------|--------|
| `workers/configuration/routing/custom-domains.mdx` | Added `:::caution` note about manual certificate cleanup after Custom Domain deletion |

## Stats

1 file changed, +4 insertions

Resolves [DEE-3625](https://jira.cfdata.org/browse/DEE-3625)