### PR TITLE
[Pipelines, R2, R2 SQL] Simplify pricing tables to single pricing column

### DIFF
--- a/src/content/docs/pipelines/platform/pricing.mdx
+++ b/src/content/docs/pipelines/platform/pricing.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Pricing
-description: Cloudflare Pipelines pricing for SQL transforms, sinks, and free tier details.
+description: Cloudflare Pipelines pricing for SQL transforms, sinks, and included usage details.
 sidebar:
   order: 1
 head:
@@ -22,17 +22,17 @@ All included usage is on a monthly basis.
 
 ## Pipelines pricing
 
-|                                 | Workers Free | Workers Paid |
-| ------------------------------- | ------------ | ------------ |
-| **Streams (ingress)**           |              |              |
-| Included                        | 1 GB / month | Unlimited |
-| **SQL transforms** [^1]        |              |              |
-| Included                        | 1 GB / month | 50 GB / month |
-| Additional                      | N/A          | $0.04 / GB   |
-| **Sinks (egress)** [^2]        |              |              |
-| Included                        | 1 GB / month | 50 GB / month |
-| R2 &mdash; JSON format          | N/A          | $0.03 / GB   |
-| R2 &mdash; Parquet / Iceberg    | N/A          | $0.06 / GB   |
+|                              | Workers Paid  |
+| ---------------------------- | ------------- |
+| **Streams (ingress)**        |               |
+| Included                     | Unlimited     |
+| **SQL transforms** [^1]      |               |
+| Included                     | 50 GB / month |
+| Additional                   | $0.04 / GB    |
+| **Sinks (egress)** [^2]      |               |
+| Included                     | 50 GB / month |
+| R2 &mdash; JSON format       | $0.03 / GB    |
+| R2 &mdash; Parquet / Iceberg | $0.06 / GB    |
 
 ### Streams
 
@@ -57,23 +57,23 @@ Sink pricing is based on the volume of uncompressed data delivered to the destin
 
 A pipeline ingests 200 GB of log data per month and writes it directly to an R2 bucket in JSON format with no SQL transforms.
 
-| Dimension       | Usage  | Included | Billable | Cost        |
-| --------------- | ------ | -------- | -------- | ----------- |
-| Streams         | 200 GB | 50 GB    | 150 GB   | $0.00       |
-| SQL transforms  | 0 GB   | 50 GB    | 0 GB     | $0.00       |
-| Sinks (JSON)    | 200 GB | 50 GB    | 150 GB   | $4.50       |
-| **Total**       |        |          |          | **$4.50**   |
+| Dimension      | Usage  | Included  | Billable | Cost      |
+| -------------- | ------ | --------- | -------- | --------- |
+| Streams        | 200 GB | Unlimited | 0 GB     | $0.00     |
+| SQL transforms | 0 GB   | 50 GB     | 0 GB     | $0.00     |
+| Sinks (JSON)   | 200 GB | 50 GB     | 150 GB   | $4.50     |
+| **Total**      |        |           |          | **$4.50** |
 
 ### Example 2: Filtered ingest to Iceberg with SQL
 
 A pipeline ingests 500 GB of event data per month. A SQL transform filters and reshapes the data, reducing output to 300 GB written to an R2 Data Catalog Iceberg table.
 
-| Dimension            | Usage  | Included | Billable | Cost         |
-| -------------------- | ------ | -------- | -------- | ------------ |
-| Streams              | 500 GB | 50 GB    | 450 GB   | $0.00        |
-| SQL transforms       | 500 GB | 50 GB    | 450 GB   | $18.00       |
-| Sinks (Iceberg)      | 300 GB | 50 GB    | 250 GB   | $15.00       |
-| **Total**            |        |          |          | **$33.00**   |
+| Dimension       | Usage  | Included  | Billable | Cost       |
+| --------------- | ------ | --------- | -------- | ---------- |
+| Streams         | 500 GB | Unlimited | 0 GB     | $0.00      |
+| SQL transforms  | 500 GB | 50 GB     | 450 GB   | $18.00     |
+| Sinks (Iceberg) | 300 GB | 50 GB     | 250 GB   | $15.00     |
+| **Total**       |        |           |          | **$33.00** |
 
 ## Cloudflare billing policy
 

--- a/src/content/docs/r2-sql/platform/pricing.mdx
+++ b/src/content/docs/r2-sql/platform/pricing.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Pricing
-description: R2 SQL pricing based on data scanned, with free tier details and billing examples.
+description: R2 SQL pricing based on data scanned, with included usage details and billing examples.
 sidebar:
   order: 1
 head:
