### PR TITLE
[Access] Clarify Okta group limits

### DIFF
--- a/src/content/docs/cloudflare-one/integrations/identity-providers/okta.mdx
+++ b/src/content/docs/cloudflare-one/integrations/identity-providers/okta.mdx
@@ -183,7 +183,8 @@ To verify the integration, select **View Logs** in the Okta SCIM application.
 
 If you see the error `Failed to fetch user/group information from the identity`, double-check your Okta configuration:
 
-- If you have more than 100 Okta groups, ensure you include the API token.
+- If your Okta tenant has more than 100 groups, ensure you include an Okta API token in the identity provider configuration. Cloudflare uses the token to retrieve groups from Okta for policy evaluation.
+- If Okta returns more than 100 groups in a user's OIDC token, Okta may omit some group memberships from the token. This is an Okta token claim limitation, not a Cloudflare limit. If a required group is omitted, Cloudflare cannot evaluate policies that depend on that group. To avoid this, narrow the Okta groups claim filter so that only groups used in Cloudflare policies are included. For more information, refer to [Okta's group functions and dynamic allowlists documentation](https://support.okta.com/help/s/article/limitations-of-group-functions-dynamic-allowlists?language=en_US).
 - The request may be blocked by the [ThreatInsights feature](https://help.okta.com/en/prod/Content/Topics/Security/threat-insight/ti-index.htm) within Okta.
 
 ### Access login fails due to Okta Enhanced Dynamic Zone

--- a/src/content/partials/cloudflare-one/access/okta-zt-steps.mdx
+++ b/src/content/partials/cloudflare-one/access/okta-zt-steps.mdx
@@ -14,7 +14,7 @@ import {} from "~/components";
     - **Client secret**: Enter your Okta client secret.
     - **Okta account URL**: Enter your [Okta domain](https://developer.okta.com/docs/guides/find-your-domain/main/), for example `https://my-company.okta.com`.
 
-14. (Optional) Create an Okta API token and enter it in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **Zero Trust** > **Integrations** > **Identity providers** (the token can be read-only). This will prevent your Okta groups from failing if you have more than 100 groups.
+14. (Optional) Create an Okta API token and enter it in the [Cloudflare dashboard](https://dash.cloudflare.com/) under **Zero Trust** > **Integrations** > **Identity providers** (the token can be read-only). Use an API token if your Okta tenant has more than 100 groups. Without this token, Cloudflare may not be able to retrieve all Okta groups for policy evaluation.
 
 15. (Optional) To configure [custom OIDC claims](/cloudflare-one/integrations/identity-providers/generic-oidc/#custom-oidc-claims):
     1. In Okta, create a [custom authorization server](https://developer.okta.com/docs/guides/customize-authz-server/main/) and ensure that the `groups` scope is enabled.


### PR DESCRIPTION
Clarifies Okta group limit behavior in the Cloudflare One Okta identity provider docs. This separates the tenant-level case where Cloudflare needs an Okta API token to retrieve more than 100 groups from Okta's OIDC token group-claim limitation, where a user token with more than 100 groups can omit policy-relevant groups.\n\nValidation:\n- pnpm run format:core:check\n- pnpm run check\n- git diff --check