### PR TITLE
[Email Service] Add deploy button for MTA-STS proxy Worker

### DIFF
--- a/src/content/docs/email-service/configuration/mta-sts.mdx
+++ b/src/content/docs/email-service/configuration/mta-sts.mdx
@@ -43,17 +43,9 @@ Next you need an HTTPS endpoint at `mta-sts.example.com` to serve your policy fi
 
 To do this you need to deploy a Worker that allows email clients to pull Cloudflare's Email Service policy file using the "well-known" URI convention.
 
-1. Go to your **Account** > **Workers & Pages** and select **Create**. Pick the default "Hello World" option button, and replace the sample worker code with the following:
+1. Deploy the MTA-STS proxy Worker to your account:
 
-   ```ts
-   export default {
-   	async fetch(request, env, ctx): Promise<Response> {
-   		return await fetch(
-   			"https://mta-sts.mx.cloudflare.net/.well-known/mta-sts.txt",
-   		);
-   	},
-   } satisfies ExportedHandler;
-   ```
+   [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/docs-examples/tree/main/workers/mta-sts-proxy)
 
    This Worker proxies `https://mta-sts.mx.cloudflare.net/.well-known/mta-sts.txt` to your own domain.
 


### PR DESCRIPTION
### Summary

Replaces the manual "create a Worker and paste this code" steps on the Configure MTA-STS page with a **Deploy to Cloudflare** button. The button provisions the MTA-STS proxy Worker directly from the [`mta-sts-proxy`](https://github.com/cloudflare/docs-examples/tree/main/workers/mta-sts-proxy) example in `cloudflare/docs-examples`, so readers no longer have to copy code by hand. The custom-domain and `curl` verification steps are unchanged.

Depends on cloudflare/docs-examples#27 (merged), which adds the example the button points at.

Closes EMAIL-1161

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
