### PR TITLE
fix: correct dashboard URL for Global API key - use /profile/api-tokens instead of account-level URL

### DIFF
--- a/src/content/docs/fundamentals/api/get-started/keys.mdx
+++ b/src/content/docs/fundamentals/api/get-started/keys.mdx
@@ -41,7 +41,7 @@ To retrieve your Global API key:
 
 1. In the Cloudflare dashboard and select **User Profile** > **API Tokens**.
 
-   <DashButton url="/?to=/:account/api-tokens" />
+   <DashButton url="/profile/api-tokens" />
 
 2. In the **API Keys** section, click `View` button of **Global API Key**.
 


### PR DESCRIPTION
The **View your Global API key** step links to a Cloudflare dashboard deep-link that opens the account-level API Tokens page (`/?to=/:account/api-tokens`), but the Global API Key is under the **user profile** section, not the account section.

## What changed

`src/content/docs/fundamentals/api/get-started/keys.mdx`: Changed the `DashButton` URL from `/?to=/:account/api-tokens` to `/profile/api-tokens`.

This matches the existing `src/content/dash-routes/core.json` entry which maps `/profile/api-tokens` → "API Tokens" (user profile level) and `/?to=/:account/api-tokens` → "Account API tokens" (account level). Several other docs pages (e.g. `src/content/partials/fundamentals/api-roll-token.mdx`) already use the correct `/profile/api-tokens` path.

Fixes #31646