### PR TITLE
docs: add PowerShell Pages deployment cleanup example

### DIFF
--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -9,7 +9,7 @@ products:
 
 ---
 
-import { DashButton } from "~/components";
+import { DashButton, Tabs, TabItem } from "~/components";
 
 Here are some known bugs and issues with Cloudflare Pages:
 
@@ -106,7 +106,10 @@ npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAM
 
 Use the `--force` flag to skip the confirmation prompt and to force deletion of aliased deployments.
 
-To delete _all_ your deployments for a particular project name, you could run the following shell script:
+To delete _all_ your deployments for a particular project name, you could run one of the following scripts:
+
+<Tabs>
+	<TabItem label="macOS and Linux">
 
 ```sh
 prod_id=""
@@ -122,6 +125,37 @@ while :; do
   done <<< "$to_delete"
 done
 ```
+
+	</TabItem>
+	<TabItem label="Windows PowerShell">
+
+```powershell
+$prodId = ""
+
+while ($true) {
+	$deployments = npx wrangler pages deployment list --project-name <PROJECT_NAME> --json | ConvertFrom-Json
+	$ids = @($deployments | ForEach-Object { $_.id })
+	$toDelete = @($ids | Where-Object { $_ -ne $prodId })
+
+	if ($toDelete.Count -eq 0) {
+		Write-Output "Done. Production: $prodId"
+		break
+	}
+
+	Write-Output "Deleting $($toDelete.Count) deployments..."
+
+	foreach ($id in $toDelete) {
+		$output = npx wrangler pages deployment delete $id --project-name <PROJECT_NAME> --force 2>&1
+		$outputText = $output | Out-String
+		if ($outputText -notmatch "Successfully deleted" -and $outputText -match "active production deployment") {
+			$prodId = $id
+		}
+	}
+}
+```
+
+	</TabItem>
+</Tabs>
 
 Note that this will not delete the active production deployment if one exists.
 

--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -106,58 +106,89 @@ npx wrangler pages deployment delete <DEPLOYMENT_ID> --project-name <PROJECT_NAM
 
 Use the `--force` flag to skip the confirmation prompt and to force deletion of aliased deployments.
 
-To delete _all_ your deployments for a particular project name, you could run one of the following scripts:
+To delete _all_ of your preview deployments for a particular project, save and run one of the following scripts, passing your project name as the first argument. Each script finds your production deployment, keeps it, and deletes the remaining preview deployments in parallel. You can optionally pass a second argument to control how many deletions run at once (the default is `5`):
 
 <Tabs>
 	<TabItem label="macOS and Linux">
 
-```sh
-prod_id=""
-while :; do
-  ids=$(npx wrangler pages deployment list --project-name <PROJECT_NAME> --json | jq -r '.[].Id')
-  to_delete=$(echo "$ids" | grep -v -F -x "$prod_id" | grep .)
-  [ -z "$to_delete" ] && { echo "Done. Production: $prod_id"; break; }
-  echo "Deleting $(echo "$to_delete" | wc -l | tr -d ' ') deployments..."
-  while IFS= read -r id; do
-    if ! npx wrangler pages deployment delete "$id" --project-name <PROJECT_NAME> --force 2>&1 | tee /tmp/wrangler-del.log | grep -q "Successfully deleted"; then
-      grep -q "active production deployment" /tmp/wrangler-del.log && prod_id="$id"
-    fi
-  done <<< "$to_delete"
-done
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+project="${1:?usage: $0 <project-name> [parallelism]}"
+parallel="${2:-5}"
+
+deployments=$(npx --no-install wrangler pages deployment list \
+    --project-name "$project" --json)
+
+prod_id=$(jq -r '[.[] | select(.Environment == "Production")][0].Id // empty' <<<"$deployments")
+[ -n "$prod_id" ] || { echo "No production deployment found - aborting." >&2; exit 1; }
+
+to_delete=$(jq -r '.[] | select(.Environment != "Production") | .Id' <<<"$deployments")
+count=$(printf '%s\n' "$to_delete" | grep -c . || true)
+
+if [ "$count" -eq 0 ]; then
+    echo "Nothing to delete. Production: $prod_id"
+    exit 0
+fi
+
+echo "Production: $prod_id. Deleting $count preview deployments..."
+
+printf '%s\n' "$to_delete" | xargs -n1 -P "$parallel" -I{} \
+    sh -c 'npx --no-install wrangler pages deployment delete "$1" --project-name "$2" --force >/dev/null 2>&1 \
+           || echo "FAILED: $1"' _ {} "$project"
+
+echo "Done."
 ```
 
 	</TabItem>
 	<TabItem label="Windows PowerShell">
 
 ```powershell
-$prodId = ""
+param(
+    [Parameter(Mandatory=$true)][string]$ProjectName,
+    [int]$Throttle = 5
+)
 
-while ($true) {
-	$deployments = npx wrangler pages deployment list --project-name <PROJECT_NAME> --json | ConvertFrom-Json
-	$ids = @($deployments | ForEach-Object { $_.Id })
-	$toDelete = @($ids | Where-Object { $_ -ne $prodId })
+$ErrorActionPreference = "Stop"
+$env:CLOUDFLARE_ACCOUNT_ID = $env:CLOUDFLARE_ACCOUNT_ID  # ensure inherited into runspaces
 
-	if ($toDelete.Count -eq 0) {
-		Write-Output "Done. Production: $prodId"
-		break
-	}
+$deployments = npx --no-install wrangler pages deployment list `
+    --project-name $ProjectName --json | ConvertFrom-Json
 
