### PR TITLE
[WAF] Improve managed rules troubleshooting: payload logging and malicious uploads

### DIFF
--- a/src/content/docs/waf/managed-rules/troubleshooting.mdx
+++ b/src/content/docs/waf/managed-rules/troubleshooting.mdx
@@ -22,6 +22,8 @@ By default, WAF's managed rulesets are compatible with most websites and web app
 
 You can use [Security Events](/waf/analytics/security-events/) to help you identify what caused legitimate requests to get blocked. Add filters and adjust the report duration as needed.
 
+To get more detail about which part of a request matched a managed rule, enable [payload logging](/waf/managed-rules/payload-logging/) for the affected managed ruleset. Payload logging records the specific string that triggered each rule (encrypted with a key pair that you provide), which helps you confirm whether a match was a false positive. If you have not set it up yet, [configure payload logging](/waf/managed-rules/payload-logging/configure/) so that the matched payload is available the next time you investigate a false positive. Payload logging is available on Enterprise plans.
+
 If you encounter a false positive caused by a managed rule, do one of the following:
 
 - **Add an exception**: [Exceptions](/waf/managed-rules/waf-exceptions/) allow you to skip the execution of WAF managed rulesets or some of their rules for certain requests.
@@ -41,6 +43,8 @@ If you contact Cloudflare Support to verify whether a WAF managed rule triggers 
 - For false positives with the administrator area of your website, add an [exception](/waf/managed-rules/waf-exceptions/) disabling a managed rule for the admin section of your site resources. You can use an expression similar to the following:
 
   `http.host eq "example.com" and starts_with(http.request.uri.path, "/admin")`
+
+- WAF managed rulesets are designed to inspect standard HTTP request content. Requests that upload binary content (for example, file uploads) can resemble attack payloads and cause false positives. To scan file uploads for malicious content, use [Malicious uploads detection](/waf/detections/malicious-uploads/) instead of relying on managed rules for that traffic.
 
 ## Troubleshoot false negatives
 


### PR DESCRIPTION
Resolves DEE-3647.

Adds two pieces of guidance to the WAF managed rules troubleshooting page that were missing from the page:

- **Payload logging** (false positives): tells readers to use payload logging to see which part of a request matched a rule, and to configure it ahead of time so the payload is captured for the next investigation. Links to the payload logging overview and the dashboard configuration page. Notes it is Enterprise-only.
- **Malicious uploads / binary content** (false positives, Additional recommendations): explains that managed rulesets inspect standard HTTP content, that binary uploads can cause false positives, and points to Malicious uploads detection for scanning file uploads.

### Intentionally not changed
The ticket also suggested adding WAF attack score guidance for false negatives and clarifying exception-vs-disable behavior. Both are already documented on this page (the *Troubleshoot false negatives* section already recommends WAF attack score, and the *Troubleshoot false positives* section already covers exceptions vs disabling rules), so they were left as-is to avoid duplication.

### Notes
- Docs-only change; no product/runtime changes.
- All internal links verified against existing pages.