### PR TITLE
Update Cloudflare One Client Release Notes

### DIFF
--- a/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/index.mdx
+++ b/src/content/docs/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/index.mdx
@@ -41,11 +41,6 @@ Cloudflare also offers an unstable [beta release track](/cloudflare-one/team-and
 
 ## Linux
 
-:::note[Support for Cloudflare Mesh on RHEL 9]
-
-Starting with Cloudflare One Client version 2026.3.846.0, [Cloudflare Mesh](/cloudflare-one/networks/connectors/cloudflare-mesh/) functionality is supported for both RHEL 9 and RHEL 8, whereas full Cloudflare One Client functionality is currently only supported on RHEL 8. This note will be removed once RHEL 9 support is complete.
-:::
-
 <LinkButton href="https://pkg.cloudflareclient.com/">
 	Package repository
 </LinkButton>

--- a/src/content/partials/cloudflare-one/warp/system-requirements/linux.mdx
+++ b/src/content/partials/cloudflare-one/warp/system-requirements/linux.mdx
@@ -5,7 +5,7 @@
 
 |                       |                                                                               |
 | --------------------- | ----------------------------------------------------------------------------- |
-| **OS version**        | CentOS 8, RHEL 8, RHEL 9 [^1], Debian 12, Debian 13, Fedora 34, Fedora 35 [^3], Ubuntu 22.04 LTS, Ubuntu 24.04 LTS |
+| **OS version**        | RHEL 9 [^1], RHEL 10, Debian 12, Debian 13, Fedora 43, Fedora 44, Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, Ubuntu 26.04 LTS |
 | **Processor**         | AMD64 / x86-64 or ARM64 / AArch64                                   |
 | **HD space**          | 75 MB                                                                         |
 | **Memory**            | 35 MB                                                                         |
@@ -15,5 +15,3 @@
 [^1]: On RHEL 9 and later, enable the [Extra Packages for Enterprise Linux (EPEL)](https://docs.fedoraproject.org/en-US/epel/) repository (`sudo dnf install epel-release`) before installing `cloudflare-warp`. EPEL provides dependencies required by the client UI.
 
 [^2]: Minimum 1281 bytes with [Path MTU Discovery](/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/path-mtu-discovery/)
-
-[^3]: The Linux client UI depends on the `webkit2gtk3` library. Fedora releases newer than those listed (Fedora 41 and later) ship `webkit2gtk4.x` instead of `webkit2gtk3` and do not provide a `webkit2gtk3` package, so the `cloudflare-warp` RPM cannot currently be installed on them.

--- a/src/content/warp-releases/linux/ga/2026.6.822.0.yaml
+++ b/src/content/warp-releases/linux/ga/2026.6.822.0.yaml
@@ -1,0 +1,57 @@
+releaseNotes: |-
+  This release introduces multiple features from our previous beta release into stable release, including:
+
+  - The client now applies DNS search suffixes configured in your [device profile](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles) / [network policy](https://developers.cloudflare.com/cloudflare-one/traffic-policies/network-policies). Administrators can push a list of DNS search domains that the client appends to single-label queries, alongside any system-configured suffixes. See [DNS search suffixes](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#dns-search-suffixes) for details.
+  - Upgraded security of device registration to be hardware-backed. Registration tokens can now be generated in the TPM (with TPM 2.0+) whenever it is available to provide stronger protection against device impersonation. See [Hardware-backed registration](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/hardware-backed-registration/) for details.
+  - Added a local-file signal source for Emergency Disconnect. In addition to the existing HTTPS polling mechanism, administrators can now configure WARP to monitor for a file on disk; the presence of the file triggers an emergency disconnect even if both Cloudflare and your own infrastructure are unreachable. Either signal being asserted triggers disconnect; both must be cleared for normal operation to resume.
+  - Added new warp-cli debug commands for interactive connection diagnosis. See [Extra debug logging](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/diagnostic-logs/#extra-debug-logging) for details.
+  - The local DNS proxy now supports DNSSEC passthrough. DNSSEC-signed responses are forwarded to the application intact (including DO/AD bits and RRSIG records), so applications that validate DNSSEC locally — including resolvers and the dig/drill tooling — work correctly through the client.
+  - Added a new MDM format for organization-wide settings, including a cleaner way to configure the compliance environment (e.g. FedRAMP). The previous per-configuration approach still works, but the new format is now recommended. See the updated [Cloudflare One MDM documentation](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/#organization_configs) for details.
+
+  **Additional changes and improvements**
+
+
+  - Cloudflare Mesh functionality using the Cloudflare One Client is now supported on RHEL 9 and 10.
+  - Cloudflare Mesh now supports hostname-based routing for Cloudflare Tunnel.
+  - Client Certificate device-posture checks now support template variables (e.g. `${serial_number}`, `${device_uuid}`) in the Subject Alternative Name field. Previously only the Common Name field accepted variables, which broke posture rules that pinned identity to a SAN entry.
+  - Improved accessibility by using high contrast colors and more defined color boundaries when high contrast is enabled in the system display settings.
+  - Path MTU Discovery (PMTUD) is now enabled by default.
+  - Fixed the in-client captive-portal browser rendering a blank "Success" page on some airline Wi-Fi networks. The browser now more consistently loads the airline's real portal page so users can complete sign-in from inside the client instead of having to open a separate browser.
+  - Fixed an issue in proxy mode where hostnames containing underscores (e.g. ai_app.com) were rejected, breaking apps that depend on such hostnames (notably ChatGPT sandbox apps). The local proxy now accepts underscore-containing hostnames in CONNECT requests.
+  - Fixed an issue where DNS queries would fail after the connection was idle, requiring users to retry.
+  - Fixed an issue where some Debian releases experienced inaccurate version reporting for posture checks.
+  - Users can now register with team names in any case format without errors.
+  - New UI fixes
+    - Fixed an issue where users with invalid MDM configurations were returned to the onboarding screen after successful authentication.
+    - Added a re-auth button and banner to the home screen so users don't miss it when their session expires.
+    - Added clear error messaging when the Cloudflare certificate needs to be installed.
+    - Brought back support for pausing the tunnel when connected to user-specified Wi-Fi networks for consumer users.
+    - New client UI now surfaces Split tunnel configuration and Local Domain Fallback configuration.
+    - Added ability to configure proxy mode for consumer users.
+    - Added back the option to quit for consumer users.
+
+  For RHEL deployments, this release introduces a dependency on the [Extra Packages for Enterprise Linux](https://docs.fedoraproject.org/en-US/epel/) repository (EPEL). The EPEL repository provides packages that support the captive portal detection’s in-app browser authentication and system tray icon. See [Getting started with EPEL](https://docs.fedoraproject.org/en-US/epel/getting-started/) for instructions on enabling EPEL.
+
+  **Known issues**
+
+
+  - Registration may hang at "Checking your organization configuration" due to IPC errors. A system reboot should resolve the error, allowing registration to proceed.
+version: 2026.6.822.0
+releaseDate: 2026-06-29T19:21:09.588Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/fedora43-arm/version/2026.6.822.0
+packageSize: 75966689
+platformName: Linux
+linuxPlatforms:
+  fedora43-arm: 75966689
+  resolute-arm: 73689616
+  resolute-intel: 74384432
+  jammy-arm: 73425250
+  trixie-arm: 73735846
+  fedora44-intel: 77125297
+  trixie-intel: 74393724
+  noble-arm: 73921208
+  fedora43-intel: 77128060
+  noble-intel: 74383608
+  bookworm-intel: 74636772
+  jammy-intel: 74630568
+  bookworm-arm: 73445502

--- a/src/content/warp-releases/macos/ga/2026.6.822.0.yaml
+++ b/src/content/warp-releases/macos/ga/2026.6.822.0.yaml
@@ -1,0 +1,39 @@
+releaseNotes: |-
+  This release introduces multiple features from our previous beta release into stable release, including:
+
+  - The client now applies DNS search suffixes configured in your [device profile](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles) / [network policy](https://developers.cloudflare.com/cloudflare-one/traffic-policies/network-policies). Administrators can push a list of DNS search domains that the client appends to single-label queries, alongside any system-configured suffixes. See [DNS search suffixes](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#dns-search-suffixes) for details.
+  - Upgraded security of device registration to be hardware-backed. Registration tokens can now be generated in the Secure Enclave whenever available to provide stronger protection against device impersonation. See [Hardware-backed registration](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/hardware-backed-registration/) for details.
+  - Added a local-file signal source for Emergency Disconnect. In addition to the existing HTTPS polling mechanism, administrators can now configure WARP to monitor for a file on disk; the presence of the file triggers an emergency disconnect even if both Cloudflare and your own infrastructure are unreachable. Either signal being asserted triggers disconnect; both must be cleared for normal operation to resume.
+  - Added new warp-cli debug commands for interactive connection diagnosis. See [Extra debug logging](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/diagnostic-logs/#extra-debug-logging) for details.
+  - The local DNS proxy now supports DNSSEC passthrough. DNSSEC-signed responses are forwarded to the application intact (including DO/AD bits and RRSIG records), so applications that validate DNSSEC locally — including resolvers and the dig/drill tooling — work correctly through the client.
+  - Added a new MDM format for organization-wide settings, including a cleaner way to configure the compliance environment (e.g. FedRAMP). The previous per-configuration approach still works, but the new format is now recommended. See the updated [Cloudflare One MDM documentation](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/#organization_configs) for details.
+  - Added support for dashboard-managed client version deployments. Administrators can now upgrade or downgrade the client version on enrolled devices directly from the Zero Trust dashboard. See [Client version assignments](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/client-version-assignments/) for details.
+
+  **Additional Changes and improvements**
+
+
+  - Client Certificate device-posture checks now support template variables (e.g. `${serial_number}`, `${device_uuid}`) in the Subject Alternative Name field. Previously only the Common Name field accepted variables, which broke posture rules that pinned identity to a SAN entry.
+  - Improved accessibility by using high contrast colors and more defined color boundaries when high contrast is enabled in the macOS Display settings.
+  - Path MTU Discovery (PMTUD) is now enabled by default.
+  - Fixed the in-client captive-portal browser rendering a blank "Success" page on some airline Wi-Fi networks. The browser now more consistently loads the airline's real portal page so users can complete sign-in from inside the client instead of having to open a separate browser.
+  - Fixed an issue in proxy mode where hostnames containing underscores (e.g. ai_app.com) were rejected, breaking apps that depend on such hostnames (notably ChatGPT sandbox apps). The local proxy now accepts underscore-containing hostnames in CONNECT requests.
+  - Fixed an issue where DNS queries would fail after the connection was idle, requiring users to retry.
+  - Users can now register with team names in any case format without errors.
+  - New UI fixes
+    - Fixed an issue where users with invalid MDM configurations were returned to the onboarding screen after successful authentication.
+    - Added a re-auth button and banner to the home screen so users don't miss it when their session expires.
+    - Added clear error messaging when the Cloudflare certificate needs to be installed.
+    - Brought back support for pausing the tunnel when connected to user-specified Wi-Fi networks for consumer users.
+    - New client UI now surfaces Split tunnel configuration and Local Domain Fallback configuration.
+    - Added ability to configure proxy mode for consumer users.
+    - Added back the option to quit for consumer users.
+
+  **Known issues**
+
+
+  - Registration may hang at "Checking your organization configuration" due to IPC errors. A system reboot should resolve the error, allowing registration to proceed.
+version: 2026.6.822.0
+releaseDate: 2026-06-29T20:05:45.037Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/macos/version/2026.6.822.0
+packageSize: 151629463
+platformName: macOS

--- a/src/content/warp-releases/windows/ga/2026.6.822.0.yaml
+++ b/src/content/warp-releases/windows/ga/2026.6.822.0.yaml
@@ -1,0 +1,44 @@
+releaseNotes: |-
+  This release introduces multiple features from our previous beta release into stable release, including:
+
+  - The client now applies DNS search suffixes configured in your [device profile](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/device-profiles) / [network policy](https://developers.cloudflare.com/cloudflare-one/traffic-policies/network-policies). Administrators can push a list of DNS search domains that the client appends to single-label queries, alongside any system-configured suffixes. See [DNS search suffixes](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/configure/settings/#dns-search-suffixes) for details.
+  - Added mandatory authentication. When enabled via MDM, the Cloudflare One Client blocks all Internet traffic from the moment the machine boots until the user authenticates, closing the visibility gap on newly deployed devices and during re-authentication. See the [announcement blog](https://blog.cloudflare.com/mandatory-authentication-mfa/) and [documentation](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/windows-no-auth-no-internet/) for details.
+  - Upgraded security of device registration to be hardware-backed. Registration tokens can now be generated in the TPM (with TPM 2.0+) whenever it is available to provide stronger protection against device impersonation. See [Hardware-backed registration](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/hardware-backed-registration/) for details.
+  - Added a local-file signal source for Emergency Disconnect. In addition to the existing HTTPS polling mechanism, administrators can now configure WARP to monitor for a file on disk; the presence of the file triggers an emergency disconnect even if both Cloudflare and your own infrastructure are unreachable. Either signal being asserted triggers disconnect; both must be cleared for normal operation to resume.
+  - Added new warp-cli debug commands for interactive connection diagnosis. See [Extra debug logging](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/troubleshooting/diagnostic-logs/#extra-debug-logging) for details.
+  - The local DNS proxy now supports DNSSEC passthrough. DNSSEC-signed responses are forwarded to the application intact (including DO/AD bits and RRSIG records), so applications that validate DNSSEC locally — including resolvers and the dig/drill tooling — work correctly through the client.
+  - Added a new MDM format for organization-wide settings, including a cleaner way to configure the compliance environment (e.g. FedRAMP). The previous per-configuration approach still works, but the new format is now recommended. See the updated [Cloudflare One MDM documentation](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/parameters/#organization_configs) for details.
+  - Added support for dashboard-managed client version deployments. Administrators can now upgrade or downgrade the client version on enrolled devices directly from the Zero Trust dashboard. See [Client version assignments](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/deployment/mdm-deployment/client-version-assignments/) for details.
+
+  **Additional Changes and improvements**
+
+
+  - Client Certificate device-posture checks now support template variables (e.g. `${serial_number}`, `${device_uuid}`) in the Subject Alternative Name field. Previously only the Common Name field accepted variables, which broke posture rules that pinned identity to a SAN entry.
+  - Improved accessibility by using high contrast colors and more defined color boundaries when high contrast is enabled in Windows Accessibility settings.
+  - Path MTU Discovery (PMTUD) is now enabled by default.
+  - The UseWebView2 registry value (HKLM\SOFTWARE\Cloudflare\CloudflareWARP\UseWebView2 = y) is once again honored by the new GUI for authentication, so administrators who prefer the embedded WebView2 browser for sign-in can opt back in. This setting was effectively ignored in the previous release; the default browser was always used. This key is now also honored for re-authentications.
+  - Fixed a crash in the authentication browser when navigating to a site that prompts for browser permissions (microphone, camera, notifications, etc.). The same fix had previously landed for the captive-portal browser; this extends it to the auth browser.
+  - Fixed an issue in proxy mode where hostnames containing underscores (e.g. ai_app.com) were rejected, breaking apps that depend on such hostnames (notably ChatGPT sandbox apps). The local proxy now accepts underscore-containing hostnames in CONNECT requests.
+  - Fixed an issue where DNS queries would fail after the connection was idle, requiring users to retry.
+  - Fixed a high CPU issue when the device wakes from sleep.
+  - Users can now register with team names in any case format without errors.
+  - New UI fixes
+    - Fixed an issue where users with invalid MDM configurations were returned to the onboarding screen after successful authentication.
+    - Added a re-auth button and banner to the home screen so users don't miss it when their session expires.
+    - Added clear error messaging when the Cloudflare certificate needs to be installed.
+    - Brought back support for pausing the tunnel when connected to user-specified Wi-Fi networks for consumer users.
+    - New client UI now surfaces Split tunnel configuration and Local Domain Fallback configuration.
+    - Added ability to configure proxy mode for consumer users.
+    - Added back the option to quit for consumer users.
+
+  **Known issues**
+
+
+  - An error indicating that Microsoft Edge can't read and write to its data directory may be displayed during captive portal login; this error is benign and can be dismissed.
+  - In rare cases, a registration may hang at "Checking your organization configuration" due to IPC errors. A system reboot should resolve the error, allowing registration to proceed.
+  - Windows ARM may prompt the user to close running applications while trying to install this version. Simply click "Ok" with the default highlighted option.
+version: 2026.6.822.0
+releaseDate: 2026-06-29T20:05:45.579Z
+packageURL: https://downloads.cloudflareclient.com/v1/download/windows/version/2026.6.822.0
+packageSize: 59043840
+platformName: Windows

--- a/src/util/warp-platforms.json
+++ b/src/util/warp-platforms.json
@@ -8,6 +8,14 @@
 		"display_name": "Windows"
 	},
 	{
+		"platform": "resolute-intel",
+		"display_name": "Ubuntu 26.04 (x86-64)"
+	},
+	{
+		"platform": "resolute-arm",
+		"display_name": "Ubuntu 26.04 (arm64)"
+	},
+	{
 		"platform": "noble-intel",
 		"display_name": "Ubuntu 24.04 (x86-64)"
 	},
@@ -64,6 +72,22 @@
 		"display_name": "CentOS / RHEL 8 (arm64)"
 	},
 	{
+		"platform": "almalinux9-intel",
+		"display_name": "AlmaLinux / RHEL 9 (x86-64)"
+	},
+	{
+		"platform": "almalinux9-arm",
+		"display_name": "AlmaLinux / RHEL 9 (arm64)"
+	},
+	{
+		"platform": "almalinux10-intel",
+		"display_name": "AlmaLinux / RHEL 10 (x86-64)"
+	},
+	{
+		"platform": "almalinux10-arm",
+		"display_name": "AlmaLinux / RHEL 10 (arm64)"
+	},
+	{
 		"platform": "fedora34-intel",
 		"display_name": "Fedora 34 (x86-64)"
 	},
@@ -78,5 +102,17 @@
 	{
 		"platform": "fedora35-arm",
 		"display_name": "Fedora 35 (arm64)"
+	},
+	{
+		"platform": "fedora43-intel",
+		"display_name": "Fedora 43 (x86-64)"
+	},
+	{
+		"platform": "fedora43-arm",
+		"display_name": "Fedora 43 (arm64)"
+	},
+	{
+		"platform": "fedora44-intel",
+		"display_name": "Fedora 44 (x86-64)"
 	}
 ]


### PR DESCRIPTION
### Summary

Update the release notes [page](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/cloudflare-one-client/download/) with the new Cloudflare One Client release (v2026.6.822.0) info.

### Screenshots (optional)

<!-- Add imagery to convey the changes made by this PR (optional) -->

### Documentation checklist

<!-- Remove items that do not apply -->

- [ ] Is there a [changelog](https://developers.cloudflare.com/changelog/) entry ([guidelines](https://developers.cloudflare.com/style-guide/documentation-content-strategy/content-types/changelog/))? If you don't add one for something awesome and new (however small) — how will our customers find out? Changelogs are automatically posted to [RSS feeds](https://developers.cloudflare.com/fundamentals/new-features/available-rss-feeds/), the [Discord](https://discord.com/channels/595317990191398933/1040420029080018945), and [X](https://x.com/CFchangelog).
- [x] The change adheres to the [documentation style guide](https://developers.cloudflare.com/style-guide/).
- [x] If a larger change - such as adding a new page- an issue has been opened in relation to any incorrect or out of date information that this PR fixes.
- [x] Files which have changed name or location have been allocated [redirects](https://developers.cloudflare.com/pages/configuration/redirects/#per-file).
