### PR TITLE
docs: Fix HTML syntax for widget configurations examples

### DIFF
--- a/src/content/docs/turnstile/get-started/client-side-rendering/widget-configurations.mdx
+++ b/src/content/docs/turnstile/get-started/client-side-rendering/widget-configurations.mdx
@@ -497,12 +497,12 @@ When enabled, Turnstile automatically creates a hidden `<input>` element with th
 
 ```html title="Responsive design widget" wrap
 <div style="max-width: 500px;">
-  <div class="cf-turnstile" data-sitekey=<YOUR-SITE-KEY> data-size="flexible" data-theme="auto"></div>
+  <div class="cf-turnstile" data-sitekey="<YOUR-SITE-KEY>" data-size="flexible" data-theme="auto"></div>
 </div>
 
 ```
 
 ```html title="Mobile-optimized compact widget" wrap
-<div class="cf-turnstile" data-sitekey=<YOUR-SITE-KEY> data-size="compact" data-theme="light" data-language="en">
+<div class="cf-turnstile" data-sitekey="<YOUR-SITE-KEY>" data-size="compact" data-theme="light" data-language="en">
 </div>
 ```


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
Adding quotes for consistency with the rest of the page and to fix syntax highlight.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

|Before|After|
|-|-|
|In prod:<img width="834" height="432" alt="image" src="https://github.com/user-attachments/assets/46a70ebb-114c-4022-9201-9cca827360c5" /> broken syntax in GH too: <img width="875" height="205" alt="Screenshot 2026-06-28 at 11 26 12" src="https://github.com/user-attachments/assets/f894a35a-08ea-4286-90b1-673b552e45cb" /> | Fixed, in GH MD preview: <img width="843" height="166" alt="image" src="https://github.com/user-attachments/assets/dcd27937-434d-41bb-889d-170c52bda4e7" />|

### Documentation checklist

<!-- Remove items that do not apply -->

- [x] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
