### PR TITLE
feat: nimbus preview deploys

### DIFF
--- a/.github/workflows/nimbus-preview-deploy.yml
+++ b/.github/workflows/nimbus-preview-deploy.yml
@@ -1,0 +1,90 @@
+name: Nimbus Preview Deploy
+
+# TEMPORARY (Starlight → Nimbus migration). On every merge to `production`,
+# builds the BUILD_TARGET=nimbus output and deploys it to the stable `nimbus`
+# Preview on the SAME `cloudflare-docs` Worker:
+#   https://nimbus-cloudflare-docs.<subdomain>.workers.dev
+#
+# Safety:
+#   • Uses `wrangler preview` (private beta) — NEVER `wrangler deploy` — so it
+#     cannot overwrite the production deployment or its route.
+#   • Independent workflow: it does not gate, slow, or fail the production
+#     `publish` workflow. It is not a required status check.
+#
+# This is deliberately separate from `nimbus-build.yml` (PR-time parity build,
+# non-deploying). Delete this whole file at cutover (Epic G1/H1), along with
+# `wrangler.preview.json` and `worker/index.preview.ts`.
+on:
+  push:
+    branches:
+      - production
+
+concurrency:
+  group: nimbus-preview-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # Only deploy on merges performed by the migration author — mirrors the
+    # author scoping in `nimbus-build.yml`. On a `push` event there is no
+    # pull_request context, so we gate on `github.actor` (the person who merged
+    # the PR / pushed to production). Merges by anyone else skip this job
+    # entirely (shows as "skipped", never "failed") — zero impact on others.
+    # Extend to an allowlist if more people drive the migration.
+    if: >-
+      github.repository == 'cloudflare/cloudflare-docs' &&
+      github.actor == 'MohamedH1998'
+    name: Deploy Nimbus Preview
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          version: 11
+
+      - name: Set up node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        id: setup-node
+        with:
+          node-version: 24.x
+          cache: pnpm
+
+      - name: Restore node_modules (cache hit)
+        id: node-modules-cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('package.json') }}
+
+      - name: Install node_modules (cache miss)
+        run: pnpm install --frozen-lockfile
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+
+      - name: Restore Astro (Nimbus) assets from cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: |
+            .astro-cache-nimbus/assets
+          key: astro-nimbus-assets-${{ hashFiles('src/assets/**') }}
+          restore-keys: |
+            astro-nimbus-assets-
+
+      - name: Build Nimbus target (→ dist-nimbus)
+        run: pnpm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TARGET: nimbus
+
+      # Pushes a new deployment to the stable `nimbus` Preview on the same
+      # Worker. `wrangler preview` (private beta) never affects production.
+      - name: Deploy Nimbus Preview
+        run: pnpm exec wrangler preview --config wrangler.preview.json --name nimbus
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/worker/index.preview.ts
+++ b/worker/index.preview.ts
@@ -1,0 +1,226 @@
+// TEMPORARY — Nimbus preview Worker (Starlight -> Nimbus migration).
+//
+// This is a deliberate, self-contained COPY of `worker/index.ts`. It exists so
+// the Nimbus preview (wrangler.preview.json -> dist-nimbus) can run the exact
+// same request-handling logic as production WITHOUT touching or refactoring the
+// production Worker. The only difference from index.ts is the redirects import
+// path (`../dist-nimbus/__redirects` instead of `../dist/__redirects`).
+//
+// It is deployed manually/locally with:
+//   BUILD_TARGET=nimbus pnpm run build
+//   pnpm exec wrangler preview --config wrangler.preview.json --name nimbus
+//
+// Do NOT invest in deduplicating this against index.ts. At cutover (Epic H1)
+// delete this file and wrangler.preview.json. Production is unaffected by
+// anything here.
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { generateRedirectsEvaluator } from "redirects-in-workers";
+import redirectsFileContents from "../dist-nimbus/__redirects";
+
+const redirectsEvaluator = generateRedirectsEvaluator(redirectsFileContents, {
+	maxLineLength: 10_000, // Usually 2_000
+	maxStaticRules: 10_000, // Usually 2_000
+	maxDynamicRules: 2_000, // Usually 100
+});
+
+const LLMS_FULL_R2_PREFIX = "v1/cloudflare-docs-llms-full";
+
+// RFC 9727 requires the path to be exactly /.well-known/api-catalog with no
+// extension. The Cloudflare ASSETS binding cannot serve extensionless files
+// from dot-prefixed directories, so this must be handled directly in the worker.
+const API_CATALOG = JSON.stringify({
+	linkset: [
+		{
+			anchor: "https://developers.cloudflare.com/api/",
+			"service-desc": [
+				{
+					href: "https://developers.cloudflare.com/openapi.json",
+					type: "application/json",
+				},
+			],
+			"service-doc": [
+				{
+					href: "https://developers.cloudflare.com/api/index.md",
+					type: "text/markdown",
+				},
+				{
+					href: "https://developers.cloudflare.com/api/",
+					type: "text/html",
+				},
+			],
+			status: [
+				{
+					href: "https://www.cloudflarestatus.com/api/v2/status.json",
+					type: "application/json",
+				},
+			],
+		},
+	],
+});
+
+/**
+ * When a redirect response is returned for an index.md request, rewrite the
+ * Location header so the agent stays in Markdown land instead of landing on
+ * an HTML page.
+ *
+ * Only rewrites relative (same-origin) Location values — external redirects
+ * (e.g. to GitHub) are left untouched because appending index.md to a
+ * non-docs URL would be nonsensical.
+ */
+function rewriteRedirectForMarkdown(
+	redirect: Response,
+	requestUrl: URL,
+): Response {
+	const location = redirect.headers.get("Location");
+	if (!location) return redirect;
+
+	try {
+		const dest = new URL(location, requestUrl.origin);
+
+		// Only rewrite same-origin redirects that point to a docs path (trailing /)
+		if (dest.origin !== requestUrl.origin) return redirect;
+		if (!dest.pathname.endsWith("/")) return redirect;
+
+		dest.pathname += "index.md";
+
+		const headers = new Headers(redirect.headers);
+		headers.set("Location", dest.pathname + dest.search + dest.hash);
+		return new Response(redirect.body, {
+			status: redirect.status,
+			headers,
+		});
+	} catch {
+		return redirect;
+	}
+}
+
+export default class extends WorkerEntrypoint<Env> {
+	override async fetch(request: Request) {
+		const url = new URL(request.url);
+		const { pathname } = url;
+
+		if (pathname === "/.well-known/api-catalog") {
+			return new Response(API_CATALOG, {
+				headers: {
+					"Content-Type":
+						'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+				},
+			});
+		}
+
+		if (pathname === "/.well-known/mcp/server-card.json") {
+			const object = await this.env.MIDDLECACHE.get(
+				"v1/cloudflare-mcps/server-card.json",
+			);
+			if (!object) {
+				return new Response("server-card.json not found", { status: 404 });
+			}
+			return new Response(object.body, {
+				headers: {
+					"Content-Type": "application/json; charset=utf-8",
+				},
+			});
+		}
+
+		if (pathname === "/openapi.json") {
+			const object = await this.env.MIDDLECACHE.get(
+				"v1/cloudflare-api-schemas/openapi.json",
+			);
+			if (!object) {
+				return new Response("openapi.json not found", { status: 404 });
+			}
+			return new Response(object.body, {
+				headers: {
+					"Content-Type": "application/json; charset=utf-8",
+				},
+			});
+		}
+
+		if (pathname.endsWith("/llms-full.txt")) {
+			// pathname is e.g. "/llms-full.txt" or "/workers/llms-full.txt"
+			// R2 key: "v1/cloudflare-docs-llms-full/llms-full.txt" or
+			//         "v1/cloudflare-docs-llms-full/workers/llms-full.txt"
+			const r2Key = `${LLMS_FULL_R2_PREFIX}${pathname}`;
+			const object = await this.env.MIDDLECACHE.get(r2Key);
+
+			if (!object) {
+				return new Response("llms-full.txt not found", { status: 404 });
+			}
+
+			return new Response(object.body, {
+				headers: {
+					"Content-Type": "text/markdown; charset=utf-8",
+				},
+			});
+		}
+
+		const isMarkdownRequest = url.pathname.endsWith("/index.md");
+
+		try {
+			try {
+				// For index.md requests, evaluate redirects against the base path
+				// (without the index.md suffix) so that redirect rules written for
+				// the HTML path (e.g. /learning-paths/ → /resources/) still fire.
+				const evalRequest = isMarkdownRequest
+					? new Request(
+							url.origin +
+								url.pathname.slice(0, -"index.md".length) +
+								url.search,
+							request,
+						)
+					: request;
+
+				const redirect = await redirectsEvaluator(evalRequest, this.env.ASSETS);
+				if (redirect) {
+					return isMarkdownRequest
+						? rewriteRedirectForMarkdown(redirect, url)
+						: redirect;
+				}
+			} catch (error) {
+				console.error("Could not evaluate redirects", error);
+			}
+
+			try {
+				const forceTrailingSlashURL = new URL(
+					request.url.replace(/([^/])$/, "$1/"),
+					request.url,
+				);
+				const redirect = await redirectsEvaluator(
+					new Request(forceTrailingSlashURL, request),
+					this.env.ASSETS,
+				);
+				if (redirect) {
+					return isMarkdownRequest
+						? rewriteRedirectForMarkdown(redirect, url)
+						: redirect;
+				}
+			} catch (error) {
+				console.error(
+					"Could not evaluate redirects with a forced trailing slash",
+					error,
+				);
+			}
+		} catch (error) {
+			console.error("Unknown error", error);
+		}
+
+		const response = await this.env.ASSETS.fetch(request);
+
+		if (response.status === 404) {
+			const section = new URL(response.url).pathname.split("/").at(1);
+
+			if (!section) return response;
+
+			const notFoundResponse = await this.env.ASSETS.fetch(
+				`http://fakehost/${section}/404/`,
+			);
+
+			return new Response(notFoundResponse.body, {
+				status: 404,
+				headers: notFoundResponse.headers,
+			});
+		}
+
+		return response;
+	}
+}

--- a/wrangler.preview.json
+++ b/wrangler.preview.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "cloudflare-docs",
+	"account_id": "b54f07a6c269ecca2fa60f1ae4920c99",
+	"compatibility_date": "2025-06-02",
+	"compatibility_flags": ["nodejs_compat"],
+	"main": "./worker/index.preview.ts",
+	"rules": [
+		{ "type": "Text", "globs": ["**/__redirects"], "fallthrough": true }
+	],
+	"assets": {
+		"directory": "./dist-nimbus",
+		"binding": "ASSETS",
+		"not_found_handling": "404-page",
+		"run_worker_first": true
+	},
+	"previews": {
+		"r2_buckets": [{ "binding": "MIDDLECACHE", "bucket_name": "middlecache" }]
+	},
+	"observability": {
+		"enabled": true
+	}
+}


