### PR TITLE
Clarify Keyless SSL certificates and add DNS-only key server note

### DIFF
--- a/src/content/docs/ssl/keyless-ssl/configuration/public-dns.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/public-dns.mdx
@@ -39,7 +39,7 @@ As a security measure, you should hide the hostname of your key server.
 
 :::note
 
-If your key server hostname is on a zone you have on Cloudflare, you must create a **DNS-only** (grey-clouded) record for it — do not proxy it. If the record is proxied or missing, Cloudflare's edge resolver returns `NXDOMAIN` and the Keyless TLS handshake fails. The fix is the DNS-only record — not adding the hostname to a certificate SAN.
+If your key server hostname is on a Cloudflare zone, you must create a **DNS-only** (grey cloud) record for it — do not proxy it. If the record is proxied or missing, Cloudflare's edge resolver returns `NXDOMAIN` and the Keyless SSL handshake fails. The fix is the DNS-only record — not adding the hostname to a certificate Subject Alternative Name (SAN).
 
 :::
 

--- a/src/content/docs/ssl/keyless-ssl/configuration/public-dns.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/public-dns.mdx
@@ -37,6 +37,29 @@ As a security measure, you should hide the hostname of your key server.
 
 :::
 
+:::note
+
+If your key server hostname is on a zone you have on Cloudflare, you must create a **DNS-only** (grey-clouded) record for it — do not proxy it. If the record is proxied or missing, Cloudflare's edge resolver returns `NXDOMAIN` and the Keyless TLS handshake fails. The fix is the DNS-only record — not adding the hostname to a certificate SAN.
+
+:::
+
+---
+
+## Certificates used in Keyless SSL
+
+Keyless SSL involves **two different certificates**. Confusing them is the most common setup error.
+
+| Certificate | What it is | SAN should contain |
+| --- | --- | --- |
+| **Edge (Keyless SSL) certificate** | The public certificate Cloudflare serves for your site. | Your site hostnames only (for example, `www.example.com`) |
+| **Key server authentication certificate** | The certificate your key server uses to prove itself to Cloudflare. | The key server hostname only |
+
+:::caution
+
+Do **not** add your key server hostname to the SAN of your public edge certificate. It is not required, and it leaks internal hostnames into the public certificate and Certificate Transparency logs.
+
+:::
+
 ---
 
 ## 2. Upload Keyless SSL Certificates

--- a/src/content/docs/ssl/keyless-ssl/configuration/public-dns.mdx
+++ b/src/content/docs/ssl/keyless-ssl/configuration/public-dns.mdx
@@ -39,7 +39,7 @@ As a security measure, you should hide the hostname of your key server.
 
 :::note
 
-If your key server hostname is on a Cloudflare zone, you must create a **DNS-only** (grey cloud) record for it — do not proxy it. If the record is proxied or missing, Cloudflare's edge resolver returns `NXDOMAIN` and the Keyless SSL handshake fails. The fix is the DNS-only record — not adding the hostname to a certificate Subject Alternative Name (SAN).
+If your key server hostname is on a Cloudflare zone, you must create a DNS-only (grey cloud) record for it — do not proxy it. If the record is proxied, the hostname resolves to Cloudflare's edge IP addresses instead of your key server, so Cloudflare's keyless client cannot reach it. If the record is missing, resolution fails with NXDOMAIN. Either way, the Keyless SSL handshake fails. The fix is the DNS-only record — not adding the hostname to a certificate Subject Alternative Name (SAN).
 
 :::
 


### PR DESCRIPTION
Improves the Keyless SSL "Public DNS" setup page:

- Adds a **Certificates used in Keyless SSL** section with a table distinguishing the **edge (Keyless SSL) certificate** (SAN = site hostnames) from the **key server authentication certificate** (SAN = key server hostname).
- Adds a caution: do not add the key server hostname to the public edge cert SAN — not required, and it leaks internal hostnames into Certificate Transparency logs.
- Adds a note that a key server hostname on a Cloudflare zone must use a **DNS-only (grey-cloud)** record, or the edge returns `NXDOMAIN` and the handshake fails.
