### PR TITLE
Ai-gateway: add endpoint-model compatibility matrix to REST API docs.mdx

### DIFF
--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -18,12 +18,16 @@ No provider SDKs or API keys are needed. Authentication and billing are handled 
 
 Four endpoints are available, each suited to different use cases:
 
-| Endpoint                       | Format                         | Use case                                         |
-| ------------------------------ | ------------------------------ | ------------------------------------------------ |
-| `POST /ai/run`                 | Envelope with `model`, `input` | All models and modalities (LLM, image, TTS, ASR) |
-| `POST /ai/v1/chat/completions` | OpenAI chat completions        | LLMs — OpenAI SDK compatible                     |
-| `POST /ai/v1/responses`        | OpenAI Responses API           | Agentic workflows — OpenAI SDK compatible        |
-| `POST /ai/v1/messages`         | Anthropic Messages API         | LLMs — Anthropic SDK compatible                  |
+| Endpoint                       | Format                         | Use case                                         | Third-Party Models | Workers AI Models (`@cf/`) |
+| ------------------------------ | ------------------------------ | ------------------------------------------------ | ------------------ | -------------------------- |
+| `POST /ai/run`                 | Envelope with `model`, `input` | All models and modalities (LLM, image, TTS, ASR) | ✅ Yes             | ✅ Yes                     |
+| `POST /ai/v1/chat/completions` | OpenAI chat completions        | LLMs — OpenAI SDK compatible                     | ✅ Yes             | ✅ Yes                     |
+| `POST /ai/v1/responses`        | OpenAI Responses API           | Agentic workflows — OpenAI SDK compatible        | ✅ Yes             | ✅ Yes                     |
+| `POST /ai/v1/messages`         | Anthropic Messages API         | LLMs — Anthropic SDK compatible                  | ✅ Yes             | ❌ No                      |
+
+:::note
+The `/ai/v1/messages` endpoint strictly uses Anthropic's API schema and supports routing to Anthropic and other third-party models. Workers AI models (`@cf/`) do not support this schema and must be called via `/ai/v1/responses`, `/ai/v1/chat/completions`, or `/ai/run`.
+:::
 
 ## Authentication
 

--- a/src/content/docs/ai-gateway/usage/rest-api.mdx
+++ b/src/content/docs/ai-gateway/usage/rest-api.mdx
@@ -22,11 +22,11 @@ Four endpoints are available, each suited to different use cases:
 | ------------------------------ | ------------------------------ | ------------------------------------------------ | ------------------ | -------------------------- |
 | `POST /ai/run`                 | Envelope with `model`, `input` | All models and modalities (LLM, image, TTS, ASR) | ✅ Yes             | ✅ Yes                     |
 | `POST /ai/v1/chat/completions` | OpenAI chat completions        | LLMs — OpenAI SDK compatible                     | ✅ Yes             | ✅ Yes                     |
-| `POST /ai/v1/responses`        | OpenAI Responses API           | Agentic workflows — OpenAI SDK compatible        | ✅ Yes             | ✅ Yes                     |
+| `POST /ai/v1/responses`        | OpenAI Responses API           | Agentic workflows — OpenAI SDK compatible        | ✅ Yes             | ✅ Model dependent         |
 | `POST /ai/v1/messages`         | Anthropic Messages API         | LLMs — Anthropic SDK compatible                  | ✅ Yes             | ❌ No                      |
 
 :::note
-The `/ai/v1/messages` endpoint strictly uses Anthropic's API schema and supports routing to Anthropic and other third-party models. Workers AI models (`@cf/`) do not support this schema and must be called via `/ai/v1/responses`, `/ai/v1/chat/completions`, or `/ai/run`.
+The `/ai/v1/messages` endpoint strictly uses Anthropic's API schema and supports routing to Anthropic and other third-party models. Workers AI models (`@cf/`) do not support this schema. Use `/ai/run` or `/ai/v1/chat/completions` for Workers AI models, or `/ai/v1/responses` only for Workers AI models that support the Responses API, such as GPT-OSS.
 :::
 
 ## Authentication


### PR DESCRIPTION

The AI Gateway REST API documentation currently lists four endpoints (/ai/run, /ai/v1/chat/completions, /ai/v1/responses, /ai/v1/messages) without clarifying which endpoints support Workers AI models (@cf/) versus third-party models only.

This has led to user confusion, as the "/ai/v1/messages" endpoint (Anthropic SDK compatible)  rejects Workers AI models with: "AiError: Anthropic Messages API is not supported for model" despite the "unified API" messaging implying broad compatibility.

Changes proposed:
- Add a compatibility matrix to the Endpoints section showing support for third-party models and Workers AI models per endpoint
- Add an explicit warning note below the matrix clarifying that /ai/v1/messages supports Anthropic/third-party models only, and Workers AI models should use /ai/run, /ai/v1/chat/completions, or /ai/v1/responses instead

Proposed matrix:

| Endpoint | Format | Third-party models | Workers AI models (@cf/) | 
|----------|--------|-------------------|---------------------------| 
| POST /ai/run | Universal envelope | Yes | Yes |
| POST /ai/v1/chat/completions | OpenAI SDK compatible | Yes | Yes | 
| POST /ai/v1/responses | OpenAI Responses API compatible | Yes | Yes | 
| POST /ai/v1/messages | Anthropic SDK compatible | Yes | No |

This aligns the documentation with actual API behavior.