-	Write-Output "Deleting $($toDelete.Count) deployments..."
+$prod = $deployments | Where-Object { $_.Environment -eq "Production" } | Select-Object -First 1
+if (-not $prod) { throw "No production deployment found - aborting to avoid data loss." }
 
-	foreach ($id in $toDelete) {
-		$output = npx wrangler pages deployment delete $id --project-name <PROJECT_NAME> --force 2>&1
-		$outputText = $output | Out-String
-		if ($outputText -notmatch "Successfully deleted" -and $outputText -match "active production deployment") {
-			$prodId = $id
-		}
-	}
+$toDelete = $deployments | Where-Object { $_.Environment -ne "Production" }
+
+if ($toDelete.Count -eq 0) {
+    Write-Output "Nothing to delete. Production: $($prod.Id)"
+    return
 }
+
+Write-Output "Production: $($prod.Id). Deleting $($toDelete.Count) preview deployments..."
+
+$results = $toDelete | ForEach-Object -Parallel {
+    $id = $_.Id
+    npx --no-install wrangler pages deployment delete $id `
+        --project-name $using:ProjectName --force *> $null
+    [pscustomobject]@{ Id = $id; ExitCode = $LASTEXITCODE }
+} -ThrottleLimit $Throttle
+
+$failed = $results | Where-Object { $_.ExitCode -ne 0 }
+if ($failed) {
+    Write-Warning "$($failed.Count) deletions failed:"
+    $failed | Format-Table -AutoSize
+    exit 1
+}
+
+Write-Output "Done."
 ```
 
 	</TabItem>
 </Tabs>
 
-Note that this will not delete the active production deployment if one exists.
+Note that these scripts will not delete the active production deployment if one exists.
 
 ## Use Pages as Origin in Cloudflare Load Balancer
 

--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -122,7 +122,12 @@ deployments=$(npx --no-install wrangler pages deployment list \
     --project-name "$project" --json)
 
 prod_id=$(jq -r '[.[] | select(.Environment == "Production")][0].Id // empty' <<<"$deployments")
-[ -n "$prod_id" ] || { echo "No production deployment found - aborting." >&2; exit 1; }
+if [ -z "$prod_id" ]; then
+    echo "No production deployment found for '$project' - aborting." >&2
+    echo "This script keeps your production deployment, so it needs one to run." >&2
+    echo "Create a production deployment by deploying to your production branch (for example: npx wrangler pages deploy <output-dir> --project-name $project), then re-run this script." >&2
+    exit 1
+fi
 
 to_delete=$(jq -r '.[] | select(.Environment != "Production") | .Id' <<<"$deployments")
 count=$(printf '%s\n' "$to_delete" | grep -c . || true)
@@ -157,7 +162,9 @@ $deployments = npx --no-install wrangler pages deployment list `
     --project-name $ProjectName --json | ConvertFrom-Json
 
 $prod = $deployments | Where-Object { $_.Environment -eq "Production" } | Select-Object -First 1
-if (-not $prod) { throw "No production deployment found - aborting to avoid data loss." }
+if (-not $prod) {
+    throw "No production deployment found for '$ProjectName' - aborting to avoid data loss. This script keeps your production deployment, so it needs one to run. Create a production deployment by deploying to your production branch (for example: npx wrangler pages deploy <output-dir> --project-name $ProjectName), then re-run this script."
+}
 
 $toDelete = $deployments | Where-Object { $_.Environment -ne "Production" }
 

--- a/src/content/docs/pages/platform/known-issues.mdx
+++ b/src/content/docs/pages/platform/known-issues.mdx
@@ -134,7 +134,7 @@ $prodId = ""
 
 while ($true) {
 	$deployments = npx wrangler pages deployment list --project-name <PROJECT_NAME> --json | ConvertFrom-Json
-	$ids = @($deployments | ForEach-Object { $_.id })
+	$ids = @($deployments | ForEach-Object { $_.Id })
 	$toDelete = @($ids | Where-Object { $_ -ne $prodId })
 
 	if ($toDelete.Count -eq 0) {


### PR DESCRIPTION
## Summary
- add tabs for the Pages deployment cleanup script
- keep the existing macOS/Linux shell example
- add a Windows PowerShell version that uses `ConvertFrom-Json` instead of `jq`

Closes #31753

## Validation
- `git diff --check`

Note: I attempted `pnpm exec prettier --check src/content/docs/pages/platform/known-issues.mdx`, but it timed out locally after the dependency install did not complete within two minutes. I stopped the stale local processes and did not keep generated dependency files.