### PR TITLE
[DO] Document Memory usage chart in metrics docs

### DIFF
--- a/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
+++ b/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
@@ -38,11 +38,19 @@ You can also filter the charts to a single Durable Object by entering its [ID](/
 
 ## Memory usage
 
-The **Memory usage** chart on the **Metrics** tab shows how much [in-memory state](/durable-objects/reference/in-memory-state/) your Durable Objects hold at the time of each invocation, broken down into P50, P90, P99, and P999 percentiles.
+The **Memory usage** chart on the **Metrics** tab shows V8 [isolate](/workers/reference/how-workers-works/#isolates) memory usage at the time of each invocation, broken down into P50, P90, P99, and P999 percentiles. Each isolate is subject to a [128 MB memory limit](/workers/platform/limits/#memory).
 
-Durable Objects run in V8 [isolates](/workers/reference/how-workers-works/#isolates), subject to a [128 MB per-isolate memory limit](/workers/platform/limits/#memory). Memory usage reflects the in-memory state an object holds — such as class properties, caches, and active WebSocket connections — which persists across invocations until the object is [hibernated or evicted](/durable-objects/concepts/durable-object-lifecycle/). This state is not preserved across eviction, hibernation, or a crash, so persist anything important to [storage](/durable-objects/best-practices/access-durable-objects-storage/).
+This memory holds the in-memory state your objects accumulate — such as class properties, caches, and active WebSocket connections — which persists across invocations until an object is [hibernated or evicted](/durable-objects/concepts/durable-object-lifecycle/). This state is not preserved across eviction, hibernation, or a crash, so persist anything important to [storage](/durable-objects/best-practices/access-durable-objects-storage/).
 
-To drill down into memory usage for a specific object, filter the chart to a single Durable Object by entering its [ID](/durable-objects/api/id/) or [name](/durable-objects/api/id/#name).
+:::note[Memory is measured per isolate, not per Durable Object]
+
+A single isolate can host multiple Durable Objects of the same class, along with the surrounding Worker code, and they all share that isolate's memory. The chart always reflects the memory of the whole isolate, not an individual Durable Object.
+:::
+
+What the chart shows depends on whether you filter:
+
+- **Without a filter (namespace view):** the percentiles are computed across invocations of every Durable Object in the namespace. Each data point is the isolate memory recorded at the time of an invocation, so the chart shows the distribution of isolate memory across the namespace.
+- **Filtered by [ID](/durable-objects/api/id/) or [name](/durable-objects/api/id/#name):** the percentiles are computed only from invocations of that one Durable Object. Each data point is still the memory of the entire isolate hosting it — which may include other Durable Objects sharing that isolate — so this is not a measurement of that single object's memory in isolation.
 
 If you see memory usage trending upward over time, this may indicate a memory leak. Use [memory profiling with DevTools](/workers/observability/dev-tools/memory-usage/) locally to take heap snapshots and identify specific objects causing high memory consumption.
 

--- a/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
+++ b/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
@@ -38,19 +38,21 @@ You can also filter the charts to a single Durable Object by entering its [ID](/
 
 ## Memory usage
 
-The **Memory usage** chart on the **Metrics** tab shows V8 [isolate](/workers/reference/how-workers-works/#isolates) memory usage at the time of each invocation, broken down into P50, P90, P99, and P999 percentiles. Each isolate is subject to a [128 MB memory limit](/workers/platform/limits/#memory).
+The **Memory usage** chart on the **Metrics** tab shows V8 [isolate](/workers/reference/how-workers-works/#isolates) memory usage, sampled periodically while your Durable Objects are active, broken down into P50, P90, P99, and P999 percentiles. Each isolate is subject to a [128 MB memory limit](/workers/platform/limits/#memory).
 
-This memory holds the in-memory state your objects accumulate — such as class properties, caches, and active WebSocket connections — which persists across invocations until an object is [hibernated or evicted](/durable-objects/concepts/durable-object-lifecycle/). This state is not preserved across eviction, hibernation, or a crash, so persist anything important to [storage](/durable-objects/best-practices/access-durable-objects-storage/).
+This memory holds the in-memory state your objects accumulate — such as class properties, caches, and active WebSocket connections — which persists across requests until an object is [hibernated or evicted](/durable-objects/concepts/durable-object-lifecycle/). This state is not preserved across eviction, hibernation, or a crash, so persist anything important to [storage](/durable-objects/best-practices/access-durable-objects-storage/).
 
 :::note[Memory is measured per isolate, not per Durable Object]
 
-A single isolate can host multiple Durable Objects of the same class, along with the surrounding Worker code, and they all share that isolate's memory. The chart always reflects the memory of the whole isolate, not an individual Durable Object.
+A single isolate can host multiple Durable Objects of the same class, along with the surrounding Worker code, and they all share that isolate's memory. The chart always reports the memory of the whole isolate, not an individual Durable Object.
 :::
 
 What the chart shows depends on whether you filter:
 
-- **Without a filter (namespace view):** the percentiles are computed across invocations of every Durable Object in the namespace. Each data point is the isolate memory recorded at the time of an invocation, so the chart shows the distribution of isolate memory across the namespace.
-- **Filtered by [ID](/durable-objects/api/id/) or [name](/durable-objects/api/id/#name):** the percentiles are computed only from invocations of that one Durable Object. Each data point is still the memory of the entire isolate hosting it — which may include other Durable Objects sharing that isolate — so this is not a measurement of that single object's memory in isolation.
+- **Without a filter (namespace view):** the percentiles are computed across the periodic memory samples of every Durable Object in the namespace, showing the distribution of isolate memory across the namespace.
+- **Filtered by [ID](/durable-objects/api/id/) or [name](/durable-objects/api/id/#name):** the percentiles are computed only from the periodic samples reported for that one Durable Object. Each sample is still the memory of the entire isolate hosting it — which may include other Durable Objects sharing that isolate — so this is not a measurement of that single object's memory in isolation.
+
+Memory usage is powered by the [`durableObjectsPeriodicGroups`](#query-via-the-graphql-api) GraphQL dataset, which exposes the `memoryUsageBytes` metric. Percentile values are available as `quantiles.memoryUsageBytesP50` through `quantiles.memoryUsageBytesP999`, in bytes.
 
 If you see memory usage trending upward over time, this may indicate a memory leak. Use [memory profiling with DevTools](/workers/observability/dev-tools/memory-usage/) locally to take heap snapshots and identify specific objects causing high memory consumption.
 

--- a/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
+++ b/src/content/docs/durable-objects/observability/metrics-and-analytics.mdx
@@ -36,6 +36,16 @@ You can optionally select a time window to query. This defaults to the last 24 h
 
 You can also filter the charts to a single Durable Object by entering its [ID](/durable-objects/api/id/) or [name](/durable-objects/api/id/#name) and selecting a match. Clear the filter to return to namespace-level metrics.
 
+## Memory usage
+
+The **Memory usage** chart on the **Metrics** tab shows how much [in-memory state](/durable-objects/reference/in-memory-state/) your Durable Objects hold at the time of each invocation, broken down into P50, P90, P99, and P999 percentiles.
+
+Durable Objects run in V8 [isolates](/workers/reference/how-workers-works/#isolates), subject to a [128 MB per-isolate memory limit](/workers/platform/limits/#memory). Memory usage reflects the in-memory state an object holds — such as class properties, caches, and active WebSocket connections — which persists across invocations until the object is [hibernated or evicted](/durable-objects/concepts/durable-object-lifecycle/). This state is not preserved across eviction, hibernation, or a crash, so persist anything important to [storage](/durable-objects/best-practices/access-durable-objects-storage/).
+
+To drill down into memory usage for a specific object, filter the chart to a single Durable Object by entering its [ID](/durable-objects/api/id/) or [name](/durable-objects/api/id/#name).
+
+If you see memory usage trending upward over time, this may indicate a memory leak. Use [memory profiling with DevTools](/workers/observability/dev-tools/memory-usage/) locally to take heap snapshots and identify specific objects causing high memory consumption.
+
 ## View logs
 
 You can view Durable Object logs from the Cloudflare dashboard. Logs are aggregated by the script name and the Durable Object class name.

--- a/src/content/docs/durable-objects/reference/in-memory-state.mdx
+++ b/src/content/docs/durable-objects/reference/in-memory-state.mdx
@@ -52,6 +52,6 @@ However, in applications with more complex state, explicitly storing state in yo
 
 :::note[Observe in-memory state size]
 
-You can monitor how much memory your Durable Objects' in-memory state consumes with the **Memory usage** chart on the **Metrics** tab. Refer to [Metrics and analytics](/durable-objects/observability/metrics-and-analytics/#memory-usage) for details. Because in-memory state is not preserved across [eviction or hibernation](/durable-objects/concepts/durable-object-lifecycle/), persist anything important to [storage](/durable-objects/api/sqlite-storage-api/).
+You can monitor V8 isolate memory usage — which includes the in-memory state your Durable Objects hold — with the **Memory usage** chart on the **Metrics** tab. Memory is measured per isolate (which can host multiple Durable Objects), not per object. Refer to [Metrics and analytics](/durable-objects/observability/metrics-and-analytics/#memory-usage) for details, including how filtering by Durable Object ID or name affects what the chart shows. Because in-memory state is not preserved across [eviction or hibernation](/durable-objects/concepts/durable-object-lifecycle/), persist anything important to [storage](/durable-objects/api/sqlite-storage-api/).
 
 :::

--- a/src/content/docs/durable-objects/reference/in-memory-state.mdx
+++ b/src/content/docs/durable-objects/reference/in-memory-state.mdx
@@ -52,6 +52,6 @@ However, in applications with more complex state, explicitly storing state in yo
 
 :::note[Observe in-memory state size]
 
-You can monitor V8 isolate memory usage — which includes the in-memory state your Durable Objects hold — with the **Memory usage** chart on the **Metrics** tab. Memory is measured per isolate (which can host multiple Durable Objects), not per object. Refer to [Metrics and analytics](/durable-objects/observability/metrics-and-analytics/#memory-usage) for details, including how filtering by Durable Object ID or name affects what the chart shows. Because in-memory state is not preserved across [eviction or hibernation](/durable-objects/concepts/durable-object-lifecycle/), persist anything important to [storage](/durable-objects/api/sqlite-storage-api/).
+You can monitor V8 isolate memory usage — which includes the in-memory state your Durable Objects hold — with the **Memory usage** chart on the **Metrics** tab. Memory is measured per isolate (which can host multiple Durable Objects), not per object. Refer to [Metrics and analytics](/durable-objects/observability/metrics-and-analytics/#memory-usage) for details, including how filtering by Durable Object ID or name affects what the chart shows. Because in-memory state is not preserved across [eviction or hibernation](/durable-objects/concepts/durable-object-lifecycle/), persist anything important to [storage](/durable-objects/best-practices/access-durable-objects-storage/).
 
 :::

--- a/src/content/docs/durable-objects/reference/in-memory-state.mdx
+++ b/src/content/docs/durable-objects/reference/in-memory-state.mdx
@@ -49,3 +49,9 @@ The Durable Object's storage has a built-in in-memory cache of its own. If you u
 However, in applications with more complex state, explicitly storing state in your Object may be easier than making Storage API calls on every access. Depending on the configuration of your project, write your code in the way that is easiest for you.
 
 :::
+
+:::note[Observe in-memory state size]
+
+You can monitor how much memory your Durable Objects' in-memory state consumes with the **Memory usage** chart on the **Metrics** tab. Refer to [Metrics and analytics](/durable-objects/observability/metrics-and-analytics/#memory-usage) for details. Because in-memory state is not preserved across [eviction or hibernation](/durable-objects/concepts/durable-object-lifecycle/), persist anything important to [storage](/durable-objects/api/sqlite-storage-api/).
+
+:::


### PR DESCRIPTION
### Summary

Adds Durable Objects documentation for the new **Memory usage** chart in the Durable Objects Metrics tab. This complements [#31695](https://github.com/cloudflare/cloudflare-docs/pull/31695), which adds the changelog entry and the Workers-side metrics docs but does not touch any Durable Objects pages — even though the chart and changelog both cover DOs.

- `observability/metrics-and-analytics.mdx` — new `## Memory usage` section covering the chart (P50/P90/P99/P999), the 128 MB per-isolate model, what the namespace vs filtered (by DO ID/name) views show, the GraphQL dataset/fields, and DevTools memory profiling.
- `reference/in-memory-state.mdx` — note pointing readers to the Memory usage chart and reinforcing that in-memory state is not preserved across eviction or hibernation.

Key facts verified against source (GraphQL analytics schema `schema/schemas/durable_objects.yaml` and the dashboard `MemoryUsage.tsx` chart):

- The metric is **isolate memory** (schema descriptions: "Isolate memory usage ... reported by Durable Object periodic metrics"), not per-object — a single isolate can host multiple DOs of the same class that share its heap.
- DO memory is sampled **periodically** (not per-invocation, unlike the Workers metric) and surfaced via the `durableObjectsPeriodicGroups` dataset: `memoryUsageBytes` and `quantiles.memoryUsageBytesP50`–`memoryUsageBytesP999`.

### Documentation checklist

- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
