### PR TITLE
[Pipelines] Add Bluesky firehose fan-out example and document multi-statement SQL

### DIFF
--- a/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
+++ b/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
@@ -41,11 +41,7 @@ flowchart TD
 
 <Render file="prereqs" product="workers" />
 
-You will also need:
-
-- An [R2 API token](/r2/api/tokens/) with **Admin Read & Write** permissions, which includes R2 Data Catalog and R2 SQL access. You will pass this token to each sink.
-
-No Bluesky account or API key is required. Jetstream is public and unauthenticated.
+You will also need an [R2 API token](/r2/api/tokens/) with **Admin Read & Write** permissions, which includes R2 Data Catalog and R2 SQL access. You will pass this token to each sink. No Bluesky account or API key is required, as Jetstream is public and unauthenticated.
 
 ## 1. Create a new Worker project
 
@@ -75,9 +71,7 @@ cd bluesky-pipeline
 
 The `pipelines` commands used later require Wrangler v4 or later. If your project was scaffolded with an older version, update it now:
 
-```sh
-npm install --save-dev wrangler@latest
-```
+<PackageManagers type="add" pkg="wrangler@latest" dev />
 
 ## 2. Define the stream schema
 
@@ -108,15 +102,19 @@ Your sinks write to Iceberg tables in [R2 Data Catalog](/r2/data-catalog/), so y
 
 Create an R2 bucket named `bluesky-pipeline`:
 
-```sh
-npx wrangler r2 bucket create bluesky-pipeline
-```
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="r2 bucket create bluesky-pipeline"
+/>
 
 Enable R2 Data Catalog on the bucket:
 
-```sh
-npx wrangler r2 bucket catalog enable bluesky-pipeline
-```
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="r2 bucket catalog enable bluesky-pipeline"
+/>
 
 When you run this command, note the **Warehouse name**. You will need it to query your data with R2 SQL.
 
@@ -124,9 +122,11 @@ When you run this command, note the **Warehouse name**. You will need it to quer
 
 First, create the stream from your schema file:
 
-```sh
-npx wrangler pipelines streams create bsky_events_stream --schema-file schema.json
-```
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="pipelines streams create bsky_events_stream --schema-file schema.json"
+/>
 
 Note the **stream ID** in the output. You will use it to configure the Worker binding in the next step.
 
@@ -172,15 +172,17 @@ INSERT INTO bsky_block_sink
 
 Create the pipeline from the file:
 
