### PR TITLE
Bots: document content-use signal and transitive trust (Forwarded header)

### DIFF
--- a/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
+++ b/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
@@ -71,7 +71,7 @@ With the managed `robots.txt` enabled, Cloudflare will prepend our managed conte
 # BEGIN Cloudflare Managed content
 
 User-Agent: *
-Content-signal: search=yes, ai-train=no
+Content-signal: search=yes, ai-train=no, use=reference
 Allow: /
 
 User-agent: Amazonbot
@@ -122,8 +122,8 @@ To implement a `robots.txt` file on your domain:
 
          <DashButton url="/?to=/:account/:zone/security/settings" />
       2. Filter by **Bot traffic**.
-      3. Go to **Instruct AI bot traffic with robots.txt**.
-      4. Turn on **Instruct AI bot traffic with robots.txt**.
+      3. Go to **Set your preference to block training in robots.txt**.
+      4. Turn on **Set your preference to block training in robots.txt**.
     </Steps>
   </TabItem>
   <TabItem label="Old dashboard">

--- a/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
+++ b/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
@@ -183,6 +183,24 @@ Alternatively, you can use [Security Settings](#implementation).
 Google Search Console may occasionally report `Syntax not understood` for Content Signals and newer directives in the `robots.txt` standard. However, we have observed no impact on crawling rates or SEO as a result of these reports.
 :::
 
+## Content use signal
+
+Cloudflare is testing `content-use`, an optional extension to [Content Signals](https://contentsignals.org/) that lives in your `robots.txt`. It adds a fourth field alongside the existing `search`, `ai-input`, and `ai-train` signals to describe what a crawler may keep and reuse after accessing your content. The field takes one of three values, from least to most permissive:
+
+| Value | Meaning |
+| --- | --- |
+| `use=immediate` | Interact, but store and reuse nothing. |
+| `use=reference` | Index, excerpt, and link back. |
+| `use=full` | Summarize and reproduce. |
+
+For customers who have turned on the managed `robots.txt` setting, Cloudflare adds `use=reference` to the managed content, in line with the existing default of `search=yes,ai-train=no`:
+
+```txt title="Managed robots.txt with the content-use signal"
+User-agent: *
+Content-Signal: search=yes,ai-train=no,use=reference
+Allow: /
+```
+
 ## Availability
 
 Managed `robots.txt` for AI crawlers is available on all plans.

--- a/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
+++ b/src/content/docs/bots/additional-configurations/managed-robots-txt.mdx
@@ -196,8 +196,8 @@ Cloudflare is testing `content-use`, an optional extension to [Content Signals](
 For customers who have turned on the managed `robots.txt` setting, Cloudflare adds `use=reference` to the managed content, in line with the existing default of `search=yes,ai-train=no`:
 
 ```txt title="Managed robots.txt with the content-use signal"
-User-agent: *
-Content-Signal: search=yes,ai-train=no,use=reference
+User-Agent: *
+Content-signal: search=yes, ai-train=no, use=reference
 Allow: /
 ```
 

--- a/src/content/docs/bots/reference/bot-verification/web-bot-auth.mdx
+++ b/src/content/docs/bots/reference/bot-verification/web-bot-auth.mdx
@@ -208,6 +208,30 @@ You can test how Cloudflare interprets your signed requests against https://craw
 
 ---
 
+## Transitive trust and the `Forwarded` header
+
+An agent that reaches your site is often not operated by the company that built it. A platform can run automations on behalf of many different end users, so the operator and the end user are not the same party. Cloudflare refers to this chain — website owner → bot operator → end user — as **transitive trust**.
+
+To carry an operator's identity through that chain, Cloudflare is experimenting with the `Forwarded` header defined in [RFC 7239](https://www.rfc-editor.org/info/rfc7239). This works like `X-Forwarded-For` does for IP addresses: a preference to allow an operator holds whether that operator reaches you directly or through intermediaries that Cloudflare trusts.
+
+The operator is identified with the `for` parameter:
+
+```txt
+Forwarded: for="openai"
+```
+
+The header can also carry the [`content-use`](/bots/additional-configurations/managed-robots-txt/#content-use-signal) value that the operator commits to for the content it accesses:
+
+```txt
+Forwarded: for="openai";use="reference"
+```
+
+:::note
+Transitive trust and the `Forwarded` header are experimental and may change.
+:::
+
+---
+
 ## Limitations
 
 Cloudflare's implementation of Web Bot Auth does not support every component and parameter defined in IETF RFC 9421. If you include any of the following in your request's Signature-Input header, verification will fail.


### PR DESCRIPTION
Follow-up to the Content Independence Day 2026 bots docs, covering two items from the "Your site, your rules" blog that live outside the main bots taxonomy PR.

## Changes
- **managed `robots.txt`** (`/bots/additional-configurations/managed-robots-txt/`): document the new `content-use` extension to [Content Signals](https://contentsignals.org/) — `use=immediate`, `use=reference`, `use=full` — and note that managed `robots.txt` adds `use=reference` alongside the existing `search=yes,ai-train=no` default.
- **Web Bot Auth** (`/bots/reference/bot-verification/web-bot-auth/`): add a **Transitive trust and the `Forwarded` header** section (RFC 7239), including the `for=` operator identity and the optional `content-use` parameter (`Forwarded: for="openai";use="reference"`). Marked experimental.

## Notes
- Independent of the main bots PR (#31793); branched from `production`.
- Opening for review; please do not merge until docs owners have reviewed.
