### PR TITLE
[Browser Rendering] Add Gamut as supported MCP client

### DIFF
--- a/src/content/docs/browser-run/cdp/mcp-clients.mdx
+++ b/src/content/docs/browser-run/cdp/mcp-clients.mdx
@@ -21,7 +21,7 @@ The Model Context Protocol (MCP) is an open protocol that enables AI assistants 
 ## Prerequisites
 
 - Node.js v20.19 or newer
-- An MCP-compatible AI client (for example, Claude Desktop, Claude Code, Cursor, OpenCode)
+- An MCP-compatible AI client (for example, Claude Desktop, Claude Code, Cursor, OpenCode, Gamut)
 - A Browser Run API token with `Browser Rendering - Edit` permissions
 
 ## Configure your MCP client
@@ -94,7 +94,7 @@ Replace `ACCOUNT_ID` with your Cloudflare account ID and `API_TOKEN` with your B
 
 ### Gamut
 
-In your [Gamut](https://www.gamut.so/mcp/developer-tools/cloudflare) agent, go to **Connections**, click **Add Connection**, and search for **Cloudflare**. Click **+** to add it, then authenticate with your Cloudflare account when prompted.
+In your [Gamut](https://www.gamut.so/mcp/developer-tools/cloudflare) agent, go to **Connections**, select **Add Connection**, and search for **Cloudflare**. Select **+** to add it, then authenticate with your Cloudflare account when prompted. Ensure your account has a Browser Run API token with `Browser Rendering - Edit` permissions as described in the [Prerequisites](#prerequisites).
 
 For other MCP clients, refer to the [chrome-devtools-mcp documentation](https://github.com/ChromeDevTools/chrome-devtools-mcp/tree/main?tab=readme-ov-file#mcp-client-configuration).
 

--- a/src/content/docs/browser-run/cdp/mcp-clients.mdx
+++ b/src/content/docs/browser-run/cdp/mcp-clients.mdx
@@ -92,6 +92,10 @@ Add to `~/.cursor/mcp.json`:
 
 Replace `ACCOUNT_ID` with your Cloudflare account ID and `API_TOKEN` with your Browser Run API token. You can obtain these from your Cloudflare dashboard.
 
+### Gamut
+
+In your [Gamut](https://www.gamut.so/mcp/developer-tools/cloudflare) agent, go to **Connections**, click **Add Connection**, and search for **Cloudflare**. Click **+** to add it, then authenticate with your Cloudflare account when prompted.
+
 For other MCP clients, refer to the [chrome-devtools-mcp documentation](https://github.com/ChromeDevTools/chrome-devtools-mcp/tree/main?tab=readme-ov-file#mcp-client-configuration).
 
 ## Example usage


### PR DESCRIPTION
Adds [Gamut](https://www.gamut.so) as a supported MCP client in the Browser Run CDP docs, alongside Claude Desktop, Claude Code, OpenCode, and Cursor.

Gamut is an AI agent platform with native MCP support. Users can connect to Cloudflare's Browser Rendering MCP directly from the Gamut interface — go to **Connections**, click **Add Connection**, search for **Cloudflare**, and authenticate.