### PR TITLE
perf: sidebar class hoist

### DIFF
--- a/src/nimbus/components/ui/collapsible/CollapsibleContent.astro
+++ b/src/nimbus/components/ui/collapsible/CollapsibleContent.astro
@@ -13,15 +13,10 @@ const { class: className, ...attrs } = Astro.props;
 
 <div
   data-nb-collapsible-content
-  class={cn(
-    "grid grid-rows-[0fr] transition-[grid-template-rows] duration-250 ease-[cubic-bezier(0.87,0,0.13,1)]",
-    "data-[nb-state=open]:grid-rows-[1fr]",
-    "motion-reduce:transition-none",
-    className,
-  )}
+  class={cn(className)}
   {...attrs}
 >
-  <div class="overflow-hidden min-h-0">
+  <div>
     <slot />
   </div>
 </div>

--- a/src/nimbus/components/ui/collapsible/CollapsibleTrigger.astro
+++ b/src/nimbus/components/ui/collapsible/CollapsibleTrigger.astro
@@ -14,7 +14,7 @@ const { class: className, type, ...attrs } = Astro.props;
 <button
   type={type ?? "button"}
   data-nb-collapsible-trigger
-  class={cn("w-full text-left cursor-pointer select-none", className)}
+  class={cn(className)}
   {...attrs}
 >
   <slot />

--- a/src/nimbus/components/ui/sidebar/SidebarGroup.astro
+++ b/src/nimbus/components/ui/sidebar/SidebarGroup.astro
@@ -125,7 +125,7 @@ const isOpen = Boolean(hasActive || collapsed === false || collapsed === undefin
   <CollapsibleContent data-nb-state={isOpen ? "open" : "closed"}>
     <ul data-nb-sidebar-sublist>
       {items.map((item) => (
-        <li class="break-words">
+        <li>
           {item.type === "group" ? (
             <Astro.self
               label={item.label}

--- a/src/nimbus/styles/globals.css
+++ b/src/nimbus/styles/globals.css
@@ -703,3 +703,42 @@ body:not(:has([data-mobile-sidebar])) [data-menu-btn] {
 		@apply mt-0.5 ml-3 list-none border-l border-border p-0 pl-2 flex flex-col gap-px;
 	}
 }
+
+/*
+ * Class-hoist (page-weight): the sidebar tree re-emits the same handful of
+ * utility-class strings on thousands of elements per page (e.g. `break-words`
+ * ×736, the collapsible grid-animation string ×63). These rules move that
+ * repeated payload off per-element markup into shared selectors keyed on the
+ * data attributes the elements already carry. Faithful transport — the exact
+ * same utility tokens, so computed styles (and therefore rendering) are
+ * unchanged; only the emitted HTML shrinks. The disclosure runtime toggles
+ * `data-nb-state`, which these rules react to exactly as the inline variant did.
+ *
+ * NOTE: `@apply` hard-fails the build on an unknown utility ("Cannot apply
+ * unknown utility class"), unlike an inline class which silently no-ops. Keep
+ * every token below a real Tailwind utility; a typo here breaks the build.
+ */
+@layer components {
+	[data-nb-collapsible-content] {
+		@apply grid grid-rows-[0fr] transition-[grid-template-rows] duration-250 ease-[cubic-bezier(0.87,0,0.13,1)];
+	}
+	[data-nb-collapsible-content][data-nb-state="open"] {
+		@apply grid-rows-[1fr];
+	}
+	[data-nb-collapsible-content] > div {
+		@apply overflow-hidden min-h-0;
+	}
+	[data-nb-collapsible-trigger] {
+		@apply w-full text-left cursor-pointer select-none;
+	}
+	[data-nb-sidebar-sublist] > li {
+		@apply break-words;
+	}
+}
+
+/* Equivalent of the dropped `motion-reduce:transition-none` utility. */
+@media (prefers-reduced-motion: reduce) {
+	[data-nb-collapsible-content] {
+		transition: none;
+	}
+}


### PR DESCRIPTION
### Summary

Performance (page-weight) optimization for the **Nimbus** build target
(`src/nimbus/`). The sidebar tree re-emits the same handful of utility-class
strings on thousands of elements per page — e.g. `break-words` ~736×, and the
collapsible grid-animation string ~63×. This moves that repeated payload out of
per-element markup and into shared CSS selectors keyed on the `data-*`
attributes the elements already carry, so the emitted HTML shrinks while the
computed styles stay identical.

What changed:

| File | Change |
| --- | --- |
| `styles/globals.css` | Adds `@layer components` rules targeting `[data-nb-collapsible-content]`, `[data-nb-collapsible-trigger]`, and `[data-nb-sidebar-sublist] > li`, plus a `prefers-reduced-motion` media query replacing the dropped `motion-reduce:transition-none` utility. |
| `components/ui/collapsible/CollapsibleContent.astro` | Removes the inline grid-animation utility classes now provided by the selector. |
| `components/ui/collapsible/CollapsibleTrigger.astro` | Removes inline trigger utilities now provided by the selector. |
| `components/ui/sidebar/SidebarGroup.astro` | Drops the per-`<li>` `break-words` class now provided by the selector. |

This is a faithful transport: the same Tailwind utility tokens are applied via
shared selectors instead of inline classes, so rendering and the reduced-motion
behavior are unchanged — only the HTML payload is smaller. Scoped entirely to
`src/nimbus/`; the live Starlight site is untouched.

### Notes for reviewers

- **No visual change is intended.** The disclosure runtime still toggles
  `data-nb-state`, which the new selectors react to exactly as the inline
  variant did. Worth a quick before/after check of sidebar expand/collapse and
  reduced-motion.
- **Build-time gotcha (already handled):** `@apply` hard-fails the build on an
  unknown utility ("Cannot apply unknown utility class"), unlike an inline class
  which silently no-ops — so every hoisted token must remain a real Tailwind
  utility.

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [ ] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [ ] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
