### PR TITLE
fix: correct new line chars in mdx

### DIFF
--- a/src/content/changelog/analytics/2025-10-01-confidence-intervals.mdx
+++ b/src/content/changelog/analytics/2025-10-01-confidence-intervals.mdx
@@ -3,7 +3,7 @@ title: New Confidence Intervals in GraphQL Analytics API
 description: Confidence intervals are now supported in the GraphQL Analytics API to show statistical ranges for sampled data results
 date: 2025-10-01
 ---
- 
+
 The GraphQL Analytics API now supports confidence intervals for `sum` and `count` fields on adaptive (sampled) datasets. Confidence intervals provide a statistical range around sampled results, helping verify accuracy and quantify uncertainty. 
 
 - **Supported datasets**: Adaptive (sampled) datasets only.

--- a/src/content/changelog/fundamentals/2025-10-30-member-management-improvements.mdx
+++ b/src/content/changelog/fundamentals/2025-10-30-member-management-improvements.mdx
@@ -19,7 +19,7 @@ We overhauled the Invite Members UI to simplify inviting users and assigning per
 
 
 **Refreshed Members Overview Page**
- 
+
 We've updated the Members Overview Page to clearly display:
 - Member 2FA status
 - Which members hold Super Admin privileges

--- a/src/content/changelog/gateway/2025-07-28-Spam-domain-category-introduced.mdx
+++ b/src/content/changelog/gateway/2025-07-28-Spam-domain-category-introduced.mdx
@@ -3,9 +3,9 @@ title: Scam domain category introduced under Security Threats
 description: You can now create policies specifically targeting the Scam content
 date: 2025-07-28
 ---
- 
+
 We have introduced a new Security Threat category called **Scam**. Relevant domains are marked with the Scam category. Scam typically refers to fraudulent websites and schemes designed to trick victims into giving away money or personal information.
- 
+
 **New category added**
 
 

--- a/src/content/changelog/security-center/2025-07-18-brand-protection-api.mdx
+++ b/src/content/changelog/security-center/2025-07-18-brand-protection-api.mdx
@@ -4,9 +4,9 @@ title: New APIs for Brand Protection setup
 description: You can now use the Brand Protection API endpoints to manage your Brand Protection queries
 date: 2025-07-18
 ---
- 
+
 The Brand Protection API is now available, allowing users to create new queries and delete existing ones, fetch matches and more!
- 
+
 What you can do:
 - **create new string or logo query** 
 - **delete string or logo queries** 

--- a/src/content/changelog/security-center/2026-04-08-threat-events-notification.mdx
+++ b/src/content/changelog/security-center/2026-04-08-threat-events-notification.mdx
@@ -3,25 +3,25 @@ title: Real-time alerts and daily digests for Threat Events
 description: You can now subscribe to automated notifications for your saved views in Threat Events
 date: 2026-04-08
 ---
- 
+
 You can now automate your threat monitoring by setting up custom alerts in your saved views. Instead of manually checking the dashboard for updates, you can subscribe to notifications that trigger whenever new data matches your specific filter sets, like new activity associated to a particular threat actor or spikes in activity within your industry.
- 
+
 ### Stay ahead of emerging threats
- 
+
 By linking your saved views to the Cloudflare Notifications Center, you can ensure the right information reaches your team at the right time.
- 
+
 - **Immediate Alerts**: receive real-time notifications the moment a critical event is detected that matches your saved criteria. This is essential for high-priority monitoring, such as tracking active campaigns from specific APT groups.
- 
+
 - **Daily Digests**: opt for a summarized report delivered once a day. This is ideal for maintaining situational awareness of broader trends, like regional activity shifts or industry-wide threat landscapes, without cluttering your inbox.
- 
+
 ![Threat Events notifications](~/assets/images/changelog/security-center/threat-events-notifications.png)
- 
+
 ### How to get started
- 
+
 To set up an alert, go to **Application Security** > **Threat Intelligence** > **Threat Events**. From there:
- 
+
 1. Choose your datasets and apply your desired filters and select **Save View** (or select an existing one).
 2. Open the **Manage Saved Views** menu.
 3. Select **Add Alert** next to your chosen view to configure your notification preferences in the Cloudflare dashboard.
- 
+
 For more technical details on configuring notifications, refer to the [Threat Events documentation](/security-center/cloudforce-one/).

--- a/src/content/changelog/workers-ai/2025-10-02-deepgram-flux.mdx
+++ b/src/content/changelog/workers-ai/2025-10-02-deepgram-flux.mdx
@@ -31,19 +31,19 @@ export default {
   },
 } satisfies ExportedHandler<Env>;
 ```
- 
+
 2. Deploy your worker
 ```bash
 npx wrangler deploy
 ```
- 
+
 3. Write a client script to connect to your worker and start sending random audio bytes to it
 ```js
 const ws = new WebSocket('wss://<your-worker-url.com>');
