### PR TITLE
fix: set charset for agent setup prompt

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -16,6 +16,9 @@
 /*/index.md:
   Content-Type: text/markdown; charset=utf-8
 
+/agent-setup/prompt.md
+  Content-Type: text/markdown; charset=utf-8
+
 /.well-known/agent-skills/index.json
   Content-Type: application/json; charset=utf-8
 

--- a/worker/index.worker.test.ts
+++ b/worker/index.worker.test.ts
@@ -133,6 +133,16 @@ describe("Cloudflare Docs", () => {
 			expect(text).toContain("# Cloudflare Developer Documentation");
 		});
 
+		it("agent setup prompt declares utf-8 charset", async () => {
+			const request = new Request("http://fakehost/agent-setup/prompt.md");
+			const response = await SELF.fetch(request);
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe(
+				"text/markdown; charset=utf-8",
+			);
+		});
+
 		it("index.md requests preserve markdown through redirects", async () => {
 			// /learning-paths/ redirects to /resources/ — an index.md request
 			// should redirect to /resources/index.md, not the HTML page.


### PR DESCRIPTION
This PR sets an explicit UTF-8 charset for `/agent-setup/prompt.md` so browsers decode the Unicode completion box correctly instead of rendering mojibake.

It also adds a Worker regression test for the endpoint `Content-Type` header.

Fixes https://github.com/cloudflare/cloudflare-docs/issues/31795

CC @mvvmm @MohamedH1998 @kodster28