### PR DESCRIPTION
### Summary

Temporary tooling for the Starlight → Nimbus migration. On every merge to
`production` performed by the migration author, this builds the
`BUILD_TARGET=nimbus` output and deploys it to a stable, **non-production**
named Preview (`nimbus`) on the **same** `cloudflare-docs` Worker, reachable at
`https://nimbus-cloudflare-docs.<subdomain>.workers.dev`. Production (the
Starlight `dist/` build serving `developers.cloudflare.com`) is never touched.

This is migration scaffolding, not a product/content change. It is intended to
be deleted at cutover (Epic G1/H1).

| File | Purpose |
| --- | --- |
| `.github/workflows/nimbus-preview-deploy.yml` | On `push` to `production` (gated to `github.actor == 'MohamedH1998'`): build Nimbus, then `wrangler preview --config wrangler.preview.json --name nimbus`. Independent workflow, not a required check. |
| `wrangler.preview.json` | Preview-only Wrangler config: `assets.directory: ./dist-nimbus`, no production `route`, `MIDDLECACHE` under a `previews` block. Used **only** with `wrangler preview`. |
| `worker/index.preview.ts` | Self-contained copy of `worker/index.ts`; the only functional difference is importing `../dist-nimbus/__redirects` instead of `../dist/__redirects`. |

