### PR TITLE
[DO] Add us jurisdiction changelog and data location entry

### DIFF
--- a/src/content/changelog/durable-objects/2026-06-26-durable-objects-us-jurisdiction.mdx
+++ b/src/content/changelog/durable-objects/2026-06-26-durable-objects-us-jurisdiction.mdx
@@ -1,0 +1,27 @@
+---
+title: New `us` jurisdiction for Durable Objects
+description: Restrict Durable Objects to run and store data within the United States.
+products:
+  - durable-objects
+  - workers
+date: 2026-06-26
+---
+
+Durable Objects now supports a `us` [jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction), letting you create Durable Objects that only run and store data within the United States. Use the `us` jurisdiction when you need to keep a Durable Object's compute and storage inside the United States to meet data residency requirements.
+
+Create a namespace restricted to the `us` jurisdiction the same way as any other jurisdiction:
+
+```js
+// Worker
+export default {
+	async fetch(request, env) {
+		const usSubnamespace = env.MY_DURABLE_OBJECT.jurisdiction("us");
+		const stub = usSubnamespace.getByName("general");
+		return stub.fetch(request);
+	},
+};
+```
+
+Workers may still access Durable Objects constrained to the `us` jurisdiction from anywhere in the world. The jurisdiction constraint only controls where the Durable Object itself runs and persists data.
+
+For the full list of supported jurisdictions, refer to [Data location — Restrict Durable Objects to a jurisdiction](/durable-objects/reference/data-location/#restrict-durable-objects-to-a-jurisdiction).

--- a/src/content/docs/durable-objects/reference/data-location.mdx
+++ b/src/content/docs/durable-objects/reference/data-location.mdx
@@ -62,7 +62,7 @@ Note that it is also possible to specify a jurisdiction by creating an individua
 | --------- | ------------------------------ |
 | eu        | The European Union             |
 | us        | The United States              |
-| fedramp   | FedRAMP-compliant data centers |
+| fedramp   | FedRAMP-Moderate data centers  |
 
 ### Read the jurisdiction from inside a Durable Object
 

--- a/src/content/docs/durable-objects/reference/data-location.mdx
+++ b/src/content/docs/durable-objects/reference/data-location.mdx
@@ -61,6 +61,7 @@ Note that it is also possible to specify a jurisdiction by creating an individua
 | Parameter | Location                       |
 | --------- | ------------------------------ |
 | eu        | The European Union             |
+| us        | The United States              |
 | fedramp   | FedRAMP-compliant data centers |
 
 ### Read the jurisdiction from inside a Durable Object


### PR DESCRIPTION
### Summary

Adds a changelog entry announcing the new `us` jurisdiction for Durable Objects, which restricts a Durable Object's compute and storage to the United States.. Also updates the Data location reference page to list `us` in the supported jurisdictions table.

### Documentation checklist

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
