### PR TITLE
Remove global allow permissions in favour of OPENCODE_CONFIG_CONTENT

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -57,6 +57,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
+          # approval prompts. This is intentionally not in opencode.jsonc so
+          # local/interactive sessions keep their normal permission prompts.
+          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
         with:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
           opencode_version: "1.17.7"

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -83,6 +83,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
+          # approval prompts. This is intentionally not in opencode.jsonc so
+          # local/interactive sessions keep their normal permission prompts.
+          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           opencode_version: "1.17.7"
@@ -139,6 +143,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
+          # approval prompts. This is intentionally not in opencode.jsonc so
+          # local/interactive sessions keep their normal permission prompts.
+          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
         with:
           model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           opencode_version: "1.17.7"

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://opencode.ai/config.json",
-	"permission": "allow",
 	"experimental": {
 		"continue_loop_on_deny": true,
 	},


### PR DESCRIPTION
### Summary

Setting global allow permissions allows the AI models locally to do whatever they want without asking. This is dangerous, as the model could run rm commands for example freely, with no prompt for permissions.

Removing the global setting in favour of OPENCODE_CONFIG_CONTENT that injects it just for CI.