### PR TITLE
Add EOL date for legacy Registrar domain management API (REG-7951)

### DIFF
--- a/src/content/release-notes/api-deprecations.yaml
+++ b/src/content/release-notes/api-deprecations.yaml
@@ -3,6 +3,30 @@ link: "/fundamentals/api/reference/deprecations/"
 productName: API deprecations
 productLink: "/fundamentals/"
 entries:
+  - publish_date: "2026-06-29"
+    title: "Legacy Registrar Domain Management API"
+    description: |-
+      Deprecation date: April 10, 2026
+
+      End of life date: September 27, 2026
+
+      The legacy Registrar domain management endpoints are deprecated and will reach their end of life on September 27, 2026. These endpoints have been replaced by the new [Registrar API](/api/resources/registrar/), which provides domain search, availability checking, and registration capabilities.
+
+      Deprecated APIs:
+
+      - `GET /accounts/{account_id}/registrar/domains` — List domains
+      - `GET /accounts/{account_id}/registrar/domains/{domain_name}` — Get domain
+      - `PUT /accounts/{account_id}/registrar/domains/{domain_name}` — Update domain
+
+      Replacement: [Registrar API](/api/resources/registrar/)
+
+      - [Search for available domains](/api/resources/registrar/methods/search/) — `GET /accounts/{account_id}/registrar/domain-search`
+      - [Check domain availability](/api/resources/registrar/methods/check/) — `POST /accounts/{account_id}/registrar/domain-check`
+      - [List registrations](/api/resources/registrar/subresources/registrations/methods/list/) — `GET /accounts/{account_id}/registrar/registrations`
+      - [Create registration](/api/resources/registrar/subresources/registrations/methods/create/) — `POST /accounts/{account_id}/registrar/registrations`
+
+      Customers and integrations using the legacy domain management endpoints must migrate to the new Registrar API before September 27, 2026 to ensure uninterrupted service. After this date, the legacy endpoints will no longer be available.
+
   - publish_date: "2026-06-16"
     title: "Zone Settings Batch API"
     description: |-


### PR DESCRIPTION
## Description

Adds a deprecation entry to the API deprecations page for the legacy Registrar domain management endpoints.

**Deprecation date:** April 10, 2026
**End of life date:** September 27, 2026

### Deprecated endpoints
- `GET /accounts/{account_id}/registrar/domains` — List domains
- `GET /accounts/{account_id}/registrar/domains/{domain_name}` — Get domain
- `PUT /accounts/{account_id}/registrar/domains/{domain_name}` — Update domain

### Replacement
The new [Registrar API](https://developers.cloudflare.com/api/resources/registrar/) provides:
- `GET /accounts/{account_id}/registrar/domain-search` — Search for available domains
- `POST /accounts/{account_id}/registrar/domain-check` — Check domain availability
- `GET /accounts/{account_id}/registrar/registrations` — List registrations
- `POST /accounts/{account_id}/registrar/registrations` — Create registration

## Related
- Jira: REG-7951
- Badger OpenAPI MR (staging): https://gitlab.cfdata.org/cloudflare/reg/badger/-/merge_requests/3442
- Badger OpenAPI MR (master): https://gitlab.cfdata.org/cloudflare/reg/badger/-/merge_requests/3443