### Review scope & context (for human and AI review agents)

**Primary review objective: confirm nothing in production can break or degrade.**
Production = the `cloudflare-docs` Worker on `developers.cloudflare.com`, deployed
by `.github/workflows/publish-production.yml` via `wrangler deploy` using the
default `wrangler.jsonc` (`main: ./worker/index.ts`, assets from `./dist`).

**Invariants this PR must preserve (please verify, don't assume):**
- `worker/index.ts`, `wrangler.jsonc`, `publish-production.yml`, `nimbus-build.yml`,
  and `package.json` are unchanged.
- Production deploy runs `wrangler deploy` with **no `--config`**, so it never
  loads `wrangler.preview.json`. `worker/index.ts` does not import
  `index.preview.ts`, so the preview worker is never in the production bundle.
- The new workflow is isolated from `publish-production.yml`: separate runner,
  distinct `concurrency` group (`nimbus-preview-deploy`), namespaced caches
  (`astro-nimbus-assets-*`), no shared artifacts. It cannot gate, slow, fail, or
  cancel the production publish.
- The deploy step uses `wrangler preview` (never `wrangler deploy`), so it cannot
  overwrite the production deployment or its route.

**Design intent / why it looks the way it does:**
- `worker/index.preview.ts` is a deliberate **duplicate** of `worker/index.ts`,
  not a refactor. This is intentional: keep the production worker byte-identical
  and untouched during the migration. Do not flag the duplication as something to
  DRY up — it is removed wholesale at cutover.
- `wrangler.preview.json` deliberately uses `name: cloudflare-docs` (same Worker)
  so the named Preview attaches to the production Worker's preview environment.


### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
