### PR TITLE
[Access] Changelog: service token support for MCP server portals

### DIFF
--- a/src/content/changelog/cloudflare-one/2026-06-26-mcp-portal-service-tokens.mdx
+++ b/src/content/changelog/cloudflare-one/2026-06-26-mcp-portal-service-tokens.mdx
@@ -1,0 +1,20 @@
+---
+title: Service token support for MCP server portals
+description: You can now use an Access service token to connect autonomous agents and bots to an MCP server portal with full access to upstream MCP servers.
+date: 2026-06-26
+products:
+  - cloudflare-one
+  - access
+---
+
+You can now connect autonomous agents and bots to an [MCP server portal](/cloudflare-one/access-controls/ai-controls/mcp-portals/) using an [Access service token](/cloudflare-one/access-controls/service-credentials/service-tokens/). Service token sessions can reach upstream MCP servers through the portal without a browser-based OAuth flow.
+
+To set this up:
+
+- Add a [Service Auth policy](/cloudflare-one/access-controls/policies/#service-auth) that matches your service token to the portal's Access application.
+- Add a Service Auth policy that matches the same token to each linked MCP server's Access application.
+- Turn **Require user auth** off (`on_behalf: false`) for each linked server so the portal uses the admin credential instead of a per-user OAuth grant.
+
+The bot connects with `CF-Access-Client-Id` and `CF-Access-Client-Secret` headers and sees the tools from every linked server it is authorized for. Servers that still require per-user OAuth are excluded from service token sessions because a service token cannot complete a per-user OAuth grant.
+
+For step-by-step setup, refer to [Connect with a service token](/cloudflare-one/access-controls/ai-controls/mcp-portals/#connect-with-a-service-token).


### PR DESCRIPTION
Adds a changelog entry announcing service token support for MCP server portals.

Pairs with the docs PR in #31734, which updates the **Connect with a service token** section in the MCP server portals guide.

## Background

Backed by heimtor commit `49d3867` (MCP-204: Handle service_auth for mcp apps), released in heimtor `2026.6.7` on 2026-06-25. Service token sessions can now reach upstream MCP servers through a portal without the per-user OAuth flow, as long as each linked MCP server app has a Service Auth policy matching the token and the server's portal mapping has `on_behalf: false`.