### PR TITLE
[Workers] Add Vitest 3 to Vitest 4 migration guide for vitest-pool-workers

### DIFF
--- a/src/content/docs/workers/testing/vitest-integration/migration-guides/migrate-from-vitest-3-to-vitest-4.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/migration-guides/migrate-from-vitest-3-to-vitest-4.mdx
@@ -1,0 +1,138 @@
+---
+title: Migrate from Vitest 3 to Vitest 4
+pcx_content_type: how-to
+sidebar:
+  order: 1
+head: []
+description: Migrate the Workers Vitest integration from v0.12.x (Vitest 3) to
+  v0.13.x (Vitest 4), covering configuration and test file changes.
+products:
+  - workers
+---
+
+import { PackageManagers } from "~/components";
+
+`@cloudflare/vitest-pool-workers` v0.13.0 adds support for [Vitest 4](https://vitest.dev/blog/vitest-4). v0.12.x is the last version to support Vitest 3.x. It continues to work if you are not ready to migrate.
+
+Version 0.13.0 rearchitects the integration around a Vite plugin model. This change breaks the configuration API, but it also resolves a number of issues that were not fixable under the previous architecture:
+
+- Library imports that previously required SSR optimizer workarounds, such as Stripe, now resolve without extra configuration.
+- Bare Node.js specifiers such as `node:url` now resolve in test files.
+- `nodejs_compat_v2` and Node.js module flags are enabled automatically during tests, matching production behavior.
+- The `provide` data channel no longer has the previous ~8 KB size limit. It now uses WebSocket messages.
+- Storage is isolated per test file instead of per test, consistent with standard Vitest behavior.
+- The Vitest UI works correctly with Workers tests.
+
+This guide covers migrating an existing project from v0.12.x to v0.13.x.
+
+## Update your dependencies
+
+Install Vitest 4 and the latest version of `@cloudflare/vitest-pool-workers`:
+
+<PackageManagers pkg="vitest@^4.1.0 @cloudflare/vitest-pool-workers" dev />
+
+## Update your configuration with the codemod
+
+A codemod updates your `vitest.config.ts` to the new plugin API automatically. After installing the package, run:
+
+<PackageManagers
+	type="exec"
+	pkg="jscodeshift"
+	args="-t node_modules/@cloudflare/vitest-pool-workers/dist/codemods/vitest-v3-to-v4.mjs vitest.config.ts"
+/>
+
+To run the codemod without installing the package first, point it at the published version:
+
+<PackageManagers
+	type="exec"
+	pkg="jscodeshift"
+	args="-t https://unpkg.com/@cloudflare/vitest-pool-workers/dist/codemods/vitest-v3-to-v4.mjs --parser=ts vitest.config.ts"
+/>
+
+:::note
+The codemod only updates `vitest.config.ts`. Changes to your test files, including `cloudflare:test` import replacements, must be made manually. The remaining sections describe those changes.
+:::
+
+## Review the configuration changes
+
+The codemod replaces `defineWorkersProject` and `defineWorkersConfig` from `@cloudflare/vitest-pool-workers/config` with a `cloudflareTest()` Vite plugin exported from `@cloudflare/vitest-pool-workers`. Options previously nested under `test.poolOptions.workers` are now passed directly to `cloudflareTest()`.
+
+Before:
+
+```ts title="vitest.config.ts"
+import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersProject({
+	test: {
+		poolOptions: {
+			workers: {
+				wrangler: { configPath: "./wrangler.jsonc" },
+			},
+		},
+	},
+});
+```
+
+After:
+
+```ts title="vitest.config.ts"
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [
+		cloudflareTest({
+			wrangler: { configPath: "./wrangler.jsonc" },
+		}),
+	],
+});
+```
+
+## Update your test files
+
+The following changes must be made manually to your test files.
+
+### Replace removed isolation options
+
+The `isolatedStorage` and `singleWorker` options have been removed. Storage isolation is now per test file, matching Vitest's own isolation model. To make test files share the same storage, pass the `--max-workers=1 --no-isolate` flags to the Vitest command in your `package.json`.
+
+### Replace cloudflare:test imports
+
+The `import { env, SELF } from "cloudflare:test"` import has been removed. Use `import { env, exports } from "cloudflare:workers"` instead. `exports.default.fetch()` behaves the same as `SELF.fetch()`, except that it does not expose Assets. To test Assets, write an integration test using [`startDevWorker()`](/workers/testing/unstable_startworker/).
+
+```diff
+- import { env, SELF } from "cloudflare:test";
++ import { env, exports } from "cloudflare:workers";
+
+  it("dispatches fetch event", async () => {
+-   const response = await SELF.fetch("https://example.com");
++   const response = await exports.default.fetch("https://example.com");
+  });
+```
+
+### Replace fetchMock
+
+The `import { fetchMock } from "cloudflare:test"` import has been removed. Mock `globalThis.fetch` directly or use ecosystem libraries such as [MSW](https://mswjs.io/). Refer to the [request mocking example](https://github.com/cloudflare/workers-sdk/blob/main/fixtures/vitest-pool-workers-examples/request-mocking/test/imperative.test.ts) for a complete example.
+
+## Migrate test files with a coding agent
+
+To handle the test file changes automatically, give the following prompt to a coding agent:
+
+```txt title="Prompt for your coding agent"
+Migrate my @cloudflare/vitest-pool-workers tests from v0.12.x to v0.13.x (Vitest 4).
+
+1. Run the codemod to update vitest.config.ts: `npx jscodeshift -t https://unpkg.com/@cloudflare/vitest-pool-workers/dist/codemods/vitest-v3-to-v4.mjs --parser=ts vitest.config.ts`
+2. Replace all `import { env, SELF } from "cloudflare:test"` with `import { env, exports } from "cloudflare:workers"`. Replace uses of `SELF.fetch()` with `exports.default.fetch()`.
+3. Remove all uses of `fetchMock` imported from `cloudflare:test`. Replace with direct mocks on `globalThis.fetch`, or with MSW if the project already uses it.
+4. Remove the `isolatedStorage` and `singleWorker` options from any test-level configuration. If tests relied on shared storage across files, add `--max-workers=1 --no-isolate` to the Vitest command in package.json.
+5. Update any test files affected by upstream Vitest 4 breaking changes. Refer to the migration guide at https://vitest.dev/guide/migration#vitest-4 for the full list of changes.
+```
+
+## Upstream Vitest 4 changes
+
+For breaking changes in Vitest 4 itself that may affect your tests, refer to the [Vitest 4 migration guide](https://vitest.dev/guide/migration#vitest-4). If you run into issues, open a discussion on the [workers-sdk GitHub repository](https://github.com/cloudflare/workers-sdk/discussions).
+
+## Related resources
+
+- [Write your first test](/workers/testing/vitest-integration/write-your-first-test/) - Write unit and integration tests for Workers.
+- [Configuration](/workers/testing/vitest-integration/configuration/) - Reference for the `cloudflareTest()` plugin options.

--- a/src/content/docs/workers/testing/vitest-integration/migration-guides/migrate-from-vitest-3-to-vitest-4.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/migration-guides/migrate-from-vitest-3-to-vitest-4.mdx
@@ -19,7 +19,7 @@ Version 0.13.0 rearchitects the integration around a Vite plugin model. This cha
 - Library imports that previously required SSR optimizer workarounds, such as Stripe, now resolve without extra configuration.
 - Bare Node.js specifiers such as `node:url` now resolve in test files.
 - `nodejs_compat_v2` and Node.js module flags are enabled automatically during tests, matching production behavior.
-- The `provide` data channel no longer has the previous ~8 KB size limit. It now uses WebSocket messages.
+- The `provide` data channel is no longer limited to ~8 KB. It now uses WebSocket messages.
 - Storage is isolated per test file instead of per test, consistent with standard Vitest behavior.
 - The Vitest UI works correctly with Workers tests.
 
@@ -59,7 +59,7 @@ The codemod only updates `vitest.config.ts`, and it does not remove options that
 
 `defineWorkersProject` and `defineWorkersConfig` from `@cloudflare/vitest-pool-workers/config` have both been removed. They are replaced by a `cloudflareTest()` Vite plugin exported from `@cloudflare/vitest-pool-workers`, with options previously nested under `test.poolOptions.workers` passed directly to `cloudflareTest()`.
 
-The codemod migrates configurations that use `defineWorkersProject`. If your configuration uses `defineWorkersConfig`, or calls `defineWorkersProject` with a function instead of an object, the codemod cannot transform it and you must apply the change manually using the example below.
+The codemod migrates configurations that use `defineWorkersProject`. If your configuration uses `defineWorkersConfig`, or calls `defineWorkersProject` with a function instead of an object, the codemod cannot transform it. Apply the change manually using the following example.
 
 Before:
 
@@ -116,7 +116,7 @@ The `env` and `SELF` exports from `cloudflare:test` are deprecated in favor of `
 
 ### Replace fetchMock
 
-The `import { fetchMock } from "cloudflare:test"` import has been removed. Mock `globalThis.fetch` directly or use ecosystem libraries such as [MSW](https://mswjs.io/). Refer to the [request mocking example](https://github.com/cloudflare/workers-sdk/blob/main/fixtures/vitest-pool-workers-examples/request-mocking/test/imperative.test.ts) for a complete example.
+The `import { fetchMock } from "cloudflare:test"` import has been removed. Mock `globalThis.fetch` directly or use ecosystem libraries such as [MSW](https://mswjs.io/). Refer to the [request mocking example](https://github.com/cloudflare/workers-sdk/blob/1aee99059d6025c7ea8ef88b3ea421922eee6354/fixtures/vitest-pool-workers-examples/request-mocking/test/imperative.test.ts) for a complete example.
 
 ## Migrate test files with a coding agent
 

--- a/src/content/docs/workers/testing/vitest-integration/migration-guides/migrate-from-vitest-3-to-vitest-4.mdx
+++ b/src/content/docs/workers/testing/vitest-integration/migration-guides/migrate-from-vitest-3-to-vitest-4.mdx
@@ -31,6 +31,8 @@ Install Vitest 4 and the latest version of `@cloudflare/vitest-pool-workers`:
 
 <PackageManagers pkg="vitest@^4.1.0 @cloudflare/vitest-pool-workers" dev />
 
+`@cloudflare/vitest-pool-workers` also requires `@vitest/runner` and `@vitest/snapshot` at `^4.1.0`. Both ship as dependencies of `vitest`, so installing `vitest@^4.1.0` satisfies them.
+
 ## Update your configuration with the codemod
 
 A codemod updates your `vitest.config.ts` to the new plugin API automatically. After installing the package, run:
@@ -50,12 +52,14 @@ To run the codemod without installing the package first, point it at the publish
 />
 
 :::note
-The codemod only updates `vitest.config.ts`. Changes to your test files, including `cloudflare:test` import replacements, must be made manually. The remaining sections describe those changes.
+The codemod only updates `vitest.config.ts`, and it does not remove options that are no longer supported. Changes to your test files, including `cloudflare:test` import updates, must be made manually. The remaining sections describe those changes.
 :::
 
 ## Review the configuration changes
 
-The codemod replaces `defineWorkersProject` and `defineWorkersConfig` from `@cloudflare/vitest-pool-workers/config` with a `cloudflareTest()` Vite plugin exported from `@cloudflare/vitest-pool-workers`. Options previously nested under `test.poolOptions.workers` are now passed directly to `cloudflareTest()`.
+`defineWorkersProject` and `defineWorkersConfig` from `@cloudflare/vitest-pool-workers/config` have both been removed. They are replaced by a `cloudflareTest()` Vite plugin exported from `@cloudflare/vitest-pool-workers`, with options previously nested under `test.poolOptions.workers` passed directly to `cloudflareTest()`.
+
+The codemod migrates configurations that use `defineWorkersProject`. If your configuration uses `defineWorkersConfig`, or calls `defineWorkersProject` with a function instead of an object, the codemod cannot transform it and you must apply the change manually using the example below.
 
 Before:
 
@@ -88,17 +92,17 @@ export default defineConfig({
 });
 ```
 
+### Remove `isolatedStorage` and `singleWorker`
+
+The `isolatedStorage` and `singleWorker` options have been removed. Storage isolation is now per test file, matching Vitest's own isolation model. The codemod copies your existing `test.poolOptions.workers` options into `cloudflareTest()`, so if you previously set either option, remove it from the `cloudflareTest()` call. To make test files share the same storage instead, pass the `--max-workers=1 --no-isolate` flags to the Vitest command in your `package.json`.
+
 ## Update your test files
 
 The following changes must be made manually to your test files.
 
-### Replace removed isolation options
+### Update deprecated `cloudflare:test` imports
 
-The `isolatedStorage` and `singleWorker` options have been removed. Storage isolation is now per test file, matching Vitest's own isolation model. To make test files share the same storage, pass the `--max-workers=1 --no-isolate` flags to the Vitest command in your `package.json`.
-
-### Replace cloudflare:test imports
-
-The `import { env, SELF } from "cloudflare:test"` import has been removed. Use `import { env, exports } from "cloudflare:workers"` instead. `exports.default.fetch()` behaves the same as `SELF.fetch()`, except that it does not expose Assets. To test Assets, write an integration test using [`startDevWorker()`](/workers/testing/unstable_startworker/).
+The `env` and `SELF` exports from `cloudflare:test` are deprecated in favor of `cloudflare:workers`. Replace `import { env, SELF } from "cloudflare:test"` with `import { env, exports } from "cloudflare:workers"`. `exports.default.fetch()` behaves the same as `SELF.fetch()`, except that it does not expose Assets. To test Assets, use the `env.ASSETS` binding or write an integration test using [`startDevWorker()`](/workers/testing/unstable_startworker/). The deprecated exports still work, so this change is recommended rather than required.
 
 ```diff
 - import { env, SELF } from "cloudflare:test";
@@ -124,7 +128,7 @@ Migrate my @cloudflare/vitest-pool-workers tests from v0.12.x to v0.13.x (Vitest
 1. Run the codemod to update vitest.config.ts: `npx jscodeshift -t https://unpkg.com/@cloudflare/vitest-pool-workers/dist/codemods/vitest-v3-to-v4.mjs --parser=ts vitest.config.ts`
 2. Replace all `import { env, SELF } from "cloudflare:test"` with `import { env, exports } from "cloudflare:workers"`. Replace uses of `SELF.fetch()` with `exports.default.fetch()`.
 3. Remove all uses of `fetchMock` imported from `cloudflare:test`. Replace with direct mocks on `globalThis.fetch`, or with MSW if the project already uses it.
-4. Remove the `isolatedStorage` and `singleWorker` options from any test-level configuration. If tests relied on shared storage across files, add `--max-workers=1 --no-isolate` to the Vitest command in package.json.
+4. Remove the `isolatedStorage` and `singleWorker` options from the `cloudflareTest()` configuration in vitest.config.ts (the codemod copies them over from the old config). If tests relied on shared storage across files, add `--max-workers=1 --no-isolate` to the Vitest command in package.json.
 5. Update any test files affected by upstream Vitest 4 breaking changes. Refer to the migration guide at https://vitest.dev/guide/migration#vitest-4 for the full list of changes.
 ```
 


### PR DESCRIPTION
### Summary

Adds a new how-to page, **Migrate from Vitest 3 to Vitest 4**, under the Workers Vitest integration migration guides. It documents migrating `@cloudflare/vitest-pool-workers` from v0.12.x (Vitest 3) to v0.13.x (Vitest 4): the `cloudflareTest()` plugin config API, the `jscodeshift` codemod, the `isolatedStorage`/`singleWorker` removal, the deprecated `cloudflare:test` imports (`env`/`SELF` moving to `cloudflare:workers`), and the `fetchMock` removal.

The source material is the v0.13.0 release notes ([cloudflare/workers-sdk#11632](https://github.com/cloudflare/workers-sdk/pull/11632)), as suggested during review of #29465. This supersedes that closed PR and addresses #29463.

Content was validated line by line against the published package (npm `@cloudflare/vitest-pool-workers` `0.13.0` and the current `0.16.18`): the shipped type definitions, the codemod source, and the source PR body. Two points were corrected relative to the source changelog wording:

- `env` and `SELF` from `cloudflare:test` are **deprecated**, not removed — they are still exported (with `@deprecated` JSDoc) in both `0.13.0` and `0.16.18`, so migration is recommended rather than required. `fetchMock`, by contrast, is genuinely removed.
- The codemod transforms only `defineWorkersProject`. Both `defineWorkersProject` and `defineWorkersConfig` were removed from the API, but a config using `defineWorkersConfig` must be migrated by hand.

### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
