### PR TITLE
[Cache] Remove synchronous revalidation (legacy) section

### DIFF
--- a/src/content/docs/cache/concepts/cache-responses.mdx
+++ b/src/content/docs/cache/concepts/cache-responses.mdx
@@ -56,7 +56,7 @@ The origin web server instructed Cloudflare to bypass cache via a `Cache-Control
 
 The origin confirmed the cached resource was unchanged via a conditional request (`If-Modified-Since` or `If-None-Match`), and the response is served from Cloudflare's cache. This status reflects the synchronous validation path — the request waits for the origin to respond before being served.
 
-With [asynchronous `stale-while-revalidate`](/cache/concepts/revalidation/#asynchronous-revalidation), most revalidations now return `UPDATING` or `HIT` instead. `REVALIDATED` is seen in the following situations: `stale-while-revalidate` is not set; directives like `must-revalidate` or `no-cache` (with [Origin Cache Control](/cache/concepts/cache-control/) enabled) prevent stale content from being served; or the zone is an Enterprise zone that has not yet been migrated (refer to [Synchronous revalidation](/cache/concepts/revalidation/#synchronous-revalidation-legacy)).
+With [asynchronous `stale-while-revalidate`](/cache/concepts/revalidation/#asynchronous-revalidation), most revalidations now return `UPDATING` or `HIT` instead. `REVALIDATED` is seen in the following situations: `stale-while-revalidate` is not set; or directives like `must-revalidate` or `no-cache` (with [Origin Cache Control](/cache/concepts/cache-control/) enabled) prevent stale content from being served.
 
 ## UPDATING
 

--- a/src/content/docs/cache/concepts/revalidation.mdx
+++ b/src/content/docs/cache/concepts/revalidation.mdx
@@ -11,27 +11,11 @@ products:
 
 When a cached asset expires, Cloudflare uses the [`stale-while-revalidate`](/cache/concepts/cache-control/#revalidation) directive in `Cache-Control` to determine whether it can continue serving the stale asset while fetching a fresh copy from the origin. If the directive is present and the asset is within the allowed staleness window, Cloudflare serves the expired content to visitors and revalidates in the background. By using headers like `If-Modified-Since` and `ETag`, Cloudflare validates content without fully re-fetching it, reducing origin traffic.
 
-:::note
-Asynchronous `stale-while-revalidate` is live for all Free, Pro, and Business zones. Enterprise zones are actively being migrated. The previous synchronous behavior is described in [Synchronous revalidation](#synchronous-revalidation-legacy).
-:::
-
 ## Asynchronous revalidation
 
 Revalidation is fully asynchronous. When a cached asset expires and `stale-while-revalidate` is set, the first request that arrives after expiry triggers revalidation in the background. That request immediately receives stale content with an [UPDATING](/cache/concepts/cache-responses/#updating) status instead of blocking until the origin responds. All following requests also receive stale content with an `UPDATING` status until the origin responds. Once revalidation completes, subsequent requests receive fresh content with a [HIT](/cache/concepts/cache-responses/#hit) status.
 
 If the stale content is still valid, Cloudflare sets a new TTL. If the content has changed, the origin provides fresh content to replace the old.
-
-## Synchronous revalidation (legacy)
-
-:::note
-Synchronous revalidation refers to a previous implementation that is only available to a subset of Enterprise zones that have not been migrated yet. All other zones use [asynchronous revalidation](#asynchronous-revalidation).
-:::
-
-With synchronous revalidation (a legacy implementation), `stale-while-revalidate` blocks on the first request that arrives after a cached asset expired. That first request is held until the origin responds, and is served with a [MISS](/cache/concepts/cache-responses/#miss) or [REVALIDATED](/cache/concepts/cache-responses/#revalidated) status. Any other requests that arrive during this time for the same asset in the same cache location are served stale with the [UPDATING](/cache/concepts/cache-responses/#updating) status.
-
-For example, if 1,000 requests arrive simultaneously for an expired asset in this previous implementation, one request goes to the origin while the other 999 are served stale from cache. The first visitor experiences higher latency because they have to wait for the origin round-trip.
-
-On the other hand, with [asynchronous revalidation](#asynchronous-revalidation) all 1,000 requests are served from cache immediately and no visitor is blocked.
 
 ## Controlling stale behavior
 


### PR DESCRIPTION
## Summary

Removes the **Synchronous revalidation (legacy)** section from the Revalidation page now that the Enterprise migration to asynchronous `stale-while-revalidate` (pingora-cache) is complete.

The final cohort — Enterprise zones using the slice (origin range request) feature — was migrated from nginx-cache to pingora-cache on 2026-06-24. With no zones remaining on the legacy synchronous path, the section and its cross-references are no longer accurate.

## Changes

- `cache/concepts/revalidation.mdx`: remove the `Synchronous revalidation (legacy)` section and the now-inaccurate intro note (it stated "Enterprise zones are actively being migrated" and linked to the removed anchor).
- `cache/concepts/cache-responses.mdx`: in the `REVALIDATED` description, drop the dead `#synchronous-revalidation-legacy` link and the "Enterprise zone that has not yet been migrated" clause. The still-valid cases are kept (`stale-while-revalidate` not set, or `must-revalidate`/`no-cache` preventing stale content).

No remaining references to `#synchronous-revalidation-legacy` in `src/`.

## Reference

Enterprise async `stale-while-revalidate` rollout completion: CR-1772448 (Prem A, closed 2026-06-24) and CR-1758505 (Prem B+C, closed 2026-06-16).
