### PR TITLE
[SSL] Recommend update/renew instead of delete-and-reupload for custom certificates

### DIFF
--- a/src/content/docs/ssl/edge-certificates/custom-certificates/index.mdx
+++ b/src/content/docs/ssl/edge-certificates/custom-certificates/index.mdx
@@ -17,7 +17,7 @@ Use custom certificates when you need control over the certificate authority (CA
 Unlike [Universal SSL](/ssl/edge-certificates/universal-ssl/) or [advanced certificates](/ssl/edge-certificates/advanced-certificate-manager/), Cloudflare does not manage issuance and renewal for custom certificates. You are responsible for the following:
 
 - [Upload the certificate](/ssl/edge-certificates/custom-certificates/uploading/#upload-a-custom-certificate).
-- [Update the certificate](/ssl/edge-certificates/custom-certificates/uploading/#update-an-existing-custom-certificate) before it expires.
+- [Update the certificate](/ssl/edge-certificates/custom-certificates/uploading/#update-or-renew-an-existing-custom-certificate) before it expires.
 - [Monitor the certificate expiration date](/ssl/edge-certificates/custom-certificates/renewing/) to avoid downtime.
 
 :::note

--- a/src/content/docs/ssl/edge-certificates/custom-certificates/renewing.mdx
+++ b/src/content/docs/ssl/edge-certificates/custom-certificates/renewing.mdx
@@ -15,7 +15,7 @@ import { GlossaryTooltip, DashButton } from "~/components"
 
 ## Renew custom certificates
 
-Since Cloudflare cannot renew uploaded certificates, you should ensure that you replace or [update](/ssl/edge-certificates/custom-certificates/uploading/#update-an-existing-custom-certificate) an expiring custom certificate before it expires, otherwise your visitors may not be able to connect.
+Since Cloudflare cannot renew uploaded certificates, you should ensure that you replace or [update](/ssl/edge-certificates/custom-certificates/uploading/#update-or-renew-an-existing-custom-certificate) an expiring custom certificate before it expires, otherwise your visitors may not be able to connect.
 
 Cloudflare automatically sends email notifications 30 and 14 days before your custom certificate expires. The email is sent to users who have the SSL/TLS, Administrator, or Super Administrator [roles](/fundamentals/manage-members/roles/).
 

--- a/src/content/docs/ssl/edge-certificates/custom-certificates/troubleshooting.mdx
+++ b/src/content/docs/ssl/edge-certificates/custom-certificates/troubleshooting.mdx
@@ -64,7 +64,7 @@ As Let's Encrypt - one of the [certificate authorities (CAs)](/ssl/reference/cer
 
 If you are using a Let's Encrypt certificate uploaded by yourself as a custom certificate, consider the following:
 
-- If you use **compatible** or **modern** [bundle method](/ssl/edge-certificates/custom-certificates/bundling-methodologies/) and have uploaded your certificate before September 9, 2024, [update your custom certificate](/ssl/edge-certificates/custom-certificates/uploading/#update-an-existing-custom-certificate) so that it can be bundled with the new chain.
+- If you use **compatible** or **modern** [bundle method](/ssl/edge-certificates/custom-certificates/bundling-methodologies/) and have uploaded your certificate before September 9, 2024, [update your custom certificate](/ssl/edge-certificates/custom-certificates/uploading/#update-or-renew-an-existing-custom-certificate) so that it can be bundled with the new chain.
 - If you use **user-defined** bundle method, make sure that your certificates uploaded after September 30, 2024, do not use the Let's Encrypt cross-signed chain.
 
 ## Error codes
@@ -95,7 +95,13 @@ You have used up your custom certificate quota.
 
 **Solution**
 
-Delete some existing certificates to add a new one. If you are an Enterprise customer, you can contact your account team to acquire more custom certificates.
+If you are renewing an existing certificate, [update the existing certificate](/ssl/edge-certificates/custom-certificates/uploading/#update-or-renew-an-existing-custom-certificate) instead of uploading a new one. Updating an existing certificate via the dashboard (or the API `PATCH` method) reuses its quota slot and avoids downtime.
+
+If you genuinely need a new certificate for a different hostname, delete an unused certificate first or contact your account team (Enterprise) to increase your quota.
+
+:::caution
+Deleting a certificate removes it from Cloudflare's edge immediately. If no other certificate covers the same hostnames, visitors will see TLS errors until a replacement is uploaded and active.
+:::
 
 ### This certificate has already been submitted. (Code: 1220)
 
@@ -105,7 +111,7 @@ You are trying to upload a custom certificate that you have already uploaded.
 
 **Solution**
 
-Delete the existing one and try again.
+If you are renewing the certificate with updated expiry or key material, [update the existing certificate](/ssl/edge-certificates/custom-certificates/uploading/#update-or-renew-an-existing-custom-certificate) instead of uploading a new one. Updating via the dashboard (or the API `PATCH` method) avoids downtime and does not consume an additional quota slot.
 
 ### You already have a certificate of this signature type. (Code: 1228)
 

--- a/src/content/docs/ssl/edge-certificates/custom-certificates/uploading.mdx
+++ b/src/content/docs/ssl/edge-certificates/custom-certificates/uploading.mdx
@@ -166,7 +166,9 @@ For more guidance, refer to [Create a CAA record](/ssl/edge-certificates/caa-rec
 
 ---
 
-## Update an existing custom certificate
+## Update or renew an existing custom certificate
+
+To renew a custom certificate that is approaching expiry, or to replace a certificate with updated key material, follow the steps below. **This is the recommended renewal path** — it does not consume an additional certificate quota slot and avoids downtime.
 
 Before you update an existing custom certificate, you might want to consider having active [universal](/ssl/edge-certificates/universal-ssl/) or [advanced](/ssl/edge-certificates/advanced-certificate-manager/) certificates as fallback options. Go to the [**Edge Certificates**](https://dash.cloudflare.com/?to=/:account/:zone/ssl-tls/edge-certificates) page to check a list of hostnames and status of the edge certificates in your zone.
 
@@ -196,7 +198,7 @@ To update a certificate using the API, send a [`PATCH`](/api/resources/custom_ce
 
 :::note
 
-To update the **Private Key Restriction** setting of a certificate, delete and re-add the certificate.
+To update the **Private Key Restriction** setting of a certificate, you must delete and re-add the certificate — this is an exception to the recommended renewal flow above. Plan for potential downtime if no other certificate covers the same hostnames.
 
 :::
 

--- a/src/content/docs/ssl/reference/certificate-rotation.mdx
+++ b/src/content/docs/ssl/reference/certificate-rotation.mdx
@@ -128,4 +128,4 @@ If a new pack remains in **Pending Validation** for more than 15 minutes, check 
 
 This page covers **ACM certificate packs** (Cloudflare-managed Domain Validated certificates ordered via Advanced Certificate Manager).
 
-If you are using a **custom certificate** (a certificate you supplied), Cloudflare provides an in-place **Replace SSL certificate and key** flow that handles the rotation without requiring you to manage two packs. Refer to [Manage custom certificates](/ssl/edge-certificates/custom-certificates/uploading/#update-an-existing-custom-certificate).
+If you are using a **custom certificate** (a certificate you supplied), Cloudflare provides an in-place **Replace SSL certificate and key** flow that handles the rotation without requiring you to manage two packs. Refer to [Manage custom certificates](/ssl/edge-certificates/custom-certificates/uploading/#update-or-renew-an-existing-custom-certificate).


### PR DESCRIPTION
## Summary

Customers often delete and re-upload custom certificates when renewing, which causes downtime and unnecessarily consumes quota slots. The PATCH (update) path is the recommended renewal approach but was buried in the docs — error 1212 told customers to "delete some existing certificates" without acknowledging the downtime risk.

Source: [SSL/TLS Clarity Report, theme 19](https://jira.cfdata.org/browse/DEE-3624)

## Changes (3 updates across 2 files)

| # | File | Change |
|---|------|--------|
| 1 | `ssl/edge-certificates/custom-certificates/uploading.mdx` | Renamed `## Update an existing custom certificate` → `## Update or renew an existing custom certificate` and framed it as the recommended renewal path |
| 2 | `ssl/edge-certificates/custom-certificates/troubleshooting.mdx` | **Error 1212** (quota reached): point users to the update path first (dashboard, then API PATCH), add a caution about downtime when deleting active certificates |
| 3 | `ssl/edge-certificates/custom-certificates/troubleshooting.mdx` | **Error 1220** (duplicate certificate): point users to the update path instead of delete-and-reupload |

## Stats

2 files changed, +11 insertions, -3 deletions

Resolves [DEE-3624](https://jira.cfdata.org/browse/DEE-3624)