### PR TITLE
docs: Add PR rebase and CODEOWNERS guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,3 +273,35 @@ Shared reference files in `.agents/references/`:
 - Format: `[Product] description` or `type: description`
 - Examples: `[Workers] Fix broken link in get-started`, `docs: clarify rate limiting behavior`, `fix: correct TypeScript example`
 - Common prefixes: `docs:`, `fix:`, `chore:`, `[Product]`
+
+## Pull requests and CODEOWNERS
+
+PR operations in this repo use the `gh` CLI (see the `pr` skill for the canonical workflow — title format, body template, draft-by-default rule).
+
+### Resolving a stale PR (merge conflict with `production`)
+
+When a PR sits open long enough to conflict with `production`, the standard recovery is a rebase, not a merge:
+
+```bash
+git fetch origin production
+git rebase origin/production
+# resolve conflicts, git add, then:
+git rebase --continue
+git push --force-with-lease
+```
+
+A successful force-push **will dismiss prior approving reviews** because they are tied to the old commit SHA — expect to re-request review. Check `gh pr view <n> --json mergeStateStatus,reviewDecision` afterwards to confirm the PR is ready to merge.
+
+### CODEOWNERS
+
+The CODEOWNERS file lives at `.github/CODEOWNERS`. Entries are grouped by product with `# Product` section headers.
+
+When adding yourself (or a teammate) as a codeowner for a product, check whether sibling paths exist and add coverage to all of them — missing one is the most common reason a contributor finds out they cannot approve a PR they expected to own:
+
+- `/src/content/docs/{slug}/`
+- `/src/content/partials/{slug}/`
+- `/src/content/changelog/{slug}/`
+- `/src/content/release-notes/{slug}.yaml`
+- `/src/assets/images/{slug}/`
+
+Edits to `.github/CODEOWNERS` itself require approval from `@cloudflare/product-owners` and `@cloudflare/content-engineering` (see line 8 of the file).


### PR DESCRIPTION
### Summary

Adds a new "Pull requests and CODEOWNERS" section to `AGENTS.md` covering two areas of friction I hit while contributing:

- **Stale PR rebase recovery** — the standard `fetch / rebase / force-with-lease` flow, plus a note that force-push dismisses prior approvals (a non-obvious GitHub behavior).
- **CODEOWNERS conventions** — file location, product-section grouping, and the five sibling content paths to check when adding ownership for a product. Also notes that CODEOWNERS edits require `@cloudflare/product-owners` and `@cloudflare/content-engineering` approval.

Points to the `pr` skill as the canonical PR workflow rather than duplicating it.

### Documentation checklist

<!-- AGENTS.md change; content style guide does not apply -->