-```sh
-npx wrangler pipelines create bsky_pipeline --sql-file fanout.sql
-```
+<PackageManagers
+	type="exec"
+	pkg="wrangler"
+	args="pipelines create bsky_pipeline --sql-file fanout.sql"
+/>
 
 One pipeline writes to five tables. To add a new event type later, add one sink and one `INSERT` statement. Pipeline SQL cannot be modified after creation, so you delete and recreate the pipeline to change it. To learn more, refer to [Route one stream to multiple tables](/pipelines/pipelines/manage-pipelines/#route-one-stream-to-multiple-tables).
 
 ## 5. Bind the stream to your Worker
 
-Add the stream binding, a Durable Object to hold the WebSocket connection, and a [cron trigger](/workers/configuration/cron-triggers/) to keep the consumer alive. Replace `<STREAM_ID>` with the stream ID from step 3.
+Add the stream binding, a Durable Object to hold the WebSocket connection, and a [cron trigger](/workers/configuration/cron-triggers/) to keep the consumer alive. Replace `<STREAM_ID>` with the stream ID from step 4.
 
 <WranglerConfig>
 ```toml
@@ -270,10 +272,10 @@ export class JetstreamConsumer extends DurableObject<Env> {
 	private cursor: number | null = null;
 	private flushing = false;
 
-	// Idempotent: connect if needed and arm the reconnect alarm.
+	// Arm the reconnect watchdog first, then connect (idempotent).
 	async start() {
-		await this.ensureConnected();
 		await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
+		await this.ensureConnected();
 		return { connected: this.ws !== null };
 	}
 
@@ -339,11 +341,16 @@ export class JetstreamConsumer extends DurableObject<Env> {
 		}
 	}
 
-	// Watchdog: reconnect if dropped, flush stragglers, reschedule.
+	// Watchdog: reconnect if dropped, flush stragglers, always reschedule.
 	async alarm() {
-		await this.ensureConnected();
-		await this.flush();
-		await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
+		try {
+			await this.ensureConnected();
+			await this.flush();
+		} catch (err) {
+			console.error("alarm error", err);
+		} finally {
+			await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
+		}
 	}
 }
 
@@ -362,30 +369,29 @@ export default {
 
 Generate types for your bindings:
 
-```sh
-npx wrangler types
-```
+<PackageManagers type="exec" pkg="wrangler" args="types" />
 
 ## 7. Deploy and start the consumer
 
 Deploy the Worker:
 
-```sh
-npx wrangler deploy
-```
+<PackageManagers type="exec" pkg="wrangler" args="deploy" />
 
 Open the Worker URL once to start the firehose. The cron trigger keeps it running:
 
 ```sh
 curl https://bluesky-pipeline.YOUR_SUBDOMAIN.workers.dev
-# {"connected":true}
+```
+
+The command returns:
+
+```txt
+{ "connected": true }
 ```
 
 Tail the logs to watch it work:
 
-```sh
-npx wrangler tail
-```
+<PackageManagers type="exec" pkg="wrangler" args="tail" />
 
 ## 8. Query the tables with R2 SQL
 

--- a/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
+++ b/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
@@ -92,7 +92,7 @@ Create a `schema.json` file in the root of your project:
 		{ "name": "event_type", "type": "string", "required": true },
 		{ "name": "did", "type": "string", "required": false },
 		{ "name": "operation", "type": "string", "required": false },
-		{ "name": "time_us", "type": "int64", "required": false },
+		{ "name": "event_time", "type": "timestamp", "required": false },
 		{ "name": "created_at", "type": "string", "required": false },
 		{ "name": "text", "type": "string", "required": false },
 		{ "name": "langs", "type": "string", "required": false },
@@ -150,23 +150,23 @@ Create a `fanout.sql` file:
 
 ```sql
 INSERT INTO bsky_post_sink
-  SELECT event_id, did, operation, time_us, created_at, text, langs
+  SELECT event_id, did, operation, event_time, created_at, text, langs
   FROM bsky_events_stream WHERE event_type = 'post';
 
 INSERT INTO bsky_like_sink
-  SELECT event_id, did, operation, time_us, created_at, subject_uri
+  SELECT event_id, did, operation, event_time, created_at, subject_uri
   FROM bsky_events_stream WHERE event_type = 'like';
 
 INSERT INTO bsky_repost_sink
-  SELECT event_id, did, operation, time_us, created_at, subject_uri
+  SELECT event_id, did, operation, event_time, created_at, subject_uri
   FROM bsky_events_stream WHERE event_type = 'repost';
 
 INSERT INTO bsky_follow_sink
-  SELECT event_id, did, operation, time_us, created_at, subject_did
+  SELECT event_id, did, operation, event_time, created_at, subject_did
   FROM bsky_events_stream WHERE event_type = 'follow';
 
 INSERT INTO bsky_block_sink
-  SELECT event_id, did, operation, time_us, created_at, subject_did
+  SELECT event_id, did, operation, event_time, created_at, subject_did
   FROM bsky_events_stream WHERE event_type = 'block';
 ```
 
@@ -248,12 +248,17 @@ function toRow(ev: any) {
 		event_type,
 		did: ev.did ?? null,
 		operation: c.operation ?? null,
-		time_us: typeof ev.time_us === "number" ? ev.time_us : null,
+		event_time:
+			typeof ev.time_us === "number"
+				? new Date(ev.time_us / 1000).toISOString()
+				: null,
 		created_at: typeof r.createdAt === "string" ? r.createdAt : null,
 		text: event_type === "post" && typeof r.text === "string" ? r.text : null,
 		langs:
-			event_type === "post" && Array.isArray(r.langs) ? r.langs.join(",") : null,
-		subject_uri: typeof subject === "object" ? subject?.uri ?? null : null,
+			event_type === "post" && Array.isArray(r.langs)
+				? r.langs.join(",")
+				: null,
+		subject_uri: typeof subject === "object" ? (subject?.uri ?? null) : null,
 		subject_did: typeof subject === "string" ? subject : null,
 	};
 }
@@ -302,7 +307,10 @@ export class JetstreamConsumer extends DurableObject<Env> {
 		if (typeof ev.time_us === "number") this.cursor = ev.time_us;
 		const row = toRow(ev);
 		if (row) this.buf.push(row);
-		if (this.buf.length >= FLUSH_MAX || Date.now() - this.lastFlush >= FLUSH_MS) {
+		if (
+			this.buf.length >= FLUSH_MAX ||
+			Date.now() - this.lastFlush >= FLUSH_MS
+		) {
 			void this.flush();
 		}
 	}

--- a/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
+++ b/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
@@ -117,6 +117,12 @@ When you run this command, note the **Warehouse name**. You will need it to quer
 
 ## 4. Create the stream, sinks, and pipeline
 
+The `pipelines` commands require Wrangler v4 or later. If your project was scaffolded with an older version, update it first:
+
+```sh
+npm install --save-dev wrangler@latest
+```
+
 First, create the stream from your schema file:
 
 ```sh
@@ -257,18 +263,18 @@ subject_did: typeof subject === "string" ? subject : null,
 
 export class JetstreamConsumer extends DurableObject<Env> {
 	private ws: WebSocket | null = null;
-	private buf: unknown[] = [];
+	private buf: Record<string, unknown>[] = [];
 	private lastFlush = 0;
 	private cursor: number | null = null;
 
     // Idempotent: connect if needed and arm the reconnect alarm.
     async start() {
-    	await this.connect();
+    	await this.ensureConnected();
     	await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
     	return { connected: this.ws !== null };
     }
 
-    private async connect() {
+    private async ensureConnected() {
     	if (this.ws) return;
     	this.cursor ??= (await this.ctx.storage.get<number>("cursor")) ?? null;
 
@@ -322,7 +328,7 @@ export class JetstreamConsumer extends DurableObject<Env> {
 
     // Watchdog: reconnect if dropped, flush stragglers, reschedule.
     async alarm() {
-    	await this.connect();
+    	await this.ensureConnected();
     	await this.flush();
     	await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
     }

--- a/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
+++ b/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
@@ -268,6 +268,7 @@ export class JetstreamConsumer extends DurableObject<Env> {
 	private buf: Record<string, unknown>[] = [];
 	private lastFlush = 0;
 	private cursor: number | null = null;
+	private flushing = false;
 
 	// Idempotent: connect if needed and arm the reconnect alarm.
 	async start() {
@@ -315,16 +316,26 @@ export class JetstreamConsumer extends DurableObject<Env> {
 		}
 	}
 
+	// Serialize sends: flush one batch at a time, advancing the cursor on success.
 	private async flush() {
-		this.lastFlush = Date.now();
-		if (this.buf.length === 0) return;
-		const batch = this.buf.splice(0, this.buf.length);
+		if (this.flushing) return;
+		this.flushing = true;
 		try {
-			await this.env.BSKY_STREAM.send(batch);
-			await this.ctx.storage.put("cursor", this.cursor); // advance only on success
-		} catch (err) {
-			this.buf.unshift(...batch); // re-queue; retried on the next flush or alarm
-			console.error("send failed, will retry", err);
+			while (this.buf.length > 0) {
+				this.lastFlush = Date.now();
+				const batch = this.buf.splice(0, this.buf.length);
+				const batchCursor = this.cursor;
+				try {
+					await this.env.BSKY_STREAM.send(batch);
+					await this.ctx.storage.put("cursor", batchCursor);
+				} catch (err) {
+					this.buf.unshift(...batch);
+					console.error("send failed, will retry", err);
+					return;
+				}
+			}
+		} finally {
+			this.flushing = false;
 		}
 	}
 

--- a/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
+++ b/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
@@ -2,7 +2,7 @@
 pcx_content_type: example
 title: Fan out a stream to multiple Iceberg tables
 summary: Consume the Bluesky Jetstream firehose in a Durable Object, ingest it into a single Pipelines stream, and use one pipeline with multiple SQL statements to route events into separate R2 Data Catalog tables by type.
-description: Consume the Bluesky Jetstream firehose in a Durable Object, ingest it into a single Pipelines stream, and use one pipeline with multiple SQL statements to route events into separate R2 Data Catalog tables by type.
+description: Route Bluesky Jetstream events into multiple R2 Data Catalog tables using a single Pipelines stream and multiple SQL statements.
 products:
   - pipelines
   - r2-data-catalog
@@ -17,7 +17,6 @@ sidebar:
 import {
 	PackageManagers,
 	Render,
-	Steps,
 	TypeScriptExample,
 	WranglerConfig,
 } from "~/components";
@@ -218,17 +217,17 @@ import { DurableObject } from "cloudflare:workers";
 import type { Pipeline } from "cloudflare:pipelines";
 
 interface Env {
-BSKY_STREAM: Pipeline;
-JETSTREAM: DurableObjectNamespace<JetstreamConsumer>;
+	BSKY_STREAM: Pipeline;
+	JETSTREAM: DurableObjectNamespace<JetstreamConsumer>;
 }
 
 // Jetstream collection -> our short event_type. Only these are kept.
 const COLLECTION_TO_TYPE: Record<string, string> = {
-"app.bsky.feed.post": "post",
-"app.bsky.feed.like": "like",
-"app.bsky.feed.repost": "repost",
-"app.bsky.graph.follow": "follow",
-"app.bsky.graph.block": "block",
+	"app.bsky.feed.post": "post",
+	"app.bsky.feed.like": "like",
+	"app.bsky.feed.repost": "repost",
+	"app.bsky.graph.follow": "follow",
+	"app.bsky.graph.block": "block",
 };
 const WANTED = Object.keys(COLLECTION_TO_TYPE);
 const JETSTREAM_URL = "https://jetstream2.us-east.bsky.network/subscribe";
@@ -238,27 +237,25 @@ const RECONNECT_MS = 15000;
 
 // Flatten one Jetstream message into a unified stream row, or null to skip.
 function toRow(ev: any) {
-if (ev?.kind !== "commit" || !ev.commit) return null;
-const c = ev.commit;
-const event_type = COLLECTION_TO_TYPE[c.collection];
-if (!event_type) return null;
-const r = c.record ?? {};
-const subject = r.subject;
-return {
-event_id: `${ev.did}/${c.collection}/${c.rkey}`,
-event_type,
-did: ev.did ?? null,
-operation: c.operation ?? null,
-time_us: typeof ev.time_us === "number" ? ev.time_us : null,
-created_at: typeof r.createdAt === "string" ? r.createdAt : null,
-text: event_type === "post" && typeof r.text === "string" ? r.text : null,
-langs:
-event_type === "post" && Array.isArray(r.langs)
-? r.langs.join(",")
-: null,
-subject_uri: typeof subject === "object" ? (subject?.uri ?? null) : null,
-subject_did: typeof subject === "string" ? subject : null,
-};
+	if (ev?.kind !== "commit" || !ev.commit) return null;
+	const c = ev.commit;
+	const event_type = COLLECTION_TO_TYPE[c.collection];
+	if (!event_type) return null;
+	const r = c.record ?? {};
+	const subject = r.subject;
+	return {
+		event_id: `${ev.did}/${c.collection}/${c.rkey}`,
+		event_type,
+		did: ev.did ?? null,
+		operation: c.operation ?? null,
+		time_us: typeof ev.time_us === "number" ? ev.time_us : null,
+		created_at: typeof r.createdAt === "string" ? r.createdAt : null,
+		text: event_type === "post" && typeof r.text === "string" ? r.text : null,
+		langs:
+			event_type === "post" && Array.isArray(r.langs) ? r.langs.join(",") : null,
+		subject_uri: typeof subject === "object" ? subject?.uri ?? null : null,
+		subject_did: typeof subject === "string" ? subject : null,
+	};
 }
 
 export class JetstreamConsumer extends DurableObject<Env> {
@@ -267,72 +264,68 @@ export class JetstreamConsumer extends DurableObject<Env> {
 	private lastFlush = 0;
 	private cursor: number | null = null;
 
-    // Idempotent: connect if needed and arm the reconnect alarm.
-    async start() {
-    	await this.ensureConnected();
-    	await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
-    	return { connected: this.ws !== null };
-    }
+	// Idempotent: connect if needed and arm the reconnect alarm.
+	async start() {
+		await this.ensureConnected();
+		await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
+		return { connected: this.ws !== null };
+	}
 
-    private async ensureConnected() {
-    	if (this.ws) return;
-    	this.cursor ??= (await this.ctx.storage.get<number>("cursor")) ?? null;
+	private async ensureConnected() {
+		if (this.ws) return;
+		this.cursor ??= (await this.ctx.storage.get<number>("cursor")) ?? null;
 
-    	const params = new URLSearchParams();
-    	for (const c of WANTED) params.append("wantedCollections", c);
-    	if (this.cursor) params.set("cursor", String(this.cursor));
+		const params = new URLSearchParams();
+		for (const c of WANTED) params.append("wantedCollections", c);
+		if (this.cursor) params.set("cursor", String(this.cursor));
 
-    	const resp = await fetch(`${JETSTREAM_URL}?${params}`, {
-    		headers: { Upgrade: "websocket" },
-    	});
-    	const ws = resp.webSocket;
-    	if (!ws) throw new Error(`Jetstream handshake failed: ${resp.status}`);
-    	ws.accept();
-    	this.ws = ws;
+		const resp = await fetch(`${JETSTREAM_URL}?${params}`, {
+			headers: { Upgrade: "websocket" },
+		});
+		const ws = resp.webSocket;
+		if (!ws) throw new Error(`Jetstream handshake failed: ${resp.status}`);
+		ws.accept();
+		this.ws = ws;
 
-    	ws.addEventListener("message", (e) => this.onMessage(e));
-    	ws.addEventListener("close", () => (this.ws = null));
-    	ws.addEventListener("error", () => (this.ws = null));
-    }
+		ws.addEventListener("message", (e) => this.onMessage(e));
+		ws.addEventListener("close", () => (this.ws = null));
+		ws.addEventListener("error", () => (this.ws = null));
+	}
 
-    private onMessage(e: MessageEvent) {
-    	let ev: any;
-    	try {
-    		ev = JSON.parse(e.data as string);
-    	} catch {
-    		return;
-    	}
-    	if (typeof ev.time_us === "number") this.cursor = ev.time_us;
-    	const row = toRow(ev);
-    	if (row) this.buf.push(row);
-    	if (
-    		this.buf.length >= FLUSH_MAX ||
-    		Date.now() - this.lastFlush >= FLUSH_MS
-    	) {
-    		void this.flush();
-    	}
-    }
+	private onMessage(e: MessageEvent) {
+		let ev: any;
+		try {
+			ev = JSON.parse(e.data as string);
+		} catch {
+			return;
+		}
+		if (typeof ev.time_us === "number") this.cursor = ev.time_us;
+		const row = toRow(ev);
+		if (row) this.buf.push(row);
+		if (this.buf.length >= FLUSH_MAX || Date.now() - this.lastFlush >= FLUSH_MS) {
+			void this.flush();
+		}
+	}
 
-    private async flush() {
-    	this.lastFlush = Date.now();
-    	if (this.buf.length === 0) return;
-    	const batch = this.buf.splice(0, this.buf.length);
-    	try {
-    		await this.env.BSKY_STREAM.send(batch);
-    		await this.ctx.storage.put("cursor", this.cursor); // advance only on success
-    	} catch (err) {
-    		this.buf.unshift(...batch); // re-queue; retried on the next flush or alarm
-    		console.error("send failed, will retry", err);
-    	}
-    }
+	private async flush() {
+		this.lastFlush = Date.now();
+		if (this.buf.length === 0) return;
+		const batch = this.buf.splice(0, this.buf.length);
+		try {
+			await this.env.BSKY_STREAM.send(batch);
+			await this.ctx.storage.put("cursor", this.cursor); // advance only on success
+		} catch (err) {
+			this.buf.unshift(...batch); // re-queue; retried on the next flush or alarm
+			console.error("send failed, will retry", err);
+		}
+	}
 
-    // Watchdog: reconnect if dropped, flush stragglers, reschedule.
-    async alarm() {
-    	await this.ensureConnected();
-    	await this.flush();
-    	await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
-    }
-
+	// Watchdog: reconnect if dropped, flush stragglers, reschedule.
+	async alarm() {
+		await this.ensureConnected();
+		await this.flush();
+		await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
+	}
 }
 
 export default {

--- a/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
+++ b/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
@@ -1,0 +1,396 @@
+---
+pcx_content_type: example
+title: Fan out a stream to multiple Iceberg tables
+summary: Consume the Bluesky Jetstream firehose in a Durable Object, ingest it into a single Pipelines stream, and use one pipeline with multiple SQL statements to route events into separate R2 Data Catalog tables by type.
+description: Consume the Bluesky Jetstream firehose in a Durable Object, ingest it into a single Pipelines stream, and use one pipeline with multiple SQL statements to route events into separate R2 Data Catalog tables by type.
+products:
+  - pipelines
+  - r2-data-catalog
+  - r2-sql
+  - durable-objects
+tags:
+  - TypeScript
+sidebar:
+  order: 2
+---
+
+import {
+	PackageManagers,
+	Render,
+	Steps,
+	TypeScriptExample,
+	WranglerConfig,
+} from "~/components";
+
+In this example, you will consume the public [Bluesky Jetstream](https://github.com/bluesky-social/jetstream) firehose, a live WebSocket stream of every post, like, repost, follow, and block on the network, and land it in [R2 Data Catalog](/r2/data-catalog/) as queryable Apache Iceberg tables.
+
+You will learn a core Pipelines pattern: send every event to one stream, then use a single pipeline with multiple SQL statements to route ("fan out") that stream into several destination tables, one per event type, without running a separate pipeline for each.
+
+```mermaid
+flowchart TD
+    A[Bluesky Jetstream WebSocket] --> B[Durable Object]
+    B -->|send| C[bsky_events_stream]
+    C --> D[bsky_pipeline]
+    D --> E[bsky_post]
+    D --> F[bsky_like]
+    D --> G[bsky_repost]
+    D --> H[bsky_follow]
+    D --> I[bsky_block]
+```
+
+## Prerequisites
+
+<Render file="prereqs" product="workers" />
+
+You will also need:
+
+- An [R2 API token](/r2/api/tokens/) with **Admin Read & Write** permissions, which includes R2 Data Catalog and R2 SQL access. You will pass this token to each sink.
+
+No Bluesky account or API key is required. Jetstream is public and unauthenticated.
+
+## 1. Create a new Worker project
+
+Create a new Worker project by running the following command:
+
+<PackageManagers
+	type="create"
+	pkg="cloudflare@latest"
+	args={"bluesky-pipeline"}
+/>
+
+<Render
+	file="c3-post-run-steps"
+	product="workers"
+	params={{
+		category: "hello-world",
+		type: "Worker only",
+		lang: "TypeScript",
+	}}
+/>
+
+Change into your new project directory:
+
+```sh
+cd bluesky-pipeline
+```
+
+## 2. Define the stream schema
+
+A stream has a single schema. Because every event type flows through the same stream, the schema is the union of the fields you want across all types. Each routing statement later selects only the columns relevant to its destination.
+
+Create a `schema.json` file in the root of your project:
+
+```json
+{
+	"fields": [
+		{ "name": "event_id", "type": "string", "required": true },
+		{ "name": "event_type", "type": "string", "required": true },
+		{ "name": "did", "type": "string", "required": false },
+		{ "name": "operation", "type": "string", "required": false },
+		{ "name": "time_us", "type": "int64", "required": false },
+		{ "name": "created_at", "type": "string", "required": false },
+		{ "name": "text", "type": "string", "required": false },
+		{ "name": "langs", "type": "string", "required": false },
+		{ "name": "subject_uri", "type": "string", "required": false },
+		{ "name": "subject_did", "type": "string", "required": false }
+	]
+}
+```
+
+## 3. Create an R2 bucket and enable R2 Data Catalog
+
+Your sinks write to Iceberg tables in [R2 Data Catalog](/r2/data-catalog/), so you need a bucket with the catalog enabled.
+
+Create an R2 bucket named `bluesky-pipeline`:
+
+```sh
+npx wrangler r2 bucket create bluesky-pipeline
+```
+
+Enable R2 Data Catalog on the bucket:
+
+```sh
+npx wrangler r2 bucket catalog enable bluesky-pipeline
+```
+
+When you run this command, note the **Warehouse name**. You will need it to query your data with R2 SQL.
+
+## 4. Create the stream, sinks, and pipeline
+
+First, create the stream from your schema file:
+
+```sh
+npx wrangler pipelines streams create bsky_events_stream --schema-file schema.json
+```
+
+Note the **stream ID** in the output. You will use it to configure the Worker binding in the next step.
+
+Next, create one [sink](/pipelines/sinks/) per destination table. Each sink writes to its own Iceberg table in R2 Data Catalog. Replace `YOUR_CATALOG_TOKEN` with your R2 API token.
+
+```sh
+for t in post like repost follow block; do
+  npx wrangler pipelines sinks create bsky_${t}_sink \
+    --type r2-data-catalog \
+    --bucket bluesky-pipeline \
+    --namespace bluesky \
+    --table bsky_${t} \
+    --catalog-token YOUR_CATALOG_TOKEN \
+    --roll-interval 60
+done
+```
+
+Now create one pipeline whose SQL contains multiple `INSERT` statements, one per route. Each statement filters the stream by `event_type` and projects only the columns that matter for its table.
+
+Create a `fanout.sql` file:
+
+```sql
+INSERT INTO bsky_post_sink
+  SELECT event_id, did, operation, time_us, created_at, text, langs
+  FROM bsky_events_stream WHERE event_type = 'post';
+
+INSERT INTO bsky_like_sink
+  SELECT event_id, did, operation, time_us, created_at, subject_uri
+  FROM bsky_events_stream WHERE event_type = 'like';
+
+INSERT INTO bsky_repost_sink
+  SELECT event_id, did, operation, time_us, created_at, subject_uri
+  FROM bsky_events_stream WHERE event_type = 'repost';
+
+INSERT INTO bsky_follow_sink
+  SELECT event_id, did, operation, time_us, created_at, subject_did
+  FROM bsky_events_stream WHERE event_type = 'follow';
+
+INSERT INTO bsky_block_sink
+  SELECT event_id, did, operation, time_us, created_at, subject_did
+  FROM bsky_events_stream WHERE event_type = 'block';
+```
+
+Create the pipeline from the file:
+
+```sh
+npx wrangler pipelines create bsky_pipeline --sql-file fanout.sql
+```
+
+One pipeline writes to five tables. To add a new event type later, add one sink and one `INSERT` statement. Pipeline SQL cannot be modified after creation, so you delete and recreate the pipeline to change it. To learn more, refer to [Route one stream to multiple tables](/pipelines/pipelines/manage-pipelines/#route-one-stream-to-multiple-tables).
+
+## 5. Bind the stream to your Worker
+
+Add the stream binding, a Durable Object to hold the WebSocket connection, and a [cron trigger](/workers/configuration/cron-triggers/) to keep the consumer alive. Replace `<STREAM_ID>` with the stream ID from step 3.
+
+<WranglerConfig>
+```toml
+name = "bluesky-pipeline"
+main = "src/index.ts"
+compatibility_date = "$today"
+
+[[pipelines]]
+binding = "BSKY_STREAM"
+stream = "<STREAM_ID>"
+
+[[durable_objects.bindings]]
+name = "JETSTREAM"
+class_name = "JetstreamConsumer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["JetstreamConsumer"]
+
+[triggers]
+crons = ["*/2 * * * *"]
+```
+</WranglerConfig>
+
+## 6. Consume the firehose in a Durable Object
+
+A [Durable Object](/durable-objects/) is the right home for a long-lived WebSocket. It stays resident while the socket is open, and an [alarm](/durable-objects/api/alarms/) reconnects it if the connection drops. Buffer incoming events and `send()` them to the stream in batches to stay under the 5 MB per request limit. Persist the Jetstream `time_us` cursor so a reconnect resumes without gaps.
+
+Replace the contents of `src/index.ts` with the following:
+
+<TypeScriptExample filename="src/index.ts">
+```typescript
+import { DurableObject } from "cloudflare:workers";
+import type { Pipeline } from "cloudflare:pipelines";
+
+interface Env {
+BSKY_STREAM: Pipeline;
+JETSTREAM: DurableObjectNamespace<JetstreamConsumer>;
+}
+
+// Jetstream collection -> our short event_type. Only these are kept.
+const COLLECTION_TO_TYPE: Record<string, string> = {
+"app.bsky.feed.post": "post",
+"app.bsky.feed.like": "like",
+"app.bsky.feed.repost": "repost",
+"app.bsky.graph.follow": "follow",
+"app.bsky.graph.block": "block",
+};
+const WANTED = Object.keys(COLLECTION_TO_TYPE);
+const JETSTREAM_URL = "https://jetstream2.us-east.bsky.network/subscribe";
+const FLUSH_MAX = 500; // rows per send()
+const FLUSH_MS = 1000; // flush at least once per second
+const RECONNECT_MS = 15000;
+
+// Flatten one Jetstream message into a unified stream row, or null to skip.
+function toRow(ev: any) {
+if (ev?.kind !== "commit" || !ev.commit) return null;
+const c = ev.commit;
+const event_type = COLLECTION_TO_TYPE[c.collection];
+if (!event_type) return null;
+const r = c.record ?? {};
+const subject = r.subject;
+return {
+event_id: `${ev.did}/${c.collection}/${c.rkey}`,
+event_type,
+did: ev.did ?? null,
+operation: c.operation ?? null,
+time_us: typeof ev.time_us === "number" ? ev.time_us : null,
+created_at: typeof r.createdAt === "string" ? r.createdAt : null,
+text: event_type === "post" && typeof r.text === "string" ? r.text : null,
+langs:
+event_type === "post" && Array.isArray(r.langs)
+? r.langs.join(",")
+: null,
+subject_uri: typeof subject === "object" ? (subject?.uri ?? null) : null,
+subject_did: typeof subject === "string" ? subject : null,
+};
+}
+
+export class JetstreamConsumer extends DurableObject<Env> {
+	private ws: WebSocket | null = null;
+	private buf: unknown[] = [];
+	private lastFlush = 0;
+	private cursor: number | null = null;
+
+    // Idempotent: connect if needed and arm the reconnect alarm.
+    async start() {
+    	await this.connect();
+    	await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
+    	return { connected: this.ws !== null };
+    }
+
+    private async connect() {
+    	if (this.ws) return;
+    	this.cursor ??= (await this.ctx.storage.get<number>("cursor")) ?? null;
+
+    	const params = new URLSearchParams();
+    	for (const c of WANTED) params.append("wantedCollections", c);
+    	if (this.cursor) params.set("cursor", String(this.cursor));
+
+    	const resp = await fetch(`${JETSTREAM_URL}?${params}`, {
+    		headers: { Upgrade: "websocket" },
+    	});
+    	const ws = resp.webSocket;
+    	if (!ws) throw new Error(`Jetstream handshake failed: ${resp.status}`);
+    	ws.accept();
+    	this.ws = ws;
+
+    	ws.addEventListener("message", (e) => this.onMessage(e));
+    	ws.addEventListener("close", () => (this.ws = null));
+    	ws.addEventListener("error", () => (this.ws = null));
+    }
+
+    private onMessage(e: MessageEvent) {
+    	let ev: any;
+    	try {
+    		ev = JSON.parse(e.data as string);
+    	} catch {
+    		return;
+    	}
+    	if (typeof ev.time_us === "number") this.cursor = ev.time_us;
+    	const row = toRow(ev);
+    	if (row) this.buf.push(row);
+    	if (
+    		this.buf.length >= FLUSH_MAX ||
+    		Date.now() - this.lastFlush >= FLUSH_MS
+    	) {
+    		void this.flush();
+    	}
+    }
+
+    private async flush() {
+    	this.lastFlush = Date.now();
+    	if (this.buf.length === 0) return;
+    	const batch = this.buf.splice(0, this.buf.length);
+    	try {
+    		await this.env.BSKY_STREAM.send(batch);
+    		await this.ctx.storage.put("cursor", this.cursor); // advance only on success
+    	} catch (err) {
+    		this.buf.unshift(...batch); // re-queue; retried on the next flush or alarm
+    		console.error("send failed, will retry", err);
+    	}
+    }
+
+    // Watchdog: reconnect if dropped, flush stragglers, reschedule.
+    async alarm() {
+    	await this.connect();
+    	await this.flush();
+    	await this.ctx.storage.setAlarm(Date.now() + RECONNECT_MS);
+    }
+
+}
+
+export default {
+	async fetch(_req, env): Promise<Response> {
+		const stub = env.JETSTREAM.get(env.JETSTREAM.idFromName("singleton"));
+		return Response.json(await stub.start());
+	},
+	async scheduled(_event, env): Promise<void> {
+		const stub = env.JETSTREAM.get(env.JETSTREAM.idFromName("singleton"));
+		await stub.start();
+	},
+} satisfies ExportedHandler<Env>;
+```
+</TypeScriptExample>
+
+Generate types for your bindings:
+
+```sh
+npx wrangler types
+```
+
+## 7. Deploy and start the consumer
+
+Deploy the Worker:
+
+```sh
+npx wrangler deploy
+```
+
+Open the Worker URL once to start the firehose. The cron trigger keeps it running:
+
+```sh
+curl https://bluesky-pipeline.YOUR_SUBDOMAIN.workers.dev
+# {"connected":true}
+```
+
+Tail the logs to watch it work:
+
+```sh
+npx wrangler tail
+```
+
+## 8. Query the tables with R2 SQL
+
+The first data lands a few minutes after the first events arrive, while the pipeline warms up.
+
+Set your R2 SQL token, then query each table. Replace `YOUR_WAREHOUSE_NAME` with the warehouse name you noted in step 3.
+
+```sh
+export WRANGLER_R2_SQL_AUTH_TOKEN=YOUR_CATALOG_TOKEN
+
+npx wrangler r2 sql query "YOUR_WAREHOUSE_NAME" \
+  "SELECT COUNT(*) FROM bluesky.bsky_like"
+
+npx wrangler r2 sql query "YOUR_WAREHOUSE_NAME" \
+  "SELECT text, langs FROM bluesky.bsky_post WHERE langs LIKE '%en%' LIMIT 10"
+```
+
+Each table contains only its event type, projected to the relevant columns. The single pipeline did all the routing.
+
+## Conclusion
+
+You consumed a high-velocity public WebSocket firehose with a Durable Object, ingested it into one Pipelines stream, and used a single pipeline with multiple SQL statements to fan the stream out into five Iceberg tables by event type.
+
+This one-stream-to-many-tables pattern generalizes to any tagged event source: clickstreams (by `event_type`), logs (by `service` or `status`), or IoT telemetry (by `device_class`). To extend it, add a sink and a matching `INSERT ... WHERE` statement.
+
+To learn more about the SQL used here, refer to [SELECT statements](/pipelines/sql-reference/select-statements/) and [Manage pipelines](/pipelines/pipelines/manage-pipelines/).

--- a/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
+++ b/src/content/docs/pipelines/examples/bluesky-firehose-fanout.mdx
@@ -74,6 +74,12 @@ Change into your new project directory:
 cd bluesky-pipeline
 ```
 
+The `pipelines` commands used later require Wrangler v4 or later. If your project was scaffolded with an older version, update it now:
+
+```sh
+npm install --save-dev wrangler@latest
+```
+
 ## 2. Define the stream schema
 
 A stream has a single schema. Because every event type flows through the same stream, the schema is the union of the fields you want across all types. Each routing statement later selects only the columns relevant to its destination.
@@ -116,12 +122,6 @@ npx wrangler r2 bucket catalog enable bluesky-pipeline
 When you run this command, note the **Warehouse name**. You will need it to query your data with R2 SQL.
 
 ## 4. Create the stream, sinks, and pipeline
-
-The `pipelines` commands require Wrangler v4 or later. If your project was scaffolded with an older version, update it first:
-
-```sh
-npm install --save-dev wrangler@latest
-```
 
 First, create the stream from your schema file:
 

--- a/src/content/docs/pipelines/examples/index.mdx
+++ b/src/content/docs/pipelines/examples/index.mdx
@@ -1,0 +1,20 @@
+---
+pcx_content_type: navigation
+title: Examples
+sidebar:
+  order: 9
+  group:
+    hideIndex: true
+description: Browse examples that show how to build with Cloudflare Pipelines.
+products:
+  - pipelines
+---
+
+import { ResourcesBySelector } from "~/components";
+
+Explore the following examples for Cloudflare Pipelines.
+
+<ResourcesBySelector
+	types={["example", "tutorial"]}
+	directory="pipelines/examples/"
+/>

--- a/src/content/docs/pipelines/getting-started.mdx
+++ b/src/content/docs/pipelines/getting-started.mdx
@@ -329,3 +329,9 @@ You can also query this table with any engine that supports Apache Iceberg. To l
 	href="/pipelines/sinks/"
 	description="Configure data destinations and output formats."
 />
+
+<LinkCard
+	title="Examples"
+	href="/pipelines/examples/"
+	description="Browse end-to-end examples that show how to build with Pipelines."
+/>

--- a/src/content/docs/pipelines/index.mdx
+++ b/src/content/docs/pipelines/index.mdx
@@ -68,6 +68,12 @@ Configure destinations for your data. Write Apache Iceberg tables to R2 Data Cat
 
 </Feature>
 
+<Feature header="Examples" href="/pipelines/examples/" cta="Browse examples">
+
+Follow end-to-end examples, including how to fan one stream out into multiple Iceberg tables.
+
+</Feature>
+
 ---
 
 ## Related products

--- a/src/content/docs/pipelines/pipelines/manage-pipelines.mdx
+++ b/src/content/docs/pipelines/pipelines/manage-pipelines.mdx
@@ -100,6 +100,26 @@ SELECT
 FROM my_stream
 ```
 
+#### Route one stream to multiple tables
+
+A single pipeline can run multiple `INSERT` statements, separated by semicolons. Each statement reads from the same stream and writes to a different sink, so you can route ("fan out") events from one stream into several tables based on their content.
+
+This avoids running a separate pipeline for each destination. Each statement filters the stream with its own `WHERE` clause and projects only the columns relevant to that table.
+
+```sql
+INSERT INTO purchases_sink
+SELECT user_id, product_id, amount FROM my_stream
+WHERE event_type = 'purchase';
+
+INSERT INTO page_views_sink
+SELECT user_id, product_id FROM my_stream
+WHERE event_type = 'view_product';
+```
+
+Each `INSERT` statement requires its own sink, and each sink writes to its own table. You cannot point two statements at the same sink.
+
+For a complete example that fans a live event stream out into five tables, see [Fan out a stream to multiple Iceberg tables](/pipelines/examples/bluesky-firehose-fanout/).
+
 ## View pipeline configuration
 
 ### Dashboard

--- a/src/content/docs/pipelines/pipelines/manage-pipelines.mdx
+++ b/src/content/docs/pipelines/pipelines/manage-pipelines.mdx
@@ -118,7 +118,7 @@ WHERE event_type = 'view_product';
 
 Each `INSERT` statement requires its own sink, and each sink writes to its own table. You cannot point two statements at the same sink.
 
-For a complete example that fans a live event stream out into five tables, see [Fan out a stream to multiple Iceberg tables](/pipelines/examples/bluesky-firehose-fanout/).
+For a complete example that fans a live event stream out into five tables, refer to [Fan out a stream to multiple Iceberg tables](/pipelines/examples/bluesky-firehose-fanout/).
 
 ## View pipeline configuration
 

--- a/src/content/docs/pipelines/pipelines/manage-pipelines.mdx
+++ b/src/content/docs/pipelines/pipelines/manage-pipelines.mdx
@@ -104,7 +104,7 @@ FROM my_stream
 
 A single pipeline can run multiple `INSERT` statements, separated by semicolons. Each statement reads from the same stream and writes to a different sink, so you can route ("fan out") events from one stream into several tables based on their content.
 
-This avoids running a separate pipeline for each destination. Each statement filters the stream with its own `WHERE` clause and projects only the columns relevant to that table.
+This avoids running a separate pipeline for each destination. Each statement filters the stream with its own `WHERE` clause and projects only the columns relevant to that table. This can also be a used as a cost optimization as you will be [billed](/pipelines/platform/pricing/) once for the transformations, not per statement.
 
 ```sql
 INSERT INTO purchases_sink
@@ -115,8 +115,6 @@ INSERT INTO page_views_sink
 SELECT user_id, product_id FROM my_stream
 WHERE event_type = 'view_product';
 ```
-
-Each `INSERT` statement requires its own sink, and each sink writes to its own table. You cannot point two statements at the same sink.
 
 For a complete example that fans a live event stream out into five tables, refer to [Fan out a stream to multiple Iceberg tables](/pipelines/examples/bluesky-firehose-fanout/).
 

--- a/src/content/docs/pipelines/sql-reference/select-statements.mdx
+++ b/src/content/docs/pipelines/sql-reference/select-statements.mdx
@@ -156,4 +156,4 @@ To provide multiple statements with the Wrangler CLI, pass a file with the `--sq
 npx wrangler pipelines create my-pipeline --sql-file pipeline.sql
 ```
 
-For a worked example, see [Fan out a stream to multiple Iceberg tables](/pipelines/examples/bluesky-firehose-fanout/).
+For a worked example, refer to [Fan out a stream to multiple Iceberg tables](/pipelines/examples/bluesky-firehose-fanout/).

--- a/src/content/docs/pipelines/sql-reference/select-statements.mdx
+++ b/src/content/docs/pipelines/sql-reference/select-statements.mdx
@@ -150,12 +150,6 @@ SELECT user_id, created_at FROM events
 WHERE event_type = 'signup';
 ```
 
-When you route one stream to multiple sinks:
-
-- Each statement must write to a different sink. Two statements cannot write to the same sink.
-- Each statement can select a different subset of columns and apply its own `WHERE` clause.
-- The stream has a single schema. Each statement projects the columns relevant to its destination.
-
 To provide multiple statements with the Wrangler CLI, pass a file with the `--sql-file` flag:
 
 ```bash

--- a/src/content/docs/pipelines/sql-reference/select-statements.mdx
+++ b/src/content/docs/pipelines/sql-reference/select-statements.mdx
@@ -16,6 +16,8 @@ FROM from_item
 [WHERE condition]
 ```
 
+A pipeline runs one or more `INSERT INTO sink SELECT ... FROM stream` statements. To write to multiple sinks from the same pipeline, separate the statements with semicolons. See [Multiple statements](#multiple-statements).
+
 ## WITH clause
 
 The WITH clause allows you to define named subqueries that can be referenced in the main query. This can improve query readability by breaking down complex transformations.
@@ -133,3 +135,31 @@ This will produce:
 |       3 |
 +---------+
 ```
+
+## Multiple statements
+
+A pipeline can contain multiple `INSERT` statements, separated by semicolons. Each statement reads from a stream and writes to a sink. Use multiple statements to route events from a single stream into several sinks based on their content.
+
+```sql
+INSERT INTO purchases_sink
+SELECT user_id, product_id, amount FROM events
+WHERE event_type = 'purchase';
+
+INSERT INTO signups_sink
+SELECT user_id, created_at FROM events
+WHERE event_type = 'signup';
+```
+
+When you route one stream to multiple sinks:
+
+- Each statement must write to a different sink. Two statements cannot write to the same sink.
+- Each statement can select a different subset of columns and apply its own `WHERE` clause.
+- The stream has a single schema. Each statement projects the columns relevant to its destination.
+
+To provide multiple statements with the Wrangler CLI, pass a file with the `--sql-file` flag:
+
+```bash
+npx wrangler pipelines create my-pipeline --sql-file pipeline.sql
+```
+
+For a worked example, see [Fan out a stream to multiple Iceberg tables](/pipelines/examples/bluesky-firehose-fanout/).


### PR DESCRIPTION
### Summary

- Documents multi-statement pipeline SQL (multiple `;`-separated `INSERT … SELECT` statements in one pipeline), a supported but previously undocumented capability.
- Adds a new `/pipelines/examples/` section with a fan-out tutorial: consume the public Bluesky Jetstream firehose in a Durable Object, ingest to one stream, and route events into five R2 Data Catalog tables by type.
- Updates `select-statements.mdx` and `manage-pipelines.mdx` to describe routing one stream to multiple tables.
- Cross-links the Examples section from the Pipelines overview and getting-started pages.

### Documentation checklist

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
