### PR TITLE
[API Shield] Clarify Sequence Analytics operation states

### DIFF
--- a/src/content/docs/api-shield/get-started.mdx
+++ b/src/content/docs/api-shield/get-started.mdx
@@ -56,7 +56,7 @@ Cloudflare automatically discovers API endpoints by inspecting your traffic. Add
 Endpoint Management tracks request counts, error rates, and latency for each saved endpoint.
 
 :::note
-Schema validation, schema learning, JWT validation, Sequence Analytics, sequence mitigation, and rate limit recommendations only run on endpoints saved to Endpoint Management.
+Schema validation, schema learning, JWT validation rules, sequence mitigation rules, and rate limit recommendations use operations in the `full` state. Sequence Analytics runs on operations in the `full` or `candidate` state that API Shield can match at the edge. For more information, refer to [Operation states](/security/web-assets/manage-operations/#operation-states).
 :::
 
 You can save your endpoints directly from [API Discovery](/api-shield/management-and-monitoring/endpoint-management/#add-endpoints-from-api-discovery), [Schema validation](/api-shield/management-and-monitoring/endpoint-management/#add-endpoints-from-schema-validation), or [manually](/api-shield/management-and-monitoring/endpoint-management/#add-endpoints-manually) by method, path, and host.

--- a/src/content/docs/api-shield/security/sequence-analytics.mdx
+++ b/src/content/docs/api-shield/security/sequence-analytics.mdx
@@ -28,7 +28,7 @@ For example, a portion of a sequence made during a bank funds transfer could loo
 | 3     | `GET`  | `/api/v1/accounts/{account_id}/balance` | `account_id` is a different account belonging to the user.                                                                                     |
 | 4     | `POST` | `/api/v1/transferFunds`                 | This contains a request body detailing an account to transfer funds from, an account to transfer funds to, and an amount of money to transfer. |
 
-API Shield uses your configured <GlossaryTooltip term="session identifier">session identifier</GlossaryTooltip> and your saved endpoints to build a set of ordered API operations (HTTP host, method, and path) requested per session. API Shield may surface sequences in various lengths depending on how it scores the sequences.
+API Shield uses your configured <GlossaryTooltip term="session identifier">session identifier</GlossaryTooltip> and operations in the `full` or `candidate` state to build a set of ordered API operations (HTTP host, method, and path) requested per session. API Shield may surface sequences in various lengths depending on how it scores the sequences.
 
 ### Sequence scoring
 
@@ -56,6 +56,6 @@ Sequence Analytics is available for all API Shield customers. Pro, Business, and
 
 ## Limitations
 
-Sequence Analytics currently requires a session identifier and saved endpoints in order to build and track sequences made by an API consumer. Ensure that you have [set up your session identifier(s)](/api-shield/get-started/#session-identifiers) and [saved your endpoints](/api-shield/management-and-monitoring/endpoint-management/).
+Sequence Analytics currently requires a session identifier and operations that API Shield can match at the edge. Ensure that you have [set up your session identifier(s)](/api-shield/get-started/#session-identifiers) and reviewed your operations in the `full` and `candidate` states in [Web Assets](/security/web-assets/manage-operations/#operation-states).
 
 Sequences are currently limited to nine operations in length.


### PR DESCRIPTION
## Summary

Updates API Shield docs to describe Sequence Analytics in terms of Web Assets operation states. Sequence Analytics runs on operations in the `full` or `candidate` state that API Shield can match at the edge, while the listed rule/recommendation features use `full` operations.

WAM-1727