### PR TITLE
Enhance Error 1034 documentation with Edge IP Validation

### DIFF
--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034.mdx
@@ -11,7 +11,7 @@ products:
 
 This error indicates that the IP address used for the domain is restricted by Cloudflare's edge validation.
 
-Edge IP Validation (EIV) is a safeguard for restricted IP space that is meant to be used by specific Cloudflare accounts, such as BYOIP prefixes, dedicated/static IP allocations, or other customer-associated IP ranges. When EIV is enabled, Cloudflare checks whether incoming traffic to those IPs is associated with an authorized account before allowing the request to proceed. This helps prevent accidental misrouting or unauthorized use of dedicated IP space while keeping properly configured traffic flowing normally.
+Edge IP Validation (EIV) is a safeguard for restricted IP space that is meant to be used by specific Cloudflare accounts, such as [BYOIP](https://developers.cloudflare.com/byoip/) prefixes, dedicated/[static](https://developers.cloudflare.com/byoip/concepts/static-ips/) IP allocations, or other customer-associated IP ranges. When EIV is enabled, Cloudflare checks whether incoming traffic to those IPs is associated with an authorized account before allowing the request to proceed. This helps prevent accidental misrouting or unauthorized use of dedicated IP space while keeping properly configured traffic flowing normally.
 
 ### Common causes
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034.mdx
@@ -11,7 +11,7 @@ products:
 
 This error indicates that the IP address used for the domain is restricted by Cloudflare's edge validation.
 
-Edge IP Validation (EIV) is a safeguard for restricted IP space that is meant to be used by specific Cloudflare accounts, such as [BYOIP](https://developers.cloudflare.com/byoip/) prefixes, dedicated/[static](https://developers.cloudflare.com/byoip/concepts/static-ips/) IP allocations, or other customer-associated IP ranges. When EIV is enabled, Cloudflare checks whether incoming traffic to those IPs is associated with an authorized account before allowing the request to proceed. This helps prevent accidental misrouting or unauthorized use of dedicated IP space while keeping properly configured traffic flowing normally.
+Edge IP Validation (EIV) is a safeguard for restricted IP space that is meant to be used by specific Cloudflare accounts, such as [BYOIP](/byoip/) prefixes, dedicated/[static](/byoip/concepts/static-ips/) IP allocations, or other customer-associated IP ranges. When EIV is enabled, Cloudflare checks whether incoming traffic to those IPs is associated with an authorized account before allowing the request to proceed. This helps prevent accidental misrouting or unauthorized use of dedicated IP space while keeping properly configured traffic flowing normally.
 
 ### Common causes
 

--- a/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034.mdx
+++ b/src/content/docs/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1034.mdx
@@ -11,6 +11,8 @@ products:
 
 This error indicates that the IP address used for the domain is restricted by Cloudflare's edge validation.
 
+Edge IP Validation (EIV) is a safeguard for restricted IP space that is meant to be used by specific Cloudflare accounts, such as BYOIP prefixes, dedicated/static IP allocations, or other customer-associated IP ranges. When EIV is enabled, Cloudflare checks whether incoming traffic to those IPs is associated with an authorized account before allowing the request to proceed. This helps prevent accidental misrouting or unauthorized use of dedicated IP space while keeping properly configured traffic flowing normally.
+
 ### Common causes
 
 #### Pointing to reserved IP addresses


### PR DESCRIPTION
Added explanation of Edge IP Validation for Error 1034.

### Summary

Yeah we don't really have any public documentation for what EIV is or why we return 1034. I vibed up this general explanation to give customers a little more information about what is happening if they get this error. This should also give us something to point to when we are pushing for customers to commit to enabling EIV for their legacy byoip/static ip setups

### Documentation checklist

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).