@@ -21,10 +21,10 @@ All included usage is on a monthly basis.
 
 ## R2 SQL pricing
 
-|                | Free plan       | Paid plan                 |
-| -------------- | --------------- | ------------------------- |
-| Included       | 1 GB / month    | 10 GB / month             |
-| Data scanned   | N/A             | $0.0025 / GB ($2.50 / TB) |
+|              | Pricing                   |
+| ------------ | ------------------------- |
+| Included     | 10 GB / month             |
+| Data scanned | $0.0025 / GB ($2.50 / TB) |
 
 ### What counts as data scanned
 
@@ -40,23 +40,23 @@ Data scanned is the compressed bytes read from R2 object storage to answer your 
 
 A user stores 500 GB of Parquet data in R2 Data Catalog and runs queries that scan a total of 50 GB of compressed data during the month.
 
-| Dimension                   | Usage              | Included    | Billable           | Cost        |
-| --------------------------- | ------------------ | ----------- | ------------------ | ----------- |
-| R2 storage                  | 500 GB-month       | 10 GB-month | 490 GB-month       | $7.35       |
-| R2 SQL (data scanned)       | 50 GB              | 10 GB       | 40 GB              | $0.10       |
-| **Total**                   |                    |             |                    | **$7.45**   |
+| Dimension             | Usage        | Included    | Billable     | Cost      |
+| --------------------- | ------------ | ----------- | ------------ | --------- |
+| R2 storage            | 500 GB-month | 10 GB-month | 490 GB-month | $7.35     |
+| R2 SQL (data scanned) | 50 GB        | 10 GB       | 40 GB        | $0.10     |
+| **Total**             |              |             |              | **$7.45** |
 
 ### Example 2: Heavy query workload on 10 TB dataset
 
 A data team stores 10 TB of compressed Parquet/Iceberg data and scans 50 TB of data per month across their queries. The team also makes 2 million catalog operations with compaction processing 500 GB.
 
-| Dimension                         | Usage              | Included         | Billable            | Cost          |
-| --------------------------------- | ------------------ | ---------------- | ------------------- | ------------- |
-| R2 storage                        | 10,000 GB-month    | 10 GB-month      | 9,990 GB-month      | $149.85       |
-| R2 SQL (data scanned)             | 50,000 GB          | 10 GB            | 49,990 GB           | $124.98       |
-| R2 Data Catalog operations        | 2,000,000          | 1,000,000        | 1,000,000           | $9.00         |
-| R2 Data Catalog compaction (data) | 500 GB             | 10 GB            | 490 GB              | $2.45         |
-| **Total**                         |                    |                  |                     | **$286.28**   |
+| Dimension                         | Usage           | Included    | Billable       | Cost        |
+| --------------------------------- | --------------- | ----------- | -------------- | ----------- |
+| R2 storage                        | 10,000 GB-month | 10 GB-month | 9,990 GB-month | $149.85     |
+| R2 SQL (data scanned)             | 50,000 GB       | 10 GB       | 49,990 GB      | $124.98     |
+| R2 Data Catalog operations        | 2,000,000       | 1,000,000   | 1,000,000      | $9.00       |
+| R2 Data Catalog compaction (data) | 500 GB          | 10 GB       | 490 GB         | $2.45       |
+| **Total**                         |                 |             |                | **$286.28** |
 
 ## Frequently asked questions
 

--- a/src/content/docs/r2/data-catalog/platform/pricing.mdx
+++ b/src/content/docs/r2/data-catalog/platform/pricing.mdx
@@ -1,7 +1,7 @@
 ---
 pcx_content_type: concept
 title: Pricing
-description: R2 Data Catalog pricing for catalog operations, compaction, and free tier details.
+description: R2 Data Catalog pricing for catalog operations, compaction, and included usage details.
 sidebar:
   order: 1
 products:
@@ -17,17 +17,17 @@ All included usage is on a monthly basis.
 
 ## R2 Data Catalog pricing
 
-|                                       | Free                          | Paid                                  |
-| ------------------------------------- | ----------------------------- | ------------------------------------- |
-| **Catalog operations**                |                               |                                       |
-| Included                              | 1 million operations / month  | 1 million operations / month          |
-| Additional                            | N/A                           | $9.00 / million operations            |
-| **Data processed (Compaction)** [^1]    |                               |                                       |
-| Included                              | 10 GB / month                 | 10 GB / month                         |
-| Additional (data processed)           | N/A                           | $0.005 / GB processed                 |
-| **Objects processed (Compaction)** [^1] |                               |                                       |
-| Included                              | 1 million objects / month     | 1 million objects / month             |
-| Additional                            | N/A                           | $2.00 / million objects               |
+|                                         | Pricing                      |
+| --------------------------------------- | ---------------------------- |
+| **Catalog operations**                  |                              |
+| Included                                | 1 million operations / month |
+| Additional                              | $9.00 / million operations   |
+| **Data processed (Compaction)** [^1]    |                              |
+| Included                                | 10 GB / month                |
+| Additional (data processed)             | $0.005 / GB processed        |
+| **Objects processed (Compaction)** [^1] |                              |
+| Included                                | 1 million objects / month    |
+| Additional                              | $2.00 / million objects      |
 
 ### Catalog operations
 
@@ -56,12 +56,12 @@ When you turn on [automatic snapshot expiration](/r2/data-catalog/table-maintena
 
 A user maintains a single Iceberg table with 50 GB of data. They make 500,000 catalog operations per month and have compaction turned on, which processes 20 GB across 200,000 files.
 
-| Dimension                   | Usage              | Included          | Billable           | Cost       |
-| --------------------------- | ------------------ | ----------------- | ------------------ | ---------- |
-| Catalog operations          | 500,000            | 1,000,000         | 0                  | $0.00      |
-| Compaction (data processed) | 20 GB              | 10 GB             | 10 GB              | $0.05      |
-| Compaction (objects)        | 200,000            | 1,000,000         | 0                  | $0.00      |
-| **Total (Data Catalog)**    |                    |                   |                    | **$0.05**  |
+| Dimension                   | Usage   | Included  | Billable | Cost      |
+| --------------------------- | ------- | --------- | -------- | --------- |
+| Catalog operations          | 500,000 | 1,000,000 | 0        | $0.00     |
+| Compaction (data processed) | 20 GB   | 10 GB     | 10 GB    | $0.05     |
+| Compaction (objects)        | 200,000 | 1,000,000 | 0        | $0.00     |
+| **Total (Data Catalog)**    |         |           |          | **$0.05** |
 
 Standard R2 storage charges ($0.015 / GB-month) apply separately for the 50 GB of data stored.
 
@@ -69,13 +69,13 @@ Standard R2 storage charges ($0.015 / GB-month) apply separately for the 50 GB o
 
 A user streams data into an Iceberg table at 20 MB/s using [Pipelines](/pipelines/). Over a month (~30 days) this produces approximately 50,625 GB (~49 TB) of data, 347,000 catalog operations, and compaction processes roughly 50,625 GB across 43,200 files.
 
-| Dimension                   | Usage              | Included          | Billable           | Cost           |
-| --------------------------- | ------------------ | ----------------- | ------------------ | -------------- |
-| R2 storage                  | 50,625 GB-month    | 10 GB-month       | 50,615 GB-month    | $759.23        |
-| Catalog operations          | 347,000            | 1,000,000         | 0                  | $0.00          |
-| Compaction (data processed) | 50,625 GB          | 10 GB             | 50,615 GB          | $253.08        |
-| Compaction (objects)        | 43,200             | 1,000,000         | 0                  | $0.00          |
-| **Total**                   |                    |                   |                    | **$1,012.31**  |
+| Dimension                   | Usage           | Included    | Billable        | Cost          |
+| --------------------------- | --------------- | ----------- | --------------- | ------------- |
+| R2 storage                  | 50,625 GB-month | 10 GB-month | 50,615 GB-month | $759.23       |
+| Catalog operations          | 347,000         | 1,000,000   | 0               | $0.00         |
+| Compaction (data processed) | 50,625 GB       | 10 GB       | 50,615 GB       | $253.08       |
+| Compaction (objects)        | 43,200          | 1,000,000   | 0               | $0.00         |
+| **Total**                   |                 |             |                 | **$1,012.31** |
 
 For large-scale use cases, storage costs are typically the largest component of the bill.
 


### PR DESCRIPTION
### Summary

- Removed the "Workers Free" column from the Pipelines pricing table, keeping only "Workers Paid"
- Updated Pipelines billing examples so the Streams rows show "Unlimited" included and "0 GB" billable, matching the table
- Removed the "Free" column from the R2 Data Catalog pricing table and renamed "Paid" to "Pricing"
- Removed the "Free plan" column from the R2 SQL pricing table and renamed "Paid plan" to "Pricing"
- Replaced "free tier details" with "included usage details" in the frontmatter descriptions of all three files

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