- 
+
 ws.onopen = () => {
   console.log('Connected to WebSocket');
- 
+
   // Generate and send random audio bytes
   // You can replace this part with a function
   // that reads from your mic or other audio source
@@ -51,21 +51,21 @@ ws.onopen = () => {
   ws.send(audioData);
   console.log('Audio data sent');
 };
- 
+
 ws.onmessage = (event) => {
   // Transcription will be received here
   // Add your custom logic to parse the data
   console.log('Received:', event.data);
 };
- 
+
 ws.onerror = (error) => {
   console.error('WebSocket error:', error);
 };
- 
+
 ws.onclose = () => {
   console.log('WebSocket closed');
 };
- 
+
 // Generate random audio data (1 second of noise at 44.1kHz, mono)
 function generateRandomAudio() {
   const sampleRate = 44100;
@@ -73,11 +73,11 @@ function generateRandomAudio() {
   const numSamples = sampleRate * duration;
   const buffer = new ArrayBuffer(numSamples * 2);
   const view = new Int16Array(buffer);
- 
+
   for (let i = 0; i < numSamples; i++) {
     view[i] = Math.floor(Math.random() * 65536 - 32768);
   }
- 
+
   return buffer;
 }
 ```

--- a/src/content/changelog/workers-ai/2025-11-25-flux-2-dev-workers-ai.mdx
+++ b/src/content/changelog/workers-ai/2025-11-25-flux-2-dev-workers-ai.mdx
@@ -106,20 +106,20 @@ Through Workers AI Binding:
 async function streamToBlob(stream: ReadableStream, contentType: string): Promise<Blob> {
   const reader = stream.getReader();
   const chunks = [];
- 
+
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
     chunks.push(value);
   }
- 
+
   return new Blob(chunks, { type: contentType });
 }
 
 const image0 = await fetch("http://image-url");
 const image1 = await fetch("http://image-url");
 const form = new FormData();
- 
+
 const image_blob0 = await streamToBlob(image0.body, "image/png");
 const image_blob1 = await streamToBlob(image1.body, "image/png");
 form.append('input_image_0', image_blob0)
@@ -134,7 +134,7 @@ const formRequest = new Request('http://dummy', {
 });
 const formStream = formRequest.body;
 const formContentType = formRequest.headers.get('content-type') || 'multipart/form-data';
- 
+
 const resp = await env.AI.run("@cf/black-forest-labs/flux-2-dev", {
     multipart: {
         body: form,

--- a/src/content/changelog/workers/2025-08-15-static-assets-redirect-url.mdx
+++ b/src/content/changelog/workers/2025-08-15-static-assets-redirect-url.mdx
@@ -3,7 +3,7 @@ title: 'Workers Static Assets: Corrected handling of double slashes in redirect 
 description: Corrected handling of double slashes in redirect rule paths
 date: 2025-08-15
 ---
- 
+
 [Static Assets](/workers/static-assets/): Fixed a bug in how [redirect rules](https://developers.cloudflare.com/workers/static-assets/redirects/) defined in your Worker's `_redirects` file are processed. 
 
 If you're serving Static Assets with a `_redirects` file containing a rule like `/ja/* /:splat`, paths with double slashes were previously misinterpreted as external URLs. For example, visiting `/ja//example.com` would incorrectly redirect to `https://example.com` instead of `/example.com` on your domain. This has been fixed and double slashes now correctly resolve as local paths. Note: [Cloudflare Pages](/pages/) was not affected by this issue.

--- a/src/content/changelog/workers/2025-09-19-ratelimit-workers-ga.mdx
+++ b/src/content/changelog/workers/2025-09-19-ratelimit-workers-ga.mdx
@@ -5,7 +5,7 @@ products:
   - workers
 date: 2025-09-19
 ---
- 
+
 [Rate Limiting within Cloudflare Workers](/workers/runtime-apis/bindings/rate-limit/) is now Generally Available (GA). 
 
 The `ratelimit` binding is now stable and recommended for all production workloads. Existing deployments using the unsafe binding will continue to function to allow for a smooth transition.

--- a/src/content/docs/api-shield/reference/terraform.mdx
+++ b/src/content/docs/api-shield/reference/terraform.mdx
@@ -62,7 +62,7 @@ resource "cloudflare_api_shield_operation" "get_image" {
   host     = "example.com"
   endpoint = "/api/images/{var1}"
 }
- 
+
 resource "cloudflare_api_shield_operation" "post_image" {
   zone_id  = var.zone_id
   method   = "POST"
@@ -90,13 +90,13 @@ resource "cloudflare_schema_validation_schemas" "example_schema" {
   source             = file("./schemas/example-schema.yaml")
   validation_enabled = true
 }
- 
+
 # Block all requests that violate schema by default
 resource "cloudflare_schema_validation_settings" "zone_level_settings" {
   zone_id                              = var.zone_id
   validation_default_mitigation_action = "block"
 }
- 
+
 # For endpoint post_image - only log requests that violate schema
 resource "cloudflare_schema_validation_operation_settings" "post_image_log_only" {
   zone_id           = var.zone_id

--- a/src/content/docs/cloudflare-one/email-security/settings/detection-settings/allow-policies.mdx
+++ b/src/content/docs/cloudflare-one/email-security/settings/detection-settings/allow-policies.mdx
@@ -75,7 +75,7 @@ Below you can find a list of known services you can add when configuring an Acce
   ```.*@docusign\.net```
 
 - Twitter - Mentions/Retweets
- 
+
   ```notify@twitter.com```
 
 - GitHub (mentions and notifications)

--- a/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
+++ b/src/content/docs/d1/tutorials/d1-and-prisma-orm.mdx
@@ -230,7 +230,7 @@ npx prisma migrate diff --from-empty --to-schema-datamodel ./prisma/schema.prism
 
 </TabItem>
 </Tabs>
- 
+
 This stores a SQL statement to create a new `User` table in your migration file from before, here is what it looks like:
 
 <GitHubCode

--- a/src/content/docs/ddos-protection/advanced-ddos-systems/how-to/add-prefix-allowlist.mdx
+++ b/src/content/docs/ddos-protection/advanced-ddos-systems/how-to/add-prefix-allowlist.mdx
@@ -17,7 +17,7 @@ To add an IP address or prefix to the Advanced DDoS Protection [allowlist](/ddos
 
 <Steps>
 	1. In the Cloudflare dashboard, go to the **L3/4 DDoS protection** page.
- 
+
 		<DashButton url="/?to=/:account/network-security/ddos" />
 	2. Go to **Advanced Protection**. 
 	3. Under **General settings** > **Allowlist**, select **Edit**.

--- a/src/content/docs/ddos-protection/advanced-ddos-systems/how-to/add-prefix.mdx
+++ b/src/content/docs/ddos-protection/advanced-ddos-systems/how-to/add-prefix.mdx
@@ -17,7 +17,7 @@ To add a [prefix](/ddos-protection/advanced-ddos-systems/concepts/#prefixes) to 
 
 <Steps>
   1. In the Cloudflare dashboard, go to the **L3/4 DDoS protection** page.
- 
+
       <DashButton url="/?to=/:account/network-security/ddos" />
   2. Go to **Advanced Protection**. 
   3. Under **General settings** > **Prefixes**, select **Edit**.

--- a/src/content/docs/ddos-protection/advanced-ddos-systems/how-to/create-filter.mdx
+++ b/src/content/docs/ddos-protection/advanced-ddos-systems/how-to/create-filter.mdx
@@ -27,7 +27,7 @@ To create a [filter](/ddos-protection/advanced-ddos-systems/concepts/#filter) fo
 
 <Steps>
 	1. In the Cloudflare dashboard, go to the **L3/4 DDoS protection** page.
- 
+
 		<DashButton url="/?to=/:account/network-security/ddos" />
 	2. Go to **Advanced Protection** > **Advanced TCP Protection**.
 	3. Under the system component for which you are creating the filter (**SYN Flood Protection** or **Out-of-state TCP Protection**), select **Create** next to the type of filter you want to create:

--- a/src/content/docs/ddos-protection/advanced-ddos-systems/overview/index.mdx
+++ b/src/content/docs/ddos-protection/advanced-ddos-systems/overview/index.mdx
@@ -120,7 +120,7 @@ Enable the Advanced DDoS system and begin routing traffic through it.
 
 <Steps>
 	1. In the Cloudflare dashboard, go to the **L3/4 DDoS protection** page.
- 
+
 		<DashButton url="/?to=/:account/network-security/ddos" />	
 	2. Go to **Advanced Protection** > **General settings**.
   3. Under **General settings**, toggle the feature status **On**.

--- a/src/content/docs/learning-paths/dns-best-practices/concepts/phase-4.mdx
+++ b/src/content/docs/learning-paths/dns-best-practices/concepts/phase-4.mdx
@@ -28,7 +28,7 @@ Enable DNSSEC only after you are confident that DNS is resolving correctly throu
       <DashButton url="/?to=/:account/:zone/dns/settings" />
 
    2. Select **Enable DNSSEC**. Cloudflare will sign your zone and generate `DNSKEY` and `DS` record details. 
- 
+
 **Action at registrar:**  
    1. Log in to your domain registrar.  
    2. Navigate to the DNSSEC management section for your domain.  

--- a/src/content/docs/log-explorer/index.mdx
+++ b/src/content/docs/log-explorer/index.mdx
@@ -28,7 +28,7 @@ Contract customers can choose to store their logs in Log Explorer for up to two 
 ## Permissions
 
 Access to Log Explorer features is controlled through specific permissions. Each permission grants users the ability to perform certain actions, such as querying logs, managing datasets, or creating dashboards. 
- 
+
 | Feature | Required Permission | Description |
 |----------|--------------------|--------------|
 | **Manage datasets** | `Logs Edit` | Add, enable, or disable datasets. |

--- a/src/content/docs/logs/logpush/logpush-job/enable-destinations/r2.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/enable-destinations/r2.mdx
@@ -163,7 +163,7 @@ Once your logs are stored in R2, you can download them using various methods:
 ### Dashboard
 
 1. In the Cloudflare dashboard, go to the **R2** page.
- 
+
    <DashButton url="/?to=/:account/r2/overview" />
 
 2. Select your bucket.

--- a/src/content/docs/logs/logpush/logpush-job/filters.mdx
+++ b/src/content/docs/logs/logpush/logpush-job/filters.mdx
@@ -100,9 +100,9 @@ Here is an example request using cURL via API:
 To set filters through the dashboard:
 
 1. In the Cloudflare dashboard, go to the **Logpush** page at the account or or domain (also known as zone) level.
- 
+
    For account: <DashButton url="/?to=/:account/logs" />
- 
+
    For domain (also known as zone): <DashButton url="/?to=/:account/:zone/analytics/logs" />
 
 

--- a/src/content/docs/logs/reference/change-notices/2023-02-01-security-fields-updates.mdx
+++ b/src/content/docs/logs/reference/change-notices/2023-02-01-security-fields-updates.mdx
@@ -143,7 +143,7 @@ After updating Logpush jobs, you may need to update external filters or reports 
 ### Update Logpush job in the dashboard
 
 1. In the Cloudflare dashboard, go to the **Logpush** page.
- 
+
     <DashButton url="/?to=/:account/:zone/analytics/logs" />
 
 2. Select **Edit** next to the Logpush job you wish to edit.

--- a/src/content/docs/speed/observatory/rum-beacon.mdx
+++ b/src/content/docs/speed/observatory/rum-beacon.mdx
@@ -8,7 +8,7 @@ tags:
   - Privacy
 sidebar:
   order: 4
- 
+
 ---
 
 The RUM beacon is a JavaScript snippet that runs when a Cloudflare customer enables RUM through [Web Analytics](/web-analytics/) or [Observatory](/speed/observatory/). This script runs in users' browsers when they visit the customer's site, and its purpose is to collect performance-related data, for example, page load time, and send it to Cloudflare's systems for processing. This [data](/web-analytics/data-metrics/) is then presented to the customer, providing valuable insights into the website's performance and usage.

--- a/src/content/docs/waiting-room/how-to/control-user-session.mdx
+++ b/src/content/docs/waiting-room/how-to/control-user-session.mdx
@@ -26,7 +26,7 @@ To terminate a user's session when they perform a specific action, you can send 
 
 To enable this feature in the Cloudflare Dashboard, check the box next to Allow session termination via origin commands from the dashboard. 
 To enable this feature through the [Cloudflare API](/api/resources/waiting_rooms/methods/update/), update the `enabled_origin_commands` property to include the value `”revoke”` in the list of enabled origin commands.
- 
+
 Then, to return a revocation origin command and revoke the user's session associated with the current request, add the `Cf-Waiting-Room-Command: revoke` HTTP header to the response from your origin.
 
 To get the number of sessions revoked, you can query `sessionsRevoked` metrics from your [Waiting Room analytics](/waiting-room/waiting-room-analytics/#graphql-analytics) data via GraphQL API.

--- a/src/content/partials/logs/enable-logpush-job.mdx
+++ b/src/content/partials/logs/enable-logpush-job.mdx
@@ -6,9 +6,9 @@
 import { DashButton } from "~/components";
 
 1. In the Cloudflare dashboard, go to the **Logpush** page at the account or or domain (also known as zone) level.
- 
+
    For account: <DashButton url="/?to=/:account/logs" />
- 
+
    For domain (also known as zone): <DashButton url="/?to=/:account/:zone/analytics/logs" />
 
 2. Depending on your choice, you have access to [account-scoped datasets](/logs/logpush/logpush-job/datasets/account/) and [zone-scoped datasets](/logs/logpush/logpush-job/datasets/zone/), respectively.


### PR DESCRIPTION
Replace blank lines that contained a single trailing space with truly empty lines. Pure whitespace cleanup with no rendered output change; makes the files cleaner under any MDX parser, Satteri or otherwise.