### PR TITLE
Document account-level Security Insights limit for accounts with more than 10,000 zones

### DIFF
--- a/src/content/docs/security/security-insights/index.mdx
+++ b/src/content/docs/security/security-insights/index.mdx
@@ -65,6 +65,12 @@ Security Insights scans run periodically and use heuristics to detect potential 
 
 To remove a resolved or inaccurate insight from your dashboard, [archive the insight](/security/security-insights/review-insights/#archive-insights) or wait for the next automatic scan.
 
+:::note[Accounts with more than 10,000 zones]
+Account-level Security Insights are available for accounts with up to 10,000 zones. For accounts with more than 10,000 zones, Cloudflare does not aggregate insights at the account level, so the dashboard cannot display account-level Security Insights.
+
+To review security findings for these accounts, use per-zone [Security Analytics](/waf/analytics/security-analytics/) on individual domains. To analyze or retain activity across your entire account, export logs to a security information and event management (SIEM) system with [Logpush](/logs/logpush/).
+:::
+
 ## More resources
 
 For more information on available operations for Security Insights, refer to [Review Security Insights](/security/security-insights/review-insights/).

--- a/src/content/docs/security/security-insights/index.mdx
+++ b/src/content/docs/security/security-insights/index.mdx
@@ -66,7 +66,7 @@ Security Insights scans run periodically and use heuristics to detect potential 
 To remove a resolved or inaccurate insight from your dashboard, [archive the insight](/security/security-insights/review-insights/#archive-insights) or wait for the next automatic scan.
 
 :::note[Accounts with more than 10,000 zones]
-Account-level Security Insights are available for accounts with up to 10,000 zones. For accounts with more than 10,000 zones, Cloudflare does not aggregate insights at the account level, so the dashboard cannot display account-level Security Insights.
+Cloudflare aggregates account-level Security Insights for accounts with up to 10,000 zones. For accounts with more than 10,000 zones, Cloudflare does not aggregate insights at the account level, so the dashboard cannot display account-level Security Insights.
 
 To review security findings for these accounts, use per-zone [Security Analytics](/waf/analytics/security-analytics/) on individual domains. To analyze or retain activity across your entire account, export logs to a security information and event management (SIEM) system with [Logpush](/logs/logpush/).
 :::


### PR DESCRIPTION
## Summary

Adds a note to the [Security Insights](https://developers.cloudflare.com/security/security-insights/) **Known limitations** section documenting that account-level Security Insights are aggregated only for accounts with up to 10,000 zones. For accounts with more than 10,000 zones, the dashboard cannot display account-level Security Insights.

The note directs affected users to per-zone [Security Analytics](https://developers.cloudflare.com/waf/analytics/security-analytics/) for individual domains, and to [Logpush](https://developers.cloudflare.com/logs/logpush/) for exporting account-wide activity to a SIEM.

## Why

Accounts above the 10,000-zone account-level aggregation limit currently have no public documentation explaining why account-level Security Insights do not display, or what to use instead. This note closes that gap.

## Page changed

- `src/content/docs/security/security-insights/index.mdx` — new `:::note` in the **Known limitations** section.