### PR TITLE
[Workers] Document cf.vary request option

### DIFF
--- a/src/content/changelog/workers/2026-06-28-cf-vary-request-option.mdx
+++ b/src/content/changelog/workers/2026-06-28-cf-vary-request-option.mdx
@@ -1,0 +1,41 @@
+---
+title: Workers fetch requests now support cf.vary
+description: Use the `cf.vary` request option to control cache variants for Workers subrequests that receive origin Vary responses.
+products:
+  - workers
+date: 2026-06-28
+---
+
+import { TypeScriptExample } from "~/components";
+
+Workers `fetch()` requests now support the `cf.vary` request option. Use `cf.vary` to control how Cloudflare caches origin responses with a `Vary` header for a single subrequest.
+
+<TypeScriptExample filename="src/index.ts">
+
+```ts
+export default {
+	async fetch(request): Promise<Response> {
+		return fetch(request, {
+			cf: {
+				vary: {
+					default: { action: "bypass" },
+					headers: {
+						accept: {
+							action: "normalize",
+							media_types: ["text/html", "application/json"],
+						},
+						"accept-language": {
+							action: "normalize",
+							languages: ["en", "fr", "de"],
+						},
+					},
+				},
+			},
+		});
+	},
+} satisfies ExportedHandler;
+```
+
+</TypeScriptExample>
+
+For more information, refer to [`cf.vary`](/workers/runtime-apis/request/#the-cfvary-property).

--- a/src/content/docs/cache/concepts/vary.mdx
+++ b/src/content/docs/cache/concepts/vary.mdx
@@ -18,7 +18,7 @@ By default, Cloudflare's CDN constructs [cache keys](/cache/how-to/cache-keys/) 
 A response containing `Vary: *` always bypasses cache, regardless of your Vary configuration.
 :::
 
-This page explains how Vary affects caching. To configure it, refer to [Vary](/cache/how-to/cache-rules/settings/#vary) in the Cache Rules settings.
+This page explains how Vary affects caching. To configure Vary, use [Vary](/cache/how-to/cache-rules/settings/#vary) in Cache Rules settings, or [`cf.vary`](/workers/runtime-apis/request/#the-cfvary-property) for Workers subrequests.
 
 This feature is distinct from [Vary for images](/cache/advanced-configuration/vary-for-images/), which serves image format variants based on the `Accept` header through a separate cache variants rule.
 

--- a/src/content/docs/workers/examples/cache-using-fetch.mdx
+++ b/src/content/docs/workers/examples/cache-using-fetch.mdx
@@ -26,7 +26,7 @@ If you want to get started quickly, click on the button below.
 
 This creates a repository in your GitHub account and deploys the application to Cloudflare Workers.
 
-import { TabItem, Tabs } from "~/components";
+import { TabItem, Tabs, TypeScriptExample } from "~/components";
 
 <Tabs syncKey="workersExamples"> <TabItem label="JavaScript" icon="seti:javascript">
 
@@ -311,6 +311,40 @@ export default app;
 </TabItem> </Tabs>
 
 Workers operating on behalf of different zones cannot affect each other's cache. You can only override cache keys when making requests within your own zone (in the above example `event.request.url` was the key stored), or requests to hosts that are not on Cloudflare. When making a request to another Cloudflare zone (for example, belonging to a different Cloudflare customer), that zone fully controls how its own content is cached within Cloudflare; you cannot override it.
+
+## Cache expected Vary responses
+
+Use `cf.vary` when an origin returns a `Vary` header and you want a Worker subrequest to cache expected variants. This setting applies only to the `fetch()` request where you set it.
+
+For Vary behavior details, refer to [Vary](/cache/concepts/vary/). For the full request init object, refer to [`cf.vary`](/workers/runtime-apis/request/#the-cfvary-property).
+
+<TypeScriptExample filename="src/index.ts">
+
+```ts
+export default {
+	async fetch(request): Promise<Response> {
+		return fetch(request, {
+			cf: {
+				vary: {
+					default: { action: "bypass" },
+					headers: {
+						accept: {
+							action: "normalize",
+							media_types: ["text/html", "application/json"],
+						},
+						"accept-language": {
+							action: "normalize",
+							languages: ["en", "fr", "de"],
+						},
+					},
+				},
+			},
+		});
+	},
+} satisfies ExportedHandler;
+```
+
+</TypeScriptExample>
 
 ## Override based on origin response code
 

--- a/src/content/docs/workers/runtime-apis/request.mdx
+++ b/src/content/docs/workers/runtime-apis/request.mdx
@@ -131,6 +131,10 @@ Invalid or incorrectly-named keys in the `cf` object will be silently ignored. C
 
   * This option is a version of the `cacheTtl` feature which chooses a TTL based on the response’s status code. If the response to this request has a status code that matches, Cloudflare will cache for the instructed time and override cache instructives sent by the origin. For example: `{ "200-299": 86400, "404": 1, "500-599": 0 }`. The value can be any integer, including zero and negative integers. A value of `0` indicates that the cache asset expires immediately. Any negative value instructs Cloudflare not to cache at all. This option applies to `GET` and `HEAD` request methods only.
 
+* `vary` <Type text="RequestInitCfPropertiesVary" /> <MetaInfo text="optional" />
+
+  * Controls how Cloudflare caches origin responses with a `Vary` header for a single `fetch()` request. If both `cf.vary` and [Cache Rules Vary](/cache/how-to/cache-rules/settings/#vary) apply, `cf.vary` takes precedence for this subrequest.
+
 * `image` Object | null optional
 
   * Enables [Image Resizing](/images/optimization/transformations/overview/) for this request. The possible values are described in [Transform images via Workers](/images/optimization/transformations/transform-via-workers/) documentation.
@@ -151,6 +155,73 @@ Invalid or incorrectly-named keys in the `cf` object will be silently ignored. C
 
   * Enables or disables [WebP](https://blog.cloudflare.com/a-very-webp-new-year-from-cloudflare/) image format in [Polish](/images/polish/).
 
+
+
+#### The `cf.vary` property
+
+The `cf.vary` object controls how Cloudflare handles request headers named by the origin `Vary` response header for a single `fetch()` request. It uses the same `default` and `headers` shape as [Cache Rules Vary](/cache/how-to/cache-rules/settings/#vary), and the same actions and normalization behavior as [Vary](/cache/concepts/vary/).
+
+If you omit `cf.vary`, Cloudflare uses other Vary behavior for the zone, including Cache Rules Vary if configured.
+
+The origin response must include a `Vary` header for this setting to affect the cache key. A response containing `Vary: *` always bypasses cache.
+
+The `cf.vary` object supports these keys:
+
+| Key       | Required | Description                                                                                        |
+| --------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `default` | Yes      | Configuration for any header name in the origin `Vary` response that is not included in `headers`. |
+| `headers` | No       | A map of lowercase request header names to configuration objects.                                  |
+
+If the `vary` object is present, `default` is required. An empty `vary` object is invalid. Invalid `cf.vary` configurations are ignored for that request.
+
+Each header configuration object, and the `default` object, must include an `action` key set to one of `normalize`, `passthrough`, or `bypass`. For guidance, refer to [Actions](/cache/concepts/vary/#actions).
+
+Additional parameters can be specified for certain header names:
+
+| Header            | Additional key | Description                                                                                                 |
+| ----------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
+| `accept`          | `media_types`  | MIME types to keep when normalizing the `Accept` header. Maximum 10 items and 255 characters per item.    |
+| `accept-language` | `languages`    | Languages to keep when normalizing the `Accept-Language` header. Maximum 20 items and 64 characters per item. |
+
+The `default` object and custom header entries support only `action`.
+
+For most deployments, set `default` to `bypass`, add entries for expected origin `Vary` headers, and use `normalize` for `accept` and `accept-language` unless your origin requires raw header values.
+
+The following limits and validation rules apply:
+
+- Header names in `headers` must be lowercase.
+- Header names can contain lowercase letters, numbers, underscores, and hyphens.
+- Header names cannot exceed 128 characters.
+- Header names beginning with `cf-` or `cf_` are not allowed.
+- Certain hop-by-hop, cache-control, or proxy-control headers are not allowed. Examples include `connection`, `content-length`, `cache-control`, `host`, `range`, `origin`, and `x-forwarded-for`.
+- `headers` can contain up to 50 entries.
+- `accept.media_types` can contain up to 10 entries.
+- `accept-language.languages` can contain up to 20 entries.
+- Values in `media_types` and `languages` must be non-empty printable ASCII strings.
+
+The following request init fragment normalizes `Accept` and `Accept-Language`, and bypasses cache for any other header in the origin `Vary` response:
+
+```json title="Request init fragment"
+{
+	"cf": {
+		"vary": {
+			"default": {
+				"action": "bypass"
+			},
+			"headers": {
+				"accept": {
+					"action": "normalize",
+					"media_types": ["text/html", "application/json"]
+				},
+				"accept-language": {
+					"action": "normalize",
+					"languages": ["en", "fr", "de"]
+				}
+			}
+		}
+	}
+}
+```
 
 
 ***

--- a/src/content/docs/workers/runtime-apis/request.mdx
+++ b/src/content/docs/workers/runtime-apis/request.mdx
@@ -183,9 +183,9 @@ Additional parameters can be specified for certain header names:
 | `accept`          | `media_types`  | MIME types to keep when normalizing the `Accept` header. Maximum 10 items and 255 characters per item.    |
 | `accept-language` | `languages`    | Languages to keep when normalizing the `Accept-Language` header. Maximum 20 items and 64 characters per item. |
 
-The `default` object and custom header entries support only `action`.
+The `default` object and `headers` entries other than `accept` and `accept-language` support only `action`.
 
-For most deployments, set `default` to `bypass`, add entries for expected origin `Vary` headers, and use `normalize` for `accept` and `accept-language` unless your origin requires raw header values.
+For most deployments, set `default.action` to `bypass`, add `headers` entries for expected origin `Vary` headers, and use `normalize` for `accept` and `accept-language` unless your origin requires raw header values.
 
 The following limits and validation rules apply:
 


### PR DESCRIPTION
Add Workers Request cf.vary reference docs, a fetch cache example, and a Cache Vary cross-link.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [ ] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
