### PR TITLE
[Secrets Store] Clarify role, API token, and scope permissions

### DIFF
--- a/src/content/docs/secrets-store/access-control.mdx
+++ b/src/content/docs/secrets-store/access-control.mdx
@@ -15,6 +15,13 @@ Secrets Store allows security administrators to have more control by implementin
 While all Cloudflare accounts will have access to the Secrets Store section on the dashboard, only users with the necessary permissions will be able to interact with it, as described below.
 :::
 
+Access to a secret is controlled by two independent checks that must both pass:
+
+1. **Authorization** — the caller must have permission to perform the action. The permission comes from either a [user role](#relevant-roles) (when the dashboard authenticates the request) or an [API token permission](#api-token-permissions) (when the request is made with an API token). A given request is evaluated against one or the other, not both.
+2. **Secret scope** — the [scope list](#secret-scopes) on the secret must include the consuming service.
+
+For example, deploying a Worker that binds a secret requires a role or API token that can bind secrets, and a secret whose scope includes `workers`.
+
 ## Relevant roles
 
 Refer to the list below for default role definitions.
@@ -42,7 +49,27 @@ Refer to the list below for default role definitions.
 
 ## API token permissions
 
-The following API token permissions can also be used to grant access to Secrets Store resources.
+[API tokens](/fundamentals/api/get-started/create-token/) have two Secrets Store permission levels: **Read** and **Edit**. The permission you need depends on what the token is doing, not on whether you intend to modify the secret itself.
 
-- **Account Secrets Store Edit**: Allows a user to create, edit, duplicate, or delete secrets.
-- **Account Secrets Store Read**: Allows a user to view secrets metadata.
+- **Account Secrets Store Read**: Allows the caller to view metadata for secrets (for example, listing secrets or fetching the name, ID, scopes, and comments of a secret). This permission does not grant access to the value of a secret, and does not allow binding a secret to another resource.
+- **Account Secrets Store Edit**: Allows the caller to create, edit, duplicate, or delete secrets. **Edit is also required to bind a secret to another Cloudflare resource**, such as adding a Secrets Store binding to a Worker or associating a secret with an AI Gateway. Attaching a secret to a resource is treated as a write against the secret.
+
+:::caution[Deploying Workers from CI/CD]
+If you use Wrangler in a CI/CD pipeline (for example, [`wrangler-action`](https://github.com/cloudflare/wrangler-action) in GitHub Actions) to deploy a Worker that has a [Secrets Store binding](/secrets-store/integrations/workers/), the API token used by the pipeline must have **Account Secrets Store Edit** permission. A token with only **Read** will fail at deploy time with an authorization error such as `failed to fetch secrets store binding due to authorization error - check deploy permissions and secret scopes`.
+:::
+
+## Secret scopes
+
+Each secret has a list of **scopes** that determine which Cloudflare services are allowed to consume it. Scopes are set when a secret is created, and can be updated later by editing the secret.
+
+The currently supported scopes are:
+
+- `workers` — allows the secret to be [bound to a Worker](/secrets-store/integrations/workers/).
+- `ai-gateway` — allows the secret to be [associated with an AI Gateway](/ai-gateway/configuration/bring-your-own-keys/).
+
+A request to bind or associate a secret with a service will be rejected if that service is not in the scope list, even if the caller has the correct role or API token permission. Deploying a Worker with a Secrets Store binding therefore requires both:
+
+- A user role or API token that can bind secrets (Super Administrator or Secrets Store Deployer role, or **Account Secrets Store Edit** API token permission).
+- A scope list on the secret that includes `workers`.
+
+You can set scopes when [creating a secret](/secrets-store/manage-secrets/) using the dashboard, the API (`scopes` field), or Wrangler (`--scopes` flag).


### PR DESCRIPTION
- Describe the three independent permission layers (user roles, API token permissions, secret scopes) and the fact that all three must be satisfied for actions like deploying a Worker with a Secrets Store binding.
- Clarify that Account Secrets Store Read only allows viewing metadata, and that Account Secrets Store Edit is required to bind a secret to another Cloudflare resource (Workers, AI Gateway).
- Add a CI/CD caution callout reproducing the error message users hit when their wrangler-action token only has Read permission (cloudflare/workers-sdk#8964).
- Add a Secret scopes section documenting the workers and ai-gateway scopes and how to set them via dashboard, API, or Wrangler.

### Summary
Attempt to clarify the proper API token permissions required for deploying a secret and the additional level of per service authorization required on the secret scopes.

### Screenshots (optional)
Overview change
<img width="963" height="571" alt="Screenshot 2026-06-26 at 11 00 37 AM" src="https://github.com/user-attachments/assets/a59844e9-0373-4310-af18-36c874f843d9" />

API Token permission clarifications
<img width="710" height="470" alt="Screenshot 2026-06-26 at 11 00 49 AM" src="https://github.com/user-attachments/assets/e37a365f-b995-49da-afc0-ed7e40e41cfd" />

Secret scope clarifications
<img width="686" height="538" alt="Screenshot 2026-06-26 at 11 00 54 AM" src="https://github.com/user-attachments/assets/43733cd2-4b02-4c9e-8045-b0709a40fc85" />


### Documentation checklist

- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).