### PR TITLE
[Version Management] Update API limitation, fix troubleshooting page, add code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@ package.json @cloudflare/content-engineering
 /src/content/docs/tenant/ @jhutchings1 @cloudflare/product-owners
 /src/content/docs/terraform/ @jhutchings1 @cloudflare/product-owners
 /src/content/docs/version-management/ @jhutchings1 @cloudflare/product-owners
+/src/content/partials/version-management/ @jhutchings1 @cloudflare/product-owners
 
 # Billing
 

--- a/src/content/docs/version-management/troubleshooting.mdx
+++ b/src/content/docs/version-management/troubleshooting.mdx
@@ -94,13 +94,9 @@ To avoid this:
 - Deploy Workers using Wrangler before creating new versions that reference the same routes.
 - Avoid configuring the same custom domains across multiple versions.
 
-## API and Terraform are not supported
+## Terraform is not supported
 
-Version Management does not currently expose a public API. You can only manage versions through the [Cloudflare dashboard](https://dash.cloudflare.com/).
-
-[Terraform](/terraform/) is also not supported. If you currently use Terraform to manage your zone configuration, you should choose either Terraform or Version Management — using both simultaneously is not supported.
-
-If you receive a `10001` authentication error when attempting to access Version Management endpoints through the API, this is expected behavior. There is no public API available at this time.
+[Terraform](/terraform/) is not supported by Version Management. If you currently use Terraform to manage your zone configuration, you should choose either Terraform or Version Management — using both simultaneously is not supported.
 
 ## Analytics discrepancies
 

--- a/src/content/partials/version-management/product-limitations.mdx
+++ b/src/content/partials/version-management/product-limitations.mdx
@@ -51,7 +51,7 @@ Version Management does not currently support or have limited support for the fo
 <Details header="Cloudflare API">
 
 - Version Management environments — including their routing expressions and version assignments — can be managed through the public [Environments API](/api/resources/zones/subresources/environments/).
-- Creating, cloning, and editing zone versions (the configuration snapshots themselves) is currently only available through the [Cloudflare dashboard](https://dash.cloudflare.com/).
+- Creating, cloning, and editing zone versions (the configuration snapshots themselves) are currently only available through the [Cloudflare dashboard](https://dash.cloudflare.com/).
 
 </Details>
 

--- a/src/content/partials/version-management/product-limitations.mdx
+++ b/src/content/partials/version-management/product-limitations.mdx
@@ -50,8 +50,8 @@ Version Management does not currently support or have limited support for the fo
 
 <Details header="Cloudflare API">
 
-- Version Management does not currently expose a public [API](/api/).
-- Customers can only use Version Management through the [Cloudflare dashboard](https://dash.cloudflare.com/).
+- Version Management environments — including their routing expressions and version assignments — can be managed through the public [Environments API](/api/resources/zones/subresources/environments/).
+- Creating, cloning, and editing zone versions (the configuration snapshots themselves) is currently only available through the [Cloudflare dashboard](https://dash.cloudflare.com/).
 
 </Details>
 


### PR DESCRIPTION
## Summary

Update the Version Management documentation to reflect that the public Environments API is available, and add @jhutchings1 as code owner for the version-management partials.

## Changes

| Topic | File | Change |
|---|---|---|
| **Environments API** | `partials/version-management/product-limitations.mdx` | Document that Version Management environments can be managed through the public Environments API; clarify that creating, cloning, and editing zone versions remains dashboard-only |
| **Troubleshooting** | `docs/version-management/troubleshooting.mdx` | Remove outdated claims that no public API exists and that the `10001` error is expected behavior; keep the Terraform mutual-exclusion guidance under a renamed section |
| **CODEOWNERS** | `.github/CODEOWNERS` | Add `@jhutchings1` as code owner for `/src/content/partials/version-management/` |

Replaces #31525.