### PR TITLE
[Access] Clarify that a new JWT scoped to App B's AUD tag is issued for linked app token requests

### DIFF
--- a/src/content/docs/cloudflare-one/access-controls/applications/linked-app-token.mdx
+++ b/src/content/docs/cloudflare-one/access-controls/applications/linked-app-token.mdx
@@ -64,7 +64,7 @@ When Access receives the request to Application B, it will:
 
 1. Extract the token from the `Cf-Access-Token` header.
 2. Validate that the token was issued for Application A (matching the `app_uid` in the Linked App Token rule).
-3. If valid, allow the request. The user's identity from the token is propagated to the upstream headers and audit log.
+3. If valid, Access issues a new `Cf-Access-Jwt-Assertion` scoped to Application B's AUD tag, forwards it to Application B's origin, and attributes the request to the original user in the audit log.
 
 ## SaaS to self-hosted
 


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->

The docs previously stated how linked app tokens worked but left it ambiguous as to what audience would be expected in application b. It should be obvious that it's the audience for application B that is used but this change just makes it 100% clearly documented.

### Documentation checklist

<!-- Remove items that do not apply -->

- [X] